### PR TITLE
Add basic exact matching support for X509 URI SANs 

### DIFF
--- a/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
+++ b/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
@@ -8,7 +8,7 @@ using namespace vespalib;
 using namespace vespalib::net::tls;
 
 bool glob_matches(vespalib::stringref pattern, vespalib::stringref string_to_check) {
-    auto glob = HostGlobPattern::create_from_glob(pattern);
+    auto glob = CredentialMatchPattern::create_from_glob(pattern);
     return glob->matches(string_to_check);
 }
 
@@ -61,9 +61,22 @@ TEST("special extended regex characters are ignored") {
 }
 
 // TODO CN + SANs
+PeerCredentials creds_with_sans(std::vector<vespalib::string> dns_sans, std::vector<vespalib::string> uri_sans) {
+    PeerCredentials creds;
+    creds.dns_sans = std::move(dns_sans);
+    creds.uri_sans = std::move(uri_sans);
+    return creds;
+}
+
 PeerCredentials creds_with_dns_sans(std::vector<vespalib::string> dns_sans) {
     PeerCredentials creds;
     creds.dns_sans = std::move(dns_sans);
+    return creds;
+}
+
+PeerCredentials creds_with_uri_sans(std::vector<vespalib::string> uri_sans) {
+    PeerCredentials creds;
+    creds.uri_sans = std::move(uri_sans);
     return creds;
 }
 
@@ -93,7 +106,7 @@ TEST("Non-empty policies do not allow all authenticated peers") {
     EXPECT_FALSE(allow_not_all.allows_all_authenticated());
 }
 
-TEST("SAN requirement without glob pattern is matched as exact string") {
+TEST("DNS SAN requirement without glob pattern is matched as exact string") {
     auto authorized = authorized_peers({policy_with({required_san_dns("hello.world")})});
     EXPECT_TRUE(verify(authorized,  creds_with_dns_sans({{"hello.world"}})));
     EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"foo.bar"}})));
@@ -103,7 +116,7 @@ TEST("SAN requirement without glob pattern is matched as exact string") {
     EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"hello.world.bar"}})));
 }
 
-TEST("SAN requirement can include glob wildcards") {
+TEST("DNS SAN requirement can include glob wildcards") {
     auto authorized = authorized_peers({policy_with({required_san_dns("*.w?rld")})});
     EXPECT_TRUE(verify(authorized,  creds_with_dns_sans({{"hello.world"}})));
     EXPECT_TRUE(verify(authorized,  creds_with_dns_sans({{"greetings.w0rld"}})));
@@ -111,23 +124,40 @@ TEST("SAN requirement can include glob wildcards") {
     EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"world"}})));
 }
 
