### PR TITLE
Use an injected VespaDocumentAccess for streaming search

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
@@ -24,6 +24,8 @@ import com.yahoo.documentapi.messagebus.protocol.DocumentProtocolPoliciesConfig;
 import com.yahoo.vespa.config.content.DistributionConfig;
 import com.yahoo.vespa.config.content.LoadTypeConfig;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Wraps a lazily initialised MessageBusDocumentAccess. Lazy to allow it to always be set up.
  * Inject this class directly (instead of DocumentAccess) for use in internal code.
@@ -33,9 +35,8 @@ import com.yahoo.vespa.config.content.LoadTypeConfig;
 public class VespaDocumentAccess extends DocumentAccess {
 
     private final MessageBusParams parameters;
-    private final Object monitor = new Object();
 
-    private DocumentAccess delegate = null;
+    private final AtomicReference<MessageBusDocumentAccess> delegate = new AtomicReference<>();
     private boolean shutDown = false;
 
     VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig,
@@ -52,26 +53,29 @@ public class VespaDocumentAccess extends DocumentAccess {
         this.parameters.getMessageBusParams().setMessageBusConfig(messagebusConfig);
     }
 
-    private DocumentAccess delegate() {
-        synchronized (monitor) {
-            if (delegate == null) {
-                if (shutDown)
-                    throw new IllegalStateException("This document access has been shut down");
+    public MessageBusDocumentAccess delegate() {
+        MessageBusDocumentAccess access = delegate.getAcquire();
+        return access != null ? access : delegate.updateAndGet(value -> {
+            if (value != null)
+                return value;
 
-                delegate = new MessageBusDocumentAccess(parameters);
-            }
-            return delegate;
-        }
+            if (shutDown)
+                throw new IllegalStateException("This document access has been shut down");
+
+            return new MessageBusDocumentAccess(parameters);
+        });
     }
 
     @Override
     public void shutdown() {
-        synchronized (monitor) {
+        delegate.updateAndGet(access -> {
             super.shutdown();
             shutDown = true;
-            if (delegate != null)
-                delegate.shutdown();
-        }
+            if (access != null)
+                access.shutdown();
+
+            return null;
+        });
     }
 
     @Override

--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
@@ -27,7 +27,7 @@ import com.yahoo.vespa.config.content.LoadTypeConfig;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Wraps a lazily initialised MessageBusDocumentAccess. Lazy to allow it to always be set up.
+ * Wraps a lazily initialised {@link DocumentAccess}. Lazy to allow it to always be set up.
  * Inject this class directly (instead of DocumentAccess) for use in internal code.
  *
  * @author jonmv
@@ -36,7 +36,7 @@ public class VespaDocumentAccess extends DocumentAccess {
 
     private final MessageBusParams parameters;
 
-    private final AtomicReference<MessageBusDocumentAccess> delegate = new AtomicReference<>();
+    private final AtomicReference<DocumentAccess> delegate = new AtomicReference<>();
     private boolean shutDown = false;
 
     VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig,
@@ -53,8 +53,8 @@ public class VespaDocumentAccess extends DocumentAccess {
         this.parameters.getMessageBusParams().setMessageBusConfig(messagebusConfig);
     }
 
-    public MessageBusDocumentAccess delegate() {
-        MessageBusDocumentAccess access = delegate.getAcquire();
+    public DocumentAccess delegate() {
+        DocumentAccess access = delegate.getAcquire();
         return access != null ? access : delegate.updateAndGet(value -> {
             if (value != null)
                 return value;

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -1,11 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.cluster;
 
+import com.google.inject.Inject;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.QrConfig;
 import com.yahoo.container.QrSearchersConfig;
+import com.yahoo.container.core.documentapi.VespaDocumentAccess;
 import com.yahoo.container.handler.VipStatus;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.fastsearch.ClusterParams;
@@ -61,13 +63,14 @@ public class ClusterSearcher extends Searcher {
 
     private VespaBackEndSearcher server = null;
 
+    @Inject
     public ClusterSearcher(ComponentId id,
                            QrSearchersConfig qrsConfig,
                            ClusterConfig clusterConfig,
                            DocumentdbInfoConfig documentDbConfig,
                            ComponentRegistry<Dispatcher> dispatchers,
                            QrConfig qrConfig,
-                           VipStatus vipStatus) {
+                           VespaDocumentAccess access) {
         super(id);
 
         int searchClusterIndex = clusterConfig.clusterId();
@@ -93,7 +96,7 @@ public class ClusterSearcher extends Searcher {
 
         if (searchClusterConfig.indexingmode() == STREAMING) {
             VdsStreamingSearcher searcher = vdsCluster(qrConfig.discriminator(), searchClusterIndex,
-                                                       searchClusterConfig, docSumParams, documentDbConfig);
+                                                       searchClusterConfig, docSumParams, documentDbConfig, access);
             addBackendSearcher(searcher);
             vipStatus.addToRotation(searcher.getName());
         } else {
@@ -139,13 +142,14 @@ public class ClusterSearcher extends Searcher {
                                                    int searchclusterIndex,
                                                    QrSearchersConfig.Searchcluster searchClusterConfig,
                                                    SummaryParameters docSumParams,
-                                                   DocumentdbInfoConfig documentdbInfoConfig) {
+                                                   DocumentdbInfoConfig documentdbInfoConfig,
+                                                   VespaDocumentAccess access) {
         if (searchClusterConfig.searchdef().size() != 1) {
             throw new IllegalArgumentException("Search clusters in streaming search shall only contain a single searchdefinition : " + searchClusterConfig.searchdef());
         }
         ClusterParams clusterParams = makeClusterParams(searchclusterIndex);
-        VdsStreamingSearcher searcher = new VdsStreamingSearcher();
-        searcher.setSearchClusterConfigId(searchClusterConfig.rankprofiles().configid());
+        VdsStreamingSearcher searcher = new VdsStreamingSearcher(access);
+        searcher.setSearchClusterName(searchClusterConfig.rankprofiles().configid());
         searcher.setDocumentType(searchClusterConfig.searchdef(0));
         searcher.setStorageClusterRouteSpec(searchClusterConfig.storagecluster().routespec());
         searcher.init(serverId, docSumParams, clusterParams, documentdbInfoConfig);

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -9,6 +9,7 @@ import com.yahoo.container.QrConfig;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.core.documentapi.VespaDocumentAccess;
 import com.yahoo.container.handler.VipStatus;
+import com.yahoo.documentapi.DocumentAccess;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.fastsearch.ClusterParams;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
@@ -70,6 +71,7 @@ public class ClusterSearcher extends Searcher {
                            DocumentdbInfoConfig documentDbConfig,
                            ComponentRegistry<Dispatcher> dispatchers,
                            QrConfig qrConfig,
+                           VipStatus vipStatus,
                            VespaDocumentAccess access) {
         super(id);
 

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -1,9 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.streamingvisitors;
 
+import com.yahoo.container.core.documentapi.VespaDocumentAccess;
 import com.yahoo.document.DocumentId;
 import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.document.select.parser.TokenMgrException;
+import com.yahoo.documentapi.VisitorParameters;
+import com.yahoo.documentapi.VisitorSession;
+import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.fs4.DocsumPacket;
 import com.yahoo.messagebus.routing.Route;
 import com.yahoo.prelude.Ping;
@@ -53,15 +57,15 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
 
     private Route route;
     /** The configId used to access the searchcluster. */
-    private String searchClusterConfigId = null;
+    private String searchClusterName = null;
     private String documentType;
     /** The route to the storage cluster. */
     private String storageClusterRouteSpec = null;
 
-    private String getSearchClusterConfigId() { return searchClusterConfigId; }
+    private String getSearchClusterName() { return searchClusterName; }
     private String getStorageClusterRouteSpec() { return storageClusterRouteSpec; }
-    public final void setSearchClusterConfigId(String clusterName) {
-        this.searchClusterConfigId = clusterName;
+    public final void setSearchClusterName(String clusterName) {
+        this.searchClusterName = clusterName;
     }
     public final void setDocumentType(String documentType) {
         this.documentType = documentType;
@@ -71,16 +75,35 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
         this.storageClusterRouteSpec = storageClusterRouteSpec;
     }
 
-    private static class VdsVisitorFactory implements VisitorFactory {
+    private static class VespaVisitorFactory implements VdsVisitor.VisitorSessionFactory, VisitorFactory {
+
+        private final VespaDocumentAccess access;
+
+        private VespaVisitorFactory(VespaDocumentAccess access) {
+            this.access = access;
+        }
+
+        @Override
+        public VisitorSession createVisitorSession(VisitorParameters params) throws ParseException {
+            return access.createVisitorSession(params);
+        }
+
+        @Override
+        public LoadTypeSet getLoadTypeSet() {
+            return access.delegate().getParams().getLoadTypes();
+        }
+
         @Override
         public Visitor createVisitor(Query query, String searchCluster, Route route, String documentType, int traceLevelOverride) {
-            return new VdsVisitor(query, searchCluster, route, documentType, traceLevelOverride);
+            return new VdsVisitor(query, searchCluster, route, documentType, this, traceLevelOverride);
         }
+
     }
 
-    public VdsStreamingSearcher() {
-        this(new VdsVisitorFactory());
+    public VdsStreamingSearcher(VespaDocumentAccess access) {
+        this(new VespaVisitorFactory(access));
     }
+
     VdsStreamingSearcher(VisitorFactory visitorFactory) {
         this.visitorFactory = visitorFactory;
         tracingOptions = TracingOptions.DEFAULT;
@@ -146,11 +169,11 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
                     "only one of these query parameters to be set: streaming.userid, streaming.groupname, " +
                     "streaming.selection"));
         }
-        query.trace("Routing to search cluster " + getSearchClusterConfigId() + " and document type " + documentType, 4);
+        query.trace("Routing to search cluster " + getSearchClusterName() + " and document type " + documentType, 4);
         long timeStartedNanos = tracingOptions.getClock().nanoTimeNow();
         int effectiveTraceLevel = inferEffectiveQueryTraceLevel(query);
 
-        Visitor visitor = visitorFactory.createVisitor(query, getSearchClusterConfigId(), route, documentType, effectiveTraceLevel);
+        Visitor visitor = visitorFactory.createVisitor(query, getSearchClusterName(), route, documentType, effectiveTraceLevel);
         try {
             visitor.doSearch();
         } catch (ParseException e) {

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -7,6 +7,7 @@ import com.yahoo.document.select.parser.ParseException;
 import com.yahoo.document.select.parser.TokenMgrException;
 import com.yahoo.documentapi.VisitorParameters;
 import com.yahoo.documentapi.VisitorSession;
+import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.fs4.DocsumPacket;
 import com.yahoo.messagebus.routing.Route;
@@ -90,7 +91,7 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
 
         @Override
         public LoadTypeSet getLoadTypeSet() {
-            return access.delegate().getParams().getLoadTypes();
+            return ((MessageBusDocumentAccess) access.delegate()).getParams().getLoadTypes();
         }
 
         @Override

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
@@ -530,7 +530,7 @@ public class ClusterSearcherTestCase {
                                    documentDbConfig.build(),
                                    dispatchers,
                                    new QrConfig.Builder().build(),
-                                   vipStatus);
+                                   null);
     }
 
     private static ClusterInfoConfig createClusterInfoConfig() {

--- a/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/cluster/ClusterSearcherTestCase.java
@@ -530,6 +530,7 @@ public class ClusterSearcherTestCase {
                                    documentDbConfig.build(),
                                    dispatchers,
                                    new QrConfig.Builder().build(),
+                                   vipStatus,
                                    null);
     }
 

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
@@ -4,17 +4,16 @@ package com.yahoo.feedapi;
 import com.yahoo.concurrent.SystemTimer;
 import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.container.jdisc.HttpRequest;
-import com.yahoo.vespa.config.content.LoadTypeConfig;
-import com.yahoo.documentapi.VisitorParameters;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadType;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.documentapi.messagebus.protocol.DocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
-import java.util.logging.Level;
 import com.yahoo.messagebus.Message;
 import com.yahoo.messagebus.routing.Route;
+import com.yahoo.vespa.config.content.LoadTypeConfig;
 import com.yahoo.vespaclient.config.FeederConfig;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -247,22 +246,6 @@ public class MessagePropertyProcessor implements ConfigSubscriber.SingleSubscrib
             }
         }
 
-        public void process(VisitorParameters params) {
-            if (route != null) {
-                params.setRoute(route);
-            }
-            params.setTimeoutMs(timeout);
-
-            params.setTraceLevel(Math.max(getFeederOptions().getTraceLevel(), traceLevel));
-
-            if (loadType != null) {
-                params.setLoadType(loadType);
-                params.setPriority(loadType.getPriority());
-            }
-
-            if (priority != null) {
-                params.setPriority(priority);
-            }
-        }
     }
+
 }


### PR DESCRIPTION
@baldersheim please review. This ensures document access shutdown, and avoids the need for getting config on the first query, when new searchers are constructed. Wee may want to hold merge until the messagebus config consistency issue in the container has been solvedd.