### PR TITLE
Don't autoscale if a deployment is ongoing

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcher.java
@@ -56,7 +56,7 @@ public class MetricsV2MetricsFetcher extends AbstractComponent implements Metric
         NodeList applicationNodes = nodeRepository.list(application).state(Node.State.active);
 
         // Do not try to draw conclusions from utilization while unstable
-        if (Autoscaler.unstable(applicationNodes.asList())) return Collections.emptyList();
+        if (Autoscaler.unstable(applicationNodes.asList(), nodeRepository)) return Collections.emptyList();
 
         Optional<Node> metricsV2Container = applicationNodes.container()
                                                             .matching(node -> expectedUp(node))

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
  */
 public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
 
-    private final MetricsDb metricsDb;
     private final Autoscaler autoscaler;
     private final Deployer deployer;
     private final Metric metric;
@@ -40,7 +39,6 @@ public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
                                  Duration interval) {
         super(nodeRepository, interval, metric);
         this.autoscaler = new Autoscaler(metricsDb, nodeRepository);
-        this.metricsDb = metricsDb;
         this.metric = metric;
         this.deployer = deployer;
     }


### PR DESCRIPTION
This avoids trying to do another rescaling (which will fail on activate)
if a deployment is already ongoing, for example if another config server
has already decided to autoscale.
