### PR TITLE
Fix reconfigure call

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -96,8 +96,9 @@ public class Reconfigurer extends AbstractComponent {
     }
 
     private static List<String> servers(ZookeeperServerConfig config) {
+        // See https://zookeeper.apache.org/doc/r3.5.8/zookeeperReconfig.html#sc_reconfig_clientport for format
         return config.server().stream()
-                     .map(server -> server.hostname() + ":" + server.quorumPort() + ":" + server.electionPort())
+                     .map(server -> server.id() + "=" + server.hostname() + ":" + server.quorumPort() + ":" + server.electionPort())
                      .collect(Collectors.toList());
     }
 

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -8,6 +8,7 @@ import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.admin.ZooKeeperAdmin;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -61,7 +62,7 @@ public class Reconfigurer extends AbstractComponent {
         List<String> joiningServers = reconfigurationInfo.joiningServers();
         List<String> leavingServers = reconfigurationInfo.leavingServers();
 
-        log.log(Level.INFO, "Will reconfigure zookeeper cluster. Joining servers: " + joiningServers +
+        log.log(Level.INFO, "Will reconfigure ZooKeeper cluster. Joining servers: " + joiningServers +
                             ", leaving servers: " + leavingServers);
         try {
             ZooKeeperAdmin zooKeeperAdmin = new ZooKeeperAdmin(connectionSpec(reconfigurationInfo.existingConfig()),
@@ -72,7 +73,8 @@ public class Reconfigurer extends AbstractComponent {
             String joiningServersString = String.join(",", joiningServers);
             String leavingServersString = String.join(",", leavingServers);
             // Using string parameters because the List variant of reconfigure fails to join empty lists (observed on 3.5.6, fixed in 3.7.0)
-            zooKeeperAdmin.reconfigure(joiningServersString, leavingServersString, null, fromConfig, null);
+            byte[] appliedConfig = zooKeeperAdmin.reconfigure(joiningServersString, leavingServersString, null, fromConfig, null);
+            log.log(Level.INFO, "Applied ZooKeeper config: " + new String(appliedConfig, StandardCharsets.UTF_8));
         } catch (IOException | KeeperException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -60,11 +60,9 @@ public class Reconfigurer extends AbstractComponent {
     void reconfigure(ReconfigurationInfo reconfigurationInfo) {
         List<String> joiningServers = reconfigurationInfo.joiningServers();
         List<String> leavingServers = reconfigurationInfo.leavingServers();
-        List<String> addedServers = reconfigurationInfo.addedServers();
 
         log.log(Level.INFO, "Will reconfigure zookeeper cluster. Joining servers: " + joiningServers +
-                            ", leaving servers: " + leavingServers +
-                            ", new members: " + addedServers);
+                            ", leaving servers: " + leavingServers);
         try {
             ZooKeeperAdmin zooKeeperAdmin = new ZooKeeperAdmin(connectionSpec(reconfigurationInfo.existingConfig()),
                                                                (int) sessionTimeout.toMillis(),
@@ -73,9 +71,8 @@ public class Reconfigurer extends AbstractComponent {
             long fromConfig = -1;
             String joiningServersString = String.join(",", joiningServers);
             String leavingServersString = String.join(",", leavingServers);
-            String addedServersString = String.join(",", addedServers);
             // Using string parameters because the List variant of reconfigure fails to join empty lists (observed on 3.5.6, fixed in 3.7.0)
-            zooKeeperAdmin.reconfigure(joiningServersString, leavingServersString, addedServersString, fromConfig, null);
+            zooKeeperAdmin.reconfigure(joiningServersString, leavingServersString, null, fromConfig, null);
         } catch (IOException | KeeperException | InterruptedException e) {
             throw new RuntimeException(e);
         }
@@ -111,7 +108,6 @@ public class Reconfigurer extends AbstractComponent {
         private final ZookeeperServerConfig existingConfig;
         private final List<String> joiningServers;
         private final List<String> leavingServers;
-        private final List<String> addedServers;
 
         public ReconfigurationInfo(ZookeeperServerConfig existingConfig, ZookeeperServerConfig newConfig) {
             this.existingConfig = existingConfig;
@@ -119,7 +115,6 @@ public class Reconfigurer extends AbstractComponent {
 
             this.joiningServers = servers(newConfig);
             this.leavingServers = setDifference(originalServers, servers(newConfig));
-            this.addedServers = setDifference(servers(newConfig), originalServers);
         }
 
         public ZookeeperServerConfig existingConfig() {
@@ -132,10 +127,6 @@ public class Reconfigurer extends AbstractComponent {
 
         public List<String> leavingServers() {
             return leavingServers;
-        }
-
-        public List<String> addedServers() {
-            return addedServers;
         }
 
     }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -1,6 +1,7 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.zookeeper;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ZookeeperServerConfig;
 import com.yahoo.component.AbstractComponent;
@@ -10,8 +11,6 @@ import org.apache.zookeeper.admin.ZooKeeperAdmin;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.logging.Level;
@@ -58,35 +57,22 @@ public class Reconfigurer extends AbstractComponent {
         return new ZooKeeperRunner(zookeeperServerConfig);
     }
 
-    void reconfigure(ReconfigurationInfo reconfigurationInfo) {
-        List<String> joiningServers = reconfigurationInfo.joiningServers();
-        List<String> leavingServers = reconfigurationInfo.leavingServers();
+    void reconfigure(ReconfigurationInfo info) {
 
-        log.log(Level.INFO, "Will reconfigure ZooKeeper cluster. Joining servers: " + joiningServers +
-                            ", leaving servers: " + leavingServers);
+        log.log(Level.INFO, "Will reconfigure ZooKeeper cluster. Joining servers: " + info.joiningServers() +
+                            ", leaving servers: " + info.leavingServers());
         try {
-            ZooKeeperAdmin zooKeeperAdmin = new ZooKeeperAdmin(connectionSpec(reconfigurationInfo.existingConfig()),
+            ZooKeeperAdmin zooKeeperAdmin = new ZooKeeperAdmin(connectionSpec(info.existingConfig()),
                                                                (int) sessionTimeout.toMillis(),
                                                                null);
 
             long fromConfig = -1;
-            String joiningServersString = String.join(",", joiningServers);
-            String leavingServersString = String.join(",", leavingServers);
             // Using string parameters because the List variant of reconfigure fails to join empty lists (observed on 3.5.6, fixed in 3.7.0)
-            byte[] appliedConfig = zooKeeperAdmin.reconfigure(joiningServersString, leavingServersString, null, fromConfig, null);
+            byte[] appliedConfig = zooKeeperAdmin.reconfigure(info.joiningServers(), info.leavingServers(), null, fromConfig, null);
             log.log(Level.INFO, "Applied ZooKeeper config: " + new String(appliedConfig, StandardCharsets.UTF_8));
         } catch (IOException | KeeperException | InterruptedException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    /**
-     * Returns items in set a that are not in set b
-     */
-    static List<String> setDifference(List<String> a, List<String> b) {
-        Set<String> ret = new HashSet<>(a);
-        ret.removeAll(b);
-        return new ArrayList<>(ret);
     }
 
     private String connectionSpec(ZookeeperServerConfig config) {
@@ -109,26 +95,26 @@ public class Reconfigurer extends AbstractComponent {
     static class ReconfigurationInfo {
 
         private final ZookeeperServerConfig existingConfig;
-        private final List<String> joiningServers;
-        private final List<String> leavingServers;
+        private final String joiningServers;
+        private final String leavingServers;
 
         public ReconfigurationInfo(ZookeeperServerConfig existingConfig, ZookeeperServerConfig newConfig) {
             this.existingConfig = existingConfig;
-            List<String> originalServers = List.copyOf(servers(existingConfig));
-
-            this.joiningServers = servers(newConfig);
-            this.leavingServers = setDifference(originalServers, servers(newConfig));
+            Set<Integer> existingIds = existingConfig.server().stream().map(ZookeeperServerConfig.Server::id).collect(Collectors.toSet());
+            Set<Integer> newIds = newConfig.server().stream().map(ZookeeperServerConfig.Server::id).collect(Collectors.toSet());
+            this.leavingServers = Sets.difference(existingIds, newIds).stream().map(String::valueOf).collect(Collectors.joining(","));
+            this.joiningServers = servers(newConfig).stream().collect(Collectors.joining(","));
         }
 
         public ZookeeperServerConfig existingConfig() {
             return existingConfig;
         }
 
-        public List<String> joiningServers() {
+        public String joiningServers() {
             return joiningServers;
         }
 
-        public List<String> leavingServers() {
+        public String leavingServers() {
             return leavingServers;
         }
 

--- a/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -37,7 +37,7 @@ public class ReconfigurerTest {
     @Test
     public void testStartupAndReconfigure() {
         Reconfigurer reconfigurer = new Reconfigurer();
-        ZookeeperServerConfig initialConfig = createConfig(2);
+        ZookeeperServerConfig initialConfig = createConfig(3);
         reconfigurer.startOrReconfigure(initialConfig);
         assertEquals(initialConfig, reconfigurer.existingConfig());
 
@@ -45,7 +45,7 @@ public class ReconfigurerTest {
         assertFalse(reconfigurer.shouldReconfigure(createConfig(3)));
 
         // Increase number of servers, created config has dynamicReconfig set to true
-        assertReconfiguration(3, reconfigurer);
+        assertReconfiguration(5, reconfigurer);
 
         // Decrease number of servers, Created config has dynamicReconfig set to true
         assertReconfiguration(1, reconfigurer);
@@ -89,17 +89,29 @@ public class ReconfigurerTest {
         ZookeeperServerConfig existingConfig = reconfigurer.existingConfig();
         int currentServerCount = reconfigurer.existingConfig().server().size();
         int expectedLeavingServers = Math.max(0, currentServerCount - numberOfServers);
-
         ZookeeperServerConfig newConfig = createConfigAllowReconfiguring(numberOfServers);
         assertTrue(reconfigurer.shouldReconfigure(newConfig));
         Reconfigurer.ReconfigurationInfo reconfigurationInfo = new Reconfigurer.ReconfigurationInfo(existingConfig, newConfig);
+        StringBuilder joiningServers = new StringBuilder();
         for (int electionPort = 0; electionPort < numberOfServers; electionPort++) {
-            String joiningServer = reconfigurationInfo.joiningServers().get(electionPort);
             int quorumPort = electionPort + 1;
-            assertEquals(electionPort + "=localhost:" + quorumPort + ":" + electionPort, joiningServer);
+            joiningServers.append(electionPort)
+                          .append("=localhost:")
+                          .append(quorumPort).append(":")
+                          .append(electionPort)
+                          .append(",");
         }
-        assertEquals(numberOfServers, reconfigurationInfo.joiningServers().size());
-        assertEquals(expectedLeavingServers, reconfigurationInfo.leavingServers().size());
+        joiningServers.setLength(joiningServers.length() - 1); // Remove trailing comma
+        assertEquals(joiningServers.toString(), reconfigurationInfo.joiningServers());
+        StringBuilder leavingServers = new StringBuilder();
+        for (int i = 0; i < expectedLeavingServers; i++) {
+            leavingServers.append(i + 1)
+                          .append(",");
+        }
+        if (leavingServers.length() > 0) {
+            leavingServers.setLength(leavingServers.length() - 1); // Remove trailing comma
+        }
+        assertEquals(leavingServers.toString(), reconfigurationInfo.leavingServers());
     }
 
 }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -89,14 +89,12 @@ public class ReconfigurerTest {
         ZookeeperServerConfig existingConfig = reconfigurer.existingConfig();
         int currentServerCount = reconfigurer.existingConfig().server().size();
         int expectedLeavingServers = Math.max(0, currentServerCount - numberOfServers);
-        int expectedAddedServers = Math.max(0, numberOfServers - currentServerCount);
 
         ZookeeperServerConfig newConfig = createConfigAllowReconfiguring(numberOfServers);
         assertTrue(reconfigurer.shouldReconfigure(newConfig));
         Reconfigurer.ReconfigurationInfo reconfigurationInfo = new Reconfigurer.ReconfigurationInfo(existingConfig, newConfig);
         assertEquals(numberOfServers, reconfigurationInfo.joiningServers().size());
         assertEquals(expectedLeavingServers, reconfigurationInfo.leavingServers().size());
-        assertEquals(expectedAddedServers, reconfigurationInfo.addedServers().size());
     }
 
 }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -93,6 +93,11 @@ public class ReconfigurerTest {
         ZookeeperServerConfig newConfig = createConfigAllowReconfiguring(numberOfServers);
         assertTrue(reconfigurer.shouldReconfigure(newConfig));
         Reconfigurer.ReconfigurationInfo reconfigurationInfo = new Reconfigurer.ReconfigurationInfo(existingConfig, newConfig);
+        for (int electionPort = 0; electionPort < numberOfServers; electionPort++) {
+            String joiningServer = reconfigurationInfo.joiningServers().get(electionPort);
+            int quorumPort = electionPort + 1;
+            assertEquals(electionPort + "=localhost:" + quorumPort + ":" + electionPort, joiningServer);
+        }
         assertEquals(numberOfServers, reconfigurationInfo.joiningServers().size());
         assertEquals(expectedLeavingServers, reconfigurationInfo.leavingServers().size());
     }


### PR DESCRIPTION
(hopefully)

This fixes a bunch of things. From what I understand from fine-reading docs and
https://github.com/apache/zookeeper/blob/master/zookeeper-server/src/test/java/org/apache/zookeeper/test/ReconfigTest.java,
and some manual experiments with `reconfig` CLI, we want to use incremental
reconfig where each reconfig request is applied in order.

* When using incremental reconfig, the third parameter (`newMembers`) to
`reconfigure` should be `null`.
* The format of joining servers *must* include the server ID.
* The format of leaving servers *must* only contain server IDs.

@hmusum