### PR TITLE
Block ideal state operations towards buckets that are locked

### DIFF
--- a/storage/src/tests/distributor/blockingoperationstartertest.cpp
+++ b/storage/src/tests/distributor/blockingoperationstartertest.cpp
@@ -2,6 +2,7 @@
 #include <vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.h>
 #include <vespa/storage/distributor/blockingoperationstarter.h>
 #include <vespa/storage/distributor/pendingmessagetracker.h>
+#include <vespa/storage/distributor/operation_sequencer.h>
 #include <tests/distributor/maintenancemocks.h>
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/vespalib/gtest/gtest.h>
@@ -26,6 +27,7 @@ struct BlockingOperationStarterTest : Test {
     std::unique_ptr<MockOperationStarter> _starterImpl;
     std::unique_ptr<StorageComponentRegisterImpl> _compReg;
     std::unique_ptr<PendingMessageTracker> _messageTracker;
+    std::unique_ptr<OperationSequencer> _operation_sequencer;
     std::unique_ptr<BlockingOperationStarter> _operationStarter;
 
     void SetUp() override;
@@ -39,7 +41,8 @@ BlockingOperationStarterTest::SetUp()
     _compReg->setClock(_clock);
     _clock.setAbsoluteTimeInSeconds(1);
     _messageTracker = std::make_unique<PendingMessageTracker>(*_compReg);
-    _operationStarter = std::make_unique<BlockingOperationStarter>(*_messageTracker, *_starterImpl);
+    _operation_sequencer = std::make_unique<OperationSequencer>();
+    _operationStarter = std::make_unique<BlockingOperationStarter>(*_messageTracker, *_operation_sequencer, *_starterImpl);
 }
 
 TEST_F(BlockingOperationStarterTest, operation_not_blocked_when_no_messages_pending) {

--- a/storage/src/tests/distributor/distributor_message_sender_stub.cpp
+++ b/storage/src/tests/distributor/distributor_message_sender_stub.cpp
@@ -12,7 +12,8 @@ namespace storage {
 DistributorMessageSenderStub::DistributorMessageSenderStub()
     : _stub_impl(),
       _cluster_name("storage"),
-      _pending_message_tracker(nullptr)
+      _pending_message_tracker(nullptr),
+      _operation_sequencer(nullptr)
 {}
 
 DistributorMessageSenderStub::~DistributorMessageSenderStub() = default;

--- a/storage/src/tests/distributor/distributor_message_sender_stub.h
+++ b/storage/src/tests/distributor/distributor_message_sender_stub.h
@@ -13,6 +13,7 @@ class DistributorMessageSenderStub : public distributor::DistributorMessageSende
     MessageSenderStub _stub_impl;
     vespalib::string _cluster_name;
     distributor::PendingMessageTracker* _pending_message_tracker;
+    distributor::OperationSequencer* _operation_sequencer;
 public:
 
     DistributorMessageSenderStub();
@@ -93,6 +94,15 @@ public:
 
     void setPendingMessageTracker(distributor::PendingMessageTracker& tracker) {
         _pending_message_tracker = &tracker;
+    }
+
+    const distributor::OperationSequencer& operation_sequencer() const noexcept override {
+        assert(_operation_sequencer);
+        return *_operation_sequencer;
+    }
+
+    void set_operation_sequencer(distributor::OperationSequencer& op_seq) {
+        _operation_sequencer = &op_seq;
     }
 };
 

--- a/storage/src/tests/distributor/idealstatemanagertest.cpp
+++ b/storage/src/tests/distributor/idealstatemanagertest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/storage/distributor/bucketdbupdater.h>
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/storage/distributor/operations/idealstate/mergeoperation.h>
+#include <vespa/storage/distributor/operation_sequencer.h>
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/storageapi/message/visitor.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
@@ -41,16 +42,18 @@ struct IdealStateManagerTest : Test, DistributorTestUtil {
 
     bool checkBlock(const IdealStateOperation& op,
                     const document::Bucket& bucket,
-                    const PendingMessageTracker& tracker) const
+                    const PendingMessageTracker& tracker,
+                    const OperationSequencer& op_seq) const
     {
-        return op.checkBlock(bucket, tracker);
+        return op.checkBlock(bucket, tracker, op_seq);
     }
 
     bool checkBlockForAllNodes(const IdealStateOperation& op,
                                const document::Bucket& bucket,
-                               const PendingMessageTracker& tracker) const
+                               const PendingMessageTracker& tracker,
+                               const OperationSequencer& op_seq) const
     {
-        return op.checkBlockForAllNodes(bucket, tracker);
+        return op.checkBlockForAllNodes(bucket, tracker, op_seq);
     }
 
     std::vector<document::BucketSpace> _bucketSpaces;
