### PR TITLE
no more default tensor engine

### DIFF
--- a/eval/src/tests/eval/engine_or_factory/engine_or_factory_override_test.cpp
+++ b/eval/src/tests/eval/engine_or_factory/engine_or_factory_override_test.cpp
@@ -1,21 +1,20 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/eval/eval/engine_or_factory.h>
-#include <vespa/eval/tensor/default_tensor_engine.h>
 #include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/simple_value.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace vespalib::eval;
-using namespace vespalib::tensor;
 
 TEST(EngineOrFactoryOverrideTest, set_can_override_get_result) {
-    EngineOrFactory::set(DefaultTensorEngine::ref());
-    EXPECT_EQ(EngineOrFactory::get().to_string(), "DefaultTensorEngine");
+    EngineOrFactory::set(SimpleValueBuilderFactory::get());
+    EXPECT_EQ(EngineOrFactory::get().to_string(), "SimpleValueBuilderFactory");
 }
 
 TEST(EngineOrFactoryOverrideTest, set_with_same_value_is_allowed) {
-    EngineOrFactory::set(DefaultTensorEngine::ref());
+    EngineOrFactory::set(SimpleValueBuilderFactory::get());
 }
 
 TEST(EngineOrFactoryOverrideTest, set_with_another_value_is_not_allowed) {

--- a/eval/src/tests/eval/engine_or_factory/engine_or_factory_test.cpp
+++ b/eval/src/tests/eval/engine_or_factory/engine_or_factory_test.cpp
@@ -1,13 +1,12 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/eval/eval/engine_or_factory.h>
-#include <vespa/eval/tensor/default_tensor_engine.h>
 #include <vespa/eval/eval/fast_value.h>
+#include <vespa/eval/eval/simple_value.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace vespalib::eval;
-using namespace vespalib::tensor;
 
 TEST(EngineOrFactoryTest, default_is_fast_value_builder_factory) {
     EXPECT_EQ(EngineOrFactory::get().to_string(), "FastValueBuilderFactory");
@@ -18,7 +17,7 @@ TEST(EngineOrFactoryTest, set_with_same_value_is_allowed) {
 }
 
 TEST(EngineOrFactoryTest, set_with_another_value_is_not_allowed) {
-    EXPECT_THROW(EngineOrFactory::set(DefaultTensorEngine::ref()), vespalib::IllegalStateException);
+    EXPECT_THROW(EngineOrFactory::set(SimpleValueBuilderFactory::get()), vespalib::IllegalStateException);
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/eval/src/vespa/eval/eval/engine_or_factory.cpp
+++ b/eval/src/vespa/eval/eval/engine_or_factory.cpp
@@ -138,6 +138,7 @@ EngineOrFactory::rename(const Value &a, const std::vector<vespalib::string> &fro
 void
 EngineOrFactory::set(EngineOrFactory wanted)
 {
+    assert(wanted.is_factory());
     auto engine = get_shared(wanted);
     if (engine._value != wanted._value) {
         auto msg = fmt("EngineOrFactory: trying to set implementation to [%s] when [%s] is already in use",

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -19,7 +19,6 @@
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/eval/eval/engine_or_factory.h>
 #include <vespa/eval/eval/fast_value.h>
-#include <vespa/eval/tensor/default_tensor_engine.h>
 #include <vespa/searchcore/proton/flushengine/flush_engine_explorer.h>
 #include <vespa/searchcore/proton/flushengine/flushengine.h>
 #include <vespa/searchcore/proton/flushengine/tls_stats_factory.h>
@@ -78,7 +77,7 @@ void
 set_tensor_implementation(const ProtonConfig& cfg)
 {
     if (cfg.tensorImplementation == ProtonConfig::TensorImplementation::TENSOR_ENGINE) {
-        EngineOrFactory::set(vespalib::tensor::DefaultTensorEngine::ref());
+        LOG(error, "Old tensor engine implementation no longer available");
     } else if (cfg.tensorImplementation == ProtonConfig::TensorImplementation::FAST_VALUE) {
         EngineOrFactory::set(vespalib::eval::FastValueBuilderFactory::get());
     }


### PR DESCRIPTION
* disallow using engine as default
* remove DefaultTensorEngine as a configurable implementation

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review
@geirst FYI
