### PR TITLE
Split the persistence thread and the message handler.

### DIFF
--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -18,8 +18,8 @@
 #include <vespa/storage/persistence/bucketownershipnotifier.h>
 #include <vespa/storage/persistence/filestorage/filestorhandlerimpl.h>
 #include <vespa/storage/persistence/filestorage/filestormanager.h>
-#include <vespa/storage/persistence/filestorage/modifiedbucketchecker.h>
 #include <vespa/storage/persistence/persistencethread.h>
+#include <vespa/storage/persistence/persistencehandler.h>
 #include <vespa/storage/storageserver/statemanager.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/vdslib/state/random.h>

--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -194,17 +194,11 @@ bool fileExistsWithin(const std::string& path, const std::string& file) {
 }
 
 std::unique_ptr<DiskThread>
-createThread(vdstestlib::DirConfig& config,
-             TestServiceLayerApp& node,
-             spi::PersistenceProvider& provider,
+createThread(PersistenceHandler & persistenceHandler,
              FileStorHandler& filestorHandler,
-             BucketOwnershipNotifier & notifier,
-             FileStorThreadMetrics& metrics)
+             framework::Component & component)
 {
-    (void) config;
-    vespa::config::content::StorFilestorConfig cfg;
-    return std::make_unique<PersistenceThread>(node.executor(), node.getComponentRegister(), cfg,
-                                               provider, filestorHandler, notifier, metrics);
+    return std::make_unique<PersistenceThread>(persistenceHandler, filestorHandler, 0, component);
 }
 
 namespace {
@@ -402,8 +396,7 @@ TEST_F(FileStorManagerTest, handler_priority) {
 
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     filestorHandler.setGetNextMessageTimeout(50ms);
-    uint32_t stripeId = filestorHandler.getNextStripeId();
-    ASSERT_EQ(0u, stripeId);
+    uint32_t stripeId = 0;
 
     std::string content("Here is some content which is in all documents");
     std::ostringstream uri;
@@ -469,7 +462,7 @@ public:
     std::atomic<bool> _threadDone;
 
     explicit MessageFetchingThread(FileStorHandler& handler)
-        : _threadId(handler.getNextStripeId()), _handler(handler), _config(0), _fetchedCount(0), _done(false),
+        : _threadId(0), _handler(handler), _config(0), _fetchedCount(0), _done(false),
           _failed(false), _threadDone(false)
     {}
 
@@ -556,7 +549,7 @@ TEST_F(FileStorManagerTest, handler_pause) {
 
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     filestorHandler.setGetNextMessageTimeout(50ms);
-    uint32_t stripeId = filestorHandler.getNextStripeId();
+    uint32_t stripeId = 0;
 
     std::string content("Here is some content which is in all documents");
     std::ostringstream uri;
@@ -660,7 +653,7 @@ TEST_F(FileStorManagerTest, handler_timeout) {
 
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     filestorHandler.setGetNextMessageTimeout(50ms);
-    uint32_t stripeId = filestorHandler.getNextStripeId();
+    uint32_t stripeId = 0;
 
     std::string content("Here is some content which is in all documents");
     std::ostringstream uri;
@@ -721,12 +714,14 @@ TEST_F(FileStorManagerTest, priority) {
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
-    std::unique_ptr<DiskThread> thread(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
-    std::unique_ptr<DiskThread> thread2(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[1]));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
+    std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
+
+    PersistenceHandler persistenceHandler2(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                           filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[1]);
+    std::unique_ptr<DiskThread> thread2(createThread(persistenceHandler2, filestorHandler, component));
 
     // Creating documents to test with. Different gids, 2 locations.
     std::vector<document::Document::SP > documents;
@@ -803,9 +798,10 @@ TEST_F(FileStorManagerTest, split1) {
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
-    std::unique_ptr<DiskThread> thread(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
+    std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
     // Creating documents to test with. Different gids, 2 locations.
     std::vector<document::Document::SP > documents;
     for (uint32_t i=0; i<20; ++i) {
@@ -814,8 +810,7 @@ TEST_F(FileStorManagerTest, split1) {
 
         uri << "id:footype:testdoctype1:n=" << (i % 3 == 0 ? 0x10001 : 0x0100001)
                                << ":mydoc-" << i;
-        Document::SP doc(createDocument(
-                content, uri.str()).release());
+        Document::SP doc(createDocument(content, uri.str()).release());
         documents.push_back(doc);
     }
     document::BucketIdFactory factory;
@@ -824,11 +819,9 @@ TEST_F(FileStorManagerTest, split1) {
     {
         // Populate bucket with the given data
         for (uint32_t i=0; i<documents.size(); ++i) {
-            document::BucketId bucket(16, factory.getBucketId(
-                                             documents[i]->getId()).getRawId());
+            document::BucketId bucket(16, factory.getBucketId(documents[i]->getId()).getRawId());
 
-            _node->getPersistenceProvider().createBucket(
-                    makeSpiBucket(bucket), context);
+            _node->getPersistenceProvider().createBucket(makeSpiBucket(bucket), context);
 
             auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), documents[i], 100 + i);
             auto address = std::make_unique<api::StorageMessageAddress>("storage", lib::NodeType::STORAGE, 3);
@@ -946,15 +939,16 @@ TEST_F(FileStorManagerTest, split_single_group) {
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
     spi::Context context(defaultLoadType, spi::Priority(0), spi::Trace::TraceLevel(0));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
     for (uint32_t j=0; j<1; ++j) {
         // Test this twice, once where all the data ends up in file with
         // splitbit set, and once where all the data ends up in file with
         // splitbit unset
         bool state = (j == 0);
 
-        std::unique_ptr<DiskThread> thread(createThread(
-                *config, *_node, _node->getPersistenceProvider(),
-                filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
+        std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
         // Creating documents to test with. Different gids, 2 locations.
         std::vector<document::Document::SP> documents;
         for (uint32_t i=0; i<20; ++i) {
@@ -1059,9 +1053,10 @@ TEST_F(FileStorManagerTest, split_empty_target_with_remapped_ops) {
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
-    std::unique_ptr<DiskThread> thread(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
+    std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
 
     document::BucketId source(16, 0x10001);
 
@@ -1126,9 +1121,10 @@ TEST_F(FileStorManagerTest, notify_on_split_source_ownership_changed) {
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
-    std::unique_ptr<DiskThread> thread(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
+    std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
 
     document::BucketId source(getFirstBucketNotOwnedByDistributor(0));
     createBucket(source, 0);
@@ -1158,8 +1154,7 @@ TEST_F(FileStorManagerTest, join) {
     // Setup a filestorthread to test
     DummyStorageLink top;
     DummyStorageLink *dummyManager;
-    top.push_back(std::unique_ptr<StorageLink>(
-                dummyManager = new DummyStorageLink));
+    top.push_back(std::unique_ptr<StorageLink>(dummyManager = new DummyStorageLink));
     top.open();
     ForwardingMessageSender messageSender(*dummyManager);
 
@@ -1169,9 +1164,10 @@ TEST_F(FileStorManagerTest, join) {
     FileStorHandlerImpl filestorHandler(messageSender, metrics, _node->getComponentRegister());
     ServiceLayerComponent component(_node->getComponentRegister(), "test");
     BucketOwnershipNotifier bucketOwnershipNotifier(component, messageSender);
-    std::unique_ptr<DiskThread> thread(createThread(
-            *config, *_node, _node->getPersistenceProvider(),
-            filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]));
+    vespa::config::content::StorFilestorConfig cfg;
+    PersistenceHandler persistenceHandler(_node->executor(), component, cfg, _node->getPersistenceProvider(),
+                                          filestorHandler, bucketOwnershipNotifier, *metrics.disks[0]->threads[0]);
+    std::unique_ptr<DiskThread> thread(createThread(persistenceHandler, filestorHandler, component));
     // Creating documents to test with. Different gids, 2 locations.
     std::vector<document::Document::SP > documents;
     for (uint32_t i=0; i<20; ++i) {
@@ -1259,8 +1255,7 @@ createIterator(DummyStorageLink& link,
 {
     spi::Bucket bucket(makeSpiBucket(bucketId));
 
-    spi::Selection selection =
-        spi::Selection(spi::DocumentSelection(docSel));
+    spi::Selection selection = spi::Selection(spi::DocumentSelection(docSel));
     selection.setFromTimestamp(spi::Timestamp(fromTime.getTime()));
     selection.setToTimestamp(spi::Timestamp(toTime.getTime()));
     auto createIterCmd = std::make_shared<CreateIteratorCommand>(

--- a/storage/src/tests/persistence/persistencequeuetest.cpp
+++ b/storage/src/tests/persistence/persistencequeuetest.cpp
@@ -42,7 +42,8 @@ PersistenceQueueTest::Fixture::Fixture(FileStorTestFixture& parent_)
       dummyManager(std::make_unique<DummyStorageLink>()),
       messageSender(*dummyManager),
       loadTypes("raw:"),
-      metrics(loadTypes.getMetricLoadTypes())
+      metrics(loadTypes.getMetricLoadTypes()),
+      stripeId(0)
 {
     top.push_back(std::move(dummyManager));
     top.open();
@@ -55,8 +56,6 @@ PersistenceQueueTest::Fixture::Fixture(FileStorTestFixture& parent_)
     // that is large enough to fail tests with high probability if this is not the case,
     // and small enough to not slow down testing too much.
     filestorHandler->setGetNextMessageTimeout(20ms);
-
-    stripeId = filestorHandler->getNextStripeId();
 }
 
 PersistenceQueueTest::Fixture::~Fixture() = default;

--- a/storage/src/tests/persistence/persistencetestutils.cpp
+++ b/storage/src/tests/persistence/persistencetestutils.cpp
@@ -9,11 +9,13 @@
 #include <vespa/persistence/dummyimpl/dummypersistence.h>
 #include <vespa/persistence/spi/test.h>
 #include <vespa/storage/persistence/filestorage/filestorhandlerimpl.h>
+#include <vespa/storage/persistence/persistencehandler.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
+#include <vespa/config-stor-filestor.h>
 #include <thread>
 
 using document::DocumentType;

--- a/storage/src/tests/persistence/persistencetestutils.h
+++ b/storage/src/tests/persistence/persistencetestutils.h
@@ -73,7 +73,7 @@ public:
     std::unique_ptr<vespalib::ISequencedTaskExecutor> _sequenceTaskExecutor;
     ReplySender _replySender;
     BucketOwnershipNotifier _bucketOwnershipNotifier;
-
+    std::unique_ptr<PersistenceHandler> _persistenceHandler;
 
     PersistenceTestUtils();
     ~PersistenceTestUtils() override;
@@ -223,11 +223,6 @@ public:
      *
      */
     void createTestBucket(const document::Bucket&);
-
-    /**
-     * Create a new persistence thread.
-     */
-    std::unique_ptr<PersistenceThread> createPersistenceThread();
 
     /**
      * In-place modify doc so that it has no more body fields.

--- a/storage/src/tests/persistence/persistencethread_splittest.cpp
+++ b/storage/src/tests/persistence/persistencethread_splittest.cpp
@@ -1,6 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storage/persistence/persistencethread.h>
+#include <vespa/storage/persistence/persistencehandler.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/persistence/spi/test.h>
 #include <tests/persistence/persistencetestutils.h>

--- a/storage/src/tests/persistence/persistencethread_splittest.cpp
+++ b/storage/src/tests/persistence/persistencethread_splittest.cpp
@@ -204,7 +204,6 @@ PersistenceThreadSplitTest::doTest(SplitCase splitCase)
         spi.put(bucket, spi::Timestamp(1000 + i), std::move(doc), context);
     }
 
-    std::unique_ptr<PersistenceThread> thread(createPersistenceThread());
     getNode().getStateUpdater().setClusterState(
             std::make_shared<lib::ClusterState>("distributor:1 storage:1"));
     document::Bucket docBucket = makeDocumentBucket(document::BucketId(currentSplitLevel, 1));
@@ -214,7 +213,7 @@ PersistenceThreadSplitTest::doTest(SplitCase splitCase)
     cmd->setMinByteSize(maxSize);
     cmd->setMinDocCount(maxCount);
     cmd->setSourceIndex(0);
-    MessageTracker::UP result = thread->splitjoinHandler().handleSplitBucket(*cmd, createTracker(cmd, docBucket));
+    MessageTracker::UP result = _persistenceHandler->splitjoinHandler().handleSplitBucket(*cmd, createTracker(cmd, docBucket));
     api::ReturnCode code(result->getResult());
     EXPECT_EQ(error, code);
     if (!code.success()) {

--- a/storage/src/tests/persistence/provider_error_wrapper_test.cpp
+++ b/storage/src/tests/persistence/provider_error_wrapper_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/persistence/spi/test.h>
 #include <tests/persistence/persistencetestutils.h>
 #include <tests/persistence/common/persistenceproviderwrapper.h>
+#include <vespa/storage/persistence/provider_error_wrapper.h>
 
 using storage::spi::test::makeSpiBucket;
 

--- a/storage/src/tests/persistence/testandsettest.cpp
+++ b/storage/src/tests/persistence/testandsettest.cpp
@@ -1,6 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 // @author Vegard Sjonfjell
-#include <vespa/storage/persistence/persistencethread.h>
+#include <vespa/storage/persistence/persistencehandler.h>
 #include <tests/persistence/persistencetestutils.h>
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/documentapi/messagebus/messages/testandsetcondition.h>

--- a/storage/src/vespa/storage/persistence/CMakeLists.txt
+++ b/storage/src/vespa/storage/persistence/CMakeLists.txt
@@ -7,6 +7,7 @@ vespa_add_library(storage_spersistence OBJECT
     fieldvisitor.cpp
     mergehandler.cpp
     messages.cpp
+    persistencehandler.cpp
     persistencethread.cpp
     persistenceutil.cpp
     processallhandler.cpp

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -215,9 +215,6 @@ public:
      */
     virtual uint32_t getNumActiveMerges() const = 0;
 
-    /// Provides the next stripe id for a certain disk.
-    virtual uint32_t getNextStripeId() = 0;
-
     /** Removes the merge status for the given bucket. */
     virtual void clearMergeStatus(const document::Bucket&) = 0;
     virtual void clearMergeStatus(const document::Bucket&, const api::ReturnCode&) = 0;

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -48,7 +48,6 @@ FileStorHandlerImpl::FileStorHandlerImpl(uint32_t numThreads, uint32_t numStripe
                                          ServiceLayerComponentRegister& compReg)
     : _component(compReg, "filestorhandlerimpl"),
       _state(FileStorHandler::AVAILABLE),
-      _nextStripeId(0),
       _metrics(nullptr),
       _stripes(),
       _messageSender(sender),

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.h
@@ -208,9 +208,6 @@ public:
     void getStatus(std::ostream& out, const framework::HttpUrlPath& path) const override;
 
     uint32_t getQueueSize() const override;
-    uint32_t getNextStripeId() override {
-        return (_nextStripeId++) % _stripes.size();
-    }
 
     std::shared_ptr<FileStorHandler::BucketLockInterface>
     lock(const document::Bucket & bucket, api::LockingRequirements lockReq) override {
@@ -236,7 +233,6 @@ public:
 private:
     ServiceLayerComponent   _component;
     std::atomic<DiskState>  _state;
-    uint32_t                _nextStripeId;
     FileStorDiskMetrics   * _metrics;
     std::vector<Stripe>     _stripes;
     MessageSender&          _messageSender;

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -41,6 +41,7 @@ class ReadBucketList;
 class BucketOwnershipNotifier;
 class AbortBucketOperationsCommand;
 struct DoneInitializeHandler;
+class PersistenceHandler;
 
 class FileStorManager : public StorageLinkQueued,
                         public framework::HtmlStatusReporter,
@@ -58,7 +59,9 @@ class FileStorManager : public StorageLinkQueued,
     const document::BucketIdFactory& _bucketIdFactory;
     config::ConfigUri                _configUri;
 
-    std::vector<DiskThread::SP>              _threads;
+    std::vector<std::unique_ptr<ServiceLayerComponent>> _persistenceComponents;
+    std::vector<std::unique_ptr<PersistenceHandler>> _persistenceHandlers;
+    std::vector<std::unique_ptr<DiskThread>>         _threads;
     std::unique_ptr<BucketOwnershipNotifier> _bucketOwnershipNotifier;
 
     std::unique_ptr<vespa::config::content::StorFilestorConfig> _config;

--- a/storage/src/vespa/storage/persistence/mergehandler.cpp
+++ b/storage/src/vespa/storage/persistence/mergehandler.cpp
@@ -111,7 +111,7 @@ MergeHandler::populateMetaData(
         const spi::Bucket& bucket,
         Timestamp maxTimestamp,
         std::vector<spi::DocEntry::UP>& entries,
-        spi::Context& context)
+        spi::Context& context) const
 {
     spi::DocumentSelection docSel("");
 
@@ -162,7 +162,7 @@ MergeHandler::buildBucketInfoList(
         Timestamp maxTimestamp,
         uint8_t myNodeIndex,
         std::vector<api::GetBucketDiffCommand::Entry>& output,
-        spi::Context& context)
+        spi::Context& context) const
 {
     assert(output.size() == 0);
     assert(myNodeIndex < 16);
@@ -336,7 +336,7 @@ MergeHandler::fetchLocalData(
         const documentapi::LoadType& /*loadType*/,
         std::vector<api::ApplyBucketDiffCommand::Entry>& diff,
         uint8_t nodeIndex,
-        spi::Context& context)
+        spi::Context& context) const
 {
     uint32_t nodeMask = 1 << nodeIndex;
         // Preload documents in memory
@@ -497,7 +497,7 @@ void
 MergeHandler::applyDiffEntry(const spi::Bucket& bucket,
                              const api::ApplyBucketDiffCommand::Entry& e,
                              spi::Context& context,
-                             const document::DocumentTypeRepo& repo)
+                             const document::DocumentTypeRepo& repo) const
 {
     spi::Timestamp timestamp(e._entry._timestamp);
     if (!(e._entry._flags & (DELETED | DELETED_IN_PLACE))) {
@@ -524,7 +524,7 @@ MergeHandler::applyDiffLocally(
         const documentapi::LoadType& /*loadType*/,
         std::vector<api::ApplyBucketDiffCommand::Entry>& diff,
         uint8_t nodeIndex,
-        spi::Context& context)
+        spi::Context& context) const
 {
     // Sort the data to apply by which file they should be added to
     LOG(spam, "Merge(%s): Applying data locally. Diff has %zu entries",
@@ -683,7 +683,7 @@ namespace {
 
 api::StorageReply::SP
 MergeHandler::processBucketMerge(const spi::Bucket& bucket, MergeStatus& status,
-                                 MessageSender& sender, spi::Context& context)
+                                 MessageSender& sender, spi::Context& context) const
 {
     // If last action failed, fail the whole merge
     if (status.reply->getResult().failed()) {
@@ -845,7 +845,7 @@ public:
 };
 
 MessageTracker::UP
-MergeHandler::handleMergeBucket(api::MergeBucketCommand& cmd, MessageTracker::UP tracker)
+MergeHandler::handleMergeBucket(api::MergeBucketCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.mergeBuckets);
 
@@ -1056,7 +1056,7 @@ namespace {
 }
 
 MessageTracker::UP
-MergeHandler::handleGetBucketDiff(api::GetBucketDiffCommand& cmd, MessageTracker::UP tracker)
+MergeHandler::handleGetBucketDiff(api::GetBucketDiffCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.getBucketDiff);
     spi::Bucket bucket(cmd.getBucket());
@@ -1167,7 +1167,7 @@ namespace {
 } // End of anonymous namespace
 
 void
-MergeHandler::handleGetBucketDiffReply(api::GetBucketDiffReply& reply, MessageSender& sender)
+MergeHandler::handleGetBucketDiffReply(api::GetBucketDiffReply& reply, MessageSender& sender) const
 {
     _env._metrics.getBucketDiffReply.inc();
     spi::Bucket bucket(reply.getBucket());
@@ -1240,7 +1240,7 @@ MergeHandler::handleGetBucketDiffReply(api::GetBucketDiffReply& reply, MessageSe
 }
 
 MessageTracker::UP
-MergeHandler::handleApplyBucketDiff(api::ApplyBucketDiffCommand& cmd, MessageTracker::UP tracker)
+MergeHandler::handleApplyBucketDiff(api::ApplyBucketDiffCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.applyBucketDiff);
 
@@ -1269,8 +1269,7 @@ MergeHandler::handleApplyBucketDiff(api::ApplyBucketDiffCommand& cmd, MessageTra
     }
     if (applyDiffHasLocallyNeededData(cmd.getDiff(), index)) {
        framework::MilliSecTimer startTime(_clock);
-       (void) applyDiffLocally(bucket, cmd.getLoadType(),
-                               cmd.getDiff(), index, tracker->context());
+       (void) applyDiffLocally(bucket, cmd.getLoadType(), cmd.getDiff(), index, tracker->context());
         _env._metrics.merge_handler_metrics.mergeDataWriteLatency.addValue(
                 startTime.getElapsedTimeAsDouble());
     } else {
@@ -1328,7 +1327,7 @@ MergeHandler::handleApplyBucketDiff(api::ApplyBucketDiffCommand& cmd, MessageTra
 }
 
 void
-MergeHandler::handleApplyBucketDiffReply(api::ApplyBucketDiffReply& reply,MessageSender& sender)
+MergeHandler::handleApplyBucketDiffReply(api::ApplyBucketDiffReply& reply,MessageSender& sender) const
 {
     _env._metrics.applyBucketDiffReply.inc();
     spi::Bucket bucket(reply.getBucket());

--- a/storage/src/vespa/storage/persistence/mergehandler.h
+++ b/storage/src/vespa/storage/persistence/mergehandler.h
@@ -45,24 +45,24 @@ public:
             Timestamp maxTimestamp,
             uint8_t myNodeIndex,
             std::vector<api::GetBucketDiffCommand::Entry>& output,
-            spi::Context& context);
+            spi::Context& context) const;
     void fetchLocalData(const spi::Bucket& bucket,
                         const documentapi::LoadType&,
                         std::vector<api::ApplyBucketDiffCommand::Entry>& diff,
                         uint8_t nodeIndex,
-                        spi::Context& context);
+                        spi::Context& context) const;
     api::BucketInfo applyDiffLocally(
                           const spi::Bucket& bucket,
                           const documentapi::LoadType&,
                           std::vector<api::ApplyBucketDiffCommand::Entry>& diff,
                           uint8_t nodeIndex,
-                          spi::Context& context);
+                          spi::Context& context) const;
 
-    MessageTrackerUP handleMergeBucket(api::MergeBucketCommand&, MessageTrackerUP);
-    MessageTrackerUP handleGetBucketDiff(api::GetBucketDiffCommand&, MessageTrackerUP);
-    void handleGetBucketDiffReply(api::GetBucketDiffReply&, MessageSender&);
-    MessageTrackerUP handleApplyBucketDiff(api::ApplyBucketDiffCommand&, MessageTrackerUP);
-    void handleApplyBucketDiffReply(api::ApplyBucketDiffReply&, MessageSender&);
+    MessageTrackerUP handleMergeBucket(api::MergeBucketCommand&, MessageTrackerUP) const;
+    MessageTrackerUP handleGetBucketDiff(api::GetBucketDiffCommand&, MessageTrackerUP) const;
+    void handleGetBucketDiffReply(api::GetBucketDiffReply&, MessageSender&) const;
+    MessageTrackerUP handleApplyBucketDiff(api::ApplyBucketDiffCommand&, MessageTrackerUP) const;
+    void handleApplyBucketDiffReply(api::ApplyBucketDiffReply&, MessageSender&) const;
 
 private:
     const framework::Clock   &_clock;
@@ -77,7 +77,7 @@ private:
     api::StorageReply::SP processBucketMerge(const spi::Bucket& bucket,
                                              MergeStatus& status,
                                              MessageSender& sender,
-                                             spi::Context& context);
+                                             spi::Context& context) const;
 
     /**
      * Invoke either put, remove or unrevertable remove on the SPI
@@ -86,7 +86,7 @@ private:
     void applyDiffEntry(const spi::Bucket&,
                         const api::ApplyBucketDiffCommand::Entry&,
                         spi::Context& context,
-                        const document::DocumentTypeRepo& repo);
+                        const document::DocumentTypeRepo& repo) const;
 
     /**
      * Fill entries-vector with metadata for bucket up to maxTimestamp,
@@ -96,7 +96,7 @@ private:
     void populateMetaData(const spi::Bucket&,
                           Timestamp maxTimestamp,
                           std::vector<spi::DocEntry::UP>& entries,
-                          spi::Context& context);
+                          spi::Context& context) const;
 
     Document::UP deserializeDiffDocument(
             const api::ApplyBucketDiffCommand::Entry& e,

--- a/storage/src/vespa/storage/persistence/persistencehandler.cpp
+++ b/storage/src/vespa/storage/persistence/persistencehandler.cpp
@@ -1,0 +1,162 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "persistencehandler.h"
+
+#include <vespa/storage/common/bucketoperationlogger.h>
+#include <vespa/document/fieldset/fieldsetrepo.h>
+#include <vespa/document/base/exceptions.h>
+#include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/isequencedtaskexecutor.h>
+#include <thread>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".persistence.thread");
+
+using vespalib::make_string_short::fmt;
+using to_str = vespalib::string;
+
+namespace storage {
+
+PersistenceHandler::PersistenceHandler(vespalib::ISequencedTaskExecutor & sequencedExecutor,
+                                     ServiceLayerComponent & component,
+                                     const vespa::config::content::StorFilestorConfig & cfg,
+                                     spi::PersistenceProvider& provider,
+                                     FileStorHandler& filestorHandler,
+                                     BucketOwnershipNotifier & bucketOwnershipNotifier,
+                                     FileStorThreadMetrics& metrics)
+    :
+      _env(component, filestorHandler, metrics, provider),
+      _spi(provider),
+      _processAllHandler(_env, provider),
+      _mergeHandler(_env, _spi, cfg.bucketMergeChunkSize,
+                    cfg.enableMergeLocalNodeChooseDocsOptimalization,
+                    cfg.commonMergeChainOptimalizationMinimumSize),
+      _asyncHandler(_env, _spi, sequencedExecutor),
+      _splitJoinHandler(_env, provider, bucketOwnershipNotifier, cfg.enableMultibitSplitOptimalization),
+      _simpleHandler(_env, provider)
+{
+}
+
+PersistenceHandler::~PersistenceHandler() = default;
+
+MessageTracker::UP
+PersistenceHandler::handleCommandSplitByType(api::StorageCommand& msg, MessageTracker::UP tracker) const
+{
+    switch (msg.getType().getId()) {
+    case api::MessageType::GET_ID:
+        return _simpleHandler.handleGet(static_cast<api::GetCommand&>(msg), std::move(tracker));
+    case api::MessageType::PUT_ID:
+        return _asyncHandler.handlePut(static_cast<api::PutCommand&>(msg), std::move(tracker));
+    case api::MessageType::REMOVE_ID:
+        return _asyncHandler.handleRemove(static_cast<api::RemoveCommand&>(msg), std::move(tracker));
+    case api::MessageType::UPDATE_ID:
+        return _asyncHandler.handleUpdate(static_cast<api::UpdateCommand&>(msg), std::move(tracker));
+    case api::MessageType::REVERT_ID:
+        return _simpleHandler.handleRevert(static_cast<api::RevertCommand&>(msg), std::move(tracker));
+    case api::MessageType::CREATEBUCKET_ID:
+        return _simpleHandler.handleCreateBucket(static_cast<api::CreateBucketCommand&>(msg), std::move(tracker));
+    case api::MessageType::DELETEBUCKET_ID:
+        return _simpleHandler.handleDeleteBucket(static_cast<api::DeleteBucketCommand&>(msg), std::move(tracker));
+    case api::MessageType::JOINBUCKETS_ID:
+        return _splitJoinHandler.handleJoinBuckets(static_cast<api::JoinBucketsCommand&>(msg), std::move(tracker));
+    case api::MessageType::SPLITBUCKET_ID:
+        return _splitJoinHandler.handleSplitBucket(static_cast<api::SplitBucketCommand&>(msg), std::move(tracker));
+       // Depends on iterators
+    case api::MessageType::STATBUCKET_ID:
+        return _processAllHandler.handleStatBucket(static_cast<api::StatBucketCommand&>(msg), std::move(tracker));
+    case api::MessageType::REMOVELOCATION_ID:
+        return _processAllHandler.handleRemoveLocation(static_cast<api::RemoveLocationCommand&>(msg), std::move(tracker));
+    case api::MessageType::MERGEBUCKET_ID:
+        return _mergeHandler.handleMergeBucket(static_cast<api::MergeBucketCommand&>(msg), std::move(tracker));
+    case api::MessageType::GETBUCKETDIFF_ID:
+        return _mergeHandler.handleGetBucketDiff(static_cast<api::GetBucketDiffCommand&>(msg), std::move(tracker));
+    case api::MessageType::APPLYBUCKETDIFF_ID:
+        return _mergeHandler.handleApplyBucketDiff(static_cast<api::ApplyBucketDiffCommand&>(msg), std::move(tracker));
+    case api::MessageType::SETBUCKETSTATE_ID:
+        return _splitJoinHandler.handleSetBucketState(static_cast<api::SetBucketStateCommand&>(msg), std::move(tracker));
+    case api::MessageType::INTERNAL_ID:
+        switch(static_cast<api::InternalCommand&>(msg).getType()) {
+        case GetIterCommand::ID:
+            return _simpleHandler.handleGetIter(static_cast<GetIterCommand&>(msg), std::move(tracker));
+        case CreateIteratorCommand::ID:
+            return _simpleHandler.handleCreateIterator(static_cast<CreateIteratorCommand&>(msg), std::move(tracker));
+        case ReadBucketList::ID:
+            return _simpleHandler.handleReadBucketList(static_cast<ReadBucketList&>(msg), std::move(tracker));
+        case ReadBucketInfo::ID:
+            return _simpleHandler.handleReadBucketInfo(static_cast<ReadBucketInfo&>(msg), std::move(tracker));
+        case InternalBucketJoinCommand::ID:
+            return _splitJoinHandler.handleInternalBucketJoin(static_cast<InternalBucketJoinCommand&>(msg), std::move(tracker));
+        case RecheckBucketInfoCommand::ID:
+            return _splitJoinHandler.handleRecheckBucketInfo(static_cast<RecheckBucketInfoCommand&>(msg), std::move(tracker));
+        default:
+            LOG(warning, "Persistence thread received unhandled internal command %s", msg.toString().c_str());
+            break;
+        }
+    default:
+        break;
+    }
+    return MessageTracker::UP();
+}
+
+void
+PersistenceHandler::handleReply(api::StorageReply& reply) const
+{
+    switch (reply.getType().getId()) {
+    case api::MessageType::GETBUCKETDIFF_REPLY_ID:
+        _mergeHandler.handleGetBucketDiffReply(static_cast<api::GetBucketDiffReply&>(reply), _env._fileStorHandler);
+        break;
+    case api::MessageType::APPLYBUCKETDIFF_REPLY_ID:
+        _mergeHandler.handleApplyBucketDiffReply(static_cast<api::ApplyBucketDiffReply&>(reply), _env._fileStorHandler);
+        break;
+    default:
+        break;
+    }
+}
+
+MessageTracker::UP
+PersistenceHandler::processMessage(api::StorageMessage& msg, MessageTracker::UP tracker) const
+{
+    MBUS_TRACE(msg.getTrace(), 5, "PersistenceHandler: Processing message in persistence layer");
+
+    _env._metrics.operations.inc();
+    if (msg.getType().isReply()) {
+        try{
+            LOG(debug, "Handling reply: %s", msg.toString().c_str());
+            LOG(spam, "Message content: %s", msg.toString(true).c_str());
+            handleReply(static_cast<api::StorageReply&>(msg));
+        } catch (std::exception& e) {
+            // It's a reply, so nothing we can do.
+            LOG(debug, "Caught exception for %s: %s", msg.toString().c_str(), e.what());
+        }
+    } else {
+        auto & initiatingCommand = static_cast<api::StorageCommand&>(msg);
+        try {
+            LOG(debug, "Handling command: %s", msg.toString().c_str());
+            LOG(spam, "Message content: %s", msg.toString(true).c_str());
+            return handleCommandSplitByType(initiatingCommand, std::move(tracker));
+        } catch (std::exception& e) {
+            LOG(debug, "Caught exception for %s: %s", msg.toString().c_str(), e.what());
+            api::StorageReply::SP reply(initiatingCommand.makeReply());
+            reply->setResult(api::ReturnCode(api::ReturnCode::INTERNAL_FAILURE, e.what()));
+            _env._fileStorHandler.sendReply(reply);
+        }
+    }
+
+    return tracker;
+}
+
+void
+PersistenceHandler::processLockedMessage(FileStorHandler::LockedMessage lock) const {
+    LOG(debug, "NodeIndex %d, ptr=%p", _env._nodeIndex, lock.second.get());
+    api::StorageMessage & msg(*lock.second);
+
+    // Important: we _copy_ the message shared_ptr instead of moving to ensure that `msg` remains
+    // valid even if the tracker is destroyed by an exception in processMessage().
+    auto tracker = std::make_unique<MessageTracker>(_env, _env._fileStorHandler, std::move(lock.first), lock.second);
+    tracker = processMessage(msg, std::move(tracker));
+    if (tracker) {
+        tracker->sendReply();
+    }
+}
+
+}

--- a/storage/src/vespa/storage/persistence/persistencehandler.h
+++ b/storage/src/vespa/storage/persistence/persistencehandler.h
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #pragma once
 
@@ -17,6 +17,11 @@ namespace storage {
 
 class BucketOwnershipNotifier;
 
+/**
+ * Handle all messages destined for the persistence layer. The detailed handling
+ * happens in other handlers, but is forked out after common setup has been done.
+ * Currently metrics are updated so each thread should have its own instance.
+ */
 class PersistenceHandler : public Types
 {
 public:
@@ -39,7 +44,6 @@ private:
     MessageTracker::UP processMessage(api::StorageMessage& msg, MessageTracker::UP tracker) const;
 
     PersistenceUtil           _env;
-    spi::PersistenceProvider& _spi;
     ProcessAllHandler         _processAllHandler;
     MergeHandler              _mergeHandler;
     AsyncHandler              _asyncHandler;

--- a/storage/src/vespa/storage/persistence/persistencehandler.h
+++ b/storage/src/vespa/storage/persistence/persistencehandler.h
@@ -1,0 +1,50 @@
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "processallhandler.h"
+#include "mergehandler.h"
+#include "asynchandler.h"
+#include "persistenceutil.h"
+#include "provider_error_wrapper.h"
+#include "splitjoinhandler.h"
+#include "simplemessagehandler.h"
+#include <vespa/storage/common/storagecomponent.h>
+#include <vespa/vespalib/util/isequencedtaskexecutor.h>
+#include <vespa/config-stor-filestor.h>
+
+namespace storage {
+
+class BucketOwnershipNotifier;
+
+class PersistenceHandler : public Types
+{
+public:
+    PersistenceHandler(vespalib::ISequencedTaskExecutor &, ServiceLayerComponent & component,
+                      const vespa::config::content::StorFilestorConfig &, spi::PersistenceProvider &,
+                      FileStorHandler &, BucketOwnershipNotifier &, FileStorThreadMetrics&);
+    ~PersistenceHandler();
+
+    void processLockedMessage(FileStorHandler::LockedMessage lock) const;
+
+    //TODO Rewrite tests to avoid this api leak
+    const AsyncHandler & asyncHandler() const { return _asyncHandler; }
+    const SplitJoinHandler & splitjoinHandler() const { return _splitJoinHandler; }
+    const SimpleMessageHandler & simpleMessageHandler() const { return _simpleHandler; }
+private:
+    // Message handling functions
+    MessageTracker::UP handleCommandSplitByType(api::StorageCommand&, MessageTracker::UP tracker) const;
+    void handleReply(api::StorageReply&) const;
+
+    MessageTracker::UP processMessage(api::StorageMessage& msg, MessageTracker::UP tracker) const;
+
+    PersistenceUtil           _env;
+    spi::PersistenceProvider& _spi;
+    ProcessAllHandler         _processAllHandler;
+    MergeHandler              _mergeHandler;
+    AsyncHandler              _asyncHandler;
+    SplitJoinHandler          _splitJoinHandler;
+    SimpleMessageHandler      _simpleHandler;
+};
+
+} // storage

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -1,55 +1,21 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "persistencethread.h"
-#include "splitbitdetector.h"
-#include "bucketownershipnotifier.h"
-#include "testandsethelper.h"
-#include <vespa/storageapi/message/bucketsplitting.h>
-#include <vespa/storage/common/bucketoperationlogger.h>
-#include <vespa/document/fieldset/fieldsetrepo.h>
-#include <vespa/document/base/exceptions.h>
-#include <vespa/vespalib/util/exceptions.h>
-#include <vespa/vespalib/util/isequencedtaskexecutor.h>
 #include <thread>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".persistence.thread");
 
-using vespalib::make_string_short::fmt;
-using to_str = vespalib::string;
-
 namespace storage {
 
-namespace {
-
-vespalib::string
-createThreadName(size_t stripeId) {
-    return fmt("PersistenceThread-%zu", stripeId);
-}
-
-}
-
-PersistenceThread::PersistenceThread(vespalib::ISequencedTaskExecutor & sequencedExecutor,
-                                     ServiceLayerComponentRegister& compReg,
-                                     const vespa::config::content::StorFilestorConfig & cfg,
-                                     spi::PersistenceProvider& provider,
-                                     FileStorHandler& filestorHandler,
-                                     BucketOwnershipNotifier & bucketOwnershipNotifier,
-                                     FileStorThreadMetrics& metrics)
-    : _stripeId(filestorHandler.getNextStripeId()),
-      _component(std::make_unique<ServiceLayerComponent>(compReg, createThreadName(_stripeId))),
-      _env(*_component, filestorHandler, metrics, provider),
-      _spi(provider),
-      _processAllHandler(_env, provider),
-      _mergeHandler(_env, _spi, cfg.bucketMergeChunkSize,
-                    cfg.enableMergeLocalNodeChooseDocsOptimalization,
-                    cfg.commonMergeChainOptimalizationMinimumSize),
-      _asyncHandler(_env, _spi, sequencedExecutor),
-      _splitJoinHandler(_env, provider, bucketOwnershipNotifier, cfg.enableMultibitSplitOptimalization),
-      _simpleHandler(_env, provider),
+PersistenceThread::PersistenceThread(PersistenceHandler & persistenceHandler, FileStorHandler & fileStorHandler,
+                                     uint32_t stripeId, framework::Component & component)
+    : _persistenceHandler(persistenceHandler),
+      _fileStorHandler(fileStorHandler),
+      _stripeId(stripeId),
       _thread()
 {
-    _thread = _component->startThread(*this, 60s, 1s);
+    _thread = component.startThread(*this, 60s, 1s);
 }
 
 PersistenceThread::~PersistenceThread()
@@ -61,138 +27,18 @@ PersistenceThread::~PersistenceThread()
     LOG(debug, "Persistence thread done with destruction");
 }
 
-MessageTracker::UP
-PersistenceThread::handleCommandSplitByType(api::StorageCommand& msg, MessageTracker::UP tracker)
-{
-    switch (msg.getType().getId()) {
-    case api::MessageType::GET_ID:
-        return _simpleHandler.handleGet(static_cast<api::GetCommand&>(msg), std::move(tracker));
-    case api::MessageType::PUT_ID:
-        return _asyncHandler.handlePut(static_cast<api::PutCommand&>(msg), std::move(tracker));
-    case api::MessageType::REMOVE_ID:
-        return _asyncHandler.handleRemove(static_cast<api::RemoveCommand&>(msg), std::move(tracker));
-    case api::MessageType::UPDATE_ID:
-        return _asyncHandler.handleUpdate(static_cast<api::UpdateCommand&>(msg), std::move(tracker));
-    case api::MessageType::REVERT_ID:
-        return _simpleHandler.handleRevert(static_cast<api::RevertCommand&>(msg), std::move(tracker));
-    case api::MessageType::CREATEBUCKET_ID:
-        return _simpleHandler.handleCreateBucket(static_cast<api::CreateBucketCommand&>(msg), std::move(tracker));
-    case api::MessageType::DELETEBUCKET_ID:
-        return _simpleHandler.handleDeleteBucket(static_cast<api::DeleteBucketCommand&>(msg), std::move(tracker));
-    case api::MessageType::JOINBUCKETS_ID:
-        return _splitJoinHandler.handleJoinBuckets(static_cast<api::JoinBucketsCommand&>(msg), std::move(tracker));
-    case api::MessageType::SPLITBUCKET_ID:
-        return _splitJoinHandler.handleSplitBucket(static_cast<api::SplitBucketCommand&>(msg), std::move(tracker));
-       // Depends on iterators
-    case api::MessageType::STATBUCKET_ID:
-        return _processAllHandler.handleStatBucket(static_cast<api::StatBucketCommand&>(msg), std::move(tracker));
-    case api::MessageType::REMOVELOCATION_ID:
-        return _processAllHandler.handleRemoveLocation(static_cast<api::RemoveLocationCommand&>(msg), std::move(tracker));
-    case api::MessageType::MERGEBUCKET_ID:
-        return _mergeHandler.handleMergeBucket(static_cast<api::MergeBucketCommand&>(msg), std::move(tracker));
-    case api::MessageType::GETBUCKETDIFF_ID:
-        return _mergeHandler.handleGetBucketDiff(static_cast<api::GetBucketDiffCommand&>(msg), std::move(tracker));
-    case api::MessageType::APPLYBUCKETDIFF_ID:
-        return _mergeHandler.handleApplyBucketDiff(static_cast<api::ApplyBucketDiffCommand&>(msg), std::move(tracker));
-    case api::MessageType::SETBUCKETSTATE_ID:
-        return _splitJoinHandler.handleSetBucketState(static_cast<api::SetBucketStateCommand&>(msg), std::move(tracker));
-    case api::MessageType::INTERNAL_ID:
-        switch(static_cast<api::InternalCommand&>(msg).getType()) {
-        case GetIterCommand::ID:
-            return _simpleHandler.handleGetIter(static_cast<GetIterCommand&>(msg), std::move(tracker));
-        case CreateIteratorCommand::ID:
-            return _simpleHandler.handleCreateIterator(static_cast<CreateIteratorCommand&>(msg), std::move(tracker));
-        case ReadBucketList::ID:
-            return _simpleHandler.handleReadBucketList(static_cast<ReadBucketList&>(msg), std::move(tracker));
-        case ReadBucketInfo::ID:
-            return _simpleHandler.handleReadBucketInfo(static_cast<ReadBucketInfo&>(msg), std::move(tracker));
-        case InternalBucketJoinCommand::ID:
-            return _splitJoinHandler.handleInternalBucketJoin(static_cast<InternalBucketJoinCommand&>(msg), std::move(tracker));
-        case RecheckBucketInfoCommand::ID:
-            return _splitJoinHandler.handleRecheckBucketInfo(static_cast<RecheckBucketInfoCommand&>(msg), std::move(tracker));
-        default:
-            LOG(warning, "Persistence thread received unhandled internal command %s", msg.toString().c_str());
-            break;
-        }
-    default:
-        break;
-    }
-    return MessageTracker::UP();
-}
-
-void
-PersistenceThread::handleReply(api::StorageReply& reply)
-{
-    switch (reply.getType().getId()) {
-    case api::MessageType::GETBUCKETDIFF_REPLY_ID:
-        _mergeHandler.handleGetBucketDiffReply(static_cast<api::GetBucketDiffReply&>(reply), _env._fileStorHandler);
-        break;
-    case api::MessageType::APPLYBUCKETDIFF_REPLY_ID:
-        _mergeHandler.handleApplyBucketDiffReply(static_cast<api::ApplyBucketDiffReply&>(reply), _env._fileStorHandler);
-        break;
-    default:
-        break;
-    }
-}
-
-MessageTracker::UP
-PersistenceThread::processMessage(api::StorageMessage& msg, MessageTracker::UP tracker)
-{
-    MBUS_TRACE(msg.getTrace(), 5, "PersistenceThread: Processing message in persistence layer");
-
-    _env._metrics.operations.inc();
-    if (msg.getType().isReply()) {
-        try{
-            LOG(debug, "Handling reply: %s", msg.toString().c_str());
-            LOG(spam, "Message content: %s", msg.toString(true).c_str());
-            handleReply(static_cast<api::StorageReply&>(msg));
-        } catch (std::exception& e) {
-            // It's a reply, so nothing we can do.
-            LOG(debug, "Caught exception for %s: %s", msg.toString().c_str(), e.what());
-        }
-    } else {
-        auto & initiatingCommand = static_cast<api::StorageCommand&>(msg);
-        try {
-            LOG(debug, "Handling command: %s", msg.toString().c_str());
-            LOG(spam, "Message content: %s", msg.toString(true).c_str());
-            return handleCommandSplitByType(initiatingCommand, std::move(tracker));
-        } catch (std::exception& e) {
-            LOG(debug, "Caught exception for %s: %s", msg.toString().c_str(), e.what());
-            api::StorageReply::SP reply(initiatingCommand.makeReply());
-            reply->setResult(api::ReturnCode(api::ReturnCode::INTERNAL_FAILURE, e.what()));
-            _env._fileStorHandler.sendReply(reply);
-        }
-    }
-
-    return tracker;
-}
-
-void
-PersistenceThread::processLockedMessage(FileStorHandler::LockedMessage lock) {
-    LOG(debug, "NodeIndex %d, ptr=%p", _env._nodeIndex, lock.second.get());
-    api::StorageMessage & msg(*lock.second);
-
-    // Important: we _copy_ the message shared_ptr instead of moving to ensure that `msg` remains
-    // valid even if the tracker is destroyed by an exception in processMessage().
-    auto tracker = std::make_unique<MessageTracker>(_env, _env._fileStorHandler, std::move(lock.first), lock.second);
-    tracker = processMessage(msg, std::move(tracker));
-    if (tracker) {
-        tracker->sendReply();
-    }
-}
-
 void
 PersistenceThread::run(framework::ThreadHandle& thread)
 {
     LOG(debug, "Started persistence thread");
 
-    while (!thread.interrupted() && !_env._fileStorHandler.closed()) {
+    while (!thread.interrupted() && !_fileStorHandler.closed()) {
         thread.registerTick();
 
-        FileStorHandler::LockedMessage lock(_env._fileStorHandler.getNextMessage(_stripeId));
+        FileStorHandler::LockedMessage lock(_fileStorHandler.getNextMessage(_stripeId));
 
         if (lock.first) {
-            processLockedMessage(std::move(lock));
+            _persistenceHandler.processLockedMessage(std::move(lock));
         }
     }
     LOG(debug, "Closing down persistence thread");
@@ -202,7 +48,7 @@ void
 PersistenceThread::flush()
 {
     //TODO Only need to check for this stripe.
-    while (_env._fileStorHandler.getQueueSize() != 0) {
+    while (_fileStorHandler.getQueueSize() != 0) {
         std::this_thread::sleep_for(1ms);
     }
 }

--- a/storage/src/vespa/storage/persistence/persistencethread.cpp
+++ b/storage/src/vespa/storage/persistence/persistencethread.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "persistencethread.h"
+#include "persistencehandler.h"
 #include <thread>
 
 #include <vespa/log/log.h>

--- a/storage/src/vespa/storage/persistence/persistencethread.h
+++ b/storage/src/vespa/storage/persistence/persistencethread.h
@@ -3,18 +3,7 @@
 #pragma once
 
 #include "diskthread.h"
-#include "processallhandler.h"
-#include "mergehandler.h"
-#include "asynchandler.h"
-#include "persistenceutil.h"
-#include "provider_error_wrapper.h"
-#include "splitjoinhandler.h"
-#include "simplemessagehandler.h"
-#include <vespa/storage/common/bucketmessages.h>
-#include <vespa/storage/common/storagecomponent.h>
-#include <vespa/storage/common/statusmessages.h>
-#include <vespa/vespalib/util/isequencedtaskexecutor.h>
-#include <vespa/config-stor-filestor.h>
+#include "persistencehandler.h"
 
 namespace storage {
 
@@ -23,39 +12,20 @@ class BucketOwnershipNotifier;
 class PersistenceThread final : public DiskThread, public Types
 {
 public:
-    PersistenceThread(vespalib::ISequencedTaskExecutor &, ServiceLayerComponentRegister &,
-                      const vespa::config::content::StorFilestorConfig &, spi::PersistenceProvider &,
-                      FileStorHandler &, BucketOwnershipNotifier &, FileStorThreadMetrics&);
+    PersistenceThread(PersistenceHandler & handler, FileStorHandler & fileStorHandler,
+                      uint32_t stripeId, framework::Component & component);
     ~PersistenceThread() override;
 
     /** Waits for current operation to be finished. */
     void flush() override;
     framework::Thread& getThread() override { return *_thread; }
 
-    //TODO Rewrite tests to avoid this api leak
-    const AsyncHandler & asyncHandler() const { return _asyncHandler; }
-    const SplitJoinHandler & splitjoinHandler() const { return _splitJoinHandler; }
-    const SimpleMessageHandler & simpleMessageHandler() const { return _simpleHandler; }
 private:
-    uint32_t                  _stripeId;
-    ServiceLayerComponent::UP _component;
-    PersistenceUtil           _env;
-    spi::PersistenceProvider& _spi;
-    ProcessAllHandler         _processAllHandler;
-    MergeHandler              _mergeHandler;
-    AsyncHandler              _asyncHandler;
-    SplitJoinHandler          _splitJoinHandler;
-    SimpleMessageHandler      _simpleHandler;
-    framework::Thread::UP     _thread;
+    PersistenceHandler    & _persistenceHandler;
+    FileStorHandler       & _fileStorHandler;
+    uint32_t                _stripeId;
+    framework::Thread::UP   _thread;
 
-    // Message handling functions
-    MessageTracker::UP handleCommandSplitByType(api::StorageCommand&, MessageTracker::UP tracker);
-    void handleReply(api::StorageReply&);
-
-    MessageTracker::UP processMessage(api::StorageMessage& msg, MessageTracker::UP tracker);
-    void processLockedMessage(FileStorHandler::LockedMessage lock);
-
-    // Thread main loop
     void run(framework::ThreadHandle&) override;
 };
 

--- a/storage/src/vespa/storage/persistence/persistencethread.h
+++ b/storage/src/vespa/storage/persistence/persistencethread.h
@@ -3,11 +3,17 @@
 #pragma once
 
 #include "diskthread.h"
-#include "persistencehandler.h"
+#include "types.h"
 
 namespace storage {
 
-class BucketOwnershipNotifier;
+namespace framework {
+    class Component;
+    class Thread;
+}
+
+class PersistenceHandler;
+class FileStorHandler;
 
 class PersistenceThread final : public DiskThread, public Types
 {
@@ -21,10 +27,10 @@ public:
     framework::Thread& getThread() override { return *_thread; }
 
 private:
-    PersistenceHandler    & _persistenceHandler;
-    FileStorHandler       & _fileStorHandler;
-    uint32_t                _stripeId;
-    framework::Thread::UP   _thread;
+    PersistenceHandler                 & _persistenceHandler;
+    FileStorHandler                    & _fileStorHandler;
+    uint32_t                             _stripeId;
+    std::unique_ptr<framework::Thread>   _thread;
 
     void run(framework::ThreadHandle&) override;
 };

--- a/storage/src/vespa/storage/persistence/persistenceutil.cpp
+++ b/storage/src/vespa/storage/persistence/persistenceutil.cpp
@@ -25,13 +25,13 @@ namespace {
     const vespalib::duration WARN_ON_SLOW_OPERATIONS = 5s;
 }
 
-MessageTracker::MessageTracker(PersistenceUtil & env,
+MessageTracker::MessageTracker(const PersistenceUtil & env,
                                MessageSender & replySender,
                                FileStorHandler::BucketLockInterface::SP bucketLock,
                                api::StorageMessage::SP msg)
     : MessageTracker(env, replySender, true, std::move(bucketLock), std::move(msg))
 {}
-MessageTracker::MessageTracker(PersistenceUtil & env,
+MessageTracker::MessageTracker(const PersistenceUtil & env,
                                MessageSender & replySender,
                                bool updateBucketInfo,
                                FileStorHandler::BucketLockInterface::SP bucketLock,
@@ -225,7 +225,7 @@ PersistenceUtil::lockAndGetDisk(const document::Bucket &bucket,
 }
 
 void
-PersistenceUtil::setBucketInfo(MessageTracker& tracker, const document::Bucket &bucket)
+PersistenceUtil::setBucketInfo(MessageTracker& tracker, const document::Bucket &bucket) const
 {
     api::BucketInfo info = getBucketInfo(bucket);
 

--- a/storage/src/vespa/storage/persistence/persistenceutil.h
+++ b/storage/src/vespa/storage/persistence/persistenceutil.h
@@ -17,7 +17,7 @@ class MessageTracker : protected Types {
 public:
     typedef std::unique_ptr<MessageTracker> UP;
 
-    MessageTracker(PersistenceUtil & env, MessageSender & replySender,
+    MessageTracker(const PersistenceUtil & env, MessageSender & replySender,
                    FileStorHandler::BucketLockInterface::SP bucketLock, api::StorageMessage::SP msg);
 
     ~MessageTracker();
@@ -74,7 +74,7 @@ public:
                      FileStorHandler::BucketLockInterface::SP bucketLock, api::StorageMessage::SP msg);
 
 private:
-    MessageTracker(PersistenceUtil & env, MessageSender & replySender, bool updateBucketInfo,
+    MessageTracker(const PersistenceUtil & env, MessageSender & replySender, bool updateBucketInfo,
                    FileStorHandler::BucketLockInterface::SP bucketLock, api::StorageMessage::SP msg);
 
     [[nodiscard]] bool count_result_as_failure() const noexcept;
@@ -84,7 +84,7 @@ private:
     FileStorHandler::BucketLockInterface::SP _bucketLock;
     api::StorageMessage::SP                  _msg;
     spi::Context                             _context;
-    PersistenceUtil                         &_env;
+    const PersistenceUtil                   &_env;
     MessageSender                           &_replySender;
     FileStorThreadMetrics::Op               *_metric; // needs a better and thread safe solution
     api::StorageReply::SP                    _reply;
@@ -132,7 +132,7 @@ struct PersistenceUtil {
 
     static api::BucketInfo convertBucketInfo(const spi::BucketInfo&);
 
-    void setBucketInfo(MessageTracker& tracker, const document::Bucket &bucket);
+    void setBucketInfo(MessageTracker& tracker, const document::Bucket &bucket) const;
 
     spi::Bucket getBucket(const document::DocumentId& id, const document::Bucket &bucket) const;
 

--- a/storage/src/vespa/storage/persistence/processallhandler.cpp
+++ b/storage/src/vespa/storage/persistence/processallhandler.cpp
@@ -74,7 +74,7 @@ public:
 }
 
 MessageTracker::UP
-ProcessAllHandler::handleRemoveLocation(api::RemoveLocationCommand& cmd, MessageTracker::UP tracker)
+ProcessAllHandler::handleRemoveLocation(api::RemoveLocationCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.removeLocation[cmd.getLoadType()]);
 
@@ -93,7 +93,7 @@ ProcessAllHandler::handleRemoveLocation(api::RemoveLocationCommand& cmd, Message
 }
 
 MessageTracker::UP
-ProcessAllHandler::handleStatBucket(api::StatBucketCommand& cmd, MessageTracker::UP tracker)
+ProcessAllHandler::handleStatBucket(api::StatBucketCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.statBucket[cmd.getLoadType()]);
     std::ostringstream ost;

--- a/storage/src/vespa/storage/persistence/processallhandler.h
+++ b/storage/src/vespa/storage/persistence/processallhandler.h
@@ -14,8 +14,8 @@ struct PersistenceUtil;
 class ProcessAllHandler : public Types {
 public:
     ProcessAllHandler(const PersistenceUtil&, spi::PersistenceProvider&);
-    MessageTrackerUP handleRemoveLocation(api::RemoveLocationCommand&, MessageTrackerUP tracker);
-    MessageTrackerUP handleStatBucket(api::StatBucketCommand&, MessageTrackerUP tracker);
+    MessageTrackerUP handleRemoveLocation(api::RemoveLocationCommand&, MessageTrackerUP tracker) const;
+    MessageTrackerUP handleStatBucket(api::StatBucketCommand&, MessageTrackerUP tracker) const;
 private:
     const PersistenceUtil& _env;
     spi::PersistenceProvider& _spi;

--- a/storage/src/vespa/storage/persistence/provider_error_wrapper.h
+++ b/storage/src/vespa/storage/persistence/provider_error_wrapper.h
@@ -13,9 +13,6 @@
 #pragma once
 
 #include <vespa/persistence/spi/persistenceprovider.h>
-#include <vector>
-#include <string>
-#include <memory>
 #include <mutex>
 
 namespace storage {

--- a/storageapi/src/vespa/storageapi/message/stat.cpp
+++ b/storageapi/src/vespa/storageapi/message/stat.cpp
@@ -3,8 +3,7 @@
 #include "stat.h"
 #include <ostream>
 
-namespace storage {
-namespace api {
+namespace storage::api {
 
 IMPLEMENT_COMMAND(StatBucketCommand, StatBucketReply)
 IMPLEMENT_REPLY(StatBucketReply)
@@ -18,7 +17,7 @@ StatBucketCommand::StatBucketCommand(const document::Bucket& bucket,
 {
 }
 
-StatBucketCommand::~StatBucketCommand() {}
+StatBucketCommand::~StatBucketCommand() = default;
 
 void
 StatBucketCommand::print(std::ostream& out, bool verbose,
@@ -102,5 +101,4 @@ operator<<(std::ostream& out, const GetBucketListReply::BucketInfo& instance)
     return out;
 }
 
-} // api
-} // storage
+}

--- a/storageapi/src/vespa/storageapi/message/stat.h
+++ b/storageapi/src/vespa/storageapi/message/stat.h
@@ -5,9 +5,7 @@
 #include <vespa/storageapi/messageapi/bucketcommand.h>
 #include <vespa/storageapi/messageapi/bucketreply.h>
 
-namespace storage {
-
-namespace api {
+namespace storage::api {
 
 /**
  * \class StatBucketCommand
@@ -89,5 +87,4 @@ public:
 
 std::ostream& operator<<(std::ostream& out, const GetBucketListReply::BucketInfo& instance);
 
-} // api
-} // storage
+}


### PR DESCRIPTION
- Let FileStorManager own and control the Component and PersistenceHandler
  separately from the Persistence thread.
- Let FileStorManager allocate and control stripe assignment.

@vekterli and @geirst PR