### PR TITLE
Support mixed tensor type in Java evaluation

### DIFF
--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -10,6 +10,7 @@ import com.yahoo.searchlib.rankingexpression.rule.ArithmeticOperator;
 import com.yahoo.searchlib.rankingexpression.rule.ConstantNode;
 import com.yahoo.searchlib.rankingexpression.rule.ExpressionNode;
 import com.yahoo.searchlib.rankingexpression.rule.IfNode;
+import com.yahoo.tensor.Tensor;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -390,6 +391,23 @@ public class EvaluationTestCase {
         tester.assertEvaluates("tensor(x{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{}):{ {x:1}:1 }");
         tester.assertEvaluates("tensor(x{},y{}):{}", "tensor0 * tensor1", "{ {x:0}:1 }", "tensor(x{},y{}):{ {x:1,y:0}:1, {x:2,y:1}:1 }");
 
+    }
+
+    @Test
+    public void testMixedTensorType() throws ParseException {
+        String expected = "tensor(x[1],y{},z[2]):{{x:0,y:a,z:0}:4.0,{x:0,y:a,z:1}:5.0,{x:0,y:b,z:0}:7.0,{x:0,y:b,z:1}:8.0}";
+        String a = "tensor(x[1],y{}):{ {x:0,y:a}:1, {x:0,y:b}:2 }";
+        String b = "tensor(y{},z[2]):{ {y:a,z:0}:3, {y:a,z:1}:4, {y:b,z:0}:5, {y:b,z:1}:6 }";
+        String expression = "a + b";
+
+        MapContext context = new MapContext();
+        context.put("a", new TensorValue(Tensor.from(a)));
+        context.put("b", new TensorValue(Tensor.from(b)));
+
+        Tensor expectedResult = Tensor.from(expected);
+        Tensor result = new RankingExpression(expression).evaluate(context).asTensor();
+        assertEquals(expectedResult, result);
+        assertEquals(expectedResult.type(), result.type());
     }
 
     @Test

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -520,27 +520,9 @@ public class TensorType {
             }
         }
 
-        private static final boolean supportsMixedTypes = false;
-
         private void addDimensionsOf(TensorType type, boolean allowDifferentSizes) {
-            if ( ! supportsMixedTypes) {  // TODO: Support it
-                addDimensionsOfAndDisallowMixedDimensions(type, allowDifferentSizes);
-            }
-            else {
-                for (Dimension dimension : type.dimensions)
-                    set(dimension.combineWith(Optional.ofNullable(dimensions.get(dimension.name())), allowDifferentSizes));
-            }
-        }
-
-        private void addDimensionsOfAndDisallowMixedDimensions(TensorType type, boolean allowDifferentSizes) {
-            boolean containsMapped = dimensions.values().stream().anyMatch(d -> ! d.isIndexed());
-            containsMapped = containsMapped || type.dimensions().stream().anyMatch(d -> ! d.isIndexed());
-
             for (Dimension dimension : type.dimensions) {
-                if (containsMapped)
-                    dimension = new MappedDimension(dimension.name());
-                Dimension existing = dimensions.get(dimension.name());
-                set(dimension.combineWith(Optional.ofNullable(existing), allowDifferentSizes));
+                set(dimension.combineWith(Optional.ofNullable(dimensions.get(dimension.name())), allowDifferentSizes));
             }
         }
 


### PR DESCRIPTION
@bratseth Please review.

Conformance system test (https://github.com/vespa-engine/system-test/blob/master/tests/search/tensor_eval/tensor_conformance.rb) passes with this. Seems like this flag (`supportsMixedTypes`) was a remnant from old.

This only fixes that the conformance test passes, not that mixed tensor evaluation in Java is efficient, as it falls back to mapped tensor implementations anyway.