### PR TITLE
move getting tensor into the attribute code

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attribute_updater.cpp
@@ -205,23 +205,6 @@ AttributeUpdater::handleUpdate(PredicateAttribute &vec, uint32_t lid, const Valu
     }
 }
 
-namespace {
-
-void
-applyTensorUpdate(TensorAttribute &vec, uint32_t lid, const document::TensorUpdate &update,
-                  bool create_empty_if_non_existing)
-{
-    auto oldTensor = vec.getTensor(lid);
-    if (!oldTensor && create_empty_if_non_existing) {
-        oldTensor = vec.getEmptyTensor();
-    }
-    if (oldTensor) {
-        vec.update_tensor(lid, update, *oldTensor);
-    }
-}
-
-}
-
 template <>
 void
 AttributeUpdater::handleUpdate(TensorAttribute &vec, uint32_t lid, const ValueUpdate &upd)
@@ -236,11 +219,11 @@ AttributeUpdater::handleUpdate(TensorAttribute &vec, uint32_t lid, const ValueUp
             updateValue(vec, lid, assign.getValue());
         }
     } else if (op == ValueUpdate::TensorModifyUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorModifyUpdate &>(upd), false);
+        vec.update_tensor(lid, static_cast<const TensorModifyUpdate &>(upd), false);
     } else if (op == ValueUpdate::TensorAddUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorAddUpdate &>(upd), true);
+        vec.update_tensor(lid, static_cast<const TensorAddUpdate &>(upd), true);
     } else if (op == ValueUpdate::TensorRemoveUpdate) {
-        applyTensorUpdate(vec, lid, static_cast<const TensorRemoveUpdate &>(upd), false);
+        vec.update_tensor(lid, static_cast<const TensorRemoveUpdate &>(upd), false);
     } else if (op == ValueUpdate::Clear) {
         vec.clearDoc(lid);
     } else {

--- a/searchlib/src/vespa/searchlib/tensor/direct_tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/direct_tensor_attribute.h
@@ -19,7 +19,7 @@ public:
     virtual void setTensor(DocId docId, const vespalib::eval::Value &tensor) override;
     void update_tensor(DocId docId,
                        const document::TensorUpdate &update,
-                       const vespalib::eval::Value &old_tensor) override;
+                       bool create_empty_if_non_existing) override;
     virtual std::unique_ptr<vespalib::eval::Value> getTensor(DocId docId) const override;
     virtual bool onLoad() override;
     virtual std::unique_ptr<AttributeSaver> onInitSave(vespalib::stringref fileName) override;

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
@@ -254,10 +254,21 @@ TensorAttribute::getRefCopy() const
 void
 TensorAttribute::update_tensor(DocId docId,
                                const document::TensorUpdate &update,
-                               const vespalib::eval::Value &old_tensor)
+                               bool create_empty_if_non_existing)
 {
-    auto new_value = update.apply_to(old_tensor, FastValueBuilderFactory::get());
-    setTensor(docId, *new_value);
+    const vespalib::eval::Value * old_v = nullptr;
+    auto old_tensor = getTensor(docId);
+    if (old_tensor) {
+        old_v = old_tensor.get();
+    } else if (create_empty_if_non_existing) {
+        old_v = _emptyTensor.get();
+    } else {
+        return;
+    }
+    auto new_value = update.apply_to(*old_v, FastValueBuilderFactory::get());
+    if (new_value) {
+        setTensor(docId, *new_value);
+    }
 }
 
 std::unique_ptr<PrepareResult>

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.h
@@ -61,7 +61,7 @@ public:
     virtual void setTensor(DocId docId, const vespalib::eval::Value &tensor) = 0;
     virtual void update_tensor(DocId docId,
                                const document::TensorUpdate &update,
-                               const vespalib::eval::Value &oldTensor);
+                               bool create_empty_if_non_existing);
     /**
      * Performs the prepare step in a two-phase operation to set a tensor for a document.
      *


### PR DESCRIPTION
* avoids taking an extra copy of the tensor
  in the DirectTensorAttribute case

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@geirst please review
@havardpe FYI
