### PR TITLE
fix bug found by AddressSanitizer

### DIFF
--- a/eval/src/vespa/eval/instruction/generic_peek.cpp
+++ b/eval/src/vespa/eval/instruction/generic_peek.cpp
@@ -46,12 +46,12 @@ struct DimSpec {
         return std::get<size_t>(child_or_label);
     }
     vespalib::stringref get_label_name() const {
-        auto label = std::get<TensorSpec::Label>(child_or_label);
+        auto & label = std::get<TensorSpec::Label>(child_or_label);
         assert(label.is_mapped());
         return label.name;
     }
     size_t get_label_index() const {
-        auto label = std::get<TensorSpec::Label>(child_or_label);
+        auto & label = std::get<TensorSpec::Label>(child_or_label);
         assert(label.is_indexed());
         return label.index;
     }


### PR DESCRIPTION
* using "auto label" would copy the TensorSpec::Label (including
  its string) into a temporary stack object, and then we would
  reference into the temporary with a stringref.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
@havardpe FYI
