### PR TITLE
Replace the use of std::list with std::vector. This avoids a lof of n…

### DIFF
--- a/vdslib/src/vespa/vdslib/distribution/distribution.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/distribution.cpp
@@ -70,6 +70,7 @@ Distribution::Distribution(const Distribution& d)
 Distribution::ConfigWrapper::ConfigWrapper(std::unique_ptr<DistributionConfig> cfg) :
     _cfg(std::move(cfg))
 { }
+
 Distribution::ConfigWrapper::~ConfigWrapper() = default;
 
 Distribution::Distribution(const ConfigWrapper & config) :
@@ -227,7 +228,7 @@ namespace {
         ScoredGroup(const Group* group, double score) noexcept
             : _group(group), _score(score) {}
 
-        bool operator<(const ScoredGroup& other) const {
+        bool operator<(const ScoredGroup& other) const noexcept {
             return (_score > other._score);
         }
     };
@@ -238,22 +239,11 @@ namespace {
         uint16_t _reliability;
         double _score;
 
-        ScoredNode(uint16_t index, uint16_t reliability, double score)
+        ScoredNode(uint16_t index, uint16_t reliability, double score) noexcept
             : _index(index), _reliability(reliability), _score(score) {}
 
-        bool operator<(const ScoredNode& other) const {
+        bool operator<(const ScoredNode& other) const noexcept {
             return (_score < other._score);
-        }
-    };
-
-    struct IndexSorter {
-        const std::vector<ScoredGroup>& _groups;
-
-        IndexSorter(const std::vector<ScoredGroup>& groups) : _groups(groups) {}
-
-        bool operator()(uint16_t a, uint16_t b) {
-            return (_groups[a]._group->getIndex()
-                        < _groups[b]._group->getIndex());
         }
     };
 
@@ -262,13 +252,11 @@ namespace {
      * decrease redundancy below total reliability. If redundancy !=
      * total reliability, see if non-last entries can be removed.
      */
-    void trimResult(std::list<ScoredNode>& nodes, uint16_t redundancy) {
+    void trimResult(std::vector<ScoredNode>& nodes, uint16_t redundancy) {
             // Initially record total reliability and use the first elements
             // until satisfied.
         uint32_t totalReliability = 0;
-        for (std::list<ScoredNode>::iterator it = nodes.begin();
-             it != nodes.end(); ++it)
-        {
+        for (auto it = nodes.begin(); it != nodes.end(); ++it) {
             if (totalReliability >= redundancy || it->_reliability == 0) {
                 nodes.erase(it, nodes.end());
                 break;
@@ -278,12 +266,10 @@ namespace {
             // If we have too high reliability, see if we can remove something
             // else
         if (totalReliability > redundancy) {
-            for (std::list<ScoredNode>::reverse_iterator it = nodes.rbegin();
-                    it != nodes.rend();)
-            {
+            for (auto it = nodes.rbegin(); it != nodes.rend();) {
                 if (it->_reliability <= (totalReliability - redundancy)) {
                     totalReliability -= it->_reliability;
-                    std::list<ScoredNode>::iterator deleteIt(it.base());
+                    auto deleteIt(it.base());
                     ++it;
                     nodes.erase(--deleteIt);
                     if (totalReliability == redundancy) break;
@@ -443,7 +429,7 @@ Distribution::getIdealNodes(const NodeType& nodeType,
         // Create temporary place to hold results. Use double linked list
         // for cheap access to back(). Stuff in redundancy fake entries to
         // avoid needing to check size during iteration.
-        std::list<ScoredNode> tmpResults(groupRedundancy, ScoredNode(0, 0, 0));
+        std::vector<ScoredNode> tmpResults(groupRedundancy, ScoredNode(0, 0, 0));
         for (uint32_t j=0, m=nodes.size(); j<m; ++j) {
             // Verify that the node is legal target before starting to grab
             // random number. Helps worst case of having to start new random
@@ -469,15 +455,17 @@ Distribution::getIdealNodes(const NodeType& nodeType,
                 score = std::pow(score, 1.0 / nodeState.getCapacity().getValue());
             }
             if (score > tmpResults.back()._score) {
-                for (std::list<ScoredNode>::iterator it = tmpResults.begin();
-                     it != tmpResults.end(); ++it)
-                {
+                tmpResults.pop_back();
+                auto it = tmpResults.begin();
+                for (; it != tmpResults.end(); ++it) {
                     if (score > it->_score) {
                         tmpResults.insert(it, ScoredNode(nodes[j], nodeState.getReliability(), score));
                         break;
                     }
                 }
-                tmpResults.pop_back();
+                if (it == tmpResults.end()) {
+                    tmpResults.emplace_back(nodes[j], nodeState.getReliability(), score);
+                }
             }
         }
         trimResult(tmpResults, groupRedundancy);
@@ -491,7 +479,7 @@ Distribution::getIdealNodes(const NodeType& nodeType,
 Distribution::ConfigWrapper
 Distribution::getDefaultDistributionConfig(uint16_t redundancy, uint16_t nodeCount)
 {
-    std::unique_ptr<vespa::config::content::StorDistributionConfigBuilder> config(new vespa::config::content::StorDistributionConfigBuilder());
+    auto config = std::make_unique<vespa::config::content::StorDistributionConfigBuilder>();
     config->redundancy = redundancy;
     config->group.resize(1);
     config->group[0].index = "invalid";

--- a/vdslib/src/vespa/vdslib/distribution/idealnodecalculator.h
+++ b/vdslib/src/vespa/vdslib/distribution/idealnodecalculator.h
@@ -11,8 +11,7 @@
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/nodetype.h>
 
-namespace storage {
-namespace lib {
+namespace storage::lib {
 
 /**
  * A list of ideal nodes, sorted in preferred order. Wraps a vector to hide
@@ -59,7 +58,7 @@ public:
         UP_STATE_COUNT
     };
 
-    virtual ~IdealNodeCalculator() {}
+    virtual ~IdealNodeCalculator() = default;
 
     virtual IdealNodeList getIdealNodes(const NodeType&,
                                         const document::BucketId&,
@@ -88,5 +87,4 @@ public:
     virtual void setClusterState(const ClusterState&) = 0;
 };
 
-} // lib
-} // storage
+}

--- a/vdslib/src/vespa/vdslib/distribution/idealnodecalculatorimpl.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/idealnodecalculatorimpl.cpp
@@ -7,11 +7,8 @@
 
 namespace storage::lib {
 
-IdealNodeList::IdealNodeList() :
-    _idealNodes()
-{ }
-
-IdealNodeList::~IdealNodeList() { }
+IdealNodeList::IdealNodeList() = default;
+IdealNodeList::~IdealNodeList() = default;
 
 void
 IdealNodeList::print(std::ostream& out, bool , const std::string &) const
@@ -31,7 +28,7 @@ IdealNodeCalculatorImpl::IdealNodeCalculatorImpl()
     initUpStateMapping();
 }
 
-IdealNodeCalculatorImpl::~IdealNodeCalculatorImpl() { }
+IdealNodeCalculatorImpl::~IdealNodeCalculatorImpl() = default;
 
 void
 IdealNodeCalculatorImpl::setDistribution(const Distribution& d) {

--- a/vdslib/src/vespa/vdslib/distribution/idealnodecalculatorimpl.h
+++ b/vdslib/src/vespa/vdslib/distribution/idealnodecalculatorimpl.h
@@ -7,8 +7,7 @@
 
 #include "idealnodecalculator.h"
 
-namespace storage {
-namespace lib {
+namespace storage::lib {
 
 class IdealNodeCalculatorImpl : public IdealNodeCalculatorConfigurable {
     std::vector<const char*> _upStates;
@@ -29,5 +28,4 @@ private:
     void initUpStateMapping();
 };
 
-} // lib
-} // storage
+}

--- a/vdslib/src/vespa/vdslib/state/clusterstate.h
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.h
@@ -57,12 +57,10 @@ public:
     uint16_t getDistributionBitCount() const { return _distributionBits; }
     const State& getClusterState() const { return *_clusterState; }
     const NodeState& getNodeState(const Node& node) const;
-    const vespalib::string& getDescription() const { return _description; }
 
     void setVersion(uint32_t version) { _version = version; }
     void setClusterState(const State& state);
     void setNodeState(const Node& node, const NodeState& state);
-    void setDescription(vespalib::stringref s) { _description = s; }
     void setDistributionBitCount(uint16_t count) { _distributionBits = count; }
 
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;

--- a/vdslib/src/vespa/vdslib/state/node.cpp
+++ b/vdslib/src/vespa/vdslib/state/node.cpp
@@ -2,21 +2,20 @@
 
 #include "node.h"
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <ostream>
 
-namespace storage {
-namespace lib {
+namespace storage::lib {
 
-Node::Node(const NodeType& type, uint16_t index)
-    : _type(&type),
-      _index(index)
+std::ostream &
+operator << (std::ostream & os, const Node & node)
 {
+    return os << node.getType() << '.' << node.getIndex();
 }
 
-void
-Node::print(vespalib::asciistream& as, const PrintProperties&) const
+vespalib::asciistream &
+operator << (vespalib::asciistream & os, const Node & node)
 {
-    as << *_type << '.' << _index;
+    return os << node.getType() << '.' << node.getIndex();
 }
 
-} // lib
-} // storage
+}

--- a/vdslib/src/vespa/vdslib/state/node.h
+++ b/vdslib/src/vespa/vdslib/state/node.h
@@ -8,28 +8,27 @@
 #pragma once
 
 #include "nodetype.h"
-#include <vespa/vespalib/util/printable.h>
 
-namespace storage {
-namespace lib {
+namespace storage::lib {
 
-class Node : public vespalib::AsciiPrintable {
+class Node {
     const NodeType* _type;
     uint16_t _index;
 
 public:
-    Node() : _type(&NodeType::STORAGE), _index(0) {}
-    Node(const NodeType& type, uint16_t index);
+    Node() noexcept : _type(&NodeType::STORAGE), _index(0) { }
+    Node(const NodeType& type, uint16_t index) noexcept
+        : _type(&type), _index(index) { }
 
     const NodeType& getType() const { return *_type; }
     uint16_t getIndex() const { return _index; }
 
-    void print(vespalib::asciistream&, const PrintProperties&) const override;
-
-    bool operator==(const Node& other) const
-        { return (other._index == _index && *other._type == *_type); }
-    bool operator!=(const Node& other) const
-        { return (other._index != _index || *other._type != *_type); }
+    bool operator==(const Node& other) const {
+        return (other._index == _index && *other._type == *_type);
+    }
+    bool operator!=(const Node& other) const {
+        return (other._index != _index || *other._type != *_type);
+    }
 
     bool operator<(const Node& n) const {
         if (*_type != *n._type) return (*_type < *n._type);
@@ -37,5 +36,7 @@ public:
     }
 };
 
-} // lib
-} // storage
+std::ostream & operator << (std::ostream & os, const Node & n);
+vespalib::asciistream & operator << (vespalib::asciistream & os, const Node & n);
+
+}

--- a/vdslib/src/vespa/vdslib/state/state.cpp
+++ b/vdslib/src/vespa/vdslib/state/state.cpp
@@ -4,23 +4,15 @@
 
 #include <vespa/vespalib/util/exceptions.h>
 
-namespace storage {
-namespace lib {
+namespace storage::lib {
 
-const State State::UNKNOWN("Unknown", "-", 0,
-        true,  true,  false, false, false);
-const State State::MAINTENANCE("Maintenance", "m", 1,
-        false, false, true,  true,  false);
-const State State::DOWN("Down", "d", 2,
-        false, false, true,  true,  true);
-const State State::STOPPING("Stopping", "s", 3,
-        true,  true,  false, false, true);
-const State State::INITIALIZING("Initializing", "i", 4,
-        true,  true,  false, false, true);
-const State State::RETIRED("Retired", "r", 5,
-        false, false, true, true,  false);
-const State State::UP("Up", "u", 6,
-        true,  true,  true,  true,  true);
+const State State::UNKNOWN("Unknown", "-", 0, true,  true,  false, false, false);
+const State State::MAINTENANCE("Maintenance", "m", 1, false, false, true,  true,  false);
+const State State::DOWN("Down", "d", 2, false, false, true,  true,  true);
+const State State::STOPPING("Stopping", "s", 3, true,  true,  false, false, true);
+const State State::INITIALIZING("Initializing", "i", 4, true,  true,  false, false, true);
+const State State::RETIRED("Retired", "r", 5, false, false, true, true,  false);
+const State State::UP("Up", "u", 6, true,  true,  true,  true,  true);
 
 const State&
 State::get(vespalib::stringref serialized)
@@ -61,9 +53,7 @@ State::State(vespalib::stringref name, vespalib::stringref serialized,
     _validWantedNodeState[distributor] = validDistributorWanted;
 }
 
-State::~State()
-{
-}
+State::~State() = default;
 
 void
 State::print(std::ostream& out, bool verbose, const std::string& indent) const
@@ -72,14 +62,4 @@ State::print(std::ostream& out, bool verbose, const std::string& indent) const
     out << (verbose ? _name : _serialized);
 }
 
-bool
-State::oneOf(const char* states) const
-{
-    for (const char* c = states; *c != '\0'; ++c) {
-        if (*c == _serialized[0]) return true;
-    }
-    return false;
 }
-
-} // lib
-} // storage

--- a/vdslib/src/vespa/vdslib/state/state.h
+++ b/vdslib/src/vespa/vdslib/state/state.h
@@ -47,14 +47,13 @@ public:
     static const State& get(vespalib::stringref serialized);
     const vespalib::string& serialize() const { return _serialized; }
 
-    bool validReportedNodeState(const NodeType& node) const
-        { return _validReportedNodeState[node]; }
-    bool validWantedNodeState(const NodeType& node) const
-        { return _validWantedNodeState[node]; }
+    bool validReportedNodeState(const NodeType& node) const { return _validReportedNodeState[node]; }
+    bool validWantedNodeState(const NodeType& node) const { return _validWantedNodeState[node]; }
     bool validClusterState() const { return _validClusterState; }
 
-    bool maySetWantedStateForThisNodeState(const State& wantedState) const
-        { return (wantedState._rankValue <= _rankValue); }
+    bool maySetWantedStateForThisNodeState(const State& wantedState) const {
+        return (wantedState._rankValue <= _rankValue);
+    }
 
     /**
      * Get a string that represents a more human readable version of
@@ -76,7 +75,12 @@ public:
      * states, given as the single character they are serialized as.
      * For instance, "um" will check if this state is up or maintenance.
      */
-    bool oneOf(const char* states) const;
+    bool oneOf(const char* states) const {
+        for (const char* c = states; *c != '\0'; ++c) {
+            if (*c == _serialized[0]) return true;
+        }
+        return false;
+    }
 };
 
 }


### PR DESCRIPTION
…ew/delete.

The number of elements that are moved around is small and significantly less than
the gain by more efficient memory management.

@vekterli PR This brought down execution time from 400s to 120s.