### PR TITLE
Expose node archive URL in nodes response

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -60,6 +60,7 @@ public class NodeRepository extends AbstractComponent {
     private final JobControl jobControl;
     private final Applications applications;
     private final LoadBalancers loadBalancers;
+    private final FlagSource flagSource;
     private final int spareCount;
 
     /**
@@ -122,6 +123,7 @@ public class NodeRepository extends AbstractComponent {
         this.jobControl = new JobControl(new JobControlFlags(db, flagSource));
         this.applications = new Applications(db);
         this.loadBalancers = new LoadBalancers(db);
+        this.flagSource = flagSource;
         this.spareCount = spareCount;
         rewriteNodes();
     }
@@ -174,6 +176,14 @@ public class NodeRepository extends AbstractComponent {
 
     public HostResourcesCalculator resourcesCalculator() { return resourcesCalculator; }
 
+    public FlagSource flagSource() { return flagSource; }
+
+    /** Returns the time keeper of this system */
+    public Clock clock() { return clock; }
+
+    /** Returns the zone of this system */
+    public Zone zone() { return zone; }
+
     /** The number of nodes we should ensure has free capacity for node failures whenever possible */
     public int spareCount() { return spareCount; }
 
@@ -203,11 +213,5 @@ public class NodeRepository extends AbstractComponent {
                    transaction.nested());
         applications.remove(transaction);
     }
