### PR TITLE
Remove the sync interface from Bucket Executor. Due to the nature of …

### DIFF
--- a/persistence/src/vespa/persistence/dummyimpl/dummy_bucket_executor.h
+++ b/persistence/src/vespa/persistence/dummyimpl/dummy_bucket_executor.h
@@ -18,7 +18,7 @@ public:
     DummyBucketExecutor(size_t numExecutors);
     ~DummyBucketExecutor() override;
     std::unique_ptr<BucketTask> execute(const Bucket & bucket, std::unique_ptr<BucketTask> task) override;
-    void sync() override;
+    void sync();
 private:
     std::unique_ptr<vespalib::SyncableThreadExecutor> _executor;
     std::mutex                                        _lock;

--- a/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
+++ b/persistence/src/vespa/persistence/dummyimpl/dummypersistence.cpp
@@ -866,14 +866,10 @@ DummyPersistence::register_resource_usage_listener(IResourceUsageListener &liste
 
 namespace {
 
-class SyncExecutorOnDestruction : public vespalib::IDestructorCallback {
+class ExecutorRegistration : public vespalib::IDestructorCallback {
 public:
-    explicit SyncExecutorOnDestruction(std::shared_ptr<BucketExecutor> executor) : _executor(std::move(executor)) { }
-    ~SyncExecutorOnDestruction() override {
-        if (_executor) {
-            _executor->sync();
-        }
-    }
+    explicit ExecutorRegistration(std::shared_ptr<BucketExecutor> executor) : _executor(std::move(executor)) { }
+    ~ExecutorRegistration() override = default;
 private:
     std::shared_ptr<BucketExecutor> _executor;
 };
@@ -885,7 +881,7 @@ DummyPersistence::register_executor(std::shared_ptr<BucketExecutor> executor)
 {
     assert(_bucket_executor.expired());
     _bucket_executor = executor;
-    return std::make_unique<SyncExecutorOnDestruction>(executor);
+    return std::make_unique<ExecutorRegistration>(executor);
 }
 
 std::string

--- a/persistence/src/vespa/persistence/spi/bucketexecutor.h
+++ b/persistence/src/vespa/persistence/spi/bucketexecutor.h
@@ -29,7 +29,6 @@ public:
 struct BucketExecutor {
     virtual ~BucketExecutor() = default;
     virtual std::unique_ptr<BucketTask> execute(const Bucket & bucket, std::unique_ptr<BucketTask> task) = 0;
-    virtual void sync() = 0;
 };
 
 }

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
@@ -5,8 +5,9 @@
 #include <vespa/persistence/spi/bucketexecutor.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
+namespace storage::spi::dummy { class DummyBucketExecutor; }
 struct JobTestBase : public ::testing::TestWithParam<bool> {
-    std::unique_ptr<storage::spi::BucketExecutor> _bucketExecutor;
+    std::unique_ptr<storage::spi::dummy::DummyBucketExecutor> _bucketExecutor;
     std::unique_ptr<vespalib::SyncableThreadExecutor> _singleExecutor;
     std::unique_ptr<searchcorespi::index::IThreadService> _master;
     std::shared_ptr<MyHandler> _handler;
@@ -54,7 +55,7 @@ struct JobTest : public JobTestBase {
     std::unique_ptr<IMaintenanceJobRunner> _jobRunner;
 
     JobTest();
-    ~JobTest();
+    ~JobTest() override;
     void init(uint32_t allowedLidBloat,
               double allowedLidBloatFactor,
               double resourceLimitFactor = RESOURCE_LIMIT_FACTOR,
@@ -68,7 +69,7 @@ struct JobTest : public JobTestBase {
 class JobDisabledByRemoveOpsTest : public JobTest {
 public:
     JobDisabledByRemoveOpsTest();
-    ~JobDisabledByRemoveOpsTest();
+    ~JobDisabledByRemoveOpsTest() override;
 
     void job_is_disabled_while_remove_ops_are_ongoing(bool remove_batch);
     void job_becomes_disabled_if_remove_ops_starts(bool remove_batch);
@@ -80,7 +81,7 @@ struct MyCountJobRunner;
 struct MaxOutstandingJobTest : public JobTest {
     std::unique_ptr<MyCountJobRunner> runner;
     MaxOutstandingJobTest();
-    ~MaxOutstandingJobTest();
+    ~MaxOutstandingJobTest() override;
     void init(uint32_t maxOutstandingMoveOps);
     void assertRunToBlocked();
     void assertRunToNotBlocked();

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.h
@@ -130,7 +130,6 @@ public:
     WriteGuard getWLock() const;
     ResourceUsageTracker &get_resource_usage_tracker() noexcept { return *_resource_usage_tracker; }
     std::unique_ptr<BucketTask> execute(const Bucket &bucket, std::unique_ptr<BucketTask> task) override;
-    void sync() override;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
@@ -130,6 +130,9 @@ LidSpaceCompactionJobBase::run()
     }
 
     if (_scanItr && !_scanItr->valid()) {
+        if (!inSync()) {
+            return false;
+        }
         if (shouldRestartScanDocuments(_handler->getLidStatus())) {
             _scanItr = _handler->getIterator();
         } else {

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
@@ -50,6 +50,7 @@ private:
     void compactLidSpace(const search::LidUsageStats &stats);
     bool remove_batch_is_ongoing() const;
     bool remove_is_ongoing() const;
+    virtual bool inSync() const { return true; }
 protected:
     search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats, bool retryLastDocument);
 public:

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
@@ -4,8 +4,9 @@
 
 #include "lid_space_compaction_job_base.h"
 #include <vespa/document/bucket/bucketspace.h>
+#include <atomic>
 
-namespace storage::spi { struct BucketExecutor;}
+namespace storage::spi { struct BucketExecutor; }
 namespace searchcorespi::index { struct IThreadService; }
 namespace vespalib { class IDestructorCallback; }
 namespace proton {
@@ -28,11 +29,14 @@ private:
     IThreadService          & _master;
     BucketExecutor          &_bucketExecutor;
     document::BucketSpace    _bucketSpace;
+    std::atomic<bool>        _stopped;
+    std::atomic<size_t>      _startedCount;
+    std::atomic<size_t>      _executedCount;
 
     bool scanDocuments(const search::LidUsageStats &stats) override;
     void moveDocument(const search::DocumentMetaData & meta, std::shared_ptr<IDestructorCallback> onDone);
     void onStop() override;
-    void sync();
+    bool inSync() const override;
 public:
     CompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
                   std::shared_ptr<ILidSpaceCompactionHandler> handler,

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -49,10 +49,6 @@ public:
         return _executor.execute(bucket, std::move(task));
     }
 
-    void sync() override {
-        _executor.sync();
-    }
-
 private:
     spi::BucketExecutor & _executor;
 };
@@ -988,10 +984,6 @@ FileStorManager::execute(const spi::Bucket &bucket, std::unique_ptr<spi::BucketT
         }
     }
     return task;
-}
-
-void
-FileStorManager::sync() {
 }
 
 } // storage

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -175,7 +175,6 @@ private:
     void update_reported_state_after_db_init();
 
     std::unique_ptr<spi::BucketTask> execute(const spi::Bucket &bucket, std::unique_ptr<spi::BucketTask> task) override;
-    void sync() override;
 };
 
 } // storage


### PR DESCRIPTION
…requiring a bucket lock it is very hard to get sync to work in a safe way.

Instead the users must do their own accounting as they know their own threading model.

@vekterli and @toregge PR