### PR TITLE
Second attempt at overriding access log for hosted configserver/controller

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -147,8 +147,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         this.httpServerEnabled = networking == Networking.enable;
     }
 
-    protected boolean isConfigserver() { return false; }
-
     @Override
     public List<ConfigModelId> handlesElements() {
         return configModelIds;
@@ -340,11 +338,11 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         addConfiguredComponents(deployState, cluster, spec, "server");
     }
 
-    private void addAccessLogs(DeployState deployState, ApplicationContainerCluster cluster, Element spec) {
+    protected void addAccessLogs(DeployState deployState, ApplicationContainerCluster cluster, Element spec) {
         List<Element> accessLogElements = getAccessLogElements(spec);
 
         for (Element accessLog : accessLogElements) {
-            AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog, isConfigserver()).ifPresent(cluster::addComponent);
+            AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog).ifPresent(cluster::addComponent);
         }
 
         if (accessLogElements.isEmpty() && deployState.getAccessLoggingEnabledByDefault())


### PR DESCRIPTION
Override addAccessLogs in ConfigServerContainerModelBuilder to override
access log configuration for hosted configserver/controller.
Previous attempt did not work as information in DeployState was not reliable.

FYI @tokle 