### PR TITLE
Stop using deprecated clientPort statement

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -79,7 +79,6 @@ public class Configurator {
         sb.append("maxClientCnxns=").append(config.maxClientConnections()).append("\n");
         sb.append("snapCount=").append(config.snapshotCount()).append("\n");
         sb.append("dataDir=").append(getDefaults().underVespaHome(config.dataDir())).append("\n");
-        sb.append("clientPort=").append(config.clientPort()).append("\n");
         sb.append("secureClientPort=").append(config.secureClientPort()).append("\n");
         sb.append("autopurge.purgeInterval=").append(config.autopurge().purgeInterval()).append("\n");
         sb.append("autopurge.snapRetainCount=").append(config.autopurge().snapRetainCount()).append("\n");
@@ -94,7 +93,7 @@ public class Configurator {
         sb.append("reconfigEnabled=true").append("\n");
         sb.append("skipACL=yes").append("\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
-        config.server().forEach(server -> addServerToCfg(sb, server));
+        config.server().forEach(server -> addServerToCfg(sb, server, config.clientPort()));
         SSLContext sslContext = new SslContextBuilder().build();
         sb.append(new TlsQuorumConfig(sslContext, jksKeyStoreFilePath).createConfig(config, transportSecurityOptions));
         sb.append(new TlsClientServerConfig(sslContext, jksKeyStoreFilePath).createConfig(config, transportSecurityOptions));
@@ -139,8 +138,18 @@ public class Configurator {
         }
     }
 
-    private void addServerToCfg(StringBuilder sb, ZookeeperServerConfig.Server server) {
-        sb.append("server.").append(server.id()).append("=").append(server.hostname()).append(":").append(server.quorumPort()).append(":").append(server.electionPort()).append("\n");
+    private void addServerToCfg(StringBuilder sb, ZookeeperServerConfig.Server server, int clientPort) {
+        sb.append("server.")
+          .append(server.id())
+          .append("=")
+          .append(server.hostname())
+          .append(":")
+          .append(server.quorumPort())
+          .append(":")
+          .append(server.electionPort())
+          .append(";")
+          .append(clientPort)
+          .append("\n");
     }
 
     static Set<String> zookeeperServerHostnames(ZookeeperServerConfig zookeeperServerConfig) {

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -168,7 +168,6 @@ public class ConfiguratorTest {
                "maxClientCnxns=0\n" +
                "snapCount=50000\n" +
                "dataDir=" + getDefaults().underVespaHome("var/zookeeper") + "\n" +
-               "clientPort=2181\n" +
                "secureClientPort=2184\n" +
                "autopurge.purgeInterval=1\n" +
                "autopurge.snapRetainCount=15\n" +
@@ -204,7 +203,7 @@ public class ConfiguratorTest {
     private void validateConfigFileSingleHost(File cfgFile) throws IOException {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 commonTlsQuorumConfig() +
                 "sslQuorum=false\n" +
                 "portUnification=false\n" +
@@ -232,9 +231,9 @@ public class ConfiguratorTest {
     private void validateConfigFileMultipleHosts(File cfgFile) throws IOException {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
-                "server.1=bar:432:234\n" +
-                "server.2=baz:543:345\n" +
+                "server.0=foo:321:123;2181\n" +
+                "server.1=bar:432:234;2181\n" +
+                "server.2=baz:543:345;2181\n" +
                 commonTlsQuorumConfig() +
                 "sslQuorum=false\n" +
                 "portUnification=false\n" +
@@ -246,7 +245,7 @@ public class ConfiguratorTest {
     private void validateConfigFilePortUnification(File cfgFile, File jksKeyStoreFile, File caCertificatesFile) throws IOException {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 commonTlsQuorumConfig() +
                 "sslQuorum=false\n" +
                 "portUnification=true\n" +
@@ -260,7 +259,7 @@ public class ConfiguratorTest {
     private void validateConfigFileTlsWithPortUnification(File cfgFile, File jksKeyStoreFile, File caCertificatesFile) throws IOException {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 commonTlsQuorumConfig() +
                 "sslQuorum=true\n" +
                 "portUnification=true\n" +
@@ -274,7 +273,7 @@ public class ConfiguratorTest {
     private void validateConfigFileTlsOnly(File cfgFile, File jksKeyStoreFile, File caCertificatesFile) throws IOException {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 commonTlsQuorumConfig() +
                 "sslQuorum=true\n" +
                 "portUnification=false\n" +


### PR DESCRIPTION
Specifying client port address using `clientPortAddress` appears to follow a
different code path than specifying it as part of `server`. This may solve the
unnecessary port-rebinding on reconfig, but I'm not 100% sure.

@hmusum