### PR TITLE
Remove the syncFeedView upcall as it has no purpose other than forcin…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -76,9 +76,6 @@ struct ConfigDir4 { static vespalib::string dir() { return TEST_PATH("cfg4"); } 
 
 struct MySubDBOwner : public IDocumentSubDBOwner
 {
-    uint32_t _syncCnt;
-    MySubDBOwner() : _syncCnt(0) {}
-    void syncFeedView() override { ++_syncCnt; }
     document::BucketSpace getBucketSpace() const override { return makeBucketSpace(); }
     vespalib::string getName() const override { return "owner"; }
     uint32_t getDistributionKey() const override { return -1; }
@@ -572,32 +569,6 @@ TEST_F("require that reconfigured attributes are accessible via feed view", Fast
 TEST_F("require that reconfigured attributes are accessible via feed view", SearchableFixture)
 {
     requireThatReconfiguredAttributesAreAccessibleViaFeedView(f);
-}
-
-template <typename Fixture>
-void
-requireThatOwnerIsNotifiedWhenFeedViewChanges(Fixture &f)
-{
-    EXPECT_EQUAL(0u, f.getOwner()._syncCnt);
-    f.basicReconfig(10);
-    EXPECT_EQUAL(1u, f.getOwner()._syncCnt);
-}
-
-TEST_F("require that owner is noticed when feed view changes", StoreOnlyFixture)
-{
-    requireThatOwnerIsNotifiedWhenFeedViewChanges(f);
-}
-
-TEST_F("require that owner is noticed when feed view changes", FastAccessFixture)
-{
-    requireThatOwnerIsNotifiedWhenFeedViewChanges(f);
-}
-
-TEST_F("require that owner is noticed when feed view changes", SearchableFixture)
-{
-    EXPECT_EQUAL(1u, f.getOwner()._syncCnt); // NOTE: init also notifies owner
-    f.basicReconfig(10);
-    EXPECT_EQUAL(2u, f.getOwner()._syncCnt);
 }
 
 template <typename Fixture>

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -911,6 +911,7 @@ DocumentDB::syncFeedView()
     IFeedView::SP oldFeedView(_feedView.get());
     IFeedView::SP newFeedView(_subDBs.getFeedView());
 
+    _maintenanceController.killJobs();
     _writeService.sync();
 
     _feedView.set(newFeedView);

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -472,6 +472,7 @@ DocumentDB::applyConfig(DocumentDBConfig::SP configSnapshot, SerialNum serialNum
             // Changes applied while online should not trigger reprocessing
             assert(_subDBs.getReprocessingRunner().empty());
         }
+        syncFeedView();
     }
     if (params.shouldIndexManagerChange()) {
         setIndexSchema(*configSnapshot, serialNum);

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -200,6 +200,8 @@ private:
      */
     void tearDownReferences();
 
+    void syncFeedView();
+
     template <typename FunctionType>
     inline void masterExecute(FunctionType &&function);
 
@@ -383,7 +385,6 @@ public:
     /*
      * Implements IDocumentSubDBOwner
      */
-    void syncFeedView() override;
     document::BucketSpace getBucketSpace() const override;
     vespalib::string getName() const override;
     uint32_t getDistributionKey() const override;

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
@@ -274,7 +274,6 @@ FastAccessDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const
             reconfigureAttributeMetrics(*newMgr, *oldMgr);
         }
         _iFeedView.set(_fastAccessFeedView.get());
-        _owner.syncFeedView();
     }
     return tasks;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/i_document_subdb_owner.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_document_subdb_owner.h
@@ -15,7 +15,6 @@ class IDocumentSubDBOwner
 {
 public:
     virtual ~IDocumentSubDBOwner() {}
-    virtual void syncFeedView() = 0;
     virtual document::BucketSpace getBucketSpace() const = 0;
     virtual vespalib::string getName() const = 0;
     virtual uint32_t getDistributionKey() const = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -64,7 +64,6 @@ SearchableDocSubDB::syncViews()
 {
     _iSearchView.set(_rSearchView.get());
     _iFeedView.set(_rFeedView.get());
-    _owner.syncFeedView();
 }
 
 SerialNum

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -411,7 +411,6 @@ StoreOnlyDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const 
     assert(_writeService.master().isCurrentThread());
     reconfigure(newConfigSnapshot.getStoreConfig());
     initFeedView(newConfigSnapshot);
-    _owner.syncFeedView();
     return IReprocessingTask::List();
 }
 


### PR DESCRIPTION
…g it more than necessary.

Instead do it in the main documentdb after all subds are reconfigured.

@toregge and @geirst PR