### PR TITLE
Add exception to log message

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/StripedExecutor.java
@@ -68,7 +68,7 @@ public class StripedExecutor<Key> {
                 command.run();
             }
             catch (RuntimeException e) {
-                logger.log(Level.WARNING, () -> "Exception caught: " + Exceptions.toMessageString(e));
+                logger.log(Level.WARNING, e, () -> "Exception caught: " + Exceptions.toMessageString(e));
             }
         }
     }


### PR DESCRIPTION
Hard to figure out what's wrong when you only get the message, so add exception so that stack trace will logged
