### PR TITLE
Allow concurrent safe maintenance [run-systemtest]

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterInfo.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterInfo.java
@@ -32,8 +32,10 @@ public class ClusterInfo {
     /** Information about the current state of all nodes - always consists of both sets of nodes in the two maps above */
     private final Map<Node, NodeInfo> allNodeInfo = new TreeMap<>(); // TODO: Remove
 
+    /** Returns non-null iff index is a configured nodes (except perhaps in tests). */
     DistributorNodeInfo getDistributorNodeInfo(int index) { return distributorNodeInfo.get(index); }
 
+    /** Returns non-null iff index is a configured nodes (except perhaps in tests). */
     StorageNodeInfo getStorageNodeInfo(int index) { return storageNodeInfo.get(index); }
 
     NodeInfo getNodeInfo(NodeType type, int index) { return getNodeInfo(new Node(type, index)); }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -7,13 +7,22 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.vdslib.distribution.ConfiguredNode;
-import com.yahoo.vdslib.state.*;
 import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.distribution.Group;
+import com.yahoo.vdslib.state.ClusterState;
+import com.yahoo.vdslib.state.Node;
+import com.yahoo.vdslib.state.NodeState;
+import com.yahoo.vdslib.state.NodeType;
+import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.status.statuspage.VdsClusterHtmlRenderer;
 import com.yahoo.vespa.clustercontroller.utils.staterestapi.requests.SetUnitStateRequest;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import static com.yahoo.vdslib.state.NodeState.ORCHESTRATOR_RESERVED_DESCRIPTION;
@@ -177,15 +186,18 @@ public class ContentCluster {
      * @param node the node to be checked for upgrad
      * @param clusterState the current cluster state version
      * @param condition the upgrade condition
+     * @param oldState the old/current wanted state
      * @param newState state wanted to be set  @return NodeUpgradePrechecker.Response
      */
     public NodeStateChangeChecker.Result calculateEffectOfNewState(
-            Node node, ClusterState clusterState, SetUnitStateRequest.Condition condition, NodeState oldState, NodeState newState) {
+            Node node, ClusterState clusterState, SetUnitStateRequest.Condition condition,
+            NodeState oldState, NodeState newState) {
 
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
                 minStorageNodesUp,
                 minRatioOfStorageNodesUp,
                 distribution.getRedundancy(),
+                new HierarchicalGroupVisitingAdapter(distribution),
                 clusterInfo
         );
         return nodeStateChangeChecker.evaluateTransition(node, clusterState, condition, oldState, newState);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisiting.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisiting.java
@@ -1,0 +1,14 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+//
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.distribution.GroupVisitor;
+
+@FunctionalInterface
+public interface HierarchicalGroupVisiting {
+    /**
+     * Invoke the visitor for each leaf group of an implied group.  If the group is non-hierarchical
+     * (flat), the visitor will not be invoked.
+     */
+    void visit(GroupVisitor visitor);
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisitingAdapter.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisitingAdapter.java
@@ -1,0 +1,35 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+//
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.distribution.Distribution;
+import com.yahoo.vdslib.distribution.GroupVisitor;
+
+/**
+ * Exposes {@link Distribution} as a {@link HierarchicalGroupVisiting}.
+ *
+ * @author hakon
+ */
+public class HierarchicalGroupVisitingAdapter implements HierarchicalGroupVisiting {
+    private final Distribution distribution;
+
+    public HierarchicalGroupVisitingAdapter(Distribution distribution) {
+        this.distribution = distribution;
+    }
+
+    @Override
+    public void visit(GroupVisitor visitor) {
+        if (distribution.getRootGroup().isLeafGroup()) {
+            // A flat non-hierarchical cluster
+            return;
+        }
+
+        distribution.visitGroups(group -> {
+            if (group.isLeafGroup()) {
+                return visitor.visitGroup(group);
+            }
+
+            return true;
+        });
+    }
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -602,5 +602,4 @@ public class NodeStateChangeCheckerTest {
             nodes.add(new ConfiguredNode(i, false));
         return nodes;
     }
-
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -61,7 +61,8 @@ public class NodeStateChangeCheckerTest {
     }
 
     private NodeStateChangeChecker createChangeChecker(ContentCluster cluster) {
-        return new NodeStateChangeChecker(minStorageNodesUp, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+        return new NodeStateChangeChecker(minStorageNodesUp, minRatioOfStorageNodesUp, requiredRedundancy,
+                visitor -> {}, cluster.clusterInfo());
     }
 
     private ContentCluster createCluster(Collection<ConfiguredNode> nodes) {
@@ -136,7 +137,8 @@ public class NodeStateChangeCheckerTest {
     public void testUnknownStorageNode() {
         ContentCluster cluster = createCluster(createNodes(4));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy,
+                visitor -> {}, cluster.clusterInfo());
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -161,7 +163,8 @@ public class NodeStateChangeCheckerTest {
         ContentCluster cluster = createCluster(createNodes(4));
         setAllNodesUp(cluster, HostInfo.createHostInfo(createDistributorHostInfo(4, 5, 6)));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, cluster.clusterInfo());
+                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, visitor -> {},
+                cluster.clusterInfo());
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 nodeStorage, defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -317,10 +320,10 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
-    public void testDifferentDescriptionImpliesAlreadySet() {
+    public void testDifferentDescriptionImpliesDenied() {
         NodeStateChangeChecker.Result result = transitionToSameState("foo", "bar");
         assertFalse(result.settingWantedStateIsAllowed());
-        assertTrue(result.wantedStateAlreadySet());
+        assertFalse(result.wantedStateAlreadySet());
     }
 
     private NodeStateChangeChecker.Result transitionToMaintenanceWithOneStorageNodeDown(

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core.restapiv2;
 
 import com.yahoo.time.TimeBudget;
 import com.yahoo.vdslib.state.NodeType;
+import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.MasterInterface;
 import com.yahoo.vespa.clustercontroller.core.RemoteClusterControllerTask;
 import com.yahoo.vespa.clustercontroller.core.restapiv2.requests.SetNodeStateRequest;
@@ -25,12 +26,15 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -205,28 +209,91 @@ public class SetNodeStateTest extends StateRestApiTest {
         SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/1")
                 .setNewState("user", "maintenance", "whatever reason.")
                 .setCondition(SetUnitStateRequest.Condition.SAFE));
-        assertThat(setResponse.getWasModified(), is(true));
         assertThat(setResponse.getReason(), is("ok"));
+        assertThat(setResponse.getWasModified(), is(true));
     }
 
     @Test
     public void testShouldModifyStorageSafeBlocked() throws Exception {
-        setUp(false);
-        {
-            SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/1")
-                    .setNewState("user", "maintenance", "whatever reason.")
-                    .setCondition(SetUnitStateRequest.Condition.SAFE));
+        // Sets up 2 groups: [0, 2, 4] and [1, 3, 5]
+        setUpBookGroup(6);
+
+        assertUnitState(1, "user", State.UP, "");
+        assertSetUnitState(1, State.MAINTENANCE, null);
+        assertUnitState(1, "user", State.MAINTENANCE, "whatever reason.");
+        assertSetUnitState(1, State.MAINTENANCE, null);  // sanity-check
+
+        // Because 2 is in a different group maintenance should be denied
+        assertSetUnitStateCausesAlreadyInMaintenance(2, State.MAINTENANCE);
+
+        // Because 3 and 5 are in the same group as 1, these should be OK
+        assertSetUnitState(3, State.MAINTENANCE, null);
+        assertUnitState(1, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
+        assertUnitState(3, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
+        assertSetUnitState(5, State.MAINTENANCE, null);
+        assertSetUnitStateCausesAlreadyInMaintenance(2, State.MAINTENANCE);  // sanity-check
+
+        // Set all to up
+        assertSetUnitState(1, State.UP, null);
+        assertSetUnitState(1, State.UP, null); // sanity-check
+        assertSetUnitState(3, State.UP, null);
+        assertSetUnitStateCausesAlreadyInMaintenance(2, State.MAINTENANCE);  // sanity-check
+        assertSetUnitState(5, State.UP, null);
+
+        // Now we should be allowed to upgrade second group, while the first group will be denied
+        assertSetUnitState(2, State.MAINTENANCE, null);
+        assertSetUnitStateCausesAlreadyInMaintenance(1, State.MAINTENANCE);  // sanity-check
+        assertSetUnitState(0, State.MAINTENANCE, null);
+        assertSetUnitState(4, State.MAINTENANCE, null);
+        assertSetUnitStateCausesAlreadyInMaintenance(1, State.MAINTENANCE);  // sanity-check
+
+        // And set second group up again
+        assertSetUnitState(0, State.MAINTENANCE, null);
+        assertSetUnitState(2, State.MAINTENANCE, null);
+        assertSetUnitState(4, State.MAINTENANCE, null);
+    }
+
+    private void assertUnitState(int index, String type, State state, String reason) throws StateRestApiException {
+        String path = "music/storage/" + index;
+        UnitResponse response = restAPI.getState(new StateRequest(path, 0));
+        Response.NodeResponse nodeResponse = (Response.NodeResponse) response;
+        UnitState unitState = nodeResponse.getStatePerType().get(type);
+        assertNotNull("No such type " + type + " at path " + path, unitState);
+        assertEquals(state.toString().toLowerCase(), unitState.getId());
+        assertEquals(reason, unitState.getReason());
+    }
+
+    private void assertSetUnitState(int index, State state, String failureReason) throws StateRestApiException {
+        SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/" + index)
+                .setNewState("user", state.toString().toLowerCase(), "whatever reason.")
+                .setCondition(SetUnitStateRequest.Condition.SAFE));
+        if (failureReason == null) {
             assertThat(setResponse.getReason(), is("ok"));
             assertThat(setResponse.getWasModified(), is(true));
-        }
-        {
-            SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/3")
-                    .setNewState("user", "maintenance", "whatever reason.")
-                    .setCondition(SetUnitStateRequest.Condition.SAFE));
-            assertThat(setResponse.getReason(), is(
-                    "There is a node already in maintenance:1"));
+        } else {
+            assertThat(setResponse.getReason(), is(failureReason));
             assertThat(setResponse.getWasModified(), is(false));
         }
+    }
+
+    private void assertSetUnitStateCausesAlreadyInMaintenance(int index, State state) throws StateRestApiException {
+        SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/" + index)
+                .setNewState("user", state.toString().toLowerCase(), "whatever reason.")
+                .setCondition(SetUnitStateRequest.Condition.SAFE));
+
+        String regex = "^There is a node already in maintenance:([0-9]+)$";
+        Matcher matcher = Pattern.compile(regex).matcher(setResponse.getReason());
+
+        String errorMessage = "Expected reason to match '" + regex + "', but got: " + setResponse.getReason() + "'";
+        assertTrue(errorMessage, matcher.find());
+
+        int alreadyMaintainedIndex = Integer.parseInt(matcher.group(1));
+        // Example: Say index 1 is in maintenance, and we try to set 2 in maintenance. This should
+        // NOT be allowed, since 2 is in a different group than 1.
+        assertEquals("Tried to set " + index + " in maintenance, but got: " + setResponse.getReason(),
+                index % 2, (alreadyMaintainedIndex + 1) % 2);
+
+        assertThat(setResponse.getWasModified(), is(false));
     }
 
     @Test


### PR DESCRIPTION
Allows setting a node safely to maintenance in these two new circumstances:

 1.  The node has state MAINTENANCE with (user) wanted state UP.
 2.  There are other nodes in the same hierarchical group that are set in
     MAINTENANCE with the same description.

Also made the following change.

 3. Deny a request for safe MAINTENANCE or DOWN, if the wanted state is already
    set but with a different description.  If the descriptions are the same, it
    is assumed to be the same operator (e.g. Orchestrator) having changed its
    mind.