### PR TITLE
Include limits to get definition of std::numeric_limits.

### DIFF
--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -4,6 +4,7 @@
 
 #include <vespa/vespalib/util/typify.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <limits>
 #include <vector>
 #include <map>
 


### PR DESCRIPTION
@baldersheim : please review
