### PR TITLE
Gjoranv/wait for deconstruct upon shutdown

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -335,7 +335,7 @@ public final class ConfiguredApplication implements Application {
         return new HandlersConfigurerDi(subscriberFactory,
                                         Container.get(),
                                         configId,
-                                        new Deconstructor(true),
+                                        new Deconstructor(Deconstructor.Mode.RECONFIG),
                                         discInjector,
                                         osgiFramework);
     }
@@ -367,7 +367,7 @@ public final class ConfiguredApplication implements Application {
         }
 
         log.info("Stop: Shutting container down");
-        configurer.shutdown(new Deconstructor(false));
+        configurer.shutdown(new Deconstructor(Deconstructor.Mode.SHUTDOWN));
         slobrokConfigSubscriber.ifPresent(SlobrokConfigSubscriber::shutdown);
         Container.get().shutdown();
 

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -46,8 +46,7 @@ public class Deconstructor implements ComponentDeconstructor {
                    // are deconstructed, to prevent shutting down while deconstruct is in progress.
     }
 
-    // TODO: make private again
-    final ScheduledExecutorService executor =
+    private final ScheduledExecutorService executor =
             Executors.newScheduledThreadPool(2, ThreadFactoryFactory.getThreadFactory("component-deconstructor"));
 
     private final Mode mode;

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -39,6 +39,7 @@ public class Deconstructor implements ComponentDeconstructor {
 
     private static final Logger log = Logger.getLogger(Deconstructor.class.getName());
 
+    private static final Duration RECONFIG_DECONSTRUCT_DELAY = Duration.ofSeconds(60);
     private static final Duration SHUTDOWN_DECONSTRUCT_TIMEOUT = Duration.ofMinutes(10);
 
     public enum Mode {
@@ -55,7 +56,7 @@ public class Deconstructor implements ComponentDeconstructor {
     private final Duration delay;
 
     public Deconstructor(Mode mode) {
-        this(mode, (mode == Mode.RECONFIG) ? Duration.ofSeconds(60) : Duration.ZERO);
+        this(mode, (mode == Mode.RECONFIG) ? RECONFIG_DECONSTRUCT_DELAY : Duration.ZERO);
     }
 
     // For testing only

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -38,7 +38,9 @@ public class Deconstructor implements ComponentDeconstructor {
     private static final Logger log = Logger.getLogger(Deconstructor.class.getName());
 
     private static final Duration RECONFIG_DECONSTRUCT_DELAY = Duration.ofSeconds(60);
-    private static final Duration SHUTDOWN_DECONSTRUCT_TIMEOUT = Duration.ofMinutes(10);
+
+    // This must be smaller than the shutdownDeadlineExecutor delay in ConfiguredApplication
+    private static final Duration SHUTDOWN_DECONSTRUCT_TIMEOUT = Duration.ofSeconds(45);
 
     public enum Mode {
         RECONFIG,  // Delay deconstruction to allow old components to finish processing in-flight requests.

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -7,24 +7,21 @@ import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.di.ComponentDeconstructor;
 import com.yahoo.container.di.componentgraph.Provider;
 import com.yahoo.jdisc.SharedResource;
-
-import java.util.List;
-
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeoutException;
-import java.util.logging.Level;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static java.util.logging.Level.FINE;

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.time.Duration;
+import java.time.Instant;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
@@ -24,7 +26,7 @@ public class DeconstructorTest {
 
     @Before
     public void init() {
-        deconstructor = new Deconstructor(Deconstructor.Mode.SHUTDOWN);
+        deconstructor = new Deconstructor(Deconstructor.Mode.RECONFIG, Duration.ZERO);
     }
 
     @Test
@@ -49,6 +51,7 @@ public class DeconstructorTest {
 
     @Test
     public void deconstruct_is_synchronous_in_shutdown_mode() {
+        deconstructor = new Deconstructor(Deconstructor.Mode.SHUTDOWN);
         var slowDeconstructComponent = new SlowDeconstructComponent();
         deconstructor.deconstruct(List.of(slowDeconstructComponent), emptyList());
         assertTrue(slowDeconstructComponent.destructed);

--- a/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
+++ b/container-disc/src/test/java/com/yahoo/container/jdisc/component/DeconstructorTest.java
@@ -9,10 +9,9 @@ import com.yahoo.jdisc.SharedResource;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.time.Duration;
-import java.time.Instant;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;


### PR DESCRIPTION
This is to prevent uninstalling bundles and ClassNotFound exceptions when the container is shutting down.

FYI: @bjorncs 