### PR TITLE
Fix thread lock detection bug 

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
@@ -30,7 +30,7 @@ public class StripedExecutor<Key> {
 
     /** Creates a new StripedExecutor which delegates to a {@link Executors#newCachedThreadPool(ThreadFactory)}. */
     public StripedExecutor() {
-        this(Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory(StripedExecutor.class.getName())));
+        this(Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory(StripedExecutor.class.getSimpleName())));
     }
 
     /** Creates a new StripedExecutor which delegates to the given executor service. */

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/ThreadLockStats.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/ThreadLockStats.java
@@ -189,7 +189,7 @@ public class ThreadLockStats {
             if (threadAcquiringLockPath == threadHoldingLockPath) {
                 // reentry
                 return;
-            } else if (threadsAcquiring.contains(threadAcquiringLockPath)) {
+            } else if (threadsAcquiring.contains(threadHoldingLockPath)) {
                 // deadlock
                 getGlobalLockMetrics(pathToAcquire).incrementDeadlockCount();
                 logger.warning(errorMessage.toString());
@@ -201,7 +201,7 @@ public class ThreadLockStats {
                 return;
             }
 
-            threadsAcquiring.add(threadHoldingLockPath);
+            threadsAcquiring.add(threadAcquiringLockPath);
             lockPath = nextLockPath.get();
             threadAcquiringLockPath = threadHoldingLockPath;
         }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/ThreadLockStats.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/ThreadLockStats.java
@@ -181,15 +181,16 @@ public class ThreadLockStats {
             }
 
             Thread threadHoldingLockPath = threadLockStats.get().thread;
+            if (threadAcquiringLockPath == threadHoldingLockPath) {
+                // reentry
+                return;
+            }
+
             errorMessage.append(", trying to acquire lock ")
                         .append(lockPath)
                         .append(" held by thread ")
                         .append(threadHoldingLockPath.getName());
-
-            if (threadAcquiringLockPath == threadHoldingLockPath) {
-                // reentry
-                return;
-            } else if (threadsAcquiring.contains(threadHoldingLockPath)) {
+            if (threadsAcquiring.contains(threadHoldingLockPath)) {
                 // deadlock
                 getGlobalLockMetrics(pathToAcquire).incrementDeadlockCount();
                 logger.warning(errorMessage.toString());


### PR DESCRIPTION
The effect of the bug was that a deadlock would be reported as long as the
current thread T0 that tries to acquire the ZK path P0 is in the following
situation:
  1. Thread T0 tries to acquire ZK path P0, held by T1.
  2. Thread T1 tries to acquire ZK path P1, held by T2.

Instead, T2 would need to equal T0.  Or,
  3. Thread T2 tries to acquire ZK path P2, held by T3 = one of (T0, T1).
etc.