### PR TITLE
Don't swallow exception

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/InitializedCounter.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/InitializedCounter.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.zookeeper;
 
 import java.util.logging.Level;
@@ -41,13 +41,7 @@ public class InitializedCounter {
      * @return true, if an application exists, false otherwise
      */
     private static boolean applicationExists(ConfigCurator configCurator, String appsPath) {
-        // TODO Need to try and catch now since interface should not expose Zookeeper exceptions
-        try {
-            return configCurator.exists(appsPath);
-        } catch (Exception e) {
-            log.log(Level.WARNING, e.getMessage());
-            return false;
-        }
+        return configCurator.exists(appsPath);
     }
 
     /**


### PR DESCRIPTION
This might lead to session counter being initialized to 1 instead of the correct value (see `InitializedCounter` constructor)