### PR TITLE
Simplify symlink

### DIFF
--- a/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
+++ b/container-accesslogging/src/main/java/com/yahoo/container/logging/LogFileHandler.java
@@ -298,14 +298,7 @@ public class LogFileHandler extends StreamHandler {
         if (symlinkName == null) return;
         File f = new File(fileName);
         File f2 = new File(f.getParent(), symlinkName);
-        String canonicalPath;
-        try {
-            canonicalPath = f.getCanonicalPath();
-        } catch (IOException e) {
-            logger.warning("Got '" + e + "' while doing f.getCanonicalPath() on file '" + f.getPath() + "'.");
-            return;
-        }
-        String [] cmd = new String[]{"/bin/ln", "-sf", canonicalPath, f2.getPath()};
+        String [] cmd = new String[]{"/bin/ln", "-sf", f.getName(), f2.getPath()};
         try {
             int retval = new ProcessExecuter().exec(cmd).getFirst();
             // Detonator pattern: Think of all the fun we can have if ln isn't what we

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LatencyMetrics.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/stats/LatencyMetrics.java
@@ -77,6 +77,6 @@ public class LatencyMetrics {
                 '}';
     }
 
-    private double secondsWithMillis(Duration duration) { return round(duration.toMillis()) / 1000.0; }
+    private double secondsWithMillis(Duration duration) { return duration.toMillis() / 1000.0; }
     private double roundTo3DecimalPlaces(double value) { return round(value * 1000) / 1000.0; }
 }


### PR DESCRIPTION
The symlink points to a file in the same directory.  Therefore, instead of
pointing to the absolute path, it should point to the filename.  This also
makes the symlink work on the host, if the symlink was made in a container (and
vice versa).

Plus, argument to Math.round() is a long, so not necessary.