### PR TITLE
Add operator overloads to avoid ambiguous reversed operators.

### DIFF
--- a/document/src/vespa/document/datatype/documenttype.h
+++ b/document/src/vespa/document/datatype/documenttype.h
@@ -87,6 +87,7 @@ public:
     std::unique_ptr<FieldValue> createFieldValue() const override;
     void print(std::ostream&, bool verbose, const std::string& indent) const override;
     bool operator==(const DataType& type) const override;
+    bool operator==(const DocumentType& type) const { return operator==(static_cast<const DataType&>(type)); }
     uint32_t getFieldCount() const override {
         return _fields->getFieldCount();
     }

--- a/document/src/vespa/document/datatype/referencedatatype.h
+++ b/document/src/vespa/document/datatype/referencedatatype.h
@@ -26,6 +26,7 @@ public:
     void onBuildFieldPath(FieldPath & path, vespalib::stringref remainingFieldName) const override;
 
     bool operator==(const DataType &type) const override;
+    bool operator==(const ReferenceDataType& type) const { return operator==(static_cast<const DataType&>(type)); }
 };
 
 } // document

--- a/document/src/vespa/document/datatype/structureddatatype.h
+++ b/document/src/vespa/document/datatype/structureddatatype.h
@@ -37,6 +37,7 @@ public:
 
     virtual StructuredDataType* clone() const override = 0;
     bool operator==(const DataType& type) const override;
+    bool operator==(const StructuredDataType& type) const { return operator==(static_cast<const DataType&>(type)); }
 
     static int32_t createId(vespalib::stringref name);
 

--- a/searchlib/src/vespa/searchlib/grouping/sketch.h
+++ b/searchlib/src/vespa/searchlib/grouping/sketch.h
@@ -100,6 +100,9 @@ struct SparseSketch : Sketch<BucketBits, HashT> {
         }
         return true;
     }
+    bool operator==(const SparseSketch<BucketBits, HashT>& other) const {
+        return operator==(static_cast<const SketchType&>(other));
+    }
 
     void print(std::ostream &out) const override {
         out << " (" << hash_set.size() << " elements)";
@@ -160,6 +163,9 @@ struct NormalSketch : Sketch<BucketBits, HashT> {
             }
         }
         return true;
+    }
+    bool operator==(const NormalSketch<BucketBits, HashT>& other) const {
+        return operator==(static_cast<const SketchType&>(other));
     }
 
     virtual void print(std::ostream &out) const override {


### PR DESCRIPTION
@baldersheim : please review
