### PR TITLE
Allow updates with only remove/clear updates and operations to single…

### DIFF
--- a/document/src/tests/fieldpathupdatetestcase.cpp
+++ b/document/src/tests/fieldpathupdatetestcase.cpp
@@ -1045,7 +1045,7 @@ DocumentUpdate::UP
 FieldPathUpdateTestCase::createDocumentUpdateForSerialization(const DocumentTypeRepo& repo)
 {
     const DocumentType *docType(repo.getDocumentType("serializetest"));
-    DocumentUpdate::UP docUp(new DocumentUpdate(repo, *docType, DocumentId("id:ns:serializetest::xlanguage")));
+    auto docUp = std::make_unique<DocumentUpdate>(repo, *docType, DocumentId("id:ns:serializetest::xlanguage")));
 
     FieldPathUpdate::CP assign(new AssignFieldPathUpdate("intfield", "", "3"));
     static_cast<AssignFieldPathUpdate&>(*assign).setRemoveIfZero(true);

--- a/document/src/tests/fieldpathupdatetestcase.cpp
+++ b/document/src/tests/fieldpathupdatetestcase.cpp
@@ -1045,7 +1045,7 @@ DocumentUpdate::UP
 FieldPathUpdateTestCase::createDocumentUpdateForSerialization(const DocumentTypeRepo& repo)
 {
     const DocumentType *docType(repo.getDocumentType("serializetest"));
-    auto docUp = std::make_unique<DocumentUpdate>(repo, *docType, DocumentId("id:ns:serializetest::xlanguage")));
+    auto docUp = std::make_unique<DocumentUpdate>(repo, *docType, DocumentId("id:ns:serializetest::xlanguage"));
 
     FieldPathUpdate::CP assign(new AssignFieldPathUpdate("intfield", "", "3"));
     static_cast<AssignFieldPathUpdate&>(*assign).setRemoveIfZero(true);

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -46,6 +46,7 @@ vespa_add_library(searchcore_server STATIC
     feedhandler.cpp
     feedstate.cpp
     feedstates.cpp
+    feed_reject_helper.cpp
     fileconfigmanager.cpp
     flushhandlerproxy.cpp
     forcecommitcontext.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.cpp
@@ -1,0 +1,75 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "feed_reject_helper.h"
+#include <vespa/searchcore/proton/feedoperation/operations.h>
+#include <vespa/document/update/documentupdate.h>
+#include <vespa/document/update/assignvalueupdate.h>
+#include <vespa/document/fieldvalue/boolfieldvalue.h>
+#include <vespa/document/fieldvalue/numericfieldvalue.h>
+
+using namespace document;
+
+namespace proton {
+
+bool
+FeedRejectHelper::isFixedSizeSingleValue(const document::FieldValue & fv) {
+    return fv.inherits(BoolFieldValue::classId) || fv.inherits(NumericFieldValueBase::classId);
+}
+
+bool
+FeedRejectHelper::mustReject(const document::ValueUpdate & valueUpdate) {
+    using namespace document;
+    switch (valueUpdate.getType()) {
+        case ValueUpdate::Add:
+        case ValueUpdate::TensorAddUpdate:
+        case ValueUpdate::TensorModifyUpdate:
+        case ValueUpdate::Map:
+            return true;
+        case ValueUpdate::Assign: {
+            const auto & assign = dynamic_cast<const AssignValueUpdate &>(valueUpdate);
+            if (assign.hasValue()) {
+                if ( ! isFixedSizeSingleValue(assign.getValue())) {
+                    return true;
+                }
+            }
+        }
+        default:
+            break;
+    }
+    return false;
+}
+
+bool
+FeedRejectHelper::mustReject(const DocumentUpdate & documentUpdate) {
+    for (const auto & update : documentUpdate.getUpdates()) {
+        for (const auto & valueUpdate : update.getUpdates()) {
+            if (mustReject(*valueUpdate)) {
+                return true;
+            }
+        }
+    }
+    return ! documentUpdate.getFieldPathUpdates().empty();
+}
+
+bool
+FeedRejectHelper::mustReject(const UpdateOperation & updateOperation) {
+    using namespace document;
+    if (updateOperation.getUpdate()) {
+        return mustReject(*updateOperation.getUpdate());
+    }
+    return false;
+}
+
+bool
+FeedRejectHelper::isRejectableFeedOperation(const FeedOperation & op)
+{
+    FeedOperation::Type type = op.getType();
+    if (type == FeedOperation::PUT) {
+        return true;
+    } else if (type == FeedOperation::UPDATE_42 || type == FeedOperation::UPDATE) {
+        return mustReject(dynamic_cast<const UpdateOperation &>(op));
+    }
+    return false;
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.h
@@ -13,6 +13,10 @@ namespace proton {
 class FeedOperation;
 class UpdateOperation;
 
+/**
+ * Tells wether an operation should be blocked when resourcelimits have been reached.
+ * It looks at the operation type and also the content if it is an 'update' operation.
+ */
 class FeedRejectHelper {
 public:
     static bool isRejectableFeedOperation(const FeedOperation & op);

--- a/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.h
+++ b/searchcore/src/vespa/searchcore/proton/server/feed_reject_helper.h
@@ -1,0 +1,26 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace document {
+    class FieldValue;
+    class DocumentUpdate;
+    class ValueUpdate;
+}
+
+namespace proton {
+
+class FeedOperation;
+class UpdateOperation;
+
+class FeedRejectHelper {
+public:
+    static bool isRejectableFeedOperation(const FeedOperation & op);
+    // Public only for testing
+    static bool isFixedSizeSingleValue(const document::FieldValue & fv);
+    static bool mustReject(const document::ValueUpdate & valueUpdate);
+    static bool mustReject(const document::DocumentUpdate & documentUpdate);
+    static bool mustReject(const UpdateOperation & updateOperation);
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/feedhandler.cpp
@@ -6,6 +6,7 @@
 #include "i_feed_handler_owner.h"
 #include "ifeedview.h"
 #include "configstore.h"
+#include "feed_reject_helper.h"
 #include <vespa/document/base/exceptions.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/repo/documenttyperepo.h>
@@ -583,14 +584,9 @@ FeedHandler::tlsPrune(SerialNum oldest_to_keep) {
 
 namespace {
 
-bool
-isRejectableFeedOperation(FeedOperation::Type type)
-{
-    return type == FeedOperation::PUT || type == FeedOperation::UPDATE_42 || type == FeedOperation::UPDATE;
-}
-
 template <typename ResultType>
-void feedOperationRejected(FeedToken & token, const vespalib::string &opType, const vespalib::string &docId,
+void
+feedOperationRejected(FeedToken & token, const vespalib::string &opType, const vespalib::string &docId,
                            const DocTypeName & docTypeName, const vespalib::string &rejectMessage)
 {
     if (token) {
@@ -621,7 +617,7 @@ notifyFeedOperationRejected(FeedToken & token, const FeedOperation &op,
 bool
 FeedHandler::considerWriteOperationForRejection(FeedToken & token, const FeedOperation &op)
 {
-    if (!_writeFilter.acceptWriteOperation() && isRejectableFeedOperation(op.getType())) {
+    if (!_writeFilter.acceptWriteOperation() && FeedRejectHelper::isRejectableFeedOperation(op)) {
         IResourceWriteFilter::State state = _writeFilter.getAcceptState();
         if (!state.acceptWriteOperation()) {
             notifyFeedOperationRejected(token, op, _docTypeName, state.message());

--- a/searchlib/src/vespa/searchlib/index/docbuilder.cpp
+++ b/searchlib/src/vespa/searchlib/index/docbuilder.cpp
@@ -618,7 +618,7 @@ DocBuilder::DocumentHandle::DocumentHandle(document::Document &doc,
 DocBuilder::DocBuilder(const Schema &schema)
     : _schema(schema),
       _doctypes_config(DocTypeBuilder(schema).makeConfig()),
-      _repo(new DocumentTypeRepo(_doctypes_config)),
+      _repo(std::make_shared<DocumentTypeRepo>(_doctypes_config)),
       _docType(*_repo->getDocumentType("searchdocument")),
       _doc(),
       _handleDoc(),
@@ -626,14 +626,14 @@ DocBuilder::DocBuilder(const Schema &schema)
 {
 }
 
-DocBuilder::~DocBuilder() {}
+DocBuilder::~DocBuilder() = default;
 
 DocBuilder &
 DocBuilder::startDocument(const vespalib::string & docId)
 {
-    _doc.reset(new Document(_docType, DocumentId(docId)));
+    _doc = std::make_unique<Document>(_docType, DocumentId(docId));
     _doc->setRepo(*_repo);
-    _handleDoc.reset(new DocumentHandle(*_doc, docId));
+    _handleDoc = std::make_shared<DocumentHandle>(*_doc, docId);
     return *this;
 }
 


### PR DESCRIPTION
… value numeric fields to pass

even when feed rejection is in effect.
The rationale is that these updates will not affect memory or disk footprint negatively,
but it can have a significant positive effect.
Note that this will only be allowed for buckets that are in sync.

@geirst and @toregge and @vekterli PR