### PR TITLE
Lazy config gen checking and set ready to now if previous value is old

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabase.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabase.java
@@ -1,7 +1,6 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.application;
 
-import com.yahoo.concurrent.StripedExecutor;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.path.Path;
@@ -19,7 +18,6 @@ import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.curator.transaction.CuratorOperations;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
 import com.yahoo.yolean.Exceptions;
-import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -116,10 +114,9 @@ public class ApplicationCuratorDatabase {
                       .collect(Collectors.toUnmodifiableList());
     }
 
-    public ApplicationReindexing readReindexingStatus(ApplicationId id) {
+    public Optional<ApplicationReindexing> readReindexingStatus(ApplicationId id) {
         return curator.getData(reindexingDataPath(id))
-                      .map(data -> ReindexingStatusSerializer.fromBytes(data))
-                      .orElse(ApplicationReindexing.empty());
+                      .map(data -> ReindexingStatusSerializer.fromBytes(data));
     }
 
     public void writeReindexingStatus(ApplicationId id, ApplicationReindexing status) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationReindexing.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationReindexing.java
@@ -31,9 +31,9 @@ public class ApplicationReindexing implements Reindexing {
         this.clusters = Map.copyOf(clusters);
     }
 
-    /** No reindexing pending or ready. */
-    public static ApplicationReindexing empty() {
-        return empty;
+    /** Reindexing for the whole application ready now. */
+    public static ApplicationReindexing ready(Instant now) {
+        return new ApplicationReindexing(new Status(now), Map.of());
     }
 
     /** Returns a copy of this with common reindexing for the whole application ready at the given instant. */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationReindexing.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/ApplicationReindexing.java
@@ -21,8 +21,6 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
  */
 public class ApplicationReindexing implements Reindexing {
 
-    private static final ApplicationReindexing empty = new ApplicationReindexing(Status.ALWAYS_READY, Map.of());
-
     private final Status common;
     private final Map<String, Cluster> clusters;
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainer.java
@@ -62,7 +62,8 @@ public class ReindexingMaintainer extends ConfigServerMaintainer {
                                          try {
                                              Collection<Long> generations = convergence.getServiceConfigGenerations(application, timeout).values();
                                              try (Lock lock = database.lock(id)) {
-                                                 ApplicationReindexing reindexing = database.readReindexingStatus(id);
+                                                 ApplicationReindexing reindexing = database.readReindexingStatus(id)
+                                                                                            .orElse(ApplicationReindexing.ready(clock.instant()));
                                                  database.writeReindexingStatus(id, withReady(reindexing, lazyGeneration(application), clock.instant()));
                                              }
                                          }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.curator.mock.MockCurator;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 
@@ -19,9 +20,9 @@ public class ApplicationCuratorDatabaseTest {
         ApplicationId id = ApplicationId.defaultId();
         ApplicationCuratorDatabase db = new ApplicationCuratorDatabase(id.tenant(), new MockCurator());
 
-        assertEquals(ApplicationReindexing.empty(), db.readReindexingStatus(id));
+        assertEquals(Optional.empty(), db.readReindexingStatus(id));
 
-        ApplicationReindexing reindexing = ApplicationReindexing.empty()
+        ApplicationReindexing reindexing = ApplicationReindexing.ready(Instant.EPOCH)
                                                                 .withReady(Instant.ofEpochMilli(1 << 20))
                                                                 .withPending("one", "a", 10)
                                                                 .withReady("two", "b", Instant.ofEpochMilli(2))
@@ -31,7 +32,7 @@ public class ApplicationCuratorDatabaseTest {
                                                                 .withReady("two", "c", Instant.ofEpochMilli(3));
 
         db.writeReindexingStatus(id, reindexing);
-        assertEquals(reindexing, db.readReindexingStatus(id));
+        assertEquals(reindexing, db.readReindexingStatus(id).orElseThrow());
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationReindexingTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationReindexingTest.java
@@ -17,7 +17,7 @@ public class ApplicationReindexingTest {
 
     @Test
     public void test() {
-        ApplicationReindexing reindexing = ApplicationReindexing.empty()
+        ApplicationReindexing reindexing = ApplicationReindexing.ready(Instant.EPOCH)
                                                                 .withReady(Instant.ofEpochMilli(1 << 20))
                                                                 .withPending("one", "a", 10)
                                                                 .withReady("two", "b", Instant.ofEpochMilli(2))

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationReindexingTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationReindexingTest.java
@@ -26,6 +26,15 @@ public class ApplicationReindexingTest {
                                                                 .withReady("one", "a", Instant.ofEpochMilli(1))
                                                                 .withReady("two", "c", Instant.ofEpochMilli(3));
 
+        assertEquals(Instant.ofEpochMilli(1 << 20),
+                     reindexing.status("one", "a").ready());
+
+        assertEquals(Instant.ofEpochMilli(1 << 20),
+                     reindexing.status("one", "d").ready());
+
+        assertEquals(Instant.ofEpochMilli(1 << 20),
+                     reindexing.status("three", "a").ready());
+
         assertEquals(new Status(Instant.ofEpochMilli(1 << 20)),
                      reindexing.common());
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainerTest.java
@@ -27,13 +27,19 @@ public class ReindexingMaintainerTest {
                                                                 .withReady("two", "c", Instant.ofEpochMilli(3));
 
         assertEquals(reindexing,
-                     withReady(reindexing, List.of(), Instant.EPOCH));
+                     withReady(reindexing, () -> -1L, Instant.EPOCH));
 
         assertEquals(reindexing,
-                     withReady(reindexing, List.of(19L), Instant.EPOCH));
+                     withReady(reindexing, () -> 19L, Instant.EPOCH));
 
-        assertEquals(reindexing.withReady("two", "b", Instant.MAX),
-                     withReady(reindexing, List.of(20L), Instant.MAX));
+        Instant later = Instant.ofEpochMilli(2).plus(ReindexingMaintainer.reindexingInterval);
+        assertEquals(reindexing.withReady("one", later)         // Had EPOCH as previous, so is updated.
+                               .withReady("two", "b", later)    // Got config convergence, so is updated.
+                               .withReady("one", "a", later),   // Had EPOCH + 1 as previous, so is updated.
+                     withReady(reindexing, () -> 20L, later));
+
+        // Verify generation supplier isn't called when no pending document types.
+        withReady(reindexing.withReady("two", "b", later), () -> { throw new AssertionError("not supposed to run"); }, later);
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainerTest.java
@@ -5,7 +5,6 @@ import com.yahoo.vespa.config.server.application.ApplicationReindexing;
 import org.junit.Test;
 
 import java.time.Instant;
-import java.util.List;
 
 import static com.yahoo.vespa.config.server.maintenance.ReindexingMaintainer.withReady;
 import static org.junit.Assert.assertEquals;
@@ -17,8 +16,7 @@ public class ReindexingMaintainerTest {
 
     @Test
     public void testReadyComputation() {
-        ApplicationReindexing reindexing = ApplicationReindexing.empty()
-                                                                .withReady(Instant.ofEpochMilli(1 << 20))
+        ApplicationReindexing reindexing = ApplicationReindexing.ready(Instant.ofEpochMilli(1 << 20))
                                                                 .withPending("one", "a", 10)
                                                                 .withReady("two", "b", Instant.ofEpochMilli(2))
                                                                 .withPending("two", "b", 20)


### PR DESCRIPTION
@bjorncs please review. 

With this change, a new application will have initial value for common reindexing set to `now` the first time the maintainer runs. The config generator can use the default `new Reindexing() { }` to avoid starting reindexing twice when a new application is deployed (one for immediate value, and one for the maintainer's value)