### PR TITLE
Allow only one node down at a time for cluster controller clusters

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -56,8 +56,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
     }
 
     @Override
-    public void verifyGroupGoingDownPermanentlyIsFine(ClusterApi clusterApi)
-            throws HostStateChangeDeniedException {
+    public void verifyGroupGoingDownPermanentlyIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException {
         // This policy is similar to verifyGroupGoingDownIsFine, except that services being down in the group
         // is no excuse to allow suspension (like it is for verifyGroupGoingDownIsFine), since if we grant
         // suspension in this case they will permanently be down/removed.
@@ -123,8 +122,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             //   I  proxy host
 
             if (clusterApi.serviceType().equals(ServiceType.CLUSTER_CONTROLLER)) {
-                // All nodes have all state and we need to be able to remove the half that are retired on cluster migration
-                return ConcurrentSuspensionLimitForCluster.FIFTY_PERCENT;
+                return ConcurrentSuspensionLimitForCluster.ONE_NODE;
             }
 
             if (Set.of(ServiceType.STORAGE, ServiceType.SEARCH, ServiceType.DISTRIBUTOR, ServiceType.TRANSACTION_LOG_SERVER)
@@ -164,7 +162,6 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             }
 
             if (ServiceType.CLUSTER_CONTROLLER.equals(clusterApi.serviceType())) {
-                // All nodes have all state and we need to be able to remove the half that are retired on cluster migration
                 return ConcurrentSuspensionLimitForCluster.ONE_NODE;
             }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -165,7 +165,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
 
             if (ServiceType.CLUSTER_CONTROLLER.equals(clusterApi.serviceType())) {
                 // All nodes have all state and we need to be able to remove the half that are retired on cluster migration
-                return ConcurrentSuspensionLimitForCluster.FIFTY_PERCENT;
+                return ConcurrentSuspensionLimitForCluster.ONE_NODE;
             }
 
             if (ServiceType.METRICS_PROXY.equals(clusterApi.serviceType())) {


### PR DESCRIPTION
If we are replacing nodes and have 3 old and 3 new nodes in a cluster,
allowing 50 per cent down would lead to 3 being allowed to go down.
When deploying to remove the 3 old nodes there might be (for a short time)
config that says that there should be 6 nodes in the zookeeper cluster.
This mean 4 of them need to be up for the cluster to have a quorum.
This will not work in this case.


