### PR TITLE
Use (override, really) the clusterid dimension in CCs content metrics

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -35,6 +35,7 @@ public class MetricUpdater {
     public void updateClusterStateMetrics(ContentCluster cluster, ClusterState state, ResourceUsageStats resourceUsage) {
         Map<String, String> dimensions = new HashMap<>();
         dimensions.put("cluster", cluster.getName());
+        dimensions.put("clusterid", cluster.getName());
         for (NodeType type : NodeType.getTypes()) {
             dimensions.put("node-type", type.toString().toLowerCase());
             MetricReporter.Context context = createContext(dimensions);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MetricReporterTest.java
@@ -43,14 +43,15 @@ public class MetricReporterTest {
         // Dimensions that are always present
         HasMetricContext.Dimension controllerDim = withDimension("controller-index", "0");
         HasMetricContext.Dimension clusterDim = withDimension("cluster", "foo");
-        return new HasMetricContext.Dimension[] { controllerDim, clusterDim };
+        HasMetricContext.Dimension clusteridDim = withDimension("clusterid", "foo");
+        return new HasMetricContext.Dimension[] { controllerDim, clusterDim, clusteridDim };
     }
 
     private static HasMetricContext.Dimension[] withNodeTypeDimension(String type) {
         // Node type-specific dimension
         HasMetricContext.Dimension nodeType = withDimension("node-type", type);
         var otherDims = withClusterDimension();
-        return new HasMetricContext.Dimension[] { otherDims[0], otherDims[1], nodeType };
+        return new HasMetricContext.Dimension[] { otherDims[0], otherDims[1], otherDims[2], nodeType };
     }
 
     @Test


### PR DESCRIPTION
@hmusum please review and merge.