### PR TITLE
Greatly simplify bucket DB persistence provider bootstrap procedure

### DIFF
--- a/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
+++ b/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
@@ -359,6 +359,21 @@ DummyPersistence::setModifiedBuckets(const BucketIdListResult::List& buckets)
     _modifiedBuckets = buckets;
 }
 
+void DummyPersistence::set_fake_bucket_set(const std::vector<std::pair<Bucket, BucketInfo>>& fake_info) {
+    std::lock_guard lock(_monitor);
+    _content.clear();
+    for (auto& info : fake_info) {
+        const auto& bucket = info.first;
+        // DummyPersistence currently only supports default bucket space
+        assert(bucket.getBucketSpace() == FixedBucketSpaces::default_space());
+        auto bucket_content = std::make_shared<BucketContent>();
+        bucket_content->getMutableBucketInfo() = info.second;
+        // Must tag as up to date, or bucket info will be recomputed implicitly from zero state in getBucketInfo
+        bucket_content->setOutdatedInfo(false);
+        _content[bucket] = std::move(bucket_content);
+    }
+}
+
 BucketIdListResult
 DummyPersistence::getModifiedBuckets(BucketSpace bucketSpace) const
 {

--- a/persistence/src/vespa/persistence/dummyimpl/dummypersistence.h
+++ b/persistence/src/vespa/persistence/dummyimpl/dummypersistence.h
@@ -144,6 +144,10 @@ public:
 
     void setModifiedBuckets(const BucketIdListResult::List& result);
 
+    // Important: any subsequent mutations to the bucket set in fake_info will reset
+    // the bucket info due to implicit recalculation of bucket info.
+    void set_fake_bucket_set(const std::vector<std::pair<Bucket, BucketInfo>>& fake_info);
+
     /**
      * Returns the list set by setModifiedBuckets(), then clears
      * the list.

--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -164,7 +164,7 @@ void BucketManagerTest::setupTestEnvironment(bool fakePersistenceLayer,
     } else {
         auto bottom = std::make_unique<FileStorManager>(
                     config.getConfigId(),
-                    _node->getPersistenceProvider(), _node->getComponentRegister());
+                    _node->getPersistenceProvider(), _node->getComponentRegister(), *_node);
         _filestorManager = bottom.get();
         _top->push_back(std::move(bottom));
     }

--- a/storage/src/tests/bucketdb/initializertest.cpp
+++ b/storage/src/tests/bucketdb/initializertest.cpp
@@ -145,7 +145,7 @@ std::map<PartitionId, DiskData>
 createMapFromBucketDatabase(StorBucketDatabase& db) {
     std::map<PartitionId, DiskData> result;
     BucketInfoLogger infoLogger(result);
-    db.for_each(std::ref(infoLogger), "createmap");
+    db.acquire_read_guard()->for_each(std::ref(infoLogger));
     return result;
 }
 // Create data we want to have in this test

--- a/storage/src/tests/bucketdb/lockablemaptest.cpp
+++ b/storage/src/tests/bucketdb/lockablemaptest.cpp
@@ -251,11 +251,11 @@ TYPED_TEST(LockableMapTest, iterating) {
     // Test that we can use functor with non-const function
     {
         NonConstProcessor<TypeParam> ncproc;
-        map.for_each_mutable(std::ref(ncproc), "foo"); // First round of mutating functor for `all`
+        map.for_each_mutable_unordered(std::ref(ncproc), "foo"); // First round of mutating functor for `all`
         EXPECT_EQ(A(4, 7, 0), *map.get(11, "foo"));
         EXPECT_EQ(A(42,1, 0), *map.get(14, "foo"));
         EXPECT_EQ(A(1, 3, 3), *map.get(16, "foo"));
-        map.for_each_mutable(std::ref(ncproc), "foo"); // Once more, with feeling.
+        map.for_each_mutable_unordered(std::ref(ncproc), "foo"); // Once more, with feeling.
         EXPECT_EQ(A(4, 8, 0), *map.get(11, "foo"));
         EXPECT_EQ(A(42,2, 0), *map.get(14, "foo"));
         EXPECT_EQ(A(1, 4, 3), *map.get(16, "foo"));
@@ -272,27 +272,13 @@ TYPED_TEST(LockableMapTest, iterating) {
     // Test that we can use const functors directly..
     map.for_each(ConstProcessor<TypeParam>(), "foo");
 
-    // Test iterator bounds
-    {
-        EntryProcessor<TypeParam> proc;
-        map.for_each_mutable(std::ref(proc), "foo", 11, 16);
-        std::string expected("11 - A(4, 8, 0)\n"
-                             "14 - A(42, 2, 0)\n"
-                             "16 - A(1, 4, 3)\n");
-        EXPECT_EQ(expected, proc.toString());
-
-        EntryProcessor<TypeParam> proc2;
-        map.for_each_mutable(std::ref(proc2), "foo", 12, 15);
-        expected = "14 - A(42, 2, 0)\n";
-        EXPECT_EQ(expected, proc2.toString());
-    }
-        // Test that we can abort iterating
+    // Test that we can abort iterating
     {
         std::vector<typename TypeParam::Decision> decisions;
         decisions.push_back(TypeParam::CONTINUE);
         decisions.push_back(TypeParam::ABORT);
         EntryProcessor<TypeParam> proc(decisions);
-        map.for_each_mutable(std::ref(proc), "foo");
+        map.for_each_mutable_unordered(std::ref(proc), "foo");
         std::string expected("11 - A(4, 8, 0)\n"
                              "14 - A(42, 2, 0)\n");
         EXPECT_EQ(expected, proc.toString());
@@ -303,7 +289,7 @@ TYPED_TEST(LockableMapTest, iterating) {
         decisions.push_back(TypeParam::CONTINUE);
         decisions.push_back(TypeParam::REMOVE); // TODO consider removing; not used
         EntryProcessor<TypeParam> proc(decisions);
-        map.for_each_mutable(std::ref(proc), "foo");
+        map.for_each_mutable_unordered(std::ref(proc), "foo");
         std::string expected("11 - A(4, 8, 0)\n"
                              "14 - A(42, 2, 0)\n"
                              "16 - A(1, 4, 3)\n");

--- a/storage/src/tests/persistence/common/filestortestfixture.cpp
+++ b/storage/src/tests/persistence/common/filestortestfixture.cpp
@@ -77,7 +77,8 @@ FileStorTestFixture::TestFileStorComponents::TestFileStorComponents(
     : _fixture(fixture),
       manager(new FileStorManager(fixture._config->getConfigId(),
                                   fixture._node->getPersistenceProvider(),
-                                  fixture._node->getComponentRegister()))
+                                  fixture._node->getComponentRegister(),
+                                  *fixture._node))
 {
     injector.inject(top);
     top.push_back(StorageLink::UP(manager));

--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -112,8 +112,7 @@ struct FileStorManagerTest : Test{
     }
 
     spi::dummy::DummyPersistence& getDummyPersistence() {
-        return static_cast<spi::dummy::DummyPersistence&>
-            (_node->getPersistenceProvider());
+        return dynamic_cast<spi::dummy::DummyPersistence&>(_node->getPersistenceProvider());
     }
 
     void setClusterState(const std::string& state) {
@@ -213,7 +212,8 @@ struct TestFileStorComponents {
     explicit TestFileStorComponents(FileStorManagerTest& test)
         : manager(new FileStorManager(test.config->getConfigId(),
                                       test._node->getPersistenceProvider(),
-                                      test._node->getComponentRegister()))
+                                      test._node->getComponentRegister(),
+                                      *test._node))
     {
         top.push_back(unique_ptr<StorageLink>(manager));
         top.open();
@@ -239,7 +239,7 @@ TEST_F(FileStorManagerTest, header_only_put) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 3);
     // Creating a document to test with
@@ -306,7 +306,7 @@ TEST_F(FileStorManagerTest, put) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 3);
     // Creating a document to test with
@@ -339,7 +339,8 @@ TEST_F(FileStorManagerTest, state_change) {
     top.push_back(unique_ptr<StorageLink>(manager =
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister())));
+                                _node->getComponentRegister(),
+                                *_node)));
     top.open();
 
     setClusterState("storage:3 distributor:3");
@@ -354,7 +355,7 @@ TEST_F(FileStorManagerTest, flush) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager = new FileStorManager(
-                config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+                config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 3);
     // Creating a document to test with
@@ -1267,7 +1268,7 @@ TEST_F(FileStorManagerTest, visiting) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager = new FileStorManager(
-            smallConfig->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            smallConfig->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
         // Adding documents to two buckets which we are going to visit
         // We want one bucket in one slotfile, and one bucket with a file split
@@ -1385,7 +1386,7 @@ TEST_F(FileStorManagerTest, remove_location) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 3);
     document::BucketId bid(8, 0);
@@ -1428,7 +1429,7 @@ TEST_F(FileStorManagerTest, delete_bucket) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager = new FileStorManager(
-                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 2);
     // Creating a document to test with
@@ -1474,7 +1475,7 @@ TEST_F(FileStorManagerTest, delete_bucket_rejects_outdated_bucket_info) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager = new FileStorManager(
-                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 2);
     // Creating a document to test with
@@ -1526,7 +1527,7 @@ TEST_F(FileStorManagerTest, delete_bucket_with_invalid_bucket_info){
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager = new FileStorManager(
-                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+                    config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 2);
     // Creating a document to test with
@@ -1569,7 +1570,7 @@ TEST_F(FileStorManagerTest, no_timestamps) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address(
             "storage", lib::NodeType::STORAGE, 3);
@@ -1613,7 +1614,7 @@ TEST_F(FileStorManagerTest, equal_timestamps) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address("storage", lib::NodeType::STORAGE, 3);
     // Creating a document to test with
@@ -1674,7 +1675,7 @@ TEST_F(FileStorManagerTest, get_iter) {
     DummyStorageLink top;
     FileStorManager *manager;
     top.push_back(unique_ptr<StorageLink>(manager =
-            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            new FileStorManager(config->getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     top.open();
     api::StorageMessageAddress address(
             "storage", lib::NodeType::STORAGE, 3);
@@ -1751,7 +1752,8 @@ TEST_F(FileStorManagerTest, set_bucket_active_state) {
     FileStorManager* manager(
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister()));
+                                _node->getComponentRegister(),
+                                *_node));
     top.push_back(unique_ptr<StorageLink>(manager));
     setClusterState("storage:4 distributor:1");
     top.open();
@@ -1829,7 +1831,8 @@ TEST_F(FileStorManagerTest, notify_owner_distributor_on_outdated_set_bucket_stat
     FileStorManager* manager(
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister()));
+                                _node->getComponentRegister(),
+                                *_node));
     top.push_back(unique_ptr<StorageLink>(manager));
 
     setClusterState("storage:2 distributor:2");
@@ -1871,7 +1874,8 @@ TEST_F(FileStorManagerTest, GetBucketDiff_implicitly_creates_bucket) {
     FileStorManager* manager(
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister()));
+                                _node->getComponentRegister(),
+                                *_node));
     top.push_back(unique_ptr<StorageLink>(manager));
     setClusterState("storage:2 distributor:1");
     top.open();
@@ -1902,7 +1906,8 @@ TEST_F(FileStorManagerTest, merge_bucket_implicitly_creates_bucket) {
     FileStorManager* manager(
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister()));
+                                _node->getComponentRegister(),
+                                *_node));
     top.push_back(unique_ptr<StorageLink>(manager));
     setClusterState("storage:3 distributor:1");
     top.open();
@@ -1932,7 +1937,8 @@ TEST_F(FileStorManagerTest, newly_created_bucket_is_ready) {
     FileStorManager* manager(
             new FileStorManager(config->getConfigId(),
                                 _node->getPersistenceProvider(),
-                                _node->getComponentRegister()));
+                                _node->getComponentRegister(),
+                                *_node));
     top.push_back(unique_ptr<StorageLink>(manager));
     setClusterState("storage:2 distributor:1");
     top.open();
@@ -2055,6 +2061,60 @@ TEST_F(FileStorManagerTest, test_and_set_condition_mismatch_not_counted_as_failu
     EXPECT_EQ(metrics.failed.getValue(), 0);
     EXPECT_EQ(metrics.test_and_set_failed.getValue(), 1);
     EXPECT_EQ(thread_metrics_of(*c.manager)->failedOperations.getValue(), 0);
+}
+
+namespace {
+
+spi::Bucket make_spi_bucket(uint32_t seed) {
+    return spi::Bucket(makeDocumentBucket(document::BucketId(15, seed)));
+}
+
+spi::BucketInfo make_dummy_spi_bucket_info(uint32_t seed) {
+    return spi::BucketInfo(spi::BucketChecksum(seed + 0x1000), seed, seed * 100, seed, seed * 200);
+}
+
+}
+
+TEST_F(FileStorManagerTest, bucket_db_is_populated_from_provider_when_initialize_is_called) {
+    TestFileStorComponents c(*this);
+    // TODO extend to test global bucket space as well. Dummy provider currently only
+    // supports default bucket space. Replace with a better mock.
+    std::vector<std::pair<spi::Bucket, spi::BucketInfo>> buckets = {
+        {make_spi_bucket(1), make_dummy_spi_bucket_info(1)},
+        {make_spi_bucket(2), make_dummy_spi_bucket_info(2)},
+        {make_spi_bucket(3), make_dummy_spi_bucket_info(3)},
+    };
+    std::sort(buckets.begin(), buckets.end(), [](auto& lhs, auto& rhs) {
+        return (lhs.first.getBucketId().toKey() < rhs.first.getBucketId().toKey());
+    });
+
+    getDummyPersistence().set_fake_bucket_set(buckets);
+    c.manager->initialize_bucket_databases_from_provider();
+
+    std::vector<std::pair<document::BucketId, api::BucketInfo>> from_db;
+    auto populate_from_db = [&from_db](uint64_t key, auto& entry) {
+        from_db.emplace_back(document::BucketId::keyToBucketId(key), entry.info);
+    };
+
+    auto& default_db = _node->content_bucket_db(document::FixedBucketSpaces::default_space());
+    default_db.acquire_read_guard()->for_each(populate_from_db);
+    ASSERT_EQ(from_db.size(), buckets.size());
+    for (size_t i = 0; i < from_db.size(); ++i) {
+        auto& wanted = buckets[i];
+        auto& actual = from_db[i];
+        EXPECT_EQ(actual.first, wanted.first.getBucket().getBucketId());
+        EXPECT_EQ(actual.second, PersistenceUtil::convertBucketInfo(wanted.second));
+    }
+
+    from_db.clear();
+    auto& global_db = _node->content_bucket_db(document::FixedBucketSpaces::global_space());
+    global_db.acquire_read_guard()->for_each(populate_from_db);
+    EXPECT_EQ(from_db.size(), 0);
+
+    auto reported_state = _node->getStateUpdater().getReportedNodeState();
+    EXPECT_EQ(reported_state->getMinUsedBits(), 15);
+    EXPECT_EQ(reported_state->getInitProgress(), 1.0); // Should be exact.
+    EXPECT_EQ(reported_state->getState(), lib::State::UP);
 }
 
 } // storage

--- a/storage/src/tests/visiting/visitormanagertest.cpp
+++ b/storage/src/tests/visiting/visitormanagertest.cpp
@@ -96,7 +96,7 @@ VisitorManagerTest::initializeTest()
                 config.getConfigId(), _node->getComponentRegister(),
                 *_messageSessionFactory)));
     _top->push_back(std::unique_ptr<StorageLink>(new FileStorManager(
-            config.getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister())));
+            config.getConfigId(), _node->getPersistenceProvider(), _node->getComponentRegister(), *_node)));
     _manager->setTimeBetweenTicks(10);
     _top->open();
 

--- a/storage/src/vespa/storage/bucketdb/abstract_bucket_map.h
+++ b/storage/src/vespa/storage/bucketdb/abstract_bucket_map.h
@@ -171,12 +171,10 @@ public:
         do_for_each_chunked(std::move(func), clientId, yieldTime, chunkSize);
     }
 
-    void for_each_mutable(std::function<Decision(uint64_t, ValueT&)> func,
-                          const char* clientId,
-                          const key_type& first = 0,
-                          const key_type& last = UINT64_MAX)
+    void for_each_mutable_unordered(std::function<Decision(uint64_t, ValueT&)> func,
+                                    const char* clientId)
     {
-        do_for_each_mutable(std::move(func), clientId, first, last);
+        do_for_each_mutable_unordered(std::move(func), clientId);
     }
 
     void for_each(std::function<Decision(uint64_t, const ValueT&)> func,
@@ -205,10 +203,8 @@ private:
                                      const char* clientId,
                                      vespalib::duration yieldTime,
                                      uint32_t chunkSize) = 0;
-    virtual void do_for_each_mutable(std::function<Decision(uint64_t, ValueT&)> func,
-                                     const char* clientId,
-                                     const key_type& first,
-                                     const key_type& last) = 0;
+    virtual void do_for_each_mutable_unordered(std::function<Decision(uint64_t, ValueT&)> func,
+                                               const char* clientId) = 0;
     virtual void do_for_each(std::function<Decision(uint64_t, const ValueT&)> func,
                              const char* clientId,
                              const key_type& first,

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.h
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.h
@@ -117,10 +117,8 @@ private:
     bool handleDecision(key_type& key, mapped_type& val, Decision decision);
     void acquireKey(const LockId & lid, std::unique_lock<std::mutex> &guard);
 
-    void do_for_each_mutable(std::function<Decision(uint64_t, mapped_type&)> func,
-                             const char* clientId,
-                             const key_type& first,
-                             const key_type& last) override;
+    void do_for_each_mutable_unordered(std::function<Decision(uint64_t, mapped_type&)> func,
+                                       const char* clientId) override;
 
     void do_for_each(std::function<Decision(uint64_t, const mapped_type&)> func,
                      const char* clientId,

--- a/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
+++ b/storage/src/vespa/storage/bucketdb/btree_lockable_map.hpp
@@ -273,16 +273,14 @@ bool BTreeLockableMap<T>::handleDecision(key_type& key, mapped_type& val,
 }
 
 template <typename T>
-void BTreeLockableMap<T>::do_for_each_mutable(std::function<Decision(uint64_t, mapped_type&)> func,
-                                              const char* clientId,
-                                              const key_type& first,
-                                              const key_type& last)
+void BTreeLockableMap<T>::do_for_each_mutable_unordered(std::function<Decision(uint64_t, mapped_type&)> func,
+                                                        const char* clientId)
 {
-    key_type key = first;
+    key_type key = 0;
     mapped_type val;
     std::unique_lock guard(_lock);
     while (true) {
-        if (findNextKey(key, val, clientId, guard) || key > last) {
+        if (findNextKey(key, val, clientId, guard)) {
             return;
         }
         Decision d(func(key, val));

--- a/storage/src/vespa/storage/bucketdb/lockablemap.h
+++ b/storage/src/vespa/storage/bucketdb/lockablemap.h
@@ -139,10 +139,8 @@ private:
     bool handleDecision(key_type& key, mapped_type& val, Decision decision);
     void acquireKey(const LockId & lid, std::unique_lock<std::mutex> &guard);
 
-    void do_for_each_mutable(std::function<Decision(uint64_t, mapped_type&)> func,
-                             const char* clientId,
-                             const key_type& first,
-                             const key_type& last) override;
+    void do_for_each_mutable_unordered(std::function<Decision(uint64_t, mapped_type&)> func,
+                                       const char* clientId) override;
 
     void do_for_each(std::function<Decision(uint64_t, const mapped_type&)> func,
                      const char* clientId,

--- a/storage/src/vespa/storage/bucketdb/lockablemap.hpp
+++ b/storage/src/vespa/storage/bucketdb/lockablemap.hpp
@@ -221,18 +221,20 @@ LockableMap<Map>::handleDecision(key_type& key, mapped_type& val,
 }
 
 template<typename Map>
-void LockableMap<Map>::do_for_each_mutable(std::function<Decision(uint64_t, mapped_type&)> func,
-                                           const char* clientId,
-                                           const key_type& first,
-                                           const key_type& last)
+void LockableMap<Map>::do_for_each_mutable_unordered(std::function<Decision(uint64_t, mapped_type&)> func,
+                                                     const char* clientId)
 {
-    key_type key = first;
+    key_type key = 0;
     mapped_type val;
     std::unique_lock<std::mutex> guard(_lock);
     while (true) {
-        if (findNextKey(key, val, clientId, guard) || key > last) return;
+        if (findNextKey(key, val, clientId, guard)) {
+            return;
+        }
         Decision d(func(const_cast<const key_type&>(key), val));
-        if (handleDecision(key, val, d)) return;
+        if (handleDecision(key, val, d)) {
+            return;
+        }
         ++key;
     }
 }
@@ -247,10 +249,14 @@ void LockableMap<Map>::do_for_each(std::function<Decision(uint64_t, const mapped
     mapped_type val;
     std::unique_lock<std::mutex> guard(_lock);
     while (true) {
-        if (findNextKey(key, val, clientId, guard) || key > last) return;
+        if (findNextKey(key, val, clientId, guard) || key > last) {
+            return;
+        }
         Decision d(func(const_cast<const key_type&>(key), val));
         assert(d == Decision::ABORT || d == Decision::CONTINUE);
-        if (handleDecision(key, val, d)) return;
+        if (handleDecision(key, val, d)) {
+            return;
+        }
         ++key;
     }
 }

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.cpp
@@ -121,13 +121,11 @@ void StorBucketDatabase::for_each_chunked(
     _impl->for_each_chunked(std::move(func), clientId, yieldTime, chunkSize);
 }
 
-void StorBucketDatabase::for_each_mutable(
+void StorBucketDatabase::for_each_mutable_unordered(
         std::function<Decision(uint64_t, bucketdb::StorageBucketInfo&)> func,
-        const char* clientId,
-        const key_type& first,
-        const key_type& last)
+        const char* clientId)
 {
-    _impl->for_each_mutable(std::move(func), clientId, first, last);
+    _impl->for_each_mutable_unordered(std::move(func), clientId);
 }
 
 void StorBucketDatabase::for_each(

--- a/storage/src/vespa/storage/bucketdb/storbucketdb.h
+++ b/storage/src/vespa/storage/bucketdb/storbucketdb.h
@@ -60,17 +60,15 @@ public:
                           vespalib::duration yieldTime = 10us,
                           uint32_t chunkSize = bucketdb::AbstractBucketMap<bucketdb::StorageBucketInfo>::DEFAULT_CHUNK_SIZE);
 
-    void for_each_mutable(std::function<Decision(uint64_t, bucketdb::StorageBucketInfo&)> func,
-                          const char* clientId,
-                          const key_type& first = key_type(),
-                          const key_type& last = key_type() - 1);
+    void for_each_mutable_unordered(std::function<Decision(uint64_t, bucketdb::StorageBucketInfo&)> func,
+                                    const char* clientId);
 
     void for_each(std::function<Decision(uint64_t, const bucketdb::StorageBucketInfo&)> func,
                   const char* clientId,
                   const key_type& first = key_type(),
                   const key_type& last = key_type() - 1);
 
-    std::unique_ptr<bucketdb::ReadGuard<Entry>> acquire_read_guard() const;
+    [[nodiscard]] std::unique_ptr<bucketdb::ReadGuard<Entry>> acquire_read_guard() const;
 
     /**
      * Returns true iff bucket has no superbuckets or sub-buckets in the

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -255,7 +255,9 @@ FileStorMetrics::FileStorMetrics(const LoadTypeSet&)
       sum("alldisks", {{"sum"}}, "", this),
       directoryEvents("directoryevents", {}, "Number of directory events received.", this),
       partitionEvents("partitionevents", {}, "Number of partition events received.", this),
-      diskEvents("diskevents", {}, "Number of disk events received.", this)
+      diskEvents("diskevents", {}, "Number of disk events received.", this),
+      bucket_db_init_latency("bucket_db_init_latency", {}, "Time taken (in ms) to initialize bucket databases with "
+                                                           "information from the persistence provider", this)
 { }
 
 FileStorMetrics::~FileStorMetrics() = default;

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -164,6 +164,7 @@ struct FileStorMetrics : public metrics::MetricSet
     metrics::LongCountMetric directoryEvents;
     metrics::LongCountMetric partitionEvents;
     metrics::LongCountMetric diskEvents;
+    metrics::LongAverageMetric bucket_db_init_latency;
 
     explicit FileStorMetrics(const metrics::LoadTypeSet&);
     ~FileStorMetrics() override;

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -357,7 +357,7 @@ PersistenceThread::checkProviderBucketInfoMatches(const spi::Bucket& bucket, con
             bucket.toString().c_str(), result.getErrorMessage().c_str());
         return false;
     }
-    api::BucketInfo providerInfo(_env.convertBucketInfo(result.getBucketInfo()));
+    api::BucketInfo providerInfo(PersistenceUtil::convertBucketInfo(result.getBucketInfo()));
     // Don't check meta fields or active/ready fields since these are not
     // that important and ready may change under the hood in a race with
     // getModifiedBuckets(). If bucket is empty it means it has already

--- a/storage/src/vespa/storage/persistence/persistenceutil.cpp
+++ b/storage/src/vespa/storage/persistence/persistenceutil.cpp
@@ -247,7 +247,7 @@ PersistenceUtil::getBucketInfo(const document::Bucket &bucket) const
 }
 
 api::BucketInfo
-PersistenceUtil::convertBucketInfo(const spi::BucketInfo& info) const
+PersistenceUtil::convertBucketInfo(const spi::BucketInfo& info)
 {
    return api::BucketInfo(info.getChecksum(),
                           info.getDocumentCount(),

--- a/storage/src/vespa/storage/persistence/persistenceutil.h
+++ b/storage/src/vespa/storage/persistence/persistenceutil.h
@@ -135,7 +135,7 @@ struct PersistenceUtil {
 
     api::BucketInfo getBucketInfo(const document::Bucket &bucket) const;
 
-    api::BucketInfo convertBucketInfo(const spi::BucketInfo&) const;
+    static api::BucketInfo convertBucketInfo(const spi::BucketInfo&);
 
     void setBucketInfo(MessageTracker& tracker, const document::Bucket &bucket);
 

--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -52,6 +52,7 @@ public:
 
 private:
     void initializeNodeSpecific() override;
+    void perform_post_chain_creation_init_steps() override { /* no-op */ }
     void createChain(IStorageChainBuilder &builder) override;
     api::Timestamp getUniqueTimestamp() override;
 

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -58,6 +58,7 @@ public:
 private:
     void subscribeToConfigs() override;
     void initializeNodeSpecific() override;
