### PR TITLE
Do not add applications nodes outside cluster in NodePrioritizer

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -202,7 +202,7 @@ public class NodePrioritizer {
      */
     private boolean canStillAllocateToParentOf(Node node) {
         if (node.parentHostname().isEmpty()) return true;
-        Optional<Node> parent = node.parentHostname().flatMap(nodeRepository::getNode);
+        Optional<Node> parent = allNodes.parentOf(node);
         if (parent.isEmpty()) return false;
         return nodeRepository.canAllocateTenantNodeTo(parent.get());
     }


### PR DESCRIPTION
No point in adding application nodes outside the cluster we are allocating for, these are immediately filtered out in `NodeAllocation` and this also simplifies grouping switch hostname