### PR TITLE
Stop including llvm/LinkAllPasses.h. We use a shared llvm library.

### DIFF
--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
@@ -12,14 +12,6 @@
 #include <llvm/Analysis/Passes.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Transforms/Scalar.h>
-#if LLVM_VERSION_MAJOR >= 9 && defined(__clang__)
-// Avoid reference to undefined symbol llvm::cfg::Update<llvm::BasicBlock*>::dump() const
-#define NDEBUG
-#endif
-#include <llvm/LinkAllPasses.h>
-#if LLVM_VERSION_MAJOR >= 9 && defined(__clang__)
-#undef NDEBUG
-#endif
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #if LLVM_VERSION_MAJOR > 9
 #include <llvm/Support/ManagedStatic.h>


### PR DESCRIPTION
@baldersheim : please review
