### PR TITLE
Enable zstd compression of hosted configserver/controller

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ConfigServerContainerModelBuilder.java
@@ -22,6 +22,8 @@ public class ConfigServerContainerModelBuilder extends ContainerModelBuilder {
         this.options = options;
     }
 
+    @Override protected boolean isConfigserver() { return true; }
+
     @Override
     public void doBuild(ContainerModel model, Element spec, ConfigModelContext modelContext) {
         ConfigserverCluster cluster = new ConfigserverCluster(modelContext.getParentProducer(), "configserver",

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -147,6 +147,8 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         this.httpServerEnabled = networking == Networking.enable;
     }
 
+    protected boolean isConfigserver() { return false; }
+
     @Override
     public List<ConfigModelId> handlesElements() {
         return configModelIds;
@@ -342,7 +344,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         List<Element> accessLogElements = getAccessLogElements(spec);
 
         for (Element accessLog : accessLogElements) {
-            AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog).ifPresent(cluster::addComponent);
+            AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog, isConfigserver()).ifPresent(cluster::addComponent);
         }
 
         if (accessLogElements.isEmpty() && deployState.getAccessLoggingEnabledByDefault())


### PR DESCRIPTION
Override configuration from services.xml if configserver/controller is
hosted. Disable old Vespa access log format + replace gzip compression
with std.

FYI @hmusum 