### PR TITLE
improve generic dense reduce with more robust cell ordering

### DIFF
--- a/eval/src/tests/instruction/generic_reduce/generic_reduce_test.cpp
+++ b/eval/src/tests/instruction/generic_reduce/generic_reduce_test.cpp
@@ -74,16 +74,14 @@ TensorSpec perform_generic_reduce(const TensorSpec &a, const std::vector<vespali
 TEST(GenericReduceTest, dense_reduce_plan_can_be_created) {
     auto type = ValueType::from_spec("tensor(a[2],aa{},b[2],bb[1],c[2],cc{},d[2],dd[1],e[2],ee{},f[2])");
     auto plan = DenseReducePlan(type, type.reduce({"a", "d", "e"}));
-    std::vector<size_t> expect_keep_loop = {4,2};
-    std::vector<size_t> expect_keep_stride = {8,1};
-    std::vector<size_t> expect_reduce_loop = {2,4};
-    std::vector<size_t> expect_reduce_stride = {32,2};
+    std::vector<size_t> expect_loop_cnt = {2,4,4,2};
+    std::vector<size_t> expect_in_stride = {32,2,8,1};
+    std::vector<size_t> expect_out_stride = {0,0,2,1};
     EXPECT_EQ(plan.in_size, 64);
     EXPECT_EQ(plan.out_size, 8);
-    EXPECT_EQ(plan.keep_loop, expect_keep_loop);
-    EXPECT_EQ(plan.keep_stride, expect_keep_stride);
-    EXPECT_EQ(plan.reduce_loop, expect_reduce_loop);
-    EXPECT_EQ(plan.reduce_stride, expect_reduce_stride);
+    EXPECT_EQ(plan.loop_cnt, expect_loop_cnt);
+    EXPECT_EQ(plan.in_stride, expect_in_stride);
+    EXPECT_EQ(plan.out_stride, expect_out_stride);
 }
 
 TEST(GenericReduceTest, sparse_reduce_plan_can_be_created) {

--- a/eval/src/vespa/eval/eval/aggr.cpp
+++ b/eval/src/vespa/eval/eval/aggr.cpp
@@ -14,8 +14,8 @@ namespace {
 template <typename T>
 struct Wrapper : Aggregator {
     T aggr;
-    virtual void first(double value) final override { aggr.first(value); }
-    virtual void next(double value) final override { aggr.next(value); }
+    virtual void first(double value) final override { aggr = T{value}; }
+    virtual void next(double value) final override { aggr.sample(value); }
     virtual double result() const final override { return aggr.result(); }
 };
 

--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -60,63 +60,75 @@ namespace aggr {
 
 template <typename T> class Avg {
 private:
-    T _sum = 0.0;
-    size_t _cnt = 0;
+    T _sum;
+    size_t _cnt;
 public:
-    void first(T value) {
-        _sum = value;
-        _cnt = 1;
-    }
-    void next(T value) {
+    constexpr Avg() : _sum{0}, _cnt{0} {}
+    constexpr Avg(T value) : _sum{value}, _cnt{1} {}
+    constexpr void sample(T value) {
         _sum += value;
         ++_cnt;
     }
-    T result() const { return (_sum / _cnt); }
+    constexpr void merge(const Avg &rhs) {
+        _sum += rhs._sum;
+        _cnt += rhs._cnt;
+    };
+    constexpr T result() const { return (_sum / _cnt); }
 };
 
 template <typename T> class Count {
 private:
-    size_t _cnt = 0;
+    size_t _cnt;
 public:
-    void first(T) { _cnt = 1; }
-    void next(T) { ++_cnt; }
-    T result() const { return _cnt; }
+    constexpr Count() : _cnt{0} {}
+    constexpr Count(T) : _cnt{1} {}
+    constexpr void sample(T) { ++_cnt; }
+    constexpr void merge(const Count &rhs) { _cnt += rhs._cnt; }
+    constexpr T result() const { return _cnt; }
 };
 
 template <typename T> class Prod {
 private:
-    T _prod = 1.0;
+    T _prod;
 public:
-    void first(T value) { _prod = value; }
-    void next(T value) { _prod *= value; }
-    T result() const { return _prod; }
+    constexpr Prod() : _prod{1} {}
+    constexpr Prod(T value) : _prod{value} {}
+    constexpr void sample(T value) { _prod *= value; }
+    constexpr void merge(const Prod &rhs) { _prod *= rhs._prod; }
+    constexpr T result() const { return _prod; }
 };
 
 template <typename T> class Sum {
 private:
-    T _sum = 0.0;
+    T _sum;
 public:
-    void first(T value) { _sum = value; }
-    void next(T value) { _sum += value; }
-    T result() const { return _sum; }
+    constexpr Sum() : _sum{0} {}
+    constexpr Sum(T value) : _sum{value} {}
+    constexpr void sample(T value) { _sum += value; }
+    constexpr void merge(const Sum &rhs) { _sum += rhs._sum; }
+    constexpr T result() const { return _sum; }
 };
 
 template <typename T> class Max {
 private:
-    T _max = -std::numeric_limits<T>::infinity();
+    T _max;
 public:
-    void first(T value) { _max = value; }
-    void next(T value) { _max = std::max(_max, value); }
-    T result() const { return _max; }
+    constexpr Max() : _max{-std::numeric_limits<T>::infinity()} {}
+    constexpr Max(T value) : _max{value} {}
+    constexpr void sample(T value) { _max = std::max(_max, value); }
+    constexpr void merge(const Max &rhs) { _max = std::max(_max, rhs._max); }
+    constexpr T result() const { return _max; }
 };
 
 template <typename T> class Min {
 private:
-    T _min = std::numeric_limits<T>::infinity();
+    T _min;
 public:
-    void first(T value) { _min = value; }
-    void next(T value) { _min = std::min(_min, value); }
-    T result() const { return _min; }
+    constexpr Min() : _min{std::numeric_limits<T>::infinity()} {}
+    constexpr Min(T value) : _min{value} {}
+    constexpr void sample(T value) { _min = std::min(_min, value); }
+    constexpr void merge(const Min &rhs) { _min = std::min(_min, rhs._min); }
+    constexpr T result() const { return _min; }
 };
 
 } // namespave vespalib::eval::aggr

--- a/eval/src/vespa/eval/instruction/generic_reduce.h
+++ b/eval/src/vespa/eval/instruction/generic_reduce.h
@@ -17,17 +17,13 @@ namespace vespalib::eval::instruction {
 struct DenseReducePlan {
     size_t in_size;
     size_t out_size;
-    std::vector<size_t> keep_loop;
-    std::vector<size_t> keep_stride;
-    std::vector<size_t> reduce_loop;
-    std::vector<size_t> reduce_stride;
+    std::vector<size_t> loop_cnt;
+    std::vector<size_t> in_stride;
+    std::vector<size_t> out_stride;
     DenseReducePlan(const ValueType &type, const ValueType &res_type);
     ~DenseReducePlan();
-    template <typename F> void execute_keep(size_t offset, const F &f) const {
-        run_nested_loop(offset, keep_loop, keep_stride, f);
-    }
-    template <typename F> void execute_reduce(size_t offset, const F &f) const {
-        run_nested_loop(offset, reduce_loop, reduce_stride, f);
+    template <typename F> void execute(size_t in_idx, const F &f) const {
+        run_nested_loop(in_idx, 0, loop_cnt, in_stride, out_stride, f);
     }
 };
 

--- a/eval/src/vespa/eval/tensor/dense/dense_single_reduce_function.cpp
+++ b/eval/src/vespa/eval/tensor/dense/dense_single_reduce_function.cpp
@@ -43,11 +43,11 @@ struct Params {
 };
 
 template <typename CT, typename AGGR>
-CT reduce_cells(const CT *src, size_t dim_size, size_t stride, AGGR &aggr) {
-    aggr.first(*src);
+CT reduce_cells(const CT *src, size_t dim_size, size_t stride) {
+    AGGR aggr(*src);
     for (size_t i = 1; i < dim_size; ++i) {
         src += stride;
-        aggr.next(*src);
+        aggr.sample(*src);
     }
     return aggr.result();
 }
@@ -57,12 +57,11 @@ void my_single_reduce_op(InterpretedFunction::State &state, uint64_t param) {
     const auto &params = unwrap_param<Params>(param);
     const CT *src = state.peek(0).cells().typify<CT>().cbegin();
     auto dst_cells = state.stash.create_array<CT>(params.outer_size * params.inner_size);
-    AGGR aggr;
     CT *dst = dst_cells.begin();
     const size_t block_size = (params.dim_size * params.inner_size);
     for (size_t outer = 0; outer < params.outer_size; ++outer) {
         for (size_t inner = 0; inner < params.inner_size; ++inner) {
-            *dst++ = reduce_cells<CT, AGGR>(src + inner, params.dim_size, params.inner_size, aggr);
+            *dst++ = reduce_cells<CT, AGGR>(src + inner, params.dim_size, params.inner_size);
         }
         src += block_size;
     }


### PR DESCRIPTION
- unroll reduce all loop
- extend benchmark with optimized instructions (to catch slow ones)
- drop SimpleTensorEngine from benchmark (always very slow)
- tweak API on templated aggregators

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review