### PR TITLE
Kkraune/autoscale debug

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Autoscaler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Autoscaler.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.hosted.provision.applications.Cluster;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * The autoscaler makes decisions about the flavor and node count that should be allocated to a cluster
@@ -18,6 +19,8 @@ import java.util.Optional;
  * @author bratseth
  */
 public class Autoscaler {
+
+    protected final Logger log = Logger.getLogger(this.getClass().getName());
 
     /** What cost difference factor is worth a reallocation? */
     private static final double costDifferenceWorthReallocation = 0.1;
@@ -57,7 +60,12 @@ public class Autoscaler {
     }
 
     private Advice autoscale(Cluster cluster, List<Node> clusterNodes, Limits limits, boolean exclusive) {
-        if (unstable(clusterNodes, nodeRepository)) return Advice.none();
+        log.fine(() -> "Autoscale " + cluster.toString());
+
+        if (unstable(clusterNodes, nodeRepository)) {
+            log.fine(() -> "Unstable - Advice.none " + cluster.toString());
+            return Advice.none();
+        }
 
         AllocatableClusterResources currentAllocation = new AllocatableClusterResources(clusterNodes, nodeRepository);
 
@@ -66,13 +74,22 @@ public class Autoscaler {
         Optional<Double> cpuLoad    = clusterTimeseries.averageLoad(Resource.cpu);
         Optional<Double> memoryLoad = clusterTimeseries.averageLoad(Resource.memory);
         Optional<Double> diskLoad   = clusterTimeseries.averageLoad(Resource.disk);
-        if (cpuLoad.isEmpty() || memoryLoad.isEmpty() || diskLoad.isEmpty()) return Advice.none();
+        if (cpuLoad.isEmpty() || memoryLoad.isEmpty() || diskLoad.isEmpty()) {
+            log.fine(() -> "Missing average load - Advice.none  " + cluster.toString());
+            return Advice.none();
+        }
         var target = ResourceTarget.idealLoad(cpuLoad.get(), memoryLoad.get(), diskLoad.get(), currentAllocation);
 
         Optional<AllocatableClusterResources> bestAllocation =
                 allocationOptimizer.findBestAllocation(target, currentAllocation, limits, exclusive);
-        if (bestAllocation.isEmpty()) return Advice.dontScale();
-        if (similar(bestAllocation.get(), currentAllocation)) return Advice.dontScale();
+        if (bestAllocation.isEmpty()) {
+            log.fine(() -> "bestAllocation.isEmpty - Advice.dontScale " + cluster.toString());
+            return Advice.dontScale();
+        }
+        if (similar(bestAllocation.get(), currentAllocation)) {
+            log.fine(() -> "Current allocation similar - Advice.dontScale " + cluster.toString());
+            return Advice.dontScale();
+        }
         return Advice.scaleTo(bestAllocation.get().toAdvertisedClusterResources());
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
@@ -17,6 +17,7 @@ import com.yahoo.vespa.hosted.provision.autoscale.MetricsDb;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -94,7 +95,7 @@ public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
     }
 
     static String toString(ClusterResources r) {
-        return String.format("%d%s * [vcpu: %.1f, memory: %.1f Gb, disk %.1f Gb]" +
+        return String.format(Locale.US, "%d%s * [vcpu: %.1f, memory: %.1f Gb, disk %.1f Gb]" +
                              " (total: [vcpu: %.1f, memory: %.1f Gb, disk: %.1f Gb])",
                              r.nodes(), r.groups() > 1 ? " (in " + r.groups() + " groups)" : "",
                              r.nodeResources().vcpu(), r.nodeResources().memoryGb(), r.nodeResources().diskGb(),


### PR DESCRIPTION
Autoscale decisions are hard to debug when no autoscale happens - is it running, why does it not autoscale? I suggest we add debug logging for now.

Should maybe add a 'reason' enum to Advice and log on outside of autoscale instead?
