### PR TITLE
Generate correct zookeeper server config and fix setup of components

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -78,9 +78,6 @@ public final class ApplicationContainer extends Container implements
 
     @Override
     public void getConfig(ZookeeperServerConfig.Builder builder) {
-        AbstractConfigProducer<?> parent = getParent();
-        if (parent == null) return;
-
         builder.myid(index());
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -81,8 +81,6 @@ public final class ApplicationContainer extends Container implements
         AbstractConfigProducer<?> parent = getParent();
         if (parent == null) return;
 
-        if (parent instanceof ApplicationContainerCluster)
-            ((ApplicationContainerCluster) this.parent).getConfig(builder);
         builder.myid(index());
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -557,7 +557,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     /**
      * Returns a config server config containing the right zone settings (and defaults for the rest).
-     * This is useful to allow applications to find out in which zone they are runnung by having the Zone
+     * This is useful to allow applications to find out in which zone they are running by having the Zone
      * object (which is constructed from this config) injected.
      */
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -347,12 +347,17 @@ public class ContainerClusterTest {
         addContainer(root.deployLogger(), cluster, "c2", "host-c2");
         addContainer(root.deployLogger(), cluster, "c3", "host-c3");
 
+        // Only myid is set for container
         ZookeeperServerConfig.Builder configBuilder = new ZookeeperServerConfig.Builder();
         cluster.getContainers().get(0).getConfig(configBuilder);
-        ZookeeperServerConfig config = configBuilder.build();
+        assertEquals(0, configBuilder.build().myid());
+
+        // the rest (e.g. servers) is set for cluster
+        cluster.getConfig(configBuilder);
+        assertEquals(0, configBuilder.build().myid());
         assertEquals(List.of("host-c1", "host-c2", "host-c3"),
-                     config.server().stream().map(ZookeeperServerConfig.Server::hostname).collect(Collectors.toList()));
-        assertEquals(0, config.myid());
+                     configBuilder.build().server().stream().map(ZookeeperServerConfig.Server::hostname).collect(Collectors.toList()));
+
     }
 
     private void verifyTesterApplicationInstalledBundles(Zone zone, List<String> expectedBundleNames) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -892,9 +892,9 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                 assertComponentConfigured(container, "com.yahoo.vespa.zookeeper.ReconfigurableVespaZooKeeperServer");
                 assertComponentConfigured(container, "com.yahoo.vespa.zookeeper.Reconfigurer");
 
-                ZookeeperServerConfig container0Config = model.getConfig(ZookeeperServerConfig.class, container.getConfigId());
-                assertEquals(container.index(), container0Config.myid());
-                assertEquals(3, container0Config.server().size());
+                ZookeeperServerConfig config = model.getConfig(ZookeeperServerConfig.class, container.getConfigId());
+                assertEquals(container.index(), config.myid());
+                assertEquals(3, config.server().size());
             });
         }
         {


### PR DESCRIPTION
Copmonents need to created so that they will subscribe with a config id
that is unique per container (since config is different for each container)

Also make sure to to only generate needed ´myid´ in config for each container.
