### PR TITLE
Fix quota request matcher

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -274,8 +274,8 @@ public class ApplicationHandler extends HttpHandler {
     }
 
     private static boolean isQuotaUsageRequest(HttpRequest request) {
-        return getBindingMatch(request).groupCount() > 7 &&
-                request.getUri().getPath().contains("/quota");
+        return getBindingMatch(request).groupCount() == 7 &&
+                request.getUri().getPath().endsWith("/quota");
     }
 
     private static String getHostNameFromRequest(HttpRequest req) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -178,6 +178,22 @@ public class ApplicationHandlerTest {
     }
 
     @Test
+    public void testGetQuota() throws Exception {
+        PrepareParams prepareParams = new PrepareParams.Builder()
+                .applicationId(applicationId)
+                .vespaVersion(vespaVersion)
+                .build();
+        applicationRepository.deploy(testApp, prepareParams).sessionId();
+
+        var url = toUrlPath(applicationId, Zone.defaultZone(), true) + "/quota";
+        var response = createApplicationHandler().handle(HttpRequest.createTestRequest(url, GET));
+        assertEquals(200, response.getStatus());
+        var renderedString = SessionHandlerTest.getRenderedString(response);
+
+        assertEquals("{\"rate\":0.0}", renderedString);
+    }
+
+    @Test
     public void testRestart() throws Exception {
         applicationRepository.deploy(testApp, prepareParams(applicationId));
         assertFalse(provisioner.restarted());


### PR DESCRIPTION
There was a bug in the `ApplicationHandler` request matcher for quotas that made fetching the quota usage fail.