### PR TITLE
Revert "Override in variant references"

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5868,7 +5868,7 @@
       "public com.yahoo.search.query.profile.DimensionValues getDimensionValues()",
       "public java.util.Map values()",
       "public java.util.List inherited()",
-      "public java.lang.Object set(java.lang.String, java.lang.Object)",
+      "public void set(java.lang.String, java.lang.Object)",
       "public void inherit(com.yahoo.search.query.profile.QueryProfile)",
       "public int compareTo(com.yahoo.search.query.profile.QueryProfileVariant)",
       "public boolean matches(com.yahoo.search.query.profile.DimensionValues)",
@@ -5899,7 +5899,6 @@
       "public int compareTo(com.yahoo.search.query.profile.QueryProfileVariants$FieldValue)",
       "public com.yahoo.search.query.profile.QueryProfileVariants$FieldValue clone(java.lang.String, java.util.List)",
       "public com.yahoo.search.query.profile.QueryProfileVariants$FieldValue clone()",
-      "public java.lang.String toString()",
       "public bridge synthetic java.lang.Object clone()",
       "public bridge synthetic int compareTo(java.lang.Object)"
     ],
@@ -5955,7 +5954,6 @@
       "public com.yahoo.search.query.profile.QueryProfileVariants clone()",
       "protected void ensureNotFrozen()",
       "public com.yahoo.search.query.profile.QueryProfileVariant getVariant(com.yahoo.search.query.profile.DimensionValues, boolean)",
-      "public java.lang.String toString()",
       "public bridge synthetic java.lang.Object clone()"
     ],
     "fields": []

