### PR TITLE
Always set 'is-master' metric. Remove 'master-change'

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -1002,7 +1002,6 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         boolean didWork = false;
         if (masterElectionHandler.isMaster()) {
             if ( ! isMaster) {
-                metricUpdater.becameMaster();
                 // If we just became master, restore state from ZooKeeper
                 stateChangeHandler.setStateChangedFlag();
                 systemStateBroadcaster.resetBroadcastedClusterStateBundle();
@@ -1032,12 +1031,12 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
             if (isMaster) {
                 eventLog.add(new ClusterEvent(ClusterEvent.Type.MASTER_ELECTION, "This node is no longer fleetcontroller master.", timer.getCurrentTimeInMillis()));
                 firstAllowedStateBroadcast = Long.MAX_VALUE;
-                metricUpdater.noLongerMaster();
                 failAllVersionDependentTasks();
             }
             wantedStateChanged = false;
             isMaster = false;
         }
+        metricUpdater.isMaster(isMaster);
         return didWork;
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -1036,7 +1036,7 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
             wantedStateChanged = false;
             isMaster = false;
         }
-        metricUpdater.isMaster(isMaster);
+        metricUpdater.updateMasterState(isMaster);
         return didWork;
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -75,14 +75,8 @@ public class MetricUpdater {
         metricReporter.set("agreed-master-votes", maxCount);
     }
 
-    public void becameMaster() {
-        metricReporter.set("is-master", 1);
-        metricReporter.add("master-change", 1);
-    }
-
-    public void noLongerMaster() {
-        metricReporter.set("is-master", 0);
-        metricReporter.add("master-change", 1);
+    public void isMaster(boolean isMaster) {
+        metricReporter.set("is-master", isMaster ? 1 : 0);
     }
 
     public void addTickTime(long millis, boolean didWork) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -75,7 +75,7 @@ public class MetricUpdater {
         metricReporter.set("agreed-master-votes", maxCount);
     }
 
-    public void isMaster(boolean isMaster) {
+    public void updateMasterState(boolean isMaster) {
         metricReporter.set("is-master", isMaster ? 1 : 0);
     }
 


### PR DESCRIPTION
Only setting `is-master` on leadership change might hide bad states.

`master-change` is unexposed/unused 