### PR TITLE
Add config to cluster controller on whether it should block feed base…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -131,5 +131,19 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
         if (minNodeRatioPerGroup != null) {
             builder.min_node_ratio_per_group(minNodeRatioPerGroup);
         }
+
+        setDefaultClusterFeedBlockLimits(builder);
+    }
+
+    private static void setDefaultClusterFeedBlockLimits(FleetcontrollerConfig.Builder builder) {
+        // TODO: Override these based on resource-limits in services.xml (if they are specified).
+        // TODO: Choose other defaults when this is default enabled.
+        // Note: The resource categories must match the ones used in host info reporting
+        // between content nodes and cluster controller:
+        // storage/src/vespa/storage/persistence/filestorage/service_layer_host_info_reporter.cpp
+        builder.cluster_feed_block_limit.put("memory", 0.79);
+        builder.cluster_feed_block_limit.put("disk", 0.79);
+        builder.cluster_feed_block_limit.put("attribute-enum-store", 0.89);
+        builder.cluster_feed_block_limit.put("attribute-multi-value", 0.89);
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -81,13 +81,27 @@ public class FleetControllerClusterTest {
 
     @Test
     public void min_node_ratio_per_group_is_implicitly_zero_when_omitted() {
-        FleetcontrollerConfig.Builder builder = new FleetcontrollerConfig.Builder();
+        var config = getConfigForBasicCluster();
+        assertEquals(0.0, config.min_node_ratio_per_group(), 0.01);
+    }
+
+    @Test
+    public void default_cluster_feed_block_limits_are_set() {
+        var config = getConfigForBasicCluster();
+        var limits = config.cluster_feed_block_limit();
+        assertEquals(4, limits.size());
+        assertEquals(0.79, limits.get("memory"), 0.0001);
+        assertEquals(0.79, limits.get("disk"), 0.0001);
+        assertEquals(0.89, limits.get("attribute-enum-store"), 0.0001);
+        assertEquals(0.89, limits.get("attribute-multi-value"), 0.0001);
+    }
+
+    FleetcontrollerConfig getConfigForBasicCluster() {
+        var builder = new FleetcontrollerConfig.Builder();
         parse("<cluster id=\"storage\">\n" +
                 "  <documents/>\n" +
                 "</cluster>").
                 getConfig(builder);
-
-        FleetcontrollerConfig config = new FleetcontrollerConfig(builder);
-        assertEquals(0.0, config.min_node_ratio_per_group(), 0.01);
+        return new FleetcontrollerConfig(builder);
     }
 }

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -181,3 +181,19 @@ enable_two_phase_cluster_state_transitions bool default=false
 
 ## Deprecated - not used
 determine_buckets_from_bucket_space_metric bool default=true
+
+# If enabled, the cluster controller observes reported (categorized) resource usage from content nodes (via host info),
+# and decides whether external feed should be blocked (or unblocked) in the entire cluster.
+#
+# Each resource category has a limit, which is specified in cluster_feed_block_limit.
+# If one resource category from one content node is above the configured limit, feed is blocked.
+# This information is pushed to all distributor nodes via a new cluster state bundle.
+# The distributor nodes handle the actual feed blocking based on this information.
+enable_cluster_feed_block bool default=false
+
+# Contains all resource categories (key) with its corresponding feed block limit (value)
+# used when the cluster controller decides whether external feed should be blocked (or unblocked) in the entire cluster.
+#
+# The keys used must match the similar keys in the host info JSON structure.
+# All limits are numbers between 0.0 and 1.0.
+cluster_feed_block_limit{} double


### PR DESCRIPTION
…d on reported resource usage from content nodes.

Each resource category has a specified limit.
This is currently disabled by default.

@vekterli please review
@toregge FYI