### PR TITLE
Enable group-suspension by default, attempt 2 [run-systemtest]

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -200,7 +200,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag GROUP_SUSPENSION = defineFeatureFlag(
-            "group-suspension", false,
+            "group-suspension", true,
             List.of("hakon"), "2021-01-22", "2021-03-22",
             "Allow all content nodes in a hierarchical group to suspend at the same time",
             "Takes effect on the next suspension request to the Orchestrator.",


### PR DESCRIPTION
The first attempt failed because a system test failed because it was allowed to
set a content node to maintenance even though another content node was down.
This was a bug fixed in https://github.com/vespa-engine/vespa/pull/16580.