### PR TITLE
2 hacks to be able to use ZooKeeper server 3.6

### DIFF
--- a/zookeeper-server/zookeeper-server-3.6.2/pom.xml
+++ b/zookeeper-server/zookeeper-server-3.6.2/pom.xml
@@ -31,6 +31,9 @@
       <artifactId>slf4j-log4j12</artifactId>
       <version>1.7.5</version>
     </dependency>
+    <!-- snappy-java and metrics-core are included here
+         to be able to work with ZooKeeper 3.6.2 due to
+         class loading issues -->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>

--- a/zookeeper-server/zookeeper-server-3.6.2/pom.xml
+++ b/zookeeper-server/zookeeper-server-3.6.2/pom.xml
@@ -32,6 +32,18 @@
       <version>1.7.5</version>
     </dependency>
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <scope>compile</scope>
+      <version>3.2.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <scope>compile</scope>
+      <version>1.1.7</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -92,6 +92,7 @@ public class Configurator {
         sb.append("standaloneEnabled=false").append("\n");
         sb.append("reconfigEnabled=true").append("\n");
         sb.append("skipACL=yes").append("\n");
+        sb.append("metricsProvider.className=org.apache.zookeeper.metrics.impl.NullMetricsProvider\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
         config.server().forEach(server -> addServerToCfg(sb, server, config.clientPort()));
         SSLContext sslContext = new SslContextBuilder().build();

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -56,10 +56,18 @@ public class ZooKeeperRunner implements Runnable {
         Path path = Paths.get(getDefaults().underVespaHome(zookeeperServerConfig.zooKeeperConfigFile()));
         log.log(Level.INFO, "Starting ZooKeeper server with config file " + path.toFile().getAbsolutePath() +
                             ". Trying to establish ZooKeeper quorum (members: " + zookeeperServerHostnames(zookeeperServerConfig) + ")");
+        // Note: Hack to make this work in ZooKeeper 3.6, where metrics provider class is
+        // loaded by using Thread.currentThread().getContextClassLoader() which does not work
+        // well in the container
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
         try {
             server.start(path);
         } catch (Throwable e) {
-            log.log(Level.SEVERE, "Starting ZooKeeper server failed:", e);
+            log.log(Level.SEVERE, "Starting ZooKeeper server failed", e);
+            throw new RuntimeException("Starting ZooKeeper server failed", e);
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
         }
     }
 

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -177,7 +177,8 @@ public class ConfiguratorTest {
                "quorumListenOnAllIPs=true\n" +
                "standaloneEnabled=false\n" +
                "reconfigEnabled=true\n" +
-               "skipACL=yes\n";
+               "skipACL=yes\n" +
+               "metricsProvider.className=org.apache.zookeeper.metrics.impl.NullMetricsProvider\n";
     }
 
     private String quorumKeyStoreAndTrustStoreConfig(File jksKeyStoreFilePath, File caCertificatesFilePath) {


### PR DESCRIPTION
Explicitly depend on io.dropwizard.metrics and org.xerial.snappy since
they are used by metrics provider (even NullMetricsProvider) when
bootstrapping ServerMetrics in zookeeper code and cannot be found
when running in a container

Do some class loading trick to circumvent zookeeper itself loading a class
with the threads current class loader, which does not work well in
a container.

There might be better ways of doing this, but this makes the zookeeper server start and work in a cluster with
3.5 and 3.6 servers. Also tested that generated config works with 3.5 server
