### PR TITLE
Add config field for whether to support dynamic reconfiguration of Zoo…

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -1,4 +1,4 @@
-# Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 namespace=cloud.config
 
 # Vespa home is prepended if the file is relative
@@ -43,3 +43,5 @@ trustEmptySnapshot bool default=true
 tlsForQuorumCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
 tlsForClientServerCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
 jksKeyStoreFile string default="conf/zookeeper/zookeeper.jks"
+
+dynamicReconfiguration bool default=false


### PR DESCRIPTION
…Keeper

Not using FlagSource directly (ref. https://github.com/vespa-engine/vespa/pull/15440), as I want to have as few dependencies as possible in the zookeeper-server submodules, where this will be used
