### PR TITLE
Revert "GC unused useDirectStoarageApiRpc flag"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -70,6 +70,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bjorncs", "jonmv"}) default double reindexerWindowSizeIncrement() { return 0.2; }
         @ModelFeatureFlag(owners = {"baldersheim"}, comment = "Revisit in May or June 2020") default double defaultTermwiseLimit() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"vekterli"}) default boolean useThreePhaseUpdates() { throw new UnsupportedOperationException("TODO specify default value"); }
+        @ModelFeatureFlag(owners = {"geirst"}, comment = "Remove when 7.336 is no longer in use") default boolean useDirectStorageApiRpc() { return true; }
         @ModelFeatureFlag(owners = {"baldersheim"}, comment = "Select sequencer type use while feeding") default String feedSequencerType() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default String responseSequencerType() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int defaultNumResponseThreads() { return 2; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -72,6 +72,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public Optional<EndpointCertificateSecrets> endpointCertificateSecrets() { return endpointCertificateSecrets; }
     @Override public double defaultTermwiseLimit() { return defaultTermwiseLimit; }
     @Override public boolean useThreePhaseUpdates() { return useThreePhaseUpdates; }
+    @Override public boolean useDirectStorageApiRpc() { return true; }
     @Override public Optional<AthenzDomain> athenzDomain() { return Optional.ofNullable(athenzDomain); }
     @Override public Optional<ApplicationRoles> applicationRoles() { return Optional.ofNullable(applicationRoles); }
     @Override public String responseSequencerType() { return responseSequencerType; }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
@@ -27,6 +27,7 @@ public abstract class ContentNode extends AbstractService
     private final boolean skipCommunicationManagerThread;
     private final boolean skipMbusRequestThread;
     private final boolean skipMbusReplyThread;
+    private final boolean useDirectStorageApiRpc;
 
     public ContentNode(ModelContext.FeatureFlags featureFlags, AbstractConfigProducer<?> parent, String clusterName, String rootDirectory, int distributionKey) {
         super(parent, "" + distributionKey);
@@ -35,6 +36,7 @@ public abstract class ContentNode extends AbstractService
         this.skipMbusRequestThread = featureFlags.skipMbusRequestThread();
         this.skipMbusReplyThread = featureFlags.skipMbusReplyThread();
         this.rootDirectory = rootDirectory;
+        this.useDirectStorageApiRpc = featureFlags.useDirectStorageApiRpc();
 
         initialize();
         setProp("clustertype", "content");
@@ -81,6 +83,7 @@ public abstract class ContentNode extends AbstractService
         builder.skip_thread(skipCommunicationManagerThread);
         builder.mbus.skip_request_thread(skipMbusRequestThread);
         builder.mbus.skip_reply_thread(skipMbusReplyThread);
+        builder.use_direct_storageapi_rpc(useDirectStorageApiRpc);
     }
 
     @Override

--- a/searchcore/src/apps/vespa-feed-bm/vespa_feed_bm.cpp
+++ b/searchcore/src/apps/vespa-feed-bm/vespa_feed_bm.cpp
@@ -494,6 +494,7 @@ struct MyStorageConfig
             stor_server.rootFolder = "storage";
         }
         make_slobroks_config(slobroks, slobrok_port);
+        stor_communicationmanager.useDirectStorageapiRpc = true;
         stor_communicationmanager.rpc.numNetworkThreads = params.get_rpc_network_threads();
         stor_communicationmanager.rpc.eventsBeforeWakeup = params.get_rpc_events_before_wakup();
         stor_communicationmanager.rpc.numTargetsPerNode = params.get_rpc_targets_per_node();

--- a/storage/src/vespa/storage/config/stor-communicationmanager.def
+++ b/storage/src/vespa/storage/config/stor-communicationmanager.def
@@ -58,7 +58,7 @@ skip_thread bool default=false
 
 ## Whether to use direct P2P RPC protocol for all StorageAPI communication
 ## instead of going via MessageBus.
-## Deprecated and ignored as it is default on. Will soon be removed.
+## Deprecated, and will soon be gone as it is default on.
 use_direct_storageapi_rpc bool default=true
 
 ## The number of network (FNET) threads used by the shared rpc resource.


### PR DESCRIPTION
Reverts vespa-engine/vespa#16074

It was still used:
  Caused by: java.lang.NoSuchMethodError: 'boolean com.yahoo.config.model.api.ModelContext$FeatureFlags.useDirectStorageApiRpc()'
        at com.yahoo.vespa.model.content.ContentNode.<init>(ContentNode.java:39)