+    void perform_post_chain_creation_init_steps() override;
     void handleLiveConfigUpdate(const InitialGuard & initGuard) override;
     VisitorMessageSession::UP createSession(Visitor&, VisitorThread&) override;
     documentapi::Priority::Value toDocumentPriority(uint8_t storagePriority) const override;

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -210,6 +210,8 @@ StorageNode::initialize()
     assert(_communicationManager != nullptr);
     _communicationManager->updateBucketSpacesConfig(*_bucketSpacesConfig);
 
+    perform_post_chain_creation_init_steps();
+
     // Start the metric manager, such that it starts generating snapshots
     // and the like. Note that at this time, all metrics should hopefully
     // have been created, such that we don't need to pay the extra cost of

--- a/storage/src/vespa/storage/storageserver/storagenode.h
+++ b/storage/src/vespa/storage/storageserver/storagenode.h
@@ -181,6 +181,7 @@ protected:
     void initialize();
     virtual void subscribeToConfigs();
     virtual void initializeNodeSpecific() = 0;
+    virtual void perform_post_chain_creation_init_steps() = 0;
     virtual void createChain(IStorageChainBuilder &builder) = 0;
     virtual void handleLiveConfigUpdate(const InitialGuard & initGuard);
     void shutdown();


### PR DESCRIPTION
@geirst please review

The legacy bucket DB initialization logic was designed for the case
where bucket information was spread across potentially millions of
files residing on spinning rust drives. It was therefore async and
running in parallel with client operations, adding much complexity
in order to deal with a myriad of concurrency edge cases.

Replace this with a very simple, synchronous init method that expects the
provider to have the required information readily and cheaply available.
This effectively removes the concept of a node's "initializing" state,
moving directly from reported state Down to Up.

Even though a node still technically starts up in Initializing state,
we never end up reporting this to the Cluster Controller as the DB init
completes before the RPC server stack is set up.

Legacy bucket DB initializer code will be removed in a separate pass.

Also simplify bucket DB interface contract for mutating iteration,
indicating that it is done in an unspecified order.

