### PR TITLE
Enable group suspension by default, attempt 2 [run-systemtest]

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -200,7 +200,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag GROUP_SUSPENSION = defineFeatureFlag(
-            "group-suspension", false,
+            "group-suspension", true,
             List.of("hakon"), "2021-01-22", "2021-03-22",
             "Allow all content nodes in a hierarchical group to suspend at the same time",
             "Takes effect on the next suspension request to the Orchestrator.",

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
@@ -114,8 +114,8 @@ public class ClusterApiImplTest {
         } catch (HostStateChangeDeniedException e) {
             assertThat(e.getMessage(),
                     containsString("Changing the state of cfg1 would violate enough-services-up: " +
-                            "Suspension of service with type 'configserver' would increase from 33% to 66%, " +
-                            "over the limit of 10%. Services down on resumed hosts: [1 missing config server]."));
+                            "Suspension of service with type 'configserver' not allowed: 33% are suspended already. " +
+                            "Services down on resumed hosts: [1 missing config server]."));
         }
 
         flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION.id(), true);


### PR DESCRIPTION
The first attempt in #16537 failed because a system test failed because it was allowed to
set a content node to maintenance even though another content node was down.
This was a bug fixed in https://github.com/vespa-engine/vespa/pull/16580.
