### PR TITLE
Avoid suggesting node moves to spares

### DIFF
--- a/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
+++ b/athenz-identity-provider-service/src/test/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/identitydocument/IdentityDocumentGeneratorTest.java
@@ -62,11 +62,11 @@ public class IdentityDocumentGeneratorTest {
                                       parentHostname,
                                       new MockNodeFlavors().getFlavorOrThrow("default"),
                                       NodeType.host).build();
-        Node containerNode = Node.createDockerNode(Set.of("::1"),
-                                                   containerHostname,
-                                                   parentHostname,
-                                                   new MockNodeFlavors().getFlavorOrThrow("default").resources(),
-                                                   NodeType.tenant)
+        Node containerNode = Node.reserve(Set.of("::1"),
+                                          containerHostname,
+                                          parentHostname,
+                                          new MockNodeFlavors().getFlavorOrThrow("default").resources(),
+                                          NodeType.tenant)
                 .allocation(allocation).build();
         NodeRepository nodeRepository = mock(NodeRepository.class);
         Nodes nodes = mock(Nodes.class);

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeType.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeType.java
@@ -10,35 +10,35 @@ import java.util.List;
  */
 public enum NodeType {
 
-    /** A node to be assigned to a tenant to run application workloads */
+    /** Node assignable to a tenant to run application workloads */
     tenant("Tenant node"),
 
-    /** A host of a set of (Docker) tenant nodes */
-    host("Tenant docker host", tenant),
+    /** Host of a tenant nodes */
+    host("Tenant host", tenant),
 
-    /** Nodes running the shared proxy layer */
+    /** Node serving the shared proxy layer */
     proxy("Proxy node"),
 
-    /** A host of a (Docker) proxy node */
-    proxyhost("Proxy docker host", proxy),
+    /** Host of a proxy node */
+    proxyhost("Proxy host", proxy),
 
-    /** A config server */
-    config("Config server"),
+    /** Config server node */
+    config("Config server node"),
 
-    /** A host of a (Docker) config server node */
-    confighost("Config docker host", config),
+    /** Host of a config server node */
+    confighost("Config server host", config),
 
-    /** A controller */
-    controller("Controller"),
+    /** Controller node */
+    controller("Controller node"),
 
-    /** A host of a (Docker) controller node */
+    /** Host of a controller node */
     controllerhost("Controller host", controller),
 
-    /** A host of multiple nodes, only used in {@link SystemName#dev} */
+    /** Host capable of running multiple node types, only used in {@link SystemName#dev} */
     devhost("Dev host", config, controller, tenant);
 
-    private final List<NodeType> childNodeTypes;
     private final String description;
+    private final List<NodeType> childNodeTypes;
 
     NodeType(String description, NodeType... childNodeTypes) {
         this.childNodeTypes = List.of(childNodeTypes);
@@ -71,10 +71,7 @@ public enum NodeType {
         return childNodeTypes;
     }
 
-    /**
-     * @param type Child {@link NodeType}
-     * @return true if the {@link NodeType} can run on this host, false otherwise.
-     */
+    /** Returns whether given node type can run on this */
     public boolean canRun(NodeType type) {
         return childNodeTypes.contains(type);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -55,7 +55,7 @@ public final class Node implements Nodelike {
     private final Optional<Allocation> allocation;
 
     /** Creates a node builder in the initial state (reserved) */
-    public static Node.Builder createDockerNode(Set<String> ipAddresses, String hostname, String parentHostname, NodeResources resources, NodeType type) {
+    public static Node.Builder reserve(Set<String> ipAddresses, String hostname, String parentHostname, NodeResources resources, NodeType type) {
         return new Node.Builder("fake-" + hostname, hostname, new Flavor(resources), State.reserved, type)
                 .ipConfig(IP.Config.ofEmptyPool(ipAddresses))
                 .parentHostname(parentHostname);
@@ -122,7 +122,7 @@ public final class Node implements Nodelike {
      *
      * - OpenStack: UUID
      * - AWS: Instance ID
-     * - Docker containers: fake-[hostname]
+     * - Linux containers: fake-[hostname]
      */
     public String id() { return id; }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -158,7 +158,7 @@ public class NodeRepository extends AbstractComponent {
     /** Returns the status of firmware checks for hosts managed by this. */
     public FirmwareChecks firmwareChecks() { return firmwareChecks; }
 
-    /** Returns the docker images to use for nodes in this. */
+    /** Returns the container images to use for nodes in this. */
     public ContainerImages containerImages() { return containerImages; }
 
     /** Returns the status of maintenance jobs managed by this. */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 /**
  * This moves expired failed nodes:
  *
- * - To parked: If the node has known hardware failure, Docker hosts are moved to parked only when all of their
+ * - To parked: If the node has known hardware failure, hosts are moved to parked only when all of their
  *              children are already in parked.
  * - To dirty: If the node is a host and has failed less than 5 times, or always if the node is a child.
  * - Otherwise the node will remain in failed.
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  * Failed content nodes are given a long expiry time to enable us to manually moved them back to
  * active to recover data in cases where the node was failed accidentally.
  *
- * Failed container (Vespa, not Docker) nodes are expired early as there's no data to potentially recover.
+ * Failed containers (Vespa, not Linux) are expired early as there's no data to potentially recover.
  *
  * The purpose of the automatic recycling to dirty + fail count is that nodes which were moved
  * to failed due to some undetected hardware failure will end up being failed again.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -75,7 +75,7 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
         nodes.forEach(node -> updateNodeMetrics(node, serviceModel));
         updateNodeCountMetrics(nodes);
         updateLockMetrics();
-        updateDockerMetrics(nodes);
+        updateContainerMetrics(nodes);
         updateTenantUsageMetrics(nodes);
         updateRepairTicketMetrics(nodes);
         updateAllocationMetrics(nodes);
@@ -315,7 +315,7 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
         }
     }
 
-    private void updateDockerMetrics(NodeList nodes) {
+    private void updateContainerMetrics(NodeList nodes) {
         NodeResources totalCapacity = getCapacityTotal(nodes);
         metric.set("hostedVespa.docker.totalCapacityCpu", totalCapacity.vcpu(), null);
         metric.set("hostedVespa.docker.totalCapacityMem", totalCapacity.memoryGb(), null);
@@ -381,10 +381,10 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
                     .reduce(new NodeResources(0, 0, 0, 0, any), NodeResources::add);
     }
 
-    private static NodeResources freeCapacityOf(NodeList nodes, Node dockerHost) {
-        return nodes.childrenOf(dockerHost).asList().stream()
+    private static NodeResources freeCapacityOf(NodeList nodes, Node host) {
+        return nodes.childrenOf(host).asList().stream()
                     .map(node -> node.flavor().resources().justNumbers())
-                    .reduce(dockerHost.flavor().resources().justNumbers(), NodeResources::subtract);
+                    .reduce(host.flavor().resources().justNumbers(), NodeResources::subtract);
     }
 
     private static class ClusterKey {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailer.java
@@ -46,7 +46,7 @@ public class NodeFailer extends NodeRepositoryMaintainer {
     /** Metric for number of hosts that we want to fail, but cannot due to throttling */
     static final String throttledHostFailuresMetric = "throttledHostFailures";
 
-    /** Metric for number of nodes (docker containers) that we want to fail, but cannot due to throttling */
+    /** Metric for number of nodes that we want to fail, but cannot due to throttling */
     static final String throttledNodeFailuresMetric = "throttledNodeFailures";
 
     /** Metric that indicates whether throttling is active where 1 means active and 0 means inactive */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
@@ -77,7 +77,7 @@ public class RetiredExpirer extends NodeRepositoryMaintainer {
 
     /**
      * Checks if the node can be removed:
-     * if the node is a docker host, it will only be removed if it has no children,
+     * if the node is a host, it will only be removed if it has no children,
      * or all its children are parked or failed.
      * Otherwise, a removal is allowed if either of these are true:
      * - The node has been in state {@link History.Event.Type#retired} for longer than {@link #retiredExpiry}
@@ -85,11 +85,10 @@ public class RetiredExpirer extends NodeRepositoryMaintainer {
      */
     private boolean canRemove(Node node) {
         if (node.type().isHost()) {
-            if (nodeRepository().nodes()
-                    .list().childrenOf(node).asList().stream()
-                    .allMatch(child -> child.state() == Node.State.parked ||
-                                       child.state() == Node.State.failed)) {
-                log.info("Docker host " + node + " has no non-parked/failed children");
+            if (nodeRepository().nodes().list().childrenOf(node).asList().stream()
+                                .allMatch(child -> child.state() == Node.State.parked ||
+                                                   child.state() == Node.State.failed)) {
+                log.info("Host " + node + " has no non-parked/failed children");
                 return true;
             }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SwitchRebalancer.java
@@ -54,7 +54,7 @@ public class SwitchRebalancer extends NodeMover<Move> {
 
     @Override
     protected Move bestMoveOf(Move a, Move b) {
-        if (b.isEmpty()) return a;
+        if (!a.isEmpty()) return a;
         return b;
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/IP.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/IP.java
@@ -225,7 +225,7 @@ public class IP {
     /**
      * A pool of addresses from which an allocation can be made.
      *
-     * Addresses in this are available for use by Docker containers
+     * Addresses in this are available for use by Linux containers.
      */
     public static class Pool {
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
@@ -16,8 +16,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 /**
- * A node ACL. The ACL contains the node which the ACL is valid for,
- * a set of nodes and networks that the node should trust.
+ * A node ACL declares which nodes, networks and ports a node should trust.
  *
  * @author mpolden
  */
@@ -57,8 +56,8 @@ public class NodeAcl {
         Set<String> trustedNetworks = new LinkedHashSet<>();
 
         // For all cases below, trust:
-        // - SSH: If the Docker host has one container, and it is using the Docker host's network namespace,
-        //   opening up SSH to the Docker host is done here as a trusted port. For simplicity all nodes have
+        // - SSH: If the host has one container, and it is using the host's network namespace,
+        //   opening up SSH to the host is done here as a trusted port. For simplicity all nodes have
         //   SSH opened (which is safe for 2 reasons: SSH daemon is not run inside containers, and NPT networks
         //   will (should) not forward port 22 traffic to container).
         // - parent host (for health checks and metrics)

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -102,13 +102,13 @@ public class Nodes {
 
     // ----------------- Node lifecycle -----------------------------------------------------------
 
-    /** Adds a list of newly created docker container nodes to the node repository as <i>reserved</i> nodes */
-    public List<Node> addDockerNodes(LockedNodeList nodes) {
+    /** Adds a list of newly created reserved nodes to the node repository */
+    public List<Node> addReservedNodes(LockedNodeList nodes) {
         for (Node node : nodes) {
             if ( ! node.flavor().getType().equals(Flavor.Type.DOCKER_CONTAINER))
-                illegal("Cannot add " + node + ": This is not a docker node");
+                illegal("Cannot add " + node + ": This is not a child node");
             if (node.allocation().isEmpty())
-                illegal("Cannot add " + node + ": Docker containers needs to be allocated");
+                illegal("Cannot add " + node + ": Child nodes need to be allocated");
             Optional<Node> existing = node(node.hostname());
             if (existing.isPresent())
                 illegal("Cannot add " + node + ": A node with this name already exists (" +
@@ -119,7 +119,7 @@ public class Nodes {
     }
 
     /**
-     * Adds a list of (newly created) nodes to the node repository as <i>provisioned</i> nodes.
+     * Adds a list of (newly created) nodes to the node repository as provisioned nodes.
      * If any of the nodes already exists in the deprovisioned state, the new node will be merged
      * with the history of that node.
      */
@@ -403,7 +403,7 @@ public class Nodes {
     }
 
     /*
-     * This method is used by the REST API to handle readying nodes for new allocations. For tenant docker
+     * This method is used by the REST API to handle readying nodes for new allocations. For Linux
      * containers this will remove the node from node repository, otherwise the node will be moved to state ready.
      */
     public Node markNodeAvailableForNewAllocation(String hostname, Agent agent, String reason) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -125,7 +125,7 @@ public class GroupPreparer {
 
             // Carry out and return allocation
             nodeRepository.nodes().reserve(allocation.reservableNodes());
-            nodeRepository.nodes().addDockerNodes(new LockedNodeList(allocation.newNodes(), allocationLock));
+            nodeRepository.nodes().addReservedNodes(new LockedNodeList(allocation.newNodes(), allocationLock));
             List<Node> acceptedNodes = allocation.finalNodes();
             surplusActiveNodes.removeAll(acceptedNodes);
             return acceptedNodes;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
@@ -405,12 +405,12 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
                                                 "Failed when allocating address on host");
             }
 
-            Node node = Node.createDockerNode(allocation.get().addresses(),
-                                              allocation.get().hostname(),
-                                              parentHostname().get(),
-                                              resources.with(parent.get().resources().diskSpeed())
+            Node node = Node.reserve(allocation.get().addresses(),
+                                     allocation.get().hostname(),
+                                     parentHostname().get(),
+                                     resources.with(parent.get().resources().diskSpeed())
                                                        .with(parent.get().resources().storageType()),
-                                              NodeType.tenant).build();
+                                     NodeType.tenant).build();
             return new ConcreteNodeCandidate(node, freeParentCapacity, parent, violatesSpares, exclusiveSwitch, isSurplus, isNew, isResizable);
 
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -8,7 +8,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.LockedNodeList;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
-import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Nodes;
 import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
@@ -62,7 +62,7 @@ public class ProvisionedHost {
 
     /** Generate {@link Node} instance representing the node running on this physical host */
     public Node generateNode() {
-        return Node.createDockerNode(Set.of(), nodeHostname(), hostHostname, nodeResources, NodeType.tenant).build();
+        return Node.reserve(Set.of(), nodeHostname(), hostHostname, nodeResources, NodeType.tenant).build();
     }
 
     public String getId() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -152,7 +152,7 @@ public class MetricsReporterTest {
     }
 
     @Test
-    public void docker_metrics() {
+    public void container_metrics() {
         NodeFlavors nodeFlavors = FlavorConfigBuilder.createDummies("host", "docker", "docker2");
         ProvisioningTester tester = new ProvisioningTester.Builder().flavors(nodeFlavors.getFlavors()).build();
         NodeRepository nodeRepository = tester.nodeRepository();
@@ -166,18 +166,18 @@ public class MetricsReporterTest {
         nodeRepository.nodes().deallocateRecursively("dockerHost", Agent.system, getClass().getSimpleName());
         nodeRepository.nodes().setReady("dockerHost", Agent.system, getClass().getSimpleName());
 
-        Node container1 = Node.createDockerNode(Set.of("::2"), "container1",
-                                                "dockerHost", new NodeResources(1, 3, 2, 1), NodeType.tenant).build();
+        Node container1 = Node.reserve(Set.of("::2"), "container1",
+                                       "dockerHost", new NodeResources(1, 3, 2, 1), NodeType.tenant).build();
         container1 = container1.with(allocation(Optional.of("app1"), container1).get());
         try (Mutex lock = nodeRepository.nodes().lockUnallocated()) {
-            nodeRepository.nodes().addDockerNodes(new LockedNodeList(List.of(container1), lock));
+            nodeRepository.nodes().addReservedNodes(new LockedNodeList(List.of(container1), lock));
         }
 
-        Node container2 = Node.createDockerNode(Set.of("::3"), "container2",
-                                                "dockerHost", new NodeResources(2, 4, 4, 1), NodeType.tenant).build();
+        Node container2 = Node.reserve(Set.of("::3"), "container2",
+                                       "dockerHost", new NodeResources(2, 4, 4, 1), NodeType.tenant).build();
         container2 = container2.with(allocation(Optional.of("app2"), container2).get());
         try (Mutex lock = nodeRepository.nodes().lockUnallocated()) {
-            nodeRepository.nodes().addDockerNodes(new LockedNodeList(List.of(container2), lock));
+            nodeRepository.nodes().addReservedNodes(new LockedNodeList(List.of(container2), lock));
         }
 
         NestedTransaction transaction = new NestedTransaction();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -444,7 +444,7 @@ public class DynamicDockerProvisionTest {
 
                         Node parent = Node.create(hostHostname, new IP.Config(Set.of(hostIp), pool), hostHostname, hostFlavor, NodeType.host)
                                 .exclusiveTo(exclusiveTo).build();
-                        Node child = Node.createDockerNode(Set.of("::" + hostIndex + ":1"), hostHostname + "-1", hostHostname, nodeResources, NodeType.tenant).build();
+                        Node child = Node.reserve(Set.of("::" + hostIndex + ":1"), hostHostname + "-1", hostHostname, nodeResources, NodeType.tenant).build();
                         ProvisionedHost provisionedHost = mock(ProvisionedHost.class);
                         when(provisionedHost.generateHost()).thenReturn(parent);
                         when(provisionedHost.generateNode()).thenReturn(child);


### PR DESCRIPTION
Moves to spares never succeed because spares can only be used in cases where
we're replacing a failed node.

Merge together with internal PR due to first commit.

@bratseth