### PR TITLE
Revert "Depend on zstd tools"

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -239,7 +239,6 @@ Summary: Vespa - The open big data serving engine - base
 Requires: java-11-openjdk-devel
 Requires: perl
 Requires: perl-Getopt-Long
-Requires: zstd # Required for zstd tools used for inspection of access log files
 Requires(pre): shadow-utils
 
 %description base


### PR DESCRIPTION
Reverts vespa-engine/vespa#16191

Can't see exactly what's wrong, but building RPMs fail with:

error: line 242: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires: zstd # Required for zstd tools used for inspection of access log files