### PR TITLE
Wait 10 minutes after last deployment before migrating to dedicated CCC

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DedicatedClusterControllerClusterMigrator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DedicatedClusterControllerClusterMigrator.java
@@ -57,18 +57,14 @@ public class DedicatedClusterControllerClusterMigrator extends ApplicationMainta
     }
 
     @Override
-    protected boolean canDeployNow(ApplicationId id) {
-        return isQuiescent(id);
-    }
-
-    @Override
     protected void deploy(ApplicationId id) {
         migrate(id);
         super.deploy(id);
     }
 
     private boolean isEligible(ApplicationId id) {
-        return flag.with(FetchVector.Dimension.APPLICATION_ID, id.serializedForm()).value();
+        return    deployer().lastDeployTime(id).map(at -> at.isBefore(clock().instant().minus(Duration.ofMinutes(10)))).orElse(false)
+               && flag.with(FetchVector.Dimension.APPLICATION_ID, id.serializedForm()).value();
     }
 
     private boolean hasNotSwitched(ApplicationId id) {


### PR DESCRIPTION
@hmusum please review.

No point in not carrying out the deployment, when `isQuiescent` has changed to false, as the flag has already been flipped. Don't want to flip it back, either, in case another deployment has taken place in the meantime, and we only want to migrate once, forward. 