### PR TITLE
Provisioning of AWS host as exclusive, shared, or any, ++

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.IP;
 import com.yahoo.vespa.hosted.provision.provisioning.FatalProvisioningException;
 import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner.HostSharing;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeResourceComparator;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisionedHost;
 import com.yahoo.yolean.Exceptions;
@@ -44,7 +45,6 @@ import java.util.stream.IntStream;
 public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
 
     private static final Logger log = Logger.getLogger(DynamicProvisioningMaintainer.class.getName());
-    private static final ApplicationId preprovisionAppId = ApplicationId.from("hosted-vespa", "tenant-host", "preprovision");
 
     private final HostProvisioner hostProvisioner;
     private final ListFlag<HostCapacity> targetCapacityFlag;
@@ -155,7 +155,8 @@ public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
             try {
                 Version osVersion = nodeRepository().osVersions().targetFor(NodeType.host).orElse(Version.emptyVersion);
                 List<Node> hosts = hostProvisioner.provisionHosts(nodeRepository().database().getProvisionIndexes(1),
-                                                                  resources, preprovisionAppId, osVersion, false)
+                                                                  resources, ApplicationId.defaultId(), osVersion,
+                                                                  HostSharing.shared)
                                                   .stream()
                                                   .map(ProvisionedHost::generateHost)
                                                   .collect(Collectors.toList());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -16,6 +16,7 @@ import com.yahoo.vespa.hosted.provision.LockedNodeList;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner.HostSharing;
 
 import java.util.List;
 import java.util.Optional;
@@ -89,7 +90,7 @@ public class GroupPreparer {
                                                                                  deficit.getFlavor(),
                                                                                  application,
                                                                                  osVersion,
-                                                                                 requestedNodes.isExclusive()))
+                                                                                 requestedNodes.isExclusive() ? HostSharing.exclusive : HostSharing.any))
                             .orElseGet(List::of);
 
                     // At this point we have started provisioning of the hosts, the first priority is to make sure that

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -16,6 +16,19 @@ import java.util.Set;
  */
 public interface HostProvisioner {
 
+    enum HostSharing {
+        /** The host must be provisioned exclusively for the applicationId */
+        exclusive,
+
+        /** The host must be provisioned to be shared with other applications. \
+         */
+        shared,
+
+        /** The client has no requirements on whether the host must be provisio\
+         ned exclusively or shared. */
+        any
+    }
+
     /**
      * Schedule provisioning of a given number of hosts.
      *
@@ -25,12 +38,12 @@ public interface HostProvisioner {
      * @param applicationId id of the application that will own the provisioned host
      * @param osVersion the OS version to use. If this version does not exist, implementations may choose a suitable
      *                  fallback version.
-     * @param forceExclusive whether to force the provisioning of an exclusive host.
+     * @param sharing puts requirements on sharing or exclusivity of the host to be provisioned.
      * @return list of {@link ProvisionedHost} describing the provisioned nodes
      */
     List<ProvisionedHost> provisionHosts(List<Integer> provisionIndexes, NodeResources resources,
                                          ApplicationId applicationId, Version osVersion,
-                                         boolean forceExclusive);
+                                         HostSharing sharing);
 
     /**
      * Continue provisioning of given list of Nodes.

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
@@ -278,7 +278,7 @@ class AutoscalingTester {
         @Override
         public List<ProvisionedHost> provisionHosts(List<Integer> provisionIndexes, NodeResources resources,
                                                     ApplicationId applicationId, Version osVersion,
-                                                    boolean forceExclusive) {
+                                                    HostSharing sharing) {
             Flavor hostFlavor = hostFlavors.stream().filter(f -> matches(f, resources)).findAny()
                                            .orElseThrow(() -> new RuntimeException("No flavor matching " + resources + ". Flavors: " + hostFlavors));
 
@@ -287,6 +287,7 @@ class AutoscalingTester {
                 hosts.add(new ProvisionedHost("host" + index,
                                               "hostname" + index,
                                               hostFlavor,
+                                              Optional.empty(),
                                               "nodename" + index,
                                               resources,
                                               osVersion));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
@@ -144,10 +144,10 @@ public class DynamicProvisioningMaintainerTest {
         assertTrue(tester.nodeRepository.getNode(host2.hostname()).isPresent());
     }
 
-    @Ignore // TODO (hakon): Fix or replace with spare-hosts flag
+    @Ignore // TODO (hakon): Enable as test of min-capacity specified in flag
     @Test
     public void provision_exact_capacity() {
-        var tester = new DynamicProvisioningTester(Cloud.builder().dynamicProvisioning(false).build());
+        var tester = new DynamicProvisioningTester(Cloud.builder().dynamicProvisioning(true).build());
         NodeResources resources1 = new NodeResources(24, 64, 100, 1);
         NodeResources resources2 = new NodeResources(16, 24, 100, 1);
         tester.flagSource.withListFlag(Flags.TARGET_CAPACITY.id(), List.of(new HostCapacity(resources1.vcpu(), resources1.memoryGb(), resources1.diskGb(), 1),
@@ -326,7 +326,7 @@ public class DynamicProvisioningMaintainerTest {
 
         @Override
         public List<ProvisionedHost> provisionHosts(List<Integer> provisionIndexes, NodeResources resources,
-                                                    ApplicationId applicationId, Version osVersion, boolean forceExclusive) {
+                                                    ApplicationId applicationId, Version osVersion, HostSharing sharing) {
             Flavor hostFlavor = flavors.getFlavors().stream()
                                        .filter(f -> !f.isDocker())
                                        .filter(f -> f.resources().compatibleWith(resources))
@@ -337,6 +337,7 @@ public class DynamicProvisioningMaintainerTest {
                 hosts.add(new ProvisionedHost("host" + index,
                                               "hostname" + index,
                                               hostFlavor,
+                                              Optional.empty(),
                                               "nodename" + index,
                                               resources,
                                               osVersion));


### PR DESCRIPTION
 - When provisioning a host, specify whether to provision the host exclusive to
   the application, or require a shared host, or if any will do.
 - Set the exclusiveTo on the host in the node repo.