### PR TITLE
Wait for resources in prepare

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -73,7 +73,9 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.stats.LockStats;
 import com.yahoo.vespa.curator.stats.ThreadLockStats;
 import com.yahoo.vespa.defaults.Defaults;
+import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FlagSource;
+import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 
@@ -138,6 +140,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     private final TesterClient testerClient;
     private final Metric metric;
     private final ClusterReindexingStatusClient clusterReindexingStatusClient;
+    private final BooleanFlag waitForResourcesInPrepareFlag;
 
     @Inject
     public ApplicationRepository(TenantRepository tenantRepository,
@@ -190,6 +193,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         this.testerClient = Objects.requireNonNull(testerClient);
         this.metric = Objects.requireNonNull(metric);
         this.clusterReindexingStatusClient = clusterReindexingStatusClient;
+        this.waitForResourcesInPrepareFlag = Flags.WAIT_FOR_RESOURCES_IN_PREPARE.bindTo(flagSource);
     }
 
     public static class Builder {
@@ -397,9 +401,10 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         SessionRepository sessionRepository = tenant.getSessionRepository();
         DeployLogger logger = new SilentDeployLogger();
         Session newSession = sessionRepository.createSessionFromExisting(activeSession, true, timeoutBudget);
+        boolean waitForResourcesInPrepare = waitForResourcesInPrepareFlag.value();
 
         return Optional.of(Deployment.unprepared(newSession, this, hostProvisioner, tenant, logger, timeout, clock,
-                                                 false /* don't validate as this is already deployed */, bootstrap));
+                                                 false /* don't validate as this is already deployed */, bootstrap, waitForResourcesInPrepare));
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -232,8 +232,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
         Set<HostSpec> preparedHosts = session.getAllocatedHosts().getHosts();
         ActivationContext context = new ActivationContext(session.getSessionId());
