### PR TITLE
Bounce reindexing visitor with BUSY if merge is pending for bucket

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
@@ -43,6 +43,8 @@ public:
     void onStart(DistributorMessageSender& sender) override;
     void onReceive(DistributorMessageSender& sender,
                    const std::shared_ptr<api::StorageReply> & msg) override;
+private:
+    bool bucket_has_pending_merge(const document::Bucket&, const PendingMessageTracker& tracker) const;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -887,6 +887,13 @@ VisitorOperation::fail_with_bucket_already_locked(DistributorMessageSender& send
     sendReply(api::ReturnCode(api::ReturnCode::BUSY, "This bucket is already locked by another operation"), sender);
 }
 
+void
+VisitorOperation::fail_with_merge_pending(DistributorMessageSender& sender)
+{
+    assert(is_read_for_write());
+    sendReply(api::ReturnCode(api::ReturnCode::BUSY, "A merge operation is pending for this bucket"), sender);
+}
+
 std::optional<document::Bucket>
 VisitorOperation::first_bucket_to_visit() const
 {

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
@@ -51,6 +51,7 @@ public:
 
     // Only valid to call if is_read_for_write() == true
     void fail_with_bucket_already_locked(DistributorMessageSender& sender);
+    void fail_with_merge_pending(DistributorMessageSender& sender);
 
     [[nodiscard]] bool verify_command_and_expand_buckets(DistributorMessageSender& sender);
 


### PR DESCRIPTION
@geirst please review

Since reindexing visitors take a bucket lock when they arrive and
wait for pending ops to drain before they start, doing so when there's
a pending merge risks starving the bucket for a long time. This is
because merges may linger for a long time in the merge throttling
queues in the cluster. By not starting such visitors if there is a
pending merge, we avoid this edge case. Functionality is already in
place to inhibit merges from starting if there's an active bucket lock
present.
