### PR TITLE
Disregard ONNX model type info if file not found

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/OnnxModelTypeResolver.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/OnnxModelTypeResolver.java
@@ -32,6 +32,11 @@ public class OnnxModelTypeResolver extends Processor {
         for (OnnxModel onnxModel : search.onnxModels().asMap().values()) {
             OnnxModelInfo onnxModelInfo = OnnxModelInfo.load(onnxModel.getFileName(), search.applicationPackage());
 
+            // Temporary, to disregard type information when model info is not available
+            if (onnxModelInfo == null) {
+                continue;
+            }
+
             // Add any missing input and output fields that were not specified in the onnx-model configuration
             for (String onnxName : onnxModelInfo.getInputs()) {
                 onnxModel.addInputNameMapping(onnxName, OnnxModelInfo.asValidIdentifier(onnxName), false);

--- a/config-model/src/main/java/com/yahoo/vespa/model/ml/OnnxModelInfo.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/ml/OnnxModelInfo.java
@@ -125,7 +125,12 @@ public class OnnxModelInfo {
         if (app.getFile(generatedModelInfoPath(pathInApplicationPackage)).exists()) {
             return loadFromGeneratedInfo(pathInApplicationPackage, app);
         }
-        throw new IllegalArgumentException("Unable to find ONNX model file or generated ONNX info file");
+
+        // Temporary:
+        return null;
+
+        // This is the correct behaviour after we've gotten applications through.
+        // throw new IllegalArgumentException("Unable to find ONNX model file or generated ONNX info file");
     }
 
     static public boolean modelExists(String path, ApplicationPackage app) {


### PR DESCRIPTION
@bratseth Please review. To ensure config servers can start for existing applications that haven't had the model info file generated yet.