### PR TITLE
Always force shutdown of non-reconfigurable ZooKeeper server

### DIFF
--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
@@ -31,4 +31,9 @@ public class ReconfigurableVespaZooKeeperServer extends AbstractComponent implem
         peer.start(configFilePath);
     }
 
+    @Override
+    public boolean reconfigurable() {
+        return true;
+    }
+
 }

--- a/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
+++ b/zookeeper-server/zookeeper-server-3.5.6/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
@@ -38,4 +38,9 @@ public class VespaZooKeeperServerImpl extends AbstractComponent implements Vespa
         peer.start(configFilePath);
     }
 
+    @Override
+    public boolean reconfigurable() {
+        return false;
+    }
+
 }

--- a/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/ReconfigurableVespaZooKeeperServer.java
@@ -31,4 +31,9 @@ public class ReconfigurableVespaZooKeeperServer extends AbstractComponent implem
         peer.start(configFilePath);
     }
 
+    @Override
+    public boolean reconfigurable() {
+        return true;
+    }
+
 }

--- a/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
+++ b/zookeeper-server/zookeeper-server-3.6.2/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServerImpl.java
@@ -38,4 +38,9 @@ public class VespaZooKeeperServerImpl extends AbstractComponent implements Vespa
         peer.start(configFilePath);
     }
 
+    @Override
+    public boolean reconfigurable() {
+        return false;
+    }
+
 }

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/DummyVespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/DummyVespaZooKeeperServer.java
@@ -21,4 +21,9 @@ public class DummyVespaZooKeeperServer extends AbstractComponent implements Vesp
     @Override
     public void start(Path configFilePath) {}
 
+    @Override
+    public boolean reconfigurable() {
+        return false;
+    }
+
 }

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServer.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperServer.java
@@ -6,12 +6,17 @@ import java.nio.file.Path;
 /**
  * Interface for a component that starts/stops a ZooKeeper server.
  *
- * @author Harald Musum
+ * @author hmusum
  */
 public interface VespaZooKeeperServer {
 
+    /** Shut down the server. Blocks until shutdown has completed */
     void shutdown();
 
+    /** Start the server with the given config file */
     void start(Path configFilePath);
+
+    /** Whether this server support dynamic reconfiguration */
+    boolean reconfigurable();
 
 }

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ReconfigurerTest.java
@@ -165,6 +165,11 @@ public class ReconfigurerTest {
         @Override
         public void start(Path configFilePath) { }
 
+        @Override
+        public boolean reconfigurable() {
+            return true;
+        }
+
     }
 
     private static class TestableVespaZooKeeperAdmin implements VespaZooKeeperAdmin {


### PR DESCRIPTION
This basically reverts to the original behaviour, where the container is forced
to exit when a new VespaZooKeeperServer component is setup.

@hmusum