### PR TITLE
Revert "Use a hash_set<int32_t> to quickly check if a field is an index field."

### DIFF
--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -355,7 +355,7 @@ struct MyAttributeWriter : public IAttributeWriter
         _updateLid = lid;
         for (const auto & fieldUpdate : upd.getUpdates()) {
             search::AttributeVector * attr = getWritableAttribute(fieldUpdate.getField().getName());
-            onUpdate.onUpdateField(fieldUpdate.getField(), attr);
+            onUpdate.onUpdateField(fieldUpdate.getField().getName(), attr);
         }
     }
     void update(SerialNum serialNum, const document::Document &doc, DocumentIdT lid, OnWriteDoneType) override {

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -680,7 +680,7 @@ AttributeWriter::update(SerialNum serialNum, const DocumentUpdate &upd, Document
         LOG(debug, "Retrieving guard for attribute vector '%s'.", fupd.getField().getName().data());
         auto found = _attrMap.find(fupd.getField().getName());
         AttributeVector * attrp = (found != _attrMap.end()) ? found->second.first : nullptr;
-        onUpdate.onUpdateField(fupd.getField(), attrp);
+        onUpdate.onUpdateField(fupd.getField().getName(), attrp);
         if (__builtin_expect(attrp == nullptr, false)) {
             LOG(spam, "Failed to find attribute vector %s", fupd.getField().getName().data());
             continue;

--- a/searchcore/src/vespa/searchcore/proton/attribute/ifieldupdatecallback.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/ifieldupdatecallback.h
@@ -5,17 +5,16 @@
 #include <vespa/vespalib/stllike/string.h>
 
 namespace search { class AttributeVector; }
-namespace document { class Field; }
 
 namespace proton {
 
 struct IFieldUpdateCallback {
-    virtual ~IFieldUpdateCallback() = default;
-    virtual void onUpdateField(const document::Field & field, const search::AttributeVector * attr) = 0;
+    virtual ~IFieldUpdateCallback() { }
+    virtual void onUpdateField(vespalib::stringref fieldName, const search::AttributeVector * attr) = 0;
 };
 
 struct DummyFieldUpdateCallback : IFieldUpdateCallback {
-    void onUpdateField(const document::Field & , const search::AttributeVector *) override {}
+    void onUpdateField(vespalib::stringref, const search::AttributeVector *) override {}
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
@@ -34,7 +34,7 @@ SearchableFeedView::SearchableFeedView(StoreOnlyFeedView::Context storeOnlyCtx, 
                                        const FastAccessFeedView::Context &fastUpdateCtx, Context ctx)
     : Parent(std::move(storeOnlyCtx), params, fastUpdateCtx),
       _indexWriter(ctx._indexWriter),
-      _hasIndexedFields(getSchema()->getNumIndexFields() > 0)
+      _hasIndexedFields(_schema->getNumIndexFields() > 0)
 { }
 
 SearchableFeedView::~SearchableFeedView() = default;


### PR DESCRIPTION
Reverts vespa-engine/vespa#15223

22 failing system tests after this PR:
Nov 09 11:00:44 terminate called after throwing an instance of 'document::FieldNotFoundException'
level=warning host=systest119.head.factory.vespa.corp.gq1.yahoo.com pid=9510 service=searchnode component=stderr 
Nov 09 11:00:44
  what():  FieldNotFoundException: Field with name surl.fragment not found at getField in /sd/workspace/src/git.vzbuilders.com/vespa/vespa/document/src/vespa/document/datatype/structdatatype.cpp:129
level=warning host=systest119.head.factory.vespa.corp.gq1.yahoo.com pid=9510 service=searchnode component=stderr 