### PR TITLE
Do not use multi-threaded maven build for plugins. 

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -74,7 +74,7 @@ mvn_install -N
 
 # and build plugins first:
 echo "Building Vespa Maven plugins."
-mvn_install --threads 1.5C -f maven-plugins/pom.xml
+mvn_install -f maven-plugins/pom.xml
 
 # now everything else should just work with normal maven dependency resolution:
 


### PR DESCRIPTION
- Parallel build of plugins with the same groupId is unsafe, as
  each thread updates the maven-metadata.xml file without any
  locking.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
