### PR TITLE
Fail safe maintenance if other nodes are not up

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -203,8 +203,6 @@ public class ContentCluster {
             NodeState oldState, NodeState newState) {
 
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                minStorageNodesUp,
-                minRatioOfStorageNodesUp,
                 distribution.getRedundancy(),
                 new HierarchicalGroupVisitingAdapter(distribution),
                 clusterInfo

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -153,11 +153,6 @@ public class NodeStateChangeChecker {
                     + currentState);
         }
 
-        Result allNodesAreUpCheck = checkAllNodesAreUp(clusterState);
-        if (!allNodesAreUpCheck.settingWantedStateIsAllowed()) {
-            return allNodesAreUpCheck;
-        }
-
         HostInfo hostInfo = nodeInfo.getHostInfo();
         Integer hostInfoNodeVersion = hostInfo.getClusterStateVersionOrNull();
         int clusterControllerVersion = clusterState.getVersion();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -29,20 +29,14 @@ public class NodeStateChangeChecker {
     public static final String BUCKETS_METRIC_NAME = "vds.datastored.bucket_space.buckets_total";
     public static final Map<String, String> BUCKETS_METRIC_DIMENSIONS = Map.of("bucketSpace", "default");
 
-    private final int minStorageNodesUp;
-    private final double minRatioOfStorageNodesUp;
     private final int requiredRedundancy;
     private final HierarchicalGroupVisiting groupVisiting;
     private final ClusterInfo clusterInfo;
 
     public NodeStateChangeChecker(
-            int minStorageNodesUp,
-            double minRatioOfStorageNodesUp,
             int requiredRedundancy,
             HierarchicalGroupVisiting groupVisiting,
             ClusterInfo clusterInfo) {
-        this.minStorageNodesUp = minStorageNodesUp;
-        this.minRatioOfStorageNodesUp = minRatioOfStorageNodesUp;
         this.requiredRedundancy = requiredRedundancy;
         this.groupVisiting = groupVisiting;
         this.clusterInfo = clusterInfo;
@@ -159,9 +153,9 @@ public class NodeStateChangeChecker {
                     + currentState);
         }
 
-        Result thresholdCheckResult = checkUpThresholds(clusterState);
-        if (!thresholdCheckResult.settingWantedStateIsAllowed()) {
-            return thresholdCheckResult;
+        Result allNodesAreUpCheck = checkAllNodesAreUp(clusterState);
+        if (!allNodesAreUpCheck.settingWantedStateIsAllowed()) {
+            return allNodesAreUpCheck;
         }
 
         HostInfo hostInfo = nodeInfo.getHostInfo();
@@ -226,19 +220,14 @@ public class NodeStateChangeChecker {
             return Result.allowSettingOfWantedState();
         }
 
-        Result ongoingChanges = anyNodeSetToMaintenance(clusterState);
-        if (!ongoingChanges.settingWantedStateIsAllowed()) {
-            return ongoingChanges;
+        Result allNodesAreUpCheck = checkAllNodesAreUp(clusterState);
+        if (!allNodesAreUpCheck.settingWantedStateIsAllowed()) {
+            return allNodesAreUpCheck;
         }
 
         Result checkDistributorsResult = checkDistributors(nodeInfo.getNode(), clusterState.getVersion());
         if (!checkDistributorsResult.settingWantedStateIsAllowed()) {
             return checkDistributorsResult;
-        }
-
-        Result thresholdCheckResult = checkUpThresholds(clusterState);
-        if (!thresholdCheckResult.settingWantedStateIsAllowed()) {
-            return thresholdCheckResult;
         }
 
         return Result.allowSettingOfWantedState();
@@ -281,48 +270,38 @@ public class NodeStateChangeChecker {
         return false;
     }
 
-    private Result anyNodeSetToMaintenance(ClusterState clusterState) {
-        for (NodeInfo nodeInfo : clusterInfo.getAllNodeInfo()) {
-            if (clusterState.getNodeState(nodeInfo.getNode()).getState() == State.MAINTENANCE) {
-                return Result.createDisallowed("Another node is already in maintenance:" + nodeInfo.getNodeIndex());
-            }
-            if (nodeInfo.getWantedState().getState() == State.MAINTENANCE) {
-                return Result.createDisallowed("Another node wants maintenance:" + nodeInfo.getNodeIndex());
-            }
-        }
-        return Result.allowSettingOfWantedState();
-    }
+    private Result checkAllNodesAreUp(ClusterState clusterState) {
+        // This method verifies both storage nodes and distributors are up (or retired).
+        // The complicated part is making a summary error message.
 
-    private int contentNodesWithAvailableNodeState(ClusterState clusterState) {
-        final int nodeCount = clusterState.getNodeCount(NodeType.STORAGE);
-        int upNodesCount = 0;
-        for (int i = 0; i < nodeCount; ++i) {
-            final Node node = new Node(NodeType.STORAGE, i);
-            final State state = clusterState.getNodeState(node).getState();
-            if (state == State.UP || state == State.RETIRED || state == State.INITIALIZING) {
-                upNodesCount++;
+        for (NodeInfo storageNodeInfo : clusterInfo.getStorageNodeInfo()) {
+            State wantedState = storageNodeInfo.getUserWantedState().getState();
+            if (wantedState != State.UP && wantedState != State.RETIRED) {
+                return Result.createDisallowed("Another storage node wants state " +
+                        wantedState.toString().toUpperCase() + ": " + storageNodeInfo.getNodeIndex());
+            }
+
+            State state = clusterState.getNodeState(storageNodeInfo.getNode()).getState();
+            if (state != State.UP && state != State.RETIRED) {
+                return Result.createDisallowed("Another storage node has state " + state.toString().toUpperCase() +
+                        ": " + storageNodeInfo.getNodeIndex());
             }
         }
-        return upNodesCount;
-    }
 
-    private Result checkUpThresholds(ClusterState clusterState) {
-        if (clusterInfo.getStorageNodeInfo().size() < minStorageNodesUp) {
-            return Result.createDisallowed("There are only " + clusterInfo.getStorageNodeInfo().size() +
-                    " storage nodes up, while config requires at least " + minStorageNodesUp);
+        for (NodeInfo distributorNodeInfo : clusterInfo.getDistributorNodeInfo()) {
+            State wantedState = distributorNodeInfo.getUserWantedState().getState();
+            if (wantedState != State.UP && wantedState != State.RETIRED) {
+                return Result.createDisallowed("Another distributor wants state " + wantedState.toString().toUpperCase() +
+                        ": " + distributorNodeInfo.getNodeIndex());
+            }
+
+            State state = clusterState.getNodeState(distributorNodeInfo.getNode()).getState();
+            if (state != State.UP && state != State.RETIRED) {
+                return Result.createDisallowed("Another distributor has state " + state.toString().toUpperCase() +
+                        ": " + distributorNodeInfo.getNodeIndex());
+            }
         }
 
-        final int nodesCount = clusterInfo.getStorageNodeInfo().size();
-        final int upNodesCount = contentNodesWithAvailableNodeState(clusterState);
-
-        if (nodesCount == 0) {
-            return Result.createDisallowed("No storage nodes in cluster state");
-        }
-        if (((double)upNodesCount) / nodesCount < minRatioOfStorageNodesUp) {
-            return Result.createDisallowed("Not enough storage nodes running: " + upNodesCount
-                    + " of " +  nodesCount + " storage nodes are up which is less that the required fraction of "
-                    + minRatioOfStorageNodesUp);
-        }
         return Result.allowSettingOfWantedState();
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -16,9 +16,7 @@ import org.junit.Test;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
@@ -32,10 +30,8 @@ import static org.mockito.Mockito.when;
 
 public class NodeStateChangeCheckerTest {
 
-    private static final int minStorageNodesUp = 3;
     private static final int requiredRedundancy = 4;
     private static final int currentClusterStateVersion = 2;
-    private static final double minRatioOfStorageNodesUp = 0.9;
 
     private static final Node nodeDistributor = new Node(NodeType.DISTRIBUTOR, 1);
     private static final Node nodeStorage = new Node(NodeType.STORAGE, 1);
@@ -61,30 +57,14 @@ public class NodeStateChangeCheckerTest {
     }
 
     private NodeStateChangeChecker createChangeChecker(ContentCluster cluster) {
-        return new NodeStateChangeChecker(minStorageNodesUp, minRatioOfStorageNodesUp, requiredRedundancy,
-                visitor -> {}, cluster.clusterInfo());
+        return new NodeStateChangeChecker(requiredRedundancy, visitor -> {}, cluster.clusterInfo());
     }
 
     private ContentCluster createCluster(Collection<ConfiguredNode> nodes) {
         Distribution distribution = mock(Distribution.class);
         Group group = new Group(2, "to");
         when(distribution.getRootGroup()).thenReturn(group);
-        return new ContentCluster("Clustername", nodes, distribution, minStorageNodesUp, 0.0);
-    }
-
-    private StorageNodeInfo createStorageNodeInfo(int index, State state) {
-        Distribution distribution = mock(Distribution.class);
-        Group group = new Group(2, "to");
-        when(distribution.getRootGroup()).thenReturn(group);
-
-        String clusterName = "Clustername";
-        Set<ConfiguredNode> configuredNodeIndexes = new HashSet<>();
-        ContentCluster cluster = new ContentCluster(clusterName, configuredNodeIndexes, distribution, minStorageNodesUp, 0.0);
-
-        String rpcAddress = "";
-        StorageNodeInfo storageNodeInfo = new StorageNodeInfo(cluster, index, false, rpcAddress, distribution);
-        storageNodeInfo.setReportedState(new NodeState(NodeType.STORAGE, state), 3 /* time */);
-        return storageNodeInfo;
+        return new ContentCluster("Clustername", nodes, distribution, 3, 0.0);
     }
 
     private String createDistributorHostInfo(int replicationfactor1, int replicationfactor2, int replicationfactor3) {
@@ -137,8 +117,7 @@ public class NodeStateChangeCheckerTest {
     public void testUnknownStorageNode() {
         ContentCluster cluster = createCluster(createNodes(4));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy,
-                visitor -> {}, cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -160,17 +139,23 @@ public class NodeStateChangeCheckerTest {
 
     @Test
     public void testCanUpgradeSafeMissingStorage() {
+        // Create a content cluster with 4 nodes, and storage node with index 3 down.
         ContentCluster cluster = createCluster(createNodes(4));
         setAllNodesUp(cluster, HostInfo.createHostInfo(createDistributorHostInfo(4, 5, 6)));
+        cluster.clusterInfo().getStorageNodeInfo(3).setReportedState(new NodeState(NodeType.STORAGE, State.DOWN), 0);
+        ClusterState clusterStateWith3Down = clusterState(String.format(
+                "version:%d distributor:4 storage:4 .3.s:d",
+                currentClusterStateVersion));
+
+        // We should then be denied setting storage node 1 safely to maintenance.
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                5 /* min storage nodes */, minRatioOfStorageNodesUp, requiredRedundancy, visitor -> {},
-                cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
-                nodeStorage, defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
+                nodeStorage, clusterStateWith3Down, SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
         assertFalse(result.settingWantedStateIsAllowed());
         assertFalse(result.wantedStateAlreadySet());
-        assertThat(result.getReason(), is("There are only 4 storage nodes up, while config requires at least 5"));
+        assertThat(result.getReason(), is("Another storage node has state DOWN: 3"));
     }
 
     @Test
@@ -402,7 +387,7 @@ public class NodeStateChangeCheckerTest {
         NodeStateChangeChecker.Result result = transitionToMaintenanceWithOneStorageNodeDown(otherIndex);
         assertFalse(result.settingWantedStateIsAllowed());
         assertFalse(result.wantedStateAlreadySet());
-        assertThat(result.getReason(), containsString("Not enough storage nodes running"));
+        assertThat(result.getReason(), containsString("Another storage node has state DOWN: 2"));
     }
 
     @Test


### PR DESCRIPTION
The test_upgrade_of_downed_node system test fails with group-suspension enabled because the Cluster Controller allows the suspension of a node even if another node is down.  Disabled, the Orchestrator blocks the suspension.

It used to be that:
 1. The CC disallowed suspension if any other node (outside the hierarchical group if any) were in maintenance or user wanted state maintenance.
 2. The CC would disallow suspension if the minStorageNodesUp or minRatiofStorageNodesUp thresholds were already violated.

The PR changes these to:
 - If any other storage node or distributor has a generated or user wanted state unlike UP or RETIRED, then disallow safe maintenance.
 - There is no requirement on other nodes being up when setting a node permanently down.
