### PR TITLE
Add extra row under content node if it's blocking feed

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeResourceExhaustion.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeResourceExhaustion.java
@@ -53,6 +53,13 @@ public class NodeResourceExhaustion {
         return String.format("%s (<= %.3g)", makeDescriptionPrefix(), limit);
     }
 
+    public String toShorthandDescription() {
+        return String.format("%s%s %.3g > %.3g",
+                resourceType,
+                (resourceUsage.getName() != null ? ":" + resourceUsage.getName() : ""),
+                resourceUsage.getUsage(), limit);
+    }
+
     private String makeDescriptionPrefix() {
         return String.format("%s%s on node %d [%s]",
                 resourceType,


### PR DESCRIPTION
@geirst please review. Prints an extra angry-looking row under a node if it's contributing to cluster feed blocking.

List all resource exhaustions for node, including enum store etc.

