### PR TITLE
Switch from mem.total.util to mem.util in autoscaling

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/AutoscalingMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/AutoscalingMetrics.java
@@ -17,7 +17,7 @@ public class AutoscalingMetrics {
     private static MetricSet create() {
         return new MetricSet("autoscaling",
                              metrics("cpu.util",
-                                     "mem_total.util",
+                                     "mem.util",
                                      "disk.util",
                                      "application_generation",
                                      "in_service"));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsResponse.java
@@ -91,7 +91,7 @@ public class MetricsResponse {
             double convertValue(double metricValue) { return (float)metricValue / 100; } // % to ratio
         },
         memory { // a node resource
-            public String metricResponseName() { return "mem_total.util"; }
+            public String metricResponseName() { return "mem.util"; }
             double convertValue(double metricValue) { return (float)metricValue / 100; } // % to ratio
         },
         disk { // a node resource

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcherTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcherTest.java
@@ -114,7 +114,7 @@ public class MetricsV2MetricsFetcherTest {
             "          {\n" +
             "            \"values\": {\n" +
             "              \"cpu.util\": 16.2,\n" +
-            "              \"mem_total.util\": 23.1,\n" +
+            "              \"mem.util\": 23.1,\n" +
             "              \"disk.util\": 82\n" +
             "            },\n" +
             "            \"dimensions\": {\n" +
@@ -157,7 +157,7 @@ public class MetricsV2MetricsFetcherTest {
             "          {\n" +
             "            \"values\": {\n" +
             "              \"cpu.util\": 10,\n" +
-            "              \"mem_total.util\": 15,\n" +
+            "              \"mem.util\": 15,\n" +
             "              \"disk.util\": 20,\n" +
             "              \"application_generation\": 3\n" +
             "            },\n" +


### PR DESCRIPTION
mem.total.util included disk cache which makes it unsuitable as a regulation target.
