### PR TITLE
tensor-type fields are not matchable, skip in setup

### DIFF
--- a/searchlib/src/vespa/searchlib/features/matchfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/matchfeature.cpp
@@ -67,6 +67,10 @@ MatchBlueprint::setup(const IIndexEnvironment & env,
 {
     for (uint32_t i = 0; i < env.getNumFields(); ++i) {
         const FieldInfo * info = env.getField(i);
+        if (info->get_data_type() == FieldInfo::DataType::TENSOR) {
+            // not matchable
+            continue;
+        }
         if ((info->type() == FieldType::INDEX) || (info->type() == FieldType::ATTRIBUTE)) {
             _params.weights.push_back(indexproperties::FieldWeight::lookup(env.getProperties(), info->name()));
             if (info->type() == FieldType::INDEX) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