-
-    /** Returns the time keeper of this system */
-    public Clock clock() { return clock; }
-
-    /** Returns the zone of this system */
-    public Zone zone() { return zone; }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -103,11 +103,10 @@ public class NodeRepository extends AbstractComponent {
                           boolean useCuratorClientCache,
                           int spareCount,
                           long nodeCacheSize) {
-        // TODO (valerijf): Uncomment when exception for prod.cd-aws is removed
-//        if (provisionServiceProvider.getHostProvisioner().isPresent() != zone.getCloud().dynamicProvisioning())
-//            throw new IllegalArgumentException(String.format(
-//                    "dynamicProvisioning property must be 1-to-1 with availability of HostProvisioner, was: dynamicProvisioning=%s, hostProvisioner=%s",
-//                    zone.getCloud().dynamicProvisioning(), provisionServiceProvider.getHostProvisioner().map(__ -> "present").orElse("empty")));
+        if (provisionServiceProvider.getHostProvisioner().isPresent() != zone.getCloud().dynamicProvisioning())
+            throw new IllegalArgumentException(String.format(
+                    "dynamicProvisioning property must be 1-to-1 with availability of HostProvisioner, was: dynamicProvisioning=%s, hostProvisioner=%s",
+                    zone.getCloud().dynamicProvisioning(), provisionServiceProvider.getHostProvisioner().map(__ -> "present").orElse("empty")));
 
         this.db = new CuratorDatabaseClient(flavors, curator, clock, zone, useCuratorClientCache, nodeCacheSize);
         this.zone = zone;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -178,7 +178,7 @@ class NodesResponse extends SlimeJsonResponse {
         node.reports().toSlime(object, "reports");
         node.modelName().ifPresent(modelName -> object.setString("modelName", modelName));
         node.switchHostname().ifPresent(switchHostname -> object.setString("switchHostname", switchHostname));
-        nodeArchiveUrl(nodeRepository.flagSource(), node).ifPresent(url -> object.setString("nodeArchiveUrl", url));
+        nodeArchiveUri(nodeRepository.flagSource(), node).ifPresent(url -> object.setString("nodeArchiveUri", url));
     }
 
     private void toSlime(ApplicationId id, Cursor object) {
@@ -233,7 +233,7 @@ class NodesResponse extends SlimeJsonResponse {
         return path.substring(lastSlash+1);
     }
 
-    static Optional<String> nodeArchiveUrl(FlagSource flagSource, Node node) {
+    static Optional<String> nodeArchiveUri(FlagSource flagSource, Node node) {
         String bucket = Flags.SYNC_HOST_LOGS_TO_S3_BUCKET.bindTo(flagSource)
                 .with(FetchVector.Dimension.NODE_TYPE, node.type().name())
                 .with(FetchVector.Dimension.APPLICATION_ID, node.allocation().map(alloc -> alloc.owner().serializedForm()).orElse(null))

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -178,7 +178,7 @@ class NodesResponse extends SlimeJsonResponse {
         node.reports().toSlime(object, "reports");
         node.modelName().ifPresent(modelName -> object.setString("modelName", modelName));
         node.switchHostname().ifPresent(switchHostname -> object.setString("switchHostname", switchHostname));
-        nodeArchiveUri(nodeRepository.flagSource(), node).ifPresent(url -> object.setString("nodeArchiveUri", url));
+        archiveUri(nodeRepository.flagSource(), node).ifPresent(uri -> object.setString("archiveUri", uri));
     }
 
     private void toSlime(ApplicationId id, Cursor object) {
@@ -233,7 +233,8 @@ class NodesResponse extends SlimeJsonResponse {
         return path.substring(lastSlash+1);
     }
 
-    static Optional<String> nodeArchiveUri(FlagSource flagSource, Node node) {
+    // TODO (freva): Store this in Application or Node
+    static Optional<String> archiveUri(FlagSource flagSource, Node node) {
         String bucket = Flags.SYNC_HOST_LOGS_TO_S3_BUCKET.bindTo(flagSource)
                 .with(FetchVector.Dimension.NODE_TYPE, node.type().name())
                 .with(FetchVector.Dimension.APPLICATION_ID, node.allocation().map(alloc -> alloc.owner().serializedForm()).orElse(null))

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
@@ -28,20 +28,20 @@ public class NodesResponseTest {
     public void node_archive_url() {
         ApplicationId app = ApplicationId.from("vespa", "music", "main");
         // Flag not set, no archive url
-        assertNodeArchiveUrl(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
-        assertNodeArchiveUrl(null, "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+        assertNodeArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertNodeArchiveUri(null, "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
 
         flagSource.withStringFlag(Flags.SYNC_HOST_LOGS_TO_S3_BUCKET.id(), "vespa-data-bucket");
         // Flag is set, but node not allocated, only sync non-tenant nodes
-        assertNodeArchiveUrl(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, null);
-        assertNodeArchiveUrl("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, null);
+        assertNodeArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, null);
+        assertNodeArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, null);
 
         // Flag is set and node is allocated
-        assertNodeArchiveUrl("s3://vespa-data-bucket/vespa/music/main/h432a/", "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
-        assertNodeArchiveUrl("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+        assertNodeArchiveUri("s3://vespa-data-bucket/vespa/music/main/h432a/", "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertNodeArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
     }
 
-    private void assertNodeArchiveUrl(String archiveUrl, String hostname, NodeType type, ApplicationId appId) {
+    private void assertNodeArchiveUri(String archiveUrl, String hostname, NodeType type, ApplicationId appId) {
         Node.Builder nodeBuilder = Node.create("id", hostname, new Flavor(NodeResources.unspecified()), Node.State.parked, type);
         Optional.ofNullable(appId)
                 .map(app -> new Allocation(app,
@@ -51,6 +51,6 @@ public class NodesResponseTest {
                         false))
                 .ifPresent(nodeBuilder::allocation);
 
-        assertEquals(archiveUrl, NodesResponse.nodeArchiveUrl(flagSource, nodeBuilder.build()).orElse(null));
+        assertEquals(archiveUrl, NodesResponse.nodeArchiveUri(flagSource, nodeBuilder.build()).orElse(null));
     }
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
@@ -1,0 +1,56 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.restapi;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterMembership;
+import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.Allocation;
+import com.yahoo.vespa.hosted.provision.node.Generation;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author freva
+ */
+public class NodesResponseTest {
+    private final InMemoryFlagSource flagSource = new InMemoryFlagSource();
+
+    @Test
+    public void node_archive_url() {
+        ApplicationId app = ApplicationId.from("vespa", "music", "main");
+        // Flag not set, no archive url
+        assertNodeArchiveUrl(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertNodeArchiveUrl(null, "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+
+        flagSource.withStringFlag(Flags.SYNC_HOST_LOGS_TO_S3_BUCKET.id(), "vespa-data-bucket");
+        // Flag is set, but node not allocated, only sync non-tenant nodes
+        assertNodeArchiveUrl(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, null);
+        assertNodeArchiveUrl("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, null);
+
+        // Flag is set and node is allocated
+        assertNodeArchiveUrl("s3://vespa-data-bucket/vespa/music/main/h432a/", "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertNodeArchiveUrl("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+    }
+
+    private void assertNodeArchiveUrl(String archiveUrl, String hostname, NodeType type, ApplicationId appId) {
+        Node.Builder nodeBuilder = Node.create("id", hostname, new Flavor(NodeResources.unspecified()), Node.State.parked, type);
+        Optional.ofNullable(appId)
+                .map(app -> new Allocation(app,
+                        ClusterMembership.from("container/default/0/0", Version.fromString("1.2.3"), Optional.empty()),
+                        NodeResources.unspecified(),
+                        Generation.initial(),
+                        false))
+                .ifPresent(nodeBuilder::allocation);
+
+        assertEquals(archiveUrl, NodesResponse.nodeArchiveUrl(flagSource, nodeBuilder.build()).orElse(null));
+    }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponseTest.java
@@ -25,23 +25,23 @@ public class NodesResponseTest {
     private final InMemoryFlagSource flagSource = new InMemoryFlagSource();
 
     @Test
-    public void node_archive_url() {
+    public void archive_uri() {
         ApplicationId app = ApplicationId.from("vespa", "music", "main");
-        // Flag not set, no archive url
-        assertNodeArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
-        assertNodeArchiveUri(null, "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+        // Flag not set, no archive uri
+        assertArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertArchiveUri(null, "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
 
         flagSource.withStringFlag(Flags.SYNC_HOST_LOGS_TO_S3_BUCKET.id(), "vespa-data-bucket");
         // Flag is set, but node not allocated, only sync non-tenant nodes
-        assertNodeArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, null);
-        assertNodeArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, null);
+        assertArchiveUri(null, "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, null);
+        assertArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, null);
 
         // Flag is set and node is allocated
-        assertNodeArchiveUri("s3://vespa-data-bucket/vespa/music/main/h432a/", "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
-        assertNodeArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
+        assertArchiveUri("s3://vespa-data-bucket/vespa/music/main/h432a/", "h432a.prod.us-south-1.vespa.domain.tld", NodeType.tenant, app);
+        assertArchiveUri("s3://vespa-data-bucket/hosted-vespa/cfg1/", "cfg1.prod.us-south-1.vespa.domain.tld", NodeType.config, app);
     }
 
-    private void assertNodeArchiveUri(String archiveUrl, String hostname, NodeType type, ApplicationId appId) {
+    private void assertArchiveUri(String archiveUri, String hostname, NodeType type, ApplicationId appId) {
         Node.Builder nodeBuilder = Node.create("id", hostname, new Flavor(NodeResources.unspecified()), Node.State.parked, type);
         Optional.ofNullable(appId)
                 .map(app -> new Allocation(app,
@@ -51,6 +51,6 @@ public class NodesResponseTest {
                         false))
                 .ifPresent(nodeBuilder::allocation);
 
-        assertEquals(archiveUrl, NodesResponse.nodeArchiveUri(flagSource, nodeBuilder.build()).orElse(null));
+        assertEquals(archiveUri, NodesResponse.archiveUri(flagSource, nodeBuilder.build()).orElse(null));
     }
 }


### PR DESCRIPTION
This exposes a remote URL (for now a path in an S3 bucket) where the node should upload their logs (for now, in future maybe core dumps, heaps, etc.) to.

Currently this just backed by a feature flag, but in future the config server will create at least 1 bucket (maybe more if there are many applications in zone), and keep track of which applications (and thereby nodes) should sync to where.