### PR TITLE
Enable reconfigurable-zookeeper-server-for-cluster-controller by default [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -89,7 +89,7 @@ public class ClusterControllerContainer extends Container implements
     }
 
     private void configureZooKeeperServer(boolean runStandaloneZooKeeper, boolean reconfigurable) {
-        if (reconfigurable) {
+        if (reconfigurable && runStandaloneZooKeeper) {
             ContainerModelBuilder.addReconfigurableZooKeeperServerComponents(this);
         } else {
             addComponent("clustercontroller-zookeeper-server",

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -207,7 +207,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag RECONFIGURABLE_ZOOKEEPER_SERVER_FOR_CLUSTER_CONTROLLER = defineFeatureFlag(
-            "reconfigurable-zookeeper-server-for-cluster-controller", false,
+            "reconfigurable-zookeeper-server-for-cluster-controller", true,
             List.of("musum", "mpolden"), "2020-12-16", "2021-03-16",
             "Whether to use reconfigurable zookeeper server for cluster controller",
             "Takes effect on (re)redeployment",


### PR DESCRIPTION
This could probably break some system tests that manipulate or expect some specific behavior of cluster controllers, so I will merge tomorrow morning