### PR TITLE
Reject two phase update operation in safe path if feed in cluster is …

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -104,6 +104,7 @@ private:
     void startSafePathUpdate(DistributorMessageSender&);
     bool lostBucketOwnershipBetweenPhases() const;
     void sendLostOwnershipTransientErrorReply(DistributorMessageSender&);
+    void send_feed_blocked_error_reply(DistributorMessageSender& sender);
     void schedulePutsWithUpdatedDocument(
             std::shared_ptr<document::Document>,
             api::Timestamp,


### PR DESCRIPTION
…blocked.

@vekterli please review
@toregge FYI.

This addresses the comment in https://github.com/vespa-engine/vespa/pull/16095#pullrequestreview-571210272.