### PR TITLE
Increase zstd frame size for compressed access log archive

### DIFF
--- a/jdisc_http_service/src/main/java/com/yahoo/container/logging/LogFileHandler.java
+++ b/jdisc_http_service/src/main/java/com/yahoo/container/logging/LogFileHandler.java
@@ -401,7 +401,7 @@ class LogFileHandler <LOGTYPE> {
         private static void runCompressionZstd(NativeIO nativeIO, Path oldFile) {
             try {
                 Path compressedFile = Paths.get(oldFile.toString() + ".zst");
-                int bufferSize = 0x400000; // 4M
+                int bufferSize = 48*1024*1024;
                 try (FileOutputStream fileOut = AtomicFileOutputStream.create(compressedFile);
                      ZstdOuputStream out = new ZstdOuputStream(fileOut, bufferSize);
                      FileInputStream in = new FileInputStream(oldFile.toFile())) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
