### PR TITLE
Subclass QuorumPeerMain to be able to use initializeAndRun()

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -100,6 +100,11 @@ public class Reconfigurer extends AbstractComponent {
         return zookeeperServerConfig;
     }
 
+    public void shutdown() {
+        if (zooKeeperRunner != null)
+            zooKeeperRunner.shutdown();
+    }
+
     static class ReconfigurationInfo {
 
         private final ZookeeperServerConfig existingConfig;

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -11,6 +11,7 @@ import org.apache.zookeeper.server.quorum.QuorumPeerMain;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,7 +37,15 @@ public class ZooKeeperRunner implements Runnable {
     }
 
     void shutdown() {
-        executorService.shutdownNow();
+        executorService.shutdown();
+        try {
+            executorService.awaitTermination(10000, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            log.log(Level.INFO, "Interrupted waiting for executor to complete", e);
+        }
+        if ( ! executorService.isTerminated()) {
+            executorService.shutdownNow();
+        }
     }
 
     @Override

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -2,8 +2,15 @@
 package com.yahoo.vespa.zookeeper;
 
 import com.yahoo.cloud.config.ZookeeperServerConfig;
+import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.security.tls.TransportSecurityUtils;
+import org.apache.zookeeper.server.admin.AdminServer;
+import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
+import org.apache.zookeeper.server.quorum.QuorumPeerMain;
 
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,23 +25,18 @@ import static com.yahoo.vespa.zookeeper.Configurator.zookeeperServerHostnames;
 public class ZooKeeperRunner implements Runnable {
     private static final Logger log = java.util.logging.Logger.getLogger(ZooKeeperRunner.class.getName());
 
-    private final Thread zkServerThread;
+    private final ExecutorService executorService;
     private final ZookeeperServerConfig zookeeperServerConfig;
 
     public ZooKeeperRunner(ZookeeperServerConfig zookeeperServerConfig) {
         this.zookeeperServerConfig = zookeeperServerConfig;
         new Configurator(zookeeperServerConfig).writeConfigToDisk(TransportSecurityUtils.getOptions());
-        zkServerThread = new Thread(this, "zookeeper server");
-        zkServerThread.start();
+        executorService = Executors.newSingleThreadExecutor(new DaemonThreadFactory("zookeeper server"));
+        executorService.submit(this);
     }
 
     void shutdown() {
-        zkServerThread.interrupt();
-        try {
-            zkServerThread.join();
-        } catch (InterruptedException e) {
-            log.log(Level.WARNING, "Error joining server thread on shutdown", e);
-        }
+        executorService.shutdownNow();
     }
 
     @Override
@@ -42,7 +44,23 @@ public class ZooKeeperRunner implements Runnable {
         String[] args = new String[]{getDefaults().underVespaHome(zookeeperServerConfig.zooKeeperConfigFile())};
         log.log(Level.INFO, "Starting ZooKeeper server with config file " + args[0] +
                             ". Trying to establish ZooKeeper quorum (members: " + zookeeperServerHostnames(zookeeperServerConfig) + ")");
-        org.apache.zookeeper.server.quorum.QuorumPeerMain.main(args);
+        new Server().initializeAndRun(args);
+    }
+
+    /**
+     * Extends QuoroumPeerMain to be able to call initializeAndRun()
+     */
+    private static class Server extends QuorumPeerMain {
+
+        @Override
+        protected void initializeAndRun(String[] args) {
+            try {
+                super.initializeAndRun(args);
+            } catch (QuorumPeerConfig.ConfigException | IOException | AdminServer.AdminServerException e) {
+                throw new RuntimeException("Exception when initializing or running ZooKeeper server", e);
+            }
+        }
+
     }
 
 }


### PR DESCRIPTION
Cannot use `QuoeumPeerMain.main()`, since it calls `System.exit()` and will not work
when running unit tests, so subclass and use `initializeAndRun()`

