### PR TITLE
Use exponential backoff for reconfig retries

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
@@ -9,6 +9,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * @author hmusum
+ */
 @SuppressWarnings("unused") // Created by injection
 public class VespaZooKeeperAdminImpl implements VespaZooKeeperAdmin {
 

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperServer.java
@@ -11,6 +11,8 @@ import java.nio.file.Path;
 /**
  * Class to start zookeeper server. Extends QuorumPeerMain to be able to call initializeAndRun() and wraps
  * exceptions so it can be used by code that does not depend on zookeeper.
+ *
+ * @author hmusum
  */
 class ZooKeeperServer extends QuorumPeerMain {
 

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ExponentialBackoff.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ExponentialBackoff.java
@@ -1,0 +1,47 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.zookeeper;
+
+import java.time.Duration;
+import java.util.Random;
+
+/**
+ * Calculate a delay using an exponential backoff algorithm. Based on ExponentialBackOff in google-http-client.
+ *
+ * @author mpolden
+ */
+public class ExponentialBackoff {
+
+    private static final double RANDOMIZATION_FACTOR = 0.5;
+
+    private final Duration initialDelay;
+    private final Duration maxDelay;
+    private final Random random;
+
+    public ExponentialBackoff(Duration initialDelay, Duration maxDelay) {
+        this(initialDelay, maxDelay, new Random());
+    }
+
+    ExponentialBackoff(Duration initialDelay, Duration maxDelay, Random random) {
+        this.initialDelay = requireNonNegative(initialDelay);
+        this.maxDelay = requireNonNegative(maxDelay);
+        this.random = random;
+    }
+
+    /** Return the delay of given attempt */
+    public Duration delay(int attempt) {
+        if (attempt < 1) throw new IllegalArgumentException("Attempt must be positive");
+        double currentDelay = attempt * initialDelay.toMillis();
+        double delta = RANDOMIZATION_FACTOR * currentDelay;
+        double lowerDelay = currentDelay - delta;
+        double upperDelay = currentDelay + delta;
+        long millis = (long) Math.min(lowerDelay + (random.nextDouble() * (upperDelay - lowerDelay + 1)),
+                                      maxDelay.toMillis());
+        return Duration.ofMillis(millis);
+    }
+
+    private static Duration requireNonNegative(Duration d) {
+        if (d.isNegative()) throw new IllegalArgumentException("Invalid duration: " + d);
+        return d;
+    }
+
+}

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ExponentialBackoffTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ExponentialBackoffTest.java
@@ -1,0 +1,32 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.zookeeper;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mpolden
+ */
+public class ExponentialBackoffTest {
+
+    @Test
+    public void delay() {
+        ExponentialBackoff b = new ExponentialBackoff(Duration.ofSeconds(1), Duration.ofSeconds(10), new Random(1000));
+        assertEquals(List.of(Duration.ofMillis(1210),
+                             Duration.ofMillis(2150),
+                             Duration.ofMillis(4340),
+                             Duration.ofMillis(2157),
+                             Duration.ofMillis(4932)),
+                     IntStream.rangeClosed(1, 5)
+                              .mapToObj(b::delay)
+                              .collect(Collectors.toList()));
+    }
+
+}


### PR DESCRIPTION
Combined with nodes connecting to localhost this should reduce the time it takes
for all nodes to complete reconfig.

@hmusum