### PR TITLE
Improved model for reindexing data

### DIFF
--- a/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/Reindexer.java
+++ b/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/Reindexer.java
@@ -117,11 +117,9 @@ public class Reindexer {
     }
 
     static Reindexing updateWithReady(Map<DocumentType, Instant> ready, Reindexing reindexing, Instant now) {
-        for (DocumentType type : ready.keySet()) { // We consider update for document types for which we have config.
+        for (DocumentType type : ready.keySet()) { // We update only for document types for which we have config.
             if ( ! ready.get(type).isAfter(now)) {
-                Status status = reindexing.status().getOrDefault(type, Status.ready(now)
-                                                                             .running()
-                                                                             .successful(now));
+                Status status = reindexing.status().getOrDefault(type, Status.ready(now));
                 if (status.startedAt().isBefore(ready.get(type)))
                     status = Status.ready(now);
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -915,12 +915,20 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     }
 
     public ApplicationReindexing getReindexing(ApplicationId id) {
-        return getTenant(id).getApplicationRepo().database().readReindexingStatus(id)
-                .orElse(ApplicationReindexing.ready(clock.instant()));
+        Tenant tenant = getTenant(id);
+        if (tenant == null)
+            throw new NotFoundException("Tenant '" + id.tenant().value() + "' not found");
+
+        return tenant.getApplicationRepo().database().readReindexingStatus(id)
+                            .orElseThrow(() -> new NotFoundException("Reindexing status not found for " + id));
     }
 
     public void modifyReindexing(ApplicationId id, UnaryOperator<ApplicationReindexing> modifications) {
-        getTenant(id).getApplicationRepo().database().modifyReindexing(id, ApplicationReindexing.ready(clock.instant()), modifications);
+        Tenant tenant = getTenant(id);
+        if (tenant == null)
+            throw new NotFoundException("Tenant '" + id.tenant().value() + "' not found");
+
+        tenant.getApplicationRepo().database().modifyReindexing(id, ApplicationReindexing.empty(), modifications);
     }
 
     public ConfigserverConfig configserverConfig() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -142,7 +142,7 @@ public class TenantApplications implements RequestHandler, HostValidator<Applica
      * Creates a node for the given application, marking its existence.
      */
     public void createApplication(ApplicationId id) {
-        database().createApplication(id, clock.instant());
+        database().createApplication(id);
     }
 
     /**

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.config.server.http.v2;
 import com.google.inject.Inject;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationFile;
+import com.yahoo.config.model.api.Model;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.HostFilter;
@@ -18,7 +19,6 @@ import com.yahoo.jdisc.application.UriPattern;
 import com.yahoo.slime.Cursor;
 import com.yahoo.text.StringUtilities;
 import com.yahoo.vespa.config.server.ApplicationRepository;
-import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.application.ApplicationReindexing;
 import com.yahoo.vespa.config.server.application.ClusterReindexing;
 import com.yahoo.vespa.config.server.http.ContentHandler;
@@ -28,7 +28,6 @@ import com.yahoo.vespa.config.server.http.HttpHandler;
 import com.yahoo.vespa.config.server.http.JSONResponse;
 import com.yahoo.vespa.config.server.http.NotFoundException;
 import com.yahoo.vespa.config.server.tenant.Tenant;
-import com.yahoo.vespa.model.VespaModel;
 
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -231,12 +230,17 @@ public class ApplicationHandler extends HttpHandler {
         throw new NotFoundException("Illegal POST request '" + request.getUri() + "'");
     }
 
+    private Model getActiveModelOrThrow(ApplicationId id) {
+        return applicationRepository.getActiveApplicationSet(id)
+                                    .orElseThrow(() -> new NotFoundException("Application '" + id + "' not found"))
+                                    .getForVersionOrLatest(Optional.empty(), applicationRepository.clock().instant())
+                .getModel();
+    }
+
     private HttpResponse triggerReindexing(HttpRequest request, ApplicationId applicationId) {
-        Application application = applicationRepository.getActiveApplicationSet(applicationId)
-                                                       .orElseThrow(() -> new NotFoundException(applicationId + " not found"))
-                                                       .getForVersionOrLatest(Optional.empty(), applicationRepository.clock().instant());
-        Map<String, Set<String>> documentTypes = application.getModel().documentTypesByCluster();
-        Map<String, Set<String>> indexedDocumentTypes = application.getModel().indexedDocumentTypesByCluster();
+        Model model = getActiveModelOrThrow(applicationId);
+        Map<String, Set<String>> documentTypes = model.documentTypesByCluster();
+        Map<String, Set<String>> indexedDocumentTypes = model.indexedDocumentTypesByCluster();
 
         boolean indexedOnly = request.getBooleanProperty("indexedOnly");
         Set<String> clusters = StringUtilities.split(request.getProperty("clusterId"));
@@ -279,9 +283,8 @@ public class ApplicationHandler extends HttpHandler {
         if (tenant == null)
             throw new NotFoundException("Tenant '" + applicationId.tenant().value() + "' not found");
 
-        return new ReindexingResponse(tenant.getApplicationRepo().database()
-                                            .readReindexingStatus(applicationId)
-                                            .orElseThrow(() -> new NotFoundException("Reindexing status not found for " + applicationId)),
+        return new ReindexingResponse(getActiveModelOrThrow(applicationId).documentTypesByCluster(),
+                                      applicationRepository.getReindexing(applicationId),
                                       applicationRepository.getClusterReindexingStatus(applicationId));
     }
 
@@ -471,33 +474,33 @@ public class ApplicationHandler extends HttpHandler {
     }
 
     static class ReindexingResponse extends JSONResponse {
-        ReindexingResponse(ApplicationReindexing reindexing, Map<String, ClusterReindexing> clusters) {
+        ReindexingResponse(Map<String, Set<String>> documentTypes, ApplicationReindexing reindexing,
+                           Map<String, ClusterReindexing> clusters) {
             super(Response.Status.OK);
             object.setBool("enabled", reindexing.enabled());
             Cursor clustersObject = object.setObject("clusters");
-            Stream<String> clusterNames = Stream.concat(clusters.keySet().stream(), reindexing.clusters().keySet().stream());
-            clusterNames.sorted()
-                        .forEach(clusterName -> {
-                            Cursor clusterObject = clustersObject.setObject(clusterName);
-                            Cursor pendingObject = clusterObject.setObject("pending");
-                            Cursor readyObject = clusterObject.setObject("ready");
+            documentTypes.forEach((cluster, types) -> {
+                Cursor clusterObject = clustersObject.setObject(cluster);
+                Cursor pendingObject = clusterObject.setObject("pending");
+                Cursor readyObject = clusterObject.setObject("ready");
 
-                            Map<String, Cursor> statuses = new HashMap<>();
-                            if (reindexing.clusters().containsKey(clusterName)) {
-                                reindexing.clusters().get(clusterName).pending().entrySet().stream().sorted(comparingByKey())
-                                          .forEach(pending -> pendingObject.setLong(pending.getKey(), pending.getValue()));
+                for (String type : types) {
+                    Cursor statusObject = readyObject.setObject(type);
+                    if (reindexing.clusters().containsKey(cluster)) {
+                        if (reindexing.clusters().get(cluster).pending().containsKey(type))
+                            pendingObject.setLong(type, reindexing.clusters().get(cluster).pending().get(type));
 
-                                reindexing.clusters().get(clusterName).ready().entrySet().stream().sorted(comparingByKey())
-                                          .forEach(ready -> setStatus(statuses.computeIfAbsent(ready.getKey(), readyObject::setObject), ready.getValue()));
-                            }
-                            if (clusters.containsKey(clusterName))
-                                clusters.get(clusterName).documentTypeStatus().entrySet().stream().sorted(comparingByKey())
-                                        .forEach(status -> setStatus(statuses.computeIfAbsent(status.getKey(), readyObject::setObject), status.getValue()));
-
-                        });
+                        if (reindexing.clusters().get(cluster).ready().containsKey(type))
+                            setStatus(statusObject, reindexing.clusters().get(cluster).ready().get(type));
+                    }
+                    if (clusters.containsKey(cluster))
+                        if (clusters.get(cluster).documentTypeStatus().containsKey(type))
+                            setStatus(statusObject, clusters.get(cluster).documentTypeStatus().get(type));
+                }
+            });
         }
 
-        private static void setStatus(Cursor object, ApplicationReindexing.Status readyStatus) {
+    private static void setStatus(Cursor object, ApplicationReindexing.Status readyStatus) {
             object.setLong("readyMillis", readyStatus.ready().toEpochMilli());
         }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -427,6 +427,7 @@ public class TenantRepository {
         return tenants.containsKey(tenant);
     }
 
+    /** Returns the tenant with the given name, or {@code null} if this does not exist. */
     public Tenant getTenant(TenantName tenantName) {
         return tenants.get(tenantName);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/application/ApplicationCuratorDatabaseTest.java
@@ -22,12 +22,10 @@ public class ApplicationCuratorDatabaseTest {
 
         assertEquals(Optional.empty(), db.readReindexingStatus(id));
 
-        ApplicationReindexing reindexing = ApplicationReindexing.ready(Instant.EPOCH)
-                                                                .withReady(Instant.ofEpochMilli(1 << 20))
+        ApplicationReindexing reindexing = ApplicationReindexing.empty()
                                                                 .withPending("one", "a", 10)
                                                                 .withReady("two", "b", Instant.ofEpochMilli(2))
                                                                 .withPending("two", "b", 20)
-                                                                .withReady("two", Instant.ofEpochMilli(2 << 10))
                                                                 .withReady("one", "a", Instant.ofEpochMilli(1))
                                                                 .withReady("two", "c", Instant.ofEpochMilli(3))
                                                                 .enabled(false);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -411,7 +411,7 @@ public class HostedDeployTest {
 
         assertEquals(4, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
         assertTrue(prepareResult.configChangeActions().getRestartActions().isEmpty()); // Handled by deployment.
-        assertEquals(Optional.of(ApplicationReindexing.ready(clock.instant())
+        assertEquals(Optional.of(ApplicationReindexing.empty()
                                                       .withPending("cluster", "music", prepareResult.sessionId())),
                      tester.tenant().getApplicationRepo().database().readReindexingStatus(tester.applicationId()));
     }


### PR DESCRIPTION
@bjorncs please reivew.

Making the users of reindexing data config aware allows getting rid of the
confusing default-for-app-and-cluster status, and the dummy first-time reindexing
in the reindexer.
Since the upgraded config servers will wipe the "common" status, the non-upgraded
config servers will read these as EPOCH, instead of some time last year. This should
not be a problem for any users of these data, as far as I can tell

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
