### PR TITLE
Acquire locks for children when patching

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
@@ -21,7 +21,11 @@ public class NodeMutex implements Mutex {
     @Override public void close() { mutex.close(); }
 
     /** Returns a node mutex with the same mutex as this, but the given node.  Be sure to close only one. */
-    public NodeMutex with(Node newNode) {
-        return new NodeMutex(newNode, mutex);
+    public NodeMutex with(Node updatedNode) {
+        if (!node.equals(updatedNode)) {
+            throw new IllegalArgumentException("Updated node not equal to current");
+        }
+
+        return new NodeMutex(updatedNode, mutex);
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
@@ -19,4 +19,9 @@ public class NodeMutex implements Mutex {
 
     public Node node() { return node; }
     @Override public void close() { mutex.close(); }
+
+    /** Returns a node mutex with the same mutex as this, but the given node.  Be sure to close only one. */
+    public NodeMutex with(Node newNode) {
+        return new NodeMutex(newNode, mutex);
+    }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeMutex.java
@@ -1,0 +1,22 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision;
+
+import com.yahoo.transaction.Mutex;
+
+/**
+ * Holds a node and mutex pair, with the mutex closed by {@link #close()}.
+ *
+ * @author hakon
+ */
+public class NodeMutex implements Mutex {
+    private final Node node;
+    private final Mutex mutex;
+
+    public NodeMutex(Node node, Mutex mutex) {
+        this.node = node;
+        this.mutex = mutex;
+    }
+
+    public Node node() { return node; }
+    @Override public void close() { mutex.close(); }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -193,7 +193,7 @@ class MaintenanceDeployment implements Closeable {
 
         /** Returns true only if this operation changes the state of the wantToRetire flag */
         private boolean markWantToRetire(Node node, boolean wantToRetire, Agent agent, NodeRepository nodeRepository) {
-            Optional<NodeMutex> nodeMutex = nodeRepository.lockNode(node);
+            Optional<NodeMutex> nodeMutex = nodeRepository.lockAndGet(node);
             if (nodeMutex.isEmpty()) return false;
 
             try (var nodeLock = nodeMutex.get()) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringUpgrader.java
@@ -62,7 +62,7 @@ public class RetiringUpgrader implements Upgrader {
     /** Retire and deprovision given host and its children */
     private void retire(Node host, Version target, Instant now, NodeList allNodes) {
         if (!host.type().isHost()) throw new IllegalArgumentException("Cannot retire non-host " + host);
-        Optional<NodeMutex> nodeMutex = nodeRepository.lockNode(host);
+        Optional<NodeMutex> nodeMutex = nodeRepository.lockAndGet(host);
         if (nodeMutex.isEmpty()) return;
         try (var lock = nodeMutex.get()) {
             host = lock.node();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -131,7 +131,7 @@ class Activator {
             if (parentNode.get().reservedTo().isEmpty()) continue;
 
             // Above is an optimization to avoid unnecessary locking - now repeat all conditions under lock
-            Optional<NodeMutex> parent = nodeRepository.lockNode(node.parentHostname().get());
+            Optional<NodeMutex> parent = nodeRepository.lockAndGet(node.parentHostname().get());
             if (parent.isEmpty()) continue;
             try (var lock = parent.get()) {
                 if (lock.node().reservedTo().isEmpty()) continue;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -8,9 +8,9 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.ParentHostUnavailableException;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.applications.Application;
 import com.yahoo.vespa.hosted.provision.applications.ScalingEvent;
@@ -126,13 +126,16 @@ class Activator {
     private void unreserveParentsOf(List<Node> nodes) {
         for (Node node : nodes) {
             if ( node.parentHostname().isEmpty()) continue;
-            Optional<Node> parent = nodeRepository.getNode(node.parentHostname().get());
+            Optional<Node> parentNode = nodeRepository.getNode(node.parentHostname().get());
+            if (parentNode.isEmpty()) continue;
+            if (parentNode.get().reservedTo().isEmpty()) continue;
+
+            // Above is an optimization to avoid unnecessary locking - now repeat all conditions under lock
+            Optional<NodeMutex> parent = nodeRepository.lockNode(node.parentHostname().get());
             if (parent.isEmpty()) continue;
-            if (parent.get().reservedTo().isEmpty()) continue;
-            try (Mutex lock = nodeRepository.lock(parent.get())) {
-                Optional<Node> lockedParent = nodeRepository.getNode(parent.get().hostname());
-                if (lockedParent.isEmpty()) continue;
-                nodeRepository.write(lockedParent.get().withoutReservedTo(), lock);
+            try (var lock = parent.get()) {
+                if (lock.node().reservedTo().isEmpty()) continue;
+                nodeRepository.write(lock.node().withoutReservedTo(), lock);
             }
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -332,7 +332,7 @@ public class NodePatcher implements AutoCloseable {
         }
 
         public List<Node> nodes() {
-            return List.copyOf(nodes.values().stream().map(NodeMutex::node).collect(Collectors.toList()));
+            return nodes.values().stream().map(NodeMutex::node).collect(Collectors.toList());
         }
 
         @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -86,8 +86,9 @@ public class NodePatcher {
             }
 
             if (RECURSIVE_FIELDS.contains(name)) {
-                for (Node child: patchedNodes.children())
+                for (Node child: patchedNodes.children()) {
                     patchedNodes.update(applyField(child, name, value, inspector, true));
+                }
             }
         } );
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -13,8 +13,11 @@ import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.slime.Type;
+import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.LockedNodeList;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Address;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
@@ -34,7 +37,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.provision.NodeResources.DiskSpeed.fast;
@@ -48,27 +50,35 @@ import static com.yahoo.config.provision.NodeResources.StorageType.remote;
  *
  * @author bratseth
  */
-public class NodePatcher {
+public class NodePatcher implements AutoCloseable {
 
     private static final String WANT_TO_RETIRE = "wantToRetire";
     private static final String WANT_TO_DEPROVISION = "wantToDeprovision";
     private static final Set<String> RECURSIVE_FIELDS = Set.of(WANT_TO_RETIRE);
 
+    private final NodeRepository nodeRepository;
     private final com.google.common.base.Supplier<LockedNodeList> memoizedNodes;
     private final PatchedNodes patchedNodes;
     private final NodeFlavors nodeFlavors;
     private final Inspector inspector;
     private final Clock clock;
 
-    public NodePatcher(NodeFlavors nodeFlavors, InputStream json, Node node, Supplier<LockedNodeList> nodes, Clock clock) {
-        this.memoizedNodes = Suppliers.memoize(nodes::get);
-        this.patchedNodes = new PatchedNodes(node);
+    public NodePatcher(NodeFlavors nodeFlavors, InputStream json, Node node, NodeRepository nodeRepository) {
+        this.nodeRepository = nodeRepository;
         this.nodeFlavors = nodeFlavors;
-        this.clock = clock;
+        this.clock = nodeRepository.clock();
         try {
             this.inspector = SlimeUtils.jsonToSlime(IOUtils.readBytes(json, 1000 * 1000)).get();
         } catch (IOException e) {
             throw new UncheckedIOException("Error reading request body", e);
+        }
+
+        this.patchedNodes = new PatchedNodes(nodeRepository.lockAndGetRequired(node));
+        try {
+            this.memoizedNodes = Suppliers.memoize(() -> nodeRepository.list(patchedNodes.nodeMutex()));
+        } catch (RuntimeException e) {
+            patchedNodes.close();
+            throw e;
         }
     }
 
@@ -81,18 +91,25 @@ public class NodePatcher {
         inspector.traverse((String name, Inspector value) -> {
             try {
                 patchedNodes.update(applyField(patchedNodes.node(), name, value, inspector, false));
+
+                if (RECURSIVE_FIELDS.contains(name)) {
+                    for (Node child: patchedNodes.children()) {
+                        patchedNodes.update(applyField(child, name, value, inspector, true));
+                    }
+                }
             } catch (IllegalArgumentException e) {
                 throw new IllegalArgumentException("Could not set field '" + name + "'", e);
             }
-
-            if (RECURSIVE_FIELDS.contains(name)) {
-                for (Node child: patchedNodes.children()) {
-                    patchedNodes.update(applyField(child, name, value, inspector, true));
-                }
-            }
-        } );
+        });
 
         return patchedNodes.nodes();
+    }
+
+    public NodeMutex nodeMutexOfHost() { return patchedNodes.nodeMutex(); }
+
+    @Override
+    public void close() {
+        patchedNodes.close();
     }
 
     private Node applyField(Node node, String name, Inspector value, Inspector root, boolean applyingAsChild) {
@@ -272,36 +289,55 @@ public class NodePatcher {
         return Optional.of(field).filter(Inspector::valid).map(this::asBoolean);
     }
 
-    private class PatchedNodes {
-        private final Map<String, Node> nodes = new HashMap<>();
+    private class PatchedNodes implements Mutex {
+        private final Map<String, NodeMutex> nodes = new HashMap<>();
         private final String hostname;
         private boolean fetchedChildren;
 
-        private PatchedNodes(Node node) {
-            this.hostname = node.hostname();
+        private PatchedNodes(NodeMutex nodeMutex) {
+            this.hostname = nodeMutex.node().hostname();
+            nodes.put(hostname, nodeMutex);
+            fetchedChildren = !nodeMutex.node().type().isHost();
+        }
 
-            nodes.put(hostname, node);
-            fetchedChildren = !node.type().isHost();
+        public NodeMutex nodeMutex() {
+            return nodes.get(hostname);
         }
 
         public Node node() {
-            return nodes.get(hostname);
+            return nodeMutex().node();
         }
 
         public List<Node> children() {
             if (!fetchedChildren) {
-                memoizedNodes.get().childrenOf(hostname).forEach(this::update);
+                memoizedNodes.get()
+                        .childrenOf(hostname)
+                        .forEach(node -> nodeRepository.lockAndGet(node)
+                                .ifPresent(nodeMutex -> nodes.put(nodeMutex.node().hostname(), nodeMutex)));
                 fetchedChildren = true;
             }
-            return nodes.values().stream().filter(node -> !node.type().isHost()).collect(Collectors.toList());
+            return nodes.values().stream()
+                    .map(NodeMutex::node)
+                    .filter(node -> !node.type().isHost())
+                    .collect(Collectors.toList());
         }
 
         public void update(Node node) {
-            nodes.put(node.hostname(), node);
+            NodeMutex currentNodeMutex = nodes.get(node.hostname());
+            if (currentNodeMutex == null) {
+                throw new IllegalStateException("unable to update non-existing child: " + node.hostname());
+            }
+
+            nodes.put(node.hostname(), currentNodeMutex.with(node));
         }
 
         public List<Node> nodes() {
-            return List.copyOf(nodes.values());
+            return List.copyOf(nodes.values().stream().map(NodeMutex::node).collect(Collectors.toList()));
+        }
+
+        @Override
+        public void close() {
+            nodes.values().forEach(NodeMutex::close);
         }
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -24,9 +24,9 @@ import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.NoSuchNodeException;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.applications.Application;
 import com.yahoo.vespa.hosted.provision.node.Address;
@@ -160,14 +160,13 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
     private HttpResponse handlePATCH(HttpRequest request) {
         String path = request.getUri().getPath();
         if (path.startsWith("/nodes/v2/node/")) {
-            // TODO: Node is fetched outside of lock, might change after getting lock
-            Node node = nodeFromRequest(request);
-            try (var lock = nodeRepository.lock(node)) {
-                var patchedNodes = new NodePatcher(nodeFlavors, request.getData(), node, () -> nodeRepository.list(lock),
-                                                   nodeRepository.clock()).apply();
+            try (NodeMutex lock = nodeRepository.lockRequiredNode(nodeFromRequest(request))) {
+                var patchedNodes = new NodePatcher(nodeFlavors, request.getData(), lock.node(), () -> nodeRepository.list(lock),
+                        nodeRepository.clock()).apply();
                 nodeRepository.write(patchedNodes, lock);
+
+                return new MessageResponse("Updated " + lock.node().hostname());
             }
-            return new MessageResponse("Updated " + node.hostname());
         }
         else if (path.startsWith("/nodes/v2/upgrade/")) {
             return setTargetVersions(request);
@@ -210,13 +209,11 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
     }
 
     private HttpResponse deleteNode(String hostname) {
-        Optional<Node> node = nodeRepository.getNode(hostname);
-        if (node.isEmpty()) throw new NotFoundException("No node with hostname '" + hostname + "'");
-        try (Mutex lock = nodeRepository.lock(node.get())) {
-            node = nodeRepository.getNode(hostname);
-            if (node.isEmpty()) throw new NotFoundException("No node with hostname '" + hostname + "'");
-            if (node.get().state() == Node.State.deprovisioned) {
-                nodeRepository.forget(node.get());
+        Optional<NodeMutex> nodeMutex = nodeRepository.lockNode(hostname);
+        if (nodeMutex.isEmpty()) throw new NotFoundException("No node with hostname '" + hostname + "'");
+        try (var lock = nodeMutex.get()) {
+            if (lock.node().state() == Node.State.deprovisioned) {
+                nodeRepository.forget(lock.node());
                 return new MessageResponse("Permanently removed " + hostname);
             } else {
                 List<Node> removedNodes = nodeRepository.removeRecursively(hostname);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
@@ -196,7 +196,7 @@ public class MockDeployer implements Deployer {
             lastDeployTimes.put(applicationId, clock.instant());
 
             for (Node node : nodeRepository.list().owner(applicationId).state(Node.State.active).wantToRetire().asList()) {
-                try (NodeMutex lock = nodeRepository.lockRequiredNode(node)) {
+                try (NodeMutex lock = nodeRepository.lockAndGetRequired(node)) {
                     nodeRepository.write(lock.node().retire(nodeRepository.clock().instant()), lock);
                 }
             }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockDeployer.java
@@ -11,9 +11,9 @@ import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.HostFilter;
 import com.yahoo.config.provision.HostSpec;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.provisioning.NodeRepositoryProvisioner;
 
@@ -196,8 +196,8 @@ public class MockDeployer implements Deployer {
             lastDeployTimes.put(applicationId, clock.instant());
 
             for (Node node : nodeRepository.list().owner(applicationId).state(Node.State.active).wantToRetire().asList()) {
-                try (Mutex lock = nodeRepository.lock(node)) {
-                    nodeRepository.write(node.retire(nodeRepository.clock().instant()), lock);
+                try (NodeMutex lock = nodeRepository.lockRequiredNode(node)) {
+                    nodeRepository.write(lock.node().retire(nodeRepository.clock().instant()), lock);
                 }
             }
             return redeployments++;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -182,7 +182,7 @@ public class NodeRepositoryTest {
         assertFalse(tester.nodeRepository().getNode("host1").get().history().hasEventAfter(History.Event.Type.deprovisioned, testStart));
 
         // Set host 1 properties and deprovision it
-        try (var lock = tester.nodeRepository().lockRequiredNode("host1")) {
+        try (var lock = tester.nodeRepository().lockAndGetRequired("host1")) {
             Node host1 = lock.node().withWantToRetire(true, true, Agent.system, tester.nodeRepository().clock().instant());
             host1 = host1.withFirmwareVerifiedAt(tester.clock().instant());
             host1 = host1.with(host1.status().withIncreasedFailCount());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InPlaceResizeProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InPlaceResizeProvisionTest.java
@@ -10,10 +10,10 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.OutOfCapacityException;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.Test;
 
@@ -206,8 +206,8 @@ public class InPlaceResizeProvisionTest {
 
         // ... same with setting a node to want to retire
         Node nodeToWantoToRetire = listCluster(content1).not().retired().asList().get(0);
-        try (Mutex lock = tester.nodeRepository().lock(nodeToWantoToRetire)) {
-            tester.nodeRepository().write(nodeToWantoToRetire.withWantToRetire(true, Agent.system,
+        try (NodeMutex lock = tester.nodeRepository().lockRequiredNode(nodeToWantoToRetire)) {
+            tester.nodeRepository().write(lock.node().withWantToRetire(true, Agent.system,
                     tester.clock().instant()), lock);
         }
         new PrepareHelper(tester, app).prepare(content1, 8, 1, halvedResources).activate();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InPlaceResizeProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/InPlaceResizeProvisionTest.java
@@ -206,7 +206,7 @@ public class InPlaceResizeProvisionTest {
 
         // ... same with setting a node to want to retire
         Node nodeToWantoToRetire = listCluster(content1).not().retired().asList().get(0);
-        try (NodeMutex lock = tester.nodeRepository().lockRequiredNode(nodeToWantoToRetire)) {
+        try (NodeMutex lock = tester.nodeRepository().lockAndGetRequired(nodeToWantoToRetire)) {
             tester.nodeRepository().write(lock.node().withWantToRetire(true, Agent.system,
                     tester.clock().instant()), lock);
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -152,7 +152,7 @@ public class ProvisioningTester {
     public List<Node> patchNodes(List<Node> nodes, UnaryOperator<Node> patcher) {
         List<Node> updated = new ArrayList<>();
         for (var node : nodes) {
-            try (var lock = nodeRepository.lockRequiredNode(node)) {
+            try (var lock = nodeRepository.lockAndGetRequired(node)) {
                 node = patcher.apply(lock.node());
                 nodeRepository.write(node, lock);
                 updated.add(node);
@@ -186,7 +186,7 @@ public class ProvisioningTester {
 
         // Add ip addresses and activate parent host if necessary
         for (HostSpec prepared : preparedNodes) {
-            try (var lock = nodeRepository.lockRequiredNode(prepared.hostname())) {
+            try (var lock = nodeRepository.lockAndGetRequired(prepared.hostname())) {
                 Node node = lock.node();
                 if (node.ipConfig().primary().isEmpty()) {
                     node = node.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of()));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -25,7 +25,6 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
 import com.yahoo.test.ManualClock;
-import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.mock.MockCurator;
@@ -153,9 +152,8 @@ public class ProvisioningTester {
     public List<Node> patchNodes(List<Node> nodes, UnaryOperator<Node> patcher) {
         List<Node> updated = new ArrayList<>();
         for (var node : nodes) {
-            try (var lock = nodeRepository.lock(node)) {
-                node = nodeRepository.getNode(node.hostname()).get();
-                node = patcher.apply(node);
+            try (var lock = nodeRepository.lockRequiredNode(node)) {
+                node = patcher.apply(lock.node());
                 nodeRepository.write(node, lock);
                 updated.add(node);
             }
@@ -188,21 +186,21 @@ public class ProvisioningTester {
 
         // Add ip addresses and activate parent host if necessary
         for (HostSpec prepared : preparedNodes) {
-            Node node = nodeRepository.getNode(prepared.hostname()).get();
-            if (node.ipConfig().primary().isEmpty()) {
-                node = node.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of()));
-                try (Mutex lock = nodeRepository.lock(node)) {
+            try (var lock = nodeRepository.lockRequiredNode(prepared.hostname())) {
+                Node node = lock.node();
+                if (node.ipConfig().primary().isEmpty()) {
+                    node = node.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of()));
                     nodeRepository.write(node, lock);
                 }
+                if (node.parentHostname().isEmpty()) continue;
+                Node parent = nodeRepository.getNode(node.parentHostname().get()).get();
+                if (parent.state() == Node.State.active) continue;
+                NestedTransaction t = new NestedTransaction();
+                if (parent.ipConfig().primary().isEmpty())
+                    parent = parent.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of("::" + 0 + ":2")));
+                nodeRepository.activate(List.of(parent), t);
+                t.commit();
             }
-            if (node.parentHostname().isEmpty()) continue;
-            Node parent = nodeRepository.getNode(node.parentHostname().get()).get();
-            if (parent.state() == Node.State.active) continue;
-            NestedTransaction t = new NestedTransaction();
-            if (parent.ipConfig().primary().isEmpty())
-                parent = parent.with(new IP.Config(Set.of("::" + 0 + ":0"), Set.of("::" + 0 + ":2")));
-            nodeRepository.activate(List.of(parent), t);
-            t.commit();
         }
 
         return activate(application, preparedNodes);


### PR DESCRIPTION
Defines a method NodeRepository::lockAndGet that implements the common and correct pattern:  having a Node, acquire the appropriate lock depending on the allocation owner, and then refetch the node under that lock.

And, acquire the lock for all children with recursive patch at /nodes/v2/node/.