### PR TITLE
Bump interval of maintainers that collide often 

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.controller.dns;
 
 import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
+import com.yahoo.yolean.Exceptions;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,7 +83,7 @@ public class NameServiceQueue {
                 request.dispatchTo(nameService);
                 queue.requests.poll();
             } catch (Exception e) {
-                log.log(Level.WARNING, "Failed to execute " + request + ": " + e.getMessage() +
+                log.log(Level.WARNING, "Failed to execute " + request + ": " + Exceptions.toMessageString(e) +
                                           ", request will be retried");
             }
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -118,13 +118,13 @@ public class ControllerMaintenance extends AbstractComponent {
             this.outstandingChangeDeployer = duration(3, MINUTES);
             this.versionStatusUpdater = duration(3, MINUTES);
             this.readyJobsTrigger = duration(1, MINUTES);
-            this.deploymentMetricsMaintainer = duration(5, MINUTES);
+            this.deploymentMetricsMaintainer = duration(6, MINUTES);
             this.applicationOwnershipConfirmer = duration(12, HOURS);
-            this.systemUpgrader = duration(1, MINUTES);
-            this.jobRunner = duration(90, SECONDS);
+            this.systemUpgrader = duration(90, SECONDS);
+            this.jobRunner = duration(105, SECONDS);
             this.osUpgrader = duration(1, MINUTES);
             this.contactInformationMaintainer = duration(12, HOURS);
-            this.nameServiceDispatcher = duration(10, SECONDS);
+            this.nameServiceDispatcher = duration(30, SECONDS);
             this.costReportMaintainer = duration(2, HOURS);
             this.resourceMeterMaintainer = duration(1, MINUTES);
             this.cloudEventReporter = duration(30, MINUTES);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -121,7 +121,7 @@ public class ControllerMaintenance extends AbstractComponent {
             this.deploymentMetricsMaintainer = duration(6, MINUTES);
             this.applicationOwnershipConfirmer = duration(12, HOURS);
             this.systemUpgrader = duration(90, SECONDS);
-            this.jobRunner = duration(105, SECONDS);
+            this.jobRunner = duration(90, SECONDS);
             this.osUpgrader = duration(1, MINUTES);
             this.contactInformationMaintainer = duration(12, HOURS);
             this.nameServiceDispatcher = duration(30, SECONDS);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -118,7 +118,7 @@ public class ControllerMaintenance extends AbstractComponent {
             this.outstandingChangeDeployer = duration(3, MINUTES);
             this.versionStatusUpdater = duration(3, MINUTES);
             this.readyJobsTrigger = duration(1, MINUTES);
-            this.deploymentMetricsMaintainer = duration(6, MINUTES);
+            this.deploymentMetricsMaintainer = duration(10, MINUTES);
             this.applicationOwnershipConfirmer = duration(12, HOURS);
             this.systemUpgrader = duration(90, SECONDS);
             this.jobRunner = duration(90, SECONDS);


### PR DESCRIPTION
Looks like these collide often:

```
$ clog -C |grep -F 'Timed out after waiting PT1S to acquire lock' |  awk '{print $NF}' | sort | uniq -c | sort -k 1 -r
2702 '/controller/v1/locks/maintenanceJobLocks/NameServiceDispatcher'
 868 '/controller/v1/locks/maintenanceJobLocks/DeploymentMetricsMaintainer'
 328 '/controller/v1/locks/maintenanceJobLocks/SystemUpgrader'
  72 '/controller/v1/locks/maintenanceJobLocks/JobRunner'
  18 '/controller/v1/locks/maintenanceJobLocks/VersionStatusUpdater'
   8 '/controller/v1/locks/maintenanceJobLocks/MetricsReporter'
   6 '/controller/v1/locks/maintenanceJobLocks/ReadyJobsTrigger'
   2 '/controller/v1/locks/maintenanceJobLocks/OutstandingChangeDeployer'
   2 '/controller/v1/locks/maintenanceJobLocks/OsVersionStatusUpdater
```

@jonmv