### PR TITLE
Allow for faster access of thread local variable.

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -114,7 +114,13 @@ createThreadName(size_t stripeId) {
     return fmt("PersistenceThread-%zu", stripeId);
 }
 
-thread_local PersistenceHandler * _G_threadLocalHandler = nullptr;
+#ifdef __PIC__
+#define TLS_LINKAGE __attribute__((visibility("hidden"), tls_model("initial-exec")))
+#else
+#define TLS_LINKAGE __attribute__((visibility("hidden"), tls_model("local-exec")))
+#endif
+
+thread_local PersistenceHandler * _G_threadLocalHandler TLS_LINKAGE = nullptr;
 
 }
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -109,7 +109,7 @@ public:
 private:
     void configure(std::unique_ptr<vespa::config::content::StorFilestorConfig> config) override;
     PersistenceHandler & createRegisteredHandler(const ServiceLayerComponent & component);
-    PersistenceHandler & getThreadLocalHandler();
+    VESPA_DLL_LOCAL PersistenceHandler & getThreadLocalHandler();
 
     void replyWithBucketNotFound(api::StorageMessage&, const document::Bucket&);
 

--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -7,6 +7,8 @@
 #include <cstdlib>
 #include <vespa/vespalib/util/alloc.h>
 
+#define VESPA_DLL_LOCAL  __attribute__ ((visibility("hidden")))
+
 namespace vespalib {
 
 /**
@@ -567,7 +569,7 @@ private:
     bool isAllocated() const { return _buf != _stack; }
     char * buffer() { return _buf; }
     const char * buffer() const { return _buf; }
-    void appendAlloc(const void * s, size_type sz) __attribute__((noinline));
+    VESPA_DLL_LOCAL void appendAlloc(const void * s, size_type sz) __attribute__((noinline));
     void init(const void *s) noexcept {
         if (__builtin_expect(_sz < StackSize, true)) {
             _bufferSize = StackSize;

--- a/vespamalloc/src/vespamalloc/malloc/threadlist.h
+++ b/vespamalloc/src/vespamalloc/malloc/threadlist.h
@@ -45,10 +45,10 @@ private:
     std::atomic<size_t>        _threadCountAccum;
     ThreadPool                 _threadVector[NUM_THREADS];
     AllocPoolT<MemBlockPtrT> & _allocPool;
-    static __thread ThreadPool * _myPool TLS_LINKAGE;
+    static thread_local ThreadPool * _myPool TLS_LINKAGE;
 };
 
 template <typename MemBlockPtrT, typename ThreadStatT>
-__thread ThreadPoolT<MemBlockPtrT, ThreadStatT> * ThreadListT<MemBlockPtrT, ThreadStatT>::_myPool TLS_LINKAGE = nullptr;
+thread_local ThreadPoolT<MemBlockPtrT, ThreadStatT> * ThreadListT<MemBlockPtrT, ThreadStatT>::_myPool TLS_LINKAGE = nullptr;
 
 }


### PR DESCRIPTION
This is possible since we do not load our code explicit as dynamic library.
Also replace __thread by standard c++ linkage thread_local.

@toregge or @vekterli PR
@geirst FYI