### PR TITLE
Revert "Use thread safe arrays too"

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/HeaderFields.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/HeaderFields.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * This is an encapsulation of the header fields that belong to either a {@link Request} or a {@link Response}. It is
@@ -141,13 +140,14 @@ public class HeaderFields implements Map<String, List<String>> {
      *         <code>key</code>.
      */
     public List<String> put(String key, String value) {
-        List<String> list = new CopyOnWriteArrayList<>(List.of(value));
+        ArrayList<String> list = new ArrayList<String>(1);
+        list.add(value);
         return content.put(key, list);
     }
 
     @Override
     public List<String> put(String key, List<String> value) {
-        return content.put(key, new CopyOnWriteArrayList<>(value));
+        return content.put(key, new ArrayList<>(value));
     }
 
     @Override


### PR DESCRIPTION
Reverts vespa-engine/vespa#15341

Broke unit tests:
``` 
00:12:53 [ERROR] Failures: 
00:12:53 [ERROR]   HttpServerTest.requireThatHeaderWithNullValueIsOmitted:462 
00:12:53 Expected: is <200>
00:12:53      but: was <500>
00:12:53 [INFO] 
00:12:53 [ERROR] Tests run: 267, Failures: 1, Errors: 0, Skipped: 0
``` 