### PR TITLE
Allow allocating to a provisioned tenant host

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -94,7 +94,7 @@ public final class Node implements Nodelike {
             requireNonEmpty(ipConfig.primary(), "Active node " + hostname + " must have at least one valid IP address");
 
         if (parentHostname.isPresent()) {
-            if (!ipConfig.pool().isEmpty()) throw new IllegalArgumentException("A child node cannot have an IP address pool");
+            if (!ipConfig.pool().getIpSet().isEmpty()) throw new IllegalArgumentException("A child node cannot have an IP address pool");
             if (modelName.isPresent()) throw new IllegalArgumentException("A child node cannot have model name set");
             if (switchHostname.isPresent()) throw new IllegalArgumentException("A child node cannot have switch hostname set");
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -460,7 +460,7 @@ public class NodeRepository extends AbstractComponent {
                     .map(node -> {
                         if (node.state() != State.provisioned && node.state() != State.dirty)
                             illegal("Can not set " + node + " ready. It is not provisioned or dirty.");
-                        if (node.type() == NodeType.host && node.ipConfig().pool().isEmpty())
+                        if (node.type() == NodeType.host && node.ipConfig().pool().getIpSet().isEmpty())
                             illegal("Can not set host " + node + " ready. Its IP address pool is empty.");
                         return node.withWantToRetire(false, false, Agent.system, clock.instant());
                     })

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -71,47 +71,47 @@ public class GroupPreparer {
         }
 
         // There were some changes, so re-do the allocation with locks
-        try (Mutex lock = nodeRepository.lock(application)) {
-            try (Mutex allocationLock = nodeRepository.lockUnallocated()) {
-                NodeAllocation allocation = prepareAllocation(application, cluster, requestedNodes, surplusActiveNodes,
-                        highestIndex, wantedGroups, allocationLock);
+        try (Mutex lock = nodeRepository.lock(application);
+             Mutex allocationLock = nodeRepository.lockUnallocated()) {
 
-                if (nodeRepository.zone().getCloud().dynamicProvisioning()) {
-                    Version osVersion = nodeRepository.osVersions().targetFor(NodeType.host).orElse(Version.emptyVersion);
-                    List<ProvisionedHost> provisionedHosts = allocation.getFulfilledDockerDeficit()
-                            .map(deficit -> hostProvisioner.get().provisionHosts(nodeRepository.database().getProvisionIndexes(deficit.getCount()),
-                                                                                 deficit.getFlavor(),
-                                                                                 application,
-                                                                                 osVersion,
-                                                                                 requestedNodes.isExclusive() ? HostSharing.exclusive : HostSharing.any))
-                            .orElseGet(List::of);
+            NodeAllocation allocation = prepareAllocation(application, cluster, requestedNodes, surplusActiveNodes,
+                    highestIndex, wantedGroups, allocationLock);
 
-                    // At this point we have started provisioning of the hosts, the first priority is to make sure that
-                    // the returned hosts are added to the node-repo so that they are tracked by the provision maintainers
-                    List<Node> hosts = provisionedHosts.stream()
-                                                       .map(ProvisionedHost::generateHost)
-                                                       .collect(Collectors.toList());
-                    nodeRepository.addNodes(hosts, Agent.application);
+            if (nodeRepository.zone().getCloud().dynamicProvisioning()) {
+                Version osVersion = nodeRepository.osVersions().targetFor(NodeType.host).orElse(Version.emptyVersion);
+                List<ProvisionedHost> provisionedHosts = allocation.getFulfilledDockerDeficit()
+                        .map(deficit -> hostProvisioner.get().provisionHosts(nodeRepository.database().getProvisionIndexes(deficit.getCount()),
+                                                                             deficit.getFlavor(),
+                                                                             application,
+                                                                             osVersion,
+                                                                             requestedNodes.isExclusive() ? HostSharing.exclusive : HostSharing.any))
+                        .orElseGet(List::of);
 
-                    // Offer the nodes on the newly provisioned hosts, this should be enough to cover the deficit
-                    List<NodeCandidate> candidates = provisionedHosts.stream()
-                                                                     .map(host -> NodeCandidate.createNewExclusiveChild(host.generateNode(),
-                                                                                                                        host.generateHost()))
-                                                                     .collect(Collectors.toList());
-                    allocation.offer(candidates);
-                }
+                // At this point we have started provisioning of the hosts, the first priority is to make sure that
+                // the returned hosts are added to the node-repo so that they are tracked by the provision maintainers
+                List<Node> hosts = provisionedHosts.stream()
+                                                   .map(ProvisionedHost::generateHost)
+                                                   .collect(Collectors.toList());
+                nodeRepository.addNodes(hosts, Agent.application);
 
-                if (! allocation.fulfilled() && requestedNodes.canFail())
-                    throw new OutOfCapacityException((cluster.group().isPresent() ? "Out of capacity on " + cluster.group().get() :"") +
-                                                     allocation.outOfCapacityDetails());
-
-                // Carry out and return allocation
-                nodeRepository.reserve(allocation.reservableNodes());
-                nodeRepository.addDockerNodes(new LockedNodeList(allocation.newNodes(), allocationLock));
-                List<Node> acceptedNodes = allocation.finalNodes();
-                surplusActiveNodes.removeAll(acceptedNodes);
-                return acceptedNodes;
+                // Offer the nodes on the newly provisioned hosts, this should be enough to cover the deficit
+                List<NodeCandidate> candidates = provisionedHosts.stream()
+                                                                 .map(host -> NodeCandidate.createNewExclusiveChild(host.generateNode(),
+                                                                                                                    host.generateHost()))
+                                                                 .collect(Collectors.toList());
+                allocation.offer(candidates);
             }
+
+            if (! allocation.fulfilled() && requestedNodes.canFail())
+                throw new OutOfCapacityException((cluster.group().isPresent() ? "Out of capacity on " + cluster.group().get() :"") +
+                                                 allocation.outOfCapacityDetails());
+
+            // Carry out and return allocation
+            nodeRepository.reserve(allocation.reservableNodes());
+            nodeRepository.addDockerNodes(new LockedNodeList(allocation.newNodes(), allocationLock));
+            List<Node> acceptedNodes = allocation.finalNodes();
+            surplusActiveNodes.removeAll(acceptedNodes);
+            return acceptedNodes;
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacity.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostCapacity.java
@@ -82,7 +82,11 @@ public class HostCapacity {
      * Number of free (not allocated) IP addresses assigned to the dockerhost.
      */
     int freeIPs(Node dockerHost) {
-        return dockerHost.ipConfig().pool().findUnused(allNodes).size();
+        if (dockerHost.type() == NodeType.host) {
+            return dockerHost.ipConfig().pool().eventuallyUnusedAddressCount(allNodes);
+        } else {
+            return dockerHost.ipConfig().pool().findUnusedIpAddresses(allNodes).size();
+        }
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
@@ -363,11 +363,11 @@ abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidate> {
             try {
                 allocation = parent.get().ipConfig().pool().findAllocation(allNodes, nodeRepository.nameResolver());
                 if (allocation.isEmpty()) return new InvalidNodeCandidate(resources, freeParentCapacity, parent.get(),
-                                                                          "No IP addresses available on parent host");
+                                                                          "No addresses available on parent host");
             } catch (Exception e) {
-                log.warning("Failed allocating IP address on " + parent.get() +": " + Exceptions.toMessageString(e));
+                log.warning("Failed allocating address on " + parent.get() +": " + Exceptions.toMessageString(e));
                 return new InvalidNodeCandidate(resources, freeParentCapacity, parent.get(),
-                                                "Failed when allocating IP address on host");
+                                                "Failed when allocating address on host");
             }
 
             Node node = Node.createDockerNode(allocation.get().addresses(),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
@@ -209,12 +209,12 @@ public class DynamicProvisioningMaintainerTest {
         tester.maintainer.maintain();
 
         assertTrue("No IP addresses written as DNS updates are failing",
-                   provisioning.get().stream().allMatch(host -> host.ipConfig().pool().isEmpty()));
+                   provisioning.get().stream().allMatch(host -> host.ipConfig().pool().getIpSet().isEmpty()));
 
         tester.hostProvisioner.without(Behaviour.failDnsUpdate);
         tester.maintainer.maintain();
         assertTrue("IP addresses written as DNS updates are succeeding",
-                   provisioning.get().stream().noneMatch(host -> host.ipConfig().pool().isEmpty()));
+                   provisioning.get().stream().noneMatch(host -> host.ipConfig().pool().getIpSet().isEmpty()));
     }
 
     private static class DynamicProvisioningTester {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/IPTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/IPTest.java
@@ -86,8 +86,8 @@ public class IPTest {
         resolver.addReverseRecord("::2", "host1");
 
         Optional<IP.Allocation> allocation = pool.findAllocation(emptyList, resolver);
-        assertEquals("::1", allocation.get().primary());
-        assertFalse(allocation.get().secondary().isPresent());
+        assertEquals(Optional.of("::1"), allocation.get().ipv6Address());
+        assertFalse(allocation.get().ipv4Address().isPresent());
         assertEquals("host3", allocation.get().hostname());
 
         // Allocation fails if DNS record is missing
@@ -105,16 +105,16 @@ public class IPTest {
         var pool = testPool(false);
         var allocation = pool.findAllocation(emptyList, resolver);
         assertFalse("Found allocation", allocation.isEmpty());
-        assertEquals("127.0.0.1", allocation.get().primary());
-        assertTrue("No secondary address", allocation.get().secondary().isEmpty());
+        assertEquals(Optional.of("127.0.0.1"), allocation.get().ipv4Address());
+        assertTrue("No IPv6 address", allocation.get().ipv6Address().isEmpty());
     }
 
     @Test
     public void test_find_allocation_dual_stack() {
         IP.Pool pool = testPool(true);
         Optional<IP.Allocation> allocation = pool.findAllocation(emptyList, resolver);
-        assertEquals("::1", allocation.get().primary());
-        assertEquals("127.0.0.2", allocation.get().secondary().get());
+        assertEquals(Optional.of("::1"), allocation.get().ipv6Address());
+        assertEquals("127.0.0.2", allocation.get().ipv4Address().get());
         assertEquals("host3", allocation.get().hostname());
     }
 


### PR DESCRIPTION
This PR changes (A) and (B) described below, which effectivelly allows
the allocation of nodes to a dynamically provisioned tenant host before
they have been assigned an IP pool.

A.  In NodePriotizer, when converting a VirtualNodeCandidate to a
ConcreteNodeCandidate with 'withNode()', primary IP addresses are currently
picked from the IP pool of the parent host and assigned to the node, along with
the corresponding hostname found using a DNS resolver.

This PR allows a ConcreteNodeCandidate to be created WITH a hostname, but
WITHOUT primary IP addresses, when 1. the parent host has no IP addresses in
the pool AND 2. there are hostnames in the address pool not yet assigned to any
child node.

This may happen for a brief period of time just after provisioning in a
dynamically provisioned zone: An asynchronous process is supposed to add IP
addresses to the pool (based on the pool hostnames) before the host can become
active, and also update the child nodes with their primary IP addresses
accordingly.  They both hold the unallocated lock to guarantee atomicity.

B.  In NodePriotizer.addCandidatesOnExistingHosts(), the
HostCapacity.hasCapacity() will now return true when (a) the parent host is
tenant, (b) there are NO IP addresses in the pool, and (c) there is a hostname
in the pool not assigned to