### PR TITLE
Skip, don't fail, if model can't be imported when put under models dir

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/configmodelview/ImportedMlModels.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/configmodelview/ImportedMlModels.java
@@ -1,7 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.rankingexpression.importer.configmodelview;
 
-import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.path.Path;
 
 import java.io.File;
@@ -11,7 +10,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Level;
 
 /**
  * All models imported from the models/ directory in the application package.

--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/configmodelview/ImportedMlModels.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/configmodelview/ImportedMlModels.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
 
 /**
  * All models imported from the models/ directory in the application package.
@@ -19,6 +20,8 @@ import java.util.Optional;
  * @author bratseth
  */
 public class ImportedMlModels {
+
+    private static final Logger log = Logger.getLogger(ImportedMlModels.class.getName());
 
     /** All imported models, indexed by their names */
     private final Map<String, ImportedMlModel> importedModels;
@@ -66,7 +69,13 @@ public class ImportedMlModels {
                 if (existing != null)
                     throw new IllegalArgumentException("The models in " + child + " and " + existing.source() +
                                                        " both resolve to the model name '" + name + "'");
-                models.put(name, importer.get().importModel(name, child));
+                try {
+                    ImportedMlModel importedModel = importer.get().importModel(name, child);
+                    models.put(name, importedModel);
+                } catch (RuntimeException e) {
+                    log.warning("Skipping import of model " + name + " as an exception occurred during import. " +
+                            "Error: " + e.getMessage());
+                }
             }
             else {
                 importRecursively(child, models, importers);


### PR DESCRIPTION
@bratseth For discussion. Ref https://github.com/vespa-engine/vespa/issues/14845. Models that are put under the `models` directory are automatically imported, and made available for instance for stateless evaluation. This uses our "old" import code that converts to Vespa expressions. However, a model that can be imported fine with ONNX Runtime, but is not supported by our code, will fail deployment if put in this directory.

This logs a warning instead and skips "global" import of the offending model. The model can still be used for onnx runtime however.

Should the deploy logger be used instead in this case?


