### PR TITLE
Improve feedback from /system-flags/v1 responses

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/wire/WireSystemFlagsDeployResult.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/wire/WireSystemFlagsDeployResult.java
@@ -24,6 +24,7 @@ public class WireSystemFlagsDeployResult {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class WireFlagDataChange {
         @JsonProperty("flag-id") public String flagId;
+        @JsonProperty("owners") @JsonInclude(JsonInclude.Include.NON_EMPTY) public List<String> owners;
         @JsonProperty("targets") public List<String> targets;
         @JsonProperty("operation") public String operation;
         @JsonProperty("data") public WireFlagData data;
@@ -34,6 +35,7 @@ public class WireSystemFlagsDeployResult {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class WireOperationFailure {
         @JsonProperty("flag-id") public String flagId;
+        @JsonProperty("owners") @JsonInclude(JsonInclude.Include.NON_EMPTY) public List<String> owners;
         @JsonProperty("message") public String message;
         @JsonProperty("targets") public List<String> targets;
         @JsonProperty("operation") public String operation;
@@ -44,6 +46,7 @@ public class WireSystemFlagsDeployResult {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class WireWarning {
         @JsonProperty("flag-id") public String flagId;
+        @JsonProperty("owners") @JsonInclude(JsonInclude.Include.NON_EMPTY) public List<String> owners;
         @JsonProperty("message") public String message;
         @JsonProperty("targets") public List<String> targets;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsDeployer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsDeployer.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.controller.restapi.systemflags;
 
 import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.config.provision.SystemName;
-import java.util.logging.Level;
 import com.yahoo.vespa.athenz.identity.ServiceIdentityProvider;
 import com.yahoo.vespa.flags.FlagId;
 import com.yahoo.vespa.flags.Flags;
@@ -25,6 +24,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -181,9 +181,11 @@ class SystemFlagsDeployer  {
                                                            Map<FlagId, FlagData> currentFlagData,
                                                            List<FlagId> definedFlags,
                                                            List<OperationError> errors) {
+        String errorMessage = "Flag not defined in target zone. If zone/configserver cluster is new, add an empty flag " +
+                "data file for this zone as a temporary measure until the stale flag data files are removed.";
         for (FlagId flagId : wantedFlagData.keySet()) {
             if (!currentFlagData.containsKey(flagId) && !definedFlags.contains(flagId)) {
-                errors.add(OperationError.createFailed("Flag not defined in target zone", target, wantedFlagData.get(flagId)));
+                errors.add(OperationError.createFailed(errorMessage, target, wantedFlagData.get(flagId)));
             }
         }
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsDeployerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsDeployerTest.java
@@ -147,8 +147,10 @@ public class SystemFlagsDeployerTest {
                 .build();
         SystemFlagsDeployer deployer = new SystemFlagsDeployer(flagsClient, SYSTEM, Set.of(prodUsEast3Target));
         SystemFlagsDeployResult result = deployer.deployFlags(archive, true);
+        String expectedErrorMessage = "Flag not defined in target zone. If zone/configserver cluster is new, " +
+                "add an empty flag data file for this zone as a temporary measure until the stale flag data files are removed.";
         assertThat(result.errors())
-                .containsOnly(SystemFlagsDeployResult.OperationError.createFailed("Flag not defined in target zone", prodUsEast3Target, prodUsEast3Data));
+                .containsOnly(SystemFlagsDeployResult.OperationError.createFailed(expectedErrorMessage, prodUsEast3Target, prodUsEast3Data));
     }
 
     @Test


### PR DESCRIPTION
Add flag owners to result/warning/error whenever available.
Make warning/error message from undefined flags more informative.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
