### PR TITLE
Add zstd as runtime dependency of Vespa

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -162,6 +162,7 @@ Requires: gdb
 Requires: nc
 Requires: net-tools
 Requires: unzip
+Requires: zstd
 %if 0%{?el7}
 Requires: llvm7.0
 Requires: vespa-icu >= 65.1.0-1


### PR DESCRIPTION
Vespa needs zstd binaries to inspect access logs. Some vespa-zstd binaries that are
installed in vespa-deps binary directory does not work (e.g zstdless assumes zstdcat is on path).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
