### PR TITLE
avoid spurious warnings when shutdown happens before successful listen

### DIFF
--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
@@ -107,7 +107,9 @@ void SharedRpcResources::wait_until_slobrok_is_ready() {
 
 void SharedRpcResources::shutdown() {
     assert(!_shutdown);
-    _slobrok_register->unregisterName(_handle);
+    if (listen_port() > 0) {
+        _slobrok_register->unregisterName(_handle);
+    }
     _transport->ShutDown(true);
     _shutdown = true;
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli @baldersheim please review and merge
