### PR TITLE
Support lower bound on number of shared hosts

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/SharedHost.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/SharedHost.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.flags.custom;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -19,20 +20,40 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class SharedHost {
+    private final int DEFAULT_MIN_COUNT = 0;
+
     private final List<HostResources> resources;
+    private final int minCount;
 
     public static SharedHost createDisabled() {
-        return new SharedHost(null);
+        return new SharedHost(null, null);
     }
 
+    /**
+     * @param resourcesOrNull the resources of the shared host (or several to support e.g. tiers or
+     *                        fast/slow disks separately)
+     * @param minCountOrNull  the minimum number of shared hosts
+     */
     @JsonCreator
-    public SharedHost(@JsonProperty("resources") List<HostResources> resources) {
-        this.resources = resources == null ? List.of() : List.copyOf(resources);
+    public SharedHost(@JsonProperty("resources") List<HostResources> resourcesOrNull,
+                      @JsonProperty("min-count") Integer minCountOrNull) {
+        this.resources = resourcesOrNull == null ? List.of() : List.copyOf(resourcesOrNull);
+        this.minCount = requireNonNegative(minCountOrNull, DEFAULT_MIN_COUNT, "min-count");
     }
 
-    @JsonProperty("resources")
+    @JsonGetter("resources")
     public List<HostResources> getResourcesOrNull() {
         return resources.isEmpty() ? null : resources;
+    }
+
+    @JsonGetter("min-count")
+    public Integer getMinCountOrNull() {
+        return minCount == DEFAULT_MIN_COUNT ? null : minCount;
+    }
+
+    @JsonIgnore
+    public boolean isEnabled() {
+        return resources.size() > 0;
     }
 
     @JsonIgnore
@@ -40,8 +61,9 @@ public class SharedHost {
         return resources;
     }
 
-    public boolean isEnabled() {
-        return resources.size() > 0;
+    @JsonIgnore
+    public int getMinCount() {
+        return minCount;
     }
 
     @Override
@@ -60,5 +82,17 @@ public class SharedHost {
     @Override
     public int hashCode() {
         return Objects.hash(resources);
+    }
+
+    private int requireNonNegative(Integer integerOrNull, int defaultValue, String fieldName) {
+        if (integerOrNull == null) {
+            return defaultValue;
+        }
+
+        if (integerOrNull < 0) {
+            throw new IllegalArgumentException(fieldName + " cannot be negative");
+        }
+
+        return integerOrNull;
     }
 }

--- a/flags/src/test/java/com/yahoo/vespa/flags/FlagsTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/FlagsTest.java
@@ -114,7 +114,8 @@ public class FlagsTest {
         SharedHost sharedHost = new SharedHost(List.of(new HostResources(
                 4.0, 16.0, 50.0, 0.3,
                 "fast", "local",
-                10)));
+                10)),
+                null);
         testGeneric(Flags.SHARED_HOST, sharedHost);
     }
 

--- a/flags/src/test/java/com/yahoo/vespa/flags/custom/SharedHostTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/custom/SharedHostTest.java
@@ -1,0 +1,25 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.flags.custom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SharedHostTest {
+    @Test
+    public void serialization() throws IOException {
+        verifySerialization(new SharedHost(List.of(new HostResources(1.0, 2.0, 3.0, 4.0, "fast", "remote", 5)), 6));
+        verifySerialization(new SharedHost(List.of(new HostResources(1.0, 2.0, 3.0, 4.0, "fast", "remote", 5)), null));
+    }
+
+    private void verifySerialization(SharedHost sharedHost) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(sharedHost);
+        SharedHost deserialized = mapper.readValue(json, SharedHost.class);
+        assertEquals(sharedHost, deserialized);
+    }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
@@ -18,6 +18,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.flags.custom.ClusterCapacity;
+import com.yahoo.vespa.flags.custom.SharedHost;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Address;
@@ -264,6 +265,50 @@ public class DynamicProvisioningMaintainerTest {
         assertTrue("Node on deprovisioned host removed", tester.nodeRepository.getNode("host2-1").isEmpty());
         assertTrue("One 1-30-20-3 node fits on host3", tester.nodeRepository.getNode("host3").isPresent());
         assertTrue("New 48-128-1000-10 host added", tester.nodeRepository.getNode("hostname100").isPresent());
+    }
+
+    @Test
+    public void verify_min_count_of_shared_hosts() {
+        // What's going on here?  We are trying to verify the impact of varying the minimum number of
+        // shared hosts (SharedHost.minCount()).
+        //
+        // addInitialNodes() adds 4 tenant hosts:
+        //   host1    shared   !removable   # not removable because it got child nodes w/allocation
+        //   host2   !shared    removable   # not counted as a shared host because it is failed
+        //   host3    shared    removable
+        //   host4    shared   !removable   # not removable because it got child nodes w/allocation
+        //
+        // Hosts 1, 3, and 4 count as "shared hosts" with respect to the minCount lower boundary.
+        // Hosts 3 and 4 are removable, that is they will be deprovisioned as excess hosts unless
+        // prevented by minCount.
+
+        // minCount=0: All (2) removable hosts are deprovisioned
+        assertWithMinCount(0, 0, 2);
+        // minCount=1: The same thing happens, because there are 2 shared hosts left
+        assertWithMinCount(1, 0, 2);
+        assertWithMinCount(2, 0, 2);
+        // minCount=3: since we require 3 shared hosts, host3 is not deprovisioned.
+        assertWithMinCount(3, 0, 1);
+        // 4 shared hosts require we provision 1 shared host
+        assertWithMinCount(4, 1, 1);
+        // 5 shared hosts require we provision 2 shared hosts
+        assertWithMinCount(5, 2, 1);
+        assertWithMinCount(6, 3, 1);
+    }
+
+    private void assertWithMinCount(int minCount, int provisionCount, int deprovisionCount) {
+        var tester = new DynamicProvisioningTester().addInitialNodes();
+        tester.hostProvisioner.provisionSharedHost("host4");
+
+        tester.flagSource.withJacksonFlag(Flags.SHARED_HOST.id(), new SharedHost(null, minCount), SharedHost.class);
+        tester.maintainer.maintain();
+        assertEquals(provisionCount, tester.hostProvisioner.provisionedHosts.size());
+        assertEquals(deprovisionCount, tester.hostProvisioner.deprovisionedHosts);
+
+        // Verify next maintain is a no-op
+        tester.maintainer.maintain();
+        assertEquals(provisionCount, tester.hostProvisioner.provisionedHosts.size());
+        assertEquals(deprovisionCount, tester.hostProvisioner.deprovisionedHosts);
     }
 
     @Test


### PR DESCRIPTION
Adds a 'minCount' field to the shared host jackson flag, denoting the minimum
number of "shared hosts" that must exist, otherwise the deficit will be
provisioned by DynamicProvisioningMaintainer.

A "shared host" is one that is considered for allocation if current tenant node
allocations were removed: It must be a tenant host, cannot be an exclusiveTo
host, etc.

minCount requires the setting of (at least one) shared host.