### PR TITLE
make generic reduce faster

### DIFF
--- a/eval/CMakeLists.txt
+++ b/eval/CMakeLists.txt
@@ -12,6 +12,7 @@ vespa_define_module(
     TESTS
     src/tests/ann
     src/tests/eval/aggr
+    src/tests/eval/array_array_map
     src/tests/eval/compile_cache
     src/tests/eval/compiled_function
     src/tests/eval/engine_or_factory

--- a/eval/src/tests/eval/array_array_map/CMakeLists.txt
+++ b/eval/src/tests/eval/array_array_map/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+vespa_add_executable(eval_array_array_map_test_app TEST
+    SOURCES
+    array_array_map_test.cpp
+    DEPENDS
+    vespaeval
+    GTest::GTest
+)
+vespa_add_test(NAME eval_array_array_map_test_app COMMAND eval_array_array_map_test_app)

--- a/eval/src/tests/eval/array_array_map/array_array_map_test.cpp
+++ b/eval/src/tests/eval/array_array_map/array_array_map_test.cpp
@@ -1,0 +1,70 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/eval/eval/array_array_map.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace vespalib;
+using namespace vespalib::eval;
+
+std::vector<int> ints(std::vector<int> vec) { return vec; }
+
+template <typename T>
+ConstArrayRef<T> refs(const std::vector<T> &vec) { return ConstArrayRef<T>(vec); }
+
+//-----------------------------------------------------------------------------
+
+TEST(ArrayArrayMapTest, simple_map_can_be_created_and_used) {
+    // ctor params: 'keys_per_entry', 'values_per_entry', 'expected_entries'
+    ArrayArrayMap<int,int> map(2,3,5);
+    EXPECT_EQ(map.size(), 0);
+    EXPECT_FALSE(map.lookup(refs(ints({1, 2}))).valid());
+    auto tag = map.add_entry(refs(ints({1, 2})));
+    EXPECT_EQ(map.size(), 1);
+    auto values = map.get_values(tag);
+    ASSERT_EQ(values.size(), 3);
+    values[0] = 10;
+    values[1] = 20;
+    values[2] = 30;
+    EXPECT_FALSE(map.lookup(refs(ints({2, 1}))).valid());
+    auto tag2 = map.lookup(refs(ints({1, 2})));
+    ASSERT_TRUE(tag2.valid());
+    EXPECT_EQ(map.get_values(tag2)[1], 20);
+}
+
+TEST(ArrayArrayMapTest, lookup_or_add_entry_works) {
+    ArrayArrayMap<int,int> map(2,3,5);
+    auto res1 = map.lookup_or_add_entry(refs(ints({1, 2})));
+    auto res2 = map.lookup_or_add_entry(refs(ints({1, 2})));
+    EXPECT_TRUE(res1.second);
+    EXPECT_FALSE(res2.second);
+    EXPECT_EQ(map.get_values(res1.first).begin(), map.get_values(res2.first).begin());
+    EXPECT_EQ(map.get_values(res1.first).size(), 3);
+}
+
+TEST(ArrayArrayMapTest, each_entry_works) {
+    ArrayArrayMap<int,int> map(2,3,5);
+    auto res1 = map.add_entry(refs(ints({1, 2})));
+    auto res2 = map.add_entry(refs(ints({2, 1})));
+    map.get_values(res1)[0] = 10;
+    map.get_values(res2)[0] = 20;
+    EXPECT_EQ(map.size(), 2);
+    bool first = true;
+    // Note: insert order is guaranteed here
+    map.each_entry([&](const auto &keys, const auto &values)
+                   {
+                       if (first) {
+                           EXPECT_EQ(keys[0], 1);
+                           EXPECT_EQ(keys[1], 2);
+                           EXPECT_EQ(values[0], 10);
+                           first = false;
+                       } else {
+                           EXPECT_EQ(keys[0], 2);
+                           EXPECT_EQ(keys[1], 1);
+                           EXPECT_EQ(values[0], 20);
+                       } 
+                   });
+}
+
+//-----------------------------------------------------------------------------
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/eval/src/vespa/eval/eval/CMakeLists.txt
+++ b/eval/src/vespa/eval/eval/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(eval_eval OBJECT
     SOURCES
     aggr.cpp
+    array_array_map.cpp
     basic_nodes.cpp
     call_nodes.cpp
     compile_tensor_function.cpp

--- a/eval/src/vespa/eval/eval/array_array_map.cpp
+++ b/eval/src/vespa/eval/eval/array_array_map.cpp
@@ -1,0 +1,7 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "array_array_map.h"
+
+namespace vespalib::eval {
+
+}

--- a/eval/src/vespa/eval/eval/array_array_map.h
+++ b/eval/src/vespa/eval/eval/array_array_map.h
@@ -1,0 +1,173 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/util/arrayref.h>
+#include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/stllike/hash_set.hpp>
+#include <vector>
+#include <cassert>
+#include <type_traits>
+
+namespace vespalib::eval {
+
+/**
+ * A map where both keys and values are arrays of some type (K and V
+ * respectively). All map entries have exactly the same number of keys
+ * and exactly the same number of values. Keys and values are stored
+ * in separate vectors external to the map itself in order to reduce
+ * memory fragmentation both by co-locating the keys and values
+ * themselves and also by reducing the internal hash node size. Once
+ * entries are added they cannot be removed. Keys cannot be
+ * overwritten, but values can.
+ **/
+template <typename K, typename V, typename H = vespalib::hash<K>, typename EQ = std::equal_to<> >
+class ArrayArrayMap
+{
+private:
+    size_t _keys_per_entry;
+    size_t _values_per_entry;
+    std::vector<K> _keys;
+    std::vector<V> _values;
+
+public:
+    size_t keys_per_entry() const { return _keys_per_entry; }
+    size_t values_per_entry() const { return _values_per_entry; }
+
+    struct Tag {
+        uint32_t id;
+        static constexpr uint32_t npos() { return uint32_t(-1); }
+        static Tag make_invalid() { return Tag{npos()}; }
+        bool valid() const { return (id != npos()); }
+    };
+
+    ConstArrayRef<K> get_keys(Tag tag) const { return {&_keys[tag.id * _keys_per_entry], _keys_per_entry}; }
+    ArrayRef<V> get_values(Tag tag) { return {&_values[tag.id * _values_per_entry], _values_per_entry}; }
+    ConstArrayRef<V> get_values(Tag tag) const { return {&_values[tag.id * _values_per_entry], _values_per_entry}; }
+
+    struct MyKey {
+        Tag tag;
+        uint32_t hash;
+    };
+
+    template <typename T> struct AltKey {
+        ConstArrayRef<T> key;
+        uint32_t hash;
+    };
+
+    struct Hash {
+        H hash_fun;
+        template <typename T> uint32_t operator()(ConstArrayRef<T> key) const {
+            uint32_t h = 0;
+            for (const T &k: key) {
+                if constexpr (std::is_pointer_v<T>) {
+                    h = h * 31 + hash_fun(*k);
+                } else {
+                    h = h * 31 + hash_fun(k);
+                }
+            }
+            return h;
+        }
+        uint32_t operator()(const MyKey &key) const { return key.hash; }
+        template <typename T> uint32_t operator()(const AltKey<T> &key) const { return key.hash; }
+    };
+
+    struct Equal {
+        const ArrayArrayMap &parent;
+        EQ eq_fun;
+        Equal(const ArrayArrayMap &parent_in) : parent(parent_in), eq_fun() {}
+        template <typename T>
+        bool operator()(const MyKey &a, const AltKey<T> &b) const {
+            if ((a.hash != b.hash) || (b.key.size() != parent.keys_per_entry())) {
+                return false;
+            }
+            auto a_key = parent.get_keys(a.tag);
+            for (size_t i = 0; i < a_key.size(); ++i) {
+                if constexpr (std::is_pointer_v<T>) {
+                    if (!eq_fun(a_key[i], *b.key[i])) {
+                        return false;
+                    }
+                } else {
+                    if (!eq_fun(a_key[i], b.key[i])) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+        bool operator()(const MyKey &a, const MyKey &b) const {
+            return operator()(a, AltKey<K>{parent.get_keys(b.tag), b.hash});
+        }
+    };
+
+    using MapType = vespalib::hash_set<MyKey,Hash,Equal>;
+
+private:
+    MapType _map;
+    Hash _hasher;
+
+    template <typename T>
+    Tag add_entry(ConstArrayRef<T> key, uint32_t hash) {
+        uint32_t tag_id = _map.size();
+        for (const auto &k: key) {
+            if constexpr (std::is_pointer_v<T>) {
+                _keys.push_back(*k);
+            } else {
+                _keys.push_back(k);
+            }
+        }
+        _values.resize(_values.size() + _values_per_entry, V{});
+        auto [pos, was_inserted] = _map.insert(MyKey{tag_id,hash});
+        assert(was_inserted);
+        return Tag{tag_id};
+    }
+
+public:
+    ArrayArrayMap(size_t keys_per_entry_in, size_t values_per_entry_in, size_t expected_entries)
+        : _keys_per_entry(keys_per_entry_in), _values_per_entry(values_per_entry_in), _keys(), _values(),
+          _map(expected_entries * 2, Hash(), Equal(*this)), _hasher()
+    {
+        _keys.reserve(_keys_per_entry * expected_entries);
+        _values.reserve(_values_per_entry * expected_entries);
+        static_assert(!std::is_pointer_v<K>, "keys cannot be pointers due to auto-deref of alt keys");
+    }
+    ~ArrayArrayMap();
+
+    size_t size() const { return _map.size(); }
+
+    template <typename T>
+    Tag lookup(ConstArrayRef<T> key) const {
+        auto pos = _map.find(AltKey<T>{key, _hasher(key)});
+        if (pos == _map.end()) {
+            return Tag::make_invalid();
+        }
+        return pos->tag;
+    }
+
+    template <typename T>
+    Tag add_entry(ConstArrayRef<T> key) {
+        return add_entry(key, _hasher(key));
+    }
+
+    template <typename T>
+    std::pair<Tag,bool> lookup_or_add_entry(ConstArrayRef<T> key) {
+        uint32_t hash = _hasher(key);
+        auto pos = _map.find(AltKey<T>{key, hash});
+        if (pos == _map.end()) {
+            return {add_entry(key, hash), true};
+        }
+        return {pos->tag, false};
+    }
+
+    template <typename F>
+    void each_entry(F &&f) const {
+        for (uint32_t i = 0; i < size(); ++i) {
+            f(get_keys(Tag{i}), get_values(Tag{i}));
+        }
+    }
+};
+
+template <typename K, typename V, typename H, typename EQ>
+ArrayArrayMap<K,V,H,EQ>::~ArrayArrayMap() = default;
+
+}

--- a/eval/src/vespa/eval/instruction/generic_reduce.h
+++ b/eval/src/vespa/eval/instruction/generic_reduce.h
@@ -23,8 +23,8 @@ struct DenseReducePlan {
     std::vector<size_t> reduce_stride;
     DenseReducePlan(const ValueType &type, const ValueType &res_type);
     ~DenseReducePlan();
-    template <typename F> void execute_keep(const F &f) const {
-        run_nested_loop(0, keep_loop, keep_stride, f);
+    template <typename F> void execute_keep(size_t offset, const F &f) const {
+        run_nested_loop(offset, keep_loop, keep_stride, f);
     }
     template <typename F> void execute_reduce(size_t offset, const F &f) const {
         run_nested_loop(offset, reduce_loop, reduce_stride, f);


### PR DESCRIPTION
* use faster map implementation
* use multiple aggregators (invert dense loops)
* handle reducing all cells separately
* extend nested loop benchmarking

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review

sparse cases seem ok for now with good room for improvements (inline for fast value, use pre-calculated label hashes and avoid extra copy of result for aggregators that are op2_t)

we might need a better strategy for dense subspace reduce. This can be solved with specific optimizers, but a faster generic solution would be preferable. (this will not be done as part of this PR)