### PR TITLE
Enforce minimum bucked used bits at document metastore load time

### DIFF
--- a/persistence/src/vespa/persistence/spi/bucket_limits.h
+++ b/persistence/src/vespa/persistence/spi/bucket_limits.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 
-namespace storage {
+namespace storage::spi {
 
 /**
  * Wrapper of constants that specify absolute lower and upper bounds for buckets

--- a/searchcore/src/tests/proton/documentmetastore/.gitignore
+++ b/searchcore/src/tests/proton/documentmetastore/.gitignore
@@ -3,4 +3,5 @@ Makefile
 gidmapattribute_test
 /documentmetastore2.dat
 /documentmetastore3.dat
+/documentmetastore4.dat
 searchcore_documentmetastore_test_app

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -5,6 +5,7 @@
 #include "operation_listener.h"
 #include "search_context.h"
 #include <vespa/fastos/file.h>
+#include <vespa/persistence/spi/bucket_limits.h>
 #include <vespa/searchcore/proton/bucketdb/bucketsessionbase.h>
 #include <vespa/searchcore/proton/bucketdb/joinbucketssession.h>
 #include <vespa/searchcore/proton/bucketdb/splitbucketsession.h>
@@ -102,7 +103,7 @@ public:
 
     uint8_t
     getNextBucketUsedBits() {
-        return _bucketUsedBitsReader.readHostOrder();
+        return std::max(_bucketUsedBitsReader.readHostOrder(), storage::spi::BucketLimits::MinUsedBits);
     }
 
     Timestamp

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -2,7 +2,7 @@
 #include "distributorconfiguration.h"
 #include <vespa/document/select/parser.h>
 #include <vespa/document/select/traversingvisitor.h>
-#include <vespa/storage/common/bucket_limits.h>
+#include <vespa/persistence/spi/bucket_limits.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <sstream>
 
@@ -126,7 +126,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _docCountSplitLimit = config.splitcount;
     _byteCountJoinLimit = config.joinsize;
     _docCountJoinLimit = config.joincount;
-    _minimalBucketSplit = std::max(config.minsplitcount, static_cast<int>(BucketLimits::MinUsedBits));
+    _minimalBucketSplit = std::max(config.minsplitcount, static_cast<int>(spi::BucketLimits::MinUsedBits));
     _maxNodesPerMerge = config.maximumNodesPerMerge;
     _max_consecutively_inhibited_maintenance_ticks = config.maxConsecutivelyInhibitedMaintenanceTicks;
 


### PR DESCRIPTION
@toregge and @geirst please review
