### PR TITLE
Use port 19071 instead for config server/controller logs 

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -1023,7 +1023,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         // most applications under hosted-vespa are not known to the model and it's OK for a user to get
         // logs for any host if they are authorized for the hosted-vespa tenant.
         if (hostname.isPresent() && HOSTED_VESPA_TENANT.equals(applicationId.tenant())) {
-            int port = List.of("zone-config-servers", "controller").contains(applicationId.application().value()) ? 4443 : 8080;
+            int port = List.of("zone-config-servers", "controller").contains(applicationId.application().value()) ? 19071 : 8080;
             return "http://" + hostname.get() + ":" + port + "/logs";
         }
 


### PR DESCRIPTION
Since 4443 is exposed to the world on controllers, we cant use that as the `/logs` is not exposed there