### PR TITLE
Do not synchronize when bootstrapping tenants

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/tenant/TenantRepository.java
@@ -286,7 +286,7 @@ public class TenantRepository {
     }
 
     // Use when bootstrapping an existing tenant based on ZooKeeper data
-    protected synchronized void bootstrapTenant(TenantName tenantName) {
+    protected void bootstrapTenant(TenantName tenantName) {
         createTenant(tenantName, readCreatedTimeFromZooKeeper(tenantName));
     }
 


### PR DESCRIPTION
This should no longer be necessary, as backing for tenants
is a synchronized map.
