### PR TITLE
add literals for sizes in KB, MB, and GB

### DIFF
--- a/config/src/tests/configfetcher/configfetcher.cpp
+++ b/config/src/tests/configfetcher/configfetcher.cpp
@@ -51,7 +51,7 @@ TEST("requireThatConfigUpdatesArePerformed") {
     FileSpec spec("test1.cfg");
     MyCallback cb;
     cb._configured = false;
-    vespalib::ThreadStackExecutor executor(1, 128 * 1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
 
     {
         ConfigFetcher fetcher(500);

--- a/config/src/tests/misc/configsystem.cpp
+++ b/config/src/tests/misc/configsystem.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/config/common/configsystem.h>
 #include <vespa/defaults.h>
 #include <vespa/fastos/file.h>
@@ -10,7 +11,7 @@ using namespace config;
 namespace {
 
 const char *VESPA_HOME="VESPA_HOME";
-char cwd[1024];
+char cwd[1_Ki];
 
 }
 

--- a/config/src/vespa/config/file_acquirer/file_acquirer.cpp
+++ b/config/src/vespa/config/file_acquirer/file_acquirer.cpp
@@ -5,6 +5,7 @@
 #include <vespa/fnet/frt/target.h>
 #include <vespa/fnet/frt/rpcrequest.h>
 #include <vespa/fnet/transport.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/thread.h>
 
 #include <vespa/log/log.h>
@@ -13,7 +14,7 @@ LOG_SETUP(".config.file_acquirer");
 namespace config {
 
 RpcFileAcquirer::RpcFileAcquirer(const vespalib::string &spec)
-    : _threadPool(std::make_unique<FastOS_ThreadPool>(1024*60)),
+    : _threadPool(std::make_unique<FastOS_ThreadPool>(60_Ki)),
       _transport(std::make_unique<FNET_Transport>()),
       _orb(std::make_unique<FRT_Supervisor>(_transport.get())),
       _spec(spec)

--- a/config/src/vespa/config/frt/frtconnectionpool.cpp
+++ b/config/src/vespa/config/frt/frtconnectionpool.cpp
@@ -2,6 +2,7 @@
 
 #include "frtconnectionpool.h"
 #include <vespa/vespalib/util/host_name.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/transport.h>
 #include <vespa/fastos/thread.h>
@@ -27,7 +28,7 @@ FRTConnectionPool::FRTConnectionKey::operator==(const FRTConnectionKey& right) c
 }
 
 FRTConnectionPool::FRTConnectionPool(const ServerSpec & spec, const TimingValues & timingValues)
-    :  _threadPool(std::make_unique<FastOS_ThreadPool>(1024*60)),
+    :  _threadPool(std::make_unique<FastOS_ThreadPool>(60_Ki)),
        _transport(std::make_unique<FNET_Transport>()),
        _supervisor(std::make_unique<FRT_Supervisor>(_transport.get())),
       _selectIdx(0),

--- a/configd/src/apps/sentinel/config-handler.cpp
+++ b/configd/src/apps/sentinel/config-handler.cpp
@@ -5,6 +5,7 @@
 
 #include <vespa/vespalib/net/socket_address.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <string>
 #include <fcntl.h>
 #include <sys/wait.h>
@@ -284,8 +285,8 @@ ConfigHandler::handleCmd(const Cmd& cmd)
     switch (cmd.type()) {
     case Cmd::LIST:
         {
-            char retbuf[65536];
-            size_t left = 65536;
+            char retbuf[64_Ki];
+            size_t left = 64_Ki;
             size_t pos = 0;
             retbuf[pos] = 0;
             for (const auto & entry : _services) {

--- a/configd/src/apps/sentinel/line-splitter.cpp
+++ b/configd/src/apps/sentinel/line-splitter.cpp
@@ -11,6 +11,7 @@
 
 #include <unistd.h>
 
+#include <vespa/vespalib/util/size_literals.h>
 #include "line-splitter.h"
 
 namespace config {
@@ -19,7 +20,7 @@ namespace sentinel {
 
 LineSplitter::LineSplitter(int fd)
     : _fd(fd),
-      _size(8192),
+      _size(8_Ki),
       _buffer(static_cast<char *>(malloc(_size))),
       _readPos(0),
       _writePos(0),

--- a/eval/src/apps/tensor_conformance/tensor_conformance.cpp
+++ b/eval/src/apps/tensor_conformance/tensor_conformance.cpp
@@ -1,23 +1,24 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/data/output_writer.h>
-#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/slime/json_format.h>
+#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/io/mapped_file_input.h>
 #include <vespa/vespalib/objects/nbostream.h>
+#include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/function.h>
 #include <vespa/eval/eval/interpreted_function.h>
-#include <vespa/eval/eval/value_type.h>
-#include <vespa/eval/eval/value.h>
-#include <vespa/eval/eval/value_codec.h>
 #include <vespa/eval/eval/simple_value.h>
-#include <vespa/eval/eval/fast_value.h>
-#include <vespa/eval/streamed/streamed_value_builder_factory.h>
+#include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/test/reference_evaluation.h>
 #include <vespa/eval/eval/test/test_io.h>
+#include <vespa/eval/eval/value.h>
+#include <vespa/eval/eval/value_codec.h>
+#include <vespa/eval/eval/value_type.h>
+#include <vespa/eval/streamed/streamed_value_builder_factory.h>
 #include <unistd.h>
 #include <functional>
 
@@ -323,7 +324,7 @@ void display(Input &in, Output &out) {
     size_t test_cnt = 0;
     auto handle_test = [&out,&test_cnt](Slime &slime)
                        {
-                           OutputWriter dst(out, 4096);
+                           OutputWriter dst(out, 4_Ki);
                            dst.printf("\n------- TEST #%zu -------\n\n", test_cnt++);
                            print_test(slime.get(), dst);
                        };

--- a/eval/src/tests/eval/compile_cache/compile_cache_test.cpp
+++ b/eval/src/tests/eval/compile_cache/compile_cache_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <set>
 
@@ -162,7 +163,7 @@ TEST("require that cache usage works") {
 }
 
 TEST("require that async cache usage works") {
-    auto executor = std::make_shared<ThreadStackExecutor>(8, 256*1024);
+    auto executor = std::make_shared<ThreadStackExecutor>(8, 256_Ki);
     auto binding = CompileCache::bind(executor);
     CompileCache::Token::UP token_a = CompileCache::compile(*Function::parse("x+y"), PassParams::SEPARATE);
     EXPECT_EQUAL(5.0, token_a->get().get_function<2>()(2.0, 3.0));
@@ -290,7 +291,7 @@ TEST_F("compile sequentially, then run all conformance tests", test::EvalSpec())
 
 TEST_F("compile concurrently (8 threads), then run all conformance tests", test::EvalSpec()) {
     f1.add_all_cases();
-    auto executor = std::make_shared<ThreadStackExecutor>(8, 256*1024);
+    auto executor = std::make_shared<ThreadStackExecutor>(8, 256_Ki);
     auto binding = CompileCache::bind(executor);
     while (executor->num_idle_workers() < 8) {
         std::this_thread::sleep_for(1ms);
@@ -325,7 +326,7 @@ TEST_MT_FF("require that deadlock is avoided with blocking executor", 8, std::sh
     size_t loop = 16;
     if (thread_id == 0) {
         auto t0 = steady_clock::now();
-        f1 = std::make_shared<BlockingThreadStackExecutor>(2, 256*1024, 3);
+        f1 = std::make_shared<BlockingThreadStackExecutor>(2, 256_Ki, 3);
         auto binding = CompileCache::bind(f1);
         TEST_BARRIER(); // #1
         for (size_t i = 0; i < num_threads; ++i) {

--- a/eval/src/tests/eval/gen_spec/gen_spec_test.cpp
+++ b/eval/src/tests/eval/gen_spec/gen_spec_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/eval/eval/test/gen_spec.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace vespalib::eval;
 using namespace vespalib::eval::test;
@@ -45,7 +46,7 @@ TEST(GenSpecTest, default_spec) {
     EXPECT_TRUE(spec.dims().empty());
     EXPECT_EQ(spec.cells(), CellType::DOUBLE);
     auto seq = spec.seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), (i + 1.0));        
     }
 }
@@ -69,21 +70,21 @@ TEST(GenSpecTest, not_scalar_float_just_yet) {
 
 TEST(SequenceTest, n) {
     GenSpec::seq_t seq = GenSpec().seq(N()).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), (i + 1.0));        
     }
 }
 
 TEST(SequenceTest, bias) {
     GenSpec::seq_t seq = GenSpec().seq(N(13.5)).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), (i + 13.5));
     }
 }
 
 TEST(SequenceTest, ax_b) {
     GenSpec::seq_t seq = GenSpec().seq(AX_B(3.5, 2.5)).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), (i * 3.5) + 2.5);
     }
 }
@@ -91,28 +92,28 @@ TEST(SequenceTest, ax_b) {
 TEST(SequenceTest, seq) {
     std::vector<double> values({1.5, 3.5, 2.5, 10.0});
     GenSpec::seq_t seq = GenSpec().seq(Seq(values)).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), values[i % values.size()]);
     }
 }
 
 TEST(SequenceTest, n_div16_sub2) {
     GenSpec::seq_t seq = GenSpec().seq(Sub2(Div16(N()))).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), ((i + 1.0) / 16.0) - 2.0);
     }
 }
 
 TEST(SequenceTest, n_op_sqrt) {
     GenSpec::seq_t seq = GenSpec().seq(OpSeq(N(), operation::Sqrt::f)).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), operation::Sqrt::f(i + 1.0));
     }
 }
 
 TEST(SequenceTest, n_sigmoidf) {
     GenSpec::seq_t seq = GenSpec().seq(SigmoidF(N())).seq();
-    for (size_t i = 0; i < 4096; ++i) {
+    for (size_t i = 0; i < 4_Ki; ++i) {
         EXPECT_EQ(seq(i), double((float)operation::Sigmoid::f(i + 1.0)));
         EXPECT_TRUE(seq(i) == double((float)operation::Sigmoid::f(i + 1.0)));
     }

--- a/eval/src/tests/eval/nested_loop/nested_loop_bench.cpp
+++ b/eval/src/tests/eval/nested_loop/nested_loop_bench.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/eval/eval/nested_loop.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using vespalib::BenchmarkTimer;
@@ -18,7 +19,7 @@ void perform_direct_1(const LIST &loop, const LIST &stride) {
         assert(idx1 == expect);
         ++expect;
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_2(const LIST &loop, const LIST &stride) {
@@ -32,7 +33,7 @@ void perform_direct_2(const LIST &loop, const LIST &stride) {
             ++expect;
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_3(const LIST &loop, const LIST &stride) {
@@ -49,7 +50,7 @@ void perform_direct_3(const LIST &loop, const LIST &stride) {
             }
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_4(const LIST &loop, const LIST &stride) {
@@ -69,7 +70,7 @@ void perform_direct_4(const LIST &loop, const LIST &stride) {
             }
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_lambda_1(const LIST &loop, const LIST &stride) {
@@ -84,7 +85,7 @@ void perform_direct_lambda_1(const LIST &loop, const LIST &stride) {
     for (size_t i = 0; i < loop[0]; ++i, idx1 += stride[0]) {
         fun(idx1);
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_lambda_2(const LIST &loop, const LIST &stride) {
@@ -102,7 +103,7 @@ void perform_direct_lambda_2(const LIST &loop, const LIST &stride) {
             fun(idx2);
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_lambda_3(const LIST &loop, const LIST &stride) {
@@ -123,7 +124,7 @@ void perform_direct_lambda_3(const LIST &loop, const LIST &stride) {
             }
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_direct_lambda_4(const LIST &loop, const LIST &stride) {
@@ -147,7 +148,7 @@ void perform_direct_lambda_4(const LIST &loop, const LIST &stride) {
             }
         }
     }
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void perform_generic(const LIST &loop, const LIST &stride) {
@@ -158,13 +159,13 @@ void perform_generic(const LIST &loop, const LIST &stride) {
         ++expect;
     };
     run_nested_loop(0, loop, stride, fun);
-    assert(expect == 4096);
+    assert(expect == 4_Ki);
 }
 
 void nop() {}
 
 double estimate_cost_1_us(call_t perform_fun) {
-    LIST loop({4096});
+    LIST loop({4_Ki});
     LIST stride({1});
     return BenchmarkTimer::benchmark([&](){ perform_fun(loop, stride); }, nop, 10000, 5.0) * 1000.0 * 1000.0;
 }

--- a/eval/src/tests/tensor/instruction_benchmark/instruction_benchmark.cpp
+++ b/eval/src/tests/tensor/instruction_benchmark/instruction_benchmark.cpp
@@ -20,30 +20,31 @@
 // implementations against each other, a smoke test is performed by
 // verifying that all implementations produce the same result.
 
-#include <vespa/eval/eval/simple_value.h>
 #include <vespa/eval/eval/fast_value.h>
 #include <vespa/eval/eval/interpreted_function.h>
+#include <vespa/eval/eval/operation.h>
+#include <vespa/eval/eval/optimize_tensor_function.h>
+#include <vespa/eval/eval/simple_value.h>
+#include <vespa/eval/eval/tensor_function.h>
+#include <vespa/eval/eval/tensor_spec.h>
+#include <vespa/eval/eval/test/gen_spec.h>
+#include <vespa/eval/eval/value_codec.h>
 #include <vespa/eval/instruction/generic_concat.h>
 #include <vespa/eval/instruction/generic_join.h>
-#include <vespa/eval/instruction/generic_reduce.h>
-#include <vespa/eval/instruction/generic_rename.h>
 #include <vespa/eval/instruction/generic_map.h>
 #include <vespa/eval/instruction/generic_merge.h>
-#include <vespa/eval/eval/tensor_spec.h>
-#include <vespa/eval/eval/value_codec.h>
-#include <vespa/eval/eval/operation.h>
-#include <vespa/eval/eval/tensor_function.h>
-#include <vespa/eval/eval/optimize_tensor_function.h>
-#include <vespa/vespalib/util/benchmark_timer.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/vespalib/objects/nbostream.h>
-#include <vespa/vespalib/util/stash.h>
-#include <vespa/vespalib/gtest/gtest.h>
-#include <vespa/vespalib/io/mapped_file_input.h>
-#include <vespa/vespalib/io/fileutil.h>
+#include <vespa/eval/instruction/generic_reduce.h>
+#include <vespa/eval/instruction/generic_rename.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/smart_buffer.h>
-#include <vespa/eval/eval/test/gen_spec.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/io/mapped_file_input.h>
+#include <vespa/vespalib/objects/nbostream.h>
+#include <vespa/vespalib/util/benchmark_timer.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/stash.h>
+#include <vespa/vespalib/util/stringfmt.h>
 #include <optional>
 #include <algorithm>
 
@@ -315,7 +316,7 @@ void load_ghost(const vespalib::string &file_name) {
 }
 
 void save_result(const vespalib::string &file_name) {
-    SmartBuffer output(4096);
+    SmartBuffer output(4_Ki);
     JsonFormat::encode(prod_result, output, false);
     Memory memory = output.obtain();
     File file(file_name);

--- a/eval/src/vespa/eval/eval/test/test_io.cpp
+++ b/eval/src/vespa/eval/eval/test/test_io.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/slime/json_format.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <unistd.h>
 #include <assert.h>
 
@@ -16,7 +17,7 @@ namespace vespalib::eval::test {
 
 //-----------------------------------------------------------------------------
 
-constexpr size_t CHUNK_SIZE = 16384;
+constexpr size_t CHUNK_SIZE = 16_Ki;
 const char *num_tests_str = "num_tests";
 
 //-----------------------------------------------------------------------------

--- a/eval/src/vespa/eval/eval/value_cache/constant_tensor_loader.cpp
+++ b/eval/src/vespa/eval/eval/value_cache/constant_tensor_loader.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/io/mapped_file_input.h>
 #include <vespa/vespalib/data/lz4_input_decoder.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <set>
 
 #include <vespa/log/log.h>
@@ -53,7 +54,7 @@ void decode_json(const vespalib::string &path, Slime &slime) {
         LOG(warning, "could not read file: %s", path.c_str());
     } else {
         if (ends_with(path, ".lz4")) {
-            size_t buffer_size = 64 * 1024;
+            size_t buffer_size = 64_Ki;
             Lz4InputDecoder lz4_decoder(file, buffer_size);
             decode_json(path, lz4_decoder, slime);
             if (lz4_decoder.failed()) {

--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -8,6 +8,7 @@
 #include <vespa/vespalib/net/tls/transport_security_options.h>
 #include <vespa/vespalib/net/tls/tls_crypto_engine.h>
 #include <vespa/vespalib/io/mapped_file_input.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include "client.h"
 #include "fbench.h"
 #include <cstring>
@@ -340,7 +341,7 @@ FBench::Main(int argc, char *argv[])
     int byteLimit   = 0;
     int ignoreCount = 0;
     int seconds     = 60;
-    int maxLineSize = 128 * 1024;
+    int maxLineSize = 128_Ki;
     const int minLineSize = 1024;
 
     const char *queryFilePattern  = "query%03d.txt";

--- a/fbench/src/httpclient/httpclient.cpp
+++ b/fbench/src/httpclient/httpclient.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "httpclient.h"
 #include <vespa/vespalib/net/socket_spec.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <util/authority.h>
 #include <cassert>
 #include <cstring>
@@ -33,7 +34,7 @@ HTTPClient::HTTPClient(vespalib::CryptoEngine::SP engine, const char *hostname, 
     _sni_spec(make_sni_spec(authority, hostname, port, _engine->use_tls_when_client())),
     _host_header_value(make_host_header_value(_sni_spec, _engine->use_tls_when_client())),
     _reuseCount(0),
-    _bufsize(10240),
+    _bufsize(10_Ki),
     _buf(new char[_bufsize]),
     _bufused(0),
     _bufpos(0),
@@ -201,7 +202,7 @@ bool
 HTTPClient::ReadHTTPHeader(std::string & headerinfo)
 {
     int     lineLen;
-    char    line[4096];
+    char    line[4_Ki];
     int     argc;
     char   *argv[32];
     int     i;
@@ -213,7 +214,7 @@ HTTPClient::ReadHTTPHeader(std::string & headerinfo)
     _keepAliveGiven       = false;
 
     // read and split status line
-    if ((lineLen = ReadLine(line, 4096)) <= 0)
+    if ((lineLen = ReadLine(line, 4_Ki)) <= 0)
         return false;
     SplitString(line, argc, argv, 32);
 
@@ -232,7 +233,7 @@ HTTPClient::ReadHTTPHeader(std::string & headerinfo)
     // printf("HTTP: status: %d\n", _requestStatus);
 
     // read and parse rest of header
-    while((lineLen = ReadLine(line, 4096)) > 0) {
+    while((lineLen = ReadLine(line, 4_Ki)) > 0) {
 
         // DEBUG
         // printf("HTTP-Header: '%s'\n", line);

--- a/fbench/src/util/filereader.cpp
+++ b/fbench/src/util/filereader.cpp
@@ -2,6 +2,7 @@
 #include "filereader.h"
 #include <iostream>
 #include <unistd.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 int GetOpt (int argc, char *argv[], const char *optionsString,
             const char* &optionArgument,
@@ -18,7 +19,7 @@ int GetOpt (int argc, char *argv[], const char *optionsString,
 FileReader::FileReader()
     : _backing(),
       _file(&std::cin),
-      _bufsize(1024*1024),
+      _bufsize(1_Mi),
       _buf(_bufsize),
       _lastReadPos(0),
       _nextReadPos(0),

--- a/fnet/src/tests/connect/connect_test.cpp
+++ b/fnet/src/tests/connect/connect_test.cpp
@@ -10,6 +10,7 @@
 #include <vespa/fnet/controlpacket.h>
 #include <vespa/vespalib/net/server_socket.h>
 #include <vespa/vespalib/net/crypto_engine.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 using namespace vespalib;
@@ -90,19 +91,19 @@ struct TransportFixture : FNET_IPacketHandler, FNET_IConnectionCleanupHandler {
     FNET_Transport transport;
     Gate conn_lost;
     Gate conn_deleted;
-    TransportFixture() : streamer(nullptr), pool(128 * 1024), transport(),
+    TransportFixture() : streamer(nullptr), pool(128_Ki), transport(),
                          conn_lost(), conn_deleted()
     {
         transport.Start(&pool);
     }
     TransportFixture(AsyncResolver::HostResolver::SP host_resolver)
-        : streamer(nullptr), pool(128 * 1024), transport(TransportConfig().resolver(make_resolver(std::move(host_resolver)))),
+        : streamer(nullptr), pool(128_Ki), transport(TransportConfig().resolver(make_resolver(std::move(host_resolver)))),
           conn_lost(), conn_deleted()
     {
         transport.Start(&pool);
     }
     TransportFixture(CryptoEngine::SP crypto)
-        : streamer(nullptr), pool(128 * 1024), transport(TransportConfig().crypto(std::move(crypto))),
+        : streamer(nullptr), pool(128_Ki), transport(TransportConfig().crypto(std::move(crypto))),
           conn_lost(), conn_deleted()
     {
         transport.Start(&pool);

--- a/fnet/src/tests/connection_spread/connection_spread_test.cpp
+++ b/fnet/src/tests/connection_spread/connection_spread_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/fnet/connector.h>
 #include <vespa/fnet/connection.h>
 #include <vespa/fastos/thread.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <thread>
 #include <chrono>
@@ -31,7 +32,7 @@ struct Fixture {
     FastOS_ThreadPool thread_pool;
     FNET_Transport client;
     FNET_Transport server;
-    Fixture() : streamer(), adapter(), thread_pool(128 * 1024), client(8), server(8)
+    Fixture() : streamer(), adapter(), thread_pool(128_Ki), client(8), server(8)
     {
         ASSERT_TRUE(client.Start(&thread_pool));
         ASSERT_TRUE(server.Start(&thread_pool));

--- a/fnet/src/tests/examples/examples_test.cpp
+++ b/fnet/src/tests/examples/examples_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/child_process.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/thread.h>
 #include <atomic>
@@ -13,7 +14,7 @@ static const int PORT1 = 18571;
 using vespalib::ChildProcess;
 
 bool runProc(ChildProcess &proc, std::atomic<bool> &done) {
-    char buf[4096];
+    char buf[4_Ki];
     proc.close(); // close stdin
     while (proc.running() && !done) {
         if (!proc.eof()) {

--- a/fnet/src/tests/frt/parallel_rpc/parallel_rpc_test.cpp
+++ b/fnet/src/tests/frt/parallel_rpc/parallel_rpc_test.cpp
@@ -9,6 +9,7 @@
 #include <vespa/vespalib/net/crypto_engine.h>
 #include <vespa/vespalib/net/tls/tls_crypto_engine.h>
 #include <vespa/vespalib/test/make_tls_options_for_testing.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 
 using namespace vespalib;
@@ -18,7 +19,7 @@ struct Rpc : FRT_Invokable {
     FNET_Transport    transport;
     FRT_Supervisor    orb;
     Rpc(CryptoEngine::SP crypto, size_t num_threads)
-        : thread_pool(128 * 1024), transport(TransportConfig(num_threads).crypto(std::move(crypto))), orb(&transport) {}
+        : thread_pool(128_Ki), transport(TransportConfig(num_threads).crypto(std::move(crypto))), orb(&transport) {}
     void start() {
         ASSERT_TRUE(transport.Start(&thread_pool));
     }

--- a/fnet/src/tests/sync_execute/sync_execute.cpp
+++ b/fnet/src/tests/sync_execute/sync_execute.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/gate.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fnet/transport.h>
 #include <vespa/fnet/iexecutable.h>
 #include <vespa/fastos/thread.h>
@@ -17,7 +18,7 @@ TEST("sync execute") {
     DoIt exe2;
     DoIt exe3;
     DoIt exe4;
-    FastOS_ThreadPool pool(128 * 1024 * 1024);
+    FastOS_ThreadPool pool(128_Ki);
     FNET_Transport transport;
     ASSERT_TRUE(transport.execute(&exe1));
     ASSERT_TRUE(transport.Start(&pool));

--- a/fnet/src/vespa/fnet/transport.cpp
+++ b/fnet/src/vespa/fnet/transport.cpp
@@ -4,6 +4,7 @@
 #include "transport_thread.h"
 #include "iocomponent.h"
 #include <vespa/vespalib/util/threadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <chrono>
 #include <xxhash.h>
 
@@ -46,7 +47,7 @@ TransportConfig::crypto() const {
 FNET_Transport::FNET_Transport(TransportConfig cfg)
     : _async_resolver(cfg.resolver()),
       _crypto_engine(cfg.crypto()),
-      _work_pool(std::make_unique<vespalib::ThreadStackExecutor>(1, 128 * 1024, fnet_work_pool, 1024)),
+      _work_pool(std::make_unique<vespalib::ThreadStackExecutor>(1, 128_Ki, fnet_work_pool, 1024)),
       _threads(),
       _config(cfg.config())
 {

--- a/logd/src/logd/empty_forwarder.cpp
+++ b/logd/src/logd/empty_forwarder.cpp
@@ -4,6 +4,7 @@
 #include "metrics.h"
 #include <vespa/log/exceptions.h>
 #include <vespa/log/log_message.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".logd.empty_forwarder");
@@ -28,7 +29,7 @@ EmptyForwarder::~EmptyForwarder() = default;
 void
 EmptyForwarder::forwardLine(std::string_view line)
 {
-    assert (line.size() < 1024*1024);
+    assert (line.size() < 1_Mi);
 
     LogMessage message;
     try {

--- a/logd/src/logd/watcher.cpp
+++ b/logd/src/logd/watcher.cpp
@@ -6,6 +6,7 @@
 #include "watcher.h"
 #include <vespa/vespalib/util/sig_catch.h>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 #include <fcntl.h>
 #include <glob.h>
@@ -29,7 +30,7 @@ void snooze(vespalib::Timer & timer)
     std::this_thread::sleep_for(1000ms - timer.elapsed());
 }
 
-constexpr size_t G_BUFSIZE = 1024*1024;
+constexpr size_t G_BUFSIZE = 1_Mi;
 } // namespace logdemon::<unnamed>
 
 

--- a/logd/src/tests/watcher/watcher_test.cpp
+++ b/logd/src/tests/watcher/watcher_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <fstream>
 #include <regex>
 #include <thread>
@@ -127,7 +128,7 @@ public:
 };
 
 WatcherTest::WatcherTest()
-    : _executor(1, 256 * 1024)
+    : _executor(1, 256_Ki)
 {
     remove_files();
     setenv("VESPA_LOG_TARGET", "file:vespa.log", true);

--- a/messagebus/src/vespa/messagebus/messagebusparams.cpp
+++ b/messagebus/src/vespa/messagebus/messagebusparams.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "messagebus.h"
 #include <vespa/messagebus/routing/retrytransienterrorspolicy.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace mbus {
 
@@ -8,7 +9,7 @@ MessageBusParams::MessageBusParams() :
     _protocols(),
     _retryPolicy(new RetryTransientErrorsPolicy()),
     _maxPendingCount(1024),
-    _maxPendingSize(128 * 1024 * 1024)
+    _maxPendingSize(128_Mi)
 { }
 
 MessageBusParams::~MessageBusParams() {}

--- a/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcnetwork.cpp
@@ -5,19 +5,20 @@
 #include "rpcsendv2.h"
 #include "rpctargetpool.h"
 #include "rpcnetworkparams.h"
-#include <vespa/messagebus/errorcode.h>
-#include <vespa/messagebus/iprotocol.h>
-#include <vespa/messagebus/emptyreply.h>
-#include <vespa/messagebus/routing/routingnode.h>
-#include <vespa/slobrok/sbregister.h>
-#include <vespa/slobrok/sbmirror.h>
-#include <vespa/vespalib/component/vtag.h>
-#include <vespa/vespalib/stllike/asciistream.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/vespalib/util/threadstackexecutor.h>
+#include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/scheduler.h>
 #include <vespa/fnet/transport.h>
-#include <vespa/fnet/frt/supervisor.h>
+#include <vespa/messagebus/emptyreply.h>
+#include <vespa/messagebus/errorcode.h>
+#include <vespa/messagebus/iprotocol.h>
+#include <vespa/messagebus/routing/routingnode.h>
+#include <vespa/slobrok/sbmirror.h>
+#include <vespa/slobrok/sbregister.h>
+#include <vespa/vespalib/component/vtag.h>
+#include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/fastos/thread.h>
 #include <thread>
 
@@ -134,8 +135,8 @@ RPCNetwork::RPCNetwork(const RPCNetworkParams &params) :
     _requestedPort(params.getListenPort()),
     _targetPool(std::make_unique<RPCTargetPool>(params.getConnectionExpireSecs())),
     _targetPoolTask(std::make_unique<TargetPoolTask>(_scheduler, *_targetPool)),
-    _servicePool(std::make_unique<RPCServicePool>(*_mirror, 4096)),
-    _executor(std::make_unique<vespalib::ThreadStackExecutor>(params.getNumThreads(), 65536)),
+    _servicePool(std::make_unique<RPCServicePool>(*_mirror, 4_Ki)),
+    _executor(std::make_unique<vespalib::ThreadStackExecutor>(params.getNumThreads(), 64_Ki)),
     _sendV1(std::make_unique<RPCSendV1>()),
     _sendV2(std::make_unique<RPCSendV2>()),
     _sendAdapters(),

--- a/messagebus/src/vespa/messagebus/network/rpcnetworkparams.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcnetworkparams.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "rpcnetworkparams.h"
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace mbus {
 
@@ -12,8 +13,8 @@ RPCNetworkParams::RPCNetworkParams(config::ConfigUri configUri) :
     _identity(Identity("")),
     _slobrokConfig(std::move(configUri)),
     _listenPort(0),
-    _maxInputBufferSize(256*1024),
-    _maxOutputBufferSize(256*1024),
+    _maxInputBufferSize(256_Ki),
+    _maxOutputBufferSize(256_Ki),
     _numThreads(4),
     _tcpNoDelay(true),
     _dispatchOnEncode(true),

--- a/messagebus/src/vespa/messagebus/network/rpcsendv2.cpp
+++ b/messagebus/src/vespa/messagebus/network/rpcsendv2.cpp
@@ -3,13 +3,14 @@
 #include "rpcsendv2.h"
 #include "rpcnetwork.h"
 #include "rpcserviceaddress.h"
+#include <vespa/fnet/frt/reflection.h>
 #include <vespa/messagebus/emptyreply.h>
 #include <vespa/messagebus/error.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/util/compressor.h>
-#include <vespa/fnet/frt/reflection.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/stringfmt.h>
 
 using vespalib::make_string;
 using vespalib::compression::CompressionConfig;
@@ -124,7 +125,7 @@ RPCSendV2::encodeRequest(FRT_RPCRequest &req, const Version &version, const Rout
     root.setLong(TRACELEVEL_F, traceLevel);
     filler.fill(BLOB_F, root);
 
-    OutputBuf rBuf(8192);
+    OutputBuf rBuf(8_Ki);
     BinaryFormat::encode(slime, rBuf);
     ConstBufferRef toCompress(rBuf.getBuf().getData(), rBuf.getBuf().getDataLen());
     DataBuffer buf(vespalib::roundUp2inN(rBuf.getBuf().getDataLen()));
@@ -254,7 +255,7 @@ RPCSendV2::createResponse(FRT_Values & ret, const string & version, Reply & repl
         }
     }
 
-    OutputBuf rBuf(8192);
+    OutputBuf rBuf(8_Ki);
     BinaryFormat::encode(slime, rBuf);
     ConstBufferRef toCompress(rBuf.getBuf().getData(), rBuf.getBuf().getDataLen());
     DataBuffer buf(vespalib::roundUp2inN(rBuf.getBuf().getDataLen()));

--- a/metrics/src/tests/metricmanagertest.cpp
+++ b/metrics/src/tests/metricmanagertest.cpp
@@ -9,6 +9,7 @@
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/xmlstream.h>
 #include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/data/simple_buffer.h>
@@ -146,7 +147,7 @@ namespace {
 std::pair<std::string, std::string>
 getMatchedMetrics(const vespalib::string& config)
 {
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     TestMetricSet mySet;
     MetricManager mm;
     mm.registerMetric(mm.getMetricLock(), mySet.set);
@@ -465,7 +466,7 @@ std::string dumpAllSnapshots(const MetricManager& mm,
 
 TEST_F(MetricManagerTest, test_snapshots)
 {
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     FakeTimer* timer = new FakeTimer(1000);
     std::unique_ptr<MetricManager::Timer> timerImpl(timer);
     TestMetricSet mySet;
@@ -567,7 +568,7 @@ TEST_F(MetricManagerTest, test_snapshots)
 
 TEST_F(MetricManagerTest, test_xml_output)
 {
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     FakeTimer* timer = new FakeTimer(1000);
     std::unique_ptr<MetricManager::Timer> timerImpl(timer);
     MetricManager mm(std::move(timerImpl));
@@ -645,7 +646,7 @@ TEST_F(MetricManagerTest, test_xml_output)
 
 TEST_F(MetricManagerTest, test_json_output)
 {
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     FakeTimer* timer = new FakeTimer(1000);
     std::unique_ptr<MetricManager::Timer> timerImpl(timer);
     MetricManager mm(std::move(timerImpl));
@@ -734,7 +735,7 @@ namespace {
 
 struct MetricSnapshotTestFixture
 {
-    static const size_t DEFAULT_THREAD_STACK_SIZE = 256 * 1024;
+    static const size_t DEFAULT_THREAD_STACK_SIZE = 256_Ki;
 
     MetricManagerTest& test;
     FastOS_ThreadPool pool;
@@ -974,7 +975,7 @@ TEST_F(MetricManagerTest, json_output_can_have_multiple_sets_with_same_name)
 
 TEST_F(MetricManagerTest, test_text_output)
 {
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     FakeTimer* timer = new FakeTimer(1000);
     std::unique_ptr<MetricManager::Timer> timerImpl(timer);
     MetricManager mm(std::move(timerImpl));
@@ -1063,7 +1064,7 @@ namespace {
 TEST_F(MetricManagerTest, test_update_hooks)
 {
     std::ostringstream output;
-    FastOS_ThreadPool pool(256 * 1024);
+    FastOS_ThreadPool pool(256_Ki);
     FakeTimer* timer = new FakeTimer(1000);
     std::unique_ptr<MetricManager::Timer> timerImpl(timer);
         // Add a metric set just so one exist

--- a/metrics/src/tests/snapshottest.cpp
+++ b/metrics/src/tests/snapshottest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/metrics/metrics.h>
 #include <vespa/metrics/summetric.hpp>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace metrics {
 
@@ -175,7 +176,7 @@ TEST_F(SnapshotTest, test_snapshot_two_days)
     TestMetricSet set("test");
 
     FakeTimer* timer;
-    FastOS_ThreadPool threadPool(256 * 1024);
+    FastOS_ThreadPool threadPool(256_Ki);
     MetricManager mm(
             std::unique_ptr<MetricManager::Timer>(timer = new FakeTimer));
     {

--- a/metrics/src/tests/stresstest.cpp
+++ b/metrics/src/tests/stresstest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/metrics/metrics.h>
 #include <vespa/metrics/summetric.hpp>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 #include <vespa/vespalib/gtest/gtest.h>
 
@@ -113,7 +114,7 @@ TEST(StressTest, test_stress)
     OuterMetricSet metrics;
 
     LOG(info, "Starting load givers");
-    FastOS_ThreadPool threadPool(256 * 1024);
+    FastOS_ThreadPool threadPool(256_Ki);
     std::vector<Hammer::UP> hammers;
     for (uint32_t i=0; i<10; ++i) {
         hammers.push_back(std::make_unique<Hammer>(metrics, threadPool));

--- a/metrics/src/vespa/metrics/memoryconsumption.cpp
+++ b/metrics/src/vespa/metrics/memoryconsumption.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "memoryconsumption.h"
 #include <vespa/vespalib/stllike/hash_set.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <sstream>
 
 namespace metrics {
@@ -125,12 +126,12 @@ MemoryConsumption::print(std::ostream& out, bool verbose,
 std::string
 MemoryConsumption::bval(uint32_t bytes) {
     std::ostringstream ost;
-    if (bytes < 10 * 1024) {
+    if (bytes < 10_Ki) {
         ost << bytes << " B";
-    } else if (bytes < 10 * 1024 * 1024) {
-        ost << (bytes / 1024) << " kB";
+    } else if (bytes < 10_Mi) {
+        ost << (bytes / 1_Ki) << " kB";
     } else {
-        ost << (bytes / (1024 * 1024)) << " MB";
+        ost << (bytes / 1_Mi) << " MB";
     }
     return ost.str();
 }

--- a/persistence/src/vespa/persistence/conformancetest/conformancetest.cpp
+++ b/persistence/src/vespa/persistence/conformancetest/conformancetest.cpp
@@ -16,6 +16,7 @@
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/config-stor-distribution.h>
 #include <algorithm>
 #include <limits>
@@ -1109,7 +1110,7 @@ TEST_F(ConformanceTest, testIterateAllDocs)
     std::vector<DocAndTimestamp> docs(feedDocs(*spi, testDocMan, b, 100));
     CreateIteratorResult iter(createIterator(*spi, b, createSelection("")));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
     verifyDocs(docs, chunks);
 
     spi->destroyIterator(iter.getIteratorId(), context);
@@ -1137,7 +1138,7 @@ TEST_F(ConformanceTest, testIterateAllDocsNewestVersionOnly)
 
     CreateIteratorResult iter(createIterator(*spi, b, createSelection("")));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
     verifyDocs(newDocs, chunks);
 
     spi->destroyIterator(iter.getIteratorId(), context);
@@ -1173,7 +1174,7 @@ TEST_F(ConformanceTest, testMaxByteSize)
     spi->createBucket(b, context);
 
     std::vector<DocAndTimestamp> docs(
-            feedDocs(*spi, testDocMan, b, 100, 4096, 4096));
+            feedDocs(*spi, testDocMan, b, 100, 4_Ki, 4096));
 
     Selection sel(createSelection(""));
     CreateIteratorResult iter(createIterator(*spi, b, sel));
@@ -1221,7 +1222,7 @@ TEST_F(ConformanceTest, testIterateMatchTimestampRange)
 
     CreateIteratorResult iter(createIterator(*spi, b, sel));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2048);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2_Ki);
     verifyDocs(docsToVisit, chunks);
 
     spi->destroyIterator(iter.getIteratorId(), context);
@@ -1270,7 +1271,7 @@ TEST_F(ConformanceTest, testIterateExplicitTimestampSubset)
 
     CreateIteratorResult iter(createIterator(*spi, b, sel));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2048);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2_Ki);
     verifyDocs(docsToVisit, chunks, removes);
 
     spi->destroyIterator(iter.getIteratorId(), context);
@@ -1308,7 +1309,7 @@ TEST_F(ConformanceTest, testIterateRemoves)
         Selection sel(createSelection(""));
         CreateIteratorResult iter(createIterator(*spi, b, sel));
 
-        std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+        std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
         verifyDocs(nonRemovedDocs, chunks);
         spi->destroyIterator(iter.getIteratorId(), context);
     }
@@ -1317,7 +1318,7 @@ TEST_F(ConformanceTest, testIterateRemoves)
         Selection sel(createSelection(""));
         CreateIteratorResult iter(createIterator(*spi, b, sel, NEWEST_DOCUMENT_OR_REMOVE));
 
-        std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+        std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
         std::vector<DocEntry::UP> entries = getEntriesFromChunks(chunks);
         EXPECT_EQ(docs.size(), entries.size());
         verifyDocs(nonRemovedDocs, chunks, removedDocs);
@@ -1350,7 +1351,7 @@ TEST_F(ConformanceTest, testIterateMatchSelection)
 
     CreateIteratorResult iter(createIterator(*spi, b, createSelection("testdoctype1.headerval % 3 == 0")));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2048 * 1024);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 2_Mi);
     verifyDocs(docsToVisit, chunks);
 
     spi->destroyIterator(iter.getIteratorId(), context);
@@ -1377,7 +1378,7 @@ TEST_F(ConformanceTest, testIterationRequiringDocumentIdOnlyMatching)
     CreateIteratorResult iter(createIterator(*spi, b, sel, NEWEST_DOCUMENT_OR_REMOVE));
     EXPECT_TRUE(iter.getErrorCode() == Result::ErrorType::NONE);
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
     std::vector<DocAndTimestamp> docs;
     std::set<vespalib::string> removes;
     removes.insert(removedId.toString());
@@ -1397,7 +1398,7 @@ TEST_F(ConformanceTest, testIterateBadDocumentSelection)
     {
         CreateIteratorResult iter(createIterator(*spi, b, createSelection("the muppet show")));
         if (iter.getErrorCode() == Result::ErrorType::NONE) {
-            IterateResult result(spi->iterate(iter.getIteratorId(), 4096, context));
+            IterateResult result(spi->iterate(iter.getIteratorId(), 4_Ki, context));
             EXPECT_EQ(Result::ErrorType::NONE, result.getErrorCode());
             EXPECT_EQ(size_t(0), result.getEntries().size());
             EXPECT_EQ(true, result.isCompleted());
@@ -1409,7 +1410,7 @@ TEST_F(ConformanceTest, testIterateBadDocumentSelection)
     {
         CreateIteratorResult iter(createIterator(*spi, b, createSelection("unknownddoctype.something=thatthing")));
         if (iter.getErrorCode() == Result::ErrorType::NONE) {
-            IterateResult result(spi->iterate(iter.getIteratorId(), 4096, context));
+            IterateResult result(spi->iterate(iter.getIteratorId(), 4_Ki, context));
             EXPECT_EQ(Result::ErrorType::NONE, result.getErrorCode());
             EXPECT_EQ(size_t(0), result.getEntries().size());
             EXPECT_EQ(true, result.isCompleted());
@@ -1433,10 +1434,10 @@ TEST_F(ConformanceTest, testIterateAlreadyCompleted)
     Selection sel(createSelection(""));
     CreateIteratorResult iter(createIterator(*spi, b, sel));
 
-    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4096);
+    std::vector<Chunk> chunks = doIterate(*spi, iter.getIteratorId(), 4_Ki);
     verifyDocs(docs, chunks);
 
-    IterateResult result(spi->iterate(iter.getIteratorId(), 4096, context));
+    IterateResult result(spi->iterate(iter.getIteratorId(), 4_Ki, context));
     EXPECT_EQ(Result::ErrorType::NONE, result.getErrorCode());
     EXPECT_EQ(size_t(0), result.getEntries().size());
     EXPECT_TRUE(result.isCompleted());
@@ -1456,7 +1457,7 @@ TEST_F(ConformanceTest, testIterateEmptyBucket)
 
     CreateIteratorResult iter(createIterator(*spi, b, sel));
 
-    IterateResult result(spi->iterate(iter.getIteratorId(), 4096, context));
+    IterateResult result(spi->iterate(iter.getIteratorId(), 4_Ki, context));
     EXPECT_EQ(Result::ErrorType::NONE, result.getErrorCode());
     EXPECT_EQ(size_t(0), result.getEntries().size());
     EXPECT_TRUE(result.isCompleted());

--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -36,6 +36,7 @@
 #include <vespa/config-indexschema.h>
 #include <vespa/config-summary.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("persistenceconformance_test");
@@ -217,7 +218,7 @@ public:
                                _fileHeaderContext,
                                _config_stores.getConfigStore(docType.toString()),
                                std::make_shared<vespalib::ThreadStackExecutor>
-                               (16, 128 * 1024),
+                               (16, 128_Ki),
                                HwInfo());
     }
 };
@@ -231,7 +232,7 @@ DocumentDBFactory::DocumentDBFactory(const vespalib::string &baseDir, int tlsLis
       _queryLimiter(),
       _clock(),
       _metricsWireService(),
-      _summaryExecutor(8, 128 * 1024),
+      _summaryExecutor(8, 128_Ki),
       _bucketExecutor(2)
 {}
 DocumentDBFactory::~DocumentDBFactory()  = default;

--- a/searchcore/src/apps/vespa-feed-bm/vespa_feed_bm.cpp
+++ b/searchcore/src/apps/vespa-feed-bm/vespa_feed_bm.cpp
@@ -74,6 +74,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <getopt.h>
 #include <iostream>
 #include <thread>
@@ -722,7 +723,7 @@ PersistenceProviderFixture::PersistenceProviderFixture(const BMParams& params)
       _clock(),
       _metrics_wire_service(),
       _config_stores(),
-      _summary_executor(8, 128 * 1024),
+      _summary_executor(8, 128_Ki),
       _document_db_owner(),
       _bucket_space(makeBucketSpace(_doc_type_name.getName())),
       _document_db(),
@@ -813,7 +814,7 @@ PersistenceProviderFixture::create_document_db(const BMParams & params)
                                                 _metrics_wire_service,
                                                 _file_header_context,
                                                 _config_stores.getConfigStore(_doc_type_name.toString()),
-                                                std::make_shared<vespalib::ThreadStackExecutor>(16, 128 * 1024),
+                                                std::make_shared<vespalib::ThreadStackExecutor>(16, 128_Ki),
                                                 HwInfo());
     _document_db->start();
     _document_db->waitForOnlineState();
@@ -1327,7 +1328,7 @@ void benchmark_async_spi(const BMParams &bm_params)
         f.start_message_bus();
     }
     f.create_feed_handler(bm_params);
-    vespalib::ThreadStackExecutor executor(bm_params.get_client_threads(), 128 * 1024);
+    vespalib::ThreadStackExecutor executor(bm_params.get_client_threads(), 128_Ki);
     auto put_feed = make_feed(executor, bm_params, [&f](BMRange range, BucketSelector bucket_selector) { return make_put_feed(f, range, bucket_selector); }, f.num_buckets(), "put");
     auto update_feed = make_feed(executor, bm_params, [&f](BMRange range, BucketSelector bucket_selector) { return make_update_feed(f, range, bucket_selector); }, f.num_buckets(), "update");
     auto remove_feed = make_feed(executor, bm_params, [&f](BMRange range, BucketSelector bucket_selector) { return make_remove_feed(f, range, bucket_selector); }, f.num_buckets(), "remove");

--- a/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
+++ b/searchcore/src/apps/vespa-gen-testdocs/vespa-gen-testdocs.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/fastos/app.h>
 #include <iostream>
@@ -66,7 +67,7 @@ shafile(const string &baseDir,
     string fullFile(prependBaseDir(baseDir, file));
     FastOS_File f;
     std::ostringstream os;
-    Alloc buf = Alloc::alloc_aligned(65536, 0x1000);
+    Alloc buf = Alloc::alloc_aligned(64_Ki, 0x1000);
     f.EnableDirectIO();
     bool openres = f.OpenReadOnly(fullFile.c_str());
     if (!openres) {

--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -36,6 +36,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -253,7 +254,7 @@ ParallelAttributeManager::ParallelAttributeManager(search::SerialNum configSeria
       alloc_strategy(),
       fastAccessAttributesOnly(false),
       mgr(std::make_shared<AttributeManager::SP>()),
-      masterExecutor(1, 128 * 1024),
+      masterExecutor(1, 128_Ki),
       master(masterExecutor),
       initializer(std::make_shared<AttributeManagerInitializer>(configSerialNum, documentMetaStoreInitTask,
                                                                 documentMetaStore, baseAttrMgr, attrCfg,
@@ -261,7 +262,7 @@ ParallelAttributeManager::ParallelAttributeManager(search::SerialNum configSeria
                                                                 fastAccessAttributesOnly, master, mgr))
 {
     documentMetaStore->setCommittedDocIdLimit(docIdLimit);
-    vespalib::ThreadStackExecutor executor(3, 128 * 1024);
+    vespalib::ThreadStackExecutor executor(3, 128_Ki);
     initializer::TaskRunner taskRunner(executor);
     taskRunner.runTask(initializer);
 }

--- a/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
@@ -2,6 +2,7 @@
 #include <vespa/log/log.h>
 LOG_SETUP("attribute_usage_filter_test");
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchcore/proton/attribute/attribute_usage_filter.h>
 #include <vespa/searchcore/proton/attribute/i_attribute_usage_listener.h>
 
@@ -14,14 +15,9 @@ using vespalib::AddressSpace;
 namespace
 {
 
-vespalib::AddressSpace enumStoreOverLoad(30 * 1024 * 1024 * UINT64_C(1024),
-                                         0,
-                                         32 * 1024 * 1024 * UINT64_C(1024));
+vespalib::AddressSpace enumStoreOverLoad(30_Gi, 0, 32_Gi);
 
-vespalib::AddressSpace multiValueOverLoad(127 * 1024 * 1024,
-                                          0,
-                                          128 * 1024 * 1024);
-
+vespalib::AddressSpace multiValueOverLoad(127_Mi, 0, 128_Mi);
 
 
 class MyAttributeStats : public AttributeUsageStats

--- a/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
@@ -17,6 +17,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <thread>
 
@@ -77,7 +78,7 @@ public:
     GateSP gate;
 
     FlushHandler()
-        : _executor(1, 65536),
+        : _executor(1, 64_Ki),
           gate()
     { }
     ~FlushHandler();
@@ -581,7 +582,7 @@ Test::requireThatShrinkWorks()
     EXPECT_EQUAL(1000u, av->getNumDocs());
     EXPECT_EQUAL(100u, av->getCommittedDocIdLimit());
     EXPECT_EQUAL(createSerialNum - 1, ft->getFlushedSerialNum());
-    vespalib::ThreadStackExecutor exec(1, 128 * 1024);
+    vespalib::ThreadStackExecutor exec(1, 128_Ki);
     vespalib::Executor::Task::UP task = ft->initFlush(53, std::make_shared<search::FlushToken>());
     exec.execute(std::move(task));
     exec.sync();

--- a/searchcore/src/tests/proton/common/hw_info_sampler/hw_info_sampler_test.cpp
+++ b/searchcore/src/tests/proton/common/hw_info_sampler/hw_info_sampler_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchcore/config/config-hwinfo.h>
 #include <vespa/searchcore/proton/common/hw_info_sampler.h>
 #include <vespa/searchlib/test/directory_handler.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/testkit/testapp.h>
 
 using proton::HwInfoSampler;
@@ -17,7 +18,7 @@ using Config = HwInfoSampler::Config;
 namespace {
 
 const vespalib::string test_dir = "temp";
-constexpr uint64_t sampleLen = 1024 * 1024 * 40;
+constexpr uint64_t sampleLen = 40_Mi;
 constexpr bool sharedDisk = false;
 
 long time_point_to_long(Clock::time_point tp)

--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -36,6 +36,7 @@
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/simple_buffer.h>
 #include <vespa/vespalib/encoding/base64.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/config-bucketspaces.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <regex>
@@ -101,7 +102,7 @@ public:
         : _dmk("summary"),
           _bld(schema),
           _repo(std::make_shared<DocumentTypeRepo>(_bld.getDocumentType())),
-          _summaryExecutor(4, 128 * 1024),
+          _summaryExecutor(4, 128_Ki),
           _noTlSyncer(),
           _str(_summaryExecutor, "summary",
                LogDocumentStore::Config(
@@ -193,7 +194,7 @@ public:
         : _dmk(docTypeName),
           _fileHeaderContext(),
           _tls("tmp", 9013, ".", _fileHeaderContext),
-          _summaryExecutor(8, 128*1024),
+          _summaryExecutor(8, 128_Ki),
           _bucketExecutor(2),
           _mkdirOk(FastOS_File::MakeDirectory("tmpdb")),
           _queryLimiter(),
@@ -224,7 +225,7 @@ public:
                                             DocTypeName(docTypeName), makeBucketSpace(), *b->getProtonConfigSP(), *this,
                                             _summaryExecutor, _summaryExecutor, _bucketExecutor, _tls, _dummy, _fileHeaderContext,
                                             std::make_unique<MemoryConfigStore>(),
-                                            std::make_shared<vespalib::ThreadStackExecutor>(16, 128 * 1024), _hwInfo),
+                                            std::make_shared<vespalib::ThreadStackExecutor>(16, 128_Ki), _hwInfo),
         _ddb->start();
         _ddb->waitForOnlineState();
         _aw = std::make_unique<AttributeWriter>(_ddb->getReadySubDB()->getAttributeManager());

--- a/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/configurer/configurer_test.cpp
@@ -26,6 +26,7 @@
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace config;
 using namespace document;
@@ -165,7 +166,7 @@ Fixture::Fixture()
       _queryLimiter(),
       _constantValueFactory(),
       _constantValueRepo(_constantValueFactory),
-      _summaryExecutor(8, 128*1024),
+      _summaryExecutor(8, 128_Ki),
       _pendingLidsForCommit(std::make_shared<PendingLidTracker>()),
       _views(),
       _resolver(),

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -29,6 +29,7 @@
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace cloud::config::filedistribution;
 using namespace document;
@@ -293,7 +294,7 @@ struct FixtureBase
     typename Traits::SubDB _subDb;
     IFeedView::SP _tmpFeedView;
     FixtureBase()
-        : _summaryExecutor(1, 64 * 1024),
+        : _summaryExecutor(1, 64_Ki),
           _writeService(_summaryExecutor),
           _cfg(),
           _bucketDB(std::make_shared<bucketdb::BucketDBOwner>()),
@@ -319,7 +320,7 @@ struct FixtureBase
     void init() {
         DocumentSubDbInitializer::SP task =
             _subDb.createInitializer(*_snapshot->_cfg, Traits::configSerial(), IndexConfig());
-        vespalib::ThreadStackExecutor executor(1, 1024 * 1024);
+        vespalib::ThreadStackExecutor executor(1, 1_Mi);
         initializer::TaskRunner taskRunner(executor);
         taskRunner.runTask(task);
         auto sessionMgr = std::make_shared<SessionManager>(1);

--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -25,6 +25,7 @@
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/config-bucketspaces.h>
 #include <vespa/vespalib/testkit/test_kit.h>
 
@@ -84,7 +85,7 @@ struct Fixture {
 Fixture::Fixture()
     : _dummy(),
       _myDBOwner(),
-      _summaryExecutor(8, 128*1024),
+      _summaryExecutor(8, 128_Ki),
       _hwInfo(),
       _bucketExecutor(2),
       _db(),
@@ -110,7 +111,7 @@ Fixture::Fixture()
                              makeBucketSpace(),
                              *b->getProtonConfigSP(), _myDBOwner, _summaryExecutor, _summaryExecutor, _bucketExecutor, _tls, _dummy,
                              _fileHeaderContext, std::make_unique<MemoryConfigStore>(),
-                             std::make_shared<vespalib::ThreadStackExecutor>(16, 128 * 1024), _hwInfo);
+                             std::make_shared<vespalib::ThreadStackExecutor>(16, 128_Ki), _hwInfo);
     _db->start();
     _db->waitForOnlineState();
 }

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -29,17 +29,18 @@
 #include <vespa/searchcore/proton/test/disk_mem_usage_notifier.h>
 #include <vespa/searchcore/proton/test/mock_attribute_manager.h>
 #include <vespa/searchcore/proton/test/test.h>
-#include <vespa/persistence/dummyimpl/dummy_bucket_executor.h>
+#include <vespa/config-attributes.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/test/make_bucket_space.h>
-#include <vespa/config-attributes.h>
-#include <vespa/vespalib/util/destructor_callbacks.h>
+#include <vespa/persistence/dummyimpl/dummy_bucket_executor.h>
 #include <vespa/searchlib/common/idocumentmetastore.h>
 #include <vespa/searchlib/index/docbuilder.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/testkit/testapp.h>
-#include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/util/gate.h>
+#include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/fastos/thread.h>
 #include <unistd.h>
@@ -747,7 +748,7 @@ MyFeedHandler::appendOperation(const FeedOperation &op, DoneCallback)
 }
 
 MyExecutor::MyExecutor()
-    : vespalib::ThreadStackExecutor(1, 128 * 1024),
+    : vespalib::ThreadStackExecutor(1, 128_Ki),
       _threadId()
 {
     execute(makeLambdaTask([this]() {

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -21,6 +21,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <thread>
 
@@ -1896,7 +1897,7 @@ TEST(DocumentMetaStoreTest, shrink_via_flush_target_works)
     EXPECT_TRUE(ft->getApproxMemoryGain().getBefore() >
                 ft->getApproxMemoryGain().getAfter());
 
-    vespalib::ThreadStackExecutor exec(1, 128 * 1024);
+    vespalib::ThreadStackExecutor exec(1, 128_Ki);
     vespalib::Executor::Task::UP task = ft->initFlush(11, std::make_shared<search::FlushToken>());
     exec.execute(std::move(task));
     exec.sync();

--- a/searchcore/src/tests/proton/index/indexcollection_test.cpp
+++ b/searchcore/src/tests/proton/index/indexcollection_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/searchcore/proton/matching/fakesearchcontext.h>
 #include <vespa/searchcorespi/index/warmupindexcollection.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -87,7 +88,7 @@ public:
           _source1(new MockIndexSearchable({3, 5})),
           _source2(new MockIndexSearchable({7, 11})),
           _fusion_source(new FakeIndexSearchable),
-          _executor(1, 128*1024),
+          _executor(1, 128_Ki),
           _warmup(new FakeIndexSearchable)
     {}
     ~IndexCollectionTest() = default;

--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -20,6 +20,7 @@
 #include <vespa/searchlib/test/index/mock_field_length_inspector.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/time.h>
 #include <set>
@@ -316,7 +317,7 @@ TEST_F(IndexManagerTest, require_that_memory_index_is_flushed)
 
 TEST_F(IndexManagerTest, require_that_large_memory_footprint_triggers_urgent_flush) {
     using FlushStats = IndexMaintainer::FlushStats;
-    constexpr size_t G = 1024*1024*1024l;
+    constexpr size_t G =1_Gi;
     // IndexMaintainer::FlushStats small_15G(15*G, 0, 1, 1);
     EXPECT_FALSE(IndexFlushTarget(_index_manager->getMaintainer()).needUrgentFlush());
     EXPECT_FALSE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(15*G)).needUrgentFlush());

--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -317,11 +317,10 @@ TEST_F(IndexManagerTest, require_that_memory_index_is_flushed)
 
 TEST_F(IndexManagerTest, require_that_large_memory_footprint_triggers_urgent_flush) {
     using FlushStats = IndexMaintainer::FlushStats;
-    constexpr size_t G =1_Gi;
-    // IndexMaintainer::FlushStats small_15G(15*G, 0, 1, 1);
+    // IndexMaintainer::FlushStats small_15G(15_Gi, 0, 1, 1);
     EXPECT_FALSE(IndexFlushTarget(_index_manager->getMaintainer()).needUrgentFlush());
-    EXPECT_FALSE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(15*G)).needUrgentFlush());
-    EXPECT_TRUE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(17*G)).needUrgentFlush());
+    EXPECT_FALSE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(15_Gi)).needUrgentFlush());
+    EXPECT_TRUE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(17_Gi)).needUrgentFlush());
 }
 
 TEST_F(IndexManagerTest, require_that_multiple_flushes_gives_multiple_indexes)

--- a/searchcore/src/tests/proton/initializer/task_runner_test.cpp
+++ b/searchcore/src/tests/proton/initializer/task_runner_test.cpp
@@ -4,8 +4,9 @@ LOG_SETUP("task_runner_test");
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchcore/proton/initializer/initializer_task.h>
 #include <vespa/searchcore/proton/initializer/task_runner.h>
-#include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
 #include <mutex>
 
 using proton::initializer::InitializerTask;
@@ -113,7 +114,7 @@ struct Fixture
     TaskRunner _taskRunner;
 
     Fixture(uint32_t numThreads = 1)
-        : _executor(numThreads, 128 * 1024),
+        : _executor(numThreads, 128_Ki),
           _taskRunner(_executor)
     {
     }

--- a/searchcore/src/tests/proton/matching/docid_range_scheduler/docid_range_scheduler_bench.cpp
+++ b/searchcore/src/tests/proton/matching/docid_range_scheduler/docid_range_scheduler_bench.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchcore/proton/matching/docid_range_scheduler.h>
 #include <vespa/vespalib/util/rendezvous.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 using namespace proton::matching;
@@ -146,7 +147,7 @@ struct SchedulerList {
         factory_list.push_back(std::make_unique<TaskSchedulerFactory>(num_threads, 64));
         factory_list.push_back(std::make_unique<TaskSchedulerFactory>(num_threads, 256));
         factory_list.push_back(std::make_unique<TaskSchedulerFactory>(num_threads, 1024));
-        factory_list.push_back(std::make_unique<TaskSchedulerFactory>(num_threads, 4096));
+        factory_list.push_back(std::make_unique<TaskSchedulerFactory>(num_threads, 4_Ki));
         factory_list.push_back(std::make_unique<AdaptiveSchedulerFactory>(num_threads, 1000));
         factory_list.push_back(std::make_unique<AdaptiveSchedulerFactory>(num_threads, 100));
         factory_list.push_back(std::make_unique<AdaptiveSchedulerFactory>(num_threads, 10));

--- a/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
+++ b/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchlib/query/tree/querybuilder.h>
 #include <vespa/vespalib/data/smart_buffer.h>
 #include <vespa/vespalib/data/output_writer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <string>
 
 using namespace proton::matching;
@@ -69,7 +70,7 @@ struct DumpQuery : QueryVisitor {
 };
 
 std::string dump_query(Node &root) {
-    SmartBuffer buffer(4096);
+    SmartBuffer buffer(4_Ki);
     {
         OutputWriter writer(buffer, 1024);
         DumpQuery dumper(writer, 0);

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -24,6 +24,7 @@
 #include <vespa/searchcore/config/config-onnx-models.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/searchcommon/common/schemaconfigurer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/config-bucketspaces.h>
@@ -272,7 +273,7 @@ struct MyProtonConfigurerOwner : public IProtonConfigurerOwner,
     MyProtonConfigurerOwner()
         : IProtonConfigurerOwner(),
           MyLog(),
-          _executor(1, 128 * 1024),
+          _executor(1, 128_Ki),
           _dbs()
     {
     }

--- a/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
+++ b/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchcore/proton/server/memory_flush_config_updater.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace proton;
 using vespa::config::search::core::ProtonConfig;
@@ -41,8 +42,7 @@ belowLimit()
     return ResourceUsageState(0.7, 0.6);
 }
 
-const HwInfo::Memory defaultMemory(8ul * 1024ul * 1024ul * 1024ul);
-constexpr size_t ONE_G = 1024ul * 1024ul * 1024ul;;
+const HwInfo::Memory defaultMemory(8_Gi);
 
 struct Fixture
 {
@@ -83,7 +83,7 @@ TEST("require that we use configured memory limits") {
 
 TEST("require that we cap configured limits based on available memory") {
     const uint64_t LIMIT = defaultMemory.sizeBytes()/4;
-    constexpr uint64_t MEM_4G = 4 * ONE_G;
+    constexpr uint64_t MEM_4G = 4_Gi;
     auto cfg = MemoryFlushConfigUpdater::convertConfig(getConfig(MEM_4G, MEM_4G, 30), defaultMemory);
     EXPECT_EQUAL(cfg.maxGlobalMemory, LIMIT);
     EXPECT_EQUAL(uint64_t(cfg.maxMemoryGain), LIMIT);

--- a/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
+++ b/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
@@ -83,8 +83,7 @@ TEST("require that we use configured memory limits") {
 
 TEST("require that we cap configured limits based on available memory") {
     const uint64_t LIMIT = defaultMemory.sizeBytes()/4;
-    constexpr uint64_t MEM_4G = 4_Gi;
-    auto cfg = MemoryFlushConfigUpdater::convertConfig(getConfig(MEM_4G, MEM_4G, 30), defaultMemory);
+    auto cfg = MemoryFlushConfigUpdater::convertConfig(getConfig(4_Gi, 4_Gi, 30), defaultMemory);
     EXPECT_EQUAL(cfg.maxGlobalMemory, LIMIT);
     EXPECT_EQUAL(uint64_t(cfg.maxMemoryGain), LIMIT);
 }

--- a/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchcore/config/config-hwinfo.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <filesystem>
 #include <thread>
 #include <vespa/log/log.h>
@@ -80,7 +81,7 @@ double measureDiskWriteSpeed(const vespalib::string &path,
 {
     FastOS_File testFile;
     vespalib::string fileName = path + "/hwinfo-writespeed";
-    size_t bufferLen = 1024 * 1024;
+    size_t bufferLen = 1_Mi;
     Alloc buffer(Alloc::allocMMap(bufferLen));
     memset(buffer.get(), 0, buffer.size());
     testFile.EnableDirectIO();
@@ -100,7 +101,7 @@ double measureDiskWriteSpeed(const vespalib::string &path,
     testFile.Close();
     vespalib::unlink(fileName);
     double elapsed = vespalib::to_s(after - before);
-    double diskWriteSpeed = diskWriteLen / elapsed / 1024 / 1024;
+    double diskWriteSpeed = diskWriteLen / elapsed / 1_Mi;
     return diskWriteSpeed;
 }
 
@@ -148,7 +149,7 @@ HwInfoSampler::setDiskWriteSpeed(const vespalib::string &path, const Config &con
 void
 HwInfoSampler::sampleDiskWriteSpeed(const vespalib::string &path, const Config &config)
 {
-    size_t minDiskWriteLen = 1024u * 1024u;
+    size_t minDiskWriteLen = 1_Mi;
     size_t diskWriteLen = config.diskSampleWriteSize;
     diskWriteLen = std::max(diskWriteLen, minDiskWriteLen);
     _sampleTime = Clock::now();

--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/common/location.h>
 #include <vespa/searchlib/common/matching_elements.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
@@ -65,7 +66,7 @@ DocsumReply::UP
 DocsumContext::createReply()
 {
     auto reply = std::make_unique<DocsumReply>();
-    search::RawBuf buf(4096);
+    search::RawBuf buf(4_Ki);
     _docsumWriter.InitState(_attrMgr, &_docsumState);
     reply->docsums.resize(_docsumState._docsumcnt);
     SymbolTable::UP symbols = std::make_unique<SymbolTable>();

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -9,6 +9,7 @@
 #include <vespa/searchcore/proton/common/eventlogger.h>
 #include <vespa/searchlib/common/flush_token.h>
 #include <vespa/vespalib/util/jsonwriter.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -82,10 +83,10 @@ FlushEngine::FlushEngine(std::shared_ptr<flushengine::ITlsStatsFactory> tlsStats
       _maxConcurrent(numThreads),
       _idleInterval(idleInterval),
       _taskId(0),
-      _threadPool(128 * 1024),
+      _threadPool(128_Ki),
       _strategy(std::move(strategy)),
       _priorityStrategy(),
-      _executor(numThreads, 128 * 1024, flush_engine_executor),
+      _executor(numThreads, 128_Ki, flush_engine_executor),
       _lock(),
       _cond(),
       _handlers(),

--- a/searchcore/src/vespa/searchcore/proton/initializer/task_runner.cpp
+++ b/searchcore/src/vespa/searchcore/proton/initializer/task_runner.cpp
@@ -2,6 +2,7 @@
 
 #include "task_runner.h"
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <future>
 
@@ -93,7 +94,7 @@ TaskRunner::internalRunTasks(const TaskList &taskList, Context::SP context)
 void
 TaskRunner::runTask(InitializerTask::SP task)
 {
-    vespalib::ThreadStackExecutor executor(1, 128 * 1024, task_runner);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki, task_runner);
     std::promise<void> promise;
     auto future = promise.get_future();
     runTask(task, executor, makeLambdaTask([&]() { promise.set_value(); }));

--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/data/slime/cursor.h>
 #include <vespa/vespalib/data/smart_buffer.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 
@@ -47,7 +48,7 @@ MatchEngine::MatchEngine(size_t numThreads, size_t threadsPerSearch, uint32_t di
       _distributionKey(distributionKey),
       _closed(false),
       _handlers(),
-      _executor(std::max(size_t(1), numThreads / threadsPerSearch), 256 * 1024, match_engine_executor),
+      _executor(std::max(size_t(1), numThreads / threadsPerSearch), 256_Ki, match_engine_executor),
       _threadBundlePool(std::max(size_t(1), threadsPerSearch)),
       _nodeUp(false)
 {
@@ -146,7 +147,7 @@ MatchEngine::performSearch(search::engine::SearchRequest::Source req,
         ret->request->trace().getRoot().setLong("distribution-key", _distributionKey);
         ret->request->trace().done();
         search::fef::Properties & trace = ret->propertiesMap.lookupCreate("trace");
-        vespalib::SmartBuffer output(4096);
+        vespalib::SmartBuffer output(4_Ki);
         vespalib::slime::BinaryFormat::encode(ret->request->trace().getSlime(), output);
         trace.add("slime", output.obtain().make_stringref());
     }

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -36,6 +36,7 @@
 #include <vespa/searchlib/engine/searchreply.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 #include <vespa/searchcorespi/index/warmupconfig.h>
@@ -68,7 +69,7 @@ using searchcorespi::IFlushTarget;
 namespace proton {
 
 namespace {
-constexpr uint32_t indexing_thread_stack_size = 128 * 1024;
+constexpr uint32_t indexing_thread_stack_size = 128_Ki;
 
 index::IndexConfig
 makeIndexConfig(const ProtonConfig::Index & cfg) {

--- a/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "memory_flush_config_updater.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/log/log.h>
 
 LOG_SETUP(".proton.server.memory_flush_config_updater");

--- a/searchcore/src/vespa/searchcore/proton/server/memoryflush.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/memoryflush.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <algorithm>
 
 #include <vespa/log/log.h>
@@ -30,8 +31,6 @@ getName(const IFlushHandler & handler, const IFlushTarget & target)
     return (handler.getName() + "." + target.getName());
 }
 
-static constexpr uint64_t gibi = UINT64_C(1024) * UINT64_C(1024) * UINT64_C(1024);
-
 uint64_t
 estimateNeededTlsSizeForFlushTarget(const TlsStats &tlsStats, SerialNum flushedSerialNum)
 {
@@ -52,10 +51,10 @@ estimateNeededTlsSizeForFlushTarget(const TlsStats &tlsStats, SerialNum flushedS
 }
 
 MemoryFlush::Config::Config()
-    : maxGlobalMemory(4000*1024*1024ul),
-      maxGlobalTlsSize(20 * gibi),
+    : maxGlobalMemory(4000_Mi),
+      maxGlobalTlsSize(20_Gi),
       globalDiskBloatFactor(0.2),
-      maxMemoryGain(1000*1024*1024ul),
+      maxMemoryGain(1000_Mi),
       diskBloatFactor(0.2),
       maxTimeGain(std::chrono::hours(24))
 { }

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
@@ -6,6 +6,7 @@
 #include "i_proton_configurer.h"
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 #include <cassert>
 
@@ -25,7 +26,7 @@ ProtonConfigFetcher::ProtonConfigFetcher(const config::ConfigUri & configUri, IP
       _owner(owner),
       _mutex(),
       _dbManagerMap(),
-      _threadPool(128 * 1024, 1),
+      _threadPool(128_Ki, 1),
       _oldDocumentTypeRepos(),
       _currentDocumentTypeRepo()
 {

--- a/searchcore/src/vespa/searchcore/proton/server/rpc_hooks.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/rpc_hooks.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchcore/proton/summaryengine/docsum_by_slime.h>
 #include <vespa/searchcore/proton/matchengine/matchengine.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/transport.h>
 
@@ -198,7 +199,7 @@ RPCHooksBase::RPCHooksBase(Params &params)
       _regAPI(*_orb, slobrok::ConfiguratorFactory(params.slobrok_config)),
       _stateLock(),
       _stateCond(),
-      _executor(params.numRpcThreads, 128 * 1024, proton_rpc_executor)
+      _executor(params.numRpcThreads, 128_Ki, proton_rpc_executor)
 { }
 
 void

--- a/searchcore/src/vespa/searchcore/proton/summaryengine/docsum_by_slime.cpp
+++ b/searchcore/src/vespa/searchcore/proton/summaryengine/docsum_by_slime.cpp
@@ -1,10 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "docsum_by_slime.h"
-#include <vespa/vespalib/util/compressor.h>
-#include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
-#include <vespa/searchlib/common/packets.h>
 #include <vespa/fnet/frt/rpcrequest.h>
+#include <vespa/searchlib/common/packets.h>
+#include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/compressor.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.summaryengine.docsum_by_slime");
@@ -123,7 +124,7 @@ DocsumByRPC::getDocsums(FRT_RPCRequest & req)
     vespalib::Slime::UP summaries = _slimeDocsumServer.getDocsums(summariesToGet.get());
     assert(summaries);  // Mandatory, not optional.
 
-    search::RawBuf rbuf(4096);
+    search::RawBuf rbuf(4_Ki);
     search::SlimeOutputRawBufAdapter output(rbuf);
     BinaryFormat::encode(*summaries, output);
     ConstBufferRef buf(rbuf.GetDrainPos(), rbuf.GetUsedLen());

--- a/searchcore/src/vespa/searchcore/proton/summaryengine/summaryengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/summaryengine/summaryengine.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "summaryengine.h"
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".proton.summaryengine.summaryengine");
@@ -62,7 +63,7 @@ SummaryEngine::SummaryEngine(size_t numThreads)
     : _lock(),
       _closed(false),
       _handlers(),
-      _executor(numThreads, 128 * 1024, summary_engine_executor),
+      _executor(numThreads, 128_Ki, summary_engine_executor),
       _metrics(std::make_unique<DocsumMetrics>())
 { }
 

--- a/searchcorespi/src/vespa/searchcorespi/index/indexflushtarget.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexflushtarget.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "indexflushtarget.h"
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchcorespi.index.indexflushtarget");
@@ -41,7 +42,7 @@ IndexFlushTarget::needUrgentFlush() const
 {
     // Due to limitation of 16G address space of single datastore
     // TODO: Even better if urgency was decided by memory index itself.
-    constexpr int64_t G = 1024*1024*1024l;
+    constexpr int64_t G =1_Gi;
     bool urgent = (_numFrozenMemoryIndexes > _maxFrozenMemoryIndexes) ||
                   (getApproxMemoryGain().gain() > 16*G);
     SerialNum flushedSerial = _indexMaintainer.getFlushedSerialNum();

--- a/searchcorespi/src/vespa/searchcorespi/index/indexflushtarget.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexflushtarget.cpp
@@ -42,9 +42,8 @@ IndexFlushTarget::needUrgentFlush() const
 {
     // Due to limitation of 16G address space of single datastore
     // TODO: Even better if urgency was decided by memory index itself.
-    constexpr int64_t G =1_Gi;
     bool urgent = (_numFrozenMemoryIndexes > _maxFrozenMemoryIndexes) ||
-                  (getApproxMemoryGain().gain() > 16*G);
+                  (getApproxMemoryGain().gain() > ssize_t(16_Gi));
     SerialNum flushedSerial = _indexMaintainer.getFlushedSerialNum();
     LOG(debug, "Num frozen: %u Memory gain: %ld Urgent: %d, flushedSerial=%" PRIu64,
         _numFrozenMemoryIndexes, getApproxMemoryGain().gain(), static_cast<int>(urgent), flushedSerial);

--- a/searchlib/src/apps/docstore/benchmarkdatastore.cpp
+++ b/searchlib/src/apps/docstore/benchmarkdatastore.cpp
@@ -2,10 +2,11 @@
 
 #include <vespa/searchlib/docstore/logdatastore.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
-#include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/fastos/app.h>
 #include <unistd.h>
 #include <random>
@@ -95,12 +96,12 @@ BenchmarkDataStoreApp::benchmark(const vespalib::string & dir, size_t numReads, 
         tuning._randRead.setWantMemoryMap();
     }
     search::index::DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     transactionlog::NoSyncProxy noTlSyncer;
     LogDataStore store(executor, dir, config, growStrategy, tuning,
                        fileHeaderContext,
                        noTlSyncer, NULL, true);
-    vespalib::ThreadStackExecutor bmPool(numThreads, 128*1024);
+    vespalib::ThreadStackExecutor bmPool(numThreads, 128_Ki);
     LOG(info, "Start read benchmark with %lu threads doing %lu reads in chunks of %lu reads. Totally %lu objects", numThreads, numReads, perChunk, numThreads * numReads * perChunk);
     for (size_t i(0); i < numThreads; i++) {
         bmPool.execute(vespalib::makeLambdaTask([&]() { read(numReads, perChunk, static_cast<const IDataStore *>(&store)); }));

--- a/searchlib/src/apps/docstore/documentstoreinspect.cpp
+++ b/searchlib/src/apps/docstore/documentstoreinspect.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
 #include <vespa/fastos/app.h>
 #include <vespa/vespalib/objects/nbostream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <cinttypes>
 
@@ -106,7 +107,7 @@ DocumentStoreInspectApp::verify(const vespalib::string & dir)
     GrowStrategy growStrategy;
     TuneFileSummary tuning;
     search::index::DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     transactionlog::NoSyncProxy noTlSyncer;
 
     LogDataStore store(executor, dir, config, growStrategy, tuning,

--- a/searchlib/src/apps/docstore/verifylogdatastore.cpp
+++ b/searchlib/src/apps/docstore/verifylogdatastore.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
 #include <vespa/fastos/app.h>
 #include <vespa/vespalib/util/exception.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 using namespace search;
@@ -49,7 +50,7 @@ VerifyLogDataStoreApp::verify(const vespalib::string & dir)
     GrowStrategy growStrategy;
     TuneFileSummary tuning;
     search::index::DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     transactionlog::NoSyncProxy noTlSyncer;
 
     try {

--- a/searchlib/src/apps/tests/biglogtest.cpp
+++ b/searchlib/src/apps/tests/biglogtest.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/data/databuffer.h>
 
@@ -134,7 +135,7 @@ factory<LogDataStore>::factory(std::string dir)
     : DioTune(),
       _fileHeaderContext(),
       _config(),
-      _executor(1, 128*1024),
+      _executor(1, 128_Ki),
       _noTlSyncer(),
       _datastore(_executor, dir, _config, GrowStrategy(), tuning, _fileHeaderContext, _noTlSyncer, NULL)
 {}

--- a/searchlib/src/apps/tests/btreestress_test.cpp
+++ b/searchlib/src/apps/tests/btreestress_test.cpp
@@ -1,12 +1,16 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/testkit/test_kit.h>
-#include <vespa/vespalib/btree/btreeroot.h>
+#include <vespa/vespalib/btree/btree.h>
 #include <vespa/vespalib/btree/btreebuilder.h>
 #include <vespa/vespalib/btree/btreenodeallocator.h>
-#include <vespa/vespalib/btree/btree.h>
+#include <vespa/vespalib/btree/btreeroot.h>
 #include <vespa/vespalib/btree/btreestore.h>
+
+#include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/vespalib/util/rand48.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/vespalib/btree/btreenodeallocator.hpp>
 #include <vespa/vespalib/btree/btreenode.hpp>
@@ -17,9 +21,6 @@
 #include <vespa/vespalib/btree/btree.hpp>
 #include <vespa/vespalib/btree/btreestore.hpp>
 #include <vespa/vespalib/btree/btreeaggregator.hpp>
-
-#include <vespa/vespalib/util/threadstackexecutor.h>
-#include <vespa/vespalib/util/lambdatask.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("btreestress_test");
@@ -62,8 +63,8 @@ Fixture::Fixture()
     : _generationHandler(),
       _tree(),
       _writeItr(_tree.begin()),
-      _writer(1, 128 * 1024),
-      _readers(4, 128 * 1024),
+      _writer(1, 128_Ki),
+      _readers(4, 128_Ki),
       _rnd(),
       _keyLimit(1000000),
       _readSeed(50),

--- a/searchlib/src/apps/tests/memoryindexstress_test.cpp
+++ b/searchlib/src/apps/tests/memoryindexstress_test.cpp
@@ -24,6 +24,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("memoryindexstress_test");
@@ -248,13 +249,13 @@ VESPA_THREAD_STACK_TAG(push_executor)
 Fixture::Fixture(uint32_t readThreads)
     : schema(makeSchema()),
       repo(makeDocTypeRepoConfig()),
-      _executor(1, 128 * 1024),
+      _executor(1, 128_Ki),
       _invertThreads(vespalib::SequencedTaskExecutor::create(invert_executor, 2)),
       _pushThreads(vespalib::SequencedTaskExecutor::create(push_executor, 2)),
       index(schema, MockFieldLengthInspector(), *_invertThreads, *_pushThreads),
       _readThreads(readThreads),
-      _writer(1, 128 * 1024),
-      _readers(readThreads, 128 * 1024),
+      _writer(1, 128_Ki),
+      _readers(readThreads, 128_Ki),
       _rnd(),
       _keyLimit(1000000),
       _readSeed(50),

--- a/searchlib/src/tests/alignment/alignment.cpp
+++ b/searchlib/src/tests/alignment/alignment.cpp
@@ -5,6 +5,7 @@ LOG_SETUP("alignment_test");
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 struct Timer {
     rusage usage;
@@ -30,7 +31,7 @@ timeAccess(void *bufp, uint32_t len, double &sum)
     double *buf = (double *)bufp;
     Timer timer;
     timer.start();
-    for(uint32_t i = 0; i < 512 * 1024; ++i) {
+    for(uint32_t i = 0; i < 512_Ki; ++i) {
         for (uint32_t j = 0; j < len; ++j) {
             sum += buf[j];
         }

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -20,6 +20,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchlib/util/bufferwriter.h>
 #include <vespa/vespalib/util/compress.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/databuffer.h>
 
 #include <limits>
@@ -58,7 +59,7 @@ public:
     }
 
     virtual Buffer allocBuf(size_t size) override {
-        return std::make_unique<BufferBuf>(size, 4096);
+        return std::make_unique<BufferBuf>(size, 4_Ki);
     }
 
     virtual void writeBuf(Buffer buf_in) override {

--- a/searchlib/src/tests/attribute/multi_value_mapping/multi_value_mapping_test.cpp
+++ b/searchlib/src/tests/attribute/multi_value_mapping/multi_value_mapping_test.cpp
@@ -3,11 +3,12 @@
 #include <vespa/searchlib/attribute/multi_value_mapping.h>
 #include <vespa/searchlib/attribute/multi_value_mapping.hpp>
 #include <vespa/searchlib/attribute/not_implemented_attribute.h>
-#include <vespa/vespalib/util/rand48.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/generationhandler.h>
+#include <vespa/vespalib/util/rand48.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("multivaluemapping_test");
@@ -82,7 +83,7 @@ public:
     }
     void setup(uint32_t maxSmallArraySize, bool enable_free_lists = true) {
         ArrayStoreConfig config(maxSmallArraySize,
-                                ArrayStoreConfig::AllocSpec(0, RefType::offsetSize(), 8 * 1024, ALLOC_GROW_FACTOR));
+                                ArrayStoreConfig::AllocSpec(0, RefType::offsetSize(), 8_Ki, ALLOC_GROW_FACTOR));
         config.enable_free_lists(enable_free_lists);
         _mvMapping = std::make_unique<MvMapping>(config);
         _attr = std::make_unique<AttributeType>(*_mvMapping);

--- a/searchlib/src/tests/attribute/posting_list_merger/posting_list_merger_test.cpp
+++ b/searchlib/src/tests/attribute/posting_list_merger/posting_list_merger_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/searchlib/attribute/posting_list_merger.h>
 #include <vespa/vespalib/test/insertion_operators.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <algorithm>
 
 using vespalib::btree::BTreeNoLeafData;
@@ -56,7 +57,7 @@ public:
     }
 };
 
-constexpr uint32_t docIdLimit = 16384;
+constexpr uint32_t docIdLimit = 16_Ki;
 
 struct WeightedFixture
 {

--- a/searchlib/src/tests/attribute/sourceselector/sourceselector_test.cpp
+++ b/searchlib/src/tests/attribute/sourceselector/sourceselector_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchcommon/common/undefinedvalues.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/file.h>
 
 #include <vespa/log/log.h>
@@ -20,7 +21,7 @@ using search::index::DummyFileHeaderContext;
 namespace {
 template <typename T, size_t N> size_t arraysize(const T (&)[N]) { return N; }
 
-const uint32_t maxDocId = 4096;
+const uint32_t maxDocId = 4_Ki;
 struct DocSource { uint32_t docId; uint8_t source; };
 const DocSource docs[] = { {0,1}, {1, 0}, {2, 2}, {4, 3}, {8, 9}, {16, 178},
                            {32, 1}, {64, 2}, {128, 3}, {256,4}, {512, 2},

--- a/searchlib/src/tests/bitcompression/expgolomb/expgolomb_test.cpp
+++ b/searchlib/src/tests/bitcompression/expgolomb/expgolomb_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/searchlib/bitcompression/compression.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vector>
 #include <algorithm>
 
@@ -498,7 +499,7 @@ TestFixture<bigEndian>::testBoundaries(int kValue, bool small, std::vector<uint6
 {
     EC e;
     search::ComprFileWriteContext wc(e);
-    wc.allocComprBuf(32768, 32768);
+    wc.allocComprBuf(32_Ki, 32_Ki);
     e.setupWrite(wc);
     for (auto num : v) {
         e.encodeExpGolomb(num, kValue);
@@ -554,7 +555,7 @@ TestFixture<bigEndian>::testRandNums(int kValue)
 {
     EC e;
     search::ComprFileWriteContext wc(e);
-    wc.allocComprBuf(32768, 32768);
+    wc.allocComprBuf(32_Ki, 32_Ki);
     e.setupWrite(wc);
     for (auto num : _randNums) {
         e.encodeExpGolomb(num, kValue);

--- a/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
+++ b/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
@@ -1,21 +1,22 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchlib/common/bitvector.h>
-#include <vespa/vespalib/util/rand48.h>
-#include <vespa/searchlib/test/fakedata/fakeword.h>
-#include <vespa/searchlib/test/fakedata/fakewordset.h>
-#include <vespa/searchlib/index/docidandfeatures.h>
-#include <vespa/searchlib/index/field_length_info.h>
-#include <vespa/searchlib/index/postinglisthandle.h>
-#include <vespa/searchlib/diskindex/zcposoccrandread.h>
-#include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/schemautil.h>
-#include <vespa/searchlib/diskindex/fieldwriter.h>
 #include <vespa/searchlib/diskindex/fieldreader.h>
-#include <vespa/vespalib/io/fileutil.h>
+#include <vespa/searchlib/diskindex/fieldwriter.h>
 #include <vespa/searchlib/diskindex/pagedict4file.h>
 #include <vespa/searchlib/diskindex/pagedict4randread.h>
+#include <vespa/searchlib/diskindex/zcposoccrandread.h>
+#include <vespa/searchlib/index/docidandfeatures.h>
+#include <vespa/searchlib/index/dummyfileheadercontext.h>
+#include <vespa/searchlib/index/field_length_info.h>
+#include <vespa/searchlib/index/postinglisthandle.h>
+#include <vespa/searchlib/index/schemautil.h>
+#include <vespa/searchlib/test/fakedata/fakeword.h>
+#include <vespa/searchlib/test/fakedata/fakewordset.h>
+#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/rand48.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/time.h>
 #include <openssl/sha.h>
 #include <vespa/fastos/app.h>
@@ -55,7 +56,7 @@ void FastS_block_usr2() { }
 namespace fieldwriter {
 
 uint32_t minSkipDocs = 64;
-uint32_t minChunkDocs = 262144;
+uint32_t minChunkDocs = 256_Ki;
 
 vespalib::string dirprefix = "index/";
 
@@ -296,7 +297,7 @@ FileChecksum::FileChecksum(const vespalib::string &file_name)
 {
     SHA256_CTX c; 
     FastOS_File f;
-    Alloc buf = Alloc::alloc(65536);
+    Alloc buf = Alloc::alloc(64_Ki);
     vespalib::string full_file_name(dirprefix + file_name);
     bool openres = f.OpenReadOnly(full_file_name.c_str());
     if (!openres) {
@@ -706,7 +707,7 @@ main(int argc, char **argv)
 {
     fieldwriter::FieldWriterTest app;
 
-    setvbuf(stdout, nullptr, _IOLBF, 32768);
+    setvbuf(stdout, nullptr, _IOLBF, 32_Ki);
     app._rnd.srand48(32);
     return app.Entry(argc, argv);
 }

--- a/searchlib/src/tests/diskindex/pagedict4/pagedict4_hugeword_cornercase_test.cpp
+++ b/searchlib/src/tests/diskindex/pagedict4/pagedict4_hugeword_cornercase_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/bitcompression/compression.h>
 #include <vespa/searchlib/bitcompression/countcompression.h>
 #include <vespa/searchlib/bitcompression/pagedict4.h>
@@ -15,8 +16,8 @@ LOG_SETUP("pagedict4_hugeword_cornercase_test");
 using search::index::PostingListCounts;
 using search::ComprFileWriteContext;
 
-constexpr uint32_t minChunkDocs = 262144;
-constexpr uint32_t numWordIds = 65536;
+constexpr uint32_t minChunkDocs = 256_Ki;
+constexpr uint32_t numWordIds = 64_Ki;
 
 struct BitBuffer
 {
@@ -141,7 +142,7 @@ using SeqReader = search::diskindex::test::PageDict4MemSeqReader;
  */
 void testPageSizedCounts()
 {
-    uint32_t pageBitSize = 32768;
+    uint32_t pageBitSize = 32_Ki;
     uint32_t startBits = 15 * 3 + 12;
 
     uint32_t ssPad = 64;

--- a/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
+++ b/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
@@ -12,6 +12,7 @@
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -236,8 +237,8 @@ Fixture::Fixture()
       _repo(makeDocTypeRepoConfig()),
       _storeConfig(DocumentStore::Config(CompressionConfig::NONE, 0, 0),
                    LogDataStore::Config().setMaxFileSize(50000).setMaxBucketSpread(3.0)
-                           .setFileConfig(WriteableFileChunk::Config(CompressionConfig(), 16384))),
-      _executor(1, 128 * 1024),
+                           .setFileConfig(WriteableFileChunk::Config(CompressionConfig(), 16_Ki))),
+      _executor(1, 128_Ki),
       _fileHeaderContext(),
       _tlSyncer(),
       _store(),

--- a/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
+++ b/searchlib/src/tests/docstore/logdatastore/logdatastore_test.cpp
@@ -15,6 +15,7 @@
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <iomanip>
 
 using document::BucketId;
@@ -134,33 +135,33 @@ checkStats(IDataStore &store,
 
 #ifdef __linux__
 TEST("test that DirectIOPadding works accordng to spec") {
-    constexpr ssize_t FILE_SIZE = 4096*3;
+    constexpr ssize_t FILE_SIZE = 4_Ki*3;
     FastOS_File file("directio.test");
     file.EnableDirectIO();
     EXPECT_TRUE(file.OpenReadWrite());
-    Alloc buf(Alloc::alloc_aligned(FILE_SIZE, 4096));
+    Alloc buf(Alloc::alloc_aligned(FILE_SIZE, 4_Ki));
     memset(buf.get(), 'a', buf.size());
     EXPECT_EQUAL(FILE_SIZE, file.Write2(buf.get(), FILE_SIZE));
     size_t padBefore(0);
     size_t padAfter(0);
 
-    EXPECT_TRUE(file.DirectIOPadding(4096, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4_Ki, 4096, padBefore, padAfter));
     EXPECT_EQUAL(0u, padBefore);
     EXPECT_EQUAL(0u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4095, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4095, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(4095u, padBefore);
     EXPECT_EQUAL(1u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4097, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4097, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(1u, padBefore);
     EXPECT_EQUAL(4095u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4096, 4097, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4_Ki, 4097, padBefore, padAfter));
     EXPECT_EQUAL(0u, padBefore);
     EXPECT_EQUAL(4095u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4096, 4095, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4_Ki, 4095, padBefore, padAfter));
     EXPECT_EQUAL(0u, padBefore);
     EXPECT_EQUAL(1u, padAfter);
 
@@ -168,15 +169,15 @@ TEST("test that DirectIOPadding works accordng to spec") {
     EXPECT_EQUAL(1u, padBefore);
     EXPECT_EQUAL(0u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4097, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4097, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(1u, padBefore);
     EXPECT_EQUAL(4095u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(4097, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4097, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(1u, padBefore);
     EXPECT_EQUAL(4095u, padAfter);
 
-    EXPECT_FALSE(file.DirectIOPadding(FILE_SIZE-1, 4096, padBefore, padAfter));
+    EXPECT_FALSE(file.DirectIOPadding(FILE_SIZE-1, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(0u, padBefore);
     EXPECT_EQUAL(0u, padAfter);
     EXPECT_EQUAL(FILE_SIZE, file.GetSize());
@@ -190,11 +191,11 @@ TEST("test that DirectIOPadding works accordng to spec") {
     EXPECT_EQUAL(FILE_SIZE*2, file2.GetSize());
     EXPECT_TRUE(file2.Close());
 
-    EXPECT_TRUE(file.DirectIOPadding(4097, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(4097, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(1u, padBefore);
     EXPECT_EQUAL(4095u, padAfter);
 
-    EXPECT_TRUE(file.DirectIOPadding(FILE_SIZE-1, 4096, padBefore, padAfter));
+    EXPECT_TRUE(file.DirectIOPadding(FILE_SIZE-1, 4_Ki, padBefore, padAfter));
     EXPECT_EQUAL(4095u, padBefore);
     EXPECT_EQUAL(1u, padAfter);
 
@@ -205,7 +206,7 @@ TEST("test that DirectIOPadding works accordng to spec") {
 
 void verifyGrowing(const LogDataStore::Config & config, uint32_t minFiles, uint32_t maxFiles) {
     DirectoryHandler tmpDir("growing");
-    vespalib::ThreadStackExecutor executor(4, 128*1024);
+    vespalib::ThreadStackExecutor executor(4, 128_Ki);
     DummyFileHeaderContext fileHeaderContext;
     MyTlSyncer tlSyncer;
     {
@@ -276,7 +277,7 @@ void fetchAndTest(IDataStore & datastore, uint32_t lid, const void *a, size_t sz
 TEST("testTruncatedIdxFile"){
     LogDataStore::Config config;
     DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     MyTlSyncer tlSyncer;
     {
         // Files comes from the 'growing test'.
@@ -305,7 +306,7 @@ TEST("testTruncatedIdxFile"){
 TEST("testThatEmptyIdxFilesAndDanglingDatFilesAreRemoved") {
     LogDataStore::Config config;
     DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     MyTlSyncer tlSyncer;
     LogDataStore datastore(executor, "dangling-test", config,
                            GrowStrategy(), TuneFileSummary(),
@@ -318,7 +319,7 @@ TEST("testThatEmptyIdxFilesAndDanglingDatFilesAreRemoved") {
 TEST("testThatIncompleteCompactedFilesAreRemoved") {
     LogDataStore::Config config;
     DummyFileHeaderContext fileHeaderContext;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     MyTlSyncer tlSyncer;
     LogDataStore datastore(executor, "incompletecompact-test", config,
                            GrowStrategy(), TuneFileSummary(),
@@ -338,7 +339,7 @@ public:
         _myDir("visitcache"),
         _config(),
         _fileHeaderContext(),
-        _executor(1, 128*1024),
+        _executor(1, 128_Ki),
         _tlSyncer(),
         _datastore(_executor, _myDir.getDir(), _config, GrowStrategy(),
                    TuneFileSummary(), _fileHeaderContext, _tlSyncer, nullptr)
@@ -525,9 +526,9 @@ VisitCacheStore::VisitCacheStore(UpdateStrategy strategy) :
     _config(DocumentStore::Config(CompressionConfig::LZ4, 1000000, 0)
                     .allowVisitCaching(true).updateStrategy(strategy),
             LogDataStore::Config().setMaxFileSize(50000).setMaxBucketSpread(3.0)
-                    .setFileConfig(WriteableFileChunk::Config(CompressionConfig(), 16384))),
+                    .setFileConfig(WriteableFileChunk::Config(CompressionConfig(), 16_Ki))),
     _fileHeaderContext(),
-    _executor(1, 128*1024),
+    _executor(1, 128_Ki),
     _tlSyncer(),
     _datastore(std::make_unique<LogDocumentStore>(_executor, _myDir.getDir(), _config, GrowStrategy(),
                                                   TuneFileSummary(), _fileHeaderContext, _tlSyncer, nullptr)),
@@ -669,7 +670,7 @@ TEST("testWriteRead") {
     {
         EXPECT_TRUE(FastOS_File::MakeDirectory("empty"));
         DummyFileHeaderContext fileHeaderContext;
-        vespalib::ThreadStackExecutor executor(1, 128*1024);
+        vespalib::ThreadStackExecutor executor(1, 128_Ki);
         MyTlSyncer tlSyncer;
         LogDataStore datastore(executor, "empty", config, GrowStrategy(),
                                TuneFileSummary(), fileHeaderContext, tlSyncer, nullptr);
@@ -705,7 +706,7 @@ TEST("testWriteRead") {
     }
     {
         DummyFileHeaderContext fileHeaderContext;
-        vespalib::ThreadStackExecutor executor(1, 128*1024);
+        vespalib::ThreadStackExecutor executor(1, 128_Ki);
         MyTlSyncer tlSyncer;
         LogDataStore datastore(executor, "empty", config,
                                GrowStrategy(), TuneFileSummary(),
@@ -756,7 +757,7 @@ TEST("requireThatFlushTimeIsAvailableAfterFlush") {
     vespalib::system_time before(vespalib::system_clock::now());
     DummyFileHeaderContext fileHeaderContext;
     LogDataStore::Config config;
-    vespalib::ThreadStackExecutor executor(1, 128*1024);
+    vespalib::ThreadStackExecutor executor(1, 128_Ki);
     MyTlSyncer tlSyncer;
     LogDataStore store(executor, testDir.getDir(), config, GrowStrategy(),
                        TuneFileSummary(), fileHeaderContext, tlSyncer, nullptr);
@@ -842,7 +843,7 @@ struct Fixture {
 
     Fixture(const vespalib::string &dirName = "tmp",
             bool dirCleanup = true,
-            size_t maxFileSize = 4096 * 2)
+            size_t maxFileSize = 4_Ki * 2)
         : executor(1, 0x20000),
           dir(dirName),
           serialNum(0),

--- a/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
+++ b/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/docstore/storebybucket.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -66,7 +67,7 @@ private:
 TEST("require that StoreByBucket gives bucket by bucket and ordered within")
 {
     vespalib::MemoryDataStore backing;
-    vespalib::ThreadStackExecutor executor(8, 128*1024);
+    vespalib::ThreadStackExecutor executor(8, 128_Ki);
     StoreByBucket sbb(backing, executor, CompressionConfig::LZ4);
     for (size_t i(1); i <=500; i++) {
         add(sbb, i);

--- a/searchlib/src/tests/fef/featurenameparser/featurenameparser_test.cpp
+++ b/searchlib/src/tests/fef/featurenameparser/featurenameparser_test.cpp
@@ -3,6 +3,7 @@
 LOG_SETUP("featurenameparser_test");
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/fef/featurenameparser.h>
 #include <vector>
 #include <string>
@@ -61,7 +62,7 @@ Test::testParse(const vespalib::string &input, bool valid,
 void
 Test::testFile(const vespalib::string &name)
 {
-    char buf[4096];
+    char buf[4_Ki];
     uint32_t lineN = 0;
     FILE *f = fopen(name.c_str(), "r");
     ASSERT_TRUE(f != 0);

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -13,9 +13,10 @@
 #include <vespa/searchlib/queryeval/fake_search.h>
 #include <vespa/searchlib/queryeval/fake_searchable.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
+#include <vespa/vespalib/util/sequencedtaskexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
-#include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 #include <vespa/log/log.h>
@@ -126,7 +127,7 @@ VESPA_THREAD_STACK_TAG(push_executor)
 
 Index::Index(const MySetup &setup)
     : schema(setup.schema),
-      _executor(1, 128 * 1024),
+      _executor(1, 128_Ki),
       _invertThreads(SequencedTaskExecutor::create(invert_executor, 2)),
       _pushThreads(SequencedTaskExecutor::create(push_executor, 2)),
       index(schema, setup, *_invertThreads, *_pushThreads),

--- a/searchlib/src/tests/postinglistbm/postinglistbm.cpp
+++ b/searchlib/src/tests/postinglistbm/postinglistbm.cpp
@@ -11,6 +11,7 @@
 #include <vespa/searchlib/test/fakedata/fakewordset.h>
 #include <vespa/searchlib/test/fakedata/fpfactory.h>
 #include <vespa/vespalib/util/rand48.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 
@@ -232,7 +233,7 @@ main(int argc, char **argv)
 {
     postinglistbm::PostingListBM app;
 
-    setvbuf(stdout, nullptr, _IOLBF, 32768);
+    setvbuf(stdout, nullptr, _IOLBF, 32_Ki);
     app._rnd.srand48(32);
     return app.Entry(argc, argv);
 }

--- a/searchlib/src/tests/postinglistbm/stress_runner.cpp
+++ b/searchlib/src/tests/postinglistbm/stress_runner.cpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/test/fakedata/fakeword.h>
 #include <vespa/searchlib/test/fakedata/fakewordset.h>
 #include <vespa/searchlib/test/fakedata/fpfactory.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/time.h>
 #include <condition_variable>
 #include <mutex>
@@ -159,7 +160,7 @@ StressMaster::StressMaster(vespalib::Rand48 &rnd,
 {
     LOG(info, "StressMaster::StressMaster()");
 
-    _threadPool = new FastOS_ThreadPool(128 * 1024, 400);
+    _threadPool = new FastOS_ThreadPool(128_Ki, 400);
 }
 
 StressMaster::~StressMaster()

--- a/searchlib/src/tests/query/streaming_query_large_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_large_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchlib/query/tree/simplequery.h>
 #include <vespa/searchlib/query/tree/stackdumpcreator.h>
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <sys/resource.h>
 
 using namespace search;
@@ -36,9 +37,9 @@ void setMaxStackSize(rlim_t maxStackSize)
 TEST("testveryLongQueryResultingInBug6850778") {
     const uint32_t NUMITEMS=20000;
 #ifdef __SANITIZE_ADDRESS__
-    setMaxStackSize(12 * 1024 * 1024);
+    setMaxStackSize(12_Mi);
 #else
-    setMaxStackSize(4 * 1024 * 1024);
+    setMaxStackSize(4_Mi);
 #endif
     QueryBuilder<SimpleQueryNodeTypes> builder;
     for (uint32_t i=0; i <= NUMITEMS; i++) {

--- a/searchlib/src/tests/tensor/hnsw_index/stress_hnsw_mt.cpp
+++ b/searchlib/src/tests/tensor/hnsw_index/stress_hnsw_mt.cpp
@@ -22,6 +22,7 @@
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
 #include <vespa/vespalib/util/generationhandler.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/simple_buffer.h>
 
 #include <vespa/log/log.h>
@@ -59,7 +60,7 @@ struct MallocPointVector {
 };
 static MallocPointVector *aligned_alloc_pv(size_t num) {
     size_t num_bytes = num * sizeof(MallocPointVector);
-    double mega_bytes = num_bytes / (1024.0*1024.0);
+    double mega_bytes = num_bytes / double(1_Mi);
     fprintf(stderr, "allocate %.2f MB of vectors\n", mega_bytes);
     char *mem = (char *)malloc(num_bytes + 512);
     mem += 512;
@@ -221,8 +222,8 @@ public:
           vectors(),
           gen_handler(),
           index(),
-          multi_prepare_workers(10, 128*1024, 50),
-          write_thread(1, 128*1024, 500)
+          multi_prepare_workers(10, 128_Ki, 50),
+          write_thread(1, 128_Ki, 500)
     {
         loaded_vectors.load();
     }

--- a/searchlib/src/tests/util/slime_output_raw_buf_adapter/slime_output_raw_buf_adapter_test.cpp
+++ b/searchlib/src/tests/util/slime_output_raw_buf_adapter/slime_output_raw_buf_adapter_test.cpp
@@ -2,12 +2,13 @@
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace search;
 using namespace vespalib::slime::convenience;
 
 TEST("use slime with rawbuf") {
-    RawBuf buffer(4096);
+    RawBuf buffer(4_Ki);
     Slime src;
     Slime dst;
     {

--- a/searchlib/src/tests/vespa-fileheader-inspect/vespa-fileheader-inspect_test.cpp
+++ b/searchlib/src/tests/vespa-fileheader-inspect/vespa-fileheader-inspect_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/searchlib/util/fileheadertk.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/file.h>
 
 using namespace search;
@@ -24,7 +25,7 @@ vespalib::string readFile(const vespalib::string &fileName) {
     FastOS_File file;
     ASSERT_TRUE(file.OpenReadOnly(fileName.c_str()));
 
-    char buf[4096];
+    char buf[4_Ki];
     uint32_t len = file.Read(buf, sizeof(buf));
     EXPECT_LESS(len, sizeof(buf)); // make sure we got everything
 

--- a/searchlib/src/vespa/searchlib/attribute/attributefilewriter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributefilewriter.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchlib/common/fileheadercontext.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/file.h>
 
 #include <vespa/log/log.h>
@@ -19,15 +20,15 @@ namespace search {
 
 namespace {
 
-const uint32_t headerAlign = 4096;
-const uint32_t MIN_ALIGNMENT = 4096;
+const uint32_t headerAlign = 4_Ki;
+const uint32_t MIN_ALIGNMENT = 4_Ki;
 
 void
 writeDirectIOAligned(FastOS_FileInterface &file, const void *buf, size_t length)
 {
     const char * data(static_cast<const char *>(buf));
     size_t remaining(length);
-    for (size_t maxChunk(2048*1024); maxChunk >= MIN_ALIGNMENT; maxChunk >>= 1) {
+    for (size_t maxChunk(2_Mi); maxChunk >= MIN_ALIGNMENT; maxChunk >>= 1) {
         for ( ; remaining > maxChunk; remaining -= maxChunk, data += maxChunk) {
             file.WriteBuf(data, maxChunk);
         }

--- a/searchlib/src/vespa/searchlib/attribute/attributememoryfilewriter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributememoryfilewriter.cpp
@@ -3,12 +3,13 @@
 #include "attributememoryfilewriter.h"
 #include "attributememoryfilebufferwriter.h"
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search {
 
 namespace {
 
-const uint32_t MIN_ALIGNMENT = 4096;
+const uint32_t MIN_ALIGNMENT = 4_Ki;
 
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -19,6 +19,7 @@
 #include <vespa/searchlib/query/query_term_decoder.h>
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/util/logutil.h>
 #include <vespa/searchcommon/attribute/attribute_utils.h>
 #include <thread>
@@ -45,7 +46,7 @@ const vespalib::string dataTypeTag = "datatype";
 const vespalib::string collectionTypeTag = "collectiontype";
 const vespalib::string docIdLimitTag = "docIdLimit";
 
-constexpr size_t DIRECTIO_ALIGNMENT(4096);
+constexpr size_t DIRECTIO_ALIGNMENT(4_Ki);
 
 }
 
@@ -643,7 +644,7 @@ IExtendAttribute *AttributeVector::getExtendInterface() { return nullptr; }
 uint64_t
 AttributeVector::getEstimatedSaveByteSize() const
 {
-    uint64_t headerSize = 4096;
+    uint64_t headerSize = 4_Ki;
     uint64_t totalValueCount = _status.getNumValues();
     uint64_t uniqueValueCount = _status.getNumUniqueValues();
     uint64_t docIdLimit = getCommittedDocIdLimit();
@@ -785,10 +786,10 @@ AttributeVector::update_config(const Config& cfg)
     if (cfg.getCompactionStrategy() == _config.getCompactionStrategy()) {
         return;
     }
-    drain_hold(1024 * 1024); // Wait until 1MiB or less on hold
+    drain_hold(1_Mi); // Wait until 1MiB or less on hold
     _config.setCompactionStrategy(cfg.getCompactionStrategy());
     commit(); // might trigger compaction
-    drain_hold(1024 * 1024); // Wait until 1MiB or less on hold
+    drain_hold(1_Mi); // Wait until 1MiB or less on hold
 }
 
 template bool AttributeVector::append<StringChangeData>(ChangeVectorT< ChangeTemplate<StringChangeData> > &changes, uint32_t , const StringChangeData &, int32_t, bool);

--- a/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/predicate_attribute.cpp
@@ -9,6 +9,7 @@
 #include <vespa/searchlib/predicate/predicate_index.h>
 #include <vespa/searchlib/util/fileutil.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.attribute.predicate_attribute");
@@ -134,7 +135,7 @@ PredicateAttribute::onGenerationChange(generation_t generation)
 void
 PredicateAttribute::onSave(IAttributeSaveTarget &saveTarget) {
     LOG(info, "Saving predicate attribute version %d", getVersion());
-    IAttributeSaveTarget::Buffer buffer(saveTarget.datWriter().allocBuf(4096));
+    IAttributeSaveTarget::Buffer buffer(saveTarget.datWriter().allocBuf(4_Ki));
     _index->serialize(*buffer);
     uint32_t  highest_doc_id = static_cast<uint32_t>(_min_feature.size() - 1);
     buffer->writeInt32(highest_doc_id);

--- a/searchlib/src/vespa/searchlib/attribute/readerbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/readerbase.cpp
@@ -6,6 +6,7 @@
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/searchlib/util/filesizecalculator.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".search.attribute.readerbase");
@@ -18,7 +19,7 @@ const vespalib::string versionTag = "version";
 const vespalib::string docIdLimitTag = "docIdLimit";
 const vespalib::string createSerialNumTag = "createSerialNum";
 
-constexpr size_t DIRECTIO_ALIGNMENT(4096);
+constexpr size_t DIRECTIO_ALIGNMENT(4_Ki);
 
 uint64_t
 extractCreateSerialNum(const vespalib::GenericHeader &header)

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
@@ -9,6 +9,7 @@
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/searchlib/common/bitvectoriterator.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search {
 
@@ -244,7 +245,7 @@ SingleBoolAttribute::onShrinkLidSpace()
 uint64_t
 SingleBoolAttribute::getEstimatedSaveByteSize() const
 {
-    constexpr uint64_t headerSize = 4096 + sizeof(uint32_t);
+    constexpr uint64_t headerSize = 4_Ki + sizeof(uint32_t);
     return headerSize + _bv.sizeBytes();
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattributesaver.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattributesaver.cpp
@@ -3,6 +3,7 @@
 #include "singlenumericattributesaver.h"
 #include "iattributesavetarget.h"
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using vespalib::GenerationHandler;
 
@@ -10,7 +11,7 @@ namespace search {
 
 namespace {
 
-const uint32_t MIN_ALIGNMENT = 4096;
+const uint32_t MIN_ALIGNMENT = 4_Ki;
 
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/query/query_term_simple.h>
 #include <vespa/searchlib/queryeval/emptysearch.h>
 #include <vespa/vespalib/data/databuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search {
 
@@ -199,7 +200,7 @@ SingleValueSmallNumericAttribute::onShrinkLidSpace()
 uint64_t
 SingleValueSmallNumericAttribute::getEstimatedSaveByteSize() const
 {
-    uint64_t headerSize = 4096;
+    uint64_t headerSize = 4_Ki;
     const size_t numDocs(getCommittedDocIdLimit());
     const size_t numDataWords((numDocs + _valueShiftMask) >> _wordShift);
     const size_t sz((numDataWords + 1) * sizeof(Word));

--- a/searchlib/src/vespa/searchlib/attribute/sourceselector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/sourceselector.cpp
@@ -3,6 +3,7 @@
 #include "sourceselector.h"
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/searchlib/common/fileheadercontext.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using search::queryeval::Source;
 using vespalib::FileHeader;
@@ -82,7 +83,7 @@ SourceSelector::LoadInfo::load()
     // XXX no checking for success
     file.ReadOpen(fileName.c_str());
 
-    FileHeader fileHeader(4096);
+    FileHeader fileHeader(4_Ki);
     fileHeader.readFile(file);
     if (fileHeader.hasTag(defaultSourceTag)) {
         _header._defaultSource = fileHeader.getTag(defaultSourceTag).asInteger();

--- a/searchlib/src/vespa/searchlib/bitcompression/compression.cpp
+++ b/searchlib/src/vespa/searchlib/bitcompression/compression.cpp
@@ -6,10 +6,11 @@
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/util/arrayref.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search::bitcompression {
 
-uint8_t CodingTables::_log2Table[65536];
+uint8_t CodingTables::_log2Table[64_Ki];
 
 CodingTables tables;  // Static initializer
 
@@ -18,7 +19,7 @@ CodingTables::CodingTables()
     unsigned int x;
     uint8_t log2Val;
 
-    for (x = 0; x < 65536; x++) {
+    for (x = 0; x < 64_Ki; x++) {
         unsigned int val = x;
         for (log2Val = 0; (val >>= 1) != 0; log2Val++) {
         }
@@ -172,7 +173,7 @@ readHeader(vespalib::GenericHeader &header, int64_t fileSize)
 {
     size_t hhSize = vespalib::GenericHeader::getMinSize();
     assert(static_cast<int64_t>(hhSize) <= fileSize);
-    vespalib::DataBuffer dataBuffer(32768u);
+    vespalib::DataBuffer dataBuffer(32_Ki);
     dataBuffer.ensureFree(hhSize);
     readBytes(reinterpret_cast<uint8_t *>(dataBuffer.getFree()),
               hhSize);
@@ -297,7 +298,7 @@ void
 FeatureEncodeContext<bigEndian>::
 writeHeader(const vespalib::GenericHeader &header)
 {
-    vespalib::DataBuffer dataBuffer(32768u);
+    vespalib::DataBuffer dataBuffer(32_Ki);
     vespalib::GenericHeader::BufferWriter bufferWriter(dataBuffer);
     dataBuffer.ensureFree(header.getSize());
     header.write(bufferWriter);

--- a/searchlib/src/vespa/searchlib/common/documentsummary.cpp
+++ b/searchlib/src/vespa/searchlib/common/documentsummary.cpp
@@ -3,6 +3,7 @@
 #include "documentsummary.h"
 #include <vespa/fastlib/io/bufferedfile.h>
 #include <vespa/searchlib/util/filekit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/error.h>
 
 #include <vespa/log/log.h>
@@ -17,7 +18,7 @@ bool
 DocumentSummary::readDocIdLimit(const vespalib::string &dir, uint32_t &count)
 {
     char numbuf[20];
-    Fast_BufferedFile qcntfile(4096);
+    Fast_BufferedFile qcntfile(4_Ki);
     unsigned int qcnt;
     vespalib::string qcntname;
     const char *p;

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/common/fileheadercontext.h>
 #include <vespa/vespalib/data/fileheader.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cassert>
 
 namespace search::diskindex {
@@ -18,13 +19,13 @@ void
 readHeader(vespalib::FileHeader &h,
            const vespalib::string &name)
 {
-    Fast_BufferedFile file(32768u);
+    Fast_BufferedFile file(32_Ki);
     file.OpenReadOnly(name.c_str());
     h.readFile(file);
     file.Close();
 }
 
-const size_t FILE_HEADERSIZE_ALIGNMENT = 4096;
+const size_t FILE_HEADERSIZE_ALIGNMENT = 4_Ki;
 
 }
 

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/common/fileheadercontext.h>
 #include <vespa/vespalib/data/fileheader.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cassert>
 
 namespace search::diskindex {
@@ -17,13 +18,13 @@ namespace {
 void
 readHeader(vespalib::FileHeader &h, const vespalib::string &name)
 {
-    Fast_BufferedFile file(32768u);
+    Fast_BufferedFile file(32_Ki);
     file.OpenReadOnly(name.c_str());
     h.readFile(file);
     file.Close();
 }
 
-const size_t FILE_HEADERSIZE_ALIGNMENT = 4096;
+const size_t FILE_HEADERSIZE_ALIGNMENT = 4_Ki;
 
 }
 

--- a/searchlib/src/vespa/searchlib/diskindex/pagedict4file.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/pagedict4file.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/io/fileutil.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".diskindex.pagedict4file");
@@ -37,7 +38,7 @@ namespace search::diskindex {
 
 namespace {
 
-const uint32_t headerAlign = 4096;
+const uint32_t headerAlign = 4_Ki;
 
 }
 
@@ -211,12 +212,12 @@ PageDict4FileSeqRead::open(const vespalib::string &name,
 
     _spReadContext.setFile(&_spfile);
     _spReadContext.setFileSize(_spfile.GetSize());
-    _spReadContext.allocComprBuf(65536u, 32768u);
+    _spReadContext.allocComprBuf(64_Ki, 32_Ki);
     _spd.emptyBuffer(0);
 
     _pReadContext.setFile(&_pfile);
     _pReadContext.setFileSize(_pfile.GetSize());
-    _pReadContext.allocComprBuf(65536u, 32768u);
+    _pReadContext.allocComprBuf(64_Ki, 32_Ki);
     _pd.emptyBuffer(0);
 
     uint64_t fileSize = _ssfile.GetSize();
@@ -224,7 +225,7 @@ PageDict4FileSeqRead::open(const vespalib::string &name,
     _ssReadContext.setFileSize(fileSize);
     _ssReadContext.allocComprBuf((fileSize + sizeof(uint64_t) - 1) /
                                  sizeof(uint64_t),
-                                 32768u);
+                                 32_Ki);
     _ssd.emptyBuffer(0);
 
     _ssReadContext.readComprBuffer();
@@ -357,9 +358,9 @@ PageDict4FileSeqWrite::open(const vespalib::string &name,
     assertOpenWriteOnly(ok, ssname);
     _ssWriteContext.setFile(&_ssfile);
 
-    _pWriteContext.allocComprBuf(65536u, 32768u);
-    _spWriteContext.allocComprBuf(65536u, 32768u);
-    _ssWriteContext.allocComprBuf(65536u, 32768u);
+    _pWriteContext.allocComprBuf(64_Ki, 32_Ki);
+    _spWriteContext.allocComprBuf(64_Ki, 32_Ki);
+    _ssWriteContext.allocComprBuf(64_Ki, 32_Ki);
 
     uint64_t pFileSize = _pfile.GetSize();
     uint64_t spFileSize = _spfile.GetSize();

--- a/searchlib/src/vespa/searchlib/docstore/chunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.cpp
@@ -3,6 +3,7 @@
 #include "chunk.h"
 #include "chunkformats.h"
 #include <vespa/vespalib/stllike/hash_map.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search {
 
@@ -59,7 +60,7 @@ Chunk::Chunk(uint32_t id, const Config & config) :
     _lastSerial(static_cast<uint64_t>(-1l)),
     _format(std::make_unique<ChunkFormatV2>(config.getMaxBytes()))
 {
-    _lids.reserve(4096/sizeof(Entry));
+    _lids.reserve(4_Ki/sizeof(Entry));
 }
 
 Chunk::Chunk(uint32_t id, const void * buffer, size_t len, bool skipcrc) :

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.cpp
@@ -9,6 +9,7 @@
 #include <vespa/vespalib/stllike/cache.hpp>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/util/compressor.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 
@@ -76,7 +77,7 @@ BackingStore::visit(const IDocumentStore::LidVector &lids, const DocumentTypeRep
 bool
 BackingStore::read(DocumentIdT key, Value &value) const {
     bool found(false);
-    vespalib::DataBuffer buf(4096);
+    vespalib::DataBuffer buf(4_Ki);
     ssize_t len = _backingStore.read(key, buf);
     if (len > 0) {
         value.set(std::move(buf), len, _compression);
@@ -355,7 +356,7 @@ void
 DocumentStore::WrapVisitor<Visitor>::visit(uint32_t lid, const void *buffer, size_t sz)
 {
     Value value;
-    vespalib::DataBuffer buf(4096);
+    vespalib::DataBuffer buf(4_Ki);
     buf.clear();
     buf.writeBytes(buffer, sz);
     ssize_t len = sz;

--- a/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.cpp
@@ -6,6 +6,7 @@
 #include "randreaders.h"
 #include <vespa/searchlib/util/filekit.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/stllike/asciistream.h>
@@ -343,7 +344,7 @@ FileChunk::appendTo(vespalib::ThreadExecutor & executor, const IGetLid & db, IWr
     vespalib::GenerationHandler::Guard lidReadGuard(db.getLidReadGuard());
     assert(numChunks <= getNumChunks());
     FixedParams fixedParams = {db, dest, lidReadGuard, getFileId().getId(), visitorProgress};
-    vespalib::BlockingThreadStackExecutor singleExecutor(1, 64*1024, executor.getNumThreads()*2);
+    vespalib::BlockingThreadStackExecutor singleExecutor(1, 64_Ki, executor.getNumThreads()*2);
     for (size_t chunkId(0); chunkId < numChunks; chunkId++) {
         std::promise<Chunk::UP> promisedChunk;
         std::future<Chunk::UP> futureChunk = promisedChunk.get_future();

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -9,6 +9,7 @@
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/rcuvector.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -18,7 +19,7 @@ namespace search {
 
 namespace {
     constexpr size_t DEFAULT_MAX_FILESIZE = 1000000000ul;
-    constexpr uint32_t DEFAULT_MAX_LIDS_PER_FILE = 32 * 1024 * 1024;
+    constexpr uint32_t DEFAULT_MAX_LIDS_PER_FILE = 32_Mi;
 }
 
 using vespalib::getLastErrorString;

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -5,6 +5,7 @@
 #include "summaryexceptions.h"
 #include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/vespalib/util/array.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/fileheader.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/searchlib/common/fileheadercontext.h>
@@ -26,8 +27,8 @@ namespace search {
 
 namespace {
 
-const uint64_t Alignment = 4096;
-const uint64_t headerAlign = 4096;
+const uint64_t Alignment = 4_Ki;
+const uint64_t headerAlign = 4_Ki;
 
 }
 

--- a/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
+++ b/searchlib/src/vespa/searchlib/engine/proto_converter.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
 #include <vespa/vespalib/data/smart_buffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace search::engine {
 
@@ -149,7 +150,7 @@ void
 ProtoConverter::docsum_reply_to_proto(const DocsumReply &reply, ProtoDocsumReply &proto)
 {
     if (reply._root) {
-        vespalib::SmartBuffer buf(4096);
+        vespalib::SmartBuffer buf(4_Ki);
         vespalib::slime::BinaryFormat::encode(*reply._root, buf);
         proto.set_slime_summaries(buf.obtain().data, buf.obtain().size);
     }

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
@@ -4,6 +4,7 @@
 #include "blueprintfactory.h"
 #include "featurenameparser.h"
 #include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <stack>
 #include <cassert>
 #include <set>
@@ -282,9 +283,9 @@ BlueprintResolver::compile()
                                    }
                                });
     compile_thread.join();
-    int stack_usage = compiler.stack_usage();
-    if (stack_usage > (128 * 1024)) {
-        LOG(warning, "high stack usage: %d bytes", stack_usage);
+    size_t stack_usage = compiler.stack_usage();
+    if (stack_usage > (128_Ki)) {
+        LOG(warning, "high stack usage: %zu bytes", stack_usage);
     }
     return !compiler.failed();
 }

--- a/searchlib/src/vespa/searchlib/fef/rank_program.cpp
+++ b/searchlib/src/vespa/searchlib/fef/rank_program.cpp
@@ -4,6 +4,7 @@
 #include "featureoverrider.h"
 #include <vespa/vespalib/locale/c.h>
 #include <vespa/vespalib/stllike/hash_set.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <algorithm>
 #include <cassert>
 
@@ -157,7 +158,7 @@ RankProgram::resolve(const BlueprintResolver::FeatureMap &features, bool unbox_s
 
 RankProgram::RankProgram(BlueprintResolver::SP resolver)
     : _resolver(std::move(resolver)),
-      _hot_stash(32768),
+      _hot_stash(32_Ki),
       _cold_stash(),
       _executors(),
       _unboxed_seeds(),

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -6,6 +6,7 @@
 #include "termnodes.h"
 #include <vespa/vespalib/objects/nbo.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/parsequery/parse.h>
 
 using vespalib::string;
@@ -271,7 +272,7 @@ class QueryNodeConverter : public QueryVisitor {
 
 public:
     QueryNodeConverter()
-        : _buf(4096)
+        : _buf(4_Ki)
     {
     }
 

--- a/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.cpp
@@ -4,12 +4,13 @@
 #include <vespa/eval/eval/value.h>
 #include <vespa/vespalib/datastore/datastore.hpp>
 #include <vespa/vespalib/datastore/buffer_type.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 
 using vespalib::datastore::EntryRef;
 
 namespace search::tensor {
 
-constexpr size_t MIN_BUFFER_ARRAYS = 8192;
+constexpr size_t MIN_BUFFER_ARRAYS = 8_Ki;
 
 DirectTensorStore::TensorBufferType::TensorBufferType()
     : ParentType(1, MIN_BUFFER_ARRAYS, TensorStoreType::RefType::offsetSize())

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -11,6 +11,7 @@
 #include <vespa/vespalib/datastore/array_store.hpp>
 #include <vespa/vespalib/util/memory_allocator.h>
 #include <vespa/vespalib/util/rcuvector.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/log/log.h>
 
 LOG_SETUP(".searchlib.tensor.hnsw_index");
@@ -23,8 +24,8 @@ using vespalib::datastore::EntryRef;
 namespace {
 
 // TODO: Move this to MemoryAllocator, with name PAGE_SIZE.
-constexpr size_t small_page_size = 4 * 1024;
-constexpr size_t min_num_arrays_for_new_buffer = 8 * 1024;
+constexpr size_t small_page_size = 4_Ki;
+constexpr size_t min_num_arrays_for_new_buffer = 8_Ki;
 constexpr float alloc_grow_factor = 0.2;
 // TODO: Adjust these numbers to what we accept as max in config.
 constexpr size_t max_level_array_size = 16;

--- a/searchlib/src/vespa/searchlib/tensor/streamed_value_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/streamed_value_store.cpp
@@ -9,6 +9,7 @@
 #include <vespa/vespalib/datastore/buffer_type.hpp>
 #include <vespa/vespalib/datastore/datastore.hpp>
 #include <vespa/vespalib/objects/nbostream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/typify.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/log/log.h>
@@ -154,7 +155,7 @@ StreamedValueStore::TensorEntryImpl<CT>::~TensorEntryImpl() = default;
 
 //-----------------------------------------------------------------------------
 
-constexpr size_t MIN_BUFFER_ARRAYS = 8192;
+constexpr size_t MIN_BUFFER_ARRAYS = 8_Ki;
 
 StreamedValueStore::TensorBufferType::TensorBufferType() noexcept
     : ParentType(1, MIN_BUFFER_ARRAYS, TensorStoreType::RefType::offsetSize())

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakeword.cpp
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/bitcompression/compression.h>
 #include <vespa/searchlib/bitcompression/posocccompression.h>
 #include <vespa/searchlib/bitcompression/posocc_fields_params.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using search::fef::TermFieldMatchData;
 using search::fef::TermFieldMatchDataPosition;
@@ -232,7 +233,7 @@ FakeWord::fakeup(search::BitVector &bitmap,
         wpf.clear();
         for (unsigned int j = 0; j < positions; ++j) {
             DocWordPosFeature dwpf;
-            dwpf._wordPos = rnd.lrand48() % 8192;
+            dwpf._wordPos = rnd.lrand48() % 8_Ki;
             dwpf._elementId = 0;
             if (_fieldsParams.getFieldParams()[0]._hasElements) {
                 dwpf._elementId = rnd.lrand48() % 4;
@@ -258,7 +259,7 @@ FakeWord::fakeup(search::BitVector &bitmap,
                     lastwordpos = i->_wordPos;
                     ++i;
                 }
-                uint32_t elementLen = (rnd.lrand48() % 8192) + 1 + lastwordpos;
+                uint32_t elementLen = (rnd.lrand48() % 8_Ki) + 1 + lastwordpos;
                 int32_t elementWeight = 1;
                 if (_fieldsParams.getFieldParams()[0].
                     _hasElementWeights) {

--- a/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/file.h>
 #include <algorithm>
 #include <thread>
@@ -37,7 +38,7 @@ Domain::Domain(const string &domainName, const string & baseDir, Executor & exec
     : _config(cfg),
       _currentChunk(createCommitChunk(cfg)),
       _lastSerial(0),
-      _singleCommitter(std::make_unique<vespalib::ThreadStackExecutor>(1, 128 * 1024)),
+      _singleCommitter(std::make_unique<vespalib::ThreadStackExecutor>(1, 128_Ki)),
       _executor(executor),
       _sessionId(1),
       _syncMonitor(),

--- a/searchlib/src/vespa/searchlib/transactionlog/translogclient.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogclient.cpp
@@ -7,6 +7,7 @@
 #include <vespa/fnet/frt/rpcrequest.h>
 #include <vespa/fnet/transport.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/thread.h>
 
 
@@ -46,10 +47,10 @@ struct RpcTask : public vespalib::Executor::Task {
 }
 
 TransLogClient::TransLogClient(const vespalib::string & rpcTarget) :
-    _executor(std::make_unique<vespalib::ThreadStackExecutor>(1, 128 * 1024, translogclient_rpc_callback)),
+    _executor(std::make_unique<vespalib::ThreadStackExecutor>(1, 128_Ki, translogclient_rpc_callback)),
     _rpcTarget(rpcTarget),
     _sessions(),
-    _threadPool(std::make_unique<FastOS_ThreadPool>(1024*60)),
+    _threadPool(std::make_unique<FastOS_ThreadPool>(60_Ki)),
     _transport(std::make_unique<FNET_Transport>()),
     _supervisor(std::make_unique<FRT_Supervisor>(_transport.get())),
     _target(nullptr)

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/frt/rpcrequest.h>
 #include <vespa/fnet/transport.h>
@@ -96,8 +97,8 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
       _name(name),
       _baseDir(baseDir),
       _domainConfig(cfg),
-      _executor(maxThreads, 128 * 1024, tls_executor),
-      _threadPool(std::make_unique<FastOS_ThreadPool>(1024*120)),
+      _executor(maxThreads, 128_Ki, tls_executor),
+      _threadPool(std::make_unique<FastOS_ThreadPool>(120_Ki)),
       _transport(std::make_unique<FNET_Transport>()),
       _supervisor(std::make_unique<FRT_Supervisor>(_transport.get())),
       _domains(),

--- a/searchlib/src/vespa/searchlib/util/comprfile.cpp
+++ b/searchlib/src/vespa/searchlib/util/comprfile.cpp
@@ -2,6 +2,7 @@
 
 #include "comprfile.h"
 #include <vespa/fastos/file.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cassert>
 #include <cstring>
 
@@ -453,7 +454,7 @@ ComprFileWriteContext::allocComprBuf(unsigned int comprBufSize, size_t preferred
 void
 ComprFileWriteContext::allocComprBuf()
 {
-    allocComprBuf(32768, 32768);
+    allocComprBuf(32_Ki, 32_Ki);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
+++ b/searchlib/src/vespa/searchlib/util/dirtraverse.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "dirtraverse.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/file.h>
 #include <cassert>
 #include <cstring>
@@ -234,7 +235,7 @@ DirectoryTraverse::GetTreeSize()
 {
     FastOS_StatInfo statInfo;
     uint64_t size = 0;
-    const uint64_t blockSize = 4096;
+    const uint64_t blockSize = 4_Ki;
 
     while (NextName()) {
         const char *relname = GetRelName();

--- a/searchlib/src/vespa/searchlib/util/filealign.cpp
+++ b/searchlib/src/vespa/searchlib/util/filealign.cpp
@@ -2,6 +2,7 @@
 
 #include "filealign.h"
 #include <vespa/fastos/file.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cassert>
 
 namespace search {
@@ -97,8 +98,8 @@ FileAlign::setupAlign(size_t elements,
         _directIOFileAlign = 1;
         _directIOMemAlign = 1;
     }
-    if (preferredFileAlignment < 4096)
-        preferredFileAlignment = 4096;
+    if (preferredFileAlignment < 4_Ki)
+        preferredFileAlignment = 4_Ki;
     _preferredFileAlign = preferredFileAlignment;
 
     size_t minDirectIOElements = getMinBlocking(elemSize, _directIOFileAlign);

--- a/searchsummary/src/tests/docsumformat/docsum-pack.cpp
+++ b/searchsummary/src/tests/docsumformat/docsum-pack.cpp
@@ -4,6 +4,7 @@
 #include <vespa/searchsummary/docsummary/general_result.h>
 #include <vespa/searchsummary/docsummary/resultconfig.h>
 #include <vespa/searchsummary/docsummary/resultpacker.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fastos/app.h>
 #include <vespa/log/log.h>
 LOG_SETUP("docsum-pack");
@@ -343,8 +344,8 @@ MyApp::TestCompressInplace()
     const char *buf;
     uint32_t buflen;
 
-    search::RawBuf         field1(32768);
-    search::RawBuf         field2(32768);
+    search::RawBuf         field1(32_Ki);
+    search::RawBuf         field2(32_Ki);
     const ResultClass   *resClass;
     GeneralResult *gres;
 

--- a/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
+++ b/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/searchsummary/docsummary/docsumstate.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace vespalib::slime::convenience;
 using namespace search::docsummary;
@@ -37,7 +38,7 @@ struct DocsumFixture : IDocsumStore, GetDocsumsStateCallback {
     ~DocsumFixture();
     void getDocsum(Slime &slime) {
         uint32_t classId;
-        search::RawBuf buf(4096);
+        search::RawBuf buf(4_Ki);
         writer->WriteDocsum(1u, &state, this, &buf);
         ASSERT_GREATER(buf.GetUsedLen(), sizeof(classId));
         memcpy(&classId, buf.GetDrainPos(), sizeof(classId));

--- a/searchsummary/src/tests/extractkeywords/extractkeywordstest.cpp
+++ b/searchsummary/src/tests/extractkeywords/extractkeywordstest.cpp
@@ -3,6 +3,7 @@
 #include "extractkeywordstest.h"
 #include <vespa/searchsummary/docsummary/keywordextractor.h>
 #include "simplequerystack.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/time.h>
 
 #define NUMTESTS 5
@@ -157,7 +158,7 @@ bool
 ExtractKeywordsTest::RunTest(int testno, bool verify)
 {
     search::SimpleQueryStack stack;
-    search::RawBuf buf(32768);
+    search::RawBuf buf(32_Ki);
     const char *correct = nullptr;
     const char *keywords = nullptr;
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
@@ -5,6 +5,7 @@
 #include "idocsumenvironment.h"
 #include <vespa/searchlib/parsequery/stackdumpiterator.h>
 #include <vespa/vespalib/stllike/hashtable.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 
 /** Tell us what parts of the query we are interested in */
 
@@ -153,7 +154,7 @@ char *
 KeywordExtractor::ExtractKeywords(vespalib::stringref buf) const
 {
     search::SimpleQueryStackDumpIterator si(buf);
-    char keywordstore[4096]; // Initial storage for keywords buffer
+    char keywordstore[4_Ki]; // Initial storage for keywords buffer
     search::RawBuf keywords(keywordstore, sizeof(keywordstore));
 
     while (si.next()) {

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultpacker.cpp
@@ -2,6 +2,7 @@
 
 #include "resultpacker.h"
 #include <vespa/searchcommon/common/undefinedvalues.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docsummary.resultpacker");
@@ -57,8 +58,8 @@ ResultPacker::SetFormatError(ResType type)
 
 
 ResultPacker::ResultPacker(const ResultConfig *resConfig)
-    : _buf(32768),
-      _cbuf(32768),
+    : _buf(32_Ki),
+      _cbuf(32_Ki),
       _resConfig(resConfig),
       _resClass(nullptr),
       _entryIdx(0),

--- a/searchsummary/src/vespa/searchsummary/docsummary/summaryfieldconverter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/summaryfieldconverter.cpp
@@ -30,6 +30,7 @@
 #include <vespa/vespalib/encoding/base64.h>
 #include <vespa/vespalib/geo/zcurve.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/objects/nbostream.h>
@@ -556,7 +557,7 @@ public:
         SlimeInserter inserter(slime);
         SlimeFiller visitor(inserter, _tokenize, _matching_elems);
         input.accept(visitor);
-        search::RawBuf rbuf(4096);
+        search::RawBuf rbuf(4_Ki);
         search::SlimeOutputRawBufAdapter adapter(rbuf);
         vespalib::slime::BinaryFormat::encode(slime, adapter);
         return std::make_unique<RawFieldValue>(rbuf.GetDrainPos(), rbuf.GetUsedLen());

--- a/staging_vespalib/src/tests/directio/directio.cpp
+++ b/staging_vespalib/src/tests/directio/directio.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/fastos/file.h>
 
@@ -21,12 +22,12 @@ TEST("that DirectIOException is thrown on unaligned buf.") {
     FastOS_File f("staging_vespalib_directio_test_app");
     f.EnableDirectIO();
     EXPECT_TRUE(f.OpenReadOnly());
-    DataBuffer buf(10000, 4096);
+    DataBuffer buf(10000, 4_Ki);
     bool caught(false);
     try {
-        f.ReadBuf(buf.getFree()+1, 4096, 0);
+        f.ReadBuf(buf.getFree()+1, 4_Ki, 0);
     } catch (const DirectIOException & e) {
-        EXPECT_EQUAL(4096u, e.getLength());
+        EXPECT_EQUAL(4_Ki, e.getLength());
         EXPECT_EQUAL(0u, e.getOffset());
         EXPECT_EQUAL(buf.getFree()+1, e.getBuffer());
         EXPECT_EQUAL(string(f.GetFileName()), e.getFileName());
@@ -39,12 +40,12 @@ TEST("that DirectIOException is thrown on unaligned offset.") {
     FastOS_File f("staging_vespalib_directio_test_app");
     f.EnableDirectIO();
     EXPECT_TRUE(f.OpenReadOnly());
-    DataBuffer buf(10000, 4096);
+    DataBuffer buf(10000, 4_Ki);
     bool caught(false);
     try {
-        f.ReadBuf(buf.getFree(), 4096, 1);
+        f.ReadBuf(buf.getFree(), 4_Ki, 1);
     } catch (const DirectIOException & e) {
-        EXPECT_EQUAL(4096u, e.getLength());
+        EXPECT_EQUAL(4_Ki, e.getLength());
         EXPECT_EQUAL(1u, e.getOffset());
         EXPECT_EQUAL(buf.getFree(), e.getBuffer());
         EXPECT_EQUAL(string(f.GetFileName()), e.getFileName());

--- a/staging_vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
+++ b/staging_vespalib/src/tests/util/process_memory_stats/process_memory_stats_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <iostream>
 #include <fstream>
 #include <sys/mman.h>
@@ -41,7 +42,7 @@ TEST("grow anonymous memory")
 {
     ProcessMemoryStats stats1(ProcessMemoryStats::create(SIZE_EPSILON));
     std::cout << toString(stats1) << std::endl;
-    size_t mapLen = 64 * 1024;
+    size_t mapLen = 64_Ki;
     void *mapAddr = mmap(nullptr, mapLen, PROT_READ | PROT_WRITE,
                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     EXPECT_NOT_EQUAL(reinterpret_cast<void *>(-1), mapAddr);
@@ -59,7 +60,7 @@ TEST("grow anonymous memory")
 TEST("grow mapped memory")
 {
     std::ofstream of("mapfile");
-    size_t mapLen = 64 * 1024;
+    size_t mapLen = 64_Ki;
     std::vector<char> buf(mapLen, 4);
     of.write(&buf[0], buf.size());
     of.close();

--- a/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.cpp
@@ -3,6 +3,7 @@
 #include <vespa/fnet/scheduler.h>
 #include <vespa/fnet/task.h>
 #include <vespa/fnet/transport.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib {
 
@@ -35,7 +36,7 @@ public:
 };
 
 ScheduledExecutor::ScheduledExecutor()
-    : _threadPool(128 * 1024),
+    : _threadPool(128_Ki),
       _transport(new FNET_Transport()),
       _lock(),
       _taskList()

--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.cpp
@@ -4,6 +4,7 @@
 #include "adaptive_sequenced_executor.h"
 #include "singleexecutor.h"
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/stllike/hashtable.h>
 #include <cassert>
 
@@ -11,7 +12,7 @@ namespace vespalib {
 
 namespace {
 
-constexpr uint32_t stackSize = 128 * 1024;
+constexpr uint32_t stackSize = 128_Ki;
 constexpr uint8_t MAGIC = 255;
 
 bool

--- a/storage/src/tests/common/testhelper.cpp
+++ b/storage/src/tests/common/testhelper.cpp
@@ -106,7 +106,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode, const std::string & ro
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4096");
+    config->set("minimum_file_size", "4_Ki");
     config->set("num_threads", "1");
     config->set("dir_spread", "4");
     config->set("dir_levels", "0");

--- a/storage/src/tests/common/testhelper.cpp
+++ b/storage/src/tests/common/testhelper.cpp
@@ -106,7 +106,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode, const std::string & ro
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4_Ki");
+    config->set("minimum_file_size", "4096");
     config->set("num_threads", "1");
     config->set("dir_spread", "4");
     config->set("dir_levels", "0");

--- a/storage/src/tests/distributor/splitbuckettest.cpp
+++ b/storage/src/tests/distributor/splitbuckettest.cpp
@@ -9,6 +9,7 @@
 #include <vespa/storageapi/message/persistence.h>
 #include <tests/common/dummystoragelink.h>
 #include <tests/distributor/distributortestutil.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include "dummy_cluster_context.h"
 
@@ -39,7 +40,7 @@ struct SplitOperationTest : Test, DistributorTestUtil {
 };
 
 SplitOperationTest::SplitOperationTest()
-    : splitByteSize(10*1024*1024),
+    : splitByteSize(10_Mi),
       tooLargeBucketSize(splitByteSize * 1.1),
       splitCount(UINT32_MAX),
       maxSplitBits(58)

--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -26,6 +26,7 @@
 #include <vespa/vdslib/state/random.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/gate.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <atomic>
 #include <thread>
 
@@ -593,7 +594,7 @@ TEST_F(FileStorManagerTest, handler_paused_multi_thread) {
 
     Document::SP doc(createDocument(content, "id:footype:testdoctype1:n=1234:bar").release());
 
-    FastOS_ThreadPool pool(512 * 1024);
+    FastOS_ThreadPool pool(512_Ki);
     MessagePusherThread pushthread(filestorHandler, doc);
     pushthread.start(pool);
 
@@ -1277,7 +1278,7 @@ TEST_F(FileStorManagerTest, visiting) {
     // Visit bucket with no split, using no selection
     {
         spi::IteratorId iterId(createIterator(top, ids[0], "true"));
-        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[0]), iterId, 16*1024);
+        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[0]), iterId, 16_Ki);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1293,7 +1294,7 @@ TEST_F(FileStorManagerTest, visiting) {
         uint32_t totalDocs = 0;
         spi::IteratorId iterId(createIterator(top, ids[1], "testdoctype1.hstringval = \"John Doe\""));
         while (true) {
-            auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[1]), iterId, 16*1024);
+            auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[1]), iterId, 16_Ki);
             top.sendDown(cmd);
             top.waitForMessages(1, _waitTime);
             ASSERT_EQ(1, top.getNumReplies());
@@ -1320,7 +1321,7 @@ TEST_F(FileStorManagerTest, visiting) {
                                framework::MicroSecTime(40)));
         uint32_t totalDocs = 0;
         while (true) {
-            auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[1]), iterId, 16*1024);
+            auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(ids[1]), iterId, 16_Ki);
             top.sendDown(cmd);
             top.waitForMessages(1, _waitTime);
             ASSERT_EQ(1, top.getNumReplies());
@@ -1631,7 +1632,7 @@ TEST_F(FileStorManagerTest, get_iter) {
     // Sending a getiter request that will only visit some of the docs
     spi::IteratorId iterId(createIterator(top, bid, ""));
     {
-        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(bid), iterId, 2048);
+        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(bid), iterId, 2_Ki);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1656,7 +1657,7 @@ TEST_F(FileStorManagerTest, get_iter) {
         EXPECT_EQ(ReturnCode(ReturnCode::OK), reply->getResult());
     }
     {
-        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(bid), iterId, 2048);
+        auto cmd = std::make_shared<GetIterCommand>(makeDocumentBucket(bid), iterId, 2_Ki);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());

--- a/storage/src/tests/persistence/mergehandlertest.cpp
+++ b/storage/src/tests/persistence/mergehandlertest.cpp
@@ -8,6 +8,7 @@
 #include <tests/common/message_sender_stub.h>
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/vespalib/objects/nbostream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <gmock/gmock.h>
 #include <cmath>
 
@@ -626,7 +627,7 @@ MergeHandlerTest::createDummyGetBucketDiff(int timestampOffset, uint16_t hasMask
         diff.push_back(e);
     }
 
-    auto getBucketDiffCmd = std::make_shared<api::GetBucketDiffCommand>(_bucket, _nodes, 1024*1024);
+    auto getBucketDiffCmd = std::make_shared<api::GetBucketDiffCommand>(_bucket, _nodes, 1_Mi);
     getBucketDiffCmd->getDiff() = diff;
     return getBucketDiffCmd;
 }

--- a/storage/src/tests/storageserver/statereportertest.cpp
+++ b/storage/src/tests/storageserver/statereportertest.cpp
@@ -13,6 +13,7 @@
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/data/simple_buffer.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -60,7 +61,7 @@ struct MetricClock : public metrics::MetricManager::Timer
 }
 
 StateReporterTest::StateReporterTest()
-    : _threadPool(256*1024),
+    : _threadPool(256_Ki),
       _clock(nullptr),
       _top(),
       _stateReporter()

--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/datastore/array_store.hpp>
 #include <vespa/vespalib/datastore/buffer_type.hpp>
 #include <vespa/vespalib/util/memory_allocator.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <iostream>
 
 /*
@@ -37,7 +38,7 @@ using document::BucketId;
 template <typename ReplicaStore>
 vespalib::datastore::ArrayStoreConfig make_default_array_store_config() {
     return ReplicaStore::optimizedConfigForHugePage(1023, vespalib::alloc::MemoryAllocator::HUGEPAGE_SIZE,
-                                                    4 * 1024, 8 * 1024, 0.2).enable_free_lists(true);
+                                                    4_Ki, 8_Ki, 0.2).enable_free_lists(true);
 }
 
 namespace {

--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -4,6 +4,7 @@
 #include <vespa/storageframework/storageframework.h>
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/component/vtag.h>
 #include <vespa/vespalib/net/crypto_engine.h>
 #include <functional>
@@ -77,7 +78,7 @@ void StatusWebServer::configure(std::unique_ptr<vespa::config::content::core::St
 StatusWebServer::WebServer::WebServer(StatusWebServer& status, uint16_t port)
     : _status(status),
       _server(vespalib::Portal::create(vespalib::CryptoEngine::get_default(), port)),
-      _executor(1, 256 * 1024),
+      _executor(1, 256_Ki),
       _root(_server->bind("/", *this))
 {
 }

--- a/storage/src/vespa/storage/storageserver/rpc/slime_cluster_state_bundle_codec.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/slime_cluster_state_bundle_codec.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using document::FixedBucketSpaces;
 using vespalib::slime::Cursor;
@@ -77,7 +78,7 @@ EncodedClusterStateBundle SlimeClusterStateBundleCodec::encode(
         feed_block.setString(DescriptionField, bundle.feed_block()->description());
     }
 
-    OutputBuf out_buf(4096);
+    OutputBuf out_buf(4_Ki);
     BinaryFormat::encode(slime, out_buf);
     ConstBufferRef to_compress(out_buf.getBuf().getData(), out_buf.getBuf().getDataLen());
     auto buf = std::make_unique<DataBuffer>(vespalib::roundUp2inN(out_buf.getBuf().getDataLen()));

--- a/storageapi/src/tests/mbusprot/storageprotocoltest.cpp
+++ b/storageapi/src/tests/mbusprot/storageprotocoltest.cpp
@@ -16,6 +16,7 @@
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/document/test/make_bucket_space.h>
 #include <vespa/vespalib/util/growablebytebuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <sstream>
 
@@ -626,7 +627,7 @@ TEST_P(StorageProtocolTest, get_bucket_diff) {
     entries.back()._gid = document::GlobalId("1234567890abcdef");
     entries.back()._timestamp = 123456;
     entries.back()._headerSize = 100;
-    entries.back()._bodySize = 65536;
+    entries.back()._bodySize = 64_Ki;
     entries.back()._flags = 1;
     entries.back()._hasMask = 3;
 

--- a/storageframework/src/vespa/storageframework/defaultimplementation/thread/threadpoolimpl.cpp
+++ b/storageframework/src/vespa/storageframework/defaultimplementation/thread/threadpoolimpl.cpp
@@ -3,6 +3,7 @@
 #include "threadpoolimpl.h"
 #include "threadimpl.h"
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 #include <vespa/log/log.h>
 LOG_SETUP(".storageframework.thread_pool_impl");
@@ -13,7 +14,7 @@ using vespalib::IllegalStateException;
 namespace storage::framework::defaultimplementation {
 
 ThreadPoolImpl::ThreadPoolImpl(Clock& clock)
-    : _backendThreadPool(512 * 1024),
+    : _backendThreadPool(512_Ki),
       _clock(clock),
       _stopping(false)
 { }

--- a/storageserver/src/tests/testhelper.cpp
+++ b/storageserver/src/tests/testhelper.cpp
@@ -50,7 +50,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode) {
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4_Ki");
+    config->set("minimum_file_size", "4096");
     config->set("threads[1]");
     config->set("threads[0].lowestpri 255");
     config->set("dir_spread", "4");
@@ -66,7 +66,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode) {
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4_Ki");
+    config->set("minimum_file_size", "4096");
     config->set("dir_spread", "4");
     config->set("dir_levels", "0");
     config = &dc.addConfig("persistence");

--- a/storageserver/src/tests/testhelper.cpp
+++ b/storageserver/src/tests/testhelper.cpp
@@ -50,7 +50,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode) {
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4096");
+    config->set("minimum_file_size", "4_Ki");
     config->set("threads[1]");
     config->set("threads[0].lowestpri 255");
     config->set("dir_spread", "4");
@@ -66,7 +66,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode) {
     // Easier to see what goes wrong with only 1 thread per disk.
     config->set("minimum_file_meta_slots", "2");
     config->set("minimum_file_header_block_size", "368");
-    config->set("minimum_file_size", "4096");
+    config->set("minimum_file_size", "4_Ki");
     config->set("dir_spread", "4");
     config->set("dir_levels", "0");
     config = &dc.addConfig("persistence");

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -14,6 +14,7 @@
 #include <vespa/vespalib/geo/zcurve.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/fnet/databuffer.h>
 #include "matching_elements_filler.h"
 
@@ -113,7 +114,7 @@ SearchVisitor::SummaryGenerator::SummaryGenerator() :
     _docsumState(_callback),
     _docsumFilter(),
     _docsumWriter(nullptr),
-    _rawBuf(4096)
+    _rawBuf(4_Ki)
 {
 }
 

--- a/vbench/src/vbench/core/socket.cpp
+++ b/vbench/src/vbench/core/socket.cpp
@@ -3,6 +3,7 @@
 #include "socket.h"
 #include <vespa/vespalib/net/socket_options.h>
 #include <vespa/vespalib/net/socket_spec.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vbench {
 
@@ -17,7 +18,7 @@ vespalib::SocketHandle connect(const string &host, int port) {
 
 } // namespace vbench::<unnamed>
 
-constexpr size_t READ_SIZE = 32768;
+constexpr size_t READ_SIZE = 32_Ki;
 
 Socket::Socket(SyncCryptoSocket::UP socket)
     : _socket(std::move(socket)),

--- a/vdslib/src/tests/distribution/distributiontest.cpp
+++ b/vdslib/src/tests/distribution/distributiontest.cpp
@@ -14,6 +14,7 @@
 #include <vespa/vespalib/stllike/lexical_cast.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/vespalib/util/benchmark_timer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <gmock/gmock.h>
 #include <chrono>
 #include <thread>
@@ -221,7 +222,7 @@ TEST(DistributionTest, test_unchanged_distribution)
     Distribution distr(Distribution::getDefaultDistributionConfig(3, 10));
     std::ifstream in("distribution/testdata/41-distributordistribution");
 
-    for (unsigned i = 0; i < 65536; i++) {
+    for (unsigned i = 0; i < 64_Ki; i++) {
         uint16_t node = distr.getIdealDistributorNode(
                 state, document::BucketId(16, i), "u");
 
@@ -403,8 +404,8 @@ TEST(DistributionTest, testHighSplitBit)
 
 TEST(DistributionTest, test_distribution)
 {
-    const int min_buckets = 1024*64;
-    const int max_buckets = 1024*64;
+    const int min_buckets = 64_Ki;
+    const int max_buckets = 64_Ki;
     const int min_nodes = 2;
     const int max_nodes = 50;
 

--- a/vdslib/src/vespa/vdslib/container/documentsummary.cpp
+++ b/vdslib/src/vespa/vdslib/container/documentsummary.cpp
@@ -3,6 +3,7 @@
 #include "documentsummary.h"
 #include <vespa/vespalib/util/growablebytebuffer.h>
 #include <vespa/document/util/bytebuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <algorithm>
 
 namespace vdslib {
@@ -12,7 +13,7 @@ DocumentSummary::DocumentSummary() :
     _summary(),
     _summarySize(0)
 {
-    _summaryBuffer.reset(new vespalib::MallocPtr(4096));
+    _summaryBuffer.reset(new vespalib::MallocPtr(4_Ki));
 }
 
 DocumentSummary::DocumentSummary(document::ByteBuffer& buf) :

--- a/vdslib/src/vespa/vdslib/container/searchresult.cpp
+++ b/vdslib/src/vespa/vdslib/container/searchresult.cpp
@@ -3,6 +3,7 @@
 #include "searchresult.h"
 #include <vespa/document/util/bytebuffer.h>
 #include <vespa/vespalib/util/growablebytebuffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <algorithm>
 
 namespace vdslib {
@@ -102,7 +103,7 @@ SearchResult::SearchResult() :
     _docIdBuffer(),
     _numDocIdBytes(0)
 {
-    _docIdBuffer.reset(new vespalib::MallocPtr(4096));
+    _docIdBuffer.reset(new vespalib::MallocPtr(4_Ki));
 }
 
 SearchResult::SearchResult(document::ByteBuffer & buf) :

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -134,6 +134,7 @@ vespa_define_module(
     src/tests/util/md5
     src/tests/util/rcuvector
     src/tests/util/reusable_set
+    src/tests/util/size_literals
     src/tests/valgrind
     src/tests/visit_ranges
     src/tests/websocket

--- a/vespalib/src/apps/vespa-detect-hostname/detect_hostname.cpp
+++ b/vespalib/src/apps/vespa-detect-hostname/detect_hostname.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/net/socket_address.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <set>
 
 using vespalib::SocketAddress;
@@ -18,7 +19,7 @@ std::set<vespalib::string> make_ip_set() {
 }
 
 vespalib::string get_hostname() {
-    std::vector<char> result(4096, '\0');
+    std::vector<char> result(4_Ki, '\0');
     gethostname(&result[0], 4000);
     return SocketAddress::normalize(&result[0]);
 }

--- a/vespalib/src/tests/alloc/alloc_test.cpp
+++ b/vespalib/src/tests/alloc/alloc_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/alloc.h>
 #include <vespa/vespalib/util/mmap_file_allocator.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cstddef>
 #include <sys/mman.h>
 
@@ -24,11 +25,11 @@ testSwap(T & a, T & b)
 {
     void * tmpA(a.get());
     void * tmpB(b.get());
-    EXPECT_EQUAL(4096ul, a.size());
-    EXPECT_EQUAL(8192ul, b.size());
+    EXPECT_EQUAL(4_Ki, a.size());
+    EXPECT_EQUAL(8_Ki, b.size());
     std::swap(a, b);
-    EXPECT_EQUAL(4096ul, b.size());
-    EXPECT_EQUAL(8192ul, a.size());
+    EXPECT_EQUAL(4_Ki, b.size());
+    EXPECT_EQUAL(8_Ki, a.size());
     EXPECT_EQUAL(tmpA, b.get());
     EXPECT_EQUAL(tmpB, a.get());
 }
@@ -54,30 +55,30 @@ TEST("test basics") {
     }
     {
         EXPECT_EXCEPTION(Alloc::allocAlignedHeap(100, 7), IllegalArgumentException, "Alloc::allocAlignedHeap(100, 7) does not support 7 alignment");
-        Alloc h = Alloc::allocAlignedHeap(100, 1024);
+        Alloc h = Alloc::allocAlignedHeap(100, 1_Ki);
         EXPECT_EQUAL(100u, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
         Alloc h = Alloc::allocMMap(100);
-        EXPECT_EQUAL(4096u, h.size());
+        EXPECT_EQUAL(4_Ki, h.size());
         EXPECT_TRUE(h.get() != nullptr);
     }
     {
-        Alloc a = Alloc::allocHeap(4096), b = Alloc::allocHeap(8192);
+        Alloc a = Alloc::allocHeap(4_Ki), b = Alloc::allocHeap(8_Ki);
         testSwap(a, b);
     }
     {
-        Alloc a = Alloc::allocMMap(4096), b = Alloc::allocMMap(8192);
+        Alloc a = Alloc::allocMMap(4_Ki), b = Alloc::allocMMap(8_Ki);
         testSwap(a, b);
     }
     {
-        Alloc a = Alloc::allocAlignedHeap(4096, 1024), b = Alloc::allocAlignedHeap(8192, 1024);
+        Alloc a = Alloc::allocAlignedHeap(4_Ki, 1_Ki), b = Alloc::allocAlignedHeap(8_Ki, 1_Ki);
         testSwap(a, b);
     }
     {
-        Alloc a = Alloc::allocHeap(4096);
-        Alloc b = Alloc::allocMMap(8192);
+        Alloc a = Alloc::allocHeap(4_Ki);
+        Alloc b = Alloc::allocMMap(8_Ki);
         testSwap(a, b);
     }
     {
@@ -90,8 +91,8 @@ TEST("test basics") {
 
 TEST("test correct alignment") {
     {
-        Alloc buf = Alloc::alloc(10, MemoryAllocator::HUGEPAGE_SIZE, 1024);
-        EXPECT_TRUE(reinterpret_cast<ptrdiff_t>(buf.get()) % 1024 == 0);
+        Alloc buf = Alloc::alloc(10, MemoryAllocator::HUGEPAGE_SIZE, 1_Ki);
+        EXPECT_TRUE(reinterpret_cast<ptrdiff_t>(buf.get()) % 1_Ki == 0);
     }
 
     {
@@ -215,7 +216,7 @@ TEST("mmap alloc can be extended if room") {
     Alloc buf = Alloc::allocMMap(100);
 
     TEST_DO(ensureRoomForExtension(buf, reserved));
-    TEST_DO(verifyExtension(buf, 4096, 4096*2));
+    TEST_DO(verifyExtension(buf, 4_Ki, 4_Ki*2));
 }
 
 TEST("mmap alloc can not be extended if no room") {
@@ -223,7 +224,7 @@ TEST("mmap alloc can not be extended if no room") {
     Alloc reserved = Alloc::allocMMap(100);
     Alloc buf = Alloc::allocMMap(100);
 
-    TEST_DO(verifyNoExtensionWhenNoRoom(buf, reserved, 4096));
+    TEST_DO(verifyNoExtensionWhenNoRoom(buf, reserved, 4_Ki));
 }
 #endif
 #endif
@@ -240,10 +241,10 @@ TEST("heap alloc can not be shrinked") {
 TEST("mmap alloc can be shrinked") {
     Alloc buf = Alloc::allocMMap(4097);
     void * oldPtr = buf.get();
-    EXPECT_EQUAL(8192ul, buf.size());
+    EXPECT_EQUAL(8_Ki, buf.size());
     EXPECT_TRUE(buf.resize_inplace(4095));
     EXPECT_EQUAL(oldPtr, buf.get());
-    EXPECT_EQUAL(4096ul, buf.size());
+    EXPECT_EQUAL(4_Ki, buf.size());
 }
 
 TEST("auto alloced heap alloc can not be shrinked") {

--- a/vespalib/src/tests/array/array_test.cpp
+++ b/vespalib/src/tests/array/array_test.cpp
@@ -1,8 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/vespalib/util/array.hpp>
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/array.hpp>
+#include <vespa/vespalib/util/size_literals.h>
 #include <deque>
 #include <atomic>
 
@@ -139,14 +140,14 @@ TEST("test that organic growth is by 2 in N and reserve resize are exact")
     EXPECT_EQUAL(512u, c.capacity());
     c.push_back('j');
     EXPECT_EQUAL(513u, c.size());
-    EXPECT_EQUAL(1024u, c.capacity());
+    EXPECT_EQUAL(1_Ki, c.capacity());
     for(size_t i(513); i < 1024; i++) {
         c.push_back('a');
     }
-    EXPECT_EQUAL(1024u, c.size());
-    EXPECT_EQUAL(1024u, c.capacity());
+    EXPECT_EQUAL(1_Ki, c.size());
+    EXPECT_EQUAL(1_Ki, c.capacity());
     c.reserve(1025);
-    EXPECT_EQUAL(1024u, c.size());
+    EXPECT_EQUAL(1_Ki, c.size());
     EXPECT_EQUAL(1025u, c.capacity());
     c.push_back('b');   // Within, no growth
     EXPECT_EQUAL(1025u, c.size());
@@ -345,7 +346,7 @@ TEST_F("require that try_unreserve() succeedes if mmap can be shrinked", Unreser
     int *oldPtr = &f.arr[0];
     f.arr.resize(512);
     EXPECT_TRUE(f.arr.try_unreserve(1023));
-    EXPECT_EQUAL(1024u, f.arr.capacity());
+    EXPECT_EQUAL(1_Ki, f.arr.capacity());
     int *newPtr = &f.arr[0];
     EXPECT_EQUAL(oldPtr, newPtr);
 }

--- a/vespalib/src/tests/data/databuffer/databuffer_test.cpp
+++ b/vespalib/src/tests/data/databuffer/databuffer_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <iostream>
 
@@ -28,7 +29,7 @@ Test::testBasic()
     EXPECT_EQUAL(256u, a.getBufSize());
     EXPECT_EQUAL(a.getFreeLen(), a.getBufSize());
     a.ensureFree(1000);
-    EXPECT_EQUAL(1024u, a.getBufSize());
+    EXPECT_EQUAL(1_Ki, a.getBufSize());
     EXPECT_EQUAL(a.getFreeLen(), a.getBufSize());
     EXPECT_EQUAL(0u, a.getDeadLen());
     EXPECT_EQUAL(0u, a.getDataLen());

--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -7,6 +7,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/memory_allocator.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/traits.h>
 #include <vector>
 
@@ -35,7 +36,7 @@ struct Fixture
     generation_t generation;
     Fixture(uint32_t maxSmallArraySize, bool enable_free_lists = true)
         : store(ArrayStoreConfig(maxSmallArraySize,
-                                 ArrayStoreConfig::AllocSpec(16, RefT::offsetSize(), 8 * 1024,
+                                 ArrayStoreConfig::AllocSpec(16, RefT::offsetSize(), 8_Ki,
                                                              ALLOC_GROW_FACTOR)).enable_free_lists(enable_free_lists)),
           refStore(),
           generation(1)
@@ -403,7 +404,7 @@ TEST_F("require that address space usage is ratio between used arrays and number
 
 TEST_F("require that offset in EntryRefT is within bounds when allocating memory buffers where wanted number of bytes is not a power of 2 and less than huge page size",
        ByteFixture(ByteFixture::ArrayStoreType::optimizedConfigForHugePage(1023, vespalib::alloc::MemoryAllocator::HUGEPAGE_SIZE,
-                                                                           4 * 1024, 8 * 1024, ALLOC_GROW_FACTOR)))
+                                                                           4_Ki, 8_Ki, ALLOC_GROW_FACTOR)))
 {
     // The array store config used in this test is equivalent to the one multi-value attribute uses when initializing multi-value mapping.
     // See similar test in datastore_test.cpp for more details on what happens during memory allocation.

--- a/vespalib/src/tests/datastore/array_store_config/array_store_config_test.cpp
+++ b/vespalib/src/tests/datastore/array_store_config/array_store_config_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/datastore/entryref.h>
 #include <vespa/vespalib/datastore/array_store_config.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace vespalib::datastore;
 using AllocSpec = ArrayStoreConfig::AllocSpec;
@@ -64,7 +65,7 @@ TEST_F("require that we can generate config optimized for a given huge page", Fi
                                                                                       4 * KB,
                                                                                       8 * KB))
 {
-    EXPECT_EQUAL(1024u, f.cfg.maxSmallArraySize());
+    EXPECT_EQUAL(1_Ki, f.cfg.maxSmallArraySize());
     TEST_DO(f.assertSpec(0, 8 * KB)); // large arrays
     TEST_DO(f.assertSpec(1, 256 * KB));
     TEST_DO(f.assertSpec(2, 256 * KB));

--- a/vespalib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/vespalib/src/tests/datastore/datastore/datastore_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/test/memory_allocator_observer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("datastore_test");
@@ -143,8 +144,8 @@ assertMemStats(const DataStoreBase::MemStats &exp,
 TEST(DataStoreTest, require_that_entry_ref_is_working)
 {
     using MyRefType = EntryRefT<22>;
-    EXPECT_EQ(4194304u, MyRefType::offsetSize());
-    EXPECT_EQ(1024u, MyRefType::numBuffers());
+    EXPECT_EQ(4_Mi, MyRefType::offsetSize());
+    EXPECT_EQ(1_Ki, MyRefType::numBuffers());
     {
         MyRefType r(0, 0);
         EXPECT_EQ(0u, r.offset());
@@ -171,8 +172,8 @@ TEST(DataStoreTest, require_that_entry_ref_is_working)
 TEST(DataStoreTest, require_that_aligned_entry_ref_is_working)
 {
     using MyRefType = AlignedEntryRefT<22, 2>; // 4 byte alignement
-    EXPECT_EQ(4 * 4194304u, MyRefType::offsetSize());
-    EXPECT_EQ(1024u, MyRefType::numBuffers());
+    EXPECT_EQ(16_Mi, MyRefType::offsetSize());
+    EXPECT_EQ(1_Ki, MyRefType::numBuffers());
     EXPECT_EQ(0u, MyRefType::align(0));
     EXPECT_EQ(4u, MyRefType::align(1));
     EXPECT_EQ(4u, MyRefType::align(2));

--- a/vespalib/src/tests/executor/blockingthreadstackexecutor_test.cpp
+++ b/vespalib/src/tests/executor/blockingthreadstackexecutor_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
 #include <vespa/vespalib/util/executor.h>
 #include <vespa/vespalib/util/backtrace.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <thread>
 
 using namespace vespalib;
@@ -122,14 +123,14 @@ vespalib::string get_worker_stack_trace(BlockingThreadStackExecutor &executor) {
 
 VESPA_THREAD_STACK_TAG(my_stack_tag);
 
-TEST_F("require that executor has appropriate default thread stack tag", BlockingThreadStackExecutor(1, 128*1024, 10)) {
+TEST_F("require that executor has appropriate default thread stack tag", BlockingThreadStackExecutor(1, 128_Ki, 10)) {
     vespalib::string trace = get_worker_stack_trace(f1);
     if (!EXPECT_TRUE(trace.find("unnamed_blocking_executor") != vespalib::string::npos)) {
         fprintf(stderr, "%s\n", trace.c_str());
     }
 }
 
-TEST_F("require that executor thread stack tag can be set", BlockingThreadStackExecutor(1, 128*1024, 10, my_stack_tag)) {
+TEST_F("require that executor thread stack tag can be set", BlockingThreadStackExecutor(1, 128_Ki, 10, my_stack_tag)) {
     vespalib::string trace = get_worker_stack_trace(f1);
     if (!EXPECT_TRUE(trace.find("my_stack_tag") != vespalib::string::npos)) {
         fprintf(stderr, "%s\n", trace.c_str());
@@ -139,7 +140,7 @@ TEST_F("require that executor thread stack tag can be set", BlockingThreadStackE
 TEST_F("require that tasks posted from internal worker thread will not block executor", TimeBomb(60)) {
     size_t cnt = 0;
     Gate fork_done;
-    BlockingThreadStackExecutor executor(1, 128*1024, 10);
+    BlockingThreadStackExecutor executor(1, 128_Ki, 10);
     struct IncTask : Executor::Task {
         size_t &cnt;
         IncTask(size_t &cnt_in) : cnt(cnt_in) {}

--- a/vespalib/src/tests/executor/threadstackexecutor_test.cpp
+++ b/vespalib/src/tests/executor/threadstackexecutor_test.cpp
@@ -3,6 +3,7 @@
 
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/backtrace.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <atomic>
 
 using namespace vespalib;
@@ -171,14 +172,14 @@ vespalib::string get_worker_stack_trace(ThreadStackExecutor &executor) {
 
 VESPA_THREAD_STACK_TAG(my_stack_tag);
 
-TEST_F("require that executor has appropriate default thread stack tag", ThreadStackExecutor(1, 128*1024)) {
+TEST_F("require that executor has appropriate default thread stack tag", ThreadStackExecutor(1, 128_Ki)) {
     vespalib::string trace = get_worker_stack_trace(f1);
     if (!EXPECT_TRUE(trace.find("unnamed_nonblocking_executor") != vespalib::string::npos)) {
         fprintf(stderr, "%s\n", trace.c_str());
     }
 }
 
-TEST_F("require that executor thread stack tag can be set", ThreadStackExecutor(1, 128*1024, my_stack_tag)) {
+TEST_F("require that executor thread stack tag can be set", ThreadStackExecutor(1, 128_Ki, my_stack_tag)) {
     vespalib::string trace = get_worker_stack_trace(f1);
     if (!EXPECT_TRUE(trace.find("my_stack_tag") != vespalib::string::npos)) {
         fprintf(stderr, "%s\n", trace.c_str());

--- a/vespalib/src/tests/io/fileutil/fileutiltest.cpp
+++ b/vespalib/src/tests/io/fileutil/fileutiltest.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <regex>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib {
 
@@ -406,7 +407,7 @@ TEST("require that vespalib::copy works")
     MallocAutoPtr buffer = getAlignedBuffer(5000);
     memset(buffer.get(), 0, 5000);
     strncpy(static_cast<char*>(buffer.get()), "Hello World!\n", 14);
-    f.write(buffer.get(), 4096, 0);
+    f.write(buffer.get(), 4_Ki, 0);
     f.close();
     std::cerr << "Simple copy\n";
         // Simple copy works (4096b dividable file)

--- a/vespalib/src/tests/net/crypto_socket/crypto_socket_test.cpp
+++ b/vespalib/src/tests/net/crypto_socket/crypto_socket_test.cpp
@@ -13,6 +13,7 @@
 #include <vespa/vespalib/net/socket_utils.h>
 #include <vespa/vespalib/data/smart_buffer.h>
 #include <vespa/vespalib/test/make_tls_options_for_testing.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <fcntl.h>
@@ -38,7 +39,7 @@ bool is_blocked(int res) {
 }
 
 void read(CryptoSocket &socket, SmartBuffer &buffer) {
-    size_t chunk_size = std::max(size_t(4096), socket.min_read_buffer_size());
+    size_t chunk_size = std::max(size_t(4_Ki), socket.min_read_buffer_size());
     auto chunk = buffer.reserve(chunk_size);
     int res = socket.read(chunk.data, chunk.size);
     if (res > 0) {
@@ -50,7 +51,7 @@ void read(CryptoSocket &socket, SmartBuffer &buffer) {
 
 void drain(CryptoSocket &socket, SmartBuffer &buffer) {
     int res;
-    size_t chunk_size = std::max(size_t(4096), socket.min_read_buffer_size());
+    size_t chunk_size = std::max(size_t(4_Ki), socket.min_read_buffer_size());
     do {
         auto chunk = buffer.reserve(chunk_size);
         res = socket.drain(chunk.data, chunk.size);
@@ -105,7 +106,7 @@ void read_EOF(CryptoSocket &socket, SmartBuffer &read_buffer) {
     ASSERT_EQUAL(read_buffer.obtain().size, 0u);
     SingleFdSelector selector(socket.get_fd());
     ASSERT_TRUE(selector.wait_readable());
-    size_t chunk_size = std::max(size_t(4096), socket.min_read_buffer_size());
+    size_t chunk_size = std::max(size_t(4_Ki), socket.min_read_buffer_size());
     auto chunk = read_buffer.reserve(chunk_size);
     auto res = socket.read(chunk.data, chunk.size);
     while (is_blocked(res)) {
@@ -205,7 +206,7 @@ void verify_handshake(CryptoSocket &socket) {
 void verify_crypto_socket(SocketPair &sockets, CryptoEngine &engine, bool is_server) {
     SocketHandle &my_handle = is_server ? sockets.server : sockets.client;
     my_handle.set_blocking(false);
-    SmartBuffer read_buffer(4096);
+    SmartBuffer read_buffer(4_Ki);
     CryptoSocket::UP my_socket = is_server
                                  ? engine.create_server_crypto_socket(std::move(my_handle))
                                  : engine.create_client_crypto_socket(std::move(my_handle), local_spec);

--- a/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
+++ b/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
@@ -12,6 +12,7 @@
 #include <vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h>
 #include <vespa/vespalib/test/make_tls_options_for_testing.h>
 #include <vespa/vespalib/test/peer_policy_utils.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <stdexcept>
 #include <stdlib.h>
 
@@ -83,8 +84,8 @@ struct Fixture {
           tls_ctx(TlsContext::create_default_context(tls_opts, AuthorizationMode::Enforce)),
           client(create_openssl_codec(tls_ctx, CryptoCodec::Mode::Client)),
           server(create_openssl_codec(tls_ctx, CryptoCodec::Mode::Server)),
-          client_to_server(64 * 1024),
-          server_to_client(64 * 1024)
+          client_to_server(64_Ki),
+          server_to_client(64_Ki)
     {}
     ~Fixture();
 

--- a/vespalib/src/tests/shared_string_repo/shared_string_repo_test.cpp
+++ b/vespalib/src/tests/shared_string_repo/shared_string_repo_test.cpp
@@ -3,6 +3,7 @@
 #include <vespa/vespalib/util/shared_string_repo.h>
 #include <vespa/vespalib/util/rendezvous.h>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/testkit/test_kit.h>
@@ -18,7 +19,7 @@ using Stats = SharedStringRepo::Stats;
 
 bool verbose = false;
 double budget = 0.10;
-size_t work_size = 4096;
+size_t work_size = 4_Ki;
 
 //-----------------------------------------------------------------------------
 

--- a/vespalib/src/tests/simple_thread_bundle/threading_speed_test.cpp
+++ b/vespalib/src/tests/simple_thread_bundle/threading_speed_test.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/simple_thread_bundle.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/box.h>
 #include <thread>
 
@@ -8,7 +9,7 @@ using namespace vespalib;
 
 uint64_t doWork(uint64_t data) {
     uint64_t value = data;
-    for (size_t i = 0; i < 1024 * 1024; ++i) {
+    for (size_t i = 0; i < 1_Mi; ++i) {
         value = (value << 16) + (value >> 8) + (value << 32);
     }
     return value;

--- a/vespalib/src/tests/slime/summary-feature-benchmark/summary-feature-benchmark.cpp
+++ b/vespalib/src/tests/slime/summary-feature-benchmark/summary-feature-benchmark.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/data/slime/slime.h>
 
@@ -9,7 +10,7 @@ using namespace vespalib::slime::convenience;
 struct MyBuffer : public Output {
     std::vector<char> data;
     size_t            used;
-    MyBuffer() : data(1024 * 1024), used(0) {}
+    MyBuffer() : data(1_Mi), used(0) {}
     ~MyBuffer();
     WritableMemory reserve(size_t bytes) override {
         assert(data.size() >= (used + bytes));

--- a/vespalib/src/tests/stash/stash.cpp
+++ b/vespalib/src/tests/stash/stash.cpp
@@ -244,7 +244,7 @@ TEST("require that multiple chunks can be used by the stash") {
     EXPECT_EQUAL(100 * 512 + count * chunk_header_size(), stash.count_used());
 }
 
-TEST("require that default chunk size is 4_Ki") {
+TEST("require that default chunk size is 4096") {
     Stash stash;
     EXPECT_EQUAL(4_Ki, stash.get_chunk_size());
 }

--- a/vespalib/src/tests/stash/stash.cpp
+++ b/vespalib/src/tests/stash/stash.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stash.h>
 #include <vespa/vespalib/util/traits.h>
 
@@ -171,7 +172,7 @@ TEST("require that large object creation and destruction works") {
         Stash stash;
         stash.create<Large>(destructed);
         EXPECT_EQUAL(0u, stash.count_used());
-        EXPECT_GREATER(sizeof(Large), 1024u);
+        EXPECT_GREATER(sizeof(Large), 1_Ki);
         EXPECT_FALSE(destructed);
     }
     EXPECT_TRUE(destructed);
@@ -193,7 +194,7 @@ TEST("require that large objects can skip destruction") {
         Stash stash;
         stash.create<Large_NoDelete>(destructed);
         EXPECT_EQUAL(0u, stash.count_used());
-        EXPECT_GREATER(sizeof(Large_NoDelete), 1024u);
+        EXPECT_GREATER(sizeof(Large_NoDelete), 1_Ki);
     }
     EXPECT_FALSE(destructed);
 }
@@ -243,9 +244,9 @@ TEST("require that multiple chunks can be used by the stash") {
     EXPECT_EQUAL(100 * 512 + count * chunk_header_size(), stash.count_used());
 }
 
-TEST("require that default chunk size is 4096") {
+TEST("require that default chunk size is 4_Ki") {
     Stash stash;
-    EXPECT_EQUAL(4096u, stash.get_chunk_size());
+    EXPECT_EQUAL(4_Ki, stash.get_chunk_size());
 }
 
 TEST("require that the chunk size can be adjusted") {
@@ -460,7 +461,7 @@ void check_array(ArrayRef<float> arr, size_t expect_size) {
 }
 
 TEST("require that uninitialized arrays can be created") {
-    Stash stash(4096);
+    Stash stash(4_Ki);
     EXPECT_EQUAL(0u, stash.count_used());
     ArrayRef<float> small_arr = stash.create_uninitialized_array<float>(64);
     TEST_DO(check_array(small_arr, 64));

--- a/vespalib/src/tests/util/generationhandler_stress/generation_handler_stress_test.cpp
+++ b/vespalib/src/tests/util/generationhandler_stress/generation_handler_stress_test.cpp
@@ -2,9 +2,9 @@
 #include <vespa/log/log.h>
 LOG_SETUP("generation_handler_stress_test");
 #include <vespa/vespalib/testkit/testapp.h>
-
 #include <vespa/vespalib/util/generationhandler.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using vespalib::Executor;
 using vespalib::GenerationHandler;
@@ -52,8 +52,8 @@ private:
 Fixture::Fixture(uint32_t readThreads)
     : _generationHandler(),
       _readThreads(readThreads),
-      _writer(1, 128 * 1024),
-      _readers(readThreads, 128 * 1024),
+      _writer(1, 128_Ki),
+      _readers(readThreads, 128_Ki),
       _doneWriteWork(0),
       _doneReadWork(0),
       _stopRead(0),

--- a/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
+++ b/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/rcuvector.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 using namespace vespalib;
 
@@ -241,13 +242,13 @@ struct ShrinkFixture {
     GenerationHolder g;
     RcuVectorBase<int> vec;
     int *oldPtr;
-    ShrinkFixture() : g(), vec(4096, 50, 0, g, alloc::Alloc::allocMMap()), oldPtr()
+    ShrinkFixture() : g(), vec(4_Ki, 50, 0, g, alloc::Alloc::allocMMap()), oldPtr()
     {
         for (size_t i = 0; i < 4000; ++i) {
             vec.push_back(7);
         }
         EXPECT_EQUAL(4000u, vec.size());
-        EXPECT_EQUAL(4096u, vec.capacity());
+        EXPECT_EQUAL(4_Ki, vec.capacity());
         assertEmptyHoldList();
         oldPtr = &vec[0];
     }
@@ -263,7 +264,7 @@ TEST_F("require that shrink() does not increase allocated memory", ShrinkFixture
 {
     f.vec.shrink(2732);
     EXPECT_EQUAL(2732u, f.vec.size());
-    EXPECT_EQUAL(4096u, f.vec.capacity());
+    EXPECT_EQUAL(4_Ki, f.vec.capacity());
     TEST_DO(f.assertOldEqualNewBuffer());
     TEST_DO(f.assertEmptyHoldList());
 }

--- a/vespalib/src/tests/util/size_literals/CMakeLists.txt
+++ b/vespalib/src/tests/util/size_literals/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_size_literals_test_app TEST
+    SOURCES
+    size_literals_test.cpp
+    DEPENDS
+    vespalib
+    GTest::GTest
+)
+vespa_add_test(NAME vespalib_size_literals_test_app COMMAND vespalib_size_literals_test_app)

--- a/vespalib/src/tests/util/size_literals/size_literals_test.cpp
+++ b/vespalib/src/tests/util/size_literals/size_literals_test.cpp
@@ -1,0 +1,41 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+template<typename T> bool is_size_t(T) { return false; }
+template<> bool is_size_t<size_t>(size_t) { return true; }
+
+TEST(SizeLiteralsTest, simple_usage)
+{
+    auto v1k = 1_Ki;
+    auto v1m = 1_Mi;
+    auto v1g = 1_Gi;
+    auto v1t = 1_Ti;
+    auto v42k = 42_Ki;
+    auto v42m = 42_Mi;
+    auto v42g = 42_Gi;
+    auto v42t = 42_Ti;
+
+    EXPECT_EQ(v1k, 1024ul);
+    EXPECT_EQ(v1m, 1024ul * 1024ul);
+    EXPECT_EQ(v1g, 1024ul * 1024ul * 1024ul);
+    EXPECT_EQ(v1t, 1024ul * 1024ul * 1024ul * 1024ul);;
+
+    EXPECT_EQ(v42k, 42ul * 1024ul);
+    EXPECT_EQ(v42m, 42ul * 1024ul * 1024ul);
+    EXPECT_EQ(v42g, 42ul * 1024ul * 1024ul * 1024ul);
+    EXPECT_EQ(v42t, 42ul * 1024ul * 1024ul * 1024ul * 1024ul);
+
+    EXPECT_TRUE(is_size_t(v1k));
+    EXPECT_TRUE(is_size_t(v1g));
+    EXPECT_TRUE(is_size_t(v1g));
+    EXPECT_TRUE(is_size_t(v1t));
+
+    EXPECT_TRUE(is_size_t(v42k));
+    EXPECT_TRUE(is_size_t(v42g));
+    EXPECT_TRUE(is_size_t(v42g));
+    EXPECT_TRUE(is_size_t(v42t));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_allocator.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_allocator.hpp
@@ -5,10 +5,11 @@
 #include "unique_store_allocator.h"
 #include "unique_store_value_filter.h"
 #include "datastore.hpp"
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib::datastore {
 
-constexpr size_t NUM_ARRAYS_FOR_NEW_UNIQUESTORE_BUFFER = 1024u;
+constexpr size_t NUM_ARRAYS_FOR_NEW_UNIQUESTORE_BUFFER = 1_Ki;
 constexpr float ALLOC_GROW_FACTOR = 0.2;
 
 template <typename EntryT, typename RefT>

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_string_allocator.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_string_allocator.cpp
@@ -2,12 +2,13 @@
 
 #include "unique_store_string_allocator.hpp"
 #include "buffer_type.hpp"
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib::datastore {
 
 namespace {
 
-constexpr size_t NUM_ARRAYS_FOR_NEW_UNIQUESTORE_BUFFER = 1024u;
+constexpr size_t NUM_ARRAYS_FOR_NEW_UNIQUESTORE_BUFFER = 1_Ki;
 constexpr float ALLOC_GROW_FACTOR = 0.2;
 
 }

--- a/vespalib/src/vespa/vespalib/io/fileutil.cpp
+++ b/vespalib/src/vespa/vespalib/io/fileutil.cpp
@@ -3,6 +3,7 @@
 #include "fileutil.h"
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/fastos/file.h>
 #include <ostream>
@@ -369,7 +370,7 @@ File::readAll() const
 
     // Limit ourselves to 4K on the stack. If this becomes a problem we should
     // allocate on the heap.
-    char buffer[4096];
+    char buffer[4_Ki];
     off_t offset = 0;
 
     while (true) {
@@ -702,8 +703,8 @@ rename(const string & frompath, const string & topath,
 
 namespace {
 
-    uint32_t bufferSize = 1024 * 1024;
-    uint32_t diskAlignmentSize = 4096;
+    uint32_t bufferSize = 1_Mi;
+    uint32_t diskAlignmentSize = 4_Ki;
 
 }
 

--- a/vespalib/src/vespa/vespalib/net/async_resolver.cpp
+++ b/vespalib/src/vespa/vespalib/net/async_resolver.cpp
@@ -2,6 +2,7 @@
 
 #include "async_resolver.h"
 #include "socket_spec.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -150,7 +151,7 @@ AsyncResolver::SP AsyncResolver::_shared_resolver(nullptr);
 
 AsyncResolver::AsyncResolver(HostResolver::SP resolver, size_t num_threads)
     : _resolver(std::move(resolver)),
-      _executor(std::make_unique<ThreadStackExecutor>(num_threads, 128*1024, async_resolver_executor_thread))
+      _executor(std::make_unique<ThreadStackExecutor>(num_threads, 128_Ki, async_resolver_executor_thread))
 {
 }
 

--- a/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
+++ b/vespalib/src/vespa/vespalib/net/crypto_engine.cpp
@@ -11,6 +11,7 @@
 #include <vespa/vespalib/net/tls/transport_security_options.h>
 #include <vespa/vespalib/net/tls/transport_security_options_reading.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vector>
 #include <chrono>
 #include <thread>
@@ -57,7 +58,7 @@ public:
 class XorCryptoSocket : public CryptoSocket
 {
 private:
-    static constexpr size_t CHUNK_SIZE = 16 * 1024;
+    static constexpr size_t CHUNK_SIZE = 16_Ki;
     enum class OP { READ_KEY, WRITE_KEY };
     std::vector<OP> _op_stack;
     char            _my_key;

--- a/vespalib/src/vespa/vespalib/net/socket_address.cpp
+++ b/vespalib/src/vespa/vespalib/net/socket_address.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "socket_address.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <sys/types.h>
 #include <sys/un.h>
@@ -71,7 +72,7 @@ SocketAddress::ip_address() const
 vespalib::string
 SocketAddress::reverse_lookup() const
 {
-    std::vector<char> result(4096, '\0');
+    std::vector<char> result(4_Ki, '\0');
     getnameinfo(addr(), _size, &result[0], 4000, nullptr, 0, NI_NAMEREQD);
     return &result[0];
 }

--- a/vespalib/src/vespa/vespalib/net/tls/crypto_codec_adapter.h
+++ b/vespalib/src/vespa/vespalib/net/tls/crypto_codec_adapter.h
@@ -5,6 +5,7 @@
 #include "tls_crypto_socket.h"
 #include <vespa/vespalib/net/socket_handle.h>
 #include <vespa/vespalib/data/smart_buffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include "crypto_codec.h"
 
 namespace vespalib::net::tls {
@@ -32,7 +33,7 @@ private:
     ssize_t flush_all();  // -1/0 -> error/ok
 public:
     CryptoCodecAdapter(SocketHandle socket, std::unique_ptr<CryptoCodec> codec)
-        : _input(64 * 1024), _output(64 * 1024), _socket(std::move(socket)), _codec(std::move(codec)),
+        : _input(64_Ki), _output(64_Ki), _socket(std::move(socket)), _codec(std::move(codec)),
           _got_tls_close(false), _encoded_tls_close(false) {}
     void inject_read_data(const char *buf, size_t len) override;
     int get_fd() const override { return _socket.get(); }

--- a/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.cpp
@@ -5,6 +5,7 @@
 #include "tls_crypto_socket.h"
 #include "protocol_snooping.h"
 #include <vespa/vespalib/data/smart_buffer.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib {
 
@@ -30,7 +31,7 @@ private:
 
 public:
     MyCryptoSocket(CryptoSocket::UP &self, SocketHandle socket, std::shared_ptr<AbstractTlsCryptoEngine> tls_engine)
-        : _self(self), _socket(std::move(socket)), _factory(std::move(tls_engine)), _buffer(4096)
+        : _self(self), _socket(std::move(socket)), _factory(std::move(tls_engine)), _buffer(4_Ki)
     {
         static_assert(SNOOP_SIZE == 8);
     }

--- a/vespalib/src/vespa/vespalib/net/tls/protocol_snooping.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/protocol_snooping.cpp
@@ -1,5 +1,6 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "protocol_snooping.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <iostream>
 #include <cstdlib>
 #include <stdint.h>
@@ -63,14 +64,14 @@ TlsSnoopingResult snoop_client_hello_header(const char* buf) noexcept {
     if (!is_expected_tls_protocol_version(buf)) {
         return TlsSnoopingResult::ProtocolVersionMismatch;
     }
-    // Length of TLS record follows. Must be <= 16KiB + 2048 (16KiB + 256 on v1.3).
+    // Length of TLS record follows. Must be <= 16KiB + 2_Ki (16KiB + 256 on v1.3).
     // We expect that the first record contains _only_ a ClientHello with no coalescing
     // and no fragmentation. This is technically a violation of the TLS spec, but this
     // particular detection logic is only intended to be used against other Vespa nodes
     // where we control frame sizes and where such fragmentation should not take place.
     // We also do not support TLSv1.3 0-RTT which may trigger early data.
     uint16_t length = tls_record_length(buf);
-    if ((length < 4) || (length > (16384 + 2048))) {
+    if ((length < 4) || (length > (16_Ki + 2048))) {
         return TlsSnoopingResult::RecordSizeRfcViolation;
     }
     if (!is_client_hello_handshake_record(buf)) {

--- a/vespalib/src/vespa/vespalib/net/tls/protocol_snooping.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/protocol_snooping.cpp
@@ -71,7 +71,7 @@ TlsSnoopingResult snoop_client_hello_header(const char* buf) noexcept {
     // where we control frame sizes and where such fragmentation should not take place.
     // We also do not support TLSv1.3 0-RTT which may trigger early data.
     uint16_t length = tls_record_length(buf);
-    if ((length < 4) || (length > (16_Ki + 2048))) {
+    if ((length < 4) || (length > (16_Ki + 2_Ki))) {
         return TlsSnoopingResult::RecordSizeRfcViolation;
     }
     if (!is_client_hello_handshake_record(buf)) {

--- a/vespalib/src/vespa/vespalib/portal/http_connection.cpp
+++ b/vespalib/src/vespa/vespalib/portal/http_connection.cpp
@@ -2,13 +2,14 @@
 
 #include "http_connection.h"
 #include <vespa/vespalib/data/output_writer.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <cassert>
 
 namespace vespalib::portal {
 
 namespace {
 
-constexpr size_t CHUNK_SIZE = 4096;
+constexpr size_t CHUNK_SIZE = 4_Ki;
 
 enum class ReadRes { OK, END, FAIL };
 enum class WriteRes { OK, BLOCKED, FAIL };

--- a/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/memory.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/locale/c.h>
 #include <vespa/fastos/file.h>
 #include <algorithm>
@@ -614,7 +615,7 @@ asciistream asciistream::createFromDevice(stringref fileName)
     FastOS_File file(vespalib::string(fileName).c_str());
     asciistream is;
     if (file.OpenReadOnly()) {
-        char buf[8192];
+        char buf[8_Ki];
         for (ssize_t actual = file.Read(buf, sizeof(buf)); actual > 0; actual = file.Read(buf, sizeof(buf))) {
             is << stringref(buf, actual);
         }

--- a/vespalib/src/vespa/vespalib/testkit/test_hook.cpp
+++ b/vespalib/src/vespa/vespalib/testkit/test_hook.cpp
@@ -2,6 +2,7 @@
 
 #include "test_hook.h"
 #include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <regex>
 #include <vespa/fastos/thread.h>
 
@@ -18,7 +19,7 @@ struct FastOSTestThreadRunner : FastOS_Runnable {
 
 struct FastOSTestThreadFactory : TestThreadFactory {
     FastOS_ThreadPool threadPool;
-    FastOSTestThreadFactory() : threadPool(256 * 1024) {}
+    FastOSTestThreadFactory() : threadPool(256_Ki) {}
     void createThread(TestThreadEntry &entry) override {
         threadPool.NewThread(new FastOSTestThreadRunner(entry), 0);
     }

--- a/vespalib/src/vespa/vespalib/util/alloc.cpp
+++ b/vespalib/src/vespa/vespalib/util/alloc.cpp
@@ -233,9 +233,9 @@ createAutoAllocatorsWithDefault() {
 
 AutoAllocatorsMapWithDefault  _G_availableAutoAllocators = createAutoAllocatorsWithDefault();
 alloc::HeapAllocator _G_heapAllocatorDefault;
-alloc::AlignedHeapAllocator _G_4KalignedHeapAllocator(1024);
-alloc::AlignedHeapAllocator _G_1KalignedHeapAllocator(4_Ki);
 alloc::AlignedHeapAllocator _G_512BalignedHeapAllocator(512);
+alloc::AlignedHeapAllocator _G_1KalignedHeapAllocator(1_Ki);
+alloc::AlignedHeapAllocator _G_4KalignedHeapAllocator(4_Ki);
 alloc::MMapAllocator _G_mmapAllocatorDefault;
 
 MemoryAllocator &

--- a/vespalib/src/vespa/vespalib/util/alloc.cpp
+++ b/vespalib/src/vespa/vespalib/util/alloc.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/backtrace.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <map>
 #include <atomic>
 #include <unordered_map>
@@ -233,7 +234,7 @@ createAutoAllocatorsWithDefault() {
 AutoAllocatorsMapWithDefault  _G_availableAutoAllocators = createAutoAllocatorsWithDefault();
 alloc::HeapAllocator _G_heapAllocatorDefault;
 alloc::AlignedHeapAllocator _G_4KalignedHeapAllocator(1024);
-alloc::AlignedHeapAllocator _G_1KalignedHeapAllocator(4096);
+alloc::AlignedHeapAllocator _G_1KalignedHeapAllocator(4_Ki);
 alloc::AlignedHeapAllocator _G_512BalignedHeapAllocator(512);
 alloc::MMapAllocator _G_mmapAllocatorDefault;
 

--- a/vespalib/src/vespa/vespalib/util/child_process.cpp
+++ b/vespalib/src/vespa/vespalib/util/child_process.cpp
@@ -3,6 +3,7 @@
 #include "guard.h"
 #include "child_process.h"
 #include <cstring>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib {
 
@@ -296,7 +297,7 @@ ChildProcess::run(const std::string &input, const char *cmd,
 {
     ChildProcess proc(cmd);
     child_process::Timer timer(msTimeout);
-    char buf[4096];
+    char buf[4_Ki];
     proc.write(input.data(), input.length());
     proc.close(); // close stdin
     while (!proc.eof() && !timer.timeOut()) {

--- a/vespalib/src/vespa/vespalib/util/size_literals.h
+++ b/vespalib/src/vespa/vespalib/util/size_literals.h
@@ -1,0 +1,21 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <cstddef>
+
+constexpr size_t operator "" _Ki(unsigned long long k_in) {
+	return size_t(k_in << 10u);
+}
+
+constexpr size_t operator "" _Mi(unsigned long long m_in) {
+	return size_t(m_in << 20u);
+}
+
+constexpr size_t operator "" _Gi(unsigned long long g_in) {
+	return size_t(g_in << 30u);
+}
+
+constexpr size_t operator "" _Ti(unsigned long long t_in) {
+	return size_t(t_in << 40u);
+}

--- a/vespalib/src/vespa/vespalib/websocket/connection.cpp
+++ b/vespalib/src/vespa/vespalib/websocket/connection.cpp
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "connection.h"
+#include <vespa/vespalib/util/size_literals.h>
 #include <cstdarg>
 #include <cassert>
 
@@ -52,7 +53,7 @@ bool
 Connection::fill_input(size_t min_bytes)
 {
     while (_input.used() < min_bytes) {
-        size_t max_read = (8 * 1024);
+        size_t max_read = (8_Ki);
         char *ptr = _input.reserve(max_read);
         ssize_t read_res = _socket->read(ptr, max_read);
         if (read_res > 0) {

--- a/vsm/src/vespa/vsm/searcher/futf8strchrfieldsearcher.cpp
+++ b/vsm/src/vespa/vsm/searcher/futf8strchrfieldsearcher.cpp
@@ -2,6 +2,7 @@
 
 #include "futf8strchrfieldsearcher.h"
 #include "fold.h"
+#include <vespa/vespalib/util/size_literals.h>
 
 using search::byte;
 using search::streaming::QueryTerm;
@@ -18,11 +19,11 @@ FUTF8StrChrFieldSearcher::duplicate() const
 
 FUTF8StrChrFieldSearcher::FUTF8StrChrFieldSearcher()
     : UTF8StrChrFieldSearcher(),
-      _folded(4096)
+      _folded(4_Ki)
 { }
 FUTF8StrChrFieldSearcher::FUTF8StrChrFieldSearcher(FieldIdT fId)
     : UTF8StrChrFieldSearcher(fId),
-      _folded(4096)
+      _folded(4_Ki)
 { }
 FUTF8StrChrFieldSearcher::~FUTF8StrChrFieldSearcher() {}
 

--- a/vsm/src/vespa/vsm/vsm/slimefieldwriter.cpp
+++ b/vsm/src/vespa/vsm/vsm/slimefieldwriter.cpp
@@ -3,6 +3,7 @@
 #include "slimefieldwriter.h"
 #include <vespa/searchlib/util/slime_output_raw_buf_adapter.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".vsm.slimefieldwriter");
@@ -160,7 +161,7 @@ SlimeFieldWriter::explorePath(vespalib::stringref candidate)
 }
 
 SlimeFieldWriter::SlimeFieldWriter() :
-    _rbuf(4096),
+    _rbuf(4_Ki),
     _slime(),
     _inputFields(nullptr),
     _currPath()


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review - I want to use this a lot all over the place.  Should 128_MB maybe be 128_KB though?