### PR TITLE
Make it possible to specify feed block resource limits in content clu…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -19,12 +19,14 @@ import org.w3c.dom.Element;
 public class ClusterControllerConfig extends AbstractConfigProducer<ClusterControllerConfig> implements FleetcontrollerConfig.Producer {
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<ClusterControllerConfig> {
-        String clusterName;
-        ModelElement clusterElement;
+        private final String clusterName;
+        private final ModelElement clusterElement;
+        private final ResourceLimits resourceLimits;
 
-        public Builder(String clusterName, ModelElement clusterElement) {
+        public Builder(String clusterName, ModelElement clusterElement, ResourceLimits resourceLimits) {
             this.clusterName = clusterName;
             this.clusterElement = clusterElement;
+            this.resourceLimits = resourceLimits;
         }
 
         @Override
@@ -51,27 +53,29 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
                         tuning.childAsDouble("min-storage-up-ratio"),
                         bucketSplittingMinimumBits,
                         minNodeRatioPerGroup,
-                        enableClusterFeedBlock);
+                        enableClusterFeedBlock,
+                        resourceLimits);
             } else {
                 return new ClusterControllerConfig(ancestor, clusterName,
                         null, null, null, null, null, null,
                         bucketSplittingMinimumBits,
                         minNodeRatioPerGroup,
-                        enableClusterFeedBlock);
+                        enableClusterFeedBlock, resourceLimits);
             }
         }
     }
 
-    String clusterName;
-    Duration initProgressTime;
-    Duration transitionTime;
-    Long maxPrematureCrashes;
-    Duration stableStateTimePeriod;
-    Double minDistributorUpRatio;
-    Double minStorageUpRatio;
-    Integer minSplitBits;
-    private Double minNodeRatioPerGroup;
-    private boolean enableClusterFeedBlock = false;
+    private final String clusterName;
+    private final Duration initProgressTime;
+    private final Duration transitionTime;
+    private final Long maxPrematureCrashes;
+    private final Duration stableStateTimePeriod;
+    private final Double minDistributorUpRatio;
+    private final Double minStorageUpRatio;
+    private final Integer minSplitBits;
+    private final Double minNodeRatioPerGroup;
+    private final boolean enableClusterFeedBlock;
+    private final ResourceLimits resourceLimits;
 
     // TODO refactor; too many args
     private ClusterControllerConfig(AbstractConfigProducer parent,
@@ -84,7 +88,8 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
                                     Double minStorageUpRatio,
                                     Integer minSplitBits,
                                     Double minNodeRatioPerGroup,
-                                    boolean enableClusterFeedBlock) {
+                                    boolean enableClusterFeedBlock,
+                                    ResourceLimits resourceLimits) {
         super(parent, "fleetcontroller");
 
         this.clusterName = clusterName;
@@ -97,6 +102,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
         this.minSplitBits = minSplitBits;
         this.minNodeRatioPerGroup = minNodeRatioPerGroup;
         this.enableClusterFeedBlock = enableClusterFeedBlock;
+        this.resourceLimits = resourceLimits;
     }
 
     @Override
@@ -139,18 +145,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
             builder.min_node_ratio_per_group(minNodeRatioPerGroup);
         }
         builder.enable_cluster_feed_block(enableClusterFeedBlock);
-        setDefaultClusterFeedBlockLimits(builder);
+        resourceLimits.getConfig(builder);
     }
 
