### PR TITLE
Make a lidspace job that uses a bucket executor to hold the bucket lock.

### DIFF
--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_compaction_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_compaction_test.cpp
@@ -1,10 +1,16 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchcore/proton/server/i_lid_space_compaction_handler.h>
+#include <vespa/searchcore/proton/server/i_document_scan_iterator.h>
 #include <vespa/searchcore/proton/server/ifrozenbuckethandler.h>
 #include <vespa/searchcore/proton/server/imaintenancejobrunner.h>
 #include <vespa/searchcore/proton/server/lid_space_compaction_handler.h>
 #include <vespa/searchcore/proton/server/lid_space_compaction_job.h>
+#include <vespa/searchcore/proton/server/remove_operations_rate_tracker.h>
+#include <vespa/searchcore/proton/server/maintenancedocumentsubdb.h>
+#include <vespa/searchcore/proton/server/i_operation_storer.h>
+#include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
+#include <vespa/searchcore/proton/feedoperation/moveoperation.h>
+#include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/searchcore/proton/test/clusterstatehandler.h>
 #include <vespa/searchcore/proton/test/disk_mem_usage_notifier.h>
 #include <vespa/searchcore/proton/test/test.h>
@@ -65,6 +71,9 @@ struct MyScanIterator : public IDocumentScanIterator {
             _validItr = false;
         }
         return search::DocumentMetaData();
+    }
+    search::DocumentMetaData getMetaData(uint32_t lid) const override {
+        return search::DocumentMetaData(lid, TIMESTAMP_1, BUCKET_ID_1, GID_1);
     }
 };
 

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -17,6 +17,7 @@
 #include <vespa/searchcore/proton/feedoperation/removeoperation.h>
 #include <vespa/searchcore/proton/server/blockable_maintenance_job.h>
 #include <vespa/searchcore/proton/server/executor_thread_service.h>
+#include <vespa/searchcore/proton/server/i_document_scan_iterator.h>
 #include <vespa/searchcore/proton/server/i_operation_storer.h>
 #include <vespa/searchcore/proton/server/ibucketmodifiedhandler.h>
 #include <vespa/searchcore/proton/server/idocumentmovehandler.h>

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h
@@ -14,17 +14,14 @@ private:
 public:
     CompactLidSpaceOperation();
     CompactLidSpaceOperation(uint32_t subDbId, uint32_t lidLimit);
-    virtual ~CompactLidSpaceOperation() {}
+    ~CompactLidSpaceOperation() override = default;
 
     uint32_t getSubDbId() const { return _subDbId; }
     uint32_t getLidLimit() const { return _lidLimit; }
 
-    // Implements FeedOperation
-    virtual void serialize(vespalib::nbostream &os) const override;
-    virtual void deserialize(vespalib::nbostream &is,
-                             const document::DocumentTypeRepo &) override;
-    virtual vespalib::string toString() const override;
+    void serialize(vespalib::nbostream &os) const override;
+    void deserialize(vespalib::nbostream &is, const document::DocumentTypeRepo &) override;
+    vespalib::string toString() const override;
 };
 
-} // namespace proton
-
+}

--- a/searchcore/src/vespa/searchcore/proton/feedoperation/moveoperation.h
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/moveoperation.h
@@ -19,17 +19,16 @@ public:
                   const DocumentSP &doc,
                   DbDocumentId sourceDbdId,
                   uint32_t targetSubDbId);
-    virtual ~MoveOperation();
+    ~MoveOperation() override;
     const DocumentSP &getDocument() const { return _doc; }
     DbDocumentId getSourceDbdId() const { return getPrevDbDocumentId(); }
     DbDocumentId getTargetDbdId() const { return getDbDocumentId(); }
     void setTargetLid(search::DocumentIdT lid) {
         setDbDocumentId(DbDocumentId(getSubDbId(), lid));
     }
-    virtual void serialize(vespalib::nbostream &os) const override;
-    virtual void deserialize(vespalib::nbostream &is,
-                             const document::DocumentTypeRepo &repo) override;
-    virtual vespalib::string toString() const override;
+    void serialize(vespalib::nbostream &os) const override;
+    void deserialize(vespalib::nbostream &is, const document::DocumentTypeRepo &repo) override;
+    vespalib::string toString() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -58,6 +58,8 @@ vespa_add_library(searchcore_server STATIC
     job_tracked_maintenance_job.cpp
     lid_space_compaction_handler.cpp
     lid_space_compaction_job.cpp
+    lid_space_compaction_job_base.cpp
+    lid_space_compaction_job_take2.cpp
     maintenance_controller_explorer.cpp
     maintenance_jobs_injector.cpp
     maintenancecontroller.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/bucketmovejob.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bucketmovejob.h
@@ -176,7 +176,7 @@ public:
 
     // IBucketStateChangedHandler API
     void notifyBucketStateChanged(const document::BucketId &bucketId,
-                                          storage::spi::BucketInfo::ActiveState newState) override;
+                                  storage::spi::BucketInfo::ActiveState newState) override;
 
     void notifyDiskMemUsage(DiskMemUsageState state) override;
 

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
@@ -39,4 +39,14 @@ DocumentScanIterator::next(uint32_t compactLidLimit, bool retry)
     return DocumentMetaData();
 }
 
