### PR TITLE
Increase time to keep unused file references

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -1,4 +1,4 @@
-# Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 namespace=cloud.config
 
 # Ports
@@ -51,7 +51,7 @@ ztsUrl string default=""
 
 # Maintainers
 maintainerIntervalMinutes int default=30
-keepUnusedFileReferencesHours int default=2
+keepUnusedFileReferencesMinutes int default=240
 
 # Bootstrapping
 # How long bootstrapping can take before giving up (in seconds)

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
@@ -1,4 +1,4 @@
-// Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.maintenance;
 
 import com.yahoo.vespa.config.server.ApplicationRepository;
@@ -28,7 +28,7 @@ public class FileDistributionMaintainer extends ConfigServerMaintainer {
                                FlagSource flagSource) {
         super(applicationRepository, curator, flagSource, applicationRepository.clock().instant(), interval);
         this.applicationRepository = applicationRepository;
-        this.maxUnusedFileReferenceAge = Duration.ofHours(applicationRepository.configserverConfig().keepUnusedFileReferencesHours());
+        this.maxUnusedFileReferenceAge = Duration.ofMinutes(applicationRepository.configserverConfig().keepUnusedFileReferencesMinutes());
         this.fileReferencesDir = new File(Defaults.getDefaults().underVespaHome(applicationRepository.configserverConfig().fileReferencesDir()));
     }
 


### PR DESCRIPTION
In case of network issues, failed deployments etc. there might be a need
to serve unused file references for some time (think an upgrade that takes
a long time and a node that comes back to life on an old version).

Also change to use minutes as resolution to make it easier to write tests.
