### PR TITLE
Enforce minimum 8 configured distributor split bits

### DIFF
--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -1188,4 +1188,15 @@ TEST_F(DistributorTest, prioritize_global_bucket_merges_config_is_propagated_to_
     EXPECT_FALSE(getConfig().prioritize_global_bucket_merges());
 }
 
+TEST_F(DistributorTest, wanted_split_bit_count_is_lower_bounded) {
+    createLinks();
+    setupDistributor(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    ConfigBuilder builder;
+    builder.minsplitcount = 7;
+    configureDistributor(builder);
+
+    EXPECT_EQ(getConfig().getMinimalBucketSplit(), 8);
+}
+
 }

--- a/storage/src/vespa/storage/common/bucket_limits.h
+++ b/storage/src/vespa/storage/common/bucket_limits.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace storage {
+
+/**
+ * Wrapper of constants that specify absolute lower and upper bounds for buckets
+ * that are to be processed on a node. These invariants must be maintained by
+ * split and join operations, as well as bucket creation.
+ */
+struct BucketLimits {
+    constexpr static uint8_t MinUsedBits = 8;
+    constexpr static uint8_t MaxUsedBits = 58;
+};
+
+}

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -2,6 +2,7 @@
 #include "distributorconfiguration.h"
 #include <vespa/document/select/parser.h>
 #include <vespa/document/select/traversingvisitor.h>
+#include <vespa/storage/common/bucket_limits.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <sstream>
 
@@ -125,7 +126,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _docCountSplitLimit = config.splitcount;
     _byteCountJoinLimit = config.joinsize;
     _docCountJoinLimit = config.joincount;
-    _minimalBucketSplit = config.minsplitcount;
+    _minimalBucketSplit = std::max(config.minsplitcount, static_cast<int>(BucketLimits::MinUsedBits));
     _maxNodesPerMerge = config.maximumNodesPerMerge;
     _max_consecutively_inhibited_maintenance_ticks = config.maxConsecutivelyInhibitedMaintenanceTicks;
 


### PR DESCRIPTION
@geirst please review

Even if the config model's distribution type now enforces a minimum
of 8 bits, it's still possible to violate this with explicit config
overrides. Ensure that we have a hard limit internally to be safe
even against this.