### PR TITLE
Scale content clusters to minimum 3 nodes

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterResources.java
@@ -31,6 +31,7 @@ public class ClusterResources {
     public NodeResources nodeResources() { return nodeResources; }
 
     public ClusterResources with(NodeResources resources) { return new ClusterResources(nodes, groups, resources); }
+    public ClusterResources withNodes(int nodes) { return new ClusterResources(nodes, groups, nodeResources); }
     public ClusterResources withGroups(int groups) { return new ClusterResources(nodes, groups, nodeResources); }
 
     /** Returns true if this is smaller than the given resources in any dimension */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
@@ -114,9 +114,10 @@ public class AllocationOptimizer {
         return nonScaled.withVcpu(cpu).withMemoryGb(memory).withDiskGb(disk);
     }
 
-    /** Returns a copy of the given limits where the minimum nodes are at least the given value */
-    private Limits atLeast(int nodes, Limits limits) {
-        return limits.withMin(limits.min().withNodes(Math.max(nodes, limits.min().nodes())));
+    /** Returns a copy of the given limits where the minimum nodes are at least the given value when allowed */
+    private Limits atLeast(int min, Limits limits) {
+        if (limits.max().nodes() < min) return limits; // not allowed
+        return limits.withMin(limits.min().withNodes(Math.max(min, limits.min().nodes())));
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
@@ -38,6 +38,14 @@ public class Limits {
         return max;
     }
 
+    public Limits withMin(ClusterResources min) {
+        return new Limits(min, max);
+    }
+
+    public Limits withMax(ClusterResources max) {
+        return new Limits(min, max);
+    }
+
     /** Caps the given resources at the limits of this. If it is empty the node resources are returned as-is */
     public NodeResources cap(NodeResources resources) {
         if (isEmpty()) return resources;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DockerProvisioningTest.java
@@ -279,7 +279,7 @@ public class DockerProvisioningTest {
         tester.makeReadyHosts(2, hostFlavor.resources()).activateTenantHosts();
 
         ApplicationId app1 = ProvisioningTester.applicationId("app1");
-        ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.content, new ClusterSpec.Id("cluster1")).vespaVersion("7").build();
+        ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.container, new ClusterSpec.Id("cluster1")).vespaVersion("7").build();
 
         var resources = new NodeResources(1, 8, 10, 1);
         tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, resources),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -249,14 +249,14 @@ public class DynamicDockerProvisionTest {
         tester.activate(app1, cluster1, Capacity.from(resources(2, 1, 2, 20, 40),
                                                       resources(4, 1, 2, 20, 40)));
         tester.assertNodes("Allocation specifies memory in the advertised amount",
-                           2, 1, 2, 20, 40,
+                           3, 1, 2, 20, 40,
                            app1, cluster1);
 
         // Redeploy the same
         tester.activate(app1, cluster1, Capacity.from(resources(2, 1, 2, 20, 40),
                                                       resources(4, 1, 2, 20, 40)));
         tester.assertNodes("Allocation specifies memory in the advertised amount",
-                           2, 1, 2, 20, 40,
+                           3, 1, 2, 20, 40,
                            app1, cluster1);
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -440,7 +440,25 @@ public class ProvisioningTest {
     }
 
     @Test
-    public void test_node_limits_only() {
+    public void test_node_limits_only_container() {
+        Flavor hostFlavor = new Flavor(new NodeResources(20, 40, 100, 4));
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east")))
+                                                                    .flavors(List.of(hostFlavor))
+                                                                    .build();
+        tester.makeReadyHosts(4, hostFlavor.resources()).activateTenantHosts();
+
+        ApplicationId app1 = ProvisioningTester.applicationId("app1");
+        ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.container, new ClusterSpec.Id("cluster1")).vespaVersion("7").build();
+
+        tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, NodeResources.unspecified()),
+                                                      new ClusterResources(4, 1, NodeResources.unspecified())));
+        tester.assertNodes("Initial allocation at min with default resources",
+                           2, 1, 1.5, 8, 50, 0.3,
+                           app1, cluster1);
+    }
+
+    @Test
+    public void test_node_limits_only_content() {
         Flavor hostFlavor = new Flavor(new NodeResources(20, 40, 100, 4));
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east")))
                                                                     .flavors(List.of(hostFlavor))
@@ -452,8 +470,8 @@ public class ProvisioningTest {
 
         tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, NodeResources.unspecified()),
                                                       new ClusterResources(4, 1, NodeResources.unspecified())));
-        tester.assertNodes("Initial allocation at min with default resources",
-                           2, 1, 1.5, 8, 50, 0.3,
+        tester.assertNodes("Initial allocation at (allowable) min with default resources",
+                           3, 1, 1.5, 8, 50, 0.3,
                            app1, cluster1);
     }
 


### PR DESCRIPTION
There is no cluster controller redundancy with 2 nodes
and this leads to operational problems.
