### PR TITLE
There is now no need to have the 10k maxdocs limit to avoid iterating…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.cpp
@@ -55,8 +55,7 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig()
       _allowedLidBloatFactor(1.0),
       _remove_batch_block_rate(0.5),
       _remove_block_rate(100),
-      _disabled(false),
-      _maxDocsToScan(10000)
+      _disabled(false)
 {
 }
 
@@ -65,16 +64,14 @@ DocumentDBLidSpaceCompactionConfig::DocumentDBLidSpaceCompactionConfig(vespalib:
                                                                        double allowedLidBloatFactor,
                                                                        double remove_batch_block_rate,
                                                                        double remove_block_rate,
-                                                                       bool disabled,
-                                                                       uint32_t maxDocsToScan)
+                                                                       bool disabled)
     : _delay(std::min(MAX_DELAY_SEC, interval)),
       _interval(interval),
       _allowedLidBloat(allowedLidBloat),
       _allowedLidBloatFactor(allowedLidBloatFactor),
       _remove_batch_block_rate(remove_batch_block_rate),
       _remove_block_rate(remove_block_rate),
-      _disabled(disabled),
-      _maxDocsToScan(maxDocsToScan)
+      _disabled(disabled)
 {
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_db_maintenance_config.h
@@ -50,7 +50,6 @@ private:
     double               _remove_batch_block_rate;
     double               _remove_block_rate;
     bool                 _disabled;
-    uint32_t             _maxDocsToScan;
 
 public:
     DocumentDBLidSpaceCompactionConfig();
@@ -59,8 +58,7 @@ public:
                                        double allowwedLidBloatFactor,
                                        double remove_batch_block_rate,
                                        double remove_block_rate,
-                                       bool disabled,
-                                       uint32_t maxDocsToScan = 10000);
+                                       bool disabled);
 
     static DocumentDBLidSpaceCompactionConfig createDisabled();
     bool operator==(const DocumentDBLidSpaceCompactionConfig &rhs) const;
@@ -71,7 +69,6 @@ public:
     double get_remove_batch_block_rate() const { return _remove_batch_block_rate; }
     double get_remove_block_rate() const { return _remove_block_rate; }
     bool isDisabled() const { return _disabled; }
-    uint32_t getMaxDocsToScan() const { return _maxDocsToScan; }
 };
 
 class BlockableMaintenanceJobConfig {

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
@@ -23,12 +23,12 @@ DocumentScanIterator::valid() const
 }
 
 DocumentMetaData
-DocumentScanIterator::next(uint32_t compactLidLimit, uint32_t maxDocsToScan, bool retry)
+DocumentScanIterator::next(uint32_t compactLidLimit, bool retry)
 {
     if (!retry) {
         --_lastLid;
     }
-    for (uint32_t i(0); (_lastLid > compactLidLimit) && (i < maxDocsToScan); ++i, --_lastLid) {
+    for (uint32_t i(0); _lastLid > compactLidLimit; ++i, --_lastLid) {
         if (_metaStore.validLid(_lastLid)) {
             const RawDocumentMetaData &metaData = _metaStore.getRawMetaData(_lastLid);
             return DocumentMetaData(_lastLid, metaData.getTimestamp(),

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
@@ -20,9 +20,8 @@ private:
 
 public:
     DocumentScanIterator(const IDocumentMetaStore &_metaStore);
-
     bool valid() const override;
-    search::DocumentMetaData next(uint32_t compactLidLimit, uint32_t maxDocsToScan, bool retry) override;
+    search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
@@ -14,7 +14,7 @@ struct IDocumentScanIterator
 {
     typedef std::unique_ptr<IDocumentScanIterator> UP;
 
-    virtual ~IDocumentScanIterator() {}
+    virtual ~IDocumentScanIterator() = default;
 
     /**
      * Returns false if we are certain there are no more documents to scan, true otherwise.
@@ -24,16 +24,12 @@ struct IDocumentScanIterator
 
     /**
      * Returns the next document that has lid > compactLidLimit to be moved.
-     * Returns an invalid document if no documents satisfy the limit or
-     * if max documents are scanned.
+     * Returns an invalid document if no documents satisfy the limit.
      *
      * @param compactLidLimit The returned document must have lid larger than this limit.
-     * @param maxDocsToScan The maximum documents to scan before returning.
      * @param retry Whether we should start the scan with the previous returned document.
      */
-    virtual search::DocumentMetaData next(uint32_t compactLidLimit,
-                                          uint32_t maxDocsToScan,
-                                          bool retry) = 0;
+    virtual search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
@@ -35,9 +35,7 @@ LidSpaceCompactionJob::shouldRestartScanDocuments(const LidUsageStats &stats) co
 DocumentMetaData
 LidSpaceCompactionJob::getNextDocument(const LidUsageStats &stats)
 {
-    DocumentMetaData document =
-        _scanItr->next(std::max(stats.getLowestFreeLid(), stats.getUsedLids()),
-                       _cfg.getMaxDocsToScan(), _retryFrozenDocument);
+    DocumentMetaData document = _scanItr->next(std::max(stats.getLowestFreeLid(), stats.getUsedLids()), _retryFrozenDocument);
     _retryFrozenDocument = false;
     return document;
 }


### PR DESCRIPTION
… too long.

Now we iterate in the most efficient way by scanning a bit vector and maxtime wil be so small that it can be ignored.

@geirst or @toregge PR