### PR TITLE
Remove lock metrics not used in dashboard

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -147,25 +147,14 @@ public class MetricsReporterTest {
 
         // Verify sum of values across dimensions, and remove these metrics to avoid checking against
         // metric.values below, which is not sensitive to dimensions.
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquire", 3);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquireFailed", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquireTimedOut", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.locked", 3);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.release", 3);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.releaseFailed", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.reentry", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.deadlock", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.nakedRelease", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquireWithoutRelease", 0);
-        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.foreignRelease", 0);
-        metric.remove("lockAttempt.acquireLatency");
         metric.remove("lockAttempt.acquireMaxActiveLatency");
         metric.remove("lockAttempt.acquireHz");
         metric.remove("lockAttempt.acquireLoad");
         metric.remove("lockAttempt.lockedLatency");
-        metric.remove("lockAttempt.lockedMaxActiveLatency");
-        metric.remove("lockAttempt.lockedHz");
         metric.remove("lockAttempt.lockedLoad");
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.acquireTimedOut", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.deadlock", 0);
+        verifyAndRemoveIntegerMetricSum(metric, "lockAttempt.errors", 0);
 
         assertEquals(expectedMetrics, new TreeMap<>(metric.values));
     }


### PR DESCRIPTION
Reduces the number of lock metrics set in MetricsReporter from 19 to 8.

Most/all metrics in MetricsReporter ought to cause 1 metric to be emitted, like the lock metrics. However the framework emits 3 (last, average, and max), and it's not easily fixed.

