### PR TITLE
avoid unrolling reduce all loop

### DIFF
--- a/eval/src/vespa/eval/instruction/generic_reduce.cpp
+++ b/eval/src/vespa/eval/instruction/generic_reduce.cpp
@@ -114,23 +114,13 @@ template <typename ICT, typename OCT, typename AGGR>
 void my_full_reduce_op(State &state, uint64_t) {
     auto cells = state.peek(0).cells().typify<ICT>();
     if (cells.size() > 0) {
-        AGGR aggr[4];
-        size_t i = 0;
-        for (; (i + 3) < cells.size(); i += 4) {
-            aggr[0].sample(cells[i+0]);
-            aggr[1].sample(cells[i+1]);
-            aggr[2].sample(cells[i+2]);
-            aggr[3].sample(cells[i+3]);
+        AGGR aggr;
+        for (ICT value: cells) {
+            aggr.sample(value);
         }
-        for (; i < cells.size(); ++i) {
-            aggr[0].sample(cells[i]);
-        }
-        aggr[0].merge(aggr[1]);
-        aggr[0].merge(aggr[2]);
-        aggr[0].merge(aggr[3]);
-        state.pop_push(state.stash.create<ScalarValue<OCT>>(aggr[0].result()));
+        state.pop_push(state.stash.create<ScalarValue<OCT>>(aggr.result()));
     } else {
-        state.pop_push(state.stash.create<ScalarValue<OCT>>(0.0));
+        state.pop_push(state.stash.create<ScalarValue<OCT>>(OCT{0}));
     }
 };
 


### PR DESCRIPTION
This is to see if it helps the number stability of the BERT performance
test. Note that unrolling made it go 4 times faster, so we might want
to re-introduce it again later.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
@arnej27959 FYI