### PR TITLE
Update billing privileges for public

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/Policy.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/Policy.java
@@ -145,32 +145,32 @@ enum Policy {
     /** Read your own instrument information */
     paymentInstrumentRead(Privilege.grant(Action.read)
                                    .on(PathGroup.billingInstrument)
-                                   .in(SystemName.PublicCd)),
+                                   .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Ability to update tenant payment instrument */
     paymentInstrumentUpdate(Privilege.grant(Action.update)
                                      .on(PathGroup.billingInstrument)
-                                     .in(SystemName.PublicCd)),
+                                     .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Ability to remove your own payment instrument */
     paymentInstrumentDelete(Privilege.grant(Action.delete)
                                      .on(PathGroup.billingInstrument)
-                                     .in(SystemName.PublicCd)),
+                                     .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Get the token to view instrument form */
     paymentInstrumentCreate(Privilege.grant(Action.read)
                                     .on(PathGroup.billingToken)
-                                    .in(SystemName.PublicCd)),
+                                    .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Ability to update tenant payment instrument */
     planUpdate(Privilege.grant(Action.update)
             .on(PathGroup.billingPlan)
-            .in(SystemName.PublicCd)),
+            .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Ability to update tenant collection method */
     collectionMethodUpdate(Privilege.grant(Action.update)
             .on(PathGroup.billingCollection)
-            .in(SystemName.PublicCd)),
+            .in(SystemName.PublicCd, SystemName.Public)),
 
 
     /** Read the generated bills */
@@ -181,7 +181,7 @@ enum Policy {
     /** Invoice management */
     hostedAccountant(Privilege.grant(Action.all())
                                     .on(PathGroup.hostedAccountant)
-                                    .in(SystemName.PublicCd)),
+                                    .in(SystemName.PublicCd, SystemName.Public)),
 
     /** Listing endpoint certificate request info */
     endpointCertificateRequestInfo(Privilege.grant(Action.read)

--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/role/RoleTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/role/RoleTest.java
@@ -190,7 +190,7 @@ public class RoleTest {
 
     @Test
     public void billing_test() {
-        var tester = new EnforcerTester(publicCdEnforcer);
+        var tester = new EnforcerTester(publicEnforcer);
 
         var accountant = Role.hostedAccountant();
         var operator = Role.hostedOperator();
@@ -201,7 +201,7 @@ public class RoleTest {
 
         tester.on("/billing/v1/tenant/t1/token")
                 .assertAction(accountant)
-                .assertAction(operator, Action.read)
+                .assertAction(operator)
                 .assertAction(reader)
                 .assertAction(developer)
                 .assertAction(admin,    Action.read)


### PR DESCRIPTION
Many of the policies were explicitly set for PublicCd only.  Update them to be for Public and make the test assertions for Public.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
