### PR TITLE
To ensure that lid stats is sampled after everything has been complet…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
@@ -111,6 +111,7 @@ JobTestBase::endScan() {
 
 JobTestBase &
 JobTestBase::compact() {
+    EXPECT_FALSE(run());
     EXPECT_TRUE(run());
     return *this;
 }

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
@@ -138,6 +138,7 @@ LidSpaceCompactionJobBase::run()
         } else {
             _scanItr = IDocumentScanIterator::UP();
             _shouldCompactLidSpace = true;
+            return false;
         }
     }
 


### PR DESCRIPTION
…ed compaction must happen in 2 stages.

First it must reach inSync, then it must rescheduled once more in the master thread. Then all movement is visible in the master thread.

@geirst or @toregge PR