### PR TITLE
Revert "Expand config to allow mulitple clusters per reindexer"

### DIFF
--- a/configdefinitions/src/vespa/reindexing.def
+++ b/configdefinitions/src/vespa/reindexing.def
@@ -6,13 +6,8 @@ namespace=vespa.config.content.reindexing
 # Whether reindexing should run at all
 enabled                bool default=false
 
-# TODO jonmv: remove after 7.310 is gone
 # The name of the content cluster to reindex documents from
-clusterName            string default=""
+clusterName            string
 
-# TODO jonmv: remove after 7.310 is gone
 # Epoch millis after which latest reprocessing may begin, per document type
 status{}.readyAtMillis long
-
-# Epoch millis after which latest reprocessing may begin, per document type, per cluster
-clusters{}.documentTypes{}.readyAtMillis long


### PR DESCRIPTION
Reverts vespa-engine/vespa#15665

Seems to have broken a unit test

```
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.036 s <<< FAILURE! - in ai.vespa.reindexing.ReindexingMaintainerTest
12:07:50 [ERROR] testParsing  Time elapsed: 0.033 s  <<< FAILURE!
12:07:50 org.opentest4j.AssertionFailedError: Unexpected exception type thrown ==> expected: <java.lang.IllegalArgumentException> but was: <java.lang.NullPointerException>
12:07:50 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:65)
12:07:50 	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:37)
12:07:50 	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3007)
12:07:50 	at ai.vespa.reindexing.ReindexingMaintainerTest.testParsing(ReindexingMaintainerTest.java:42)
12:07:50 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
12:07:50 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
12:07:50 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:07:50 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
12:07:50 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:688)

```