### PR TITLE
simplify generic reduce and nested loops

### DIFF
--- a/eval/src/tests/eval/aggr/aggr_test.cpp
+++ b/eval/src/tests/eval/aggr/aggr_test.cpp
@@ -20,7 +20,7 @@ TEST("require that aggregator list returns appropriate entries") {
 TEST("require that AVG aggregator works as expected") {
     Stash stash;
     Aggregator &aggr = Aggregator::create(Aggr::AVG, stash);
-    EXPECT_EQUAL(aggr.result(), 0.0);
+    EXPECT_TRUE(std::isnan(aggr.result()));
     aggr.first(10.0),  EXPECT_EQUAL(aggr.result(), 10.0);
     aggr.next(20.0),   EXPECT_EQUAL(aggr.result(), 15.0);
     aggr.next(30.0),   EXPECT_EQUAL(aggr.result(), 20.0);
@@ -42,7 +42,7 @@ TEST("require that COUNT aggregator works as expected") {
 TEST("require that PROD aggregator works as expected") {
     Stash stash;
     Aggregator &aggr = Aggregator::create(Aggr::PROD, stash);
-    EXPECT_EQUAL(aggr.result(), 0.0);
+    EXPECT_EQUAL(aggr.result(), 1.0);
     aggr.first(10.0),  EXPECT_EQUAL(aggr.result(), 10.0);
     aggr.next(20.0),   EXPECT_EQUAL(aggr.result(), 200.0);
     aggr.next(30.0),   EXPECT_EQUAL(aggr.result(), 6000.0);
@@ -64,7 +64,7 @@ TEST("require that SUM aggregator works as expected") {
 TEST("require that MAX aggregator works as expected") {
     Stash stash;
     Aggregator &aggr = Aggregator::create(Aggr::MAX, stash);
-    EXPECT_EQUAL(aggr.result(), 0.0);
+    EXPECT_EQUAL(aggr.result(), -std::numeric_limits<double>::infinity());
     aggr.first(10.0),  EXPECT_EQUAL(aggr.result(), 10.0);
     aggr.next(20.0),   EXPECT_EQUAL(aggr.result(), 20.0);
     aggr.next(30.0),   EXPECT_EQUAL(aggr.result(), 30.0);
@@ -75,7 +75,7 @@ TEST("require that MAX aggregator works as expected") {
 TEST("require that MIN aggregator works as expected") {
     Stash stash;
     Aggregator &aggr = Aggregator::create(Aggr::MIN, stash);
-    EXPECT_EQUAL(aggr.result(), 0.0);
+    EXPECT_EQUAL(aggr.result(), std::numeric_limits<double>::infinity());
     aggr.first(10.0),  EXPECT_EQUAL(aggr.result(), 10.0);
     aggr.next(20.0),   EXPECT_EQUAL(aggr.result(), 10.0);
     aggr.next(30.0),   EXPECT_EQUAL(aggr.result(), 10.0);

--- a/eval/src/tests/eval/nested_loop/nested_loop_bench.cpp
+++ b/eval/src/tests/eval/nested_loop/nested_loop_bench.cpp
@@ -161,17 +161,6 @@ void perform_generic(const LIST &loop, const LIST &stride) {
     assert(expect == 4096);
 }
 
-void perform_generic_isolate_first(const LIST &loop, const LIST &stride) {
-    size_t expect = 0;
-    auto fun = [&](size_t idx) {
-        (void) idx;
-        assert(idx == expect);
-        ++expect;
-    };
-    run_nested_loop(0, loop, stride, fun, fun);
-    assert(expect == 4096);
-}
-
 void nop() {}
 
 double estimate_cost_1_us(call_t perform_fun) {
@@ -205,22 +194,18 @@ TEST(NestedLoopBenchmark, single_loop) {
     fprintf(stderr, "manual direct single loop (1 layer): %g us\n", estimate_cost_1_us(perform_direct_1));
     fprintf(stderr, "manual call lambda single loop (1 layer): %g us\n", estimate_cost_1_us(perform_direct_lambda_1));
     fprintf(stderr, "generic single loop (1 layer): %g us\n", estimate_cost_1_us(perform_generic));
-    fprintf(stderr, "generic single loop (1 layer, isolate first): %g us\n", estimate_cost_1_us(perform_generic_isolate_first));
     fprintf(stderr, "---------------------------------------------------------------\n");
     fprintf(stderr, "manual direct single loop (2 layers): %g us\n", estimate_cost_2_us(perform_direct_2));
     fprintf(stderr, "manual call lambda single loop (2 layers): %g us\n", estimate_cost_2_us(perform_direct_lambda_2));
     fprintf(stderr, "generic single loop (2 layers): %g us\n", estimate_cost_2_us(perform_generic));
-    fprintf(stderr, "generic single loop (2 layers, isolate first): %g us\n", estimate_cost_2_us(perform_generic_isolate_first));
     fprintf(stderr, "---------------------------------------------------------------\n");
     fprintf(stderr, "manual direct single loop (3 layers): %g us\n", estimate_cost_3_us(perform_direct_3));
     fprintf(stderr, "manual call lambda single loop (3 layers): %g us\n", estimate_cost_3_us(perform_direct_lambda_3));
     fprintf(stderr, "generic single loop (3 layers): %g us\n", estimate_cost_3_us(perform_generic));
-    fprintf(stderr, "generic single loop (3 layers, isolate first): %g us\n", estimate_cost_3_us(perform_generic_isolate_first));
     fprintf(stderr, "---------------------------------------------------------------\n");
     fprintf(stderr, "manual direct single loop (4 layers): %g us\n", estimate_cost_4_us(perform_direct_4));
     fprintf(stderr, "manual call lambda single loop (4 layers): %g us\n", estimate_cost_4_us(perform_direct_lambda_4));
     fprintf(stderr, "generic single loop (4 layers): %g us\n", estimate_cost_4_us(perform_generic));
-    fprintf(stderr, "generic single loop (4 layers, isolate first): %g us\n", estimate_cost_4_us(perform_generic_isolate_first));
     fprintf(stderr, "---------------------------------------------------------------\n");
 }
 

--- a/eval/src/tests/eval/nested_loop/nested_loop_test.cpp
+++ b/eval/src/tests/eval/nested_loop/nested_loop_test.cpp
@@ -13,16 +13,6 @@ std::vector<size_t> run_single(size_t idx_in, const std::vector<size_t> &loop, c
     return result;
 }
 
-std::pair<std::vector<size_t>,std::vector<size_t>> run_single_isolated(size_t idx_in, const std::vector<size_t> &loop, const std::vector<size_t> &stride) {
-    std::vector<size_t> res1;
-    std::vector<size_t> res2;
-    auto capture1 = [&](size_t idx_out) { res1.push_back(idx_out); };
-    auto capture2 = [&](size_t idx_out) { res2.push_back(idx_out); };
-    assert(loop.size() == stride.size());
-    run_nested_loop(idx_in, loop, stride, capture1, capture2);
-    return std::make_pair(res1, res2);
-}
-
 std::vector<std::pair<size_t,size_t>> run_double(size_t idx1_in, size_t idx2_in, const std::vector<size_t> &loop,
                                                  const std::vector<size_t> &stride1, const std::vector<size_t> &stride2)
 {
@@ -32,16 +22,6 @@ std::vector<std::pair<size_t,size_t>> run_double(size_t idx1_in, size_t idx2_in,
     assert(loop.size() == stride2.size());
     run_nested_loop(idx1_in, idx2_in, loop, stride1, stride2, capture);
     return result;
-}
-
-void verify_isolated(size_t idx_in, const std::vector<size_t> &loop, const std::vector<size_t> &stride) {
-    auto full = run_single(idx_in, loop, stride);
-    auto actual = run_single_isolated(idx_in, loop, stride);
-    ASSERT_EQ(actual.first.size(), 1);
-    ASSERT_EQ(actual.second.size(), full.size() - 1);
-    EXPECT_EQ(actual.first[0], full[0]);
-    full.erase(full.begin());
-    EXPECT_EQ(actual.second, full);
 }
 
 void verify_double(size_t idx1_in, size_t idx2_in, const std::vector<size_t> &loop,
@@ -67,14 +47,6 @@ TEST(NestedLoopTest, single_nested_loop_can_be_executed) {
     EXPECT_EQ(v({100,110,100,110,101,111,101,111}), run_single(100, {2,2,2}, {1,0,10}));
     EXPECT_EQ(v({100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115}),
               run_single(100, {2,2,2,2}, {8,4,2,1}));
-}
-
-TEST(NestedLoopTest, single_nested_loop_with_first_entry_isolated_can_be_executed) {
-    verify_isolated(10, {}, {});
-    verify_isolated(10, {3}, {5});
-    verify_isolated(10, {3,3}, {2,3});
-    verify_isolated(10, {3,3,2}, {2,0,3});
-    verify_isolated(10, {2,3,2,3}, {7,2,1,3});
 }
 
 TEST(NestedLoopTest, double_nested_loop_can_be_executed) {

--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -60,7 +60,7 @@ namespace aggr {
 template <typename T> class Avg {
 private:
     T _sum = 0.0;
-    size_t _cnt = 1;
+    size_t _cnt = 0;
 public:
     void first(T value) {
         _sum = value;
@@ -84,7 +84,7 @@ public:
 
 template <typename T> class Prod {
 private:
-    T _prod = 0.0;
+    T _prod = 1.0;
 public:
     void first(T value) { _prod = value; }
     void next(T value) { _prod *= value; }
@@ -102,7 +102,7 @@ public:
 
 template <typename T> class Max {
 private:
-    T _max = 0.0;
+    T _max = -std::numeric_limits<T>::infinity();
 public:
     void first(T value) { _max = value; }
     void next(T value) { _max = std::max(_max, value); }
@@ -111,7 +111,7 @@ public:
 
 template <typename T> class Min {
 private:
-    T _min = 0.0;
+    T _min = std::numeric_limits<T>::infinity();
 public:
     void first(T value) { _min = value; }
     void next(T value) { _min = std::min(_min, value); }

--- a/eval/src/vespa/eval/eval/nested_loop.h
+++ b/eval/src/vespa/eval/eval/nested_loop.h
@@ -42,38 +42,6 @@ template <typename F> void execute_many(size_t idx, const size_t *loop, const si
 
 //-----------------------------------------------------------------------------
 
-template <typename FIRST, typename NEXT, size_t N>
-void execute_few(size_t idx, const size_t *loop, const size_t *stride, const FIRST &first, const NEXT &next) {
-    if constexpr (N == 0) {
-        first(idx);
-    } else {
-        execute_few<FIRST, NEXT, N - 1>(idx, loop + 1, stride + 1, first, next);
-        idx += *stride;
-        for (size_t i = 1; i < *loop; ++i, idx += *stride) {
-            execute_few<NEXT, N - 1>(idx, loop + 1, stride + 1, next);
-        }
-    }
-}
-
-template <typename FIRST, typename NEXT>
-void execute_many(size_t idx, const size_t *loop, const size_t *stride, size_t levels, const FIRST &first, const NEXT &next) {
-    if ((levels - 1) == 3) {
-        execute_few<FIRST, NEXT, 3>(idx, loop + 1, stride + 1, first, next);
-    } else {
-        execute_many<FIRST, NEXT>(idx, loop + 1, stride + 1, levels - 1, first, next);
-    }
-    idx += *stride;
-    for (size_t i = 1; i < *loop; ++i, idx += *stride) {
-        if ((levels - 1) == 3) {
-            execute_few<NEXT, 3>(idx, loop + 1, stride + 1, next);
-        } else {
-            execute_many<NEXT>(idx, loop + 1, stride + 1, levels - 1, next);
-        }
-    }
-}
-
-//-----------------------------------------------------------------------------
-
 template <typename F, size_t N> void execute_few(size_t idx1, size_t idx2, const size_t *loop, const size_t *stride1, const size_t *stride2, const F &f) {
     if constexpr (N == 0) {
         f(idx1, idx2);
@@ -108,20 +76,6 @@ void run_nested_loop(size_t idx, const std::vector<size_t> &loop, const std::vec
     case 2: return nested_loop::execute_few<F, 2>(idx, &loop[0], &stride[0], f);
     case 3: return nested_loop::execute_few<F, 3>(idx, &loop[0], &stride[0], f);
     default: return nested_loop::execute_many<F>(idx, &loop[0], &stride[0], levels, f);
-    }
-}
-
-// Run a nested loop and pass the first index to 'first' and all
-// subsequent indexes to 'next'
-template <typename FIRST, typename NEXT>
-void run_nested_loop(size_t idx, const std::vector<size_t> &loop, const std::vector<size_t> &stride, const FIRST &first, const NEXT &next) {
-    size_t levels = loop.size();
-    switch(levels) {
-    case 0: return first(idx);
-    case 1: return nested_loop::execute_few<FIRST, NEXT, 1>(idx, &loop[0], &stride[0], first, next);
-    case 2: return nested_loop::execute_few<FIRST, NEXT, 2>(idx, &loop[0], &stride[0], first, next);
-    case 3: return nested_loop::execute_few<FIRST, NEXT, 3>(idx, &loop[0], &stride[0], first, next);
-    default: return nested_loop::execute_many<FIRST, NEXT>(idx, &loop[0], &stride[0], levels, first, next);
     }
 }
 

--- a/eval/src/vespa/eval/instruction/generic_reduce.h
+++ b/eval/src/vespa/eval/instruction/generic_reduce.h
@@ -29,9 +29,6 @@ struct DenseReducePlan {
     template <typename F> void execute_reduce(size_t offset, const F &f) const {
         run_nested_loop(offset, reduce_loop, reduce_stride, f);
     }
-    template <typename FIRST, typename NEXT> void execute_reduce(size_t offset, const FIRST &first, const NEXT &next) const {
-        run_nested_loop(offset, reduce_loop, reduce_stride, first, next);
-    }
 };
 
 struct SparseReducePlan {


### PR DESCRIPTION
by creating aggregators with initial values that enables us to only
call 'next' without first calling 'first'.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review