### PR TITLE
be more exact in memory accounting

### DIFF
--- a/eval/src/tests/tensor/packed_mappings/packed_mappings_test.cpp
+++ b/eval/src/tests/tensor/packed_mappings/packed_mappings_test.cpp
@@ -35,8 +35,7 @@ const char *float_tensor_types[] = {
     "tensor<float>(x{},y{})",
     "tensor<float>(x{},z[3])",
     "tensor<float>(w[5],x{},y{},z[3])",
-    "tensor<float>(z[2])",
-    "tensor<float>()"
+    "tensor<float>(z[2])"
 };
 
     vespalib::string label1(""),

--- a/eval/src/vespa/eval/tensor/mixed/packed_labels.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_labels.cpp
@@ -38,7 +38,7 @@ PackedLabels::get_label(uint32_t index) const
 }
 
 MemoryUsage
-PackedLabels::estimate_extra_memory_usage() const
+PackedLabels::extra_memory_usage() const
 {
     MemoryUsage extra_usage;
     size_t offsets_size = _offsets.size() * sizeof(uint32_t);

--- a/eval/src/vespa/eval/tensor/mixed/packed_labels.h
+++ b/eval/src/vespa/eval/tensor/mixed/packed_labels.h
@@ -33,7 +33,7 @@ public:
 
     vespalib::stringref get_label(uint32_t index) const;
 
-    MemoryUsage estimate_extra_memory_usage() const;
+    MemoryUsage extra_memory_usage() const;
 private:
     const ConstArrayRef<uint32_t> _offsets;
     const ConstArrayRef<char> _label_store;

--- a/eval/src/vespa/eval/tensor/mixed/packed_mappings.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mappings.cpp
@@ -100,12 +100,12 @@ PackedMappings::fill_address_by_sortid(uint32_t internal_index, Address &address
 }
 
 MemoryUsage
-PackedMappings::estimate_extra_memory_usage() const
+PackedMappings::extra_memory_usage() const
 {
     MemoryUsage extra_usage;
     size_t store_size = _int_store.size() * sizeof(uint32_t);
     extra_usage.merge(MemoryUsage(store_size, store_size, 0, 0));
-    extra_usage.merge(_label_store.estimate_extra_memory_usage());
+    extra_usage.merge(_label_store.extra_memory_usage());
     return extra_usage;
 }
 

--- a/eval/src/vespa/eval/tensor/mixed/packed_mappings.h
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mappings.h
@@ -48,7 +48,8 @@ public:
     // mapping from label enum to stringref (and vice versa)
     const PackedLabels & label_store() const { return _label_store; }
 
-    MemoryUsage estimate_extra_memory_usage() const;
+    MemoryUsage extra_memory_usage() const;
+
 private:
     PackedMappings(uint32_t num_dims, uint32_t num_mappings,
                    ConstArrayRef<uint32_t> int_store,
@@ -101,7 +102,13 @@ private:
     int32_t sortid_of_address(const Address &address) const;
     int32_t sortid_of_enums(const InternalAddress &address) const;
 public:
-    static void operator delete(void* ptr) { ::operator delete(ptr); }
+    static void operator delete(void *ptr, size_t sz) {
+        if (sz != sizeof(PackedMappings)) {
+            abort();
+        }
+        size_t extra = ((const PackedMappings *)ptr)->extra_memory_usage().usedBytes();
+        ::operator delete(ptr, sz + extra);
+    }
 };
 
 } // namespace

--- a/eval/src/vespa/eval/tensor/mixed/packed_mappings_builder.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mappings_builder.cpp
@@ -26,7 +26,7 @@ PackedMappingsBuilder::add_mapping_for(ConstArrayRef<vespalib::stringref> addres
 size_t
 PackedMappingsBuilder::extra_memory() const
 {
-    size_t int_store_cnt = (2 + _num_dims) * _mappings.size();
+    size_t int_store_cnt = (1 + _num_dims) * _mappings.size();
     size_t int_store_size = int_store_cnt * sizeof(uint32_t);
     size_t label_cnt = _labels.size();
     size_t label_offsets_size = (1 + label_cnt) * sizeof(uint32_t);

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor.cpp
@@ -203,14 +203,26 @@ PackedMixedTensorAllMappings::next_result(ConstArrayRef<vespalib::stringref*> ad
 
 /*********************************************************************************/
 
+PackedMixedTensor::PackedMixedTensor(const ValueType &type,
+                                     TypedCells cells,
+                                     const PackedMappings &mappings)
+    : _type(type),
+      _cells(cells),
+      _mappings(mappings)
+{
+    assert(type.cell_type() == _cells.type);
+}
+
 PackedMixedTensor::~PackedMixedTensor() = default;
 
 MemoryUsage
 PackedMixedTensor::get_memory_usage() const {
     MemoryUsage usage = self_memory_usage<PackedMixedTensor>();
-    size_t cells_size = typify_invoke<1,TypifyCellType,MySize>(type().cell_type(), cells());
+    usage.merge(_mappings.extra_memory_usage());
+    size_t plus = add_for_alignment(usage.usedBytes());
+    usage.merge(MemoryUsage(plus, plus, 0, 0));
+    size_t cells_size = typify_invoke<1,TypifyCellType,MySize>(_cells.type, _cells);
     usage.merge(MemoryUsage(cells_size, cells_size, 0, 0));
-    usage.merge(_mappings.estimate_extra_memory_usage());
     return usage;
 }
 

--- a/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor_builder.cpp
+++ b/eval/src/vespa/eval/tensor/mixed/packed_mixed_tensor_builder.cpp
@@ -25,9 +25,8 @@ PackedMixedTensorBuilder<T>::build(std::unique_ptr<ValueBuilder<T>>)
 {
     size_t self_size = sizeof(PackedMixedTensor);
     size_t mappings_size = _mappings_builder.extra_memory();
-    // align:
-    mappings_size += 15ul;
-    mappings_size &= ~15ul;
+    // align cells:
+    mappings_size += PackedMixedTensor::add_for_alignment(self_size + mappings_size);
     size_t cells_size = sizeof(T) * _cells.size();
     size_t total_size = self_size + mappings_size + cells_size;
 


### PR DESCRIPTION
* override the delete with size and forward to
  global delete with actually-allocated size,
  thereby making it possible for AddressSanitizer
  to check our accounting
* unit test explicitly made a float-cell builder for
  a double-value, that didn't work out and should not
  be allowed
* put alignment adjustment in a common place
* fix off-by-one leftover over-allocation
* memory usage stats are no longer estimates, rename correspondingly

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
@havardpe FYI
