### PR TITLE
Initial support for backend reindexing visitor functionality

### DIFF
--- a/storage/src/tests/distributor/CMakeLists.txt
+++ b/storage/src/tests/distributor/CMakeLists.txt
@@ -32,6 +32,7 @@ vespa_add_executable(storage_distributor_gtest_runner_app TEST
     pendingmessagetrackertest.cpp
     persistence_metrics_set_test.cpp
     putoperationtest.cpp
+    read_for_write_visitor_operation_test.cpp
     removebucketoperationtest.cpp
     removelocationtest.cpp
     removeoperationtest.cpp

--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -5,7 +5,10 @@
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/operations/external/getoperation.h>
+#include <vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h>
+#include <vespa/storage/common/reindexing_constants.h>
 #include <vespa/storageapi/message/persistence.h>
+#include <vespa/storageapi/message/visitor.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/update/documentupdate.h>
 #include <vespa/document/fieldset/fieldsets.h>
@@ -558,6 +561,80 @@ TEST_F(ExternalOperationHandlerTest, gets_are_sent_with_strong_consistency_by_de
 
 TEST_F(ExternalOperationHandlerTest, gets_are_sent_with_weak_consistency_if_config_enabled) {
     do_test_get_weak_consistency_is_propagated(true);
+}
+
+struct OperationHandlerSequencingTest : ExternalOperationHandlerTest {
+    void SetUp() override {
+        set_up_distributor_for_sequencing_test();
+    }
+
+    static documentapi::TestAndSetCondition bucket_lock_bypass_tas_condition() {
+        return documentapi::TestAndSetCondition(reindexing_bucket_lock_bypass_value());
+    }
+};
+
+TEST_F(OperationHandlerSequencingTest, put_not_allowed_through_locked_bucket_if_special_tas_token_not_present) {
+    auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
+    auto bucket = makeDocumentBucket(document::BucketId(16, 1));
+    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket);
+    ASSERT_TRUE(bucket_handle.valid());
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(put));
+}
+
+TEST_F(OperationHandlerSequencingTest, put_allowed_through_locked_bucket_if_special_tas_token_present) {
+    set_up_distributor_for_sequencing_test();
+
+    auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
+    put->setCondition(bucket_lock_bypass_tas_condition());
+
+    auto bucket = makeDocumentBucket(document::BucketId(16, 1));
+    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket);
+    ASSERT_TRUE(bucket_handle.valid());
+
+    Operation::SP op;
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(put, op));
+}
+
+TEST_F(OperationHandlerSequencingTest, put_with_bucket_lock_tas_token_is_rejected_if_no_bucket_lock_present) {
+    auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
+    put->setCondition(bucket_lock_bypass_tas_condition());
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(put));
+    // TODO determine most appropriate error code here. Want to fail the bucket but
+    // not the entire visitor operation. Will likely need to be revisited (heh!) soon.
+    EXPECT_EQ("ReturnCode(REJECTED, Operation expects a read-for-write bucket lock to be present, "
+              "but none currently exists)",
+              _sender.reply(0)->getResult().toString());
+}
+
+// This test is a variation of the above, but whereas it tests the case where _no_ lock is
+// present, this tests the case where a lock is present but it's not a bucket-level lock.
+TEST_F(OperationHandlerSequencingTest, put_with_bucket_lock_tas_token_is_rejected_if_document_lock_present) {
+    auto put = makePutCommand("testdoctype1", _dummy_id);
+    put->setCondition(bucket_lock_bypass_tas_condition());
+    Operation::SP op;
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(makeUpdateCommand("testdoctype1", _dummy_id), op));
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(std::move(put)));
+    EXPECT_EQ("ReturnCode(REJECTED, Operation expects a read-for-write bucket lock to be present, "
+              "but none currently exists)",
+              _sender.reply(0)->getResult().toString());
+}
+
+TEST_F(OperationHandlerSequencingTest, reindexing_visitor_creates_read_for_write_operation) {
+    auto cmd = std::make_shared<api::CreateVisitorCommand>(
+            document::FixedBucketSpaces::default_space(), "reindexingvisitor", "foo", "");
+    Operation::SP op;
+    getExternalOperationHandler().handleMessage(cmd, op);
+    ASSERT_TRUE(op.get() != nullptr);
+    ASSERT_TRUE(dynamic_cast<ReadForWriteVisitorOperationStarter*>(op.get()) != nullptr);
+}
+
+TEST_F(OperationHandlerSequencingTest, reindexing_visitor_library_check_is_case_insensitive) {
+    auto cmd = std::make_shared<api::CreateVisitorCommand>(
+            document::FixedBucketSpaces::default_space(), "ReIndexingVisitor", "foo", "");
+    Operation::SP op;
+    getExternalOperationHandler().handleMessage(cmd, op);
+    ASSERT_TRUE(op.get() != nullptr);
+    ASSERT_TRUE(dynamic_cast<ReadForWriteVisitorOperationStarter*>(op.get()) != nullptr);
 }
 
 // TODO support sequencing of RemoveLocation? It's a mutating operation, but supporting it with

--- a/storage/src/tests/distributor/operation_sequencer_test.cpp
+++ b/storage/src/tests/distributor/operation_sequencer_test.cpp
@@ -1,46 +1,94 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/document/base/documentid.h>
+#include <vespa/document/bucket/fixed_bucket_spaces.h>
 #include <vespa/storage/distributor/operation_sequencer.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 namespace storage::distributor {
 
 using document::DocumentId;
+using namespace ::testing;
 
