### PR TITLE
Delete dynamic config files if server is not a reconfigurable server

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
@@ -23,4 +23,6 @@ public class ReconfigurableVespaZooKeeperServer extends AbstractComponent implem
         new ZooKeeperServer().start(configFilePath);
     }
 
+    public boolean reconfigurable() { return true; }
+
 }

--- a/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
@@ -23,4 +23,6 @@ public class ReconfigurableVespaZooKeeperServer extends AbstractComponent implem
         new ZooKeeperServer().start(configFilePath);
     }
 
+    public boolean reconfigurable() { return true; }
+
 }

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServer.java
@@ -12,4 +12,6 @@ public interface VespaZooKeeperServer {
 
     void start(Path configFilePath);
 
+    default boolean reconfigurable() { return false; }
+
 }


### PR DESCRIPTION
Delete ZooKeeper dynamic config files before starting server. They do not have to be used in cases where we are not going to dynamically reconfigure the ZooKeeper cluster and there are ZooKeeper bugs related to dynamic reconfig, at least on versions 3.5.x