--- a/container-search/src/main/java/com/yahoo/search/query/profile/AllValuesQueryProfileVisitor.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/AllValuesQueryProfileVisitor.java
@@ -3,6 +3,9 @@ package com.yahoo.search.query.profile;
 
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.query.profile.compiled.ValueWithSource;
+import com.yahoo.search.query.profile.types.FieldDescription;
+import com.yahoo.search.query.profile.types.QueryProfileFieldType;
+import com.yahoo.search.query.profile.types.QueryProfileType;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -13,7 +16,7 @@ import java.util.Map;
  */
 final class AllValuesQueryProfileVisitor extends PrefixQueryProfileVisitor {
 
-    private final Map<String, ValueWithSource> values = new HashMap<>();
+    private Map<String, ValueWithSource> values = new HashMap<>();
 
     /* Lists all values starting at prefix */
     public AllValuesQueryProfileVisitor(CompoundName prefix) {

--- a/container-search/src/main/java/com/yahoo/search/query/profile/BackedOverridableQueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/BackedOverridableQueryProfile.java
@@ -22,7 +22,7 @@ import java.util.Map;
 public class BackedOverridableQueryProfile extends OverridableQueryProfile implements Cloneable {
 
     /** The backing read only query profile, or null if this is not backed */
-    private final QueryProfile backingProfile;
+    private QueryProfile backingProfile;
 
     /**
      * Creates an overridable profile from the given backing profile. The backing profile will never be
@@ -95,16 +95,16 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
     }
 
     @Override
-    protected void visitInherited(boolean allowContent, QueryProfileVisitor visitor, DimensionBinding dimensionBinding, QueryProfile owner) {
-        super.visitInherited(allowContent, visitor, dimensionBinding, owner);
+    protected void visitInherited(boolean allowContent,QueryProfileVisitor visitor,DimensionBinding dimensionBinding, QueryProfile owner) {
+        super.visitInherited(allowContent,visitor,dimensionBinding, owner);
         if (visitor.isDone()) return;
-        backingProfile.visitInherited(allowContent, visitor, dimensionBinding,owner);
+        backingProfile.visitInherited(allowContent,visitor,dimensionBinding,owner);
     }
 
     /** Returns a value from the content of this: The value in this, or the value from the backing if not set in this */
     protected Object getContent(String localKey) {
-        Object value = super.getContent(localKey);
-        if (value != null) return value;
+        Object value=super.getContent(localKey);
+        if (value!=null) return value;
         return backingProfile.getContent(localKey);
     }
 
@@ -125,7 +125,7 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
 
     @Override
     public String toString() {
-        return "overridable wrapper of " + backingProfile;
+        return "overridable wrapper of " + backingProfile.toString();
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
@@ -366,7 +366,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
      * @throws IllegalArgumentException if the given name is illegal given the types of this or any nested query profile
      * @throws IllegalStateException if this query profile is frozen
      */
-    public final void set(String name, Object value, DimensionValues dimensionValues, QueryProfileRegistry registry) {
+    public final void set(String name,Object value, DimensionValues dimensionValues, QueryProfileRegistry registry) {
         set(new CompoundName(name), value, DimensionBinding.createFrom(getDimensions(), dimensionValues), registry);
     }
 
@@ -527,6 +527,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
                       QueryProfileVisitor visitor,
                       DimensionBinding dimensionBinding,
                       QueryProfile owner) {
+        //System.out.println("    visiting " + this);
         visitor.onQueryProfile(this, dimensionBinding, owner, null);
         if (visitor.isDone()) return;
 
@@ -540,6 +541,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
 
         if (visitor.visitInherited())
             visitInherited(allowContent, visitor, dimensionBinding, owner);
+        //System.out.println("    done visiting " + this);
     }
 
     protected void visitVariants(boolean allowContent, QueryProfileVisitor visitor, DimensionBinding dimensionBinding) {
@@ -736,7 +738,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
         parent.overridable.put(fieldName.last(), overridable);
     }
 
-    /** Sets a value to a (possibly non-local) node. */
+    /** Sets a value to a (possibly non-local) node. The parent query profile holding the value is returned */
     private void setNode(CompoundName name, Object value, QueryProfileType parentType,
                          DimensionBinding dimensionBinding, QueryProfileRegistry registry) {
         ensureNotFrozen();
@@ -809,18 +811,19 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
         validateName(localName);
         value = convertToSubstitutionString(value);
 
-
         if (dimensionBinding.isNull()) {
-            Object combinedValue = value instanceof QueryProfile
-                                   ? combineValues(value, content == null ? null : content.get(localName))
-                                   : combineValues(value, localLookup(localName, dimensionBinding));
-            if (combinedValue != null)
+            Object combinedValue;
+            if (value instanceof QueryProfile)
+                combinedValue = combineValues(value, content == null ? null : content.get(localName));
+            else
+                combinedValue = combineValues(value, localLookup(localName, dimensionBinding));
+
+            if (combinedValue!=null)
                 content.put(localName, combinedValue);
         }
         else {
-            if (variants == null) {
+            if (variants == null)
                 variants = new QueryProfileVariants(dimensionBinding.getDimensions(), this);
-            }
             variants.set(localName, dimensionBinding.getValues(), value);
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileVariant.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileVariant.java
@@ -16,13 +16,13 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
 
     private List<QueryProfile> inherited = null;
 
-    private final DimensionValues dimensionValues;
+    private DimensionValues dimensionValues;
 
     private Map<String, Object> values;
 
     private boolean frozen = false;
 
-    private final QueryProfile owner;
+    private QueryProfile owner;
 
     public QueryProfileVariant(DimensionValues dimensionValues, QueryProfile owner) {
         this.dimensionValues = dimensionValues;
@@ -59,16 +59,20 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
         return inherited;
     }
 
-    public Object set(String key, Object newValue) {
+    public void set(String key, Object newValue) {
         if (values == null)
             values = new HashMap<>();
 
         Object oldValue = values.get(key);
 
-        Object combinedOrNull = QueryProfile.combineValues(newValue, oldValue);
-        if (combinedOrNull != null)
-            values.put(key, combinedOrNull);
-        return combinedOrNull;
+        if (oldValue == null) {
+            values.put(key, newValue);
+        } else {
+            Object combinedOrNull = QueryProfile.combineValues(newValue, oldValue);
+            if (combinedOrNull != null) {
+                values.put(key, combinedOrNull);
+            }
+        }
     }
 
     public void inherit(QueryProfile profile) {
@@ -134,7 +138,6 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
         frozen=true;
     }
 
-    @Override
     public QueryProfileVariant clone() {
         if (frozen) return this;
        try {
@@ -153,7 +156,7 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
 
     @Override
     public String toString() {
-        return "query profile variant of " + owner + " for " + dimensionValues;
+        return "query profile variant for " + dimensionValues;
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/query/profile/test/QueryProfileVariantsTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/test/QueryProfileVariantsTestCase.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -72,57 +71,6 @@ public class QueryProfileVariantsTestCase {
         assertGet("a.1.*.5","a", new String[] {"x1","y?","z5"}, profile, cprofile);
         assertGet("a.1.5.*","a", new String[] {"x1","y5","z5"}, profile, cprofile); // Left dimension gets precedence
         assertGet("a.2.*.*","a", new String[] {"x2","y?","z?"}, profile, cprofile);
-    }
-
-    @Test
-    public void testReferenceInVariant() {
-        QueryProfileRegistry registry = new QueryProfileRegistry();
-        QueryProfile test = new QueryProfile("test");
-        test.setDimensions(new String[] { "d1" });
-        registry.register(test);
-
-        QueryProfile references = new QueryProfile("referenced");
-        references.setDimensions(new String[] { "d1" });
-        registry.register(references);
-
-        QueryProfile other = new QueryProfile("other");
-        other.setDimensions(new String[] { "d1" });
-        registry.register(other);
-
-        test.set( "a", references,  new String[] { "d1v"}, registry);
-        test.set( "a.b", "test-value",  new String[] { "d1v"}, registry);
-        other.set( "a", references,  new String[] { "d1v"}, registry);
-        other.set("a.b", "other-value", new String[] { "d1v"}, registry);
-
-        assertEquals("test-value", test.get("a.b", new String[] { "d1v"}));
-        assertEquals("other-value", other.get("a.b", new String[] { "d1v"}));
-        assertNull(references.get("b", new String[] { "d1v"}));
-
-        var cRegistry = registry.compile();
-        assertEquals("test-value",
-                     cRegistry.getComponent("test").get("a.b", Map.of("d1", "d1v")));
-    }
-
-    @Test
-    public void testReference() {
-        QueryProfileRegistry registry = new QueryProfileRegistry();
-        QueryProfile test = new QueryProfile("test");
-        registry.register(test);
-
-        QueryProfile references = new QueryProfile("referenced");
-        registry.register(references);
-
-        QueryProfile other = new QueryProfile("other");
-        registry.register(other);
-
-        test.set( "a", references, registry);
-        test.set( "a.b", "test-value", registry);
-        other.set( "a", references, registry);
-        other.set("a.b", "other-value", registry);
-
-        assertEquals("test-value", test.get("a.b"));
-        assertEquals("other-value", other.get("a.b"));
-        assertNull(references.get("b"));
     }
 
     @Test

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogManager.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogManager.java
@@ -26,11 +26,12 @@ class OsgiLogManager implements LogService {
         this.configureLogLevel = configureLogLevel;
     }
 
-    public void install(BundleContext osgiContext) {
+    @SuppressWarnings("unchecked")
+    public void install(final BundleContext osgiContext) {
         if (tracker != null) {
             throw new IllegalStateException("OsgiLogManager already installed.");
         }
-        tracker = new ServiceTracker<>(osgiContext, LogService.class, new ServiceTrackerCustomizer<>() {
+        tracker = new ServiceTracker<>(osgiContext, LogService.class, new ServiceTrackerCustomizer<LogService,LogService>() {
 
             @Override
             public LogService addingService(ServiceReference<LogService> reference) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#15180

Unit test fails with:
[ERROR]   QueryProfileVariantsTestCase.testConfigCreation2:35 expected:<...ryprofilevariant[0].[reference[0].name "model"