### PR TITLE
avoid calling nativeIO.dropPartialFileFromCache too often

### DIFF
--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
@@ -125,8 +125,10 @@ public class LogFileHandler extends StreamHandler {
         try {
             if (currentOutputStream != null) {
                 long newPos = currentOutputStream.getChannel().position();
-                nativeIO.dropPartialFileFromCache(currentOutputStream.getFD(), lastDropPosition, newPos, true);
-                lastDropPosition = newPos;
+                if (newPos > lastDropPosition + 102400) {
+                    nativeIO.dropPartialFileFromCache(currentOutputStream.getFD(), lastDropPosition, newPos, true);
+                    lastDropPosition = newPos;
+                }
             }
         } catch (IOException e) {
             logger.warning("Failed dropping from cache : " + Exceptions.toMessageString(e));


### PR DESCRIPTION
* there is no need to call fsync() every 100 milliseconds just to drop
  minimal amounts of data from the file system cache.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