+search::DocumentMetaData
+DocumentScanIterator::getMetaData(uint32_t lid) const {
+    if (_metaStore.validLid(lid)) {
+        const RawDocumentMetaData &metaData = _metaStore.getRawMetaData(_lastLid);
+        return DocumentMetaData(_lastLid, metaData.getTimestamp(),
+                                metaData.getBucketId(), metaData.getGid());
+    }
+    return DocumentMetaData();
+}
+
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
@@ -22,6 +22,7 @@ public:
     DocumentScanIterator(const IDocumentMetaStore &_metaStore);
     bool valid() const override;
     search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) override;
+    search::DocumentMetaData getMetaData(uint32_t lid) const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
@@ -6,7 +6,6 @@
 #include <vespa/document/base/globalid.h>
 #include <vespa/searchlib/query/base.h>
 #include <persistence/spi/types.h>
-#include "ifrozenbuckethandler.h"
 
 namespace proton {
 

--- a/searchcore/src/vespa/searchcore/proton/server/i_disk_mem_usage_notifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_disk_mem_usage_notifier.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-namespace proton
-{
+namespace proton {
 
 class IDiskMemUsageListener;
 
@@ -14,7 +13,7 @@ class IDiskMemUsageListener;
 class IDiskMemUsageNotifier
 {
 public:
-    virtual ~IDiskMemUsageNotifier() {}
+    virtual ~IDiskMemUsageNotifier() = default;
     virtual void addDiskMemUsageListener(IDiskMemUsageListener *listener) = 0;
     virtual void removeDiskMemUsageListener(IDiskMemUsageListener *listener) = 0;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
@@ -30,6 +30,8 @@ struct IDocumentScanIterator
      * @param retry Whether we should start the scan with the previous returned document.
      */
     virtual search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) = 0;
+
+    virtual search::DocumentMetaData getMetaData(uint32_t lid) const = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_lid_space_compaction_handler.h
@@ -2,17 +2,18 @@
 
 #pragma once
 
-#include "i_document_scan_iterator.h"
-#include "ifrozenbuckethandler.h"
-#include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
-#include <vespa/searchcore/proton/feedoperation/moveoperation.h>
 #include <vespa/searchlib/common/lid_usage_stats.h>
+#include <vector>
 
 namespace vespalib { class IDestructorCallback; }
-
+namespace search { class DocumentMetaData; }
 namespace proton::documentmetastore { class OperationListener; }
 
 namespace proton {
+
+class MoveOperation;
+class CompactLidSpaceOperation;
+class IDocumentScanIterator;
 
 /**
  * Interface for handling of lid space compaction, used by a LidSpaceCompactionJob.
@@ -51,12 +52,12 @@ struct ILidSpaceCompactionHandler
     /**
      * Returns an iterator for scanning documents.
      */
-    virtual IDocumentScanIterator::UP getIterator() const = 0;
+    virtual std::unique_ptr<IDocumentScanIterator> getIterator() const = 0;
 
     /**
      * Creates a move operation for moving the given document to the given lid.
      */
-    virtual MoveOperation::UP createMoveOperation(const search::DocumentMetaData &document, uint32_t moveToLid) const = 0;
+    virtual std::unique_ptr<MoveOperation> createMoveOperation(const search::DocumentMetaData &document, uint32_t moveToLid) const = 0;
 
     /**
      * Performs the actual move operation.

--- a/searchcore/src/vespa/searchcore/proton/server/iclusterstatechangednotifier.h
+++ b/searchcore/src/vespa/searchcore/proton/server/iclusterstatechangednotifier.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-namespace proton
-{
+namespace proton {
 
 class IClusterStateChangedHandler;
 
@@ -13,13 +12,10 @@ class IClusterStateChangedHandler;
 class IClusterStateChangedNotifier
 {
 public:
-    virtual ~IClusterStateChangedNotifier() { }
+    virtual ~IClusterStateChangedNotifier() = default;
 
-    virtual void
-    addClusterStateChangedHandler(IClusterStateChangedHandler *handler) = 0;
-
-    virtual void
-    removeClusterStateChangedHandler(IClusterStateChangedHandler *handler) = 0;
+    virtual void addClusterStateChangedHandler(IClusterStateChangedHandler *handler) = 0;
+    virtual void removeClusterStateChangedHandler(IClusterStateChangedHandler *handler) = 0;
 };
 
-} // namespace proton
+}

--- a/searchcore/src/vespa/searchcore/proton/server/ifrozenbuckethandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ifrozenbuckethandler.h
@@ -4,8 +4,7 @@
 
 #include <vespa/document/bucket/bucketid.h>
 
-namespace proton
-{
+namespace proton {
 
 class IBucketFreezeListener;
 
@@ -22,12 +21,10 @@ public:
         document::BucketId _bucketId;
     };
 
-    virtual ~IFrozenBucketHandler() { }
+    virtual ~IFrozenBucketHandler() = default;
     virtual ExclusiveBucketGuard::UP acquireExclusiveBucket(document::BucketId bucket) = 0;
     virtual void addListener(IBucketFreezeListener *listener) = 0;
     virtual void removeListener(IBucketFreezeListener *listener) = 0;
 };
 
-
-} // namespace proton
-
+}

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.cpp
@@ -3,10 +3,11 @@
 #include "document_scan_iterator.h"
 #include "ifeedview.h"
 #include "lid_space_compaction_handler.h"
-#include <vespa/document/fieldvalue/document.h>
-#include <vespa/searchcore/proton/docsummary/isummarymanager.h>
-#include <vespa/searchcore/proton/documentmetastore/i_document_meta_store_context.h>
+#include "maintenancedocumentsubdb.h"
+#include <vespa/searchcore/proton/feedoperation/moveoperation.h>
+#include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
 #include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
+#include <vespa/document/fieldvalue/document.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
 
 using document::BucketId;
@@ -25,6 +26,16 @@ LidSpaceCompactionHandler::LidSpaceCompactionHandler(const MaintenanceDocumentSu
 }
 
 LidSpaceCompactionHandler::~LidSpaceCompactionHandler() = default;
+
+vespalib::string
+LidSpaceCompactionHandler::getName() const {
+    return _docTypeName + "." + _subDb.name();
+}
+
+uint32_t
+LidSpaceCompactionHandler::getSubDbId() const {
+    return _subDb.sub_db_id();
+}
 
 void
 LidSpaceCompactionHandler::set_operation_listener(documentmetastore::OperationListener::SP op_listener)

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_handler.h
@@ -2,9 +2,10 @@
 #pragma once
 
 #include "i_lid_space_compaction_handler.h"
-#include "maintenancedocumentsubdb.h"
 
 namespace proton {
+
+class MaintenanceDocumentSubDB;
 
 /**
  * Class that handles lid space compaction over a single document sub db.
@@ -20,14 +21,12 @@ public:
                               const vespalib::string& docTypeName);
     ~LidSpaceCompactionHandler() override;
 
-    vespalib::string getName() const override {
-        return _docTypeName + "." + _subDb.name();
-    }
+    vespalib::string getName() const override;
     void set_operation_listener(std::shared_ptr<documentmetastore::OperationListener> op_listener) override;
-    uint32_t getSubDbId() const override { return _subDb.sub_db_id(); }
+    uint32_t getSubDbId() const override;
     search::LidUsageStats getLidStatus() const override;
-    IDocumentScanIterator::UP getIterator() const override;
-    MoveOperation::UP createMoveOperation(const search::DocumentMetaData &document, uint32_t moveToLid) const override;
+    std::unique_ptr<IDocumentScanIterator> getIterator() const override;
+    std::unique_ptr<MoveOperation> createMoveOperation(const search::DocumentMetaData &document, uint32_t moveToLid) const override;
     void handleMove(const MoveOperation &op, std::shared_ptr<vespalib::IDestructorCallback> doneCtx) override;
     void handleCompactLidSpace(const CompactLidSpaceOperation &op, std::shared_ptr<vespalib::IDestructorCallback> compact_done_context) override;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.cpp
@@ -1,16 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "i_disk_mem_usage_notifier.h"
-#include "iclusterstatechangednotifier.h"
-#include "imaintenancejobrunner.h"
 #include "lid_space_compaction_job.h"
-#include <vespa/searchcore/proton/common/eventlogger.h>
-#include <vespa/vespalib/util/destructor_callbacks.h>
-#include <vespa/vespalib/util/gate.h>
-#include <cassert>
-
-#include <vespa/log/log.h>
-LOG_SETUP(".proton.server.lid_space_compaction_job");
+#include "i_document_scan_iterator.h"
+#include "ifrozenbuckethandler.h"
+#include "i_lid_space_compaction_handler.h"
+#include "i_operation_storer.h"
+#include <vespa/searchcore/proton/feedoperation/moveoperation.h>
 
 using search::DocumentMetaData;
 using search::LidUsageStats;
@@ -18,33 +13,11 @@ using search::LidUsageStats;
 namespace proton {
 
 bool
-LidSpaceCompactionJob::hasTooMuchLidBloat(const LidUsageStats &stats) const
-{
-    return (stats.getLidBloat() >= _cfg.getAllowedLidBloat() &&
-            stats.getLidBloatFactor() >= _cfg.getAllowedLidBloatFactor() &&
-            stats.getLidLimit() > stats.getLowestFreeLid());
-}
-
-bool
-LidSpaceCompactionJob::shouldRestartScanDocuments(const LidUsageStats &stats) const
-{
-    return (stats.getUsedLids() + _cfg.getAllowedLidBloat()) < stats.getHighestUsedLid() &&
-        stats.getLowestFreeLid() < stats.getHighestUsedLid();
-}
-
-DocumentMetaData
-LidSpaceCompactionJob::getNextDocument(const LidUsageStats &stats)
-{
-    DocumentMetaData document = _scanItr->next(std::max(stats.getLowestFreeLid(), stats.getUsedLids()), _retryFrozenDocument);
-    _retryFrozenDocument = false;
-    return document;
-}
-
-bool
 LidSpaceCompactionJob::scanDocuments(const LidUsageStats &stats)
 {
     if (_scanItr->valid()) {
-        DocumentMetaData document = getNextDocument(stats);
+        DocumentMetaData document = getNextDocument(stats, _retryFrozenDocument);
+        _retryFrozenDocument = false;
         if (document.valid()) {
             IFrozenBucketHandler::ExclusiveBucketGuard::UP bucketGuard = _frozenHandler.acquireExclusiveBucket(document.bucketId);
             if ( ! bucketGuard ) {
@@ -53,7 +26,7 @@ LidSpaceCompactionJob::scanDocuments(const LidUsageStats &stats)
                 _retryFrozenDocument = true;
                 return true;
             } else {
-                MoveOperation::UP op = _handler.createMoveOperation(document, stats.getLowestFreeLid());
+                std::unique_ptr<MoveOperation> op = _handler.createMoveOperation(document, stats.getLowestFreeLid());
                 if ( ! op ) {
                     return false;
                 }
@@ -66,40 +39,7 @@ LidSpaceCompactionJob::scanDocuments(const LidUsageStats &stats)
             }
         }
     }
-    if (!_scanItr->valid()){
-        if (shouldRestartScanDocuments(_handler.getLidStatus())) {
-            _scanItr = _handler.getIterator();
-        } else {
-            _scanItr = IDocumentScanIterator::UP();
-            _shouldCompactLidSpace = true;
-        }
-    }
-    return false; // more work to do (scan documents or compact lid space)
-}
-
-void
-LidSpaceCompactionJob::compactLidSpace(const LidUsageStats &stats)
-{
-    uint32_t wantedLidLimit = stats.getHighestUsedLid() + 1;
-    CompactLidSpaceOperation op(_handler.getSubDbId(), wantedLidLimit);
-    vespalib::Gate gate;
-    auto commit_result = _opStorer.appendAndCommitOperation(op, std::make_shared<vespalib::GateCallback>(gate));
-    gate.await();
-    _handler.handleCompactLidSpace(op, std::make_shared<vespalib::KeepAlive<decltype(commit_result)>>(std::move(commit_result)));
-    EventLogger::lidSpaceCompactionComplete(_handler.getName(), wantedLidLimit);
-    _shouldCompactLidSpace = false;
-}
-
-bool
-LidSpaceCompactionJob::remove_batch_is_ongoing() const
-{
-    return _ops_rate_tracker->remove_batch_above_threshold();
-}
-
-bool
-LidSpaceCompactionJob::remove_is_ongoing() const
-{
-    return _ops_rate_tracker->remove_above_threshold();
+    return scanDocumentsPost();
 }
 
 LidSpaceCompactionJob::LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
@@ -110,94 +50,13 @@ LidSpaceCompactionJob::LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionC
                                              const BlockableMaintenanceJobConfig &blockableConfig,
                                              IClusterStateChangedNotifier &clusterStateChangedNotifier,
                                              bool nodeRetired)
-    : BlockableMaintenanceJob("lid_space_compaction." + handler.getName(),
-            config.getDelay(), config.getInterval(), blockableConfig),
-      _cfg(config),
-      _handler(handler),
-      _opStorer(opStorer),
+    : LidSpaceCompactionJobBase(config, handler, opStorer, diskMemUsageNotifier,
+                                blockableConfig, clusterStateChangedNotifier, nodeRetired),
       _frozenHandler(frozenHandler),
-      _scanItr(),
-      _retryFrozenDocument(false),
-      _shouldCompactLidSpace(false),
-      _diskMemUsageNotifier(diskMemUsageNotifier),
-      _clusterStateChangedNotifier(clusterStateChangedNotifier),
-      _ops_rate_tracker(std::make_shared<RemoveOperationsRateTracker>(config.get_remove_batch_block_rate(),
-                                                                      config.get_remove_block_rate())),
-      _is_disabled(false)
+      _retryFrozenDocument(false)
 {
-    _diskMemUsageNotifier.addDiskMemUsageListener(this);
-    _clusterStateChangedNotifier.addClusterStateChangedHandler(this);
-    if (nodeRetired) {
-        setBlocked(BlockedReason::CLUSTER_STATE);
-    }
-    handler.set_operation_listener(_ops_rate_tracker);
 }
 
-LidSpaceCompactionJob::~LidSpaceCompactionJob()
-{
-    _clusterStateChangedNotifier.removeClusterStateChangedHandler(this);
-    _diskMemUsageNotifier.removeDiskMemUsageListener(this);
-}
+LidSpaceCompactionJob::~LidSpaceCompactionJob() = default;
 
-bool
-LidSpaceCompactionJob::run()
-{
-    if (isBlocked()) {
-        return true; // indicate work is done since no work can be done
-    }
-    LidUsageStats stats = _handler.getLidStatus();
-    if (remove_batch_is_ongoing()) {
-        // Note that we don't set the job as blocked as the decision to un-block it is not driven externally.
-        LOG(info, "%s: Lid space compaction is disabled while remove batch (delete buckets) is ongoing",
-            _handler.getName().c_str());
-        _is_disabled = true;
-        return true;
-    }
-    if (remove_is_ongoing()) {
-        // Note that we don't set the job as blocked as the decision to un-block it is not driven externally.
-        LOG(info, "%s: Lid space compaction is disabled while remove operations are ongoing",
-            _handler.getName().c_str());
-        _is_disabled = true;
-        return true;
-    }
-    if (_is_disabled) {
-        LOG(info, "%s: Lid space compaction is re-enabled as remove operations are no longer ongoing",
-            _handler.getName().c_str());
-        _is_disabled = false;
-    }
-    if (_scanItr) {
-        return scanDocuments(stats);
-    } else if (_shouldCompactLidSpace) {
-        compactLidSpace(stats);
-    } else if (hasTooMuchLidBloat(stats)) {
-        assert(!_scanItr);
-        _scanItr = _handler.getIterator();
-        return scanDocuments(stats);
-    }
-    return true;
 }
-
-void
-LidSpaceCompactionJob::notifyDiskMemUsage(DiskMemUsageState state)
-{
-    // Called by master write thread
-    internalNotifyDiskMemUsage(state);
-}
-
-void
-LidSpaceCompactionJob::notifyClusterStateChanged(const IBucketStateCalculator::SP &newCalc)
-{
-    // Called by master write thread
-    bool nodeRetired = newCalc->nodeRetired();
-    if (!nodeRetired) {
-        if (isBlocked(BlockedReason::CLUSTER_STATE)) {
-            LOG(info, "%s: Lid space compaction is un-blocked as node is no longer retired", _handler.getName().c_str());
-            unBlock(BlockedReason::CLUSTER_STATE);
-        }
-    } else {
-        LOG(info, "%s: Lid space compaction is blocked as node is retired", _handler.getName().c_str());
-        setBlocked(BlockedReason::CLUSTER_STATE);
-    }
-}
-
-} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
@@ -1,21 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "blockable_maintenance_job.h"
-#include "document_db_maintenance_config.h"
-#include "i_disk_mem_usage_listener.h"
-#include "i_lid_space_compaction_handler.h"
-#include "i_operation_storer.h"
-#include "ibucketstatecalculator.h"
-#include "iclusterstatechangedhandler.h"
-#include "iclusterstatechangednotifier.h"
-#include "remove_operations_rate_tracker.h"
+#include "lid_space_compaction_job_base.h"
 
 namespace proton {
 
 class IFrozenBucketHandler;
-class IDiskMemUsageNotifier;
-class IClusterStateChangedNotifier;
 
 /**
  * Job that regularly checks whether lid space compaction should be performed
@@ -24,30 +14,13 @@ class IClusterStateChangedNotifier;
  * Compaction is handled by moving documents from high lids to low free lids.
  * A handler is typically working over a single document sub db.
  */
-class LidSpaceCompactionJob : public BlockableMaintenanceJob,
-                              public IDiskMemUsageListener,
-                              public IClusterStateChangedHandler
+class LidSpaceCompactionJob : public LidSpaceCompactionJobBase
 {
 private:
-    const DocumentDBLidSpaceCompactionConfig _cfg;
-    ILidSpaceCompactionHandler   &_handler;
-    IOperationStorer             &_opStorer;
     IFrozenBucketHandler         &_frozenHandler;
-    IDocumentScanIterator::UP     _scanItr;
     bool                          _retryFrozenDocument;
-    bool                          _shouldCompactLidSpace;
-    IDiskMemUsageNotifier        &_diskMemUsageNotifier;
-    IClusterStateChangedNotifier &_clusterStateChangedNotifier;
-    std::shared_ptr<RemoveOperationsRateTracker> _ops_rate_tracker;
-    bool _is_disabled;
 
-    bool hasTooMuchLidBloat(const search::LidUsageStats &stats) const;
-    bool shouldRestartScanDocuments(const search::LidUsageStats &stats) const;
-    search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats);
-    bool scanDocuments(const search::LidUsageStats &stats);
-    void compactLidSpace(const search::LidUsageStats &stats);
-    bool remove_batch_is_ongoing() const;
-    bool remove_is_ongoing() const;
+    bool scanDocuments(const search::LidUsageStats &stats) override;
 
 public:
     LidSpaceCompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
@@ -58,16 +31,7 @@ public:
                           const BlockableMaintenanceJobConfig &blockableConfig,
                           IClusterStateChangedNotifier &clusterStateChangedNotifier,
                           bool nodeRetired);
-    ~LidSpaceCompactionJob();
-
-    // Implements IDiskMemUsageListener
-    void notifyDiskMemUsage(DiskMemUsageState state) override;
-
-    // Implements IClusterStateChangedNofifier
-    void notifyClusterStateChanged(const IBucketStateCalculator::SP &newCalc) override;
-
-    // Implements IMaintenanceJob
-    bool run() override;
+    ~LidSpaceCompactionJob() override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
@@ -1,0 +1,180 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "lid_space_compaction_job_base.h"
+#include "imaintenancejobrunner.h"
+#include "i_document_scan_iterator.h"
+#include "i_lid_space_compaction_handler.h"
+#include "i_operation_storer.h"
+#include "remove_operations_rate_tracker.h"
+#include "i_disk_mem_usage_notifier.h"
+#include "iclusterstatechangednotifier.h"
+#include <vespa/searchcore/proton/feedoperation/compact_lid_space_operation.h>
+#include <vespa/searchcore/proton/common/eventlogger.h>
+#include <vespa/vespalib/util/destructor_callbacks.h>
+#include <vespa/vespalib/util/gate.h>
+#include <cassert>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".proton.server.lid_space_compaction_job");
+
+using search::DocumentMetaData;
+using search::LidUsageStats;
+
+namespace proton {
+
+bool
+LidSpaceCompactionJobBase::hasTooMuchLidBloat(const LidUsageStats &stats) const
+{
+    return (stats.getLidBloat() >= _cfg.getAllowedLidBloat() &&
+            stats.getLidBloatFactor() >= _cfg.getAllowedLidBloatFactor() &&
+            stats.getLidLimit() > stats.getLowestFreeLid());
+}
+
+bool
+LidSpaceCompactionJobBase::shouldRestartScanDocuments(const LidUsageStats &stats) const
+{
+    return (stats.getUsedLids() + _cfg.getAllowedLidBloat()) < stats.getHighestUsedLid() &&
+        stats.getLowestFreeLid() < stats.getHighestUsedLid();
+}
+
+DocumentMetaData
+LidSpaceCompactionJobBase::getNextDocument(const LidUsageStats &stats, bool retryLastDocument)
+{
+    return _scanItr->next(std::max(stats.getLowestFreeLid(), stats.getUsedLids()), retryLastDocument);
+}
+
+bool
+LidSpaceCompactionJobBase::scanDocumentsPost()
+{
+    if (!_scanItr->valid()) {
+        if (shouldRestartScanDocuments(_handler.getLidStatus())) {
+            _scanItr = _handler.getIterator();
+        } else {
+            _scanItr = IDocumentScanIterator::UP();
+            _shouldCompactLidSpace = true;
+        }
+    }
+    return false; // more work to do (scan documents or compact lid space)
+}
+
+void
+LidSpaceCompactionJobBase::compactLidSpace(const LidUsageStats &stats)
+{
+    uint32_t wantedLidLimit = stats.getHighestUsedLid() + 1;
+    CompactLidSpaceOperation op(_handler.getSubDbId(), wantedLidLimit);
+    vespalib::Gate gate;
+    auto commit_result = _opStorer.appendAndCommitOperation(op, std::make_shared<vespalib::GateCallback>(gate));
+    gate.await();
+    _handler.handleCompactLidSpace(op, std::make_shared<vespalib::KeepAlive<decltype(commit_result)>>(std::move(commit_result)));
+    EventLogger::lidSpaceCompactionComplete(_handler.getName(), wantedLidLimit);
+    _shouldCompactLidSpace = false;
+}
+
+bool
+LidSpaceCompactionJobBase::remove_batch_is_ongoing() const
+{
+    return _ops_rate_tracker->remove_batch_above_threshold();
+}
+
+bool
+LidSpaceCompactionJobBase::remove_is_ongoing() const
+{
+    return _ops_rate_tracker->remove_above_threshold();
+}
+
+LidSpaceCompactionJobBase::LidSpaceCompactionJobBase(const DocumentDBLidSpaceCompactionConfig &config,
+                                             ILidSpaceCompactionHandler &handler,
+                                             IOperationStorer &opStorer,
+                                             IDiskMemUsageNotifier &diskMemUsageNotifier,
+                                             const BlockableMaintenanceJobConfig &blockableConfig,
+                                             IClusterStateChangedNotifier &clusterStateChangedNotifier,
+                                             bool nodeRetired)
+    : BlockableMaintenanceJob("lid_space_compaction." + handler.getName(),
+            config.getDelay(), config.getInterval(), blockableConfig),
+      _cfg(config),
+      _handler(handler),
+      _opStorer(opStorer),
+      _scanItr(),
+      _diskMemUsageNotifier(diskMemUsageNotifier),
+      _clusterStateChangedNotifier(clusterStateChangedNotifier),
+      _ops_rate_tracker(std::make_shared<RemoveOperationsRateTracker>(config.get_remove_batch_block_rate(),
+                                                                      config.get_remove_block_rate())),
+      _is_disabled(false),
+      _shouldCompactLidSpace(false)
+{
+    _diskMemUsageNotifier.addDiskMemUsageListener(this);
+    _clusterStateChangedNotifier.addClusterStateChangedHandler(this);
+    if (nodeRetired) {
+        setBlocked(BlockedReason::CLUSTER_STATE);
+    }
+    handler.set_operation_listener(_ops_rate_tracker);
+}
+
+LidSpaceCompactionJobBase::~LidSpaceCompactionJobBase()
+{
+    _clusterStateChangedNotifier.removeClusterStateChangedHandler(this);
+    _diskMemUsageNotifier.removeDiskMemUsageListener(this);
+}
+
+bool
+LidSpaceCompactionJobBase::run()
+{
+    if (isBlocked()) {
+        return true; // indicate work is done since no work can be done
+    }
+    LidUsageStats stats = _handler.getLidStatus();
+    if (remove_batch_is_ongoing()) {
+        // Note that we don't set the job as blocked as the decision to un-block it is not driven externally.
+        LOG(info, "%s: Lid space compaction is disabled while remove batch (delete buckets) is ongoing",
+            _handler.getName().c_str());
+        _is_disabled = true;
+        return true;
+    }
+    if (remove_is_ongoing()) {
+        // Note that we don't set the job as blocked as the decision to un-block it is not driven externally.
+        LOG(info, "%s: Lid space compaction is disabled while remove operations are ongoing",
+            _handler.getName().c_str());
+        _is_disabled = true;
+        return true;
+    }
+    if (_is_disabled) {
+        LOG(info, "%s: Lid space compaction is re-enabled as remove operations are no longer ongoing",
+            _handler.getName().c_str());
+        _is_disabled = false;
+    }
+    if (_scanItr) {
+        return scanDocuments(stats);
+    } else if (_shouldCompactLidSpace) {
+        compactLidSpace(stats);
+    } else if (hasTooMuchLidBloat(stats)) {
+        assert(!_scanItr);
+        _scanItr = _handler.getIterator();
+        return scanDocuments(stats);
+    }
+    return true;
+}
+
+void
+LidSpaceCompactionJobBase::notifyDiskMemUsage(DiskMemUsageState state)
+{
+    // Called by master write thread
+    internalNotifyDiskMemUsage(state);
+}
+
+void
+LidSpaceCompactionJobBase::notifyClusterStateChanged(const IBucketStateCalculator::SP &newCalc)
+{
+    // Called by master write thread
+    bool nodeRetired = newCalc->nodeRetired();
+    if (!nodeRetired) {
+        if (isBlocked(BlockedReason::CLUSTER_STATE)) {
+            LOG(info, "%s: Lid space compaction is un-blocked as node is no longer retired", _handler.getName().c_str());
+            unBlock(BlockedReason::CLUSTER_STATE);
+        }
+    } else {
+        LOG(info, "%s: Lid space compaction is blocked as node is retired", _handler.getName().c_str());
+        setBlocked(BlockedReason::CLUSTER_STATE);
+    }
+}
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
@@ -1,0 +1,72 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "blockable_maintenance_job.h"
+#include "document_db_maintenance_config.h"
+#include "i_disk_mem_usage_listener.h"
+#include "iclusterstatechangedhandler.h"
+#include <vespa/searchlib/common/idocumentmetastore.h>
+
+namespace proton {
+    class IDiskMemUsageNotifier;
+    class IClusterStateChangedNotifier;
+    class IOperationStorer;
+    class ILidSpaceCompactionHandler;
+    class IDocumentScanIterator;
+    class RemoveOperationsRateTracker;
+}
+
+namespace proton {
+
+/**
+ * Job that regularly checks whether lid space compaction should be performed
+ * for the given handler.
+ *
+ * Compaction is handled by moving documents from high lids to low free lids.
+ * A handler is typically working over a single document sub db.
+ */
+class LidSpaceCompactionJobBase : public BlockableMaintenanceJob,
+                                  public IDiskMemUsageListener,
+                                  public IClusterStateChangedHandler
+{
+private:
+    const DocumentDBLidSpaceCompactionConfig _cfg;
+protected:
+    ILidSpaceCompactionHandler   &_handler;
+    IOperationStorer             &_opStorer;
+    std::unique_ptr<IDocumentScanIterator>     _scanItr;
+private:
+    IDiskMemUsageNotifier        &_diskMemUsageNotifier;
+    IClusterStateChangedNotifier &_clusterStateChangedNotifier;
+    std::shared_ptr<RemoveOperationsRateTracker> _ops_rate_tracker;
+    bool                          _is_disabled;
+    bool                          _shouldCompactLidSpace;
+
+
+    bool hasTooMuchLidBloat(const search::LidUsageStats &stats) const;
+    bool shouldRestartScanDocuments(const search::LidUsageStats &stats) const;
+    virtual bool scanDocuments(const search::LidUsageStats &stats) = 0;
+    void compactLidSpace(const search::LidUsageStats &stats);
+    bool remove_batch_is_ongoing() const;
+    bool remove_is_ongoing() const;
+protected:
+    search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats, bool retryLastDocument);
+    bool scanDocumentsPost();
+public:
+    LidSpaceCompactionJobBase(const DocumentDBLidSpaceCompactionConfig &config,
+                              ILidSpaceCompactionHandler &handler,
+                              IOperationStorer &opStorer,
+                              IDiskMemUsageNotifier &diskMemUsageNotifier,
+                              const BlockableMaintenanceJobConfig &blockableConfig,
+                              IClusterStateChangedNotifier &clusterStateChangedNotifier,
+                              bool nodeRetired);
+    ~LidSpaceCompactionJobBase() override;
+
+    void notifyDiskMemUsage(DiskMemUsageState state) override;
+    void notifyClusterStateChanged(const IBucketStateCalculator::SP &newCalc) override;
+    bool run() override;
+};
+
+} // namespace proton
+

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.cpp
@@ -1,0 +1,70 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "lid_space_compaction_job_take2.h"
+#include "i_document_scan_iterator.h"
+#include "i_lid_space_compaction_handler.h"
+#include "i_operation_storer.h"
+#include <vespa/searchcore/proton/feedoperation/moveoperation.h>
+#include <vespa/persistence/spi/bucket_tasks.h>
+#include <vespa/vespalib/util/destructor_callbacks.h>
+#include <cassert>
+
+using search::DocumentMetaData;
+using search::LidUsageStats;
+using storage::spi::makeBucketTask;
+using storage::spi::Bucket;
+
+namespace proton::lidspace {
+
+bool
+CompactionJob::scanDocuments(const LidUsageStats &stats)
+{
+    if (_scanItr->valid()) {
+        DocumentMetaData document = getNextDocument(stats, false);
+        if (document.valid()) {
+            Bucket metaBucket(document::Bucket(document::BucketSpace::placeHolder(), document.bucketId));
+            IDestructorCallback::SP context = _moveOpsLimiter->beginOperation();
+            auto failed = _bucketExecutor.execute(metaBucket, makeBucketTask([this, meta=document, opsTracker=std::move(context)] (const Bucket & bucket, std::shared_ptr<IDestructorCallback> onDone) {
+                assert(bucket.getBucketId() == meta.bucketId);
+                using DoneContext = vespalib::KeepAlive<std::pair<IDestructorCallback::SP, IDestructorCallback::SP>>;
+                moveDocument(meta, std::make_shared<DoneContext>(std::make_pair(std::move(opsTracker), std::move(onDone))));
+            }));
+            if (failed) return false;
+            if (isBlocked(BlockedReason::OUTSTANDING_OPS)) {
+                return true;
+            }
+        }
+    }
+    return scanDocumentsPost();
+}
+
+void
+CompactionJob::moveDocument(const search::DocumentMetaData & metaThen, std::shared_ptr<IDestructorCallback> context) {
+    search::DocumentMetaData metaNow = _scanItr->getMetaData(metaThen.lid);
+    if (metaNow.lid != metaThen.lid) return;
+    if (metaNow.bucketId != metaThen.bucketId) return;
+
+    MoveOperation::UP op = _handler.createMoveOperation(metaNow, _handler.getLidStatus().getLowestFreeLid());
+    if (!op) return;
+
+    _opStorer.appendOperation(*op, context);
+    _handler.handleMove(*op, std::move(context));
+}
+
+CompactionJob::CompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
+                             ILidSpaceCompactionHandler &handler,
+                             IOperationStorer &opStorer,
+                             BucketExecutor & bucketExecutor,
+                             IDiskMemUsageNotifier &diskMemUsageNotifier,
+                             const BlockableMaintenanceJobConfig &blockableConfig,
+                             IClusterStateChangedNotifier &clusterStateChangedNotifier,
+                             bool nodeRetired)
+    : LidSpaceCompactionJobBase(config, handler, opStorer, diskMemUsageNotifier,
+                                blockableConfig, clusterStateChangedNotifier, nodeRetired),
+      _bucketExecutor(bucketExecutor)
+{
+}
+
+CompactionJob::~CompactionJob() = default;
+
+} // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
@@ -1,0 +1,45 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "lid_space_compaction_job_base.h"
+
+namespace storage::spi { class BucketExecutor;}
+namespace proton {
+    class IDiskMemUsageNotifier;
+    class IClusterStateChangedNotifier;
+}
+
+namespace proton::lidspace {
+
+/**
+ * Job that regularly checks whether lid space compaction should be performed
+ * for the given handler.
+ *
+ * Compaction is handled by moving documents from high lids to low free lids.
+ * A handler is typically working over a single document sub db.
+ */
+class CompactionJob : public LidSpaceCompactionJobBase
+{
+private:
+    using BucketExecutor = storage::spi::BucketExecutor;
+    using IDestructorCallback = vespalib::IDestructorCallback;
+    BucketExecutor               &_bucketExecutor;
+
+    bool scanDocuments(const search::LidUsageStats &stats) override;
+    void moveDocument(const search::DocumentMetaData & meta, std::shared_ptr<IDestructorCallback> onDone);
+
+public:
+    CompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
+                  ILidSpaceCompactionHandler &handler,
+                  IOperationStorer &opStorer,
+                  BucketExecutor & bucketExecutor,
+                  IDiskMemUsageNotifier &diskMemUsageNotifier,
+                  const BlockableMaintenanceJobConfig &blockableConfig,
+                  IClusterStateChangedNotifier &clusterStateChangedNotifier,
+                  bool nodeRetired);
+    ~CompactionJob() override;
+};
+
+} // namespace proton
+

--- a/storage/src/tests/distributor/btree_bucket_database_test.cpp
+++ b/storage/src/tests/distributor/btree_bucket_database_test.cpp
@@ -1,7 +1,7 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "bucketdatabasetest.h"
 #include <vespa/storage/bucketdb/btree_bucket_database.h>
-#include <tests/distributor/bucketdatabasetest.h>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/storage/src/tests/distributor/bucketdatabasetest.cpp
+++ b/storage/src/tests/distributor/bucketdatabasetest.cpp
@@ -1,4 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 #include "bucketdatabasetest.h"
 #include <vespa/vespalib/util/benchmark_timer.h>
 #include <chrono>


### PR DESCRIPTION
@geirst pr @toregge PR
This refactor the lid space job into a base class and the current based on frozen bucket, and the new that uses the content layer to acquire the proper bucket lock. No new code is wired in.
I will refactor the test in a separate PR.