### PR TITLE
Don't perform unsafe std::move of functor when it may be used again

### DIFF
--- a/storage/src/vespa/storage/common/content_bucket_space_repo.h
+++ b/storage/src/vespa/storage/common/content_bucket_space_repo.h
@@ -28,25 +28,9 @@ public:
     size_t getBucketMemoryUsage() const;
 
     template <typename Functor>
-    void forEachBucket(Functor &functor,
-                       const char *clientId) const {
-        for (const auto &elem : _map) {
-            elem.second->bucketDatabase().for_each(std::ref(functor), clientId);
-        }
-    }
-
-    template <typename Functor>
-    void forEachBucketChunked(Functor &functor,
-                              const char *clientId) const {
-        for (const auto &elem : _map) {
-            elem.second->bucketDatabase().for_each_chunked(std::ref(functor), clientId);
-        }
-    }
-
-    template <typename Functor>
     void for_each_bucket(Functor functor) const {
         for (const auto& elem : _map) {
-            elem.second->bucketDatabase().acquire_read_guard()->for_each(std::move(functor));
+            elem.second->bucketDatabase().acquire_read_guard()->for_each(functor);
         }
     }
 


### PR DESCRIPTION
@geirst please review

All callsites explicitly wrapped the functor in `std::ref`, which
is why this hasn't been a problem in practice (likely no-op move).

Also remove unused DB iteration methods.
