### PR TITLE
Revert "Log more when downloading file fails"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.filedistribution;
 
 import com.google.inject.Inject;
@@ -20,6 +20,7 @@ import com.yahoo.yolean.Exceptions;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
@@ -156,11 +157,7 @@ public class FileServer {
 
         boolean fileExists;
         try {
-            String client = request.target().toString();
-            FileReferenceDownload fileReferenceDownload = new FileReferenceDownload(new FileReference(fileReference),
-                                                                                    downloadFromOtherSourceIfNotFound,
-                                                                                    client);
-            fileExists = hasFile(fileReference) || download(fileReferenceDownload);
+            fileExists = hasFile(fileReference) || download(fileReference, downloadFromOtherSourceIfNotFound);
             if (fileExists) startFileServing(fileReference, receiver);
         } catch (IllegalArgumentException e) {
             fileExists = false;
@@ -176,14 +173,19 @@ public class FileServer {
 
     // downloadFromOtherSourceIfNotFound is true when the request comes from another config server.
     // This is to avoid config servers asking each other for a file that does not exist
-    private boolean download(FileReferenceDownload fileReferenceDownload) {
-        if (fileReferenceDownload.downloadFromOtherSourceIfNotFound()) {
+    private boolean download(String fileReference, boolean downloadFromOtherSourceIfNotFound) {
+        if (downloadFromOtherSourceIfNotFound) {
             log.log(Level.FINE, "File not found, downloading from another source");
-            return downloader.getFile(fileReferenceDownload).isPresent();
+            return download(fileReference).isPresent();
         } else {
             log.log(Level.FINE, "File not found, will not download from another source since request came from another config server");
             return false;
         }
+    }
+
+    private Optional<File> download(String fileReference) {
+        /* downloadFromOtherSourceIfNotFound should be false here, since this request is from a config server */
+        return downloader.getFile(new FileReferenceDownload(new FileReference(fileReference), false));
     }
 
     public FileDownloader downloader() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.rpc;
 
 import com.google.inject.Inject;
@@ -567,9 +567,7 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
                     Stream.of(fileReferenceStrings)
                             .map(FileReference::new)
                             .forEach(fileReference -> downloader.downloadIfNeeded(
-                                    new FileReferenceDownload(fileReference,
-                                                              false, /* downloadFromOtherSourceIfNotFound */
-                                                              req.target().toString())));
+                                    new FileReferenceDownload(fileReference, false /* downloadFromOtherSourceIfNotFound */)));
                     req.returnValues().add(new Int32Value(0));
                 });
     }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -5,7 +5,6 @@ import com.yahoo.config.FileReference;
 import java.util.logging.Level;
 import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.defaults.Defaults;
-import com.yahoo.yolean.Exceptions;
 
 import java.io.File;
 import java.time.Duration;
@@ -56,8 +55,7 @@ public class FileDownloader implements AutoCloseable {
         try {
             return getFutureFile(fileReferenceDownload).get(timeout.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            log.log(Level.WARNING, "Failed downloading '" + fileReferenceDownload +
-                                   "', removing from download queue: " + Exceptions.toMessageString(e));
+            log.log(Level.WARNING, "Failed downloading '" + fileReferenceDownload.fileReference().value() + "', removing from download queue: " + e.getMessage());
             fileReferenceDownloader.failedDownloading(fileReferenceDownload.fileReference());
             return Optional.empty();
         }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 package com.yahoo.vespa.filedistribution;
 
@@ -15,17 +15,15 @@ public class FileReferenceDownload {
     // If a config server wants to download from another config server (because it does not have the
     // file itself) we set this flag to true to avoid an eternal loop
     private final boolean downloadFromOtherSourceIfNotFound;
-    private final String client;
 
     public FileReferenceDownload(FileReference fileReference) {
-        this(fileReference, true, "unknown");
+        this(fileReference, true);
     }
 
-    public FileReferenceDownload(FileReference fileReference, boolean downloadFromOtherSourceIfNotFound, String client) {
+    public FileReferenceDownload(FileReference fileReference, boolean downloadFromOtherSourceIfNotFound) {
         this.fileReference = fileReference;
         this.future = new CompletableFuture<>();
         this.downloadFromOtherSourceIfNotFound = downloadFromOtherSourceIfNotFound;
-        this.client = client;
     }
 
     FileReference fileReference() {
@@ -36,13 +34,7 @@ public class FileReferenceDownload {
         return future;
     }
 
-    public boolean downloadFromOtherSourceIfNotFound() {
+    boolean downloadFromOtherSourceIfNotFound() {
         return downloadFromOtherSourceIfNotFound;
     }
-
-    @Override
-    public String toString() {
-        return fileReference + ", client: " + client;
-    }
-
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#14858

Seems like I changed the code to not set the the flag `downloadFromOtherSourceIfNotFound` to `false` when doing download in this PR, that was not intended. Need to change code to make this clearer and see code can be changed so this is tested