### PR TITLE
Propagate type of transformer token helper functions

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/TokenTransformer.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/TokenTransformer.java
@@ -186,7 +186,7 @@ public class TokenTransformer extends ExpressionTransformer<RankProfileTransform
         }
     }
 
-    private TensorType createTensorType(String featureName, ExpressionNode argument) {
+    public static TensorType createTensorType(String featureName, ExpressionNode argument) {
         try {
             int length = Integer.parseInt(argument.toString());
             return new TensorType.Builder(TensorType.Value.FLOAT).indexed("d0", 1).indexed("d1", length).build();

--- a/config-model/src/test/integration/onnx-model/schemas/test.sd
+++ b/config-model/src/test/integration/onnx-model/schemas/test.sd
@@ -99,6 +99,15 @@ search test {
         }
     }
 
+    rank-profile test_dynamic_model_with_transformer_tokens {
+        function my_function() {
+            expression: tokenTypeIds(2, attribute(document_field))
+        }
+        first-phase {
+            expression: onnx(dynamic_model){d0:0,d1:1}
+        }
+    }
+
     rank-profile test_unbound_model {
         function my_function() {
             expression: tensor(d0[1],d1[2])(d1)
@@ -107,6 +116,5 @@ search test {
             expression: onnx(unbound_model){d0:0,d1:1}
         }
     }
-
 
 }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
@@ -113,7 +113,7 @@ public class RankingExpressionWithOnnxModelTestCase {
         RankProfilesConfig.Builder builder = new RankProfilesConfig.Builder();
         ((RankProfilesConfig.Producer) db).getConfig(builder);
         RankProfilesConfig config = new RankProfilesConfig(builder);
-        assertEquals(8, config.rankprofile().size());
+        assertEquals(9, config.rankprofile().size());
 
         assertEquals("test_model_config", config.rankprofile(2).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(2).fef().property(0).name());
@@ -150,10 +150,14 @@ public class RankingExpressionWithOnnxModelTestCase {
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(6).fef().property(5).name());
         assertEquals("onnxModel(dynamic_model).my_output{d0:0, d1:2}", config.rankprofile(6).fef().property(5).value());
 
-        assertEquals("test_unbound_model", config.rankprofile(7).name());
-        assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(7).fef().property(0).name());
-        assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(7).fef().property(3).name());
-        assertEquals("onnxModel(unbound_model).my_output{d0:0, d1:1}", config.rankprofile(7).fef().property(3).value());
+        assertEquals("test_dynamic_model_with_transformer_tokens", config.rankprofile(7).name());
+        assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(7).fef().property(1).name());
+        assertEquals("tensor<float>(d0[1],d1[2])((if (d1 < rankingExpression(__token_length@-1993461420) + 2, 0, 1)))", config.rankprofile(7).fef().property(1).value());
+
+        assertEquals("test_unbound_model", config.rankprofile(8).name());
+        assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(8).fef().property(0).name());
+        assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(8).fef().property(3).name());
+        assertEquals("onnxModel(unbound_model).my_output{d0:0, d1:1}", config.rankprofile(8).fef().property(3).value());
 
 
     }


### PR DESCRIPTION
@bratseth Please review. Transformer token helper functions `tokenInputIds`, `tokenTypeIds`, and `tokenAttentionMask` are converted to Vespa expressions, but that happens after rank profile outputs are tested for their types. This is to make their types available during processing.

@thigm85 FYI.