### PR TITLE
Enforce that no cluster state can be published unless confirmed written to ZooKeeper

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -407,6 +407,10 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         try {
             database.saveLatestSystemStateVersion(databaseContext, stateBundle.getVersion());
             database.saveLatestClusterStateBundle(databaseContext, stateBundle);
+            // It's possible that due to transient ZK quorum errors, we were not able to actually
+            // fully store the state. Gate state broadcasting on the actually synchronously ACKed
+            // stored state instead of what's _hopefully_ stored.
+            systemStateBroadcaster.setLastClusterStateVersionWrittenToZooKeeper(database.getLastKnownStateBundleVersionWrittenBySelf());
         } catch (InterruptedException e) {
             // Rethrow as RuntimeException to propagate exception up to main thread method.
             // Don't want to hide failures to write cluster state version.
@@ -579,6 +583,9 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         synchronized (monitor) {
             boolean didWork;
             didWork = database.doNextZooKeeperTask(databaseContext);
+            // In case of delayed ZK writes caused by intermittent failures, make sure to tag any newly written versions.
+            systemStateBroadcaster.setLastClusterStateVersionWrittenToZooKeeper(
+                    database.getLastKnownStateBundleVersionWrittenBySelf());
             didWork |= updateMasterElectionState();
             didWork |= handleLeadershipEdgeTransitions();
             stateChangeHandler.setMaster(isMaster);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -28,7 +28,6 @@ public class SystemStateBroadcaster {
 
     private int lastStateVersionBundleAcked = 0;
     private int lastClusterStateVersionConverged = 0;
-    private int lastClusterStateVersionWrittenToZooKeeper = 0;
     private ClusterStateBundle lastClusterStateBundleConverged;
 
     private final SetClusterStateWaiter setClusterStateWaiter = new SetClusterStateWaiter();
@@ -256,19 +255,12 @@ public class SystemStateBroadcaster {
         return lastClusterStateVersionConverged == clusterStateBundle.getVersion();
     }
 
-    public void setLastClusterStateVersionWrittenToZooKeeper(int version) {
-        lastClusterStateVersionWrittenToZooKeeper = version;
-    }
-
-    private boolean currentStateVersionHasBeenWrittenToZooKeeper() {
+    public boolean broadcastNewStateBundleIfRequired(DatabaseHandler.Context dbContext, Communicator communicator,
+                                                     int lastClusterStateVersionWrittenToZooKeeper) {
         if (clusterStateBundle == null) {
             return false;
         }
-        return clusterStateBundle.getVersion() == lastClusterStateVersionWrittenToZooKeeper;
-    }
-
-    public boolean broadcastNewStateBundleIfRequired(DatabaseHandler.Context dbContext, Communicator communicator) {
-        if (!currentStateVersionHasBeenWrittenToZooKeeper()) {
+        if (clusterStateBundle.getVersion() != lastClusterStateVersionWrittenToZooKeeper) {
             return false;
         }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -28,6 +28,7 @@ public class SystemStateBroadcaster {
 
     private int lastStateVersionBundleAcked = 0;
     private int lastClusterStateVersionConverged = 0;
+    private int lastClusterStateVersionWrittenToZooKeeper = 0;
     private ClusterStateBundle lastClusterStateBundleConverged;
 
     private final SetClusterStateWaiter setClusterStateWaiter = new SetClusterStateWaiter();
@@ -255,8 +256,19 @@ public class SystemStateBroadcaster {
         return lastClusterStateVersionConverged == clusterStateBundle.getVersion();
     }
 
-    public boolean broadcastNewStateBundleIfRequired(DatabaseHandler.Context dbContext, Communicator communicator) {
+    public void setLastClusterStateVersionWrittenToZooKeeper(int version) {
+        lastClusterStateVersionWrittenToZooKeeper = version;
+    }
+
+    private boolean currentStateVersionHasBeenWrittenToZooKeeper() {
         if (clusterStateBundle == null) {
+            return false;
+        }
+        return clusterStateBundle.getVersion() == lastClusterStateVersionWrittenToZooKeeper;
+    }
+
+    public boolean broadcastNewStateBundleIfRequired(DatabaseHandler.Context dbContext, Communicator communicator) {
+        if (!currentStateVersionHasBeenWrittenToZooKeeper()) {
             return false;
         }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -954,7 +954,7 @@ public class StateChangeTest extends FleetControllerTest {
         options.minTimeBeforeFirstSystemStateBroadcast = 3 * 60 * 1000;
         setUpSystem(true, options);
         setUpVdsNodes(true, new DummyVdsNodeOptions(), true);
-            // Leave one node down to avoid sending cluster state due to having seen all node states.
+        // Leave one node down to avoid sending cluster state due to having seen all node states.
         for (int i=0; i<nodes.size(); ++i) {
             if (i != 3) {
                 nodes.get(i).connect();
@@ -973,7 +973,7 @@ public class StateChangeTest extends FleetControllerTest {
             @Override int expectedMessageCount(final DummyVdsNode node) { return 0; }
         };
 
-            // Pass time and see that the nodes get state
+        // Pass time and see that the nodes get state
         timer.advanceTime(3 * 60 * 1000);
         waiter.waitForState("version:\\d+ distributor:10 storage:10 .1.s:d", timeoutMS);
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcasterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcasterTest.java
@@ -42,9 +42,9 @@ public class SystemStateBroadcasterTest {
             cf.cluster().getNodeInfo(Node.ofDistributor(0)).setReportedState(new NodeState(NodeType.DISTRIBUTOR, State.UP).setStartTimestamp(500), 3000);
         }
 
-        void simulateBroadcastTick(ClusterFixture cf) {
+        void simulateBroadcastTick(ClusterFixture cf, int stateVersion) {
             broadcaster.processResponses();
-            broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), mockCommunicator);
+            broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), mockCommunicator, stateVersion);
             try {
                 broadcaster.checkIfClusterStateIsAckedByAllDistributors(
                         mockDatabaseHandler, dbContextFrom(cf.cluster()), mockFleetController);
@@ -89,7 +89,7 @@ public class SystemStateBroadcasterTest {
         ClusterStateBundle stateBundle = ClusterStateBundleUtil.makeBundle("distributor:2 storage:2");
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 0);
         cf.cluster().getNodeInfo().forEach(nodeInfo -> verify(f.mockCommunicator).setSystemState(eq(stateBundle), eq(nodeInfo), any()));
     }
 
@@ -100,7 +100,7 @@ public class SystemStateBroadcasterTest {
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.simulateNodePartitionedAwaySilently(cf);
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 0);
 
         clusterNodeInfos(cf.cluster(), Node.ofDistributor(1), Node.ofStorage(0), Node.ofStorage(1)).forEach(nodeInfo -> {
             // Only distributor 0 should observe startup timestamps
@@ -118,7 +118,7 @@ public class SystemStateBroadcasterTest {
                 StateMapping.of("upsidedown", "distributor:2 .0.s:d storage:2"));
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 0);
 
         cf.cluster().getNodeInfo().forEach(nodeInfo -> verify(f.mockCommunicator).setSystemState(eq(stateBundle), eq(nodeInfo), any()));
     }
@@ -132,7 +132,7 @@ public class SystemStateBroadcasterTest {
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.simulateNodePartitionedAwaySilently(cf);
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 0);
 
         clusterNodeInfos(cf.cluster(), Node.ofDistributor(1), Node.ofStorage(0), Node.ofStorage(1)).forEach(nodeInfo -> {
             // Only distributor 0 should observe startup timestamps
@@ -150,8 +150,7 @@ public class SystemStateBroadcasterTest {
         ClusterStateBundle stateBundle = ClusterStateBundleUtil.makeBundle("version:100 distributor:2 storage:2");
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.setLastClusterStateVersionWrittenToZooKeeper(99);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 99);
 
         cf.cluster().getNodeInfo().forEach(nodeInfo -> {
             verify(f.mockCommunicator, times(0)).setSystemState(any(), eq(nodeInfo), any());
@@ -164,8 +163,7 @@ public class SystemStateBroadcasterTest {
         ClusterStateBundle stateBundle = ClusterStateBundleUtil.makeBundle("version:100 distributor:2 storage:2");
         ClusterFixture cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
         f.broadcaster.handleNewClusterStates(stateBundle);
-        f.broadcaster.setLastClusterStateVersionWrittenToZooKeeper(100);
-        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator);
+        f.broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), f.mockCommunicator, 100);
 
         cf.cluster().getNodeInfo().forEach(nodeInfo -> {
             verify(f.mockCommunicator, times(1)).setSystemState(any(), eq(nodeInfo), any());
@@ -230,8 +228,7 @@ public class SystemStateBroadcasterTest {
                     .deriveAndBuild();
             cf = ClusterFixture.forFlatCluster(2).bringEntireClusterUp().assignDummyRpcAddresses();
             broadcaster.handleNewClusterStates(stateBundle);
-            broadcaster.setLastClusterStateVersionWrittenToZooKeeper(stateBundle.getVersion());
-            broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), mockCommunicator);
+            broadcaster.broadcastNewStateBundleIfRequired(dbContextFrom(cf.cluster()), mockCommunicator, stateBundle.getVersion());
 
             d0Waiter = ArgumentCaptor.forClass(Communicator.Waiter.class);
             d1Waiter = ArgumentCaptor.forClass(Communicator.Waiter.class);
@@ -248,11 +245,11 @@ public class SystemStateBroadcasterTest {
         @SuppressWarnings("unchecked") // Type erasure of Waiter in mocked argument capture
         void ackStateBundleFromBothDistributors() {
             expectSetSystemStateInvocationsToBothDistributors();
-            simulateBroadcastTick(cf);
+            simulateBroadcastTick(cf, 123);
 
             respondToSetClusterStateBundle(cf.cluster.getNodeInfo(Node.ofDistributor(0)), stateBundle, d0Waiter.getValue());
             respondToSetClusterStateBundle(cf.cluster.getNodeInfo(Node.ofDistributor(1)), stateBundle, d1Waiter.getValue());
-            simulateBroadcastTick(cf);
+            simulateBroadcastTick(cf, 123);
         }
 
         static StateActivationFixture withTwoPhaseEnabled() {
@@ -271,11 +268,11 @@ public class SystemStateBroadcasterTest {
         var cf = f.cf;
 
         f.expectSetSystemStateInvocationsToBothDistributors();
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         // Respond from distributor 0, but not yet from distributor 1
         respondToSetClusterStateBundle(cf.cluster.getNodeInfo(Node.ofDistributor(0)), f.stateBundle, f.d0Waiter.getValue());
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         // No activations should be sent yet
         cf.cluster().getNodeInfo().forEach(nodeInfo -> {
@@ -284,7 +281,7 @@ public class SystemStateBroadcasterTest {
         assertNull(f.broadcaster.getLastClusterStateBundleConverged());
 
         respondToSetClusterStateBundle(cf.cluster.getNodeInfo(Node.ofDistributor(1)), f.stateBundle, f.d1Waiter.getValue());
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         // Activation should now be sent to _all_ nodes (distributor and storage)
         cf.cluster().getNodeInfo().forEach(nodeInfo -> {
@@ -312,13 +309,13 @@ public class SystemStateBroadcasterTest {
 
         respondToActivateClusterStateVersion(cf.cluster.getNodeInfo(Node.ofDistributor(0)),
                                              f.stateBundle, d0ActivateWaiter.getValue());
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         assertNull(f.broadcaster.getLastClusterStateBundleConverged()); // Not yet converged
 
         respondToActivateClusterStateVersion(cf.cluster.getNodeInfo(Node.ofDistributor(1)),
                                              f.stateBundle, d1ActivateWaiter.getValue());
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         // Finally, all distributors have ACKed the version! State is marked as converged.
         assertEquals(f.stateBundle, f.broadcaster.getLastClusterStateBundleConverged());
@@ -363,7 +360,7 @@ public class SystemStateBroadcasterTest {
         // considered converged since it's not an exact version match.
         respondToActivateClusterStateVersion(cf.cluster.getNodeInfo(Node.ofDistributor(1)),
                 f.stateBundle, 124, d1ActivateWaiter.getValue());
-        f.simulateBroadcastTick(cf);
+        f.simulateBroadcastTick(cf, 123);
 
         assertNull(f.broadcaster.getLastClusterStateBundleConverged());
     }


### PR DESCRIPTION
@geirst please review

This avoids some subtle edge cases in the first few seconds after leader
election, where we may inhibit storing a state to ZooKeeper but where it
may still be sent to the nodes once a grace period has expired.

To ensure liveness, add an extra condition where a cluster state version
may be published after the grace period has expired even if there are no
other triggers at this point.