@@ -178,6 +181,7 @@ TEST_F(IdealStateManagerTest, block_ideal_state_ops_on_full_request_bucket_info)
 
     framework::defaultimplementation::FakeClock clock;
     PendingMessageTracker tracker(_node->getComponentRegister());
+    OperationSequencer op_seq;
 
     document::BucketId bid(16, 1234);
     std::vector<document::BucketId> buckets;
@@ -193,14 +197,14 @@ TEST_F(IdealStateManagerTest, block_ideal_state_ops_on_full_request_bucket_info)
     {
         RemoveBucketOperation op("storage",
                                  BucketAndNodes(makeDocumentBucket(bid), toVector<uint16_t>(3, 4)));
-        EXPECT_TRUE(op.isBlocked(tracker));
+        EXPECT_TRUE(op.isBlocked(tracker, op_seq));
     }
 
     {
         // Don't trigger on requests to other nodes.
         RemoveBucketOperation op("storage",
                                  BucketAndNodes(makeDocumentBucket(bid), toVector<uint16_t>(3, 5)));
-        EXPECT_FALSE(op.isBlocked(tracker));
+        EXPECT_FALSE(op.isBlocked(tracker, op_seq));
     }
 
     // Don't block on null-bucket messages that aren't RequestBucketInfo.
@@ -213,7 +217,7 @@ TEST_F(IdealStateManagerTest, block_ideal_state_ops_on_full_request_bucket_info)
     {
         RemoveBucketOperation op("storage",
                                  BucketAndNodes(makeDocumentBucket(bid), toVector<uint16_t>(7)));
-        EXPECT_FALSE(op.isBlocked(tracker));
+        EXPECT_FALSE(op.isBlocked(tracker, op_seq));
     }
 }
 
@@ -221,6 +225,7 @@ TEST_F(IdealStateManagerTest, block_check_for_all_operations_to_specific_bucket)
     setupDistributor(2, 10, "distributor:1 storage:2");
     framework::defaultimplementation::FakeClock clock;
     PendingMessageTracker tracker(_node->getComponentRegister());
+    OperationSequencer op_seq;
     document::BucketId bid(16, 1234);
 
     {
@@ -232,9 +237,30 @@ TEST_F(IdealStateManagerTest, block_check_for_all_operations_to_specific_bucket)
         RemoveBucketOperation op("storage",
                                  BucketAndNodes(makeDocumentBucket(bid), toVector<uint16_t>(7)));
         // Not blocked for exact node match.
-        EXPECT_FALSE(checkBlock(op, makeDocumentBucket(bid), tracker));
+        EXPECT_FALSE(checkBlock(op, makeDocumentBucket(bid), tracker, op_seq));
         // But blocked for bucket match!
-        EXPECT_TRUE(checkBlockForAllNodes(op, makeDocumentBucket(bid), tracker));
+        EXPECT_TRUE(checkBlockForAllNodes(op, makeDocumentBucket(bid), tracker, op_seq));
+    }
+}
+
+TEST_F(IdealStateManagerTest, block_operations_with_locked_buckets) {
+    setupDistributor(2, 10, "distributor:1 storage:2");
+    framework::defaultimplementation::FakeClock clock;
+    PendingMessageTracker tracker(_node->getComponentRegister());
+    OperationSequencer op_seq;
+    const auto bucket = makeDocumentBucket(document::BucketId(16, 1234));
+
+    {
+        auto msg = std::make_shared<api::JoinBucketsCommand>(bucket);
+        msg->setAddress(api::StorageMessageAddress::create(&_Storage, lib::NodeType::STORAGE, 1));
+        tracker.insert(msg);
+    }
+    auto token = op_seq.try_acquire(bucket);
+    EXPECT_TRUE(token.valid());
+    {
+        RemoveBucketOperation op("storage", BucketAndNodes(bucket, toVector<uint16_t>(0)));
+        EXPECT_TRUE(checkBlock(op, bucket, tracker, op_seq));
+        EXPECT_TRUE(checkBlockForAllNodes(op, bucket, tracker, op_seq));
     }
 }
 