-        ApplicationTransaction transaction = new ApplicationTransaction(
-                new ProvisionLock(session.getApplicationId(), () -> {}), new NestedTransaction());
+        ProvisionLock lock = new ProvisionLock(session.getApplicationId(), () -> {});
         AtomicReference<TransientException> lastException = new AtomicReference<>();
 
         while (true) {
@@ -243,6 +242,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
 
             try {
                 // Call to activate to make sure that everything is ready, but do not commit the transaction
+                ApplicationTransaction transaction = new ApplicationTransaction(lock, new NestedTransaction());
                 provisioner.get().activate(preparedHosts, context, transaction);
                 return;
             } catch (TransientException e) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/PrepareParams.java
@@ -45,6 +45,7 @@ public final class PrepareParams {
     static final String APPLICATION_CONTAINER_ROLE = "applicationContainerRole";
     static final String QUOTA_PARAM_NAME = "quota";
     static final String FORCE_PARAM_NAME = "force";
+    static final String WAIT_FOR_RESOURCES_IN_PREPARE = "waitForResourcesInPrepare";
 
     private final ApplicationId applicationId;
     private final TimeoutBudget timeoutBudget;
@@ -53,6 +54,7 @@ public final class PrepareParams {
     private final boolean verbose;
     private final boolean isBootstrap;
     private final boolean force;
+    private final boolean waitForResourcesInPrepare;
     private final Optional<Version> vespaVersion;
     private final List<ContainerEndpoint> containerEndpoints;
     private final Optional<String> tlsSecretsKeyName;
@@ -67,7 +69,8 @@ public final class PrepareParams {
                           List<ContainerEndpoint> containerEndpoints, Optional<String> tlsSecretsKeyName,
                           Optional<EndpointCertificateMetadata> endpointCertificateMetadata,
                           Optional<DockerImage> dockerImageRepository, Optional<AthenzDomain> athenzDomain,
-                          Optional<ApplicationRoles> applicationRoles, Optional<Quota> quota, boolean force) {
+                          Optional<ApplicationRoles> applicationRoles, Optional<Quota> quota, boolean force,
+                          boolean waitForResourcesInPrepare) {
         this.timeoutBudget = timeoutBudget;
         this.applicationId = Objects.requireNonNull(applicationId);
         this.ignoreValidationErrors = ignoreValidationErrors;
@@ -83,6 +86,7 @@ public final class PrepareParams {
         this.applicationRoles = applicationRoles;
         this.quota = quota;
         this.force = force;
+        this.waitForResourcesInPrepare = waitForResourcesInPrepare;
     }
 
     public static class Builder {
@@ -92,6 +96,7 @@ public final class PrepareParams {
         private boolean verbose = false;
         private boolean isBootstrap = false;
         private boolean force = false;
+        private boolean waitForResourcesInPrepare = false;
         private ApplicationId applicationId = null;
         private TimeoutBudget timeoutBudget = new TimeoutBudget(Clock.systemUTC(), Duration.ofSeconds(60));
         private Optional<Version> vespaVersion = Optional.empty();
@@ -203,6 +208,11 @@ public final class PrepareParams {
             return this;
         }
 
+        public Builder waitForResourcesInPrepare(boolean waitForResourcesInPrepare) {
+            this.waitForResourcesInPrepare = waitForResourcesInPrepare;
+            return this;
+        }
+
         public Builder force(boolean force) {
             this.force = force;
             return this;
@@ -212,7 +222,7 @@ public final class PrepareParams {
             return new PrepareParams(applicationId, timeoutBudget, ignoreValidationErrors, dryRun,
                                      verbose, isBootstrap, vespaVersion, containerEndpoints, tlsSecretsKeyName,
                                      endpointCertificateMetadata, dockerImageRepository, athenzDomain,
-                                     applicationRoles, quota, force);
+                                     applicationRoles, quota, force, waitForResourcesInPrepare);
         }
     }
 
@@ -231,6 +241,7 @@ public final class PrepareParams {
                             .applicationRoles(ApplicationRoles.fromString(request.getProperty(APPLICATION_HOST_ROLE), request.getProperty(APPLICATION_CONTAINER_ROLE)))
                             .quota(request.getProperty(QUOTA_PARAM_NAME))
                             .force(request.getBooleanProperty(FORCE_PARAM_NAME))
+                            .waitForResourcesInPrepare(request.getBooleanProperty(WAIT_FOR_RESOURCES_IN_PREPARE))
                             .build();
     }
 
@@ -279,6 +290,8 @@ public final class PrepareParams {
     public boolean isBootstrap() { return isBootstrap; }
 
     public boolean force() { return force; }
+
+    public boolean waitForResourcesInPrepare() { return waitForResourcesInPrepare; }
 
     public TimeoutBudget getTimeoutBudget() {
         return timeoutBudget;

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -50,6 +50,12 @@ public class Flags {
             "Takes effect on the next run of RetiredExpirer.",
             HOSTNAME);
 
+    public static final UnboundBooleanFlag WAIT_FOR_RESOURCES_IN_PREPARE = defineFeatureFlag(
+            "wait-for-resources-in-prepare", false,
+            List.of("freva"), "2021-01-21", "2021-04-01",
+            "Whether deployment prepare should wait until all resources (parent hosts, LBs, etc.) are ready before returning",
+            "Takes effect at redeployment.");
+
     public static final UnboundDoubleFlag DEFAULT_TERM_WISE_LIMIT = defineDoubleFlag(
             "default-term-wise-limit", 1.0,
             List.of("baldersheim"), "2020-12-02", "2021-02-01",


### PR DESCRIPTION
VESPA-19467: Node-repository maintainers assume that once a `prepare()` goes through, the `activate()` will not fail, but in dynamically provisioned zones `activate()` will throw `TransientException`s until node's hosts are `active`. To avoid that, we should instead wait in `prepare()` until the parent hosts are ready, at least for internal deployments (for external deployments, the transient failures are retried by the controller and each failure provides live feedback to the user in the deployment log about the progress).
