### PR TITLE
Karowan/replacing or by wand 16360

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -1,0 +1,43 @@
+package com.yahoo.search.querytransform;
+
+import com.yahoo.prelude.query.*;
+import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+
+public class WeakAndReplacementSearcher extends Searcher {
+    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakand.replace");
+
+    @Override public Result search(Query query, Execution execution) {
+        if (!query.properties().getBoolean(WEAKAND_REPLACE)) {
+            return execution.search(query);
+        }
+        replaceOrItems(query);
+        return execution.search(query);
+    }
+
+    private void replaceOrItems(Query query) {
+        Item root = query.getModel().getQueryTree().getRoot();
+        int hits = query.properties().getInteger("wand.hits", WeakAndItem.defaultN);
+        query.getModel().getQueryTree().setRoot(replaceOrItems(root, hits));
+    }
+
+    private Item replaceOrItems(Item item, int hits) {
+        if (!(item instanceof CompositeItem)) {
+            return item;
+        }
+        CompositeItem compositeItem = (CompositeItem) item;
+        if (item instanceof OrItem) {
+            WeakAndItem newItem = new WeakAndItem(hits);
+            newItem.setWeight(item.getWeight());
+            compositeItem.items().forEach(newItem::addItem);
+            compositeItem = newItem;
+        }
+        for (int i = 0; i < compositeItem.getItemCount(); i++) {
+            compositeItem.setItem(i, replaceOrItems(compositeItem.getItem(i), hits));
+        }
+        return compositeItem;
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -12,7 +12,7 @@ import com.yahoo.search.searchchain.Execution;
  * Otherwise a noop searcher
  */
 public class WeakAndReplacementSearcher extends Searcher {
-    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakand.replace");
+    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakAnd.replace");
 
     @Override public Result search(Query query, Execution execution) {
         if (!query.properties().getBoolean(WEAKAND_REPLACE)) {

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -44,14 +44,18 @@ public class WeakAndReplacementSearcher extends Searcher {
             return item;
         }
         CompositeItem compositeItem = (CompositeItem) item;
-        if (item instanceof OrItem) {
+        if (compositeItem instanceof OrItem) {
             WeakAndItem newItem = new WeakAndItem(hits);
-            newItem.setWeight(item.getWeight());
+            newItem.setWeight(compositeItem.getWeight());
             compositeItem.items().forEach(newItem::addItem);
             compositeItem = newItem;
         }
         for (int i = 0; i < compositeItem.getItemCount(); i++) {
-            compositeItem.setItem(i, replaceOrItems(compositeItem.getItem(i), hits));
+            Item subItem = compositeItem.getItem(i);
+            Item replacedItem = replaceOrItems(subItem, hits);
+            if (replacedItem != subItem) {
+                compositeItem.setItem(i, replacedItem);
+            }
         }
         return compositeItem;
     }

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -7,6 +7,10 @@ import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.searchchain.Execution;
 
+/**
+ * Recursively replaces all instances of OrItems with WeakAndItems if the query property weakand.replace is true.
+ * Otherwise a noop searcher
+ */
 public class WeakAndReplacementSearcher extends Searcher {
     private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakand.replace");
 
@@ -18,12 +22,23 @@ public class WeakAndReplacementSearcher extends Searcher {
         return execution.search(query);
     }
 
+    /**
+     * Extracts the queryTree root and the wand.hits property to send to the recursive replacement function
+     * @param query the search query
+     */
     private void replaceOrItems(Query query) {
         Item root = query.getModel().getQueryTree().getRoot();
         int hits = query.properties().getInteger("wand.hits", WeakAndItem.defaultN);
         query.getModel().getQueryTree().setRoot(replaceOrItems(root, hits));
     }
 
+
+    /**
+     * Recursively iterates over an Item to replace all instances of OrItems with WeakAndItems
+     * @param item the current item in the replacement iteration
+     * @param hits the wand.hits property from the request which is assigned to the N value of the new WeakAndItem
+     * @return The original item or a WeakAndItem replacement of an OrItem
+     */
     private Item replaceOrItems(Item item, int hits) {
         if (!(item instanceof CompositeItem)) {
             return item;

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -32,6 +32,8 @@ public class WeakAndReplacementSearcher extends Searcher {
         Item root = query.getModel().getQueryTree().getRoot();
         int hits = query.properties().getInteger("wand.hits", WeakAndItem.defaultN);
         query.getModel().getQueryTree().setRoot(replaceOrItems(root, hits));
+        if (root != query.getModel().getQueryTree().getRoot())
+            query.trace("Replaced OR by WeakAnd", true, 2);
     }
 
 

--- a/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/WeakAndReplacementSearcher.java
@@ -9,7 +9,9 @@ import com.yahoo.search.searchchain.Execution;
 
 /**
  * Recursively replaces all instances of OrItems with WeakAndItems if the query property weakand.replace is true.
- * Otherwise a noop searcher
+ * Otherwise a noop searcher.
+ *
+ * @author karowan
  */
 public class WeakAndReplacementSearcher extends Searcher {
     private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakAnd.replace");

--- a/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
@@ -1,0 +1,104 @@
+package com.yahoo.search.querytransform;
+
+import com.yahoo.component.chain.Chain;
+import com.yahoo.prelude.query.*;
+import com.yahoo.processing.request.CompoundName;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.searchchain.Execution;
+import org.junit.Test;
+
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class WeakAndReplacementSearcherTestCase {
+
+    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakand.replace");
+    private static final int N = 99;
+
+
+    private Execution buildExec() {
+        return new Execution(new Chain<Searcher>(new WeakAndReplacementSearcher()),
+                Execution.Context.createContextStub());
+    }
+
+    private Query buildDefaultQuery(boolean searcherEnabled) {
+        Query query = new Query();
+        query.properties().set("wand.hits", N);
+        query.properties().set(WEAKAND_REPLACE, searcherEnabled);
+        OrItem root = new OrItem();
+        root.addItem(new WordItem("text"));
+        NotItem notItem = new NotItem();
+        OrItem notItemOr = new OrItem();
+        notItemOr.addItem(new IntItem(1, "index"));
+        notItemOr.addItem(new WordItem("positive"));
+        notItem.addPositiveItem(notItemOr);
+        notItem.addNegativeItem(new WordItem("negative"));
+        query.getModel().getQueryTree().setRoot(root);
+        return query;
+    }
+
+
+
+
+    @Test
+    public void requireOrItemsToBeReplaced() {
+        Query query = buildDefaultQuery(true);
+        Result result = buildExec().search(query);
+        Item root = TestUtils.getQueryTreeRoot(result);
+        assertFalse(orItemsExist(root));
+        assertTrue(root instanceof WeakAndItem);
+        assertEquals(N, ((WeakAndItem)root).getN());
+    }
+
+    @Test
+    public void requireQueryPropertyToWork() {
+        Query query = buildDefaultQuery(false);
+        Item preRoot = query.getModel().getQueryTree().getRoot();
+        Result result = buildExec().search(query);
+        Item root = TestUtils.getQueryTreeRoot(result);
+        assertTrue(orItemsExist(root));
+        assertTrue(deepEquals(root, preRoot));
+    }
+
+    @Test
+    public void requireDoNothingOnNoOrItems() {
+        Query query = new Query();
+        query.properties().set(WEAKAND_REPLACE, true);
+        AndItem andItem = new AndItem();
+        andItem.addItem(new WordItem("1"));
+        andItem.addItem(new WordItem("2"));
+        query.getModel().getQueryTree().setRoot(andItem);
+        Result result = buildExec().search(query);
+        Item root = TestUtils.getQueryTreeRoot(result);
+        assertTrue(deepEquals(root, andItem));
+    }
+
+    private boolean deepEquals(Item item1, Item item2) {
+        if (item1 != item2) {
+            return false;
+        }
+        if (!(item1 instanceof CompositeItem)) {
+            return true;
+        }
+
+        CompositeItem compositeItem1 = (CompositeItem) item1;
+        CompositeItem compositeItem2 = (CompositeItem) item2;
+        return IntStream.range(0, compositeItem1.getItemCount())
+                .allMatch(i -> deepEquals(compositeItem1.getItem(i), compositeItem2.getItem(i)));
+    }
+
+    private boolean orItemsExist(Item item) {
+        if (!(item instanceof CompositeItem)) {
+            return false;
+        }
+        if (item instanceof OrItem) {
+            return true;
+        }
+        CompositeItem compositeItem = (CompositeItem) item;
+        return compositeItem.items().stream().anyMatch(this::orItemsExist);
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
@@ -76,6 +76,21 @@ public class WeakAndReplacementSearcherTestCase {
         assertTrue(deepEquals(root, andItem));
     }
 
+    @Test
+    public void requireChildrenAreTheSame() {
+        Query query = new Query();
+        query.properties().set(WEAKAND_REPLACE, true);
+        OrItem preRoot = new OrItem();
+        preRoot.addItem(new WordItem("val1"));
+        preRoot.addItem(new WordItem("val2"));
+
+        query.getModel().getQueryTree().setRoot(preRoot);
+        Result result = buildExec().search(query);
+        WeakAndItem root = (WeakAndItem)TestUtils.getQueryTreeRoot(result);
+        assertEquals(preRoot.getItem(0), root.getItem(0));
+        assertEquals(preRoot.getItem(1), root.getItem(1));
+    }
+
     private boolean deepEquals(Item item1, Item item2) {
         if (item1 != item2) {
             return false;

--- a/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/WeakAndReplacementSearcherTestCase.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.*;
 
 public class WeakAndReplacementSearcherTestCase {
 
-    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakand.replace");
+    private static final CompoundName WEAKAND_REPLACE = new CompoundName("weakAnd.replace");
     private static final int N = 99;
 
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Pull request for #16360. This searcher recursively replaces all instances of OrItems with WeakAndItems if the query property weakand.replace is true and is otherwise a noop searcher. 

If there is a preferable name for the searcher or activating property, let me know and I will change it to whatever is asked.

I am not incredibly familiar with adding a searcher to the local chain so I will wait for some guidance on that aspect. I am assuming that it is just a matter of adding it to the [LocalProviderSpec](https://github.com/vespa-engine/vespa/blob/master/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java) but there could be a lot of things that I might be missing so I will refrain from doing so.

Thank you for any feedback.