### PR TITLE
Remove duplicate connector config generated by ssl provider implementations

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ConnectorFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ConnectorFactory.java
@@ -7,6 +7,7 @@ import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.http.ssl.DefaultSslProvider;
+import com.yahoo.vespa.model.container.http.ssl.SslProvider;
 
 import static com.yahoo.component.ComponentSpecification.fromString;
 
@@ -19,7 +20,7 @@ public class ConnectorFactory extends SimpleComponent implements ConnectorConfig
 
     private final String name;
     private final int listenPort;
-    private final SimpleComponent sslProviderComponent;
+    private final SslProvider sslProviderComponent;
 
     public ConnectorFactory(String name, int listenPort) {
         this(name, listenPort, new DefaultSslProvider(name));
@@ -27,7 +28,7 @@ public class ConnectorFactory extends SimpleComponent implements ConnectorConfig
 
     public ConnectorFactory(String name,
                             int listenPort,
-                            SimpleComponent sslProviderComponent) {
+                            SslProvider sslProviderComponent) {
         super(new ComponentModel(
                 new BundleInstantiationSpecification(new ComponentId(name),
                                                      fromString("com.yahoo.jdisc.http.server.jetty.ConnectorFactory"),
@@ -43,7 +44,7 @@ public class ConnectorFactory extends SimpleComponent implements ConnectorConfig
     public void getConfig(ConnectorConfig.Builder connectorBuilder) {
         connectorBuilder.listenPort(listenPort);
         connectorBuilder.name(name);
-        ((ConnectorConfig.Producer)sslProviderComponent).getConfig(connectorBuilder);
+        sslProviderComponent.amendConnectorConfig(connectorBuilder);
     }
 
     public String getName() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/ConfiguredDirectSslProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/ConfiguredDirectSslProvider.java
@@ -1,17 +1,12 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.http.ssl;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.ssl.impl.ConfiguredSslContextFactoryProvider;
-import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
 
 import java.util.Optional;
 
-import static com.yahoo.component.ComponentSpecification.fromString;
-import static com.yahoo.jdisc.http.ConnectorConfig.Ssl.*;
+import static com.yahoo.jdisc.http.ConnectorConfig.Ssl.ClientAuth;
 
 /**
  * Configure SSL with PEM encoded certificate/key strings
@@ -19,7 +14,7 @@ import static com.yahoo.jdisc.http.ConnectorConfig.Ssl.*;
  * @author mortent
  * @author andreer
  */
-public class ConfiguredDirectSslProvider extends SimpleComponent implements ConnectorConfig.Producer {
+public class ConfiguredDirectSslProvider extends SslProvider {
     public static final String COMPONENT_ID_PREFIX = "configured-ssl-provider@";
     public static final String COMPONENT_CLASS = ConfiguredSslContextFactoryProvider.class.getName();
     public static final String COMPONENT_BUNDLE = "jdisc_http_service";
@@ -31,10 +26,7 @@ public class ConfiguredDirectSslProvider extends SimpleComponent implements Conn
     private final ClientAuth.Enum clientAuthentication;
 
     public ConfiguredDirectSslProvider(String servername, String privateKey, String certificate, String caCertificatePath, String caCertificate, ClientAuth.Enum clientAuthentication) {
-        super(new ComponentModel(
-                new BundleInstantiationSpecification(new ComponentId(COMPONENT_ID_PREFIX+servername),
-                                                     fromString(COMPONENT_CLASS),
-                                                     fromString(COMPONENT_BUNDLE))));
+        super(COMPONENT_ID_PREFIX, servername, COMPONENT_CLASS, COMPONENT_BUNDLE);
         this.privateKey = privateKey;
         this.certificate = certificate;
         this.caCertificatePath = caCertificatePath;
@@ -43,7 +35,7 @@ public class ConfiguredDirectSslProvider extends SimpleComponent implements Conn
     }
 
     @Override
-    public void getConfig(ConnectorConfig.Builder builder) {
+    public void amendConnectorConfig(ConnectorConfig.Builder builder) {
         builder.ssl.enabled(true);
         builder.ssl.privateKey(privateKey);
         builder.ssl.certificate(certificate);
@@ -51,9 +43,4 @@ public class ConfiguredDirectSslProvider extends SimpleComponent implements Conn
         builder.ssl.caCertificate(Optional.ofNullable(caCertificate).orElse(""));
         builder.ssl.clientAuth(clientAuthentication);
     }
-
-    public SimpleComponent getComponent() {
-        return new SimpleComponent(new ComponentModel(getComponentId().stringValue(), COMPONENT_CLASS, COMPONENT_BUNDLE));
-    }
-
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/ConfiguredFilebasedSslProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/ConfiguredFilebasedSslProvider.java
@@ -1,17 +1,11 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.http.ssl;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.ssl.impl.ConfiguredSslContextFactoryProvider;
-import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
 
 import java.util.List;
 import java.util.Optional;
-
-import static com.yahoo.component.ComponentSpecification.fromString;
 
 /**
  * Configure SSL using file references
@@ -19,7 +13,7 @@ import static com.yahoo.component.ComponentSpecification.fromString;
  * @author mortent
  * @author bjorncs
  */
-public class ConfiguredFilebasedSslProvider extends SimpleComponent implements ConnectorConfig.Producer {
+public class ConfiguredFilebasedSslProvider extends SslProvider {
     public static final String COMPONENT_ID_PREFIX = "configured-ssl-provider@";
     public static final String COMPONENT_CLASS = ConfiguredSslContextFactoryProvider.class.getName();
     public static final String COMPONENT_BUNDLE = "jdisc_http_service";
@@ -38,10 +32,7 @@ public class ConfiguredFilebasedSslProvider extends SimpleComponent implements C
                                           String clientAuthentication,
                                           List<String> cipherSuites,
                                           List<String> protocolVersions) {
-        super(new ComponentModel(
-                new BundleInstantiationSpecification(new ComponentId(COMPONENT_ID_PREFIX+servername),
-                                                     fromString(COMPONENT_CLASS),
-                                                     fromString(COMPONENT_BUNDLE))));
+        super(COMPONENT_ID_PREFIX, servername, COMPONENT_CLASS, COMPONENT_BUNDLE);
         this.privateKeyPath = privateKeyPath;
         this.certificatePath = certificatePath;
         this.caCertificatePath = caCertificatePath;
@@ -51,7 +42,7 @@ public class ConfiguredFilebasedSslProvider extends SimpleComponent implements C
     }
 
     @Override
-    public void getConfig(ConnectorConfig.Builder builder) {
+    public void amendConnectorConfig(ConnectorConfig.Builder builder) {
         builder.ssl(
                 new ConnectorConfig.Ssl.Builder()
                         .enabled(true)
@@ -61,10 +52,6 @@ public class ConfiguredFilebasedSslProvider extends SimpleComponent implements C
                         .clientAuth(clientAuthentication)
                         .enabledCipherSuites(cipherSuites)
                         .enabledProtocols(protocolVersions));
-    }
-
-    public SimpleComponent getComponent() {
-        return new SimpleComponent(new ComponentModel(getComponentId().stringValue(), COMPONENT_CLASS, COMPONENT_BUNDLE));
     }
 
     private static ConnectorConfig.Ssl.ClientAuth.Enum mapToConfigEnum(String clientAuthValue) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/CustomSslProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/CustomSslProvider.java
@@ -1,29 +1,20 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.http.ssl;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.jdisc.http.ConnectorConfig;
-import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
-
-import static com.yahoo.component.ComponentSpecification.fromString;
 
 /**
  * @author mortent
  */
-public class CustomSslProvider extends SimpleComponent implements ConnectorConfig.Producer {
+public class CustomSslProvider extends SslProvider {
     public static final String COMPONENT_ID_PREFIX = "ssl-provider@";
 
     public CustomSslProvider(String serverName, String className, String bundle) {
-        super(new ComponentModel(
-                new BundleInstantiationSpecification(new ComponentId(COMPONENT_ID_PREFIX + serverName),
-                                                     fromString(className),
-                                                     fromString(bundle))));
+        super(COMPONENT_ID_PREFIX, serverName, className, bundle);
     }
 
     @Override
-    public void getConfig(ConnectorConfig.Builder builder) {
+    public void amendConnectorConfig(ConnectorConfig.Builder builder) {
         builder.ssl.enabled(true);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/DefaultSslProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/DefaultSslProvider.java
@@ -1,31 +1,21 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.http.ssl;
 
-import com.yahoo.component.ComponentId;
-import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.ssl.impl.DefaultSslContextFactoryProvider;
-import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
-
-import static com.yahoo.component.ComponentSpecification.fromString;
 
 /**
  * @author bjorncs
  */
-public class DefaultSslProvider extends SimpleComponent implements ConnectorConfig.Producer {
+public class DefaultSslProvider extends SslProvider {
 
     public static final String COMPONENT_ID_PREFIX = "default-ssl-provider@";
     public static final String COMPONENT_CLASS = DefaultSslContextFactoryProvider.class.getName();
     public static final String COMPONENT_BUNDLE = "jdisc_http_service";
 
     public DefaultSslProvider(String serverName) {
-        super(new ComponentModel(
-                new BundleInstantiationSpecification(new ComponentId(COMPONENT_ID_PREFIX + serverName),
-                                                     fromString(COMPONENT_CLASS),
-                                                     fromString(COMPONENT_BUNDLE))));
+        super(COMPONENT_ID_PREFIX, serverName, COMPONENT_CLASS, COMPONENT_BUNDLE);
     }
 
-    @Override
-    public void getConfig(ConnectorConfig.Builder builder) {}
+    @Override public void amendConnectorConfig(ConnectorConfig.Builder builder) {}
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.model.container.http.ssl;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.jdisc.http.ConnectorConfig;
 import com.yahoo.jdisc.http.ConnectorConfig.Ssl.ClientAuth;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
 
 import java.time.Duration;
@@ -47,8 +46,8 @@ public class HostedSslConnectorFactory extends ConnectorFactory {
         return new HostedSslConnectorFactory(new DefaultSslProvider(serverName), true, false);
     }
 
-    private HostedSslConnectorFactory(SimpleComponent sslProviderComponent, boolean enforceClientAuth, boolean enforceHandshakeClientAuth) {
-        super("tls4443", 4443, sslProviderComponent);
+    private HostedSslConnectorFactory(SslProvider sslProvider, boolean enforceClientAuth, boolean enforceHandshakeClientAuth) {
+        super("tls4443", 4443, sslProvider);
         this.enforceClientAuth = enforceClientAuth;
         this.enforceHandshakeClientAuth = enforceHandshakeClientAuth;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/SslProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/SslProvider.java
@@ -1,0 +1,25 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.http.ssl;
+
+import com.yahoo.component.ComponentId;
+import com.yahoo.container.bundle.BundleInstantiationSpecification;
+import com.yahoo.jdisc.http.ConnectorConfig;
+import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.model.container.component.SimpleComponent;
+
+import static com.yahoo.component.ComponentSpecification.fromString;
+
+/**
+ * @author bjorncs
+ */
+public abstract class SslProvider extends SimpleComponent {
+
+    public SslProvider(String componentIdPrefix, String serverName, String className, String bundleName) {
+        super(new ComponentModel(
+                new BundleInstantiationSpecification(new ComponentId(componentIdPrefix+serverName),
+                        fromString(className),
+                        fromString(bundleName))));
+    }
+
+    public abstract void amendConnectorConfig(ConnectorConfig.Builder builder);
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
@@ -7,11 +7,11 @@ import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
-import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
 import com.yahoo.vespa.model.container.http.ssl.ConfiguredFilebasedSslProvider;
 import com.yahoo.vespa.model.container.http.ssl.CustomSslProvider;
 import com.yahoo.vespa.model.container.http.ssl.DefaultSslProvider;
+import com.yahoo.vespa.model.container.http.ssl.SslProvider;
 import org.w3c.dom.Element;
 
 import java.util.Arrays;
@@ -31,11 +31,11 @@ public class JettyConnectorBuilder extends VespaDomBuilder.DomConfigProducerBuil
         String name = XmlHelper.getIdString(serverSpec);
         int port = HttpBuilder.readPort(new ModelElement(serverSpec), deployState.isHosted(), deployState.getDeployLogger());
 
-        SimpleComponent sslProviderComponent = getSslConfigComponents(name, serverSpec);
+        SslProvider sslProviderComponent = getSslConfigComponents(name, serverSpec);
         return new ConnectorFactory(name, port, sslProviderComponent);
     }
 
-    SimpleComponent getSslConfigComponents(String serverName, Element serverSpec) {
+    SslProvider getSslConfigComponents(String serverName, Element serverSpec) {
         Element sslConfigurator = XML.getChild(serverSpec, "ssl");
         Element sslProviderConfigurator = XML.getChild(serverSpec, "ssl-provider");
 


### PR DESCRIPTION
Change ssl providers to modify the parent connector's config instead of
generating its own connector config.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
