### PR TITLE
Revert "Add TENANT_ID as a flag dimension"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -221,9 +221,6 @@ public class SystemFlagsDataArchive {
             } else if (dimension.isEqualTo(DimensionHelper.toWire(FetchVector.Dimension.CONSOLE_USER_EMAIL))) {
                 condition.get("values").forEachArrayElement(conditionValue -> conditionValue.asString()
                         .orElseThrow(() -> new IllegalArgumentException("Non-string email address: " + conditionValue)));
-            } else if (dimension.isEqualTo(DimensionHelper.toWire(FetchVector.Dimension.TENANT_ID))) {
-                condition.get("values").forEachArrayElement(conditionValue -> conditionValue.asString()
-                        .orElseThrow(() -> new IllegalArgumentException("Non-string tenant ID: " + conditionValue)));
             }
         }));
     }

--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
@@ -236,30 +236,6 @@ public class SystemFlagsDataArchiveTest {
         }
     }
 
-    @Test
-    public void normalize_json_fail_on_invalid_tenant_id() {
-        try {
-            SystemFlagsDataArchive.normalizeJson("{\n" +
-                    "    \"id\": \"foo\",\n" +
-                    "    \"rules\": [\n" +
-                    "        {\n" +
-                    "            \"conditions\": [\n" +
-                    "                {\n" +
-                    "                    \"type\": \"whitelist\",\n" +
-                    "                    \"dimension\": \"tenant\",\n" +
-                    "                    \"values\": [ 123 ]\n" +
-                    "                }\n" +
-                    "            ],\n" +
-                    "            \"value\": true\n" +
-                    "        }\n" +
-                    "    ]\n" +
-                    "}\n");
-            fail();
-        } catch (IllegalArgumentException e) {
-            assertEquals("Non-string tenant ID: 123", e.getMessage());
-        }
-    }
-
     private static void assertArchiveReturnsCorrectTestFlagDataForTarget(SystemFlagsDataArchive archive) {
         assertFlagDataHasValue(archive, MY_TEST_FLAG, mainControllerTarget, "main.controller");
         assertFlagDataHasValue(archive, MY_TEST_FLAG, prodUsWestCfgTarget, "main.prod.us-west-1");

--- a/flags/src/main/java/com/yahoo/vespa/flags/FetchVector.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FetchVector.java
@@ -24,9 +24,6 @@ public class FetchVector {
      * Note: If this enum is changed, you must also change {@link DimensionHelper}.
      */
     public enum Dimension {
-        /** A legal value for TenantName, e.g. vespa-team */
-        TENANT_ID,
-
         /** Value from ApplicationId::serializedForm of the form tenant:applicationName:instance. */
         APPLICATION_ID,
 

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -15,7 +15,6 @@ import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.CONSOLE_USER_EMAIL;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
-import static com.yahoo.vespa.flags.FetchVector.Dimension.TENANT_ID;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.VESPA_VERSION;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.ZONE_ID;
 
@@ -267,7 +266,7 @@ public class Flags {
             "tenant-budget-quota", -1,
             "The budget in cents/hr a tenant is allowed spend per instance, as calculated by NodeResources",
             "Only takes effect on next deployment, if set to a value other than the default for flag!",
-            TENANT_ID
+            APPLICATION_ID
     );
 
     public static final UnboundBooleanFlag ONLY_PUBLIC_ACCESS = defineFeatureFlag(

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/DimensionHelper.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/DimensionHelper.java
@@ -20,7 +20,6 @@ public class DimensionHelper {
         serializedDimensions.put(FetchVector.Dimension.CLUSTER_TYPE, "cluster-type");
         serializedDimensions.put(FetchVector.Dimension.VESPA_VERSION, "vespa-version");
         serializedDimensions.put(FetchVector.Dimension.CONSOLE_USER_EMAIL, "console-user-email");
-        serializedDimensions.put(FetchVector.Dimension.TENANT_ID, "tenant");
 
         if (serializedDimensions.size() != FetchVector.Dimension.values().length) {
             throw new IllegalStateException(FetchVectorHelper.class.getName() + " is not in sync with " +


### PR DESCRIPTION
Reverts vespa-engine/vespa#15111

Unit testing fails with
```
[ERROR] Tests run: 7, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.274 s <<< FAILURE! - in com.yahoo.vespa.hosted.commands.flag.EditFlagDataCommandTest
14:14:15 [ERROR] defaultJsonIsBasedOnTheseDimensions(com.yahoo.vespa.hosted.commands.flag.EditFlagDataCommandTest)  Time elapsed: 0.005 s  <<< FAILURE!
14:14:15 java.lang.AssertionError: expected:<[CONSOLE_USER_EMAIL, HOSTNAME, CLUSTER_TYPE, NODE_TYPE, ZONE_ID, VESPA_VERSION, APPLICATION_ID]> but was:<[VESPA_VERSION, APPLICATION_ID, CLUSTER_TYPE, NODE_TYPE, CONSOLE_USER_EMAIL, ZONE_ID, HOSTNAME, TENANT_ID]>
```