### PR TITLE
Inhibit activation of replicas out of sync with a replica majority

### DIFF
--- a/storage/src/tests/distributor/distributortest.cpp
+++ b/storage/src/tests/distributor/distributortest.cpp
@@ -208,6 +208,12 @@ struct DistributorTest : Test, DistributorTestUtil {
         configureDistributor(builder);
     }
 
+    void configure_max_activation_inhibited_out_of_sync_groups(uint32_t n_groups) {
+        ConfigBuilder builder;
+        builder.maxActivationInhibitedOutOfSyncGroups = n_groups;
+        configureDistributor(builder);
+    }
+
     void configureMaxClusterClockSkew(int seconds);
     void sendDownClusterStateCommand();
     void replyToSingleRequestBucketInfoCommandWith1Bucket();
@@ -1186,6 +1192,17 @@ TEST_F(DistributorTest, prioritize_global_bucket_merges_config_is_propagated_to_
 
     configure_prioritize_global_bucket_merges(false);
     EXPECT_FALSE(getConfig().prioritize_global_bucket_merges());
+}
+
+TEST_F(DistributorTest, max_activation_inhibited_out_of_sync_groups_config_is_propagated_to_internal_config) {
+    createLinks();
+    setupDistributor(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    configure_max_activation_inhibited_out_of_sync_groups(3);
+    EXPECT_EQ(getConfig().max_activation_inhibited_out_of_sync_groups(), 3);
+
+    configure_max_activation_inhibited_out_of_sync_groups(0);
+    EXPECT_EQ(getConfig().max_activation_inhibited_out_of_sync_groups(), 0);
 }
 
 TEST_F(DistributorTest, wanted_split_bit_count_is_lower_bounded) {

--- a/storage/src/vespa/storage/bucketdb/bucketinfo.h
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.h
@@ -106,6 +106,11 @@ public:
         return _nodes;
     }
 
+    // If there is a valid majority of replicas that have the same metadata
+    // (checksum and document count), return that bucket info.
+    // Otherwise, return default-constructed info with valid() == false.
+    api::BucketInfo majority_consistent_bucket_info() const noexcept;
+
     std::string toString() const;
 
     uint32_t getHighestDocumentCount() const;

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -24,6 +24,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _idealStateChunkSize(1000),
       _maxNodesPerMerge(16),
       _max_consecutively_inhibited_maintenance_ticks(20),
+      _max_activation_inhibited_out_of_sync_groups(0),
       _lastGarbageCollectionChange(vespalib::duration::zero()),
       _garbageCollectionInterval(0),
       _minPendingMaintenanceOps(100),
@@ -165,6 +166,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _use_weak_internal_read_consistency_for_client_gets = config.useWeakInternalReadConsistencyForClientGets;
     _enable_metadata_only_fetch_phase_for_inconsistent_updates = config.enableMetadataOnlyFetchPhaseForInconsistentUpdates;
     _prioritize_global_bucket_merges = config.prioritizeGlobalBucketMerges;
+    _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_revert = config.enableRevert;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -253,6 +253,14 @@ public:
     bool prioritize_global_bucket_merges() const noexcept {
         return _prioritize_global_bucket_merges;
     }
+
+    void set_max_activation_inhibited_out_of_sync_groups(uint32_t max_groups) noexcept {
+        _max_activation_inhibited_out_of_sync_groups = max_groups;
+    }
+    uint32_t max_activation_inhibited_out_of_sync_groups() const noexcept {
+        return _max_activation_inhibited_out_of_sync_groups;
+    }
+
     bool enable_revert() const noexcept {
         return _enable_revert;
     }
@@ -274,6 +282,7 @@ private:
     uint32_t _idealStateChunkSize;
     uint32_t _maxNodesPerMerge;
     uint32_t _max_consecutively_inhibited_maintenance_ticks;
+    uint32_t _max_activation_inhibited_out_of_sync_groups;
 
     std::string _garbageCollectionSelection;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -266,7 +266,7 @@ prioritize_global_bucket_merges bool default=true
 ## and this feature is intended to prevent nodes in stale groups (whose buckets are
 ## likely to be out of sync) from serving query traffic until they have gotten back
 ## into sync.
-## Up to to the given number of groups can have their replica activation inhibited
+## Up to the given number of groups can have their replica activation inhibited
 ## by this feature. If zero, the feature is functionally disabled.
 ## If more groups are out of sync than the configured number N, the inhibited groups
 ## will be the N first groups present in the distribution config.

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -259,3 +259,17 @@ max_consecutively_inhibited_maintenance_ticks int default=20
 ## This is a live config for that reason, i.e. it can be disabled in an emergency
 ## situation if needed.
 prioritize_global_bucket_merges bool default=true
+
+## If set, activation of bucket replicas is limited to only those replicas that have
+## bucket info consistent with a majority of the other replicas for that bucket.
+## Multiple active replicas is only a feature that is enabled for grouped clusters,
+## and this feature is intended to prevent nodes in stale groups (whose buckets are
+## likely to be out of sync) from serving query traffic until they have gotten back
+## into sync.
+## Up to to the given number of groups can have their replica activation inhibited
+## by this feature. If zero, the feature is functionally disabled.
+## If more groups are out of sync than the configured number N, the inhibited groups
+## will be the N first groups present in the distribution config.
+## Note: this feature only kicks in if the number of groups in the cluster is greater
+## than 1.
+max_activation_inhibited_out_of_sync_groups int default=0

--- a/storage/src/vespa/storage/distributor/activecopy.h
+++ b/storage/src/vespa/storage/distributor/activecopy.h
@@ -17,7 +17,9 @@ struct ActiveCopy {
     friend std::ostream& operator<<(std::ostream& out, const ActiveCopy& e);
 
     static ActiveList calculate(const std::vector<uint16_t>& idealState,
-                                const lib::Distribution&, BucketDatabase::Entry&);
+                                const lib::Distribution&,
+                                BucketDatabase::Entry&,
+                                uint32_t max_activation_inhibited_out_of_sync_groups);
 
     uint16_t _nodeIndex;
     uint16_t _ideal;

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
@@ -109,7 +109,8 @@ PutOperation::insertDatabaseEntryAndScheduleCreateBucket(const OperationTargetLi
         BucketDatabase::Entry entry(_bucketSpace.getBucketDatabase().get(lastBucket));
         std::vector<uint16_t> idealState(
                 _bucketSpace.get_ideal_service_layer_nodes_bundle(lastBucket).get_available_nodes());
-        active = ActiveCopy::calculate(idealState, _bucketSpace.getDistribution(), entry);
+        active = ActiveCopy::calculate(idealState, _bucketSpace.getDistribution(), entry,
+                                       _op_ctx.distributor_config().max_activation_inhibited_out_of_sync_groups());
         LOG(debug, "Active copies for bucket %s: %s", entry.getBucketId().toString().c_str(), active.toString().c_str());
         for (uint32_t i=0; i<active.size(); ++i) {
             BucketCopy copy(*entry->getNode(active[i]._nodeIndex));

--- a/storage/src/vespa/storage/distributor/statecheckers.cpp
+++ b/storage/src/vespa/storage/distributor/statecheckers.cpp
@@ -1060,7 +1060,8 @@ BucketStateStateChecker::check(StateChecker::Context& c)
     }
 
     ActiveList activeNodes(
-            ActiveCopy::calculate(c.idealState, c.distribution, c.entry));
+            ActiveCopy::calculate(c.idealState, c.distribution, c.entry,
+                                  c.distributorConfig.max_activation_inhibited_out_of_sync_groups()));
     if (activeNodes.empty()) {
         return Result::noMaintenanceNeeded();
     }


### PR DESCRIPTION
@geirst please review

Adds a configurable max number of groups (default 0) whose replica
activation is inhibited if the replica's bucket info is out of sync
with a majority of other replicas.

Intended to be used for the case where a group comes back up after
transient unavailability and where the nodes are out of sync and
should preferably not be activated until post-merging.
