### PR TITLE
Revert "32m merge chunk size"

### DIFF
--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -41,7 +41,7 @@ common_merge_chain_optimalization_minimum_size int default=64 restart
 ##
 ## Default is set to 4 MB.
 ## Note that this will gradually be increased to reach stor-distributormanager:splitsize which is currently at 32M
-bucket_merge_chunk_size int default=33554432 restart
+bucket_merge_chunk_size int default=4190208 restart
 
 ## When merging, it is possible to send more metadata than needed in order to
 ## let local nodes in merge decide which entries fits best to add this time

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -245,7 +245,7 @@ public class Flags {
             ZONE_ID, APPLICATION_ID);
 
     public static final UnboundIntFlag MERGE_CHUNK_SIZE = defineIntFlag(
-            "merge-chunk-size", 0x2000000,
+            "merge-chunk-size", 0x400000,
             List.of("baldersheim"), "2020-12-02", "2021-02-01",
             "Size of baldersheim buffer in service layer",
             "Takes effect at redeployment",


### PR DESCRIPTION
Reverts vespa-engine/vespa#16242

Looks like a unit test needs to be updated:

 09:39:22  java.lang.AssertionError: expected:<4194304> but was:<33554432>
09:39:22 	at org.junit.Assert.fail(Assert.java:88)
09:39:22 	at org.junit.Assert.failNotEquals(Assert.java:834)
09:39:22 	at org.junit.Assert.assertEquals(Assert.java:645)
09:39:22 	at org.junit.Assert.assertEquals(Assert.java:631)
09:39:22 	at com.yahoo.vespa.config.server.ModelContextImplTest.testModelContextTest(ModelContextImplTest.java:98) 