### PR TITLE
Use null for empty reconfig params

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/Reconfigurer.java
@@ -61,6 +61,12 @@ public class Reconfigurer extends AbstractComponent {
         }
     }
 
+    void shutdown() {
+        if (zooKeeperRunner != null) {
+            zooKeeperRunner.shutdown();
+        }
+    }
+
     private boolean shouldReconfigure(ZookeeperServerConfig newConfig) {
         if (!newConfig.dynamicReconfiguration()) return false;
         if (activeConfig == null) return false;

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -24,6 +24,7 @@ import static com.yahoo.vespa.zookeeper.Configurator.zookeeperServerHostnames;
  * @author Harald Musum
  */
 public class ZooKeeperRunner implements Runnable {
+
     private static final Logger log = java.util.logging.Logger.getLogger(ZooKeeperRunner.class.getName());
 
     private final ExecutorService executorService;
@@ -39,7 +40,9 @@ public class ZooKeeperRunner implements Runnable {
     void shutdown() {
         executorService.shutdown();
         try {
-            executorService.awaitTermination(10000, TimeUnit.MILLISECONDS);
+            if (!executorService.awaitTermination(10000, TimeUnit.MILLISECONDS)) {
+                log.log(Level.WARNING, "Failed to shut down within timeout");
+            }
         } catch (InterruptedException e) {
             log.log(Level.INFO, "Interrupted waiting for executor to complete", e);
         }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.zookeeper;
 
 import com.yahoo.cloud.config.ZookeeperServerConfig;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -24,6 +25,7 @@ public class ReconfigurerTest {
 
     private File cfgFile;
     private File idFile;
+    private TestableReconfigurer reconfigurer;
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -32,11 +34,11 @@ public class ReconfigurerTest {
     public void setup() throws IOException {
         cfgFile = folder.newFile();
         idFile = folder.newFile("myid");
+        reconfigurer = new TestableReconfigurer();
     }
 
     @Test
     public void testReconfigure() {
-        TestableReconfigurer reconfigurer = new TestableReconfigurer();
         ZookeeperServerConfig initialConfig = createConfig(3, true);
         reconfigurer.startOrReconfigure(initialConfig);
         assertSame(initialConfig, reconfigurer.activeConfig());
@@ -67,7 +69,6 @@ public class ReconfigurerTest {
 
     @Test
     public void testDynamicReconfigurationDisabled() {
-        TestableReconfigurer reconfigurer = new TestableReconfigurer();
         ZookeeperServerConfig initialConfig = createConfig(3, false);
         reconfigurer.startOrReconfigure(initialConfig);
         assertSame(initialConfig, reconfigurer.activeConfig());
@@ -76,6 +77,11 @@ public class ReconfigurerTest {
         reconfigurer.startOrReconfigure(nextConfig);
         assertSame(initialConfig, reconfigurer.activeConfig());
         assertEquals(0, reconfigurer.reconfigurations);
+    }
+
+    @After
+    public void stopReconfigurer() {
+       reconfigurer.shutdown();
     }
 
     private ZookeeperServerConfig createConfig(int numberOfServers, boolean dynamicReconfiguration) {


### PR DESCRIPTION
Empty parameters (e.g. `leavingServers`) must be `null`, not empty string. Also,
`joiningServers` will now only contain the new servers, as this seems to be the
intended usage.

Did some refactoring to make it easier to test the exact parameters passed to
`ZooKeeperAdmin#reconfigure`.

@hmusum