### PR TITLE
Keep allocation in dirty state

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.hosted.provision.node.Status;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -509,7 +510,7 @@ public final class Node implements Nodelike {
         }
 
         public static Set<State> allocatedStates() {
-            return Set.of(reserved, active, inactive, failed, parked);
+            return EnumSet.of(reserved, active, inactive, dirty, failed, parked);
         }
 
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeFlavors;
-import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
@@ -54,7 +53,7 @@ public class NodeRepositoryTester {
     public List<Node> getNodes(NodeType type, Node.State ... inState) {
         return nodeRepository.nodes().list(inState).nodeType(type).asList();
     }
-    
+
     public Node addHost(String id, String hostname, String flavor, NodeType type) {
         return addNode(id, hostname, null, nodeFlavors.getFlavorOrThrow(flavor), type);
     }
@@ -63,12 +62,9 @@ public class NodeRepositoryTester {
         return addNode(id, hostname, parentHostname, nodeFlavors.getFlavorOrThrow(flavor), type);
     }
 
-    public Node addNode(String id, String hostname, String parentHostname, NodeResources resources) {
-        return addNode(id, hostname, parentHostname, new Flavor(resources), NodeType.tenant);
-    }
-
     private Node addNode(String id, String hostname, String parentHostname, Flavor flavor, NodeType type) {
-        IP.Config ipConfig = new IP.Config(nodeRepository.nameResolver().resolveAll(hostname), Set.of());
+        Set<String> ips = nodeRepository.nameResolver().resolveAll(hostname);
+        IP.Config ipConfig = new IP.Config(ips, type.isHost() ? ips : Set.of());
         Node node = Node.create(id, ipConfig, hostname, flavor, type).parentHostname(parentHostname).build();
         return nodeRepository.nodes().addNodes(List.of(node), Agent.system).get(0);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityCheckerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityCheckerTester.java
@@ -194,7 +194,7 @@ public class CapacityCheckerTester {
         nodeRepository.nodes().addNodes(hostsWithChildren.getOrDefault(tenantHostApp, List.of()), Agent.system);
         hostsWithChildren.forEach((applicationId, nodes) -> {
             if (applicationId.equals(tenantHostApp)) return;
-            nodeRepository.nodes().addNodes(nodes, Agent.system);
+            nodeRepository.database().addNodesInState(nodes, Node.State.active, Agent.system);
         });
         nodeRepository.nodes().addNodes(createEmptyHosts(numHosts, numEmptyHosts, emptyHostExcessCapacity, emptyHostExcessIps), Agent.system);
 
@@ -281,8 +281,8 @@ public class CapacityCheckerTester {
                                              nodeModel.fastDisk ? NodeResources.DiskSpeed.fast : NodeResources.DiskSpeed.slow);
         Flavor f = new Flavor(nr);
 
-        Node.Builder builder = Node.create(nodeModel.id, new IP.Config(nodeModel.ipAddresses, nodeModel.additionalIpAddresses),
-                nodeModel.hostname, f, nodeModel.type);
+        Node.Builder builder = Node.create(nodeModel.id, nodeModel.hostname, f, nodeModel.state, nodeModel.type)
+                .ipConfig(new IP.Config(nodeModel.ipAddresses, nodeModel.additionalIpAddresses));
         nodeModel.parentHostname.ifPresent(builder::parentHostname);
         Node node = builder.build();
 
@@ -314,9 +314,9 @@ public class CapacityCheckerTester {
             }
         }
 
-        nodeRepository.nodes().addNodes(hosts, Agent.system);
+        nodeRepository.database().addNodesInState(hosts, Node.State.active, Agent.system);
         nodes.forEach((application, applicationNodes) -> {
-            nodeRepository.nodes().addNodes(applicationNodes, Agent.system);
+            nodeRepository.database().addNodesInState(applicationNodes, Node.State.active, Agent.system);
         });
         updateCapacityChecker();
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -25,14 +25,13 @@ import com.yahoo.vespa.orchestrator.Orchestrator;
 import org.junit.Test;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -69,13 +68,11 @@ public class InactiveAndFailedExpirerTest {
         assertEquals(0, tester.nodeRepository().nodes().list(Node.State.inactive).size());
         NodeList dirty = tester.nodeRepository().nodes().list(Node.State.dirty);
         assertEquals(2, dirty.size());
-        assertFalse(dirty.asList().get(0).allocation().isPresent());
-        assertFalse(dirty.asList().get(1).allocation().isPresent());
 
         // One node is set back to ready
-        Node ready = tester.nodeRepository().nodes().setReady(Collections.singletonList(dirty.asList().get(0)), Agent.system, getClass().getSimpleName()).get(0);
+        Node ready = tester.nodeRepository().nodes().setReady(List.of(dirty.asList().get(0)), Agent.system, getClass().getSimpleName()).get(0);
         assertEquals("Allocated history is removed on readying",
-                Arrays.asList(History.Event.Type.provisioned, History.Event.Type.readied),
+                List.of(History.Event.Type.provisioned, History.Event.Type.readied),
                 ready.history().events().stream().map(History.Event::type).collect(Collectors.toList()));
 
         // Dirty times out for the other one
@@ -185,7 +182,7 @@ public class InactiveAndFailedExpirerTest {
         assertEquals(0, tester.nodeRepository().nodes().list(Node.State.inactive).size());
         NodeList dirty = tester.nodeRepository().nodes().list(Node.State.dirty);
         assertEquals(1, dirty.size());
-        assertFalse(dirty.first().get().allocation().isPresent());
+        assertTrue(dirty.first().get().allocation().isPresent());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -243,7 +243,7 @@ public class MetricsReporterTest {
         metricsReporter.maintain();
         assertEquals(1D, getMetric("nodes.nonActiveFraction", metric, dimensions).doubleValue(), Double.MIN_VALUE);
         assertEquals(0, getMetric("nodes.active", metric, dimensions));
-        assertEquals(3, getMetric("nodes.nonActive", metric, dimensions));
+        assertEquals(4, getMetric("nodes.nonActive", metric, dimensions));
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ReservationExpirerTest.java
@@ -55,8 +55,6 @@ public class ReservationExpirerTest {
         assertEquals(0, nodeRepository.nodes().list(Node.State.reserved).nodeType(NodeType.tenant).size());
         NodeList dirty = nodeRepository.nodes().list(Node.State.dirty).nodeType(NodeType.tenant);
         assertEquals(2, dirty.size());
-        assertFalse(dirty.asList().get(0).allocation().isPresent());
-        assertFalse(dirty.asList().get(1).allocation().isPresent());
         assertEquals(2, metric.values.get("expired.reserved"));
     }
 


### PR DESCRIPTION
In future, we probably want to require allocation for all tenant nodes, always. But that requires a lot of rewriting tests, at the moment:
* 277/349 tests fail if this requirement is placed in `Node.java` constructor, a lot of it is due to allocation not changing allocation and state at the same time. 
* 110/349 tests fail if checking at the time of writing/reading from ZK. Most due to various testers trying to allocate non-dynamically.

This change should be OK with host-admin, only notable consequence that I've found is that we might get a few extra metric values with the application tags while the container is being stopped.
I also checked controller code and haven't found any obvious issues, but I'm less familiar with it and there are multiple clients...