### PR TITLE
Recompute cluster state if set of resource exhaustions changes

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -346,12 +346,11 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
             return;
         }
         // TODO hysteresis to prevent oscillations!
-        // TODO also ensure we trigger if CC options have changed
         var calc = createResourceExhaustionCalculator();
         // Important: nodeInfo contains the _current_ host info _prior_ to newHostInfo being applied.
-        boolean previouslyExhausted = !calc.enumerateNodeResourceExhaustions(nodeInfo).isEmpty();
-        boolean nowExhausted        = !calc.resourceExhaustionsFromHostInfo(nodeInfo, newHostInfo).isEmpty();
-        if (previouslyExhausted != nowExhausted) {
+        var previouslyExhausted = calc.enumerateNodeResourceExhaustions(nodeInfo);
+        var nowExhausted        = calc.resourceExhaustionsFromHostInfo(nodeInfo, newHostInfo);
+        if (!previouslyExhausted.equals(nowExhausted)) {
             log.fine(() -> String.format("Triggering state recomputation due to change in cluster feed block: %s -> %s",
                                          previouslyExhausted, nowExhausted));
             stateChangeHandler.setStateChangedFlag();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
@@ -8,8 +8,10 @@ import com.yahoo.vespa.clustercontroller.core.hostinfo.HostInfo;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -43,7 +45,10 @@ public class ResourceExhaustionCalculator {
         if (exhaustions.size() > maxDescriptions) {
             description += String.format(" (... and %d more)", exhaustions.size() - maxDescriptions);
         }
-        return ClusterStateBundle.FeedBlock.blockedWithDescription(description);
+        // FIXME we currently will trigger a cluster state recomputation even if the number of
+        // exhaustions is greater than what is returned as part of the description. Though at
+        // that point, cluster state recomputations will be the least of your worries...!
+        return ClusterStateBundle.FeedBlock.blockedWith(description, exhaustions);
     }
 
     private static String formatNodeResourceExhaustion(NodeResourceExhaustion n) {
@@ -66,34 +71,34 @@ public class ResourceExhaustionCalculator {
         return spec.host();
     }
 
-    public List<NodeResourceExhaustion> resourceExhaustionsFromHostInfo(NodeInfo nodeInfo, HostInfo hostInfo) {
-        List<NodeResourceExhaustion> exceedingLimit = null;
+    public Set<NodeResourceExhaustion> resourceExhaustionsFromHostInfo(NodeInfo nodeInfo, HostInfo hostInfo) {
+        Set<NodeResourceExhaustion> exceedingLimit = null;
         for (var usage : hostInfo.getContentNode().getResourceUsage().entrySet()) {
             double limit = feedBlockLimits.getOrDefault(usage.getKey(), 1.0);
             if (usage.getValue().getUsage() > limit) {
                 if (exceedingLimit == null) {
-                    exceedingLimit = new ArrayList<>();
+                    exceedingLimit = new LinkedHashSet<>();
                 }
                 exceedingLimit.add(new NodeResourceExhaustion(nodeInfo.getNode(), usage.getKey(), usage.getValue(),
                                                               limit, nodeInfo.getRpcAddress()));
             }
         }
-        return (exceedingLimit != null) ? exceedingLimit : Collections.emptyList();
+        return (exceedingLimit != null) ? exceedingLimit : Collections.emptySet();
     }
 
-    public List<NodeResourceExhaustion> enumerateNodeResourceExhaustions(NodeInfo nodeInfo) {
+    public Set<NodeResourceExhaustion> enumerateNodeResourceExhaustions(NodeInfo nodeInfo) {
         if (!nodeInfo.isStorage()) {
-            return Collections.emptyList();
+            return Collections.emptySet();
         }
         return resourceExhaustionsFromHostInfo(nodeInfo, nodeInfo.getHostInfo());
     }
 
     // Returns 0-n entries per content node in the cluster, where n is the number of exhausted
     // resource types on any given node.
-    public List<NodeResourceExhaustion> enumerateNodeResourceExhaustionsAcrossAllNodes(Collection<NodeInfo> nodeInfos) {
+    public Set<NodeResourceExhaustion> enumerateNodeResourceExhaustionsAcrossAllNodes(Collection<NodeInfo> nodeInfos) {
         return nodeInfos.stream()
                 .flatMap(info -> enumerateNodeResourceExhaustions(info).stream())
-                .collect(Collectors.toList());
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/ResourceUsage.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/hostinfo/ResourceUsage.java
@@ -8,6 +8,11 @@ import java.util.Objects;
 /**
  * Encapsulation of the usage levels for a particular resource type. The resource type
  * itself is not tracked in this class; this must be done on a higher level.
+ *
+ * Note: equality checks and hash code computations do NOT include the actual floating
+ * point usage! This is so sets of ResourceUsages are de-duplicated at the resource level
+ * regardless of the relative usage (all cases where these are compared is assumed to
+ * be when feed is blocked anyway, so just varying levels over the feed block limit).
  */
 public class ResourceUsage {
     private final Double usage;
@@ -33,11 +38,11 @@ public class ResourceUsage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ResourceUsage that = (ResourceUsage) o;
-        return Objects.equals(usage, that.usage) && Objects.equals(name, that.name);
+        return Objects.equals(name, that.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(usage, name);
+        return Objects.hash(name);
     }
 }


### PR DESCRIPTION
@geirst please review. Will follow up with changes to diff calculator so that logged events are emitted when the set changes as well.

Ensures that feed block description pushed to nodes is updated as
further resource exhaustions are recorded (or disappear).
