### PR TITLE
less broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started using Vespa pick one of the quick start documents:
 
 - [Run on a Mac or Linux machine using Docker](https://docs.vespa.ai/en/vespa-quick-start.html)
 - [Run on a Windows machine using Docker](https://docs.vespa.ai/en/vespa-quick-start-windows.html)
-- [Run on a Mac or Linux machine using VirtualBox+Vagrant](https://docs.vespa.ai/en/vespa-quick-start-centos.html)
+- [Run on a Mac or Linux machine using VirtualBox+Vagrant](https://docs.vespa.ai/en/vespa-quick-start-vagrant.html)
 - [Multinode install on AWS EC2](https://docs.vespa.ai/en/vespa-quick-start-multinode-aws.html)
 - [Multinode install on AWS ECS](https://docs.vespa.ai/en/vespa-quick-start-multinode-aws-ecs.html)
 
@@ -43,7 +43,7 @@ To get started using Vespa pick one of the quick start documents:
 
 - The application created in the quickstart is fully functional and production ready, but you may want to [add more nodes](https://docs.vespa.ai/en/multinode-systems.html) for redundancy.
 - Try the [Blog search and recommendation tutorial](https://docs.vespa.ai/en/tutorials/blog-search.html) to learn more about using Vespa
-- See [developing applications](https://docs.vespa.ai/en/jdisc/developing-applications.html) on adding your own Java components to your Vespa application.
+- See [developing applications](https://docs.vespa.ai/en/developer-guide.html) on adding your own Java components to your Vespa application.
 - [Vespa APIs](https://docs.vespa.ai/en/api.html) is useful to understand how to interface with Vespa
 - Explore the [sample applications](https://github.com/vespa-engine/sample-apps/tree/master)
 

--- a/client/src/main/java/ai/vespa/client/dsl/FixedQuery.java
+++ b/client/src/main/java/ai/vespa/client/dsl/FixedQuery.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 /**
  * FixedQuery contains a 'Query' which is terminated by a 'semicolon'
  * This object holds vespa or user defined parameters
- * https://docs.vespa.ai/en/reference/search-api-reference.html
+ * https://docs.vespa.ai/en/reference/query-api-reference.html
  */
 public class FixedQuery {
 

--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/tensorflow/VariableConverter.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/tensorflow/VariableConverter.java
@@ -37,7 +37,7 @@ class VariableConverter {
         if ( args.length != 3) {
             System.out.println("Converts a TensorFlow variable into Vespa tensor document field value JSON:");
             System.out.println("A JSON map containing a 'cells' array, see");
-            System.out.println("https://docs.vespa.ai/en/reference/document-json-put-format.html#tensor)");
+            System.out.println("https://docs.vespa.ai/en/reference/document-json-format.html#tensor");
             System.out.println("");
             System.out.println("Arguments: modelDirectory tensorFlowVariableName orderedTypeSpec");
             System.out.println(" - modelDirectory: The directory of the TensorFlow SavedModel");


### PR DESCRIPTION
We also need some way to skip link checking, example https://github.com/vespa-engine/vespa/blob/master/config-lib/src/test/java/com/yahoo/config/ConfigInstanceBuilderTest.java#L191 - maybe adding a comment like `// skip-link-check`

the link to developer guide will still fail as I have not renamed another doc to this yet