### PR TITLE
always send distance threshold in NearestNeighborItem

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/NearestNeighborItem.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/NearestNeighborItem.java
@@ -80,14 +80,16 @@ public class NearestNeighborItem extends SimpleTaggableItem {
         putString(field, buffer);
         putString(queryTensorName, buffer);
         int approxNum = (approximate ? 1 : 0);
-        // should become always-true later:
-        boolean sendDistanceThreshold = (distanceThreshold < Double.POSITIVE_INFINITY);
+        // XXX remove this flag later, after backend change:
+        boolean sendDistanceThreshold = true;
         if (sendDistanceThreshold) {
+            // XXX and remove this bit:
             approxNum |= 0x40; // temporary flag bit
         }
         IntegerCompressor.putCompressedPositiveNumber(targetNumHits, buffer);
         IntegerCompressor.putCompressedPositiveNumber(approxNum, buffer);
         IntegerCompressor.putCompressedPositiveNumber(hnswExploreAdditionalHits, buffer);
+        // XXX and remove this if:
         if (sendDistanceThreshold) {
             buffer.putDouble(distanceThreshold);
         }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
next week we can probably change backend to assume the flag bit is set always.