### PR TITLE
Allow a grace period after node re-activation

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -153,7 +153,9 @@ public class NodeFailer extends NodeRepositoryMaintainer {
         Map<Node, String> nodesByFailureReason = new HashMap<>();
         for (Node node : activeNodes) {
             if (node.history().hasEventBefore(History.Event.Type.down, graceTimeEnd) && ! applicationSuspended(node)) {
-                nodesByFailureReason.put(node, "Node has been down longer than " + downTimeLimit);
+                // Allow a grace period after node re-activation
+                if ( ! node.history().hasEventAfter(History.Event.Type.activated, graceTimeEnd))
+                    nodesByFailureReason.put(node, "Node has been down longer than " + downTimeLimit);
             }
             else if (hostSuspended(node, activeNodes)) {
                 Node hostNode = node.parentHostname().flatMap(parent -> nodeRepository().getNode(parent)).orElse(node);


### PR DESCRIPTION
Common scenario: Host (and nodes on it) are failed out because they are down. Operator fixes the host and sets everything to `active`. The `down` event is still in the history from last time and it may take a few minutes before the node is up again (f.ex. due to downloading the image, waiting for services). If `NodeFailer` runs again in the meantime, the node will be failed out again.

This adds a grace period if the node was re-activated, without clearing the down time (in case it doesn't work out, we will still have the time of first down).