### PR TITLE
Store the entry refs in an vepalib::hash_map that is faster than std:…

### DIFF
--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/test/datastore/buffer_stats.h>
 #include <vespa/vespalib/test/datastore/memstats.h>
 #include <vespa/vespalib/datastore/array_store.hpp>
+#include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/traits.h>
@@ -26,7 +27,7 @@ struct Fixture
     using ConstArrayRef = typename ArrayStoreType::ConstArrayRef;
     using EntryVector = std::vector<EntryT>;
     using value_type = EntryT;
-    using ReferenceStore = std::map<EntryRef, EntryVector>;
+    using ReferenceStore = vespalib::hash_map<EntryRef, EntryVector>;
 
     ArrayStoreType store;
     ReferenceStore refStore;

--- a/vespalib/src/vespa/vespalib/datastore/entryref.h
+++ b/vespalib/src/vespa/vespalib/datastore/entryref.h
@@ -16,6 +16,7 @@ public:
     EntryRef() noexcept : _ref(0u) { }
     explicit EntryRef(uint32_t ref_) noexcept : _ref(ref_) { }
     uint32_t ref() const noexcept { return _ref; }
+    uint32_t hash() const noexcept { return _ref; }
     bool valid() const noexcept { return _ref != 0u; }
     bool operator==(const EntryRef &rhs) const noexcept { return _ref == rhs._ref; }
     bool operator!=(const EntryRef &rhs) const noexcept { return _ref != rhs._ref; }
@@ -32,17 +33,17 @@ public:
     EntryRefT() noexcept : EntryRef() {}
     EntryRefT(size_t offset_, uint32_t bufferId_) noexcept;
     EntryRefT(const EntryRef & ref_) noexcept : EntryRef(ref_.ref()) {}
-    size_t offset() const { return _ref & (offsetSize() - 1); }
-    uint32_t bufferId() const { return _ref >> OffsetBits; }
-    static size_t offsetSize() { return 1ul << OffsetBits; }
-    static uint32_t numBuffers() { return 1 << BufferBits; } 
-    static size_t align(size_t val) { return val; }
-    static size_t pad(size_t val) { (void) val; return 0ul; }
+    size_t offset() const noexcept { return _ref & (offsetSize() - 1); }
+    uint32_t bufferId() const noexcept { return _ref >> OffsetBits; }
+    static size_t offsetSize() noexcept { return 1ul << OffsetBits; }
+    static uint32_t numBuffers() noexcept { return 1 << BufferBits; }
+    static size_t align(size_t val) noexcept { return val; }
+    static size_t pad(size_t val) noexcept { (void) val; return 0ul; }
     static constexpr bool isAlignedType = false;
     // TODO: Remove following temporary methods when removing
     // AlignedEntryRefT
-    size_t unscaled_offset() const { return offset(); }
-    static size_t unscaled_offset_size() { return offsetSize(); }
+    size_t unscaled_offset() const noexcept { return offset(); }
+    static size_t unscaled_offset_size() noexcept { return offsetSize(); }
 };
 
 /**

--- a/vespalib/src/vespa/vespalib/stllike/hash_map.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_map.h
@@ -52,6 +52,7 @@ public:
     void erase(iterator it)                     { return erase(it->first); }
     void erase(const_iterator it)               { return erase(it->first); }
     iterator find(const K & key)                { return _ht.find(key); }
+    size_t count(const K & key)           const { return _ht.find(key) != _ht.end() ? 1 : 0; }
     const_iterator find(const K & key)    const { return _ht.find(key); }
 
     template< typename AltKey >


### PR DESCRIPTION
…:map. Saves 30+% of test time

@toregge PR