### PR TITLE
Add required="true" for override without node children, try 2

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/application/OverrideProcessor.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/OverrideProcessor.java
@@ -4,7 +4,6 @@ package com.yahoo.config.application;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
-import java.util.logging.Level;
 import com.yahoo.text.XML;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -19,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -219,11 +219,20 @@ class OverrideProcessor implements PreProcessor {
         // if node capacity is specified explicitly for some combination we should require that capacity
         elements.forEach(element -> {
             if (element.getTagName().equals("nodes"))
-                if (element.getChildNodes().getLength() == 0) // specifies capacity, not a list of nodes
+                if (!hasChildWithTagName(element, "node")) // specifies capacity, not a list of nodes
                     element.setAttribute("required", "true");
         });
     }
-    
+
+    private static boolean hasChildWithTagName(Element element, String childName) {
+        for (var child : XML.getChildren(element)) {
+            if (child.getTagName().equals(childName))
+                return true;
+        }
+
+        return false;
+    }
+
     /**
      * Retains all elements where at least one element is overridden. Removes non-overridden elements from map.
      */


### PR DESCRIPTION
Reverts vespa-engine/vespa#15146

The original was reverted because CapacityPolicies.decideNodeResources() skips setting disk speed to any (and cpu to 0.1) with `required`, and:

* canary-application used default disk speed `fast`, while our cd prod zone only had slow speed, thus it was "out of capacity".

canary-application has been updated to use `any`, and all other CD applications use `any`.  Public and public CD and AWS zones are presumably OK because a. the default disk speed is fast which is the only speed they have in AWS, and b. no cpu adjustments are made in AWS.

We have verified no other current applications in dev will be affected by this change.  There are 4 applications that may be affected if they deploy to dev:  they will start requesting more resources or fast disk, but if that causes out-of-capacity they are in a good position to fix their services.xml at that time.

From looking at the available services.xml, no applications in test environment should be affected by this problem. But we are fixing the tester application disk speed to `any` in a concurrent PR.