### PR TITLE
Add Vary header to CORS filters

### DIFF
--- a/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
+++ b/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
@@ -1,10 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.http.filter.security.cors;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.time.Duration;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -15,20 +12,21 @@ import java.util.TreeMap;
 class CorsLogic {
     private CorsLogic() {}
 
-    static final String CORS_PREFLIGHT_REQUEST_CACHE_TTL =  Long.toString(Duration.ofDays(7).getSeconds());
+    static final String CORS_PREFLIGHT_REQUEST_CACHE_TTL = Long.toString(Duration.ofDays(7).getSeconds());
 
     static final String ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
 
-    static final Map<String, String> ACCESS_CONTROL_HEADERS = ImmutableMap.of(
+    static final Map<String, String> ACCESS_CONTROL_HEADERS = Map.of(
             "Access-Control-Max-Age", CORS_PREFLIGHT_REQUEST_CACHE_TTL,
             "Access-Control-Allow-Headers", "Origin,Content-Type,Accept,Yahoo-Principal-Auth,Okta-Identity-Token,Okta-Access-Token,Okta-Refresh-Token",
-            "Access-Control-Allow-Methods", "OPTIONS,GET,PUT,DELETE,POST",
-            "Access-Control-Allow-Credentials", "true"
+            "Access-Control-Allow-Methods", "OPTIONS,GET,PUT,DELETE,POST,PATCH",
+            "Access-Control-Allow-Credentials", "true",
+            "Vary", "Origin"
     );
 
     static Map<String, String> createCorsResponseHeaders(String requestOriginHeader,
                                                          Set<String> allowedOrigins) {
-        if (requestOriginHeader == null) return Collections.emptyMap();
+        if (requestOriginHeader == null) return Map.of();
         TreeMap<String, String> headers = new TreeMap<>();
         allowedOrigins.stream()
                 .filter(allowedUrl -> matchesRequestOrigin(requestOriginHeader, allowedUrl))

--- a/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilter.java
+++ b/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilter.java
@@ -8,7 +8,6 @@ import com.yahoo.jdisc.http.filter.RequestView;
 import com.yahoo.jdisc.http.filter.SecurityResponseFilter;
 import com.yahoo.yolean.chain.Provides;
 
-import java.util.HashSet;
 import java.util.Set;
 
 
@@ -24,7 +23,7 @@ public class CorsResponseFilter extends AbstractResource implements SecurityResp
 
     @Inject
     public CorsResponseFilter(CorsFilterConfig config) {
-        this.allowedUrls = new HashSet<>(config.allowedUrls());
+        this.allowedUrls = Set.copyOf(config.allowedUrls());
     }
 
     @Override


### PR DESCRIPTION
Adds
* PATCH as allowed method
* `Vary: Origin` to control Control-Access-Max-Age cache; the filter only returns origin of the request, we want to force new pre-flight request if requested from another origin