### PR TITLE
Avoid memory accumulation in array attribute vectors

### DIFF
--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -150,13 +150,13 @@ TEST("require that we test with trivial and non-trivial types")
 
 TEST_F("control static sizes", NumberFixture(3)) {
 #ifdef _LIBCPP_VERSION
-    EXPECT_EQUAL(392u, sizeof(f.store));
+    EXPECT_EQUAL(400u, sizeof(f.store));
     EXPECT_EQUAL(296u, sizeof(NumberFixture::ArrayStoreType::DataStoreType));
 #else
-    EXPECT_EQUAL(424u, sizeof(f.store));
+    EXPECT_EQUAL(432u, sizeof(f.store));
     EXPECT_EQUAL(328u, sizeof(NumberFixture::ArrayStoreType::DataStoreType));
 #endif
-    EXPECT_EQUAL(64u, sizeof(NumberFixture::ArrayStoreType::SmallArrayType));
+    EXPECT_EQUAL(72u, sizeof(NumberFixture::ArrayStoreType::SmallArrayType));
     MemoryUsage usage = f.store.getMemoryUsage();
     EXPECT_EQUAL(960u, usage.allocatedBytes());
     EXPECT_EQUAL(32u, usage.usedBytes());

--- a/vespalib/src/tests/datastore/buffer_type/buffer_type_test.cpp
+++ b/vespalib/src/tests/datastore/buffer_type/buffer_type_test.cpp
@@ -30,6 +30,7 @@ struct Setup {
     Setup &minArrays(uint32_t value) { _minArrays = value; return *this; }
     Setup &used(size_t value) { _usedElems = value; return *this; }
     Setup &needed(size_t value) { _neededElems = value; return *this; }
+    Setup &dead(size_t value) { _deadElems = value; return *this; }
     Setup &bufferId(uint32_t value) { _bufferId = value; return *this; }
     Setup &resizing(bool value) { _resizing = value; return *this; }
 };
@@ -48,7 +49,7 @@ struct Fixture {
     }
     ~Fixture() {
         for (auto& setup : setups) {
-            bufferType.onHold(&setup._usedElems);
+            bufferType.onHold(&setup._usedElems, &setup._deadElems);
             bufferType.onFree(setup._usedElems);
         }
     }
@@ -61,7 +62,7 @@ struct Fixture {
         setups.push_back(setup_in);
     }
     void onActive() {
-        bufferType.onActive(curr_setup()._bufferId, &curr_setup()._usedElems, curr_setup()._deadElems, &buffer[0]);
+        bufferType.onActive(curr_setup()._bufferId, &curr_setup()._usedElems, &curr_setup()._deadElems, &buffer[0]);
     }
     size_t arraysToAlloc() {
         return bufferType.calcArraysToAlloc(curr_setup()._bufferId, curr_setup()._neededElems, curr_setup()._resizing);
@@ -129,7 +130,7 @@ TEST("require that arrays to alloc is capped to min arrays")
     TEST_DO(assertArraysToAlloc(17, Setup().used(34 * 4).needed(4).minArrays(16)));
 }
 
-TEST("arrays to alloc considers used elements across all active buffers")
+TEST("arrays to alloc considers used elements across all active buffers (no resizing)")
 {
     Fixture f(Setup().used(6 * 4));
     f.assertArraysToAlloc(6 * 0.5);
@@ -137,6 +138,32 @@ TEST("arrays to alloc considers used elements across all active buffers")
     f.assertArraysToAlloc((6 + 8) * 0.5);
     f.add_setup(Setup().used(10 * 4));
     f.assertArraysToAlloc((6 + 8 + 10) * 0.5);
+}
+
+TEST("arrays to alloc only considers used elements in current buffer when resizing")
+{
+    Fixture f(Setup().used(6 * 4));
+    f.assertArraysToAlloc(6 * 0.5);
+    f.add_setup(Setup().used(8 * 4).resizing(true));
+    f.assertArraysToAlloc(8 + 8 * 0.5);
+}
+
+TEST("arrays to alloc considers (and subtracts) dead elements across all active buffers (no resizing)")
+{
+    Fixture f(Setup().used(6 * 4).dead(2 * 4));
+    f.assertArraysToAlloc((6 - 2) * 0.5);
+    f.add_setup(Setup().used(12 * 4).dead(4 * 4));
+    f.assertArraysToAlloc((6 - 2 + 12 - 4) * 0.5);
+    f.add_setup(Setup().used(20 * 4).dead(6 * 4));
+    f.assertArraysToAlloc((6 - 2 + 12 - 4 + 20 - 6) * 0.5);
+}
+
+TEST("arrays to alloc only considers (and subtracts) dead elements in current buffer when resizing")
+{
+    Fixture f(Setup().used(6 * 4).dead(2 * 4));
+    f.assertArraysToAlloc((6 - 2) * 0.5);
+    f.add_setup(Setup().used(12 * 4).dead(4 * 4).resizing(true));
+    f.assertArraysToAlloc(12 + (12 - 4) * 0.5);
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/tests/datastore/buffer_type/buffer_type_test.cpp
+++ b/vespalib/src/tests/datastore/buffer_type/buffer_type_test.cpp
@@ -14,6 +14,7 @@ struct Setup {
     uint32_t  _minArrays;
     ElemCount _usedElems;
     ElemCount _neededElems;
+    ElemCount _deadElems;
     uint32_t  _bufferId;
     float     _allocGrowFactor;
     bool      _resizing;
@@ -21,6 +22,7 @@ struct Setup {
         : _minArrays(0),
           _usedElems(0),
           _neededElems(0),
+          _deadElems(0),
           _bufferId(1),
           _allocGrowFactor(0.5),
           _resizing(false)
@@ -33,25 +35,40 @@ struct Setup {
 };
 
 struct Fixture {
-    Setup         setup;
+    std::vector<Setup> setups;
     IntBufferType bufferType;
-    ElemCount     deadElems;
     int buffer[ARRAYS_SIZE];
     Fixture(const Setup &setup_)
-        : setup(setup_),
-          bufferType(ARRAYS_SIZE, setup._minArrays, MAX_ARRAYS, NUM_ARRAYS_FOR_NEW_BUFFER, setup._allocGrowFactor),
-          deadElems(0),
+        : setups(),
+          bufferType(ARRAYS_SIZE, setup_._minArrays, MAX_ARRAYS, NUM_ARRAYS_FOR_NEW_BUFFER, setup_._allocGrowFactor),
           buffer()
-    {}
+    {
+        setups.reserve(4);
+        setups.push_back(setup_);
+    }
     ~Fixture() {
-        bufferType.onHold(&setup._usedElems);
-        bufferType.onFree(setup._usedElems);
+        for (auto& setup : setups) {
+            bufferType.onHold(&setup._usedElems);
+            bufferType.onFree(setup._usedElems);
+        }
+    }
+    Setup& curr_setup() {
+        return setups.back();
+    }
+    void add_setup(const Setup& setup_in) {
+        // The buffer type stores pointers to ElemCount (from Setup) and we must ensure these do not move in memory.
+        assert(setups.size() < setups.capacity());
+        setups.push_back(setup_in);
     }
     void onActive() {
-        bufferType.onActive(setup._bufferId, &setup._usedElems, deadElems, &buffer[0]);
+        bufferType.onActive(curr_setup()._bufferId, &curr_setup()._usedElems, curr_setup()._deadElems, &buffer[0]);
     }
     size_t arraysToAlloc() {
-        return bufferType.calcArraysToAlloc(setup._bufferId, setup._neededElems, setup._resizing);
+        return bufferType.calcArraysToAlloc(curr_setup()._bufferId, curr_setup()._neededElems, curr_setup()._resizing);
+    }
+    void assertArraysToAlloc(size_t exp) {
+        onActive();
+        EXPECT_EQUAL(exp, arraysToAlloc());
     }
 };
 
@@ -59,8 +76,7 @@ void
 assertArraysToAlloc(size_t exp, const Setup &setup)
 {
     Fixture f(setup);
-    f.onActive();
-    EXPECT_EQUAL(exp, f.arraysToAlloc());
+    f.assertArraysToAlloc(exp);
 }
 
 TEST("require that complete arrays are allocated")
@@ -111,6 +127,16 @@ TEST("require that arrays to alloc is capped to min arrays")
     TEST_DO(assertArraysToAlloc(16, Setup().used(30 * 4).needed(4).minArrays(16)));
     TEST_DO(assertArraysToAlloc(16, Setup().used(32 * 4).needed(4).minArrays(16)));
     TEST_DO(assertArraysToAlloc(17, Setup().used(34 * 4).needed(4).minArrays(16)));
+}
+
+TEST("arrays to alloc considers used elements across all active buffers")
+{
+    Fixture f(Setup().used(6 * 4));
+    f.assertArraysToAlloc(6 * 0.5);
+    f.add_setup(Setup().used(8 * 4));
+    f.assertArraysToAlloc((6 + 8) * 0.5);
+    f.add_setup(Setup().used(10 * 4));
+    f.assertArraysToAlloc((6 + 8 + 10) * 0.5);
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/vespalib/src/tests/datastore/datastore/datastore_test.cpp
@@ -635,7 +635,7 @@ TEST(DataStoreTest, can_set_memory_allocator)
 }
 
 TEST(DataStoreTest, control_static_sizes) {
-    EXPECT_EQ(64, sizeof(BufferTypeBase));
+    EXPECT_EQ(72, sizeof(BufferTypeBase));
     EXPECT_EQ(32, sizeof(BufferState::FreeList));
     EXPECT_EQ(1, sizeof(BufferState::State));
     EXPECT_EQ(144, sizeof(BufferState));

--- a/vespalib/src/vespa/vespalib/datastore/buffer_type.h
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_type.h
@@ -60,8 +60,8 @@ public:
     virtual size_t elementSize() const = 0;
     virtual void cleanHold(void *buffer, size_t offset, ElemCount numElems, CleanContext cleanCtx) = 0;
     size_t getArraySize() const { return _arraySize; }
-    virtual void onActive(uint32_t bufferId, ElemCount *usedElems, ElemCount &deadElems, void *buffer);
-    void onHold(const ElemCount *usedElems);
+    virtual void onActive(uint32_t bufferId, ElemCount* usedElems, ElemCount* deadElems, void* buffer);
+    void onHold(const ElemCount* usedElems, const ElemCount* deadElems);
     virtual void onFree(ElemCount usedElems);
     virtual const alloc::MemoryAllocator* get_memory_allocator() const;
 
@@ -103,8 +103,8 @@ protected:
 
     public:
         AggregatedBufferCounts();
-        void add_buffer(const ElemCount* used_elems);
-        void remove_buffer(const ElemCount* used_elems);
+        void add_buffer(const ElemCount* used_elems, const ElemCount* dead_elems);
+        void remove_buffer(const ElemCount* used_elems, const ElemCount* dead_elems);
         BufferCounts last_buffer() const;
         BufferCounts all_buffers() const;
         bool empty() const { return _counts.empty(); }

--- a/vespalib/src/vespa/vespalib/datastore/bufferstate.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/bufferstate.cpp
@@ -133,7 +133,7 @@ BufferState::onActive(uint32_t bufferId, uint32_t typeId,
     assert(typeId <= std::numeric_limits<uint16_t>::max());
     _typeId = typeId;
     _arraySize = _typeHandler->getArraySize();
-    typeHandler->onActive(bufferId, &_usedElems, _deadElems, buffer);
+    typeHandler->onActive(bufferId, &_usedElems, &_deadElems, buffer);
 }
 
 
@@ -148,7 +148,7 @@ BufferState::onHold()
     assert(_holdElems <= (_usedElems - _deadElems));
     _deadElems = 0;
     _holdElems = _usedElems; // Put everyting on hold
-    _typeHandler->onHold(&_usedElems);
+    _typeHandler->onHold(&_usedElems, &_deadElems);
     if ( ! isFreeListEmpty()) {
         removeFromFreeListList();
         FreeList().swap(_freeList);


### PR DESCRIPTION
This avoids a problem were allocated memory can accumulate over time in components using an ArrayStore.
If all documents in an array attribute vector changes from one value class to another, all elements in the buffers of the previous value class are marked dead. Those buffers will eventually be compacted. Without this fix the wanted size of the resulting compacted buffer is calculated too high, and we allocate memory we are not going to use. If we move to yet another value class later, the same problem occurs again and more memory is allocated.

@toregge please review
@baldersheim FYI