### PR TITLE
Add a force_insert method to the hash_table. It is faster as it skips…

### DIFF
--- a/vespalib/src/tests/stllike/hashtable_test.cpp
+++ b/vespalib/src/tests/stllike/hashtable_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <memory>
 #include <vector>
+#include <vespa/vespalib/stllike/hash_map.h>
 
 using vespalib::hashtable;
 using std::vector;
@@ -38,17 +39,12 @@ TEST("require that hashtable can store unique_ptrs") {
     // it = table.find(42);  // This will crash, since the key is removed.
 }
 
-template<typename To, typename Entry>
-struct First : std::unary_function<To, Entry> {
-    To &operator()(Entry& p) const { return p.first; }
-    const To& operator()(const Entry& p) const { return p.first; }
-};
 
 template <typename K, typename V> using Entry =
     std::pair<K, std::unique_ptr<V>>;
 typedef hashtable<int, Entry<int, int>,
                   vespalib::hash<int>, std::equal_to<int>,
-                  First<int, Entry<int, int>>> PairHashtable;
+                  Select1st<Entry<int, int>>> PairHashtable;
 
 TEST("require that hashtable can store pairs of <key, unique_ptr to value>") {
     PairHashtable table(100);
@@ -75,7 +71,7 @@ TEST("require that hashtable<int> can be copied") {
 
 TEST("require that you can insert duplicates") {
     using Pair = std::pair<int, vespalib::string>;
-    using Map = hashtable<int, Pair, vespalib::hash<int>, std::equal_to<int>, First<int, Pair>>;
+    using Map = hashtable<int, Pair, vespalib::hash<int>, std::equal_to<int>, Select1st<Pair>>;
 
     Map m(1);
     EXPECT_EQUAL(0u, m.size());

--- a/vespalib/src/tests/stllike/hashtable_test.cpp
+++ b/vespalib/src/tests/stllike/hashtable_test.cpp
@@ -95,7 +95,14 @@ TEST("require that you can insert duplicates") {
     EXPECT_EQUAL(8u, m.capacity());
     m.force_insert(Pair(1, "1.3"));
     EXPECT_EQUAL(3u, m.size());
-    EXPECT_EQUAL(16u, m.capacity());
+    EXPECT_EQUAL(16u, m.capacity()); // Resize has been conducted
+    Pair expected[3] = {{1,"1"},{1,"1.2"},{1,"1.3"}};
+    size_t index(0);
+    for (const auto & e : m) {
+        EXPECT_EQUAL(expected[index].first, e.first);
+        EXPECT_EQUAL(expected[index].second, e.second);
+        index++;
+    }
     found = m.find(1);
     ASSERT_TRUE(found != m.end());
     EXPECT_EQUAL(found->second, "1");

--- a/vespalib/src/vespa/vespalib/stllike/hashtable.h
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.h
@@ -246,6 +246,9 @@ public:
     insert_result insert(V && node) {
         return insertInternal(std::forward<V>(node));
     }
+    // This will insert unconditionally, without checking presence, and might cause duplicates.
+    // Use at you own risk.
+    void force_insert(Value && value);
     
     /// This gives faster iteration than can be achieved by the iterators.
     template <typename Func>
@@ -274,10 +277,10 @@ public:
     size_t getMemoryUsed() const;
 
 protected:
-    /// These two methods are only for the ones that know what they are doing.
-    /// valid input here are stuff returned from iterator.getInternalIndex.
     template <typename V>
     insert_result insertInternal(V && node);
+    /// These two methods are only for the ones that know what they are doing.
+    /// valid input here are stuff returned from iterator.getInternalIndex.
     Value & getByInternalIndex(size_t index)             { return _nodes[index].getValue(); }
     const Value & getByInternalIndex(size_t index) const { return _nodes[index].getValue(); }
     template <typename MoveHandler>


### PR DESCRIPTION
… the presence check and avoid equality compare.

It allows duplicates and should hence be used carefully.
At least resize will be faster as it it can safely be used there.

@havardpe PR