### PR TITLE
Add node state expiry metrics

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
@@ -8,9 +8,9 @@ import com.yahoo.vespa.hosted.provision.node.History;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 /**
  * Superclass of expiry tasks which moves nodes from some state to the dirty state.
@@ -28,8 +28,8 @@ public abstract class Expirer extends NodeRepositoryMaintainer {
     /** The event record type which contains the timestamp to use for expiry */
     private final History.Event.Type eventType;
 
+    private final Metric metric;
     private final Clock clock;
-
     private final Duration expiryTime;
 
     Expirer(Node.State fromState, History.Event.Type eventType, NodeRepository nodeRepository,
@@ -37,20 +37,23 @@ public abstract class Expirer extends NodeRepositoryMaintainer {
         super(nodeRepository, min(Duration.ofMinutes(10), expiryTime), metric);
         this.fromState = fromState;
         this.eventType = eventType;
+        this.metric = metric;
         this.clock = clock;
         this.expiryTime = expiryTime;
     }
 
     @Override
     protected boolean maintain() {
-        List<Node> expired = new ArrayList<>();
-        for (Node node : nodeRepository().getNodes(fromState)) {
-            if (isExpired(node))
-                expired.add(node);
-        }
-        if ( ! expired.isEmpty())
+        List<Node> expired = nodeRepository().getNodes(fromState).stream()
+                .filter(this::isExpired)
+                .collect(Collectors.toList());
+
+        if ( ! expired.isEmpty()) {
             log.info(fromState + " expirer found " + expired.size() + " expired nodes: " + expired);
-        expire(expired);
+            expire(expired);
+        }
+
+        metric.add("expired." + fromState, expired.size(), null);
         return true;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
@@ -32,6 +32,7 @@ public class ReservationExpirerTest {
         ProvisioningTester tester = new ProvisioningTester.Builder().flavors(flavors.getFlavors()).build();
         ManualClock clock = tester.clock();
         NodeRepository nodeRepository = tester.nodeRepository();
+        TestMetric metric = new TestMetric();
 
         NodeResources nodeResources = new NodeResources(2, 8, 50, 1);
         NodeResources hostResources = nodeResources.add(nodeResources).add(nodeResources);
@@ -47,7 +48,7 @@ public class ReservationExpirerTest {
 
         // Reservation times out
         clock.advance(Duration.ofMinutes(14)); // Reserved but not used time out
-        new ReservationExpirer(nodeRepository, clock, Duration.ofMinutes(10), new TestMetric()).run();
+        new ReservationExpirer(nodeRepository, clock, Duration.ofMinutes(10), metric).run();
 
         // Assert nothing is reserved
         assertEquals(0, nodeRepository.getNodes(NodeType.tenant, Node.State.reserved).size());
@@ -55,6 +56,7 @@ public class ReservationExpirerTest {
         assertEquals(2, dirty.size());
         assertFalse(dirty.get(0).allocation().isPresent());
         assertFalse(dirty.get(1).allocation().isPresent());
+        assertEquals(2, metric.values.get("expired.reserved"));
     }
 
 }


### PR DESCRIPTION
`expired.reserved` metric can be used to detect issues with provisioning, `expired.(provisioned|dirty)` could be used to detect issues with hosts.