### PR TITLE
Revert "Junit 4.13 and juptier 5.7.0"

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -31,8 +31,8 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
         <jetty.version>9.4.32.v20200930</jetty.version>
-        <junit5.version>5.7.0</junit5.version>
-        <junit5.platform.version>1.7.0</junit5.platform.version>
+        <junit5.version>5.6.2</junit5.version>
+        <junit5.platform.version>1.6.2</junit5.platform.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>

--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -36,7 +36,7 @@
         <target_jdk_version>11</target_jdk_version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <junit.version>5.7.0</junit.version> <!-- NOTE: this must be in sync with junit version specified in 'tenant-cd-api' -->
+        <junit.version>5.6.2</junit.version> <!-- NOTE: this must be in sync with junit version specified in 'tenant-cd-api' -->
         <test.categories>!integration</test.categories>
 
         <!-- To allow specialized base pom to include additional "test provided" dependencies -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -762,7 +762,7 @@
         <curator.version>2.13.0</curator.version>
         <jna.version>4.5.2</jna.version>
         <commons.math3.version>3.6.1</commons.math3.version>
-        <junit.version>5.7.0</junit.version>
+        <junit.version>5.6.2</junit.version>
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
         <!-- TODO: in order to upgrade above 4.1.0, we probably need to convert fat-model-deps to a jar artifact. -->
         <maven-bundle-plugin.version>4.1.0</maven-bundle-plugin.version>

--- a/tenant-base/pom.xml
+++ b/tenant-base/pom.xml
@@ -37,7 +37,7 @@
         <target_jdk_version>11</target_jdk_version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
-        <junit.version>5.7.0</junit.version> <!-- Keep in sync with hosted-tenant-base and tenant-cd until all direct use is removed -->
+        <junit.version>5.6.2</junit.version> <!-- Keep in sync with hosted-tenant-base and tenant-cd until all direct use is removed -->
         <endpoint>https://api.vespa-external.aws.oath.cloud:4443</endpoint>
         <test.categories>!integration</test.categories>
     </properties>

--- a/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/PomXmlGenerator.java
+++ b/vespa-testrunner-components/src/main/java/com/yahoo/vespa/hosted/testrunner/PomXmlGenerator.java
@@ -38,7 +38,7 @@ public class PomXmlGenerator {
             "    <version>1.0.0</version>\n" +
             "\n" +
             "    <properties>\n" +
-            "        <junit_version>5.7.0</junit_version>\n" +
+            "        <junit_version>5.6.2</junit_version>\n" +
             "        <surefire_version>2.22.0</surefire_version>\n" +
             "%PROPERTIES%" +
             "    </properties>\n" +

--- a/vespa-testrunner-components/src/test/resources/pom.xml_system_tests
+++ b/vespa-testrunner-components/src/test/resources/pom.xml_system_tests
@@ -6,7 +6,7 @@
     <version>1.0.0</version>
 
     <properties>
-        <junit_version>5.7.0</junit_version>
+        <junit_version>5.6.2</junit_version>
         <surefire_version>2.22.0</surefire_version>
         <my-comp.jar.path>components/my-comp.jar</my-comp.jar.path>
         <main.jar.path>main.jar</main.jar.path>


### PR DESCRIPTION
Reverts vespa-engine/vespa#15043

Build fails with:
[INFO] Building cloud-tenant-base-dependencies-enforcer 7-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (default-cli) @ cloud-tenant-base-dependencies-enforcer ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.BannedDependencies failed with message:
Found Banned Dependency: org.junit.jupiter:junit-jupiter-api:jar:5.6.2
Found Banned Dependency: org.junit.platform:junit-platform-commons:jar:1.6.2