### PR TITLE
Adjust total timeout according to joining servers

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -61,7 +61,8 @@ public class ZooKeeperRunner implements Runnable {
             try {
                 log.log(Level.INFO, "Starting ZooKeeper server with config file " + path.toFile().getAbsolutePath() +
                                     ". Trying to establish ZooKeeper quorum (members: " + zookeeperServerHostnames(zookeeperServerConfig) + ")");
-                startServer(path);
+                startServer(path); // Will block in a real implementation of VespaZooKeeperServer
+                return;
             } catch (RuntimeException e) {
                 log.log(Level.INFO, "Starting ZooKeeper server failed, will retry");
                 try {

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -71,18 +71,22 @@ public class ReconfigurerTest {
 
     @Test
     public void testReconfigureFailsWithReconfigInProgressThenSucceeds() {
-        reconfigurer = new TestableReconfigurer(new TemporarilyFailVespaZooKeeperAdmin());
-        ZookeeperServerConfig initialConfig = createConfig(3, true);
-        reconfigurer.startOrReconfigure(initialConfig);
-        assertSame(initialConfig, reconfigurer.activeConfig());
+        try {
+            TestableReconfigurer reconfigurer = new TestableReconfigurer(new TestableVespaZooKeeperAdmin().failures(3));
+            ZookeeperServerConfig initialConfig = createConfig(3, true);
+            reconfigurer.startOrReconfigure(initialConfig);
+            assertSame(initialConfig, reconfigurer.activeConfig());
 
-        ZookeeperServerConfig nextConfig = createConfig(5, true);
-        reconfigurer.startOrReconfigure(nextConfig);
-        assertEquals("node1:2181", reconfigurer.connectionSpec());
-        assertEquals("3=node3:2182:2183;2181,4=node4:2182:2183;2181", reconfigurer.joiningServers());
-        assertNull("No servers are leaving", reconfigurer.leavingServers());
-        assertEquals(1, reconfigurer.reconfigurations());
-        assertSame(nextConfig, reconfigurer.activeConfig());
+            ZookeeperServerConfig nextConfig = createConfig(5, true);
+            reconfigurer.startOrReconfigure(nextConfig);
+            assertEquals("node1:2181", reconfigurer.connectionSpec());
+            assertEquals("3=node3:2182:2183;2181,4=node4:2182:2183;2181", reconfigurer.joiningServers());
+            assertNull("No servers are leaving", reconfigurer.leavingServers());
+            assertEquals(1, reconfigurer.reconfigurations());
+            assertSame(nextConfig, reconfigurer.activeConfig());
+        } finally {
+            reconfigurer.shutdown();
+        }
     }
 
     @Test
@@ -119,13 +123,13 @@ public class ReconfigurerTest {
         return builder;
     }
 
-    private static class TestableReconfigurer extends Reconfigurer implements VespaZooKeeperServer{
+    private static class TestableReconfigurer extends Reconfigurer implements VespaZooKeeperServer {
 
-        private final TestableVespaZooKeeperAdmin zkReconfigurer;
+        private final TestableVespaZooKeeperAdmin zooKeeperAdmin;
 
-        TestableReconfigurer(TestableVespaZooKeeperAdmin zkReconfigurer) {
-            super(zkReconfigurer);
-            this.zkReconfigurer = zkReconfigurer;
+        TestableReconfigurer(TestableVespaZooKeeperAdmin zooKeeperAdmin) {
+            super(zooKeeperAdmin, (ignored) -> {});
+            this.zooKeeperAdmin = zooKeeperAdmin;
             HostName.setHostNameForTestingOnly("node1");
         }
 
@@ -133,25 +137,20 @@ public class ReconfigurerTest {
             startOrReconfigure(newConfig, this);
         }
 
-        @Override
-        void startOrReconfigure(ZookeeperServerConfig newConfig, VespaZooKeeperServer server) {
-            super.startOrReconfigure(newConfig, l -> {}, this);
-        }
-
         String connectionSpec() {
-            return zkReconfigurer.connectionSpec;
+            return zooKeeperAdmin.connectionSpec;
         }
 
         String joiningServers() {
-            return zkReconfigurer.joiningServers;
+            return zooKeeperAdmin.joiningServers;
         }
 
         String leavingServers() {
-            return zkReconfigurer.leavingServers;
+            return zooKeeperAdmin.leavingServers;
         }
 
         int reconfigurations() {
-            return zkReconfigurer.reconfigurations;
+            return zooKeeperAdmin.reconfigurations;
         }
 
         @Override
@@ -166,26 +165,22 @@ public class ReconfigurerTest {
         String leavingServers;
         int reconfigurations = 0;
 
+        private int failures = 0;
+        private int attempts = 0;
+
+        public TestableVespaZooKeeperAdmin failures(int failures) {
+            this.failures = failures;
+            return this;
+        }
+
         @Override
         public void reconfigure(String connectionSpec, String joiningServers, String leavingServers) throws ReconfigException {
+            if (++attempts < failures)
+                throw new ReconfigException("Reconfig failed");
             this.connectionSpec = connectionSpec;
             this.joiningServers = joiningServers;
             this.leavingServers = leavingServers;
             this.reconfigurations++;
-        }
-
-    }
-
-    // Fails 3 times with KeeperException.ReconfigInProgress(), then succeeds
-    private static class TemporarilyFailVespaZooKeeperAdmin extends TestableVespaZooKeeperAdmin {
-
-        private int attempts = 0;
-
-        public void reconfigure(String connectionSpec, String joiningServers, String leavingServers) throws ReconfigException {
-            if (++attempts < 3)
-                throw new ReconfigException("Reconfig failed");
-            else
-                super.reconfigure(connectionSpec, joiningServers, leavingServers);
         }
 
     }


### PR DESCRIPTION
For reconfig to succeed, the current ensemble must have a majority. When an
ensemble grows and the joining servers outnumber the existing ones, we have to
wait for enough of them to start to have a majority.

The fixed timeout works for the current cases (1->3 and 3->7) where joining
servers can outnumber the existing ones. Observed that this took 2m30s when
moving from 3 to 7 nodes though, so increasing the timeout a bit just in case.

@hmusum