### PR TITLE
Remove find free port hack from test

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -223,7 +223,7 @@ public class JettyHttpServer extends AbstractServerProvider {
             logEffectiveSslConfiguration();
         } catch (final Exception e) {
             if (e instanceof IOException && e.getCause() instanceof BindException) {
-                throw new RuntimeException("Failed to start server due to BindExecption. ListenPorts = " + listenedPorts.toString(), e.getCause());
+                throw new RuntimeException("Failed to start server due to BindException. ListenPorts = " + listenedPorts.toString(), e.getCause());
             }
             throw new RuntimeException("Failed to start server.", e);
         }

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/DocumentApiApplicationTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/DocumentApiApplicationTest.java
@@ -5,9 +5,6 @@ import com.yahoo.application.Application;
 import com.yahoo.application.Networking;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.ServerSocket;
-
 /**
  * @author bratseth
  */
@@ -15,22 +12,14 @@ public class DocumentApiApplicationTest {
 
     /** Test that it is possible to instantiate an Application with a document-api */
     @Test
-    public void application_with_document_api() throws IOException {
+    public void application_with_document_api() {
         String services =
                 "<container version='1.0'>" +
-                "    <http><server port=\"" + findRandomOpenPortOnAllLocalInterfaces() + "\" id=\"foobar\"/></http>" +
+                "    <http><server port=\"0\" id=\"foobar\"/></http>" +
                 "    <document-api/>" +
                 "</container>";
         try (Application application = Application.fromServicesXml(services, Networking.enable)) {
         }
-    }
-
-    private int findRandomOpenPortOnAllLocalInterfaces() throws IOException {
-        ServerSocket socket = new ServerSocket(0);
-        socket.setReuseAddress(true);
-        int port = socket.getLocalPort();
-        socket.close();
-        return port;
     }
 
 }


### PR DESCRIPTION
Probably less racy to let Jetty find a port by itself.

Failed on a recent Factory build:

```
java.lang.RuntimeException: Failed to start server due to BindExecption. ListenPorts = [44055]
	at com.yahoo.jdisc.http.server.jetty.JettyHttpServer.start(JettyHttpServer.java:226)
	at com.yahoo.container.jdisc.ConfiguredApplication.startAndStopServers(ConfiguredApplication.java:312)
	at com.yahoo.container.jdisc.ConfiguredApplication.initializeAndActivateContainer(ConfiguredApplication.java:249)
	at com.yahoo.container.jdisc.ConfiguredApplication.start(ConfiguredApplication.java:144)
	at com.yahoo.container.standalone.StandaloneContainerApplication.start(StandaloneContainerApplication.java:157)
	at com.yahoo.jdisc.core.ApplicationLoader.start(ApplicationLoader.java:154)
	at com.yahoo.jdisc.test.TestDriver.newInstance(TestDriver.java:372)
	at com.yahoo.jdisc.test.TestDriver.newInstance(TestDriver.java:328)
	at com.yahoo.application.container.JDisc.<init>(JDisc.java:52)
	at com.yahoo.application.container.JDisc.fromPath(JDisc.java:104)
	at com.yahoo.application.Application.<init>(Application.java:71)
	at com.yahoo.application.Application.fromServicesXml(Application.java:89)
	at com.yahoo.document.restapi.DocumentApiApplicationTest.application_with_document_api(DocumentApiApplicationTest.java:24)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:383)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:344)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:417)
Caused by: java.net.BindException: Address already in use
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:455)
	at java.base/sun.nio.ch.Net.bind(Net.java:447)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
	at java.base/sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:80)
	at org.eclipse.jetty.server.ServerConnector.openAcceptChannel(ServerConnector.java:345)
	at org.eclipse.jetty.server.ServerConnector.open(ServerConnector.java:310)
	at org.eclipse.jetty.server.AbstractNetworkConnector.doStart(AbstractNetworkConnector.java:80)
	at org.eclipse.jetty.server.ServerConnector.doStart(ServerConnector.java:234)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
	at org.eclipse.jetty.server.Server.doStart(Server.java:401)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:72)
	at com.yahoo.jdisc.http.server.jetty.JettyHttpServer.start(JettyHttpServer.java:221)
	... 37 more
```

@bratseth