### PR TITLE
Treat newer OS version as converged

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -52,7 +52,7 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
 
     @Override
     protected boolean convergedOn(OsVersionTarget target, SystemApplication application, ZoneApi zone) {
-        return currentVersion(zone, application, target.osVersion().version()).equals(target.osVersion().version());
+        return !currentVersion(zone, application, target.osVersion().version()).isBefore(target.osVersion().version());
     }
 
     @Override


### PR DESCRIPTION
This is required now that nodes can choose the "closest" version on upgrade.

@freva