### PR TITLE
Remove old swap files when setting up mmap file allocator.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator_factory.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator_factory.cpp
@@ -2,6 +2,7 @@
 
 #include "mmap_file_allocator_factory.h"
 #include "mmap_file_allocator.h"
+#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 
 namespace vespalib::alloc {
@@ -21,6 +22,9 @@ MmapFileAllocatorFactory::setup(const vespalib::string& dir_name)
 {
     _dir_name = dir_name;
     _generation = 0;
+    if (!_dir_name.empty()) {
+        rmdir(_dir_name, true);
+    }
 }
 
 std::unique_ptr<MemoryAllocator>


### PR DESCRIPTION
@geirst : please review