--- a/storage/src/tests/distributor/maintenancemocks.h
+++ b/storage/src/tests/distributor/maintenancemocks.h
@@ -51,7 +51,7 @@ public:
     }
     void onStart(DistributorMessageSender&) override {}
     void onReceive(DistributorMessageSender&, const std::shared_ptr<api::StorageReply>&) override {}
-    bool isBlocked(const PendingMessageTracker&) const override {
+    bool isBlocked(const PendingMessageTracker&, const OperationSequencer&) const override {
         return _shouldBlock;
     }
     void setShouldBlock(bool shouldBlock) {
@@ -64,7 +64,7 @@ class MockMaintenanceOperationGenerator
 {
 public:
     MaintenanceOperation::SP generate(const document::Bucket&bucket) const override {
-        return MaintenanceOperation::SP(new MockOperation(bucket));
+        return std::make_shared<MockOperation>(bucket);
     }
 
     std::vector<MaintenanceOperation::SP> generateAll(
@@ -73,7 +73,7 @@ public:
     {
         (void) tracker;
         std::vector<MaintenanceOperation::SP> ret;
-        ret.push_back(MaintenanceOperation::SP(new MockOperation(bucket)));
+        ret.emplace_back(std::make_shared<MockOperation>(bucket));
         return ret;
     }
 

--- a/storage/src/tests/distributor/mergeoperationtest.cpp
+++ b/storage/src/tests/distributor/mergeoperationtest.cpp
@@ -6,6 +6,7 @@
 #include <vespa/storage/distributor/operations/idealstate/mergeoperation.h>
 #include <vespa/storage/distributor/bucketdbupdater.h>
 #include <vespa/storage/distributor/distributor.h>
+#include <vespa/storage/distributor/operation_sequencer.h>
 #include <tests/distributor/distributortestutil.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/vespalib/gtest/gtest.h>
@@ -17,11 +18,13 @@ namespace storage::distributor {
 
 struct MergeOperationTest : Test, DistributorTestUtil {
     std::unique_ptr<PendingMessageTracker> _pendingTracker;
+    OperationSequencer _operation_sequencer;
 
     void SetUp() override {
         createLinks();
         _pendingTracker = std::make_unique<PendingMessageTracker>(getComponentRegister());
         _sender.setPendingMessageTracker(*_pendingTracker);
+        _sender.set_operation_sequencer(_operation_sequencer);
     }
 
     void TearDown() override {
@@ -397,18 +400,31 @@ TEST_F(MergeOperationTest, merge_operation_is_blocked_by_any_busy_target_node) {
 
     // Should not block on nodes _not_ included in operation node set
     _pendingTracker->getNodeInfo().setBusy(3, std::chrono::seconds(10));
-    EXPECT_FALSE(op.isBlocked(*_pendingTracker));
+    EXPECT_FALSE(op.isBlocked(*_pendingTracker, _operation_sequencer));
 
     // Node 1 is included in operation node set and should cause a block
     _pendingTracker->getNodeInfo().setBusy(0, std::chrono::seconds(10));
-    EXPECT_TRUE(op.isBlocked(*_pendingTracker));
+    EXPECT_TRUE(op.isBlocked(*_pendingTracker, _operation_sequencer));
 
     getClock().addSecondsToTime(11);
-    EXPECT_FALSE(op.isBlocked(*_pendingTracker)); // No longer busy
+    EXPECT_FALSE(op.isBlocked(*_pendingTracker, _operation_sequencer)); // No longer busy
 
     // Should block on other operation nodes than the first listed as well
     _pendingTracker->getNodeInfo().setBusy(1, std::chrono::seconds(10));
-    EXPECT_TRUE(op.isBlocked(*_pendingTracker));
+    EXPECT_TRUE(op.isBlocked(*_pendingTracker, _operation_sequencer));
+}
+
+TEST_F(MergeOperationTest, merge_operation_is_blocked_by_locked_bucket) {
+    getClock().setAbsoluteTimeInSeconds(10);
+    addNodesToBucketDB(document::BucketId(16, 1), "0=10/1/1/t,1=20/1/1,2=10/1/1/t");
+    enableDistributorClusterState("distributor:1 storage:3");
+    MergeOperation op(BucketAndNodes(makeDocumentBucket(document::BucketId(16, 1)), toVector<uint16_t>(0, 1, 2)));
+    op.setIdealStateManager(&getIdealStateManager());
+
+    EXPECT_FALSE(op.isBlocked(*_pendingTracker, _operation_sequencer));
+    auto token = _operation_sequencer.try_acquire(makeDocumentBucket(document::BucketId(16, 1)));
+    EXPECT_TRUE(token.valid());
+    EXPECT_TRUE(op.isBlocked(*_pendingTracker, _operation_sequencer));
 }
 
 TEST_F(MergeOperationTest, missing_replica_is_included_in_limited_node_list) {

--- a/storage/src/vespa/storage/distributor/blockingoperationstarter.cpp
+++ b/storage/src/vespa/storage/distributor/blockingoperationstarter.cpp
@@ -7,7 +7,7 @@ namespace storage::distributor {
 bool
 BlockingOperationStarter::start(const std::shared_ptr<Operation>& operation, Priority priority)
 {
-    if (operation->isBlocked(_messageTracker)) {
+    if (operation->isBlocked(_messageTracker, _operation_sequencer)) {
         return true;
     }
     return _starterImpl.start(operation, priority);

--- a/storage/src/vespa/storage/distributor/blockingoperationstarter.h
+++ b/storage/src/vespa/storage/distributor/blockingoperationstarter.h
@@ -7,13 +7,16 @@
 namespace storage::distributor {
 
 class PendingMessageTracker;
+class OperationSequencer;
 
 class BlockingOperationStarter : public OperationStarter
 {
 public:
     BlockingOperationStarter(PendingMessageTracker& messageTracker,
+                             OperationSequencer& operation_sequencer,
                              OperationStarter& starterImpl)
         : _messageTracker(messageTracker),
+          _operation_sequencer(operation_sequencer),
           _starterImpl(starterImpl)
     {}
     BlockingOperationStarter(const BlockingOperationStarter&) = delete;
@@ -22,7 +25,8 @@ public:
     bool start(const std::shared_ptr<Operation>& operation, Priority priority) override;
 private:
     PendingMessageTracker& _messageTracker;
-    OperationStarter& _starterImpl;
+    OperationSequencer&    _operation_sequencer;
+    OperationStarter&      _starterImpl;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -34,6 +34,7 @@ namespace storage::distributor {
 class BlockingOperationStarter;
 class BucketPriorityDatabase;
 class DistributorBucketSpaceRepo;
+class OperationSequencer;
 class OwnershipTransferSafeTimePointCalculator;
 class SimpleMaintenanceScanner;
 class ThrottlingOperationStarter;
@@ -74,6 +75,10 @@ public:
 
     PendingMessageTracker& getPendingMessageTracker() override {
         return _pendingMessageTracker;
+    }
+
+    const OperationSequencer& operation_sequencer() const noexcept override {
+        return *_operation_sequencer;
     }
 
     const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const override;
@@ -274,6 +279,7 @@ private:
     OperationOwner _operationOwner;
     OperationOwner _maintenanceOperationOwner;
 
+    std::unique_ptr<OperationSequencer> _operation_sequencer;
     PendingMessageTracker _pendingMessageTracker;
     BucketDBUpdater _bucketDBUpdater;
     StatusReporterDelegate _distributorStatusDelegate;
@@ -309,7 +315,6 @@ private:
 
     DoneInitializeHandler& _doneInitializeHandler;
     bool _doneInitializing;
-
 
     std::unique_ptr<BucketPriorityDatabase> _bucketPriorityDb;
     std::unique_ptr<SimpleMaintenanceScanner> _scanner;

--- a/storage/src/vespa/storage/distributor/distributormessagesender.h
+++ b/storage/src/vespa/storage/distributor/distributormessagesender.h
@@ -8,6 +8,7 @@ namespace storage::lib { class NodeType; }
 namespace storage::distributor {
 
 class PendingMessageTracker;
+class OperationSequencer;
 
 class DistributorMessageSender : public MessageSender {
 public:
@@ -21,6 +22,7 @@ public:
     virtual int getDistributorIndex() const = 0;
     virtual const vespalib::string& getClusterName() const = 0;
     virtual const PendingMessageTracker& getPendingMessageTracker() const = 0;
+    virtual const OperationSequencer& operation_sequencer() const noexcept = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -3,6 +3,7 @@
 #include "bucket_space_distribution_context.h"
 #include "externaloperationhandler.h"
 #include "distributor.h"
+#include "operation_sequencer.h"
 #include <vespa/document/base/documentid.h>
 #include <vespa/storage/distributor/operations/external/putoperation.h>
 #include <vespa/storage/distributor/operations/external/twophaseupdateoperation.h>
@@ -54,12 +55,16 @@ public:
     const PendingMessageTracker& getPendingMessageTracker() const override {
         abort(); // Never called by the messages using this component.
     }
+    const OperationSequencer& operation_sequencer() const noexcept override {
+        abort(); // Never called by the messages using this component.
+    }
 };
 
 ExternalOperationHandler::ExternalOperationHandler(DistributorNodeContext& node_ctx,
                                                    DistributorOperationContext& op_ctx,
                                                    DistributorMetricSet& metrics,
                                                    ChainedMessageSender& msg_sender,
+                                                   OperationSequencer& operation_sequencer,
                                                    NonTrackingMessageSender& non_tracking_sender,
                                                    DocumentSelectionParser& parser,
                                                    const MaintenanceOperationGenerator& gen,
@@ -68,6 +73,7 @@ ExternalOperationHandler::ExternalOperationHandler(DistributorNodeContext& node_
       _op_ctx(op_ctx),
       _metrics(metrics),
       _msg_sender(msg_sender),
+      _operation_sequencer(operation_sequencer),
       _parser(parser),
       _direct_dispatch_sender(std::make_unique<DirectDispatchSender>(node_ctx, non_tracking_sender)),
       _operationGenerator(gen),

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "operation_sequencer.h"
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/document/bucket/bucketidfactory.h>
 #include <vespa/vdslib/state/clusterstate.h>
@@ -23,6 +22,8 @@ class DistributorMetricSet;
 class Distributor;
 class MaintenanceOperationGenerator;
 class DirectDispatchSender;
+class SequencingHandle;
+class OperationSequencer;
 class OperationOwner;
 
 class ExternalOperationHandler : public api::MessageHandler
@@ -44,6 +45,7 @@ public:
                              DistributorOperationContext& op_ctx,
                              DistributorMetricSet& metrics,
                              ChainedMessageSender& msg_sender,
+                             OperationSequencer& operation_sequencer,
                              NonTrackingMessageSender& non_tracking_sender,
                              DocumentSelectionParser& parser,
                              const MaintenanceOperationGenerator& gen,
@@ -89,10 +91,10 @@ private:
     DistributorOperationContext& _op_ctx;
     DistributorMetricSet& _metrics;
     ChainedMessageSender& _msg_sender;
+    OperationSequencer& _operation_sequencer;
     DocumentSelectionParser& _parser;
     std::unique_ptr<DirectDispatchSender> _direct_dispatch_sender;
     const MaintenanceOperationGenerator& _operationGenerator;
-    OperationSequencer _operation_sequencer;
     Operation::SP _op;
     TimePoint _rejectFeedBeforeTimeReached;
     OperationOwner& _distributor_operation_owner;

--- a/storage/src/vespa/storage/distributor/operation_sequencer.cpp
+++ b/storage/src/vespa/storage/distributor/operation_sequencer.cpp
@@ -47,6 +47,10 @@ SequencingHandle OperationSequencer::try_acquire(const document::Bucket& bucket)
     }
 }
 
+bool OperationSequencer::is_blocked(const document::Bucket& bucket) const noexcept {
+    return (_active_buckets.find(bucket) != _active_buckets.end());
+}
+
 void OperationSequencer::release(const SequencingHandle& handle) {
     assert(handle.valid());
     if (handle.has_gid()) {

--- a/storage/src/vespa/storage/distributor/operation_sequencer.h
+++ b/storage/src/vespa/storage/distributor/operation_sequencer.h
@@ -130,6 +130,8 @@ public:
     SequencingHandle try_acquire(document::BucketSpace bucket_space, const document::DocumentId& id);
 
     SequencingHandle try_acquire(const document::Bucket& bucket);
+
+    bool is_blocked(const document::Bucket&) const noexcept;
 private:
     void release(const SequencingHandle& handle);
 };

--- a/storage/src/vespa/storage/distributor/operationowner.h
+++ b/storage/src/vespa/storage/distributor/operationowner.h
@@ -48,6 +48,10 @@ public:
             return _sender.getPendingMessageTracker();
         }
 
+        const OperationSequencer& operation_sequencer() const noexcept override {
+            return _sender.operation_sequencer();
+        }
+
     private:
         OperationOwner& _owner;
         DistributorMessageSender& _sender;

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -88,6 +88,10 @@ struct IntermediateMessageSender : DistributorMessageSender {
     const PendingMessageTracker& getPendingMessageTracker() const override {
         return forward.getPendingMessageTracker();
     }
+
+    const OperationSequencer& operation_sequencer() const noexcept override {
+        return forward.operation_sequencer();
+    }
 };
 
 IntermediateMessageSender::IntermediateMessageSender(SentMessageMap& mm,

--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
@@ -182,7 +182,7 @@ public:
      * Returns true if we are blocked to start this operation given
      * the pending messages.
      */
-    bool isBlocked(const PendingMessageTracker& pendingMessages) const override;
+    bool isBlocked(const PendingMessageTracker& pendingMessages, const OperationSequencer&) const override;
 
     /**
        Returns the priority we should send messages with.
@@ -235,8 +235,12 @@ protected:
      * operations to other nodes for this bucket, these will not be part of
      * the set of messages checked.
      */
-    bool checkBlock(const document::Bucket &bucket, const PendingMessageTracker& tracker) const;
-    bool checkBlockForAllNodes(const document::Bucket &bucket, const PendingMessageTracker& tracker) const;
+    bool checkBlock(const document::Bucket& bucket,
+                    const PendingMessageTracker& tracker,
+                    const OperationSequencer&) const;
+    bool checkBlockForAllNodes(const document::Bucket& bucket,
+                               const PendingMessageTracker& tracker,
+                               const OperationSequencer&) const;
 
 };
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/joinoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/joinoperation.cpp
@@ -150,10 +150,10 @@ JoinOperation::getJoinBucket(size_t idx) const
 }
 
 bool
-JoinOperation::isBlocked(const PendingMessageTracker& tracker) const
+JoinOperation::isBlocked(const PendingMessageTracker& tracker, const OperationSequencer& op_seq) const
 {
-    return (checkBlock(getBucket(), tracker) ||
-            checkBlock(getJoinBucket(0), tracker) ||
-            (_bucketsToJoin.size() > 1 && checkBlock(getJoinBucket(1), tracker)));
+    return (checkBlock(getBucket(), tracker, op_seq) ||
+            checkBlock(getJoinBucket(0), tracker, op_seq) ||
+            (_bucketsToJoin.size() > 1 && checkBlock(getJoinBucket(1), tracker, op_seq)));
 }
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/joinoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/joinoperation.h
@@ -41,7 +41,8 @@ public:
         return JOIN_BUCKET;
     }
 
-    bool isBlocked(const PendingMessageTracker& pendingMessages) const override;
+    bool isBlocked(const PendingMessageTracker& pendingMessages,
+                   const OperationSequencer& op_seq) const override;
 
 protected:
     using NodeToBuckets = std::map<uint16_t, std::vector<document::BucketId>>;

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -233,7 +233,7 @@ MergeOperation::deleteSourceOnlyNodes(
                         BucketAndNodes(getBucket(), sourceOnlyNodes)));
         // Must not send removes to source only copies if something has caused
         // pending load to the copy after the merge was sent!
-        if (_removeOperation->isBlocked(sender.getPendingMessageTracker())) {
+        if (_removeOperation->isBlocked(sender.getPendingMessageTracker(), sender.operation_sequencer())) {
             LOG(debug,
                 "Source only removal for %s was blocked by a pending "
                 "operation",
@@ -324,14 +324,15 @@ bool MergeOperation::shouldBlockThisOperation(uint32_t messageType, uint8_t pri)
     return IdealStateOperation::shouldBlockThisOperation(messageType, pri);
 }
 
-bool MergeOperation::isBlocked(const PendingMessageTracker& pending_tracker) const {
+bool MergeOperation::isBlocked(const PendingMessageTracker& pending_tracker,
+                               const OperationSequencer& op_seq) const {
     const auto& node_info = pending_tracker.getNodeInfo();
     for (auto node : getNodes()) {
         if (node_info.isBusy(node)) {
             return true;
         }
     }
-    return IdealStateOperation::isBlocked(pending_tracker);
+    return IdealStateOperation::isBlocked(pending_tracker, op_seq);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -47,7 +47,7 @@ public:
             std::vector<MergeMetaData>&);
 
     bool shouldBlockThisOperation(uint32_t messageType, uint8_t pri) const override;
-    bool isBlocked(const PendingMessageTracker& pendingMessages) const override;
+    bool isBlocked(const PendingMessageTracker& pendingMessages, const OperationSequencer&) const override;
 private:
     static void addIdealNodes(
             const std::vector<uint16_t>& idealNodes,

--- a/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.cpp
@@ -164,9 +164,9 @@ SplitOperation::onReceive(DistributorMessageSender&, const api::StorageReply::SP
 }
 
 bool
-SplitOperation::isBlocked(const PendingMessageTracker& tracker) const
+SplitOperation::isBlocked(const PendingMessageTracker& tracker, const OperationSequencer& op_seq) const
 {
-    return checkBlockForAllNodes(getBucket(), tracker);
+    return checkBlockForAllNodes(getBucket(), tracker, op_seq);
 }
 
 bool

--- a/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.h
@@ -20,7 +20,7 @@ public:
     const char* getName() const override { return "split"; };
     Type getType() const override { return SPLIT_BUCKET; }
     uint32_t getMaxSplitBits() const { return _maxBits; }
-    bool isBlocked(const PendingMessageTracker&) const override;
+    bool isBlocked(const PendingMessageTracker&, const OperationSequencer&) const override;
     bool shouldBlockThisOperation(uint32_t, uint8_t) const override;
 protected:
     MessageTracker _tracker;

--- a/storage/src/vespa/storage/distributor/operations/operation.h
+++ b/storage/src/vespa/storage/distributor/operations/operation.h
@@ -18,6 +18,7 @@ class StorageComponent;
 namespace distributor {
 
 class PendingMessageTracker;
+class OperationSequencer;
 
 class Operation
 {
@@ -61,7 +62,7 @@ public:
      * Returns true if we are blocked to start this operation given
      * the pending messages.
      */
-    virtual bool isBlocked(const PendingMessageTracker&) const {
+    virtual bool isBlocked(const PendingMessageTracker&, const OperationSequencer&) const {
         return false;
     }
 


### PR DESCRIPTION
@geirst please review
@jonmv FYI

Prevents ideal state ops from modifying buckets that are being used in a read-for-write context.
Move `OperationSequencer` to main `Distributor` to more easily facilitate sharing of it across components.

