### PR TITLE
Provide fallback ConnectionLog instance for all container types

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -187,6 +187,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         addSimpleComponent("com.yahoo.container.jdisc.ContainerThreadFactory");
         addSimpleComponent("com.yahoo.container.handler.VipStatus");
         addSimpleComponent(com.yahoo.container.handler.ClustersStatus.class.getName());
+        addSimpleComponent("com.yahoo.container.jdisc.DisabledConnectionLogProvider");
         addJaxProviders();
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -31,7 +31,6 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.logging.FileConnectionLog;
-import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.search.rendering.RendererRegistry;
 import com.yahoo.searchdefinition.derived.RankProfileList;
@@ -350,8 +349,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         // Add connection log if access log is configured
         if (cluster.getAllComponents().stream().anyMatch(component -> component instanceof AccessLogComponent)) {
             cluster.addComponent(new ConnectionLogComponent(cluster, FileConnectionLog.class, "qrs"));
-        } else {
-            cluster.addComponent(new ConnectionLogComponent(cluster, VoidConnectionLog.class, "qrs"));
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
@@ -8,16 +8,15 @@ import com.yahoo.container.logging.ConnectionLogConfig;
 import com.yahoo.container.logging.FileConnectionLog;
 import com.yahoo.container.logging.JSONAccessLog;
 import com.yahoo.container.logging.VespaAccessLog;
-import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
 import org.junit.Test;
 import org.w3c.dom.Element;
 
 import static com.yahoo.text.StringUtilities.quote;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
 
 /**
  * @author gjoranv
@@ -127,8 +126,6 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
                 nodesXml,
                 "</container>" );
         createModel(root, clusterElem);
-        Component<?, ?> voidConnectionLogComponent = getContainerComponent("default", VoidConnectionLog.class.getName());
-        assertNotNull(voidConnectionLogComponent);
         Component<?, ?> fileConnectionLogComponent = getContainerComponent("default", FileConnectionLog.class.getName());
         assertNull(fileConnectionLogComponent);
     }

--- a/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
@@ -16,11 +16,9 @@ import com.yahoo.container.di.config.SubscriberFactory;
 import com.yahoo.container.di.osgi.BundleClasses;
 import com.yahoo.container.di.osgi.OsgiUtil;
 import com.yahoo.container.logging.AccessLog;
-import com.yahoo.container.logging.ConnectionLog;
 import com.yahoo.filedistribution.fileacquirer.FileAcquirer;
 import com.yahoo.jdisc.application.OsgiFramework;
 import com.yahoo.jdisc.handler.RequestHandler;
-import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
 import com.yahoo.jdisc.service.ClientProvider;
 import com.yahoo.jdisc.service.ServerProvider;
 import com.yahoo.osgi.OsgiImpl;
@@ -144,7 +142,6 @@ public class HandlersConfigurerDi {
                 bind(com.yahoo.statistics.Statistics.class).toInstance(Statistics.nullImplementation);
                 bind(AccessLog.class).toInstance(new AccessLog(new ComponentRegistry<>()));
                 bind(Executor.class).toInstance(Executors.newCachedThreadPool(ThreadFactoryFactory.getThreadFactory("HandlersConfigurerDI")));
-                bind(ConnectionLog.class).toInstance(new VoidConnectionLog());
                 if (vespaContainer.getFileAcquirer() != null)
                     bind(com.yahoo.filedistribution.fileacquirer.FileAcquirer.class).toInstance(vespaContainer.getFileAcquirer());
             }

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/DisabledConnectionLogProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/DisabledConnectionLogProvider.java
@@ -1,0 +1,18 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.container.jdisc;
+
+import com.yahoo.container.di.componentgraph.Provider;
+import com.yahoo.container.logging.ConnectionLog;
+import com.yahoo.jdisc.http.server.jetty.VoidConnectionLog;
+
+/**
+ * @author bjorncs
+ */
+public class DisabledConnectionLogProvider implements Provider<ConnectionLog> {
+
+    private static final ConnectionLog INSTANCE = new VoidConnectionLog();
+
+    @Override public ConnectionLog get() { return INSTANCE; }
+    @Override public void deconstruct() {}
+
+}


### PR DESCRIPTION
The ConnectionLog component was previously missing for non-application container clusters (e.g metrics-proxy and cluster-controller).
This caused the JettyHttpServer component to always reconstruct on new config.

FYI @tokle 