### PR TITLE
Make restart on deploy sticky

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -261,12 +261,16 @@ public final class ConfiguredApplication implements Application {
 
     private void startReconfigurerThread() {
         reconfigurerThread = new Thread(() -> {
+            boolean restartOnDeploy = false;
             while ( ! Thread.interrupted()) {
                 try {
                     ContainerBuilder builder = createBuilderWithGuiceBindings();
 
+                    // Restart on deploy is sticky: Once it is set no future generation should be applied until restart
+                    restartOnDeploy = restartOnDeploy || qrConfig.restartOnDeploy();
+
                     // Block until new config arrives, and it should be applied
-                    configurer.getNewComponentGraph(builder.guiceModules().activate(), qrConfig.restartOnDeploy());
+                    configurer.getNewComponentGraph(builder.guiceModules().activate(), restartOnDeploy);
                     initializeAndActivateContainer(builder);
                 } catch (ConfigInterruptedException e) {
                     break;


### PR DESCRIPTION
When restartOnDeploy is set on a config generation, no further config generations
should be applied before the node has been restarted. This is necessary because
the decision on whether restartOnDeploy shouild be set is made by comparing the
current and next config generation on the config server, not the next and the
current one active on the node.
