### PR TITLE
Revert "Set reconfigEnabled based on config value"

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -90,7 +90,7 @@ public class Configurator {
         sb.append("serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory").append("\n");
         sb.append("quorumListenOnAllIPs=true").append("\n");
         sb.append("standaloneEnabled=false").append("\n");
-        sb.append("reconfigEnabled=" + config.dynamicReconfiguration()).append("\n");
+        sb.append("reconfigEnabled=true").append("\n");
         sb.append("skipACL=yes").append("\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
         config.server().forEach(server -> addServerToCfg(sb, server, config.clientPort()));

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -69,7 +69,6 @@ public class ConfiguratorTest {
         builder.server(newServer(2, "baz", 345, 543));
         builder.myidFile(idFile.getAbsolutePath());
         builder.myid(1);
-        builder.dynamicReconfiguration(true);
         new Configurator(builder.build()).writeConfigToDisk(Optional.empty());
         validateConfigFileMultipleHosts(cfgFile);
         validateIdFile(idFile, "1\n");
@@ -115,7 +114,6 @@ public class ConfiguratorTest {
         builder.server(newServer(0, "foo", 123, 321));
         builder.myid(0);
         builder.jksKeyStoreFile(jksKeyStoreFile.getAbsolutePath());
-        builder.dynamicReconfiguration(true);
         return builder;
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#15749

This breaks upgrade of controllers. Seems like there are several bugs in this area, we might have hit one of them, see https://zookeeper.apache.org/doc/r3.6.2/releasenotes.html