-TEST("multi-SAN policy requires all SANs to be present in certificate") {
-    auto authorized = authorized_peers({policy_with({required_san_dns("hello.world"),
-                                                     required_san_dns("foo.bar")})});
-    EXPECT_TRUE(verify(authorized,  creds_with_dns_sans({{"hello.world"}, {"foo.bar"}})));
-    // Need both
-    EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"hello.world"}})));
-    EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"foo.bar"}})));
-    // OK with more SANs that strictly required
-    EXPECT_TRUE(verify(authorized,  creds_with_dns_sans({{"hello.world"}, {"foo.bar"}, {"baz.blorg"}})));
+// FIXME make this RFC 2459-compliant with subdomain matching, case insensitity for host etc
+TEST("URI SAN requirement is matched as exact string in cheeky, pragmatic violation of RFC 2459") {
+    auto authorized = authorized_peers({policy_with({required_san_uri("foo://bar.baz/zoid")})});
+    EXPECT_TRUE(verify(authorized,  creds_with_uri_sans({{"foo://bar.baz/zoid"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"foo://bar.baz/zoi"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"oo://bar.baz/zoid"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"bar://bar.baz/zoid"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"foo://bar.baz"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"foo://.baz/zoid"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_uri_sans({{"foo://BAR.baz/zoid"}})));
 }
 
-TEST("wildcard SAN in certificate is not treated as a wildcard match by policy") {
+TEST("multi-SAN policy requires all SANs to be present in certificate") {
+    auto authorized = authorized_peers({policy_with({required_san_dns("hello.world"),
+                                                     required_san_dns("foo.bar"),
+                                                     required_san_uri("foo://bar/baz")})});
+    EXPECT_TRUE(verify(authorized, creds_with_sans({{"hello.world"}, {"foo.bar"}}, {{"foo://bar/baz"}})));
+    // Need all
+    EXPECT_FALSE(verify(authorized, creds_with_sans({{"hello.world"}, {"foo.bar"}}, {})));
+    EXPECT_FALSE(verify(authorized, creds_with_sans({{"hello.world"}}, {{"foo://bar/baz"}})));
+    EXPECT_FALSE(verify(authorized, creds_with_sans({{"hello.world"}}, {})));
+    EXPECT_FALSE(verify(authorized, creds_with_sans({{"foo.bar"}}, {})));
+    EXPECT_FALSE(verify(authorized, creds_with_sans({}, {{"foo://bar/baz"}})));
+    // OK with more SANs that strictly required
+    EXPECT_TRUE(verify(authorized,  creds_with_sans({{"hello.world"}, {"foo.bar"}, {"baz.blorg"}},
+                                                    {{"foo://bar/baz"}, {"hello://world/"}})));
+}
+
+TEST("wildcard DNS SAN in certificate is not treated as a wildcard match by policy") {
     auto authorized = authorized_peers({policy_with({required_san_dns("hello.world")})});
     EXPECT_FALSE(verify(authorized, creds_with_dns_sans({{"*.world"}})));
 }
 
-TEST("wildcard SAN in certificate is still matched by wildcard policy SAN") {
+TEST("wildcard DNS SAN in certificate is still matched by wildcard policy SAN") {
     auto authorized = authorized_peers({policy_with({required_san_dns("*.world")})});
     EXPECT_TRUE(verify(authorized, creds_with_dns_sans({{"*.world"}})));
 }
@@ -141,7 +171,8 @@ struct MultiPolicyMatchFixture {
 MultiPolicyMatchFixture::MultiPolicyMatchFixture()
     : authorized(authorized_peers({policy_with({required_san_dns("hello.world")}),
                                    policy_with({required_san_dns("foo.bar")}),
-                                   policy_with({required_san_dns("zoid.berg")})}))
+                                   policy_with({required_san_dns("zoid.berg")}),
+                                   policy_with({required_san_uri("zoid://be.rg/")})}))
 {}
 
 MultiPolicyMatchFixture::~MultiPolicyMatchFixture() = default;
@@ -150,6 +181,7 @@ TEST_F("peer verifies if it matches at least 1 policy of multiple", MultiPolicyM
     EXPECT_TRUE(verify(f.authorized, creds_with_dns_sans({{"hello.world"}})));
     EXPECT_TRUE(verify(f.authorized, creds_with_dns_sans({{"foo.bar"}})));
     EXPECT_TRUE(verify(f.authorized, creds_with_dns_sans({{"zoid.berg"}})));
+    EXPECT_TRUE(verify(f.authorized, creds_with_uri_sans({{"zoid://be.rg/"}})));
 }
 
 TEST_F("peer verifies if it matches multiple policies", MultiPolicyMatchFixture) {

--- a/vespalib/src/tests/net/tls/transport_options/transport_options_reading_test.cpp
+++ b/vespalib/src/tests/net/tls/transport_options/transport_options_reading_test.cpp
@@ -111,10 +111,12 @@ TEST("can parse single peer policy with multiple requirements") {
     const char* json = R"({
       "required-credentials":[
          {"field": "SAN_DNS", "must-match": "hello.world"},
+         {"field": "SAN_URI", "must-match": "foo://bar/baz"},
          {"field": "CN", "must-match": "goodbye.moon"}
       ]
     })";
     EXPECT_EQUAL(authorized_peers({policy_with({required_san_dns("hello.world"),
+                                                required_san_uri("foo://bar/baz"),
                                                 required_cn("goodbye.moon")})}),
                  parse_policies(json).authorized_peers());
 }

--- a/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
@@ -14,6 +14,8 @@ struct PeerCredentials {
     vespalib::string common_name;
     // 0-n DNS SAN entries. Note: "DNS:" prefix is not present in strings.
     std::vector<vespalib::string> dns_sans;
+    // 0-n DNS URI entries. Note: "URI:" prefix is not present in strings.
+    std::vector<vespalib::string> uri_sans;
 
     PeerCredentials();
     ~PeerCredentials();

--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
@@ -8,22 +8,23 @@
 
 namespace vespalib::net::tls {
 
-struct HostGlobPattern {
-    virtual ~HostGlobPattern() = default;
+struct CredentialMatchPattern {
+    virtual ~CredentialMatchPattern() = default;
     [[nodiscard]] virtual bool matches(vespalib::stringref str) const = 0;
 
-    static std::shared_ptr<const HostGlobPattern> create_from_glob(vespalib::stringref pattern);
+    static std::shared_ptr<const CredentialMatchPattern> create_from_glob(vespalib::stringref pattern);
+    static std::shared_ptr<const CredentialMatchPattern> create_exact_match(vespalib::stringref pattern);
 };
 
 class RequiredPeerCredential {
 public:
     enum class Field {
-        CN, SAN_DNS
+        CN, SAN_DNS, SAN_URI
     };
 private:
     Field _field = Field::SAN_DNS;
     vespalib::string _original_pattern;
-    std::shared_ptr<const HostGlobPattern> _match_pattern;
+    std::shared_ptr<const CredentialMatchPattern> _match_pattern;
 public:
     RequiredPeerCredential() = default;
     RequiredPeerCredential(Field field, vespalib::string must_match_pattern);

--- a/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
@@ -6,8 +6,17 @@ namespace vespalib::net::tls {
 
 namespace {
 
-bool matches_single_san_requirement(const PeerCredentials& peer_creds, const RequiredPeerCredential& requirement) {
+bool matches_single_san_dns_requirement(const PeerCredentials& peer_creds, const RequiredPeerCredential& requirement) {
     for (const auto& provided_cred : peer_creds.dns_sans) {
+        if (requirement.matches(provided_cred)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool matches_single_san_uri_requirement(const PeerCredentials& peer_creds, const RequiredPeerCredential& requirement) {
+    for (const auto& provided_cred : peer_creds.uri_sans) {
         if (requirement.matches(provided_cred)) {
             return true;
         }
@@ -23,7 +32,12 @@ bool matches_all_policy_requirements(const PeerCredentials& peer_creds, const Pe
     for (const auto& required_cred : policy.required_peer_credentials()) {
         switch (required_cred.field()) {
         case RequiredPeerCredential::Field::SAN_DNS:
-            if (!matches_single_san_requirement(peer_creds, required_cred)) {
+            if (!matches_single_san_dns_requirement(peer_creds, required_cred)) {
+                return false;
+            }
+            continue;
+        case RequiredPeerCredential::Field::SAN_URI:
+            if (!matches_single_san_uri_requirement(peer_creds, required_cred)) {
                 return false;
             }
             continue;

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options_reading.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options_reading.cpp
@@ -57,6 +57,8 @@ RequiredPeerCredential parse_peer_credential(const Inspector& req_entry) {
         field = RequiredPeerCredential::Field::CN;
     } else if (field_string == "SAN_DNS") {
         field = RequiredPeerCredential::Field::SAN_DNS;
+    } else if (field_string == "SAN_URI") {
+        field = RequiredPeerCredential::Field::SAN_URI;
     } else {
         throw IllegalArgumentException(make_string(
                 "Unsupported credential field type: '%s'. Supported are: CN, SAN_DNS",

--- a/vespalib/src/vespa/vespalib/test/peer_policy_utils.cpp
+++ b/vespalib/src/vespa/vespalib/test/peer_policy_utils.cpp
@@ -12,6 +12,10 @@ RequiredPeerCredential required_san_dns(vespalib::stringref pattern) {
     return {RequiredPeerCredential::Field::SAN_DNS, pattern};
 }
 
+RequiredPeerCredential required_san_uri(vespalib::stringref pattern) {
+    return {RequiredPeerCredential::Field::SAN_URI, pattern};
+}
+
 PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds) {
     return PeerPolicy(std::move(creds));
 }

--- a/vespalib/src/vespa/vespalib/test/peer_policy_utils.h
+++ b/vespalib/src/vespa/vespalib/test/peer_policy_utils.h
@@ -7,6 +7,7 @@ namespace vespalib::net::tls {
 
 RequiredPeerCredential required_cn(vespalib::stringref pattern);
 RequiredPeerCredential required_san_dns(vespalib::stringref pattern);
+RequiredPeerCredential required_san_uri(vespalib::stringref pattern);
 PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds);
 AuthorizedPeers authorized_peers(std::vector<PeerPolicy> peer_policies);
 


### PR DESCRIPTION
@havardpe and @bjorncs please review

Adds extraction of X509 URI peer credentials during the handshake
process as well as a new SAN_URI field to the transport security
options peer policy section.

This implementation is NOT conformant with RFC 2459 since we don't
currently support case insensitive matching of scheme, host etc.,
but it's good enough for our purposes for now.
