### PR TITLE
Only let reindexing puts through locked bucket if their TaS token matches that of the lock

### DIFF
--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -569,15 +569,16 @@ struct OperationHandlerSequencingTest : ExternalOperationHandlerTest {
         set_up_distributor_for_sequencing_test();
     }
 
-    static documentapi::TestAndSetCondition bucket_lock_bypass_tas_condition() {
-        return documentapi::TestAndSetCondition(reindexing_bucket_lock_bypass_value());
+    static documentapi::TestAndSetCondition bucket_lock_bypass_tas_condition(const vespalib::string& token) {
+        return documentapi::TestAndSetCondition(
+                vespalib::make_string("%s=%s", reindexing_bucket_lock_bypass_prefix(), token.c_str()));
     }
 };
 
 TEST_F(OperationHandlerSequencingTest, put_not_allowed_through_locked_bucket_if_special_tas_token_not_present) {
     auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
     auto bucket = makeDocumentBucket(document::BucketId(16, 1));
-    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket);
+    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket, "foo");
     ASSERT_TRUE(bucket_handle.valid());
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(put));
 }
@@ -586,19 +587,28 @@ TEST_F(OperationHandlerSequencingTest, put_allowed_through_locked_bucket_if_spec
     set_up_distributor_for_sequencing_test();
 
     auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
-    put->setCondition(bucket_lock_bypass_tas_condition());
+    put->setCondition(bucket_lock_bypass_tas_condition("foo"));
 
     auto bucket = makeDocumentBucket(document::BucketId(16, 1));
-    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket);
+    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket, "foo");
     ASSERT_TRUE(bucket_handle.valid());
 
     Operation::SP op;
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(put, op));
 }
 
+TEST_F(OperationHandlerSequencingTest, put_not_allowed_through_locked_bucket_if_tas_token_mismatches_current_lock_tkoen) {
+    auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
+    put->setCondition(bucket_lock_bypass_tas_condition("bar"));
+    auto bucket = makeDocumentBucket(document::BucketId(16, 1));
+    auto bucket_handle = getExternalOperationHandler().operation_sequencer().try_acquire(bucket, "foo");
+    ASSERT_TRUE(bucket_handle.valid());
+    ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(put));
+}
+
 TEST_F(OperationHandlerSequencingTest, put_with_bucket_lock_tas_token_is_rejected_if_no_bucket_lock_present) {
     auto put = makePutCommand("testdoctype1", "id:foo:testdoctype1:n=1:bar");
-    put->setCondition(bucket_lock_bypass_tas_condition());
+    put->setCondition(bucket_lock_bypass_tas_condition("foo"));
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(put));
     // TODO determine most appropriate error code here. Want to fail the bucket but
     // not the entire visitor operation. Will likely need to be revisited (heh!) soon.
