### PR TITLE
reduce empty mixed to dense must add cells with default value

### DIFF
--- a/eval/src/tests/instruction/generic_reduce/generic_reduce_test.cpp
+++ b/eval/src/tests/instruction/generic_reduce/generic_reduce_test.cpp
@@ -23,6 +23,8 @@ std::vector<Layout> layouts = {
     {x(3),y(5),z(7)},
     float_cells({x(3),y(5),z(7)}),
     {x({"a","b","c"})},
+    {x({})},
+    {x({}),y(10)},
     {x({"a","b","c"}),y({"foo","bar"})},
     {x({"a","b","c"}),y({"foo","bar"}),z({"i","j","k","l"})},
     float_cells({x({"a","b","c"}),y({"foo","bar"}),z({"i","j","k","l"})}),
@@ -55,7 +57,9 @@ TensorSpec reference_reduce(const TensorSpec &a, const std::vector<vespalib::str
     for (const auto &my_entry: my_map) {
         result.add(my_entry.first, my_entry.second.value()->result());
     }
-    return result;
+    // use SimpleValue to add implicit cells with default value
+    const auto &factory = SimpleValueBuilderFactory::get();
+    return spec_from_value(*value_from_spec(result, factory));
 }
 
 TensorSpec perform_generic_reduce(const TensorSpec &a, const std::vector<vespalib::string> &dims, Aggr aggr) {

--- a/eval/src/vespa/eval/instruction/generic_reduce.cpp
+++ b/eval/src/vespa/eval/instruction/generic_reduce.cpp
@@ -117,6 +117,12 @@ void my_generic_reduce_op(State &state, uint64_t param_in) {
                             };
         param.dense_plan.execute_keep(reduce_cells);
     }
+    if (sparse.map.empty() && param.sparse_plan.keep_dims.empty()) {
+        auto zero = builder->add_subspace({});
+        for (size_t i = 0; i < zero.size(); ++i) {
+            zero[i] = OCT{};
+        }
+    }
     auto &result = state.stash.create<std::unique_ptr<Value>>(builder->build(std::move(builder)));
     const Value &result_ref = *(result.get());
     state.pop_push(result_ref);


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review
@geirst FYI

This should fix the reduce crash in the performance test. However, reducing an empty mixed tensor to a dense tensor with default cell values does not seem like a relevant use-case for real life (should there not be some values in the tensors?)