### PR TITLE
Extract Plan as an interface

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/CostCalculator.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/CostCalculator.java
@@ -1,0 +1,19 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.billing;
+
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.vespa.hosted.controller.api.integration.resource.CostInfo;
+import com.yahoo.vespa.hosted.controller.api.integration.resource.ResourceUsage;
+
+/**
+ * @author ogronnesby
+ */
+public interface CostCalculator {
+
+    /** Calculate the cost for the given usage */
+    CostInfo calculate(ResourceUsage usage);
+
+    /** Estimate the cost for the given resources */
+    double calculate(NodeResources resources);
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/Plan.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/Plan.java
@@ -1,0 +1,24 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.billing;
+
+/**
+ * A Plan knows about the billing calculations and the default quota for any tenant associated with the Plan.
+ * The Plan can also enforce transitions from one plan to another.
+ *
+ * @author ogronnesby
+ */
+public interface Plan {
+
+    /** Unique ID for the plan */
+    PlanId id();
+
+    /** A string to be used for display purposes */
+    String displayName();
+
+    /** The cost calculator for this plan */
+    CostCalculator calculator();
+
+    /** The quota for this plan */
+    QuotaCalculator quota();
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/QuotaCalculator.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/QuotaCalculator.java
@@ -1,0 +1,11 @@
+package com.yahoo.vespa.hosted.controller.api.integration.billing;
+
+/**
+ * Calculates the quota.  This is used in the context of a {@link Plan}.
+ *
+ * @author ogronnesby
+ */
+public interface QuotaCalculator {
+    /** Calculate the quota for a given environment */
+    Quota calculate();
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceUsage.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceUsage.java
@@ -1,0 +1,52 @@
+package com.yahoo.vespa.hosted.controller.api.integration.resource;
+
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.api.integration.billing.Plan;
+
+import java.math.BigDecimal;
+
+public class ResourceUsage {
+
+    private final ApplicationId applicationId;
+    private final ZoneId zoneId;
+    private final Plan plan;
+    private final BigDecimal cpuMillis;
+    private final BigDecimal memoryMillis;
+    private final BigDecimal diskMillis;
+
+    public ResourceUsage(ApplicationId applicationId, ZoneId zoneId, Plan plan,
+                         BigDecimal cpuMillis, BigDecimal memoryMillis, BigDecimal diskMillis) {
+        this.applicationId = applicationId;
+        this.zoneId = zoneId;
+        this.cpuMillis = cpuMillis;
+        this.memoryMillis = memoryMillis;
+        this.diskMillis = diskMillis;
+        this.plan = plan;
+    }
+
+    public ApplicationId getApplicationId() {
+        return applicationId;
+    }
+
+    public ZoneId getZoneId() {
+        return zoneId;
+    }
+
+    public BigDecimal getCpuMillis() {
+        return cpuMillis;
+    }
+
+    public BigDecimal getMemoryMillis() {
+        return memoryMillis;
+    }
+
+    public BigDecimal getDiskMillis() {
+        return diskMillis;
+    }
+
+    public Plan getPlan() {
+        return plan;
+    }
+
+}


### PR DESCRIPTION
We need to talk about plans, quotas, and cost in more places in the code base.  To prepare for this
I have extracted Plan as an interface and mad the old enum implement this.  Some other interfaces used
by plan have been moved as well.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
