### PR TITLE
Do not print stack trace for NameNotFoundException

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
@@ -24,6 +24,7 @@ import com.yahoo.vespa.hosted.provision.provisioning.NodeResourceComparator;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisionedHost;
 import com.yahoo.yolean.Exceptions;
 
+import javax.naming.NameNotFoundException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -93,7 +94,10 @@ public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
                 nodeRepository().failRecursively(
                         host.hostname(), Agent.operator, "Failed by HostProvisioner due to provisioning failure");
             } catch (RuntimeException e) {
-                log.log(Level.WARNING, "Failed to provision " + host.hostname() + ", will retry in " + interval(), e);
+                if (e.getCause() instanceof NameNotFoundException)
+                    log.log(Level.INFO, "Failed to provision " + host.hostname() + ", will retry in " + interval() + ": " + e.getMessage());
+                else
+                    log.log(Level.WARNING, "Failed to provision " + host.hostname() + ", will retry in " + interval(), e);
             }
         });
     }


### PR DESCRIPTION
```   
Failed to provision xxx, will retry in PT5M
exception=
java.lang.RuntimeException: javax.naming.NameNotFoundException: DNS name not found [response code 3]; remaining name 'xxx'
at com.yahoo.vespa.hosted.provision.persistence.DnsNameResolver.resolve(DnsNameResolver.java:40)
at com.yahoo.vespa.hosted.provision.node.IP.verifyDns(IP.java:423)
at com.yahoo.vespa.hosted.provision.maintenance.DynamicProvisioningMaintainer.verifyDns(DynamicProvisioningMaintainer.java:191)
at com.yahoo.vespa.hosted.provision.maintenance.DynamicProvisioningMaintainer.lambda$resumeProvisioning$2(DynamicProvisioningMaintainer.java:84)
at java.base/java.lang.Iterable.forEach(Iterable.java:75)
at com.yahoo.vespa.hosted.provision.maintenance.DynamicProvisioningMaintainer.resumeProvisioning(DynamicProvisioningMaintainer.java:80)
at com.yahoo.vespa.hosted.provision.maintenance.DynamicProvisioningMaintainer.maintain(DynamicProvisioningMaintainer.java:66)
at com.yahoo.concurrent.maintenance.Maintainer.lockAndMaintain(Maintainer.java:89)
at com.yahoo.concurrent.maintenance.Maintainer.run(Maintainer.java:51)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: javax.naming.NameNotFoundException: DNS name not found [response code 3]; remaining name 'xxx'
at jdk.naming.dns/com.sun.jndi.dns.DnsClient.checkResponseCode(DnsClient.java:661)
at jdk.naming.dns/com.sun.jndi.dns.DnsClient.isMatchResponse(DnsClient.java:579)
at jdk.naming.dns/com.sun.jndi.dns.DnsClient.doUdpQuery(DnsClient.java:427)
at jdk.naming.dns/com.sun.jndi.dns.DnsClient.query(DnsClient.java:212)
at jdk.naming.dns/com.sun.jndi.dns.Resolver.query(Resolver.java:81)
at jdk.naming.dns/com.sun.jndi.dns.DnsContext.c_getAttributes(DnsContext.java:434)
at java.naming/com.sun.jndi.toolkit.ctx.ComponentDirContext.p_getAttributes(ComponentDirContext.java:235)
at java.naming/com.sun.jndi.toolkit.ctx.PartialCompositeDirContext.getAttributes(PartialCompositeDirContext.java:141)
at java.naming/com.sun.jndi.toolkit.url.GenericURLDirContext.getAttributes(GenericURLDirContext.java:103)
at java.naming/javax.naming.directory.InitialDirContext.getAttributes(InitialDirContext.java:142)
at com.yahoo.vespa.hosted.provision.persistence.DnsNameResolver.lookupName(DnsNameResolver.java:60)
at com.yahoo.vespa.hosted.provision.persistence.DnsNameResolver.resolve(DnsNameResolver.java:38)
... 14 more

```