### PR TITLE
Introduce node IP address pool

### DIFF
--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
@@ -57,7 +57,7 @@ public class IdentityDocumentGeneratorTest {
                                                Generation.initial(),
                                                false);
         Node parentNode = Node.create("ostkid",
-                                      new IP.Config(Set.of("127.0.0.1"), Set.of()),
+                                      IP.Config.ofEmptyPool(Set.of("127.0.0.1")),
                                       parentHostname,
                                       new MockNodeFlavors().getFlavorOrThrow("default"),
                                       NodeType.host).build();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -55,7 +55,7 @@ public final class Node implements Nodelike {
     /** Creates a node builder in the initial state (reserved) */
     public static Node.Builder createDockerNode(Set<String> ipAddresses, String hostname, String parentHostname, NodeResources resources, NodeType type) {
         return new Node.Builder("fake-" + hostname, hostname, new Flavor(resources), State.reserved, type)
-                .ipConfig(ipAddresses, Set.of())
+                .ipConfig(IP.Config.ofEmptyPool(ipAddresses))
                 .parentHostname(parentHostname);
     }
 
@@ -573,8 +573,8 @@ public final class Node implements Nodelike {
             return this;
         }
 
-        public Builder ipConfig(Set<String> primary, Set<String> pool) {
-            this.ipConfig = new IP.Config(primary, pool);
+        public Builder ipConfigWithEmptyPool(Set<String> primary) {
+            this.ipConfig = IP.Config.ofEmptyPool(primary);
             return this;
         }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
@@ -135,12 +135,12 @@ public class CapacityChecker {
         for (var host : hosts) {
             NodeResources hostResources = host.flavor().resources();
             int occupiedIps = 0;
-            Set<String> ipPool = host.ipConfig().pool().asSet();
+            Set<String> ipPool = host.ipConfig().pool().getIpSet();
             for (var child : nodeChildren.get(host)) {
                 hostResources = hostResources.subtract(child.resources().justNumbers());
                 occupiedIps += child.ipConfig().primary().stream().filter(ipPool::contains).count();
             }
-            availableResources.put(host, new AllocationResources(hostResources, host.ipConfig().pool().asSet().size() - occupiedIps));
+            availableResources.put(host, new AllocationResources(hostResources, host.ipConfig().pool().getIpSet().size() - occupiedIps));
         }
 
         return availableResources;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Address.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Address.java
@@ -1,0 +1,49 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.node;
+
+import java.util.Objects;
+
+/**
+ * Address info about a container that might run on a host.
+ *
+ * @author hakon
+ */
+public class Address {
+    private final String hostname;
+
+    public Address(String hostname) {
+        this.hostname = validateHostname(hostname, "hostname");
+    }
+
+    public String hostname() {
+        return hostname;
+    }
+
+    @Override
+    public String toString() {
+        return "Address{" +
+                "hostname='" + hostname + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Address address = (Address) o;
+        return hostname.equals(address.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(hostname);
+    }
+
+    private String validateHostname(String value, String name) {
+        Objects.requireNonNull(value, name + " cannot be null");
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(name + " cannot be empty");
+        }
+        return value;
+    }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -26,6 +26,7 @@ import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Address;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Generation;
@@ -66,6 +67,8 @@ public class NodeSerializer {
     private static final String hostnameKey = "hostname";
     private static final String ipAddressesKey = "ipAddresses";
     private static final String ipAddressPoolKey = "additionalIpAddresses";
+    private static final String containersKey = "containers";
+    private static final String containerHostnameKey = "hostname";
     private static final String idKey = "openStackId";
     private static final String parentHostnameKey = "parentHostname";
     private static final String historyKey = "history";
@@ -146,7 +149,8 @@ public class NodeSerializer {
     private void toSlime(Node node, Cursor object) {
         object.setString(hostnameKey, node.hostname());
         toSlime(node.ipConfig().primary(), object.setArray(ipAddressesKey));
-        toSlime(node.ipConfig().pool().asSet(), object.setArray(ipAddressPoolKey));
+        toSlime(node.ipConfig().pool().getIpSet(), object.setArray(ipAddressPoolKey));
+        toSlime(node.ipConfig().pool().getAddressList(), object);
         object.setString(idKey, node.id());
         node.parentHostname().ifPresent(hostname -> object.setString(parentHostnameKey, hostname));
         toSlime(node.flavor(), object);
@@ -214,6 +218,14 @@ public class NodeSerializer {
         ipAddresses.stream().map(IP::parse).sorted(IP.NATURAL_ORDER).map(IP::asString).forEach(array::addString);
     }
 
+    private void toSlime(List<Address> addresses, Cursor object) {
+        if (addresses.isEmpty()) return;
+        Cursor addressCursor = object.setArray(containersKey);
+        addresses.forEach(address -> {
+            addressCursor.addObject().setString(containerHostnameKey, address.hostname());
+        });
+    }
+
     // ---------------- Deserialization --------------------------------------------------
 
     public Node fromJson(Node.State state, byte[] data) {
@@ -232,7 +244,8 @@ public class NodeSerializer {
         Flavor flavor = flavorFromSlime(object);
         return new Node(object.field(idKey).asString(),
                         new IP.Config(ipAddressesFromSlime(object, ipAddressesKey),
-                                      ipAddressesFromSlime(object, ipAddressPoolKey)),
+                                      ipAddressesFromSlime(object, ipAddressPoolKey),
+                                      addressesFromSlime(object)),
                         object.field(hostnameKey).asString(),
                         parentHostnameFromSlime(object),
                         flavor,
@@ -356,6 +369,16 @@ public class NodeSerializer {
         ImmutableSet.Builder<String> ipAddresses = ImmutableSet.builder();
         object.field(key).traverse((ArrayTraverser) (i, item) -> ipAddresses.add(item.asString()));
         return ipAddresses.build();
+    }
+
+    private List<Address> addressesFromSlime(Inspector object) {
+        Inspector addressesField = object.field(containersKey);
+        if (addressesField.children() == 0)
+            return List.of();
+        List<Address> addresses = new ArrayList<>(addressesField.children());
+        addressesField.traverse((ArrayTraverser) (i, elem) ->
+                addresses.add(new Address(elem.field(containerHostnameKey).asString())));
+        return addresses;
     }
 
     private Optional<String> modelNameFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 
 /**
  * Serializes a node to/from JSON.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -372,13 +372,9 @@ public class NodeSerializer {
     }
 
     private List<Address> addressesFromSlime(Inspector object) {
-        Inspector addressesField = object.field(containersKey);
-        if (addressesField.children() == 0)
-            return List.of();
-        List<Address> addresses = new ArrayList<>(addressesField.children());
-        addressesField.traverse((ArrayTraverser) (i, elem) ->
-                addresses.add(new Address(elem.field(containerHostnameKey).asString())));
-        return addresses;
+        return SlimeUtils.entriesStream(object.field(containersKey))
+                .map(elem -> new Address(elem.field(containerHostnameKey).asString()))
+                .collect(Collectors.toList());
     }
 
     private Optional<String> modelNameFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -257,7 +257,7 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
         inspector.field("additionalIpAddresses").traverse((ArrayTraverser) (i, item) -> ipAddressPool.add(item.asString()));
 
         Node.Builder builder = Node.create(inspector.field("openStackId").asString(),
-                                           new IP.Config(ipAddresses, ipAddressPool),
+                                           IP.Config.of(ipAddresses, ipAddressPool, List.of()),
                                            inspector.field("hostname").asString(),
                                            flavorFromSlime(inspector),
                                            nodeTypeFromSlime(inspector.field("type")));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -206,11 +206,11 @@ public class MockNodeRepository extends NodeRepository {
 
     private IP.Config ipConfig(int nodeIndex, int primarySize, int poolSize) {
         var primary = new LinkedHashSet<String>();
-        var pool = new LinkedHashSet<String>();
+        var ipPool = new LinkedHashSet<String>();
         for (int i = 1; i <= primarySize + poolSize; i++) {
             var set = primary;
             if (i > primarySize) {
-                set = pool;
+                set = ipPool;
             }
             var rootName = "test-node-primary";
             if (i > primarySize) {
@@ -226,7 +226,7 @@ public class MockNodeRepository extends NodeRepository {
                 set.add(ipv4Address);
             }
         }
-        return new IP.Config(primary, pool);
+        return IP.Config.of(primary, ipPool, List.of());
     }
 
     private IP.Config ipConfig(int nodeIndex) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/IPTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/IPTest.java
@@ -177,7 +177,7 @@ public class IPTest {
         }
 
         IP.Pool pool = node.ipConfig().pool();
-        assertNotEquals(dualStack, pool instanceof IP.Ipv4Pool);
+        assertNotEquals(dualStack, pool.getProtocol() == IP.IpAddresses.Protocol.ipv4);
         return pool;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -21,6 +21,7 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.Node.State;
+import com.yahoo.vespa.hosted.provision.node.Address;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Generation;
 import com.yahoo.vespa.hosted.provision.node.History;
@@ -249,15 +250,19 @@ public class NodeSerializerTest {
     public void serialize_ip_address_pool() {
         Node node = createNode();
 
-        // Test round-trip with IP address pool
-        node = node.with(node.ipConfig().with(IP.Pool.of(Set.of("::1", "::2", "::3"))));
+        // Test round-trip with address pool
+        node = node.with(node.ipConfig().withPool(IP.Pool.of(
+                Set.of("::1", "::2", "::3"),
+                List.of(new Address("a"), new Address("b"), new Address("c")))));
         Node copy = nodeSerializer.fromJson(node.state(), nodeSerializer.toJson(node));
-        assertEquals(node.ipConfig().pool().asSet(), copy.ipConfig().pool().asSet());
+        assertEquals(node.ipConfig().pool().getIpSet(), copy.ipConfig().pool().getIpSet());
+        assertEquals(Set.copyOf(node.ipConfig().pool().getAddressList()), Set.copyOf(copy.ipConfig().pool().getAddressList()));
 
-        // Test round-trip without IP address pool (handle empty pool)
+        // Test round-trip without address pool (handle empty pool)
         node = createNode();
         copy = nodeSerializer.fromJson(node.state(), nodeSerializer.toJson(node));
-        assertEquals(node.ipConfig().pool().asSet(), copy.ipConfig().pool().asSet());
+        assertEquals(node.ipConfig().pool().getIpSet(), copy.ipConfig().pool().getIpSet());
+        assertEquals(Set.copyOf(node.ipConfig().pool().getAddressList()), Set.copyOf(copy.ipConfig().pool().getAddressList()));
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
@@ -13,7 +13,7 @@ import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Generation;
 import com.yahoo.vespa.hosted.provision.node.IP;
 
-import javax.swing.*;
+import javax.swing.JFrame;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AllocationSimulator.java
@@ -11,8 +11,9 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Generation;
+import com.yahoo.vespa.hosted.provision.node.IP;
 
-import javax.swing.JFrame;
+import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -76,7 +77,7 @@ public class AllocationSimulator {
         Node.Builder builder = Node.create("fake", hostname, flavor,
                 parent.isPresent() ? Node.State.ready : Node.State.active,
                 parent.isPresent() ? NodeType.tenant : NodeType.host)
-                .ipConfig(Set.of("127.0.0.1"), parent.isPresent() ? Set.of() : getAdditionalIP());
+                .ipConfig(IP.Config.of(Set.of("127.0.0.1"), parent.isPresent() ? Set.of() : getAdditionalIP(), List.of()));
         parent.ifPresent(builder::parentHostname);
         allocation(tenant, flavor).ifPresent(builder::allocation);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacityTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacityTest.java
@@ -43,9 +43,9 @@ public class HostCapacityTest {
         NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("host", "docker", "docker2");
 
         // Create three docker hosts
-        host1 = Node.create("host1", new IP.Config(Set.of("::1"), generateIPs(2, 4)), "host1", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
-        host2 = Node.create("host2", new IP.Config(Set.of("::11"), generateIPs(12, 3)), "host2", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
-        host3 = Node.create("host3", new IP.Config(Set.of("::21"), generateIPs(22, 1)), "host3", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
+        host1 = Node.create("host1", IP.Config.of(Set.of("::1"), generateIPs(2, 4), List.of()), "host1", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
+        host2 = Node.create("host2", IP.Config.of(Set.of("::11"), generateIPs(12, 3), List.of()), "host2", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
+        host3 = Node.create("host3", IP.Config.of(Set.of("::21"), generateIPs(22, 1), List.of()), "host3", nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
 
         // Add two containers to host1
         var nodeA = Node.createDockerNode(Set.of("::2"), "nodeA", "host1", resources1, NodeType.tenant).build();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
@@ -256,7 +256,7 @@ public class LoadBalancerProvisionerTest {
     private void assignIps(List<Node> nodes) {
         try (var lock = tester.nodeRepository().lockUnallocated()) {
             for (int i = 0; i < nodes.size(); i++) {
-                tester.nodeRepository().write(nodes.get(i).with(IP.Config.EMPTY.with(Set.of("127.0.0." + i))), lock);
+                tester.nodeRepository().write(nodes.get(i).with(IP.Config.EMPTY.withPrimary(Set.of("127.0.0." + i))), lock);
             }
         }
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
@@ -133,7 +133,7 @@ public class NodeCandidateTest {
 
     private static Node node(String hostname, Node.State state) {
         return Node.create(hostname, hostname, new Flavor(new NodeResources(2, 2, 2, 2)), state, NodeType.tenant)
-                .ipConfig(Set.of("::1"), Set.of()).build();
+                .ipConfigWithEmptyPool(Set.of("::1")).build();
     }
 
     private static NodeCandidate node(String hostname,
@@ -143,9 +143,9 @@ public class NodeCandidateTest {
                                       boolean exclusiveSwitch) {
         Node node = Node.create(hostname, hostname, new Flavor(nodeResources), Node.State.ready, NodeType.tenant)
                 .parentHostname(hostname + "parent")
-                .ipConfig(Set.of("::1"), Set.of()).build();
+                .ipConfigWithEmptyPool(Set.of("::1")).build();
         Node parent = Node.create(hostname + "parent", hostname, new Flavor(totalHostResources), Node.State.ready, NodeType.host)
-                .ipConfig(Set.of("::1"), Set.of()).build();
+                .ipConfigWithEmptyPool(Set.of("::1")).build();
         return new NodeCandidate.ConcreteNodeCandidate(node, totalHostResources.subtract(allocatedHostResources), Optional.of(parent),
                                                        false, exclusiveSwitch, false, true, false);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -894,7 +894,7 @@ public class ProvisioningTest {
         Flavor flavor = tester.nodeRepository().flavors().getFlavorOrThrow("default");
         List<Node> nodes = List.of(
                 Node.create("cfghost1", new IP.Config(Set.of("::1:0"), Set.of("::1:1")), "cfghost1", flavor, NodeType.confighost).build(),
-                Node.create("cfghost2", new IP.Config(Set.of("::2:0"), Set.of("::2:1")), "cfghost2", flavor, NodeType.confighost).ipConfig(Set.of("::2:0"), Set.of("::2:1")).build(),
+                Node.create("cfghost2", new IP.Config(Set.of("::2:0"), Set.of("::2:1")), "cfghost2", flavor, NodeType.confighost).ipConfig(IP.Config.of(Set.of("::2:0"), Set.of("::2:1"), List.of())).build(),
                 Node.create("cfg1", new IP.Config(Set.of("::1:1"), Set.of()), "cfg1", flavor, NodeType.config).parentHostname("cfghost1").build(),
                 Node.create("cfg2", new IP.Config(Set.of("::2:1"), Set.of()), "cfg2", flavor, NodeType.config).parentHostname("cfghost2").build());
         tester.nodeRepository().setReady(tester.nodeRepository().addNodes(nodes, Agent.system), Agent.system, ProvisioningTest.class.getSimpleName());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -360,6 +360,23 @@ public class NodesV2ApiTest {
     }
 
     @Test
+    public void patch_hostnames() throws IOException {
+        assertFile(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "node4.json");
+
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                        Utf8.toBytes("{\"additionalHostnames\": [\"a\",\"b\"]}"), Request.Method.PATCH),
+                "{\"message\":\"Updated host4.yahoo.com\"}");
+
+        assertFile(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "node4-with-hostnames.json");
+
+        assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+                        Utf8.toBytes("{\"additionalHostnames\": []}"), Request.Method.PATCH),
+                "{\"message\":\"Updated host4.yahoo.com\"}");
+
+        assertFile(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "node4.json");
+    }
+
+    @Test
     public void post_controller_node() throws Exception {
         String data = "[{\"hostname\":\"controller1.yahoo.com\", \"openStackId\":\"fake-controller1.yahoo.com\"," +
                       createIpAddresses("127.0.0.1") +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
@@ -1,0 +1,65 @@
+{
+  "url": "http://localhost:8080/nodes/v2/node/host4.yahoo.com",
+  "id": "host4.yahoo.com",
+  "state": "active",
+  "type": "tenant",
+  "hostname": "host4.yahoo.com",
+  "parentHostname": "dockerhost1.yahoo.com",
+  "openStackId": "node4",
+  "flavor": "[vcpu: 1.0, memory: 4.0 Gb, disk 100.0 Gb, bandwidth: 1.0 Gbps, storage type: local]",
+  "resources":{"vcpu":1.0,"memoryGb":4.0,"diskGb":100.0,"bandwidthGbps":1.0,"diskSpeed":"fast","storageType":"local"},
+  "environment": "DOCKER_CONTAINER",
+  "owner": {
+    "tenant": "tenant3",
+    "application": "application3",
+    "instance": "instance3"
+  },
+  "membership": {
+    "clustertype": "content",
+    "clusterid": "id3",
+    "group": "0",
+    "index": 0,
+    "retired": false
+  },
+  "restartGeneration": 0,
+  "currentRestartGeneration": 0,
+  "wantedDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.42.0",
+  "wantedVespaVersion": "6.42.0",
+  "requestedResources": { "vcpu":1.0, "memoryGb":4.0, "diskGb":100.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
+  "allowedToBeDown": false,
+  "rebootGeneration": 1,
+  "currentRebootGeneration": 0,
+  "vespaVersion": "6.41.0",
+  "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.41.0",
+  "failCount": 0,
+  "wantToRetire": false,
+  "wantToDeprovision": false,
+  "history": [
+    {
+      "event": "provisioned",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "readied",
+      "at": 123,
+      "agent": "system"
+    },
+    {
+      "event": "reserved",
+      "at": 123,
+      "agent": "application"
+    },
+    {
+      "event": "activated",
+      "at": 123,
+      "agent": "application"
+    }
+  ],
+  "ipAddresses": [
+    "127.0.4.1",
+    "::4:1"
+  ],
+  "additionalIpAddresses": [],
+  "additionalHostnames": ["a","b"]
+}


### PR DESCRIPTION
A host that is supposed to run containers has a non-empty IP pool: A set of
IPv4 and/or IPv6 addresses that can be assigned to containers.

This PR adds a list of hostnames to this pool.  The intent is that the
hostnames and IPs match through resolving, but resolution may not yet be
available (until DNS changes propagate).

For now, only a list of hostnames are specified.  We may want to specify
(hostname, IP address) pairs or (hostname, IPv4, IPv6) triplets later, and the
serialization format allows for that by storing the hsotnames in an array of
objects, the object having a "hostname" field.

However the REST API is kept simpler for now: it exposes and allows patching of
an array of strings of a "additionalHostnames" field.