### PR TITLE
Compare .max() and .current() when calculating use

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -6,6 +6,7 @@ import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterResources;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
@@ -368,12 +369,8 @@ public class ApplicationController {
     }
 
     private QuotaUsage deploymentQuotaUsage(ZoneId zoneId, ApplicationId applicationId) {
-        var quotaUsage = configServer.nodeRepository().getApplication(zoneId, applicationId)
-                .clusters().values().stream()
-                .map(Cluster::max)
-                .mapToDouble(max -> max.nodes() * max.nodeResources().cost())
-                .sum();
-        return QuotaUsage.create(quotaUsage);
+        var application = configServer.nodeRepository().getApplication(zoneId, applicationId);
+        return DeploymentQuotaCalculator.calculateQuotaUsage(application);
     }
 
     private ApplicationPackage getApplicationPackage(ApplicationId application, ZoneId zone, ApplicationVersion revision) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/DeploymentQuotaCalculatorTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/DeploymentQuotaCalculatorTest.java
@@ -1,11 +1,20 @@
 package com.yahoo.vespa.hosted.controller.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.hosted.controller.api.integration.billing.Quota;
+import com.yahoo.vespa.hosted.controller.api.integration.noderepository.ApplicationData;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -48,4 +57,12 @@ public class DeploymentQuotaCalculatorTest {
         assertEquals(calculated.budget().get().doubleValue(), 0, 1e-5);
     }
 
+    @Test
+    public void using_highest_resource_use() throws IOException, URISyntaxException {
+        var content = new String(Files.readAllBytes(Paths.get("src/test/java/com/yahoo/vespa/hosted/controller/application/response/application.json")));
+        var mapper = new ObjectMapper();
+        var application = mapper.readValue(content, ApplicationData.class).toApplication();
+        var usage = DeploymentQuotaCalculator.calculateQuotaUsage(application);
+        assertEquals(1.164, usage.rate(), 0.001);
+    }
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/response/application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/response/application.json
@@ -1,0 +1,156 @@
+{
+  "url": "...",
+  "id": "vespa.album-recommendation.default",
+  "clusters": {
+    "default": {
+      "min": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "max": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "current": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 2.0,
+          "memoryGb": 8.0,
+          "diskGb": 50.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "remote"
+        }
+      },
+      "suggested": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 2.0,
+          "memoryGb": 8.0,
+          "diskGb": 75.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "local"
+        }
+      }
+    },
+    "logserver": {
+      "min": {
+        "nodes": 1,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "max": {
+        "nodes": 1,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "current": {
+        "nodes": 1,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.5,
+          "memoryGb": 4.0,
+          "diskGb": 50.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "remote"
+        }
+      },
+      "suggested": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 2.0,
+          "memoryGb": 4.0,
+          "diskGb": 50.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "local"
+        }
+      }
+    },
+    "music": {
+      "min": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "max": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 0.0,
+          "memoryGb": 0.0,
+          "diskGb": 0.0,
+          "bandwidthGbps": 0.0,
+          "diskSpeed": "fast",
+          "storageType": "any"
+        }
+      },
+      "current": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 2.0,
+          "memoryGb": 8.0,
+          "diskGb": 50.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "remote"
+        }
+      },
+      "suggested": {
+        "nodes": 2,
+        "groups": 1,
+        "resources": {
+          "vcpu": 2.0,
+          "memoryGb": 4.0,
+          "diskGb": 50.0,
+          "bandwidthGbps": 0.3,
+          "diskSpeed": "fast",
+          "storageType": "local"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* .max() only has a value when the user specified auto-scaling. Thus we need to compare .max() with .current() to make sure we get the correct values when calculating quota usage.

* Moved quota usage calculations into DeploymentQuotaCalculator.

* Added author and copyright notice.
