### PR TITLE
Upgrade Jetty to 9.4.38.v20210224

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -30,7 +30,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.36.v20210114</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <junit5.version>5.7.0</junit5.version>
         <junit5.platform.version>1.7.0</junit5.platform.version>
         <org.lz4.version>1.7.1</org.lz4.version>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -458,7 +458,7 @@
         <javax.inject.version>1</javax.inject.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.36.v20210114</jetty.version>
+        <jetty.version>9.4.38.v20210224</jetty.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.5</slf4j.version>


### PR DESCRIPTION
Includes fix for CVE-2020-27223

FYI @baldersheim @tokle 