### PR TITLE
Stop forcing inlining of result member function.

### DIFF
--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -174,7 +174,7 @@ public:
             _seen.push_back(value);
         }
     };
-    constexpr T result() const {
+    T result() const {
         if (_seen.empty()) {
             return std::numeric_limits<T>::quiet_NaN();
         }


### PR DESCRIPTION
@baldersheim : please review
