### PR TITLE
Make the feed concurrency computations understandable.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
@@ -363,9 +363,7 @@ public class Tuning extends AbstractConfigProducer<Tuning> implements ProtonConf
             @Override
             public void getConfig(ProtonConfig.Builder builder) {
                 if (concurrency != null) {
-                    // We divide by 2 as this number is used for 2 different thread pools.
-                    // Not perfect, but the best way to split the resources evenly.
-                    builder.feeding.concurrency(concurrency/2);
+                    builder.feeding.concurrency(concurrency);
                 }
             }
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilderTest.java
@@ -280,7 +280,7 @@ public class DomSearchTuningBuilderTest extends DomBuilderTest {
                 "<concurrency>0.7</concurrency>",
                 "</feeding>"));
         assertEquals(0.7, t.searchNode.feeding.concurrency, DELTA);
-        assertEquals(getProtonCfg(t).feeding().concurrency(), 0.35, DELTA);
+        assertEquals(getProtonCfg(t).feeding().concurrency(), 0.7, DELTA);
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/search/test/DocumentDatabaseTestCase.java
@@ -142,14 +142,14 @@ public class DocumentDatabaseTestCase {
         String feedTuning = "<feeding>" +
                 "  <concurrency>0.7</concurrency>" +
                 "</feeding>\n";
-        verifyConcurrency(Arrays.asList(DocType.create("a", "index"), DocType.create("b", "streaming")), feedTuning, 0.7, Arrays.asList(0.35, 0.0));
+        verifyConcurrency(Arrays.asList(DocType.create("a", "index"), DocType.create("b", "streaming")), feedTuning, 0.7, Arrays.asList(0.7, 0.0));
     }
     @Test
     public void requireThatConcurrencyIsReflected() {
         String feedTuning = "<feeding>" +
                             "  <concurrency>0.7</concurrency>" +
                             "</feeding>\n";
-        verifyConcurrency("index", feedTuning, 0.35, 0.35);
+        verifyConcurrency("index", feedTuning, 0.7, 0.7);
         verifyConcurrency("streaming", feedTuning, 0.7, 0.0);
         verifyConcurrency("store-only", feedTuning, 0.7, 0.0);
     }


### PR DESCRIPTION
- Default is 0.5, unless you have at least one streaming cluster. Then it is 1.0.
- If you specify it directly, what you see is what you get. No magic division by 2 in some cases.

@geirst PR