### PR TITLE
Do not run in standalone compatibility mode for single ZooKeeper servers

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -90,6 +90,7 @@ public class Configurator {
         // Need NettyServerCnxnFactory to be able to use TLS for communication
         sb.append("serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory").append("\n");
         sb.append("quorumListenOnAllIPs=true").append("\n");
+        sb.append("standaloneEnabled=false").append("\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
         config.server().forEach(server -> addServerToCfg(sb, server));
         SSLContext sslContext = new SslContextBuilder().build();

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.zookeeper;
 
 import com.yahoo.cloud.config.ZookeeperServerConfig;
@@ -175,7 +175,8 @@ public class ConfiguratorTest {
                "4lw.commands.whitelist=conf,cons,crst,dirs,dump,envi,mntr,ruok,srst,srvr,stat,wchs\n" +
                "admin.enableServer=false\n" +
                "serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory\n" +
-               "quorumListenOnAllIPs=true\n";
+               "quorumListenOnAllIPs=true\n" +
+               "standaloneEnabled=false\n";
     }
 
     private String quorumKeyStoreAndTrustStoreConfig(File jksKeyStoreFilePath, File caCertificatesFilePath) {


### PR DESCRIPTION
Always run in distrbuted mode, allows cluster to grow, and old setting
is deprecated


