### PR TITLE
Non-empty _pendingPrune will shortcut throttleing when doing flushAll.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -79,7 +79,7 @@ private:
     uint32_t initFlush(const IFlushHandler::SP &handler, const IFlushTarget::SP &target);
     void flushDone(const FlushContext &ctx, uint32_t taskId);
     bool canFlushMore(const std::unique_lock<std::mutex> &guard) const;
-    bool wait(vespalib::duration minimumWaitTimeIfReady);
+    bool wait(vespalib::duration minimumWaitTimeIfReady, bool considerPendingPrune);
     bool isFlushing(const std::lock_guard<std::mutex> &guard, const vespalib::string & name) const;
 
     friend class FlushTask;


### PR DESCRIPTION
That is done on triggerFlush and prepareForRestart. That is incorrect as it causes a memory surge.

@toregge PR