-TEST(OperationSequencerTest, can_get_sequencing_handle_for_id_without_existing_handle) {
+namespace {
+
+constexpr document::BucketSpace default_space() {
+    return document::FixedBucketSpaces::default_space();
+}
+
+constexpr document::BucketSpace global_space() {
+    return document::FixedBucketSpaces::global_space();
+}
+
+}
+
+struct OperationSequencerTest : Test {
     OperationSequencer sequencer;
-    auto handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
+};
+
+TEST_F(OperationSequencerTest, can_get_sequencing_handle_for_id_without_existing_handle) {
+    auto handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     EXPECT_TRUE(handle.valid());
+    EXPECT_FALSE(handle.was_blocked());
 }
 
-TEST(OperationSequencerTest, cannot_get_sequencing_handle_for_id_with_existing_handle) {
-    OperationSequencer sequencer;
-    auto first_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
-    auto second_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
+TEST_F(OperationSequencerTest, cannot_get_sequencing_handle_for_id_with_existing_handle) {
+    auto first_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
+    auto second_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     EXPECT_FALSE(second_handle.valid());
+    ASSERT_TRUE(second_handle.was_blocked());
+    EXPECT_EQ(second_handle.blocked_by(), SequencingHandle::BlockedBy::PendingOperation);
 }
 
-TEST(OperationSequencerTest, can_get_sequencing_handle_for_different_ids) {
-    OperationSequencer sequencer;
-    auto first_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
-    auto second_handle = sequencer.try_acquire(DocumentId("id:foo:test::efgh"));
+TEST_F(OperationSequencerTest, can_get_sequencing_handle_for_different_ids) {
+    auto first_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
+    auto second_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::efgh"));
     EXPECT_TRUE(first_handle.valid());
     EXPECT_TRUE(second_handle.valid());
 }
 
-TEST(OperationSequencerTest, releasing_handle_allows_for_getting_new_handles_for_id) {
-    OperationSequencer sequencer;
-    auto first_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
+TEST_F(OperationSequencerTest, releasing_handle_allows_for_getting_new_handles_for_id) {
+    auto first_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     // Explicit release
     first_handle.release();
     {
-        auto second_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
+        auto second_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
         EXPECT_TRUE(second_handle.valid());
         // Implicit release by scope exit
     }
-    auto third_handle = sequencer.try_acquire(DocumentId("id:foo:test::abcd"));
+    auto third_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     EXPECT_TRUE(third_handle.valid());
+}
+
+TEST_F(OperationSequencerTest, cannot_get_handle_for_gid_contained_in_locked_bucket) {
+    auto bucket_handle = sequencer.try_acquire(document::Bucket(default_space(), document::BucketId(16, 1)));
+    EXPECT_TRUE(bucket_handle.valid());
+    auto doc_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test:n=1:abcd"));
+    EXPECT_FALSE(doc_handle.valid());
+    ASSERT_TRUE(doc_handle.was_blocked());
+    EXPECT_EQ(doc_handle.blocked_by(), SequencingHandle::BlockedBy::LockedBucket);
+}
+
+TEST_F(OperationSequencerTest, can_get_handle_for_gid_not_contained_in_active_bucket) {
+    auto bucket_handle = sequencer.try_acquire(document::Bucket(default_space(), document::BucketId(16, 1)));
+    EXPECT_TRUE(bucket_handle.valid());
+    // Note: different sub-bucket than the lock
+    auto doc_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test:n=2:abcd"));
+    EXPECT_TRUE(doc_handle.valid());
+}
+
+TEST_F(OperationSequencerTest, releasing_bucket_lock_allows_gid_handles_to_be_acquired) {
+    auto bucket_handle = sequencer.try_acquire(document::Bucket(default_space(), document::BucketId(16, 1)));
+    bucket_handle.release();
+    auto doc_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test:n=1:abcd"));
+    EXPECT_TRUE(doc_handle.valid());
+}
+
+TEST_F(OperationSequencerTest, can_get_handle_for_gid_when_locked_bucket_is_in_separate_bucket_space) {
+    auto bucket_handle = sequencer.try_acquire(document::Bucket(default_space(), document::BucketId(16, 1)));
+    EXPECT_TRUE(bucket_handle.valid());
+    auto doc_handle = sequencer.try_acquire(global_space(), DocumentId("id:foo:test:n=1:abcd"));
+    EXPECT_TRUE(doc_handle.valid());
 }
 
 } // storage::distributor

--- a/storage/src/tests/distributor/operation_sequencer_test.cpp
+++ b/storage/src/tests/distributor/operation_sequencer_test.cpp
@@ -29,14 +29,14 @@ struct OperationSequencerTest : Test {
 TEST_F(OperationSequencerTest, can_get_sequencing_handle_for_id_without_existing_handle) {
     auto handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     EXPECT_TRUE(handle.valid());
-    EXPECT_FALSE(handle.was_blocked());
+    EXPECT_FALSE(handle.is_blocked());
 }
 
 TEST_F(OperationSequencerTest, cannot_get_sequencing_handle_for_id_with_existing_handle) {
     auto first_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     auto second_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test::abcd"));
     EXPECT_FALSE(second_handle.valid());
-    ASSERT_TRUE(second_handle.was_blocked());
+    ASSERT_TRUE(second_handle.is_blocked());
     EXPECT_EQ(second_handle.blocked_by(), SequencingHandle::BlockedBy::PendingOperation);
 }
 
@@ -65,7 +65,7 @@ TEST_F(OperationSequencerTest, cannot_get_handle_for_gid_contained_in_locked_buc
     EXPECT_TRUE(bucket_handle.valid());
     auto doc_handle = sequencer.try_acquire(default_space(), DocumentId("id:foo:test:n=1:abcd"));
     EXPECT_FALSE(doc_handle.valid());
-    ASSERT_TRUE(doc_handle.was_blocked());
+    ASSERT_TRUE(doc_handle.is_blocked());
     EXPECT_EQ(doc_handle.blocked_by(), SequencingHandle::BlockedBy::LockedBucket);
 }
 

--- a/storage/src/tests/distributor/read_for_write_visitor_operation_test.cpp
+++ b/storage/src/tests/distributor/read_for_write_visitor_operation_test.cpp
@@ -1,0 +1,124 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/document/base/testdocman.h>
+#include <vespa/document/bucket/fixed_bucket_spaces.h>
+#include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/document/update/documentupdate.h>
+#include <vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h>
+#include <vespa/storage/distributor/operations/external/visitoroperation.h>
+#include <vespa/storage/distributor/distributor.h>
+#include <vespa/storage/distributor/distributormetricsset.h>
+#include <vespa/storageapi/message/persistence.h>
+#include <vespa/storageapi/message/visitor.h>
+#include <tests/distributor/distributortestutil.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace ::testing;
+using document::Bucket;
+using document::BucketId;
+
+namespace storage::distributor {
+
+struct ReadForWriteVisitorOperationStarterTest : Test, DistributorTestUtil {
+    document::TestDocMan            _test_doc_man;
+    VisitorOperation::Config        _default_config;
+    std::unique_ptr<OperationOwner> _op_owner;
+    BucketId                        _superbucket;
+    BucketId                        _sub_bucket;
+
+    ReadForWriteVisitorOperationStarterTest()
+        : _test_doc_man(),
+          _default_config(100, 100),
+          _op_owner(),
+          _superbucket(16, 4),
+          _sub_bucket(17, 4)
+    {}
+
+    void SetUp() override {
+        createLinks();
+        setupDistributor(1, 1, "version:1 distributor:1 storage:1");
+        _op_owner = std::make_unique<OperationOwner>(_sender, getClock());
+
+        addNodesToBucketDB(_sub_bucket, "0=1/2/3/t");
+    }
+
+    void TearDown() override {
+        close();
+    }
+
+    static Bucket default_bucket(BucketId id) {
+        return Bucket(document::FixedBucketSpaces::default_space(), id);
+    }
+
+    std::shared_ptr<VisitorOperation> create_nested_visitor_op(bool valid_command = true) {
+        auto cmd = std::make_shared<api::CreateVisitorCommand>(
+                document::FixedBucketSpaces::default_space(), "reindexingvisitor", "foo", "");
+        if (valid_command) {
+            cmd->addBucketToBeVisited(_superbucket);
+            cmd->addBucketToBeVisited(BucketId()); // Will be inferred to first sub-bucket in DB
+        }
+        return std::make_shared<VisitorOperation>(
+                getExternalOperationHandler(), getExternalOperationHandler(),
+                getDistributorBucketSpace(), cmd, _default_config,
+                getDistributor().getMetrics().visits);
+    }
+
+    OperationSequencer& operation_sequencer() {
+        return getExternalOperationHandler().operation_sequencer();
+    }
+
+    std::shared_ptr<ReadForWriteVisitorOperationStarter> create_rfw_op(std::shared_ptr<VisitorOperation> visitor_op) {
+        return std::make_shared<ReadForWriteVisitorOperationStarter>(
+                std::move(visitor_op), operation_sequencer(),
+                *_op_owner, getDistributor().getPendingMessageTracker());
+    }
+};
+
+TEST_F(ReadForWriteVisitorOperationStarterTest, visitor_that_fails_precondition_checks_is_immediately_failed) {
+    auto op = create_rfw_op(create_nested_visitor_op(false));
+    _op_owner->start(op, OperationStarter::Priority(120));
+    EXPECT_EQ("CreateVisitorReply(last=BucketId(0x0000000000000000)) "
+              "ReturnCode(ILLEGAL_PARAMETERS, No buckets in CreateVisitorCommand for visitor 'foo')",
+              _sender.getLastReply());
+}
+
+TEST_F(ReadForWriteVisitorOperationStarterTest, visitor_immediately_started_if_no_pending_ops_to_bucket) {
+    auto op = create_rfw_op(create_nested_visitor_op(true));
+    _op_owner->start(op, OperationStarter::Priority(120));
+    ASSERT_EQ("Visitor Create => 0", _sender.getCommands(true));
+}
+
+TEST_F(ReadForWriteVisitorOperationStarterTest, visitor_start_deferred_if_pending_ops_to_bucket) {
+    auto op = create_rfw_op(create_nested_visitor_op(true));
+    // Pending mutating op to same bucket, prevents visitor from starting
+    auto update = std::make_shared<document::DocumentUpdate>(
+            _test_doc_man.getTypeRepo(),
+            *_test_doc_man.getTypeRepo().getDocumentType("testdoctype1"),
+            document::DocumentId("id::testdoctype1:n=4:foo"));
+    auto update_cmd = std::make_shared<api::UpdateCommand>(
+            default_bucket(document::BucketId(0)), std::move(update), api::Timestamp(0));
+
+    Operation::SP mutating_op;
+    getExternalOperationHandler().handleMessage(update_cmd, mutating_op);
+    ASSERT_TRUE(mutating_op);
+    _op_owner->start(mutating_op, OperationStarter::Priority(120));
+    ASSERT_EQ("Update(BucketId(0x4400000000000004), id::testdoctype1:n=4:foo, timestamp 1) => 0",
+              _sender.getCommands(true, true));
+    // Since pending message tracking normally happens in the distributor itself during sendUp,
+    // we have to emulate this and explicitly insert the sent message into the pending mapping.
+    getDistributor().getPendingMessageTracker().insert(_sender.command(0));
+
+    _op_owner->start(op, OperationStarter::Priority(120));
+    // Nothing started yet
+    ASSERT_EQ("", _sender.getCommands(true, false, 1));
+
+    // Pretend update operation completed
+    auto update_reply = std::shared_ptr<api::StorageReply>(_sender.command(0)->makeReply());
+    getDistributor().getPendingMessageTracker().reply(*update_reply);
+    _op_owner->handleReply(update_reply);
+
+    // Visitor should now be started!
+    ASSERT_EQ("Visitor Create => 0", _sender.getCommands(true, false, 1));
+}
+
+}

--- a/storage/src/vespa/storage/common/CMakeLists.txt
+++ b/storage/src/vespa/storage/common/CMakeLists.txt
@@ -9,6 +9,7 @@ vespa_add_library(storage_common OBJECT
     global_bucket_space_distribution_converter.cpp
     messagebucket.cpp
     messagesender.cpp
+    reindexing_constants.cpp
     servicelayercomponent.cpp
     statusmessages.cpp
     statusmetricconsumer.cpp

--- a/storage/src/vespa/storage/common/reindexing_constants.cpp
+++ b/storage/src/vespa/storage/common/reindexing_constants.cpp
@@ -1,0 +1,12 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "reindexing_constants.h"
+
+namespace storage {
+
+const char* reindexing_bucket_lock_bypass_value() noexcept {
+    // This is by design a string that will fail to parse as a valid document selection in the backend.
+    // It's only used to bypass the read-for-write visitor bucket lock.
+    return "@@__vespa_internal_allow_through_bucket_lock";
+}
+
+}

--- a/storage/src/vespa/storage/common/reindexing_constants.h
+++ b/storage/src/vespa/storage/common/reindexing_constants.h
@@ -1,0 +1,8 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+namespace storage {
+
+const char* reindexing_bucket_lock_bypass_value() noexcept;
+
+}

--- a/storage/src/vespa/storage/distributor/distributor.cpp
+++ b/storage/src/vespa/storage/distributor/distributor.cpp
@@ -83,7 +83,8 @@ Distributor::Distributor(DistributorComponentRegister& compReg,
       _distributorStatusDelegate(compReg, *this, *this),
       _bucketDBStatusDelegate(compReg, *this, _bucketDBUpdater),
       _idealStateManager(*this, *_bucketSpaceRepo, *_readOnlyBucketSpaceRepo, compReg, manageActiveBucketCopies),
-      _externalOperationHandler(*this, *_bucketSpaceRepo, *_readOnlyBucketSpaceRepo, _idealStateManager, compReg),
+      _externalOperationHandler(*this, *_bucketSpaceRepo, *_readOnlyBucketSpaceRepo,
+                                _idealStateManager, _operationOwner, compReg),
       _threadPool(threadPool),
       _initializingIsUp(true),
       _doneInitializeHandler(doneInitHandler),
@@ -217,6 +218,7 @@ void Distributor::onClose() {
     }
 
     LOG(debug, "Distributor::onClose invoked");
+    _pendingMessageTracker.abort_deferred_tasks();
     _bucketDBUpdater.flush();
     _externalOperationHandler.close_pending();
     _operationOwner.onClose();

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -11,8 +11,10 @@
 #include <vespa/storage/distributor/operations/external/getoperation.h>
 #include <vespa/storage/distributor/operations/external/statbucketoperation.h>
 #include <vespa/storage/distributor/operations/external/statbucketlistoperation.h>
+#include <vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h>
 #include <vespa/storage/distributor/operations/external/removelocationoperation.h>
 #include <vespa/storage/distributor/operations/external/visitoroperation.h>
+#include <vespa/storage/common/reindexing_constants.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/storageapi/message/stat.h>
@@ -55,11 +57,13 @@ ExternalOperationHandler::ExternalOperationHandler(Distributor& owner,
                                                    DistributorBucketSpaceRepo& bucketSpaceRepo,
                                                    DistributorBucketSpaceRepo& readOnlyBucketSpaceRepo,
                                                    const MaintenanceOperationGenerator& gen,
+                                                   OperationOwner& operation_owner,
                                                    DistributorComponentRegister& compReg)
     : DistributorComponent(owner, bucketSpaceRepo, readOnlyBucketSpaceRepo, compReg, "External operation handler"),
       _direct_dispatch_sender(std::make_unique<DirectDispatchSender>(owner)),
       _operationGenerator(gen),
       _rejectFeedBeforeTimeReached(), // At epoch
+      _distributor_operation_owner(operation_owner),
       _non_main_thread_ops_mutex(),
       _non_main_thread_ops_owner(*_direct_dispatch_sender, getClock()),
       _concurrent_gets_enabled(false),
@@ -239,8 +243,7 @@ void ExternalOperationHandler::bounce_or_invoke_read_only_op(
     }
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, Put)
-{
+bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd) {
     auto& metrics = getMetrics().puts;
     if (!checkTimestampMutationPreconditions(*cmd, getBucketId(cmd->getDocumentId()), metrics)) {
         return true;
@@ -250,11 +253,26 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Put)
         cmd->setTimestamp(getUniqueTimestamp());
     }
 
-    auto handle = _mutationSequencer.try_acquire(cmd->getDocumentId());
-    if (allowMutation(handle)) {
-        document::BucketSpace bucketSpace = cmd->getBucket().getBucketSpace();
+    const auto bucket_space = cmd->getBucket().getBucketSpace();
+    auto handle = _operation_sequencer.try_acquire(bucket_space, cmd->getDocumentId());
+    bool allow = allowMutation(handle);
+    const auto& tas_cond = cmd->getCondition();
+    const bool bypass_bucket_lock = (tas_cond.isPresent()
+                                     && (tas_cond.getSelection() == reindexing_bucket_lock_bypass_value()));
+    if (bypass_bucket_lock) {
+        if (!allow && handle.was_blocked() && (handle.blocked_by() == SequencingHandle::BlockedBy::LockedBucket)) {
+            cmd->setCondition(documentapi::TestAndSetCondition()); // Must clear TaS or the backend will reject the op
+            allow = true;
+        } else {
+            bounce_with_result(*cmd, api::ReturnCode(api::ReturnCode::REJECTED,
+                                                     "Operation expects a read-for-write bucket lock to be present, "
+                                                     "but none currently exists"));
+            return true;
+        }
+    }
+    if (allow) {
         _op = std::make_shared<PutOperation>(*this, *this,
-                                             _bucketSpaceRepo.get(bucketSpace),
+                                             _bucketSpaceRepo.get(bucket_space),
                                              std::move(cmd), getMetrics().puts, std::move(handle));
     } else {
         sendUp(makeConcurrentMutationRejectionReply(*cmd, cmd->getDocumentId(), metrics));
@@ -264,8 +282,7 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Put)
 }
 
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, Update)
-{
+bool ExternalOperationHandler::onUpdate(const std::shared_ptr<api::UpdateCommand>& cmd) {
     auto& metrics = getMetrics().updates;
     if (!checkTimestampMutationPreconditions(*cmd, getBucketId(cmd->getDocumentId()), metrics)) {
         return true;
@@ -274,11 +291,11 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Update)
     if (cmd->getTimestamp() == 0) {
         cmd->setTimestamp(getUniqueTimestamp());
     }
-    auto handle = _mutationSequencer.try_acquire(cmd->getDocumentId());
+    const auto bucket_space = cmd->getBucket().getBucketSpace();
+    auto handle = _operation_sequencer.try_acquire(bucket_space, cmd->getDocumentId());
     if (allowMutation(handle)) {
-        document::BucketSpace bucketSpace = cmd->getBucket().getBucketSpace();
         _op = std::make_shared<TwoPhaseUpdateOperation>(*this, *this, *this,
-                                                        _bucketSpaceRepo.get(bucketSpace),
+                                                        _bucketSpaceRepo.get(bucket_space),
                                                         std::move(cmd), getMetrics(), std::move(handle));
     } else {
         sendUp(makeConcurrentMutationRejectionReply(*cmd, cmd->getDocumentId(), metrics));
@@ -288,8 +305,7 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Update)
 }
 
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, Remove)
-{
+bool ExternalOperationHandler::onRemove(const std::shared_ptr<api::RemoveCommand>& cmd) {
     auto& metrics = getMetrics().removes;
     if (!checkTimestampMutationPreconditions(*cmd, getBucketId(cmd->getDocumentId()), metrics)) {
         return true;
@@ -298,9 +314,10 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Remove)
     if (cmd->getTimestamp() == 0) {
         cmd->setTimestamp(getUniqueTimestamp());
     }
-    auto handle = _mutationSequencer.try_acquire(cmd->getDocumentId());
+    const auto bucket_space = cmd->getBucket().getBucketSpace();
+    auto handle = _operation_sequencer.try_acquire(bucket_space, cmd->getDocumentId());
     if (allowMutation(handle)) {
-        auto &distributorBucketSpace(_bucketSpaceRepo.get(cmd->getBucket().getBucketSpace()));
+        auto &distributorBucketSpace(_bucketSpaceRepo.get(bucket_space));
 
         _op = std::make_shared<RemoveOperation>(*this, *this, distributorBucketSpace, std::move(cmd),
                                                 getMetrics().removes, std::move(handle));
@@ -311,8 +328,7 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, Remove)
     return true;
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, RemoveLocation)
-{
+bool ExternalOperationHandler::onRemoveLocation(const std::shared_ptr<api::RemoveLocationCommand>& cmd) {
     document::BucketId bid;
     RemoveLocationOperation::getBucketId(*this, *this, *cmd, bid);
     document::Bucket bucket(cmd->getBucket().getBucketSpace(), bid);
@@ -357,14 +373,12 @@ std::shared_ptr<Operation> ExternalOperationHandler::try_generate_get_operation(
                                           desired_get_read_consistency());
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, Get)
-{
+bool ExternalOperationHandler::onGet(const std::shared_ptr<api::GetCommand>& cmd) {
     _op = try_generate_get_operation(cmd);
     return true;
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, StatBucket)
-{
+bool ExternalOperationHandler::onStatBucket(const std::shared_ptr<api::StatBucketCommand>& cmd) {
     auto& metrics = getMetrics().stats;
     bounce_or_invoke_read_only_op(*cmd, cmd->getBucket(), metrics, [&](auto& bucket_space_repo) {
         auto& bucket_space = bucket_space_repo.get(cmd->getBucket().getBucketSpace());
@@ -373,8 +387,7 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, StatBucket)
     return true;
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, GetBucketList)
-{
+bool ExternalOperationHandler::onGetBucketList(const std::shared_ptr<api::GetBucketListCommand>& cmd) {
     auto& metrics = getMetrics().getbucketlists;
     bounce_or_invoke_read_only_op(*cmd, cmd->getBucket(), metrics, [&](auto& bucket_space_repo) {
         auto& bucket_space = bucket_space_repo.get(cmd->getBucket().getBucketSpace());
@@ -384,13 +397,19 @@ IMPL_MSG_COMMAND_H(ExternalOperationHandler, GetBucketList)
     return true;
 }
 
-IMPL_MSG_COMMAND_H(ExternalOperationHandler, CreateVisitor)
-{
+bool ExternalOperationHandler::onCreateVisitor(const std::shared_ptr<api::CreateVisitorCommand>& cmd) {
     // TODO same handling as Gets (VisitorOperation needs to change)
     const DistributorConfiguration& config(getDistributor().getConfig());
     VisitorOperation::Config visitorConfig(config.getMinBucketsPerVisitor(), config.getMaxVisitorsPerNodePerClientVisitor());
     auto &distributorBucketSpace(_bucketSpaceRepo.get(cmd->getBucket().getBucketSpace()));
-    _op = Operation::SP(new VisitorOperation(*this, *this, distributorBucketSpace, cmd, visitorConfig, getMetrics().visits));
+    auto visit_op = std::make_shared<VisitorOperation>(*this, *this, distributorBucketSpace, cmd, visitorConfig, getMetrics().visits);
+    if (visit_op->is_read_for_write()) {
+        _op = std::make_shared<ReadForWriteVisitorOperationStarter>(std::move(visit_op), _operation_sequencer,
+                                                                    _distributor_operation_owner,
+                                                                    getDistributor().getPendingMessageTracker());
+    } else {
+        _op = std::move(visit_op);
+    }
     return true;
 }
 

--- a/storage/src/vespa/storage/distributor/operation_sequencer.h
+++ b/storage/src/vespa/storage/distributor/operation_sequencer.h
@@ -80,11 +80,14 @@ public:
     }
 
     [[nodiscard]] bool valid() const noexcept { return (_sequencer != nullptr); }
-    [[nodiscard]] bool was_blocked() const noexcept {
+    [[nodiscard]] bool is_blocked() const noexcept {
         return std::holds_alternative<BlockedBy>(_handle);
     }
     [[nodiscard]] BlockedBy blocked_by() const noexcept {
         return std::get<BlockedBy>(_handle); // FIXME can actually throw
+    }
+    [[nodiscard]] bool is_blocked_by(BlockedBy blocker) const noexcept {
+        return (is_blocked() && blocked_by() == blocker);
     }
     [[nodiscard]] bool has_bucket() const noexcept {
         return std::holds_alternative<document::Bucket>(_handle);

--- a/storage/src/vespa/storage/distributor/operationowner.h
+++ b/storage/src/vespa/storage/distributor/operationowner.h
@@ -59,7 +59,7 @@ public:
     : _sender(sender),
       _clock(clock) {
     }
-    ~OperationOwner();
+    ~OperationOwner() override;
 
     /**
        Handles replies from storage, mapping from a message id to an operation.
@@ -81,6 +81,8 @@ public:
        appropriate callback.
      */
     void erase(api::StorageMessage::Id msgId);
+
+    [[nodiscard]] DistributorMessageSender& sender() noexcept { return _sender; }
 
     void onClose();
     uint32_t size() const { return _sentMessageMap.size(); }

--- a/storage/src/vespa/storage/distributor/operations/external/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/operations/external/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(storage_distributoroperationexternal OBJECT
     getoperation.cpp
     newest_replica.cpp
     putoperation.cpp
+    read_for_write_visitor_operation.cpp
     removelocationoperation.cpp
     removeoperation.cpp
     statbucketlistoperation.cpp

--- a/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.cpp
@@ -1,0 +1,74 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "read_for_write_visitor_operation.h"
+#include "visitoroperation.h"
+#include <vespa/storage/distributor/pendingmessagetracker.h>
+#include <vespa/storage/distributor/operationowner.h>
+#include <cassert>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".operations.external.read_for_write_visitor_operation");
+
+namespace storage::distributor {
+
+ReadForWriteVisitorOperationStarter::ReadForWriteVisitorOperationStarter(
+        std::shared_ptr<VisitorOperation> visitor_op,
+        OperationSequencer& operation_sequencer,
+        OperationOwner& stable_operation_owner,
+        PendingMessageTracker& message_tracker)
+    : _visitor_op(std::move(visitor_op)),
+      _operation_sequencer(operation_sequencer),
+      _stable_operation_owner(stable_operation_owner),
+      _message_tracker(message_tracker)
+{
+}
+
+ReadForWriteVisitorOperationStarter::~ReadForWriteVisitorOperationStarter() = default;
+
+void ReadForWriteVisitorOperationStarter::onClose(DistributorMessageSender& sender) {
+    _visitor_op->onClose(sender);
+}
+
+void ReadForWriteVisitorOperationStarter::onStart(DistributorMessageSender& sender) {
+    if (_visitor_op->verify_command_and_expand_buckets(sender)) {
+        assert(!_visitor_op->has_sent_reply());
+        auto maybe_bucket = _visitor_op->first_bucket_to_visit();
+        if (!maybe_bucket) {
+            LOG(debug, "No buckets found to visit, tagging visitor complete");
+            // No buckets to be found, start op to trigger immediate reply.
+            _visitor_op->start(sender, _startTime);
+            assert(_visitor_op->has_sent_reply());
+            return;
+        }
+        auto bucket_handle = _operation_sequencer.try_acquire(*maybe_bucket);
+        if (!bucket_handle.valid()) {
+            LOG(debug, "An operation is already pending for bucket %s, failing visitor",
+                maybe_bucket->toString().c_str());
+            _visitor_op->fail_with_bucket_already_locked(sender);
+            return;
+        }
+        LOG(debug, "Possibly deferring start of visitor for bucket %s", maybe_bucket->toString().c_str());
+        _message_tracker.run_once_no_pending_for_bucket(
+                *maybe_bucket,
+                make_deferred_task([self = shared_from_this(), handle = std::move(bucket_handle)](TaskRunState state) mutable {
+                    LOG(debug, "Starting deferred visitor");
+                    self->_visitor_op->assign_bucket_lock_handle(std::move(handle));
+                    if (state == TaskRunState::OK) {
+                        // Once started, ownership of _visitor_op will pass to the Distributor's OperationOwner
+                        self->_stable_operation_owner.start(self->_visitor_op, 120/*TODO*/);
+                    } else {
+                        self->_visitor_op->onClose(self->_stable_operation_owner.sender());
+                    }
+                }));
+    } else {
+        LOG(debug, "Failed verification of visitor, responding immediately");
+        assert(_visitor_op->has_sent_reply());
+    }
+}
+
+void ReadForWriteVisitorOperationStarter::onReceive(DistributorMessageSender& sender,
+                                                    const std::shared_ptr<api::StorageReply> & msg) {
+    _visitor_op->onReceive(sender, msg);
+}
+
+}

--- a/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
@@ -1,0 +1,48 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/storage/distributor/operations/operation.h>
+#include <vespa/storage/distributor/operation_sequencer.h>
+#include <memory>
+
+namespace storage::distributor {
+
+class PendingMessageTracker;
+class VisitorOperation;
+class OperationOwner;
+
+/**
+ * Operation starting indirection for a visitor operation that has the semantics
+ * of an exclusive bucket lock. Such operations can only resolve to a single
+ * super-bucket/sub-bucket pair and care should be taken to avoid starving client
+ * operations through long-running locks.
+ *
+ * Operation starting may be deferred to the PendingMessageTracker if there are
+ * pending operations to the sub-bucket when onStart is called. If so, the deferred
+ * operation start takes place automatically and immediately when all pending
+ * bucket operations have completed. These will be started in the context of the
+ * OperationOwner provided to the operation.
+ */
+class ReadForWriteVisitorOperationStarter
+        : public Operation,
+          public std::enable_shared_from_this<ReadForWriteVisitorOperationStarter>
+{
+    std::shared_ptr<VisitorOperation> _visitor_op;
+    OperationSequencer&               _operation_sequencer;
+    OperationOwner&                   _stable_operation_owner;
+    PendingMessageTracker&            _message_tracker;
+public:
+    ReadForWriteVisitorOperationStarter(std::shared_ptr<VisitorOperation> visitor_op,
+                                        OperationSequencer& operation_sequencer,
+                                        OperationOwner& stable_operation_owner,
+                                        PendingMessageTracker& message_tracker);
+    ~ReadForWriteVisitorOperationStarter() override;
+
+    const char* getName() const override { return "ReadForWriteVisitorOperationStarter"; }
+    void onClose(DistributorMessageSender& sender) override;
+    void onStart(DistributorMessageSender& sender) override;
+    void onReceive(DistributorMessageSender& sender,
+                   const std::shared_ptr<api::StorageReply> & msg) override;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -22,12 +22,21 @@
 
 namespace storage::distributor {
 
+/**
+ * Since the state a deferred task depends on may have changed between the
+ * time a task was scheduled and when it's actually executed, this enum provides
+ * a means of communicating if a task should be started as normal.
+ */
 enum class TaskRunState {
-    OK,
-    Aborted,
-    BucketLost
+    OK,        // Task may be started as normal
+    Aborted,   // Task should trigger an immediate abort behavior (distributor is shutting down)
+    BucketLost // Task should trigger an immediate abort behavior (bucket no longer present on node)
 };
 
+/**
+ * Represents an arbitrary task whose execution may be deferred until no
+ * further pending operations are present.
+ */
 struct DeferredTask {
     virtual ~DeferredTask() = default;
     virtual void run(TaskRunState state) = 0;

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -15,7 +15,6 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/composite_key.hpp>
-
 #include <set>
 #include <unordered_map>
 #include <chrono>
@@ -23,14 +22,41 @@
 
 namespace storage::distributor {
 
-class PendingMessageTracker : public framework::HtmlStatusReporter
-{
+enum class TaskRunState {
+    OK,
+    Aborted,
+    BucketLost
+};
 
+struct DeferredTask {
+    virtual ~DeferredTask() = default;
+    virtual void run(TaskRunState state) = 0;
+};
+
+template <typename Func>
+class LambdaDeferredTask : public DeferredTask {
+    Func _func;
+public:
+    explicit LambdaDeferredTask(Func&& f) : _func(std::move(f)) {}
+    LambdaDeferredTask(const LambdaDeferredTask&) = delete;
+    LambdaDeferredTask(LambdaDeferredTask&&) = delete;
+    ~LambdaDeferredTask() override = default;
+
+    void run(TaskRunState state) override {
+        _func(state);
+    }
+};
+
+template <typename Func>
+std::unique_ptr<DeferredTask> make_deferred_task(Func&& f) {
+    return std::make_unique<LambdaDeferredTask<std::decay_t<Func>>>(std::forward<Func>(f));
+}
+
+class PendingMessageTracker : public framework::HtmlStatusReporter {
 public:
     class Checker {
     public:
-        virtual ~Checker() {}
-
+        virtual ~Checker() = default;
         virtual bool check(uint32_t messageType, uint16_t node, uint8_t priority) = 0;
     };
 
@@ -42,8 +68,8 @@ public:
      */
     using TimePoint = std::chrono::milliseconds;
 
-    PendingMessageTracker(framework::ComponentRegister&);
-    ~PendingMessageTracker();
+    explicit PendingMessageTracker(framework::ComponentRegister&);
+    ~PendingMessageTracker() override;
 
     void insert(const std::shared_ptr<api::StorageMessage>&);
     document::Bucket reply(const api::StorageReply& reply);
@@ -89,6 +115,8 @@ public:
         _nodeBusyDuration = secs;
     }
 
+    void run_once_no_pending_for_bucket(const document::Bucket& bucket, std::unique_ptr<DeferredTask> task);
+    void abort_deferred_tasks();
 private:
     struct MessageEntry {
         TimePoint        timeStamp;
@@ -130,23 +158,29 @@ private:
     {
     };
 
-    typedef boost::multi_index::multi_index_container <
+    using Messages = boost::multi_index::multi_index_container <
         MessageEntry,
         boost::multi_index::indexed_by<
             boost::multi_index::ordered_unique<MessageIdKey>,
             boost::multi_index::ordered_non_unique<CompositeNodeBucketKey>,
             boost::multi_index::ordered_non_unique<CompositeBucketMsgNodeKey>
         >
-    > Messages;
+    >;
 
-    typedef Messages::nth_index<0>::type MessagesByMsgId;
-    typedef Messages::nth_index<1>::type MessagesByNodeAndBucket;
-    typedef Messages::nth_index<2>::type MessagesByBucketAndType;
+    using MessagesByMsgId         = Messages::nth_index<0>::type;
+    using MessagesByNodeAndBucket = Messages::nth_index<1>::type;
+    using MessagesByBucketAndType = Messages::nth_index<2>::type;
+    using DeferredBucketTaskMap   = std::unordered_multimap<
+            document::Bucket,
+            std::unique_ptr<DeferredTask>,
+            document::Bucket::hash
+        >;
 
-    Messages _messages;
-    framework::Component _component;
-    NodeInfo _nodeInfo;
-    std::chrono::seconds _nodeBusyDuration;
+    Messages              _messages;
+    framework::Component  _component;
+    NodeInfo              _nodeInfo;
+    std::chrono::seconds  _nodeBusyDuration;
+    DeferredBucketTaskMap _deferred_bucket_tasks;
 
     // Since distributor is currently single-threaded, this will only
     // contend when status page is being accessed. It is, however, required
@@ -169,6 +203,8 @@ private:
     void getStatusPerNode(std::ostream& out) const;
     void getStatusPerBucket(std::ostream& out) const;
     TimePoint currentTime() const;
+
+    std::vector<std::unique_ptr<DeferredTask>> get_deferred_ops_if_bucket_pending_drained(const document::Bucket&);
 };
 
 }

--- a/storage/src/vespa/storage/visiting/CMakeLists.txt
+++ b/storage/src/vespa/storage/visiting/CMakeLists.txt
@@ -6,6 +6,7 @@ vespa_add_library(storage_visitor OBJECT
     dumpvisitorsingle.cpp
     memory_bounded_trace.cpp
     recoveryvisitor.cpp
+    reindexing_visitor.cpp
     testvisitor.cpp
     visitor.cpp
     visitormanager.cpp

--- a/storage/src/vespa/storage/visiting/dumpvisitorsingle.h
+++ b/storage/src/vespa/storage/visiting/dumpvisitorsingle.h
@@ -26,11 +26,10 @@ struct DumpVisitorSingleFactory : public VisitorFactory {
 
     VisitorEnvironment::UP
     makeVisitorEnvironment(StorageComponent&) override {
-        return VisitorEnvironment::UP(new VisitorEnvironment);
+        return std::make_unique<VisitorEnvironment>();
     };
 
     Visitor*
-
     makeVisitor(StorageComponent& c, VisitorEnvironment&, const vdslib::Parameters& params) override {
         return new DumpVisitorSingle(c, params);
     }

--- a/storage/src/vespa/storage/visiting/reindexing_visitor.cpp
+++ b/storage/src/vespa/storage/visiting/reindexing_visitor.cpp
@@ -1,0 +1,36 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "reindexing_visitor.h"
+#include <vespa/document/fieldvalue/document.h>
+#include <vespa/documentapi/messagebus/messages/putdocumentmessage.h>
+#include <vespa/storage/common/reindexing_constants.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".visitor.instance.reindexing_visitor");
+
+namespace storage {
+
+ReindexingVisitor::ReindexingVisitor(StorageComponent& component)
+    : Visitor(component)
+{
+}
+
+void ReindexingVisitor::handleDocuments(const document::BucketId& /*bucketId*/,
+                                        std::vector<spi::DocEntry::UP>& entries,
+                                        HitCounter& hitCounter)
+{
+    LOG(debug, "Visitor %s handling block of %zu documents.", _id.c_str(), entries.size());
+    for (auto& entry : entries) {
+        if (entry->isRemove()) {
+            // We don't reindex removed documents, as that would be very silly.
+            continue;
+        }
+        const uint32_t doc_size = entry->getDocumentSize();
+        hitCounter.addHit(*entry->getDocumentId(), doc_size);
+        auto msg = std::make_unique<documentapi::PutDocumentMessage>(entry->releaseDocument());
+        msg->setApproxSize(doc_size);
+        msg->setCondition(documentapi::TestAndSetCondition(reindexing_bucket_lock_bypass_value()));
+        sendMessage(std::move(msg));
+    }
+}
+
+}

--- a/storage/src/vespa/storage/visiting/reindexing_visitor.h
+++ b/storage/src/vespa/storage/visiting/reindexing_visitor.h
@@ -5,6 +5,15 @@
 
 namespace storage {
 
+/**
+ * A visitor instance that is intended to be used for background reindexing.
+ * Only meant to be run alongside distributor-level bucket locking support
+ * that prevents concurrent writes to documents in the visited bucket.
+ *
+ * The bucket lock is explicitly bypassed by the Puts sent by the visitor
+ * by having all these be augmented with a special TaS string that is
+ * recognized by the distributor.
+ */
 class ReindexingVisitor : public Visitor {
 public:
     explicit ReindexingVisitor(StorageComponent& component);

--- a/storage/src/vespa/storage/visiting/reindexing_visitor.h
+++ b/storage/src/vespa/storage/visiting/reindexing_visitor.h
@@ -1,0 +1,27 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "visitor.h"
+
+namespace storage {
+
+class ReindexingVisitor : public Visitor {
+public:
+    explicit ReindexingVisitor(StorageComponent& component);
+    ~ReindexingVisitor() override = default;
+
+private:
+    void handleDocuments(const document::BucketId&, std::vector<spi::DocEntry::UP>&, HitCounter&) override;
+};
+
+struct ReindexingVisitorFactory : public VisitorFactory {
+    VisitorEnvironment::UP makeVisitorEnvironment(StorageComponent&) override {
+        return std::make_unique<VisitorEnvironment>();
+    };
+
+    Visitor* makeVisitor(StorageComponent& c, VisitorEnvironment&, const vdslib::Parameters&) override {
+        return new ReindexingVisitor(c);
+    }
+};
+
+}

--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -6,6 +6,7 @@
 #include "countvisitor.h"
 #include "testvisitor.h"
 #include "recoveryvisitor.h"
+#include "reindexing_visitor.h"
 #include <vespa/storage/common/statusmessages.h>
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/util/stringfmt.h>
@@ -55,6 +56,7 @@ VisitorManager::VisitorManager(const config::ConfigUri & configUri,
     _visitorFactories["testvisitor"] = std::make_shared<TestVisitorFactory>();
     _visitorFactories["countvisitor"] = std::make_shared<CountVisitorFactory>();
     _visitorFactories["recoveryvisitor"] = std::make_shared<RecoveryVisitorFactory>();
+    _visitorFactories["reindexingvisitor"] = std::make_shared<ReindexingVisitorFactory>();
     _component.registerStatusPage(*this);
 }
 


### PR DESCRIPTION
@geirst @toregge please review
@jonmv FYI

Introduces the concept of a read-for-write visitor operation which
blocks all mutating operations from starting for a bucket being
visited. This read-for-write mode is used if (and only if) the visitor
library being specified by the client is `"reindexingvisitor"`.

Since read-for-write visitors cannot race with concurrent write
operations, starting such visitors are deferred until no further
mutations are pending.

Also adds a basic `reindexingvisitor` implementation to the content node
which sends all documents as Puts containing a special TaS token
that will let the operation through even if a bucket is locked. This
token is cleared by the distributor before it is passed on to the
content nodes.

Note: this feature is not yet production ready. For now the following
caveats apply:
* Mutating vs non-mutating pending ops to a bucket are not tracked
  separately, so it’s possible to starve a reindexing visitor by
  sending constant pending read load, as read load is not blocked by
  the operation sequencer.
* Ideal state operations towards locked buckets are not blocked, so
  it's possible for e.g. a split to be sent for a bucket that is being
  visited.
