### PR TITLE
Remove use of "use-fast-value-tensor-implementation" flag.

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -69,7 +69,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"baldersheim"}, comment = "Revisit in May or June 2020") default double defaultTermwiseLimit() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"vekterli"}) default boolean useThreePhaseUpdates() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"geirst"}, comment = "Remove on 7.XXX when this is default on") default boolean useDirectStorageApiRpc() { throw new UnsupportedOperationException("TODO specify default value"); }
-        @ModelFeatureFlag(owners = {"geirst"}, comment = "Remove on 7.XXX when this is default on") default boolean useFastValueTensorImplementation() { throw new UnsupportedOperationException("TODO specify default value"); }
+        @ModelFeatureFlag(owners = {"geirst"}, comment = "Remove when 7.328 is no longer in use") default boolean useFastValueTensorImplementation() { return true; }
         @ModelFeatureFlag(owners = {"baldersheim"}, comment = "Select sequencer type use while feeding") default String feedSequencerType() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default String responseSequencerType() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int defaultNumResponseThreads() { return 2; }
@@ -127,7 +127,7 @@ public interface ModelContext {
         @Deprecated double feedConcurrency();
         @Deprecated boolean useThreePhaseUpdates();
         @Deprecated boolean useDirectStorageApiRpc();
-        @Deprecated boolean useFastValueTensorImplementation();
+        @Deprecated default boolean useFastValueTensorImplementation() { return true; }
         @Deprecated default boolean useAccessControlTlsHandshakeClientAuth() { return false; }
     }
 

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -38,7 +38,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean useDedicatedNodeForLogserver = false;
     private boolean useThreePhaseUpdates = false;
     private boolean useDirectStorageApiRpc = false;
-    private boolean useFastValueTensorImplementation = false;
+    private boolean useFastValueTensorImplementation = true;
     private double defaultTermwiseLimit = 1.0;
     private String jvmGCOptions = null;
     private String sequencerType = "LATENCY";
@@ -137,11 +137,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setUseDirectStorageApiRpc(boolean useDirectStorageApiRpc) {
         this.useDirectStorageApiRpc = useDirectStorageApiRpc;
-        return this;
-    }
-
-    public TestProperties setUseFastValueTensorImplementation(boolean useFastValueTensorImplementation) {
-        this.useFastValueTensorImplementation = useFastValueTensorImplementation;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -267,7 +267,7 @@ public class ContentSearchCluster extends AbstractConfigProducer implements Prot
         TransactionLogServer tls;
         Optional<Tuning> tuning = Optional.ofNullable(this.tuning);
         if (element == null) {
-            searchNode = SearchNode.create(deployState.getProperties(), parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec,
+            searchNode = SearchNode.create(parent, "" + node.getDistributionKey(), node.getDistributionKey(), spec,
                                            clusterName, node, flushOnShutdown, tuning, resourceLimits, parentGroup.isHosted(), combined);
             searchNode.setHostResource(node.getHostResource());
             searchNode.initService(deployState.getDeployLogger());

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -69,7 +69,6 @@ public class SearchNode extends AbstractService implements
     private AbstractService serviceLayerService;
     private final Optional<Tuning> tuning;
     private final Optional<ResourceLimits> resourceLimits;
-    private final boolean useFastValueTensorImplementation;
 
     /** Whether this search node is co-located with a container node on a hosted system */
     private final boolean combined;
@@ -100,31 +99,31 @@ public class SearchNode extends AbstractService implements
 
         @Override
         protected SearchNode doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element producerSpec) {
-            return new SearchNode(deployState.getProperties(), ancestor, name, contentNode.getDistributionKey(), nodeSpec, clusterName, contentNode,
+            return new SearchNode(ancestor, name, contentNode.getDistributionKey(), nodeSpec, clusterName, contentNode,
                                   flushOnShutdown, tuning, resourceLimits, deployState.isHosted(), combined);
         }
 
     }
 
-    public static SearchNode create(ModelContext.Properties props, AbstractConfigProducer parent, String name, int distributionKey, NodeSpec nodeSpec,
+    public static SearchNode create(AbstractConfigProducer parent, String name, int distributionKey, NodeSpec nodeSpec,
                                     String clusterName, AbstractService serviceLayerService, boolean flushOnShutdown,
                                     Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                                     boolean combined) {
-        return new SearchNode(props, parent, name, distributionKey, nodeSpec, clusterName, serviceLayerService,
+        return new SearchNode(parent, name, distributionKey, nodeSpec, clusterName, serviceLayerService,
                               flushOnShutdown, tuning, resourceLimits, isHostedVespa, combined);
     }
 
-    private SearchNode(ModelContext.Properties props, AbstractConfigProducer parent, String name, int distributionKey, NodeSpec nodeSpec,
+    private SearchNode(AbstractConfigProducer parent, String name, int distributionKey, NodeSpec nodeSpec,
                        String clusterName, AbstractService serviceLayerService, boolean flushOnShutdown,
                        Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                        boolean combined) {
-        this(props, parent, name, nodeSpec, clusterName, flushOnShutdown, tuning, resourceLimits, isHostedVespa, combined);
+        this(parent, name, nodeSpec, clusterName, flushOnShutdown, tuning, resourceLimits, isHostedVespa, combined);
         this.distributionKey = distributionKey;
         this.serviceLayerService = serviceLayerService;
         setPropertiesElastic(clusterName, distributionKey);
     }
 
-    private SearchNode(ModelContext.Properties props, AbstractConfigProducer parent, String name, NodeSpec nodeSpec, String clusterName,
+    private SearchNode(AbstractConfigProducer parent, String name, NodeSpec nodeSpec, String clusterName,
                        boolean flushOnShutdown, Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                        boolean combined) {
         super(parent, name);
@@ -142,7 +141,6 @@ public class SearchNode extends AbstractService implements
         // Properties are set in DomSearchBuilder
         this.tuning = tuning;
         this.resourceLimits = resourceLimits;
-        this.useFastValueTensorImplementation = props.featureFlags().useFastValueTensorImplementation();
     }
 
     private void setPropertiesElastic(String clusterName, int distributionKey) {
@@ -296,9 +294,6 @@ public class SearchNode extends AbstractService implements
 
             tuning.ifPresent(t -> t.getConfig(builder));
             resourceLimits.ifPresent(l -> l.getConfig(builder));
-        }
-        if (useFastValueTensorImplementation) {
-            builder.tensor_implementation(ProtonConfig.Tensor_implementation.FAST_VALUE);
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/SearchNodeTest.java
@@ -53,7 +53,7 @@ public class SearchNodeTest {
 
     private static SearchNode createSearchNode(MockRoot root, String name, int distributionKey,
                                                NodeSpec nodeSpec, boolean flushOnShutDown, boolean isHosted, boolean combined) {
-        return SearchNode.create(root.getDeployState().getProperties(), root, name, distributionKey, nodeSpec, "mycluster", null, flushOnShutDown, Optional.empty(), Optional.empty(), isHosted, combined);
+        return SearchNode.create(root, name, distributionKey, nodeSpec, "mycluster", null, flushOnShutDown, Optional.empty(), Optional.empty(), isHosted, combined);
     }
 
     private static SearchNode createSearchNode(MockRoot root) {


### PR DESCRIPTION
Has been default on since 7.319.17 (25-Nov-2020).

This partially re-applies https://github.com/vespa-engine/vespa/pull/15760.

@hmusum please review
@arnej27959 FYI