### PR TITLE
Allow non-exclusive allocation in AWS

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -134,18 +134,7 @@ public class NodePrioritizer {
                                         .filter(node -> node.type() != NodeType.host || nodeRepository.canAllocateTenantNodeTo(node))
                                         .filter(node -> node.reservedTo().isEmpty() || node.reservedTo().get().equals(application.tenant()))
                                         .collect(Collectors.toList());
-        if (allocateFully) {
-            Set<String> hostsOfThisTenant = candidates.stream()
-                                                      .filter(node -> node.type() == NodeType.tenant)
-                                                      .filter(node -> node.allocation()
-                                                                          .map(a -> a.owner().tenant().equals(this.application.tenant()))
-                                                                          .orElse(false))
-                                                      .flatMap(node -> node.parentHostname().stream())
-                                                      .collect(Collectors.toSet());
-            candidates = candidates.stream()
-                                   .filter(node -> hostsOfThisTenant.contains(node.hostname()))
-                                   .collect(Collectors.toList());
-        }
+
         for (Node host : candidates) {
             if ( spareHosts.contains(host) && !allocateForReplacement) continue;
             if ( ! capacity.hasCapacity(host, requestedNodes.resources().get())) continue;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -79,19 +79,6 @@ public class DynamicDockerProvisionTest {
     }
 
     @Test
-    public void does_not_allocate_to_available_empty_hosts() {
-        tester.makeReadyNodes(3, "small", NodeType.host, 10);
-        tester.activateTenantHosts();
-
-        ApplicationId application = ProvisioningTester.makeApplicationId();
-        NodeResources flavor = new NodeResources(1, 4, 10, 1);
-
-        mockHostProvisioner(hostProvisioner, tester.nodeRepository().flavors().getFlavorOrThrow("small"));
-        tester.prepare(application, clusterSpec("myContent.t2.a2"), 2, 1, flavor);
-        verify(hostProvisioner).provisionHosts(List.of(100, 101), flavor, application, Version.emptyVersion);
-    }
-
-    @Test
     public void allocates_to_hosts_already_hosting_nodes_by_this_tenant() {
         ApplicationId application = ProvisioningTester.makeApplicationId();
         NodeResources flavor = new NodeResources(1, 4, 10, 1);


### PR DESCRIPTION
Immediate consequence of this is that a node `n1` of application `a` can be allocated to a host initially provisioned for node `n2` of application `b` if `n2` is deallocated for some reason (e.g. `b` is deleted or rescaled) at the same time as `a` is deployed. This will also result in wrong AWS tags. This will be addressed in coming PRs.