### PR TITLE
Only fetch document IDs in bucket when splitting, not whole documents

### DIFF
--- a/storage/src/vespa/storage/persistence/bucketprocessor.cpp
+++ b/storage/src/vespa/storage/persistence/bucketprocessor.cpp
@@ -40,15 +40,15 @@ void
 BucketProcessor::iterateAll(spi::PersistenceProvider& provider,
                             const spi::Bucket& bucket,
                             const std::string& documentSelection,
+                            std::shared_ptr<document::FieldSet> field_set,
                             EntryProcessor& processor,
                             spi::IncludedVersions versions,
                             spi::Context& context)
 {
-    spi::Selection sel
-        = spi::Selection(spi::DocumentSelection(documentSelection));
+    spi::Selection sel = spi::Selection(spi::DocumentSelection(documentSelection));
     spi::CreateIteratorResult createIterResult(provider.createIterator(
             bucket,
-            std::make_shared<document::AllFields>(),
+            std::move(field_set),
             sel,
             versions,
             context));

--- a/storage/src/vespa/storage/persistence/bucketprocessor.h
+++ b/storage/src/vespa/storage/persistence/bucketprocessor.h
@@ -22,6 +22,7 @@ public:
     static void iterateAll(spi::PersistenceProvider&,
                            const spi::Bucket&,
                            const std::string& documentSelection,
+                           std::shared_ptr<document::FieldSet> field_set,
                            EntryProcessor&,
                            spi::IncludedVersions,
                            spi::Context&);

--- a/storage/src/vespa/storage/persistence/processallhandler.cpp
+++ b/storage/src/vespa/storage/persistence/processallhandler.cpp
@@ -3,6 +3,7 @@
 #include "processallhandler.h"
 #include "bucketprocessor.h"
 #include "persistenceutil.h"
+#include <vespa/document/fieldset/fieldsets.h>
 #include <vespa/persistence/spi/persistenceprovider.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
@@ -85,6 +86,7 @@ ProcessAllHandler::handleRemoveLocation(api::RemoveLocationCommand& cmd, Message
     spi::Bucket bucket(cmd.getBucket());
     UnrevertableRemoveEntryProcessor processor(_spi, bucket, tracker->context());
     BucketProcessor::iterateAll(_spi, bucket, cmd.getDocumentSelection(),
+                                std::make_shared<document::AllFields>(),
                                 processor, spi::NEWEST_DOCUMENT_ONLY,tracker->context());
 
     tracker->setReply(std::make_shared<api::RemoveLocationReply>(cmd, processor._n_removed));
@@ -102,6 +104,7 @@ ProcessAllHandler::handleStatBucket(api::StatBucketCommand& cmd, MessageTracker:
     spi::Bucket bucket(cmd.getBucket());
     StatEntryProcessor processor(ost);
     BucketProcessor::iterateAll(_spi, bucket, cmd.getDocumentSelection(),
+                                std::make_shared<document::AllFields>(),
                                 processor, spi::ALL_VERSIONS,tracker->context());
 
     tracker->setReply(std::make_shared<api::StatBucketReply>(cmd, ost.str()));


### PR DESCRIPTION
@baldersheim please review

Splitting code only needs to look at the document IDs to figure out
the distribution of the target buckets. Remove tracking of document
sizes (which _did_ need the whole documents) since it was only used
in a warning log message.
