### PR TITLE
Cap default max buckets per streaming search visitor

### DIFF
--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -64,6 +64,8 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
     private static final CompoundName streamingPriority=new CompoundName("streaming.priority");
     private static final CompoundName streamingMaxbucketspervisitor=new CompoundName("streaming.maxbucketspervisitor");
 
+    protected static final int MAX_BUCKETS_PER_VISITOR = 1024;
+
     private static final Logger log = Logger.getLogger(VdsVisitor.class.getName());
     private final VisitorParameters params = new VisitorParameters("");
     private List<SearchResult.Hit> hits = new ArrayList<>();
@@ -199,7 +201,7 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         }
 
         params.setMaxPending(Integer.MAX_VALUE);
-        params.setMaxBucketsPerVisitor(Integer.MAX_VALUE);
+        params.setMaxBucketsPerVisitor(MAX_BUCKETS_PER_VISITOR);
         params.setTraceLevel(inferSessionTraceLevel(query));
 
 

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
@@ -247,7 +247,7 @@ public class VdsVisitorTestCase {
         if (qa.maxBucketsPerVisitor != 0) {
             assertEquals(qa.maxBucketsPerVisitor, params.getMaxBucketsPerVisitor());
         } else {
-            assertEquals(Integer.MAX_VALUE, params.getMaxBucketsPerVisitor());
+            assertEquals(VdsVisitor.MAX_BUCKETS_PER_VISITOR, params.getMaxBucketsPerVisitor());
         }
         assertEquals(false, params.getDynamicallyIncreaseMaxBucketsPerVisitor());
 


### PR DESCRIPTION
@baldersheim please review

Avoids memory blow-up when visiting locations with a massive number of buckets.