### PR TITLE
Allow single-node cluster with ZooKeeper

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -115,7 +115,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private static final String ENVIRONMENT_VARIABLES_ELEMENT = "environment-variables";
 
     // The node count to enforce in a cluster running ZooKeeper
-    private static final int MIN_ZOOKEEPER_NODE_COUNT = 3;
+    private static final int MIN_ZOOKEEPER_NODE_COUNT = 1;
     private static final int MAX_ZOOKEEPER_NODE_COUNT = 7;
 
     public enum Networking { disable, enable }

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -899,7 +899,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         }
         {
             try {
-                tester.createModel(servicesXml.apply(1), true);
+                tester.createModel(servicesXml.apply(2), true);
                 fail("Expected exception");
             } catch (IllegalArgumentException ignored) {}
         }


### PR DESCRIPTION
For development purposes. Node repo (`CapacityPolicies`) will enforce the
minimum node count in production environments.

@hmusum