### PR TITLE
Ignore case on autocomplete in querybuilder

### DIFF
--- a/container-search-gui/src/main/resources/gui/editarea/edit_area/plugins/autocompletion/autocompletion.js
+++ b/container-search-gui/src/main/resources/gui/editarea/edit_area/plugins/autocompletion/autocompletion.js
@@ -277,7 +277,7 @@ var EditArea_autocompletion= {
 		nbMatch	= 0;
 		for( i =0; i<limit ; i++ )
 		{
-			if( line_string.substring( limit - i - 1, limit ) == content.substring( 0, i + 1 ) )
+			if( line_string.substring( limit - i - 1, limit ).toUpperCase() === content.substring( 0, i + 1 ).toUpperCase() )
 				nbMatch = i + 1;
 		}
 		// if characters match, we should include them in the selection that will be replaced

--- a/container-search-gui/src/main/resources/gui/editarea/edit_area/reg_syntax/yql.js
+++ b/container-search-gui/src/main/resources/gui/editarea/edit_area/reg_syntax/yql.js
@@ -72,7 +72,7 @@ editAreaLoader.load_syntax["yql"] = {
 			,"CASE_SENSITIVE": false
 			,"MAX_TEXT_LENGTH": 50		// the maximum length of the text being analyzed before the cursor position
 			,"KEYWORDS": {
-				'': [	// the prefix of thoses items
+				'': [	// the prefix of these items
 						/**
 						 * 0 : the keyword the user is typing
 						 * 1 : (optionnal) the string inserted in code ("{@}" being the new position of the cursor, "§" beeing the equivalent to the value the typed string indicated if the previous )


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

As is, if I write a small word and use autocomplete, I get my word plus choice. Established the ability to use lowercase in querybuilde.