@@ -611,7 +621,7 @@ TEST_F(OperationHandlerSequencingTest, put_with_bucket_lock_tas_token_is_rejecte
 // present, this tests the case where a lock is present but it's not a bucket-level lock.
 TEST_F(OperationHandlerSequencingTest, put_with_bucket_lock_tas_token_is_rejected_if_document_lock_present) {
     auto put = makePutCommand("testdoctype1", _dummy_id);
-    put->setCondition(bucket_lock_bypass_tas_condition());
+    put->setCondition(bucket_lock_bypass_tas_condition("foo"));
     Operation::SP op;
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_not_rejected(makeUpdateCommand("testdoctype1", _dummy_id), op));
     ASSERT_NO_FATAL_FAILURE(start_operation_verify_rejected(std::move(put)));

--- a/storage/src/tests/distributor/idealstatemanagertest.cpp
+++ b/storage/src/tests/distributor/idealstatemanagertest.cpp
@@ -255,7 +255,7 @@ TEST_F(IdealStateManagerTest, block_operations_with_locked_buckets) {
         msg->setAddress(api::StorageMessageAddress::create(&_Storage, lib::NodeType::STORAGE, 1));
         tracker.insert(msg);
     }
-    auto token = op_seq.try_acquire(bucket);
+    auto token = op_seq.try_acquire(bucket, "foo");
     EXPECT_TRUE(token.valid());
     {
         RemoveBucketOperation op("storage", BucketAndNodes(bucket, toVector<uint16_t>(0)));

--- a/storage/src/tests/distributor/mergeoperationtest.cpp
+++ b/storage/src/tests/distributor/mergeoperationtest.cpp
@@ -422,7 +422,7 @@ TEST_F(MergeOperationTest, merge_operation_is_blocked_by_locked_bucket) {
     op.setIdealStateManager(&getIdealStateManager());
 
     EXPECT_FALSE(op.isBlocked(*_pendingTracker, _operation_sequencer));
-    auto token = _operation_sequencer.try_acquire(makeDocumentBucket(document::BucketId(16, 1)));
+    auto token = _operation_sequencer.try_acquire(makeDocumentBucket(document::BucketId(16, 1)), "foo");
     EXPECT_TRUE(token.valid());
     EXPECT_TRUE(op.isBlocked(*_pendingTracker, _operation_sequencer));
 }

--- a/storage/src/tests/distributor/splitbuckettest.cpp
+++ b/storage/src/tests/distributor/splitbuckettest.cpp
@@ -313,7 +313,7 @@ TEST_F(SplitOperationTest, split_is_blocked_by_locked_bucket) {
                       maxSplitBits, splitCount, splitByteSize);
 
     EXPECT_FALSE(op.isBlocked(tracker, op_seq));
-    auto token = op_seq.try_acquire(makeDocumentBucket(source_bucket));
+    auto token = op_seq.try_acquire(makeDocumentBucket(source_bucket), "foo");
     EXPECT_TRUE(token.valid());
     EXPECT_TRUE(op.isBlocked(tracker, op_seq));
 }

--- a/storage/src/vespa/storage/common/reindexing_constants.cpp
+++ b/storage/src/vespa/storage/common/reindexing_constants.cpp
@@ -3,10 +3,14 @@
 
 namespace storage {
 
-const char* reindexing_bucket_lock_bypass_value() noexcept {
+const char* reindexing_bucket_lock_bypass_prefix() noexcept {
     // This is by design a string that will fail to parse as a valid document selection in the backend.
     // It's only used to bypass the read-for-write visitor bucket lock.
     return "@@__vespa_internal_allow_through_bucket_lock";
+}
+
+const char* reindexing_bucket_lock_visitor_parameter_key() noexcept {
+    return "__vespa_internal_reindexing_bucket_token";
 }
 
 }

--- a/storage/src/vespa/storage/common/reindexing_constants.h
+++ b/storage/src/vespa/storage/common/reindexing_constants.h
@@ -3,6 +3,8 @@
 
 namespace storage {
 
-const char* reindexing_bucket_lock_bypass_value() noexcept;
+const char* reindexing_bucket_lock_bypass_prefix() noexcept;
+
+const char* reindexing_bucket_lock_visitor_parameter_key() noexcept;
 
 }

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -9,6 +9,7 @@ vespa_add_library(storage_distributor
     bucketlistmerger.cpp
     bucket_space_distribution_context.cpp
     clusterinformation.cpp
+    crypto_uuid_generator.cpp
     distributor_bucket_space.cpp
     distributor_bucket_space_repo.cpp
     distributor.cpp

--- a/storage/src/vespa/storage/distributor/crypto_uuid_generator.cpp
+++ b/storage/src/vespa/storage/distributor/crypto_uuid_generator.cpp
@@ -1,0 +1,20 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "crypto_uuid_generator.h"
+#include <vespa/vespalib/crypto/random.h>
+
+namespace storage::distributor {
+
+vespalib::string CryptoUuidGenerator::generate_uuid() const {
+    unsigned char rand_buf[16];
+    vespalib::crypto::random_buffer(rand_buf, sizeof(rand_buf));
+    const char hex[16+1] = "0123456789abcdef";
+    vespalib::string ret(sizeof(rand_buf) * 2, '\0');
+    for (size_t i = 0; i < sizeof(rand_buf); ++i) {
+        ret[i*2 + 0] = hex[rand_buf[i] >> 4];
+        ret[i*2 + 1] = hex[rand_buf[i] & 0x0f];
+    }
+    return ret;
+}
+
+}

--- a/storage/src/vespa/storage/distributor/crypto_uuid_generator.h
+++ b/storage/src/vespa/storage/distributor/crypto_uuid_generator.h
@@ -1,0 +1,18 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "uuid_generator.h"
+
+namespace storage::distributor {
+
+/**
+ * Generates a 128-bit unique identifier (represented as a hex string) from
+ * a cryptographically strong source of pseudo-randomness.
+ */
+class CryptoUuidGenerator : public UuidGenerator {
+public:
+    ~CryptoUuidGenerator() override = default;
+    vespalib::string generate_uuid() const override;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.h
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.h
@@ -25,6 +25,7 @@ class DirectDispatchSender;
 class SequencingHandle;
 class OperationSequencer;
 class OperationOwner;
+class UuidGenerator;
 
 class ExternalOperationHandler : public api::MessageHandler
 {
@@ -100,6 +101,7 @@ private:
     OperationOwner& _distributor_operation_owner;
     mutable std::mutex _non_main_thread_ops_mutex;
     OperationOwner _non_main_thread_ops_owner;
+    std::unique_ptr<UuidGenerator> _uuid_generator;
     std::atomic<bool> _concurrent_gets_enabled;
     std::atomic<bool> _use_weak_internal_read_consistency_for_gets;
 

--- a/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h
@@ -10,6 +10,7 @@ namespace storage::distributor {
 class PendingMessageTracker;
 class VisitorOperation;
 class OperationOwner;
+class UuidGenerator;
 
 /**
  * Operation starting indirection for a visitor operation that has the semantics
@@ -31,11 +32,13 @@ class ReadForWriteVisitorOperationStarter
     OperationSequencer&               _operation_sequencer;
     OperationOwner&                   _stable_operation_owner;
     PendingMessageTracker&            _message_tracker;
+    UuidGenerator&                    _uuid_generator;
 public:
     ReadForWriteVisitorOperationStarter(std::shared_ptr<VisitorOperation> visitor_op,
                                         OperationSequencer& operation_sequencer,
                                         OperationOwner& stable_operation_owner,
-                                        PendingMessageTracker& message_tracker);
+                                        PendingMessageTracker& message_tracker,
+                                        UuidGenerator& uuid_generator);
     ~ReadForWriteVisitorOperationStarter() override;
 
     const char* getName() const override { return "ReadForWriteVisitorOperationStarter"; }

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "visitoroperation.h"
+#include <vespa/storage/common/reindexing_constants.h>
 #include <vespa/storage/storageserver/storagemetricsset.h>
 #include <vespa/storage/distributor/distributor.h>
 #include <vespa/storage/distributor/distributor_bucket_space.h>
@@ -823,6 +824,10 @@ VisitorOperation::sendStorageVisitor(uint16_t node,
 
     cmd->setTimeout(timeLeft());
 
+    if (!_put_lock_token.empty()) {
+        cmd->getParameters().set(reindexing_bucket_lock_visitor_parameter_key(), _put_lock_token);
+    }
+
     LOG(spam, "Priority is %d", cmd->getPriority());
     LOG(debug, "Sending CreateVisitor command %" PRIu64 " for storage visitor '%s' to %s",
         cmd->getMsgId(),
@@ -907,6 +912,12 @@ void
 VisitorOperation::assign_bucket_lock_handle(SequencingHandle handle)
 {
     _bucket_lock = std::move(handle);
+}
+
+void
+VisitorOperation::assign_put_lock_access_token(const vespalib::string& token)
+{
+    _put_lock_token = token;
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
@@ -62,6 +62,7 @@ public:
     [[nodiscard]] bool is_read_for_write() const noexcept { return _is_read_for_write; }
     [[nodiscard]] std::optional<document::Bucket> first_bucket_to_visit() const;
     void assign_bucket_lock_handle(SequencingHandle handle);
+    void assign_put_lock_access_token(const vespalib::string& token);
 
 private:
     struct BucketInfo {
@@ -179,6 +180,7 @@ private:
     mbus::TraceNode trace;
     framework::MilliSecTimer _operationTimer;
     SequencingHandle _bucket_lock;
+    vespalib::string _put_lock_token;
     bool _sentReply;
     bool _verified_and_expanded;
     bool _is_read_for_write;

--- a/storage/src/vespa/storage/distributor/uuid_generator.h
+++ b/storage/src/vespa/storage/distributor/uuid_generator.h
@@ -1,0 +1,19 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+
+namespace storage::distributor {
+
+/**
+ * Generator of universally unique identifiers (not actually conforming UUIDs, as these
+ * have MSB semantics) that are expected to be effectively collision free.
+ */
+class UuidGenerator {
+public:
+    virtual ~UuidGenerator() = default;
+    // Returns a string that is guaranteed ASCII-only
+    virtual vespalib::string generate_uuid() const = 0;
+};
+
+}

--- a/storage/src/vespa/storage/visiting/reindexing_visitor.h
+++ b/storage/src/vespa/storage/visiting/reindexing_visitor.h
@@ -21,6 +21,7 @@ public:
 
 private:
     void handleDocuments(const document::BucketId&, std::vector<spi::DocEntry::UP>&, HitCounter&) override;
+    vespalib::string make_lock_access_token() const;
 };
 
 struct ReindexingVisitorFactory : public VisitorFactory {

--- a/storage/src/vespa/storage/visiting/visitor.cpp
+++ b/storage/src/vespa/storage/visiting/visitor.cpp
@@ -552,7 +552,7 @@ Visitor::start(api::VisitorId id, api::StorageMessage::Id cmdId,
 }
 
 void
-Visitor::attach(std::shared_ptr<api::StorageCommand> initiatingCmd,
+Visitor::attach(std::shared_ptr<api::CreateVisitorCommand> initiatingCmd,
                 const mbus::Route& controlAddress,
                 const mbus::Route& dataAddress,
                 framework::MilliSecTime timeout)
@@ -599,6 +599,12 @@ Visitor::addBoundedTrace(uint32_t level, const vespalib::string &message) {
     mbus::Trace tempTrace;
     tempTrace.trace(level, message);
     return _trace.add(std::move(tempTrace));
+}
+
+const vdslib::Parameters&
+Visitor::visitor_parameters() const noexcept {
+    assert(_initiatingCmd);
+    return _initiatingCmd->getParameters();
 }
 
 void

--- a/storage/src/vespa/storage/visiting/visitor.h
+++ b/storage/src/vespa/storage/visiting/visitor.h
@@ -307,7 +307,7 @@ private:
     // Used by visitor client to identify what visitor messages belong to
     api::StorageMessage::Id _visitorCmdId;
     api::VisitorId _visitorId;
-    std::shared_ptr<api::StorageCommand> _initiatingCmd;
+    std::shared_ptr<api::CreateVisitorCommand> _initiatingCmd;
     api::StorageMessage::Priority _priority;
 
     api::ReturnCode _result;
@@ -348,6 +348,8 @@ protected:
      * Returns true iff message was added to internal trace tree.
      */
     bool addBoundedTrace(uint32_t level, const vespalib::string& message);
+
+    const vdslib::Parameters& visitor_parameters() const noexcept;
 public:
     Visitor(StorageComponent& component);
     virtual ~Visitor();
@@ -468,7 +470,7 @@ public:
                VisitorMessageSession::UP,
                documentapi::Priority::Value);
 
-    void attach(std::shared_ptr<api::StorageCommand> initiatingCmd,
+    void attach(std::shared_ptr<api::CreateVisitorCommand> initiatingCmd,
                 const mbus::Route& controlAddress,
                 const mbus::Route& dataAddress,
                 framework::MilliSecTime timeout);

--- a/vespalib/src/vespa/vespalib/crypto/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/crypto/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(vespalib_vespalib_crypto OBJECT
     crypto_exception.cpp
     openssl_crypto_impl.cpp
     private_key.cpp
+    random.cpp
     x509_certificate.cpp
     DEPENDS
 )

--- a/vespalib/src/vespa/vespalib/crypto/random.cpp
+++ b/vespalib/src/vespa/vespalib/crypto/random.cpp
@@ -1,0 +1,13 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "random.h"
+#include <openssl/rand.h>
+
+namespace vespalib::crypto {
+
+void random_buffer(unsigned char* buf, size_t len) noexcept {
+    if (::RAND_bytes(buf, len) != 1) {
+        abort();
+    }
+}
+
+}

--- a/vespalib/src/vespa/vespalib/crypto/random.h
+++ b/vespalib/src/vespa/vespalib/crypto/random.h
@@ -1,0 +1,11 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+#include <cstddef>
+
+namespace vespalib::crypto {
+
+// Fills `buf` with `len` bytes of cryptographically secure pseudo-random data.
+// Aborts the process if CSPRNG somehow fails.
+void random_buffer(unsigned char* buf, size_t len) noexcept;
+
+}


### PR DESCRIPTION
@geirst please review
@jonmv FYI

Avoids race condition edge case where reindexing puts from an outdated
visitor may pass through a bucket lock intended for a newly created
visitor operation

Tokens are 128-bit values derived from a CSPRNG, so uniqueness is for
all intents and purposes guaranteed.