-    private static void setDefaultClusterFeedBlockLimits(FleetcontrollerConfig.Builder builder) {
-        // TODO: Override these based on resource-limits in services.xml (if they are specified).
-        // TODO: Choose other defaults when this is default enabled.
-        // Note: The resource categories must match the ones used in host info reporting
-        // between content nodes and cluster controller:
-        // storage/src/vespa/storage/persistence/filestorage/service_layer_host_info_reporter.cpp
-        builder.cluster_feed_block_limit.put("memory", 0.79);
-        builder.cluster_feed_block_limit.put("disk", 0.79);
-        builder.cluster_feed_block_limit.put("attribute-enum-store", 0.89);
-        builder.cluster_feed_block_limit.put("attribute-multi-value", 0.89);
-    }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
@@ -1,0 +1,103 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.content;
+
+import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
+import com.yahoo.vespa.model.content.cluster.DomResourceLimitsBuilder;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Class tracking the feed block resource limits for a content cluster.
+ *
+ * This includes the limits used by the cluster controller and the content nodes (proton).
+ *
+ * @author geirst
+ */
+public class ClusterResourceLimits {
+
+    private final ResourceLimits clusterControllerLimits;
+    private final ResourceLimits contentNodeLimits;
+
+    private ClusterResourceLimits(Builder builder) {
+        clusterControllerLimits = builder.ctrlBuilder.build();
+        contentNodeLimits = builder.nodeBuilder.build();
+    }
+
+    public ResourceLimits getClusterControllerLimits() {
+        return clusterControllerLimits;
+    }
+
+    public ResourceLimits getContentNodeLimits() {
+        return contentNodeLimits;
+    }
+
+    public static class Builder {
+
+        private ResourceLimits.Builder ctrlBuilder = new ResourceLimits.Builder();
+        private ResourceLimits.Builder nodeBuilder = new ResourceLimits.Builder();
+
+        public ClusterResourceLimits build(ModelElement clusterElem) {
+
+            ModelElement tuningElem = clusterElem.childByPath("tuning");
+            if (tuningElem != null) {
+                ctrlBuilder = DomResourceLimitsBuilder.createBuilder(tuningElem);
+            }
+
+            ModelElement protonElem = clusterElem.childByPath("engine.proton");
+            if (protonElem != null) {
+                nodeBuilder = DomResourceLimitsBuilder.createBuilder(protonElem);
+            }
+
+            deriveLimits();
+            return new ClusterResourceLimits(this);
+        }
+
+        public void setClusterControllerBuilder(ResourceLimits.Builder builder) {
+            ctrlBuilder = builder;
+        }
+
+        public void setContentNodeBuilder(ResourceLimits.Builder builder) {
+            nodeBuilder = builder;
+        }
+
+        public ClusterResourceLimits build() {
+            deriveLimits();
+            return new ClusterResourceLimits(this);
+        }
+
+        private void deriveLimits() {
+            deriveClusterControllerLimit(ctrlBuilder.getDiskLimit(), nodeBuilder.getDiskLimit(), ctrlBuilder::setDiskLimit);
+            deriveClusterControllerLimit(ctrlBuilder.getMemoryLimit(), nodeBuilder.getMemoryLimit(), ctrlBuilder::setMemoryLimit);
+
+            deriveContentNodeLimit(nodeBuilder.getDiskLimit(), ctrlBuilder.getDiskLimit(), nodeBuilder::setDiskLimit);
+            deriveContentNodeLimit(nodeBuilder.getMemoryLimit(), ctrlBuilder.getMemoryLimit(), nodeBuilder::setMemoryLimit);
+        }
+
+        private void deriveClusterControllerLimit(Optional<Double> clusterControllerLimit,
+                                                  Optional<Double> contentNodeLimit,
+                                                  Consumer<Double> setter) {
+            if (!clusterControllerLimit.isPresent()) {
+                contentNodeLimit.ifPresent(limit ->
+                        // TODO: emit warning when using cluster controller resource limits are default enabled.
+                        setter.accept(limit));
+            }
+        }
+
+        private void deriveContentNodeLimit(Optional<Double> contentNodeLimit,
+                                            Optional<Double> clusterControllerLimit,
+                                            Consumer<Double> setter) {
+            if (!contentNodeLimit.isPresent()) {
+                clusterControllerLimit.ifPresent(limit ->
+                        setter.accept(calcContentNodeLimit(limit)));
+            }
+        }
+
+        private double calcContentNodeLimit(double clusterControllerLimit) {
+            // Note that validation in the range [0.0-1.0] is handled by the rnc schema.
+            return clusterControllerLimit + ((1.0 - clusterControllerLimit) / 2);
+        }
+
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -79,13 +79,15 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
         private final Map<String, NewDocumentType> documentDefinitions;
         private final Set<NewDocumentType> globallyDistributedDocuments;
         private final boolean combined;
+        private final ResourceLimits resourceLimits;
 
         public Builder(Map<String, NewDocumentType> documentDefinitions,
                        Set<NewDocumentType> globallyDistributedDocuments,
-                       boolean combined) {
+                       boolean combined, ResourceLimits resourceLimits) {
             this.documentDefinitions = documentDefinitions;
             this.globallyDistributedDocuments = globallyDistributedDocuments;
             this.combined = combined;
+            this.resourceLimits = resourceLimits;
         }
 
         @Override
@@ -106,10 +108,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
             if (tuning != null) {
                 search.setTuning(new DomSearchTuningBuilder().build(deployState, search, tuning.getXml()));
             }
-            ModelElement protonElem = clusterElem.childByPath("engine.proton");
-            if (protonElem != null) {
-                search.setResourceLimits(DomResourceLimitsBuilder.build(protonElem));
-            }
+            search.setResourceLimits(resourceLimits);
 
             buildAllStreamingSearchClusters(deployState, clusterElem, clusterName, search);
             buildIndexedSearchCluster(deployState, clusterElem, clusterName, search);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -38,6 +38,7 @@ import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.content.ClusterControllerConfig;
+import com.yahoo.vespa.model.content.ClusterResourceLimits;
 import com.yahoo.vespa.model.content.ContentSearch;
 import com.yahoo.vespa.model.content.ContentSearchCluster;
 import com.yahoo.vespa.model.content.DistributionBitCalculator;
@@ -134,11 +135,14 @@ public class ContentCluster extends AbstractConfigProducer implements
             ContentCluster c = new ContentCluster(context.getParentProducer(), getClusterId(contentElement), documentDefinitions,
                                                   globallyDistributedDocuments, routingSelection,
                                                   deployState.zone(), deployState.isHosted());
-            c.clusterControllerConfig = new ClusterControllerConfig.Builder(getClusterId(contentElement), contentElement).build(deployState, c, contentElement.getXml());
+            var resourceLimits = new ClusterResourceLimits.Builder().build(contentElement);
+            c.clusterControllerConfig = new ClusterControllerConfig.Builder(getClusterId(contentElement),
+                    contentElement,
+                    resourceLimits.getClusterControllerLimits()).build(deployState, c, contentElement.getXml());
             c.search = new ContentSearchCluster.Builder(documentDefinitions,
-                                                        globallyDistributedDocuments,
-                                                        isCombined(getClusterId(contentElement), containers))
-                               .build(deployState, c, contentElement.getXml());
+                    globallyDistributedDocuments,
+                    isCombined(getClusterId(contentElement), containers),
+                    resourceLimits.getContentNodeLimits()).build(deployState, c, contentElement.getXml());
             c.persistenceFactory = new EngineFactoryBuilder().build(contentElement, c);
             c.storageNodes = new StorageCluster.Builder().build(deployState, c, w3cContentElement);
             c.distributorNodes = new DistributorCluster.Builder(c).build(deployState, c, w3cContentElement);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
@@ -5,17 +5,17 @@ import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.ResourceLimits;
 
 /**
- * Builder for resource limits for a content cluster with engine proton.
+ * Builder for feed block resource limits.
  *
  * @author geirst
  */
 public class DomResourceLimitsBuilder {
 
-    public static ResourceLimits build(ModelElement contentXml) {
+    public static ResourceLimits.Builder createBuilder(ModelElement contentXml) {
         ResourceLimits.Builder builder = new ResourceLimits.Builder();
         ModelElement resourceLimits = contentXml.child("resource-limits");
         if (resourceLimits == null) {
-            return builder.build();
+            return builder;
         }
         if (resourceLimits.child("disk") != null) {
             builder.setDiskLimit(resourceLimits.childAsDouble("disk"));
@@ -23,7 +23,7 @@ public class DomResourceLimitsBuilder {
         if (resourceLimits.child("memory") != null) {
             builder.setMemoryLimit(resourceLimits.childAsDouble("memory"));
         }
-        return builder.build();
+        return builder;
     }
 
 }

--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -98,7 +98,8 @@ ClusterTuning = element tuning {
    ClusterControllerTuning? &
    Maintenance? &
    PersistenceThreads? &
-   MinNodeRatioPerGroup?
+   MinNodeRatioPerGroup? &
+   ResourceLimits?
 }
 
 Content = element content {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -1,0 +1,101 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.content;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author geirst
+ */
+public class ClusterResourceLimitsTest {
+
+    private static class Fixture {
+        ResourceLimits.Builder ctrlBuilder = new ResourceLimits.Builder();
+        ResourceLimits.Builder nodeBuilder = new ResourceLimits.Builder();
+
+        public Fixture ctrlDisk(double limit) {
+            ctrlBuilder.setDiskLimit(limit);
+            return this;
+        }
+        public Fixture ctrlMemory(double limit) {
+            ctrlBuilder.setMemoryLimit(limit);
+            return this;
+        }
+        public Fixture nodeDisk(double limit) {
+            nodeBuilder.setDiskLimit(limit);
+            return this;
+        }
+        public Fixture nodeMemory(double limit) {
+            nodeBuilder.setMemoryLimit(limit);
+            return this;
+        }
+        public ClusterResourceLimits build() {
+            var builder = new ClusterResourceLimits.Builder();
+            builder.setClusterControllerBuilder(ctrlBuilder);
+            builder.setContentNodeBuilder(nodeBuilder);
+            return builder.build();
+        }
+    }
+
+    @Test
+    public void content_node_limits_are_derived_from_cluster_controller_limits_if_not_set() {
+        assertLimits(0.6, 0.7, 0.8, 0.85,
+                new Fixture().ctrlDisk(0.6).ctrlMemory(0.7));
+        assertLimits(0.6, null, 0.8, null,
+                new Fixture().ctrlDisk(0.6));
+        assertLimits(null, 0.7, null, 0.85,
+                new Fixture().ctrlMemory(0.7));
+    }
+
+    @Test
+    public void content_node_limits_can_be_set_explicit() {
+        assertLimits(0.6, 0.7, 0.9, 0.95,
+                new Fixture().ctrlDisk(0.6).ctrlMemory(0.7).nodeDisk(0.9).nodeMemory(0.95));
+        assertLimits(0.6, null, 0.9, null,
+                new Fixture().ctrlDisk(0.6).nodeDisk(0.9));
+        assertLimits(null, 0.7, null, 0.95,
+                new Fixture().ctrlMemory(0.7).nodeMemory(0.95));
+    }
+
+    @Test
+    public void cluster_controller_limits_are_equal_to_content_node_limits_if_not_set() {
+        assertLimits(0.9, 0.95, 0.9, 0.95,
+                new Fixture().nodeDisk(0.9).nodeMemory(0.95));
+        assertLimits(0.9, null, 0.9, null,
+                new Fixture().nodeDisk(0.9));
+        assertLimits(null, 0.95, null, 0.95,
+                new Fixture().nodeMemory(0.95));
+    }
+
+    @Test
+    public void limits_are_derived_from_the_other_if_not_set() {
+        assertLimits(0.6, 0.95, 0.8, 0.95,
+                new Fixture().ctrlDisk(0.6).nodeMemory(0.95));
+        assertLimits(0.9, 0.7, 0.9, 0.85,
+                new Fixture().ctrlMemory(0.7).nodeDisk(0.9));
+    }
+
+    private void assertLimits(Double expCtrlDisk, Double expCtrlMemory, Double expNodeDisk, Double expNodeMemory, Fixture f) {
+        var limits = f.build();
+        assertLimits(expCtrlDisk, expCtrlMemory, limits.getClusterControllerLimits());
+        assertLimits(expNodeDisk, expNodeMemory, limits.getContentNodeLimits());
+    }
+
+    private void assertLimits(Double expDisk, Double expMemory, ResourceLimits limits) {
+        assertLimit(expDisk, limits.getDiskLimit());
+        assertLimit(expMemory, limits.getMemoryLimit());
+    }
+
+    private void assertLimit(Double expLimit, Optional<Double> actLimit) {
+        if (expLimit == null) {
+            assertFalse(actLimit.isPresent());
+        } else {
+            assertEquals(expLimit, actLimit.get(), 0.00001);
+        }
+    }
+
+}


### PR DESCRIPTION
…ster tuning.

These will be used by the cluster controller to decide whether
external feed should be blocked and stopped by the distributors.
Content node (proton) hard limits are derived from the new limits if not specified, and the other way around.
This way we are backwards compatible when the new functionality in cluster controller is enabled by default.

@toregge please review
@vekterli FYI
