### PR TITLE
reduce upper bound to speed up capacity check

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
@@ -161,7 +161,7 @@ public class CapacityChecker {
 
             int timesHostCanBeRemoved = 0;
             Optional<Node> unallocatedNode;
-            while (timesHostCanBeRemoved < 1000) { // Arbitrary upper bound
+            while (timesHostCanBeRemoved < 100) { // Arbitrary upper bound
                 unallocatedNode = tryAllocateNodes(nodeChildren.get(host), hosts, resourceMap, containedAllocations);
                 if (unallocatedNode.isEmpty()) {
                     timesHostCanBeRemoved++;


### PR DESCRIPTION
tested on real data from zones which are now timing out - 
this should be enough to get it working again