### PR TITLE
Use 8 bits as minimum for "legacy" distribution type

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributionBitCalculator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributionBitCalculator.java
@@ -31,9 +31,7 @@ public class DistributionBitCalculator {
                 return 24;
             }
         } else if (mode == ContentCluster.DistributionMode.LEGACY) {
-            if (nodes == 1) {             // min 1 bucket/node
-                return 1;
-            } else if (nodes == 2) {      // min 128 buckets/node
+            if (nodes <= 2) {             // min 128 buckets/node
                 return 8;
             } else if (nodes <= 6) {      // min 5462 buckets/node
                 return 14;

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
@@ -122,9 +122,13 @@ public class DistributorTest {
                 "    <distribution partitions=\"1|*\"/>" +
                 "    <group name=\"a\" distribution-key=\"0\">" +
                 "       <node distribution-key=\"0\" hostalias=\"mockhost\"/>" +
+                "       <node distribution-key=\"1\" hostalias=\"mockhost\"/>" +
+                "       <node distribution-key=\"2\" hostalias=\"mockhost\"/>" +
                 "    </group>" +
                 "    <group name=\"b\" distribution-key=\"1\">" +
-                "       <node distribution-key=\"1\" hostalias=\"mockhost\"/>" +
+                "       <node distribution-key=\"3\" hostalias=\"mockhost\"/>" +
+                "       <node distribution-key=\"4\" hostalias=\"mockhost\"/>" +
+                "       <node distribution-key=\"5\" hostalias=\"mockhost\"/>" +
                 "    </group>" +
                 "  </group>" +
                 "</cluster>");
@@ -136,7 +140,7 @@ public class DistributorTest {
         assertEquals(512, conf.joincount());
         assertEquals(33544432, conf.splitsize());
         assertEquals(16000000, conf.joinsize());
-        assertEquals(1, conf.minsplitcount());
+        assertEquals(14, conf.minsplitcount());
         assertTrue(conf.inlinebucketsplitting());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/storage/DistributionBitCalculatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/storage/DistributionBitCalculatorTest.java
@@ -27,7 +27,7 @@ public class DistributionBitCalculatorTest {
         assertEquals(24, DistributionBitCalculator.getDistributionBits(2500, mode));
 
         mode = ContentCluster.DistributionMode.LEGACY;
-        assertEquals( 1, DistributionBitCalculator.getDistributionBits(1, mode));
+        assertEquals( 8, DistributionBitCalculator.getDistributionBits(1, mode));
         assertEquals(14, DistributionBitCalculator.getDistributionBits(4, mode));
         assertEquals(19, DistributionBitCalculator.getDistributionBits(16, mode));
         assertEquals(23, DistributionBitCalculator.getDistributionBits(200, mode));


### PR DESCRIPTION
@geirst please review

No one should use this anyway, but since it's currently possible to
configure, enforce a minimum distribution bit amount.

