### PR TITLE
renumber Peek children, the sequel

### DIFF
--- a/eval/src/tests/instruction/generic_peek/generic_peek_test.cpp
+++ b/eval/src/tests/instruction/generic_peek/generic_peek_test.cpp
@@ -39,6 +39,7 @@ using PeekSpec = GenericPeek::SpecMap;
 
 TensorSpec reference_peek(const TensorSpec &param, const PeekSpec &spec) {
     std::vector<TensorSpec> children;
+    children.push_back(param);
     PeekSpec with_indexes;
     for (const auto & [dim_name, label_or_child] : spec) {
         const vespalib::string &dim = dim_name;
@@ -59,7 +60,7 @@ TensorSpec reference_peek(const TensorSpec &param, const PeekSpec &spec) {
                        }
                    }, label_or_child);
     }
-    return ReferenceOperations::peek(param, with_indexes, children);
+    return ReferenceOperations::peek(with_indexes, children);
 }
 
 TensorSpec perform_generic_peek(const TensorSpec &a, const ValueType &result_type,

--- a/eval/src/vespa/eval/eval/test/reference_evaluation.cpp
+++ b/eval/src/vespa/eval/eval/test/reference_evaluation.cpp
@@ -107,12 +107,6 @@ struct EvalNode : public NodeVisitor {
     }
 
     void eval_peek(const TensorPeek &node) {
-        // TODO: fix Peek API so that the 'child index' sent in the
-        // spec is actually 'child index' (as defined by the function
-        // AST and Peek TensorFunction subclass) and not 'child index'
-        // - 1. This also means that the param (the object being
-        // peeked) should be sent as the first child and not as a
-        // separate parameter.
         TensorSpec param = eval_node(node.param(), params);
         ValueType param_type = ValueType::from_spec(param.type());
         auto is_indexed = [&](const vespalib::string &dim_name) {
@@ -121,6 +115,7 @@ struct EvalNode : public NodeVisitor {
                     (param_type.dimensions()[dim_idx].is_indexed()));
         };
         std::vector<TensorSpec> children;
+        children.push_back(param);
         std::map<vespalib::string, std::variant<TensorSpec::Label, size_t>> spec;
         for (const auto &[name, label]: node.dim_list()) {
             if (label.is_expr()) {
@@ -134,7 +129,7 @@ struct EvalNode : public NodeVisitor {
                 }
             }
         }
-        result = ReferenceOperations::peek(param, spec, children);
+        result = ReferenceOperations::peek(spec, children);
     }
 
     //-------------------------------------------------------------------------

--- a/eval/src/vespa/eval/eval/test/reference_operations.cpp
+++ b/eval/src/vespa/eval/eval/test/reference_operations.cpp
@@ -176,7 +176,7 @@ TensorSpec ReferenceOperations::merge(const TensorSpec &a, const TensorSpec &b, 
 
 
 TensorSpec ReferenceOperations::peek(const PeekSpec &peek_spec, const std::vector<TensorSpec> &children) {
-    if (peek_spec.empty()) {
+    if (peek_spec.empty() || children.empty()) {
         return TensorSpec(ValueType::error_type().to_spec());
     }
     std::vector<vespalib::string> peek_dims;

--- a/eval/src/vespa/eval/eval/test/reference_operations.cpp
+++ b/eval/src/vespa/eval/eval/test/reference_operations.cpp
@@ -175,7 +175,7 @@ TensorSpec ReferenceOperations::merge(const TensorSpec &a, const TensorSpec &b, 
 }
 
 
-TensorSpec ReferenceOperations::peek(const TensorSpec &param, const PeekSpec &peek_spec, const std::vector<TensorSpec> &children) {
+TensorSpec ReferenceOperations::peek(const PeekSpec &peek_spec, const std::vector<TensorSpec> &children) {
     if (peek_spec.empty()) {
         return TensorSpec(ValueType::error_type().to_spec());
     }
@@ -183,6 +183,7 @@ TensorSpec ReferenceOperations::peek(const TensorSpec &param, const PeekSpec &pe
     for (const auto & [dim_name, label_or_child] : peek_spec) {
         peek_dims.push_back(dim_name);
     }
+    const TensorSpec &param = children[0];
     ValueType param_type = ValueType::from_spec(param.type());
     ValueType result_type = param_type.reduce(peek_dims);
     TensorSpec result(result_type.to_spec());

--- a/eval/src/vespa/eval/eval/test/reference_operations.h
+++ b/eval/src/vespa/eval/eval/test/reference_operations.h
@@ -23,7 +23,9 @@ struct ReferenceOperations {
     // mapping from cell address to index of child that computes the cell value
     using CreateSpec = tensor_function::Create::Spec;
 
-    // mapping from dimension name to verbatim label or child
+    // mapping from dimension name to verbatim label or child index.
+    // Note: child 0 is the input param, so indexes in the spec must
+    // start at 1.
     using PeekSpec = tensor_function::Peek::Spec;
 
     static TensorSpec concat(const TensorSpec &a, const TensorSpec &b, const std::string &concat_dim);
@@ -31,7 +33,7 @@ struct ReferenceOperations {
     static TensorSpec join(const TensorSpec &a, const TensorSpec &b, join_fun_t function);
     static TensorSpec map(const TensorSpec &a, map_fun_t func);
     static TensorSpec merge(const TensorSpec &a, const TensorSpec &b, join_fun_t fun);
-    static TensorSpec peek(const TensorSpec &param, const PeekSpec &spec, const std::vector<TensorSpec> &children);
+    static TensorSpec peek(const PeekSpec &spec, const std::vector<TensorSpec> &children);
     static TensorSpec reduce(const TensorSpec &a, Aggr aggr, const std::vector<vespalib::string> &dims);
     static TensorSpec rename(const TensorSpec &a, const std::vector<vespalib::string> &from, const std::vector<vespalib::string> &to);
     static TensorSpec lambda(const vespalib::string &type, lambda_fun_t fun);


### PR DESCRIPTION
* change the ReferenceOperations peek API also, putting
  the input parameter as the first child, and numbering
  child indexes in the Spec starting at 1.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review
