### PR TITLE
Workaround for faulty language level detection in IntelliJ

### DIFF
--- a/vespa_jersey2/pom.xml
+++ b/vespa_jersey2/pom.xml
@@ -56,6 +56,11 @@
   <build>
     <plugins>
       <plugin>
+        <!-- Explicit for IntelliJ to detect correct language level from parent -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
