### PR TITLE
Get quota usage from node repository

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/api/ActivateResult.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/api/ActivateResult.java
@@ -13,13 +13,11 @@ public class ActivateResult {
     private final RevisionId revisionId;
     private final PrepareResponse prepareResponse;
     private final long applicationZipSizeBytes;
-    private final double quotaUsageRate;
 
-    public ActivateResult(RevisionId revisionId, PrepareResponse prepareResponse, long applicationZipSizeBytes, double quotaUsageRate) {
+    public ActivateResult(RevisionId revisionId, PrepareResponse prepareResponse, long applicationZipSizeBytes) {
         this.revisionId = revisionId;
         this.prepareResponse = prepareResponse;
         this.applicationZipSizeBytes = applicationZipSizeBytes;
-        this.quotaUsageRate = quotaUsageRate;
     }
 
     public long applicationZipSizeBytes() {
@@ -33,9 +31,4 @@ public class ActivateResult {
     public PrepareResponse prepareResponse() {
         return prepareResponse;
     }
-
-    public double quotaUsageRate() {
-        return quotaUsageRate;
-    }
-
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/QuotaUsageTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/QuotaUsageTest.java
@@ -1,3 +1,4 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
 import com.yahoo.config.provision.zone.ZoneId;
@@ -5,6 +6,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * @author ogronnesby
+ */
 public class QuotaUsageTest {
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/QuotaUsageTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/QuotaUsageTest.java
@@ -1,0 +1,17 @@
+package com.yahoo.vespa.hosted.controller.deployment;
+
+import com.yahoo.config.provision.zone.ZoneId;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QuotaUsageTest {
+
+    @Test
+    public void testQuotaUsageIsPersisted() {
+        var tester = new DeploymentTester();
+        var context = tester.newDeploymentContext().submit().deploy();
+        assertEquals(1.062, context.deployment(ZoneId.from("prod.us-west-1")).quota().rate(), 0.01);
+    }
+
+}


### PR DESCRIPTION
The previous method for retrieving quota usage did not work consistently. Instead of finding a novel way of doing it on the controller side, I'm just copying the same way our cluster retrieval code does it by asking the node repository. To avoid some issues with system applications I had to move quota usage retrieval a bit higher up in the call path - which is probably a good thing.

@mpolden - some advise on how to test this would be appreciated.