### PR TITLE
A typo in links in app list

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -418,7 +418,7 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
         Cursor applications = root.setArray("applications");
         for (ApplicationId id : nodeRepository.applications().ids()) {
             Cursor application = applications.addObject();
-            application.setString("url", withPath("/nodes/v2/applications/" + id.toFullString(), uri).toString());
+            application.setString("url", withPath("/nodes/v2/application/" + id.toFullString(), uri).toString());
             application.setString("id", id.toFullString());
         }
         return new SlimeJsonResponse(slime);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/applications.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/applications.json
@@ -1,19 +1,19 @@
 {
   "applications" : [
     {
-      "url" : "http://localhost:8080/nodes/v2/applications/tenant4.application4.instance4",
+      "url" : "http://localhost:8080/nodes/v2/application/tenant4.application4.instance4",
       "id" : "tenant4.application4.instance4"
     },
     {
-      "url" : "http://localhost:8080/nodes/v2/applications/tenant2.application2.instance2",
+      "url" : "http://localhost:8080/nodes/v2/application/tenant2.application2.instance2",
       "id" : "tenant2.application2.instance2"
     },
     {
-      "url" : "http://localhost:8080/nodes/v2/applications/tenant3.application3.instance3",
+      "url" : "http://localhost:8080/nodes/v2/application/tenant3.application3.instance3",
       "id" : "tenant3.application3.instance3"
     },
     {
-      "url" : "http://localhost:8080/nodes/v2/applications/tenant1.application1.instance1",
+      "url" : "http://localhost:8080/nodes/v2/application/tenant1.application1.instance1",
       "id" : "tenant1.application1.instance1"
     }
   ]


### PR DESCRIPTION
The applications list generates links to `/applications/<foo>` when the handler only accepts `/application/<foo>`.