### PR TITLE
Replace image atomically

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/DockerImage.java
@@ -14,16 +14,18 @@ import java.util.Optional;
 // TODO: Rename to ContainerImage. Compatibility with older config-models must be preserved.
 public class DockerImage {
 
-    public static final DockerImage EMPTY = new DockerImage("", "", Optional.empty());
+    public static final DockerImage EMPTY = new DockerImage("", "", Optional.empty(), Optional.empty());
 
     private final String registry;
     private final String repository;
     private final Optional<String> tag;
+    private final Optional<DockerImage> replacedBy;
 
-    DockerImage(String registry, String repository, Optional<String> tag) {
+    DockerImage(String registry, String repository, Optional<String> tag, Optional<DockerImage> replacedBy) {
         this.registry = Objects.requireNonNull(registry, "registry must be non-null");
         this.repository = Objects.requireNonNull(repository, "repository must be non-null");
         this.tag = Objects.requireNonNull(tag, "tag must be non-null");
+        this.replacedBy = Objects.requireNonNull(replacedBy);
     }
 
     /** Returns the registry-part of this, i.e. the host/port of the registry. */
@@ -38,7 +40,7 @@ public class DockerImage {
 
     /** Returns the registry and repository for this image, excluding its tag */
     public String untagged() {
-        return new DockerImage(registry, repository, Optional.empty()).asString();
+        return new DockerImage(registry, repository, Optional.empty(), replacedBy).asString();
     }
 
     /** Returns this image's tag, if any */
@@ -51,14 +53,24 @@ public class DockerImage {
         return tag.map(Version::new).orElse(Version.emptyVersion);
     }
 
+    /** The image that replaces this, if any */
+    public Optional<DockerImage> replacedBy() {
+        return replacedBy;
+    }
+
     /** Returns a copy of this tagged with the given version */
     public DockerImage withTag(Version version) {
-        return new DockerImage(registry, repository, Optional.of(version.toFullString()));
+        return new DockerImage(registry, repository, Optional.of(version.toFullString()), replacedBy);
     }
 
     /** Returns a copy of this with registry set to given value */
     public DockerImage withRegistry(String registry) {
-        return new DockerImage(registry, repository, tag);
+        return new DockerImage(registry, repository, tag, replacedBy);
+    }
+
+    /** Returns a copy of this with replacement image set to given value */
+    public DockerImage withReplacedBy(DockerImage image) {
+        return new DockerImage(registry, repository, tag, Optional.of(image).filter(i -> !i.equals(EMPTY)));
     }
 
     public String asString() {
@@ -78,16 +90,17 @@ public class DockerImage {
         DockerImage that = (DockerImage) o;
         return registry.equals(that.registry) &&
                repository.equals(that.repository) &&
-               tag.equals(that.tag);
+               tag.equals(that.tag) &&
+               replacedBy.equals(that.replacedBy);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(registry, repository, tag);
+        return Objects.hash(registry, repository, tag, replacedBy);
     }
 
     public static DockerImage from(String registry, String repository) {
-        return new DockerImage(registry, repository, Optional.empty());
+        return new DockerImage(registry, repository, Optional.empty(), Optional.empty());
     }
 
     public static DockerImage fromString(String s) {
@@ -101,11 +114,11 @@ public class DockerImage {
         if (repository.isEmpty()) throw new IllegalArgumentException("Repository must be non-empty in '" + s + "'");
 
         int tagStart = repository.indexOf(':');
-        if (tagStart < 0) return new DockerImage(registry, repository, Optional.empty());
+        if (tagStart < 0) return new DockerImage(registry, repository, Optional.empty(), Optional.empty());
 
         String tag = repository.substring(tagStart + 1);
         repository = repository.substring(0, tagStart);
-        return new DockerImage(registry, repository, Optional.of(tag));
+        return new DockerImage(registry, repository, Optional.of(tag), Optional.empty());
     }
 
 }

--- a/config-provisioning/src/main/resources/configdefinitions/config.provisioning.node-repository.def
+++ b/config-provisioning/src/main/resources/configdefinitions/config.provisioning.node-repository.def
@@ -4,6 +4,10 @@ namespace=config.provisioning
 # Default container image to use for nodes.
 containerImage string default="registry.example.com:9999/myorg/vespa"
 
+# A replacement container image to use for nodes. This is used to avoid nodes seeing different wanted images in the
+# transition to a new default image or registry.
+containerImageReplacement string default=""
+
 # Whether to cache data read from ZooKeeper in-memory.
 useCuratorClientCache bool default=false
 

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/DockerImageTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -19,10 +20,10 @@ public class DockerImageTest {
     public void parse() {
         Map<String, DockerImage> tests = Map.of(
                 "", DockerImage.EMPTY,
-                "registry.example.com:9999/vespa/vespa:7.42", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.of("7.42")),
-                "registry.example.com/vespa/vespa:7.42", new DockerImage("registry.example.com", "vespa/vespa", Optional.of("7.42")),
-                "registry.example.com:9999/vespa/vespa", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.empty()),
-                "registry.example.com/vespa/vespa", new DockerImage("registry.example.com", "vespa/vespa", Optional.empty())
+                "registry.example.com:9999/vespa/vespa:7.42", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.of("7.42"), Optional.empty()),
+                "registry.example.com/vespa/vespa:7.42", new DockerImage("registry.example.com", "vespa/vespa", Optional.of("7.42"), Optional.empty()),
+                "registry.example.com:9999/vespa/vespa", new DockerImage("registry.example.com:9999", "vespa/vespa", Optional.empty(), Optional.empty()),
+                "registry.example.com/vespa/vespa", new DockerImage("registry.example.com", "vespa/vespa", Optional.empty(), Optional.empty())
         );
         tests.forEach((value, expected) -> {
             DockerImage parsed = DockerImage.fromString(value);
@@ -50,6 +51,12 @@ public class DockerImageTest {
             } catch (IllegalArgumentException ignored) {
             }
         }
+    }
+
+    @Test
+    public void empty_replacement() {
+        DockerImage image = new DockerImage("foo.example.com", "vespa/vespa", Optional.of("7.42"), Optional.empty());
+        assertTrue(image.withReplacedBy(DockerImage.EMPTY).replacedBy().isEmpty());
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -127,7 +127,8 @@ public class NodeRepository extends AbstractComponent {
              Clock.systemUTC(),
              zone,
              new DnsNameResolver(),
-             DockerImage.fromString(config.containerImage()),
+             DockerImage.fromString(config.containerImage())
+                        .withReplacedBy(DockerImage.fromString(config.containerImageReplacement())),
              flagSource,
              config.useCuratorClientCache(),
              zone.environment().isProduction() && !zone.getCloud().dynamicProvisioning() ? 1 : 0,
@@ -144,7 +145,7 @@ public class NodeRepository extends AbstractComponent {
                           Clock clock,
                           Zone zone,
                           NameResolver nameResolver,
-                          DockerImage dockerImage,
+                          DockerImage containerImage,
                           FlagSource flagSource,
                           boolean useCuratorClientCache,
                           int spareCount,
@@ -164,7 +165,7 @@ public class NodeRepository extends AbstractComponent {
         this.osVersions = new OsVersions(this);
         this.infrastructureVersions = new InfrastructureVersions(db);
         this.firmwareChecks = new FirmwareChecks(db, clock);
-        this.containerImages = new ContainerImages(db, dockerImage);
+        this.containerImages = new ContainerImages(db, containerImage, flagSource);
         this.jobControl = new JobControl(new JobControlFlags(db, flagSource));
         this.applications = new Applications(db);
         this.spareCount = spareCount;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -89,11 +89,12 @@ public class ProvisioningTester {
     private int nextHost = 0;
     private int nextIP = 0;
 
-    public ProvisioningTester(Curator curator,
+    private ProvisioningTester(Curator curator,
                               NodeFlavors nodeFlavors,
                               HostResourcesCalculator resourcesCalculator,
                               Zone zone,
                               NameResolver nameResolver,
+                              DockerImage containerImage,
                               Orchestrator orchestrator,
                               HostProvisioner hostProvisioner,
                               LoadBalancerServiceMock loadBalancerService,
@@ -109,7 +110,7 @@ public class ProvisioningTester {
                                                  clock,
                                                  zone,
                                                  nameResolver,
-                                                 DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
+                                                 containerImage,
                                                  flagSource,
                                                  true,
                                                  spareCount,
@@ -596,9 +597,9 @@ public class ProvisioningTester {
         private NameResolver nameResolver;
         private Orchestrator orchestrator;
         private HostProvisioner hostProvisioner;
-        private LoadBalancerServiceMock loadBalancerService;
         private FlagSource flagSource;
         private int spareCount = 0;
+        private DockerImage defaultImage = DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa");
 
         public Builder curator(Curator curator) {
             this.curator = curator;
@@ -636,6 +637,11 @@ public class ProvisioningTester {
             return this;
         }
 
+        public Builder defaultImage(DockerImage defaultImage) {
+            this.defaultImage = defaultImage;
+            return this;
+        }
+
         public Builder orchestrator(Orchestrator orchestrator) {
             this.orchestrator = orchestrator;
             return this;
@@ -643,11 +649,6 @@ public class ProvisioningTester {
 
         public Builder hostProvisioner(HostProvisioner hostProvisioner) {
             this.hostProvisioner = hostProvisioner;
-            return this;
-        }
-
-        public Builder loadBalancerService(LoadBalancerServiceMock loadBalancerService) {
-            this.loadBalancerService = loadBalancerService;
             return this;
         }
 
@@ -678,9 +679,10 @@ public class ProvisioningTester {
                                           resourcesCalculator,
                                           Optional.ofNullable(zone).orElseGet(Zone::defaultZone),
                                           Optional.ofNullable(nameResolver).orElseGet(() -> new MockNameResolver().mockAnyLookup()),
+                                          defaultImage,
                                           orchestrator,
                                           hostProvisioner,
-                                          Optional.ofNullable(loadBalancerService).orElseGet(LoadBalancerServiceMock::new),
+                                          new LoadBalancerServiceMock(),
                                           Optional.ofNullable(flagSource).orElseGet(InMemoryFlagSource::new),
                                           spareCount);
         }


### PR DESCRIPTION
This should allow us to switch registry across all config servers atomically.

Since each zone has its own registry, we need to use config to communicate the
new registry.

@tokle and @freva