### PR TITLE
Increase number of bucket info failures before a warning is printed

### DIFF
--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -157,7 +157,7 @@ public:
 private:
     // With 100ms resend timeout, this requires a particular node to have failed
     // for _at least_ threshold/10 seconds before a log warning is emitted.
-    constexpr static size_t RequestFailureWarningEdgeTriggerThreshold = 20;
+    constexpr static size_t RequestFailureWarningEdgeTriggerThreshold = 200;
 
     /**
      * Creates a pending cluster state that represents


### PR DESCRIPTION
Was >=2 seconds, now >=20 seconds. 2 seconds may cause spurious log
warnings on heavily loaded nodes that lag behind the distributor for
some seconds before being able to switch over to a new cluster state
version.
