### PR TITLE
Upgrade Jetty to 9.4.35

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -30,7 +30,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.32.v20200930</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <junit5.version>5.7.0</junit5.version>
         <junit5.platform.version>1.7.0</junit5.platform.version>
         <org.lz4.version>1.7.1</org.lz4.version>
@@ -259,6 +259,7 @@
                                         <include>org.eclipse.jetty:jetty-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlet:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlets:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-util-ajax:[${jetty.version}]:jar:test</include>
                                         <include>org.hamcrest:hamcrest-core:1.3:jar:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:2.1.8:jar:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-api:[${junit5.version}]:jar:test</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -446,7 +446,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.32.v20200930</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>

--- a/jdisc_http_service/pom.xml
+++ b/jdisc_http_service/pom.xml
@@ -152,6 +152,7 @@
             jetty-servlet-${jetty.version}.jar,
             jetty-servlets-${jetty.version}.jar,
             jetty-util-${jetty.version}.jar,
+            jetty-util-ajax-${jetty.version}.jar,
             component-jar-with-dependencies.jar
           </discPreInstallBundle>
         </configuration>


### PR DESCRIPTION
Jetty-util-ajax is a new bundle that is used by the new version of jetty-servlet bundle

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
