### PR TITLE
Ignore null header

### DIFF
--- a/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
+++ b/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
@@ -39,7 +39,7 @@ class CorsLogic {
     static Map<String, String> createCorsPreflightResponseHeaders(String requestOriginHeader,
                                                                   Set<String> allowedOrigins) {
         TreeMap<String, String> headers = new TreeMap<>();
-        if (allowedOrigins.contains(requestOriginHeader))
+        if (requestOriginHeader != null && allowedOrigins.contains(requestOriginHeader))
             headers.put(ALLOW_ORIGIN_HEADER, requestOriginHeader);
         ACCESS_CONTROL_HEADERS.forEach(headers::put);
         return headers;


### PR DESCRIPTION
`Set.of("foo").contains(null)` will throw NPE as the argument must be non-null.

```
Container.com.yahoo.jdisc.http.server.jetty.HttpRequestDispatch       Request failed: /
exception=
java.lang.NullPointerException
        at java.base/java.util.Objects.requireNonNull(Objects.java:221)
        at java.base/java.util.ImmutableCollections$SetN.contains(ImmutableCollections.java:618)
        at com.yahoo.jdisc.http.filter.security.cors.CorsLogic.createCorsPreflightResponseHeaders(CorsLogic.java:42)
        at com.yahoo.jdisc.http.filter.security.cors.CorsPreflightRequestFilter.filter(CorsPreflightRequestFilter.java:50)
        at com.yahoo.jdisc.http.filter.SecurityRequestFilterChain.filter(SecurityRequestFilterChain.java:40)
        at com.yahoo.jdisc.http.filter.SecurityRequestFilterChain.filter(SecurityRequestFilterChain.java:34)
        at com.yahoo.jdisc.http.server.jetty.FilteringRequestHandler.handleRequest(FilteringRequestHandler.java:81)
        at com.yahoo.jdisc.http.server.jetty.AccessLoggingRequestHandler.handleRequest(AccessLoggingRequestHandler.java:55)
        at com.yahoo.jdisc.http.server.jetty.HttpRequestDispatch.handleRequest(HttpRequestDispatch.java:177)
        at com.yahoo.jdisc.http.server.jetty.HttpRequestDispatch.dispatch(HttpRequestDispatch.java:84)
        at com.yahoo.jdisc.http.server.jetty.JDiscHttpServlet.dispatchHttpRequest(JDiscHttpServlet.java:116)
        at com.yahoo.jdisc.http.server.jetty.JDiscHttpServlet.doOptions(JDiscHttpServlet.java:73)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:716)
        at com.yahoo.jdisc.http.server.jetty.JDiscHttpServlet.service(JDiscHttpServlet.java:96)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:791)
        at org.eclipse.jetty.servlet.ServletHandler$ChainEnd.doFilter(ServletHandler.java:1626)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:548)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1435)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1350)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at com.yahoo.jdisc.http.server.jetty.SecuredRedirectHandler.handle(SecuredRedirectHandler.java:38)
        at com.yahoo.jdisc.http.server.jetty.HealthCheckProxyHandler.handle(HealthCheckProxyHandler.java:107)
        at com.yahoo.jdisc.http.server.jetty.TlsClientAuthenticationEnforcer.handle(TlsClientAuthenticationEnforcer.java:44)
        at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:716)
        at com.yahoo.jdisc.http.server.jetty.HttpResponseStatisticsCollector.handle(HttpResponseStatisticsCollector.java:112)
        at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:179)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:512)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ssl.SslConnection$DecryptedEndPoint.onFillable(SslConnection.java:540)
        at org.eclipse.jetty.io.ssl.SslConnection.onFillable(SslConnection.java:395)
        at org.eclipse.jetty.io.ssl.SslConnection$2.succeeded(SslConnection.java:161)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:773)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:905)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

@freva