### PR TITLE
Revert "Depend on zstd tools [run-systemtest]"

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -239,10 +239,6 @@ Summary: Vespa - The open big data serving engine - base
 Requires: java-11-openjdk-devel
 Requires: perl
 Requires: perl-Getopt-Long
-
-# Required for zstd tools used for inspection of access log files
-Requires: zstd
-
 Requires(pre): shadow-utils
 
 %description base


### PR DESCRIPTION
Reverts vespa-engine/vespa#16194

Installation on Docker host fails:

host-sentinel: Error: Package: vespa-base-7.347.10-1.el7.x86_64 (vespa-rpms)
host-sentinel: Requires: zstd
host-sentinel: You could try using --skip-broken to work around the problem
host-sentinel: You could try running: rpm -Va --nofiles --nodigest