### PR TITLE
renumber Peek children

### DIFF
--- a/eval/src/tests/instruction/generic_peek/generic_peek_test.cpp
+++ b/eval/src/tests/instruction/generic_peek/generic_peek_test.cpp
@@ -71,7 +71,7 @@ TensorSpec perform_generic_peek(const TensorSpec &a, const ValueType &result_typ
     Stash stash;
     std::vector<Value::CREF> my_stack;
     my_stack.push_back(*param);
-    size_t child_idx = 0;
+    size_t child_idx = 1;
     for (auto & [dim_name, label_or_child] : spec) {
         if (std::holds_alternative<size_t>(label_or_child)) {
             // here, label_or_child is a size_t specifying the value

--- a/eval/src/vespa/eval/eval/tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/tensor_function.cpp
@@ -508,7 +508,9 @@ Peek::Spec
 Peek::make_spec() const
 {
     Spec generic_spec;
-    size_t child_idx = 0;
+    // the value peeked is child 0, so
+    // children (for label computation) in spec start at 1:
+    size_t child_idx = 1;
     for (const auto & [dim_name, label_or_child] : map()) {
         std::visit(vespalib::overload {
                 [&,&dim_name = dim_name](const TensorSpec::Label &label) {

--- a/eval/src/vespa/eval/instruction/generic_peek.cpp
+++ b/eval/src/vespa/eval/instruction/generic_peek.cpp
@@ -24,7 +24,8 @@ using Spec = GenericPeek::SpecMap;
 
 size_t count_children(const Spec &spec)
 {
-    size_t num_children = 0;
+    // accounts for "input" child:
+    size_t num_children = 1;
     for (const auto & [dim_name, child_or_label] : spec) {
         if (std::holds_alternative<size_t>(child_or_label)) {
             ++num_children;
@@ -313,18 +314,19 @@ generic_mixed_peek(const ValueType &res_type,
 template <typename ICT, typename OCT>
 void my_generic_peek_op(State &state, uint64_t param_in) {
     const auto &param = unwrap_param<PeekParam>(param_in);
-    const Value & input_value = state.peek(param.num_children);
-    const size_t last_child = param.num_children - 1;
+    // stack index for children are in range [0, num_children>
+    size_t last_valid_stack_idx = param.num_children - 1;
+    const Value & input_value = state.peek(last_valid_stack_idx);
     auto get_child_value = [&] (size_t child_idx) {
-        size_t stack_idx = last_child - child_idx;
+        size_t stack_idx = last_valid_stack_idx - child_idx;
         return int64_t(state.peek(stack_idx).as_double());
     };
     auto up = generic_mixed_peek<ICT,OCT>(param.res_type, input_value,
                                           param.sparse_plan, param.dense_plan,
                                           param.factory, get_child_value);
     const Value &result = *state.stash.create<Value::UP>(std::move(up));
-    // num_children does not include the "input" param
-    state.pop_n_push(param.num_children + 1, result);
+    // num_children includes the "input" param
+    state.pop_n_push(param.num_children, result);
 }
 
 struct SelectGenericPeekOp {


### PR DESCRIPTION
* in the Peek::Spec, children now start at 1.
  0 is reserved for the "input" (peeked child) parameter.
  This corresponds to child numbering in the tensor function.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review (on Monday)
