### PR TITLE
Remove notion of node-specific reliability from C++ distribution code

### DIFF
--- a/persistence/src/vespa/persistence/conformancetest/conformancetest.cpp
+++ b/persistence/src/vespa/persistence/conformancetest/conformancetest.cpp
@@ -90,8 +90,7 @@ createClusterState(const lib::State& nodeState = lib::State::UP)
                         NodeState(NodeType::STORAGE,
                                   nodeState,
                                   "dummy desc",
-                                  1.0,
-                                  1));
+                                  1.0));
     cstate.setClusterState(State::UP);
     dc.redundancy = 1;
     dc.readyCopies = 1;

--- a/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
@@ -87,7 +87,7 @@ createClusterState(const storage::lib::State& nodeState = storage::lib::State::U
     StorDistributionConfigBuilder dc;
 
     cstate.setNodeState(Node(NodeType::STORAGE, 0),
-                        NodeState(NodeType::STORAGE, nodeState, "dummy desc", 1.0, 1));
+                        NodeState(NodeType::STORAGE, nodeState, "dummy desc", 1.0));
     cstate.setClusterState(State::UP);
     dc.redundancy = 1;
     dc.readyCopies = 1;

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -87,14 +87,12 @@ void
 ServiceLayerNode::initializeNodeSpecific()
 {
     // Give node state to mount point initialization, such that we can
-    // get capacity and reliability set in reported node state.
+    // get capacity set in reported node state.
     NodeStateUpdater::Lock::SP lock(_component->getStateUpdater().grabStateChangeLock());
     lib::NodeState ns(*_component->getStateUpdater().getReportedNodeState());
 
     ns.setCapacity(_serverConfig->nodeCapacity);
-    ns.setReliability(_serverConfig->nodeReliability);
-    LOG(debug, "Adjusting reported node state to include capacity and reliability: %s",
-        ns.toString().c_str());
+    LOG(debug, "Adjusting reported node state to include capacity: %s", ns.toString().c_str());
     _component->getStateUpdater().setReportedNodeState(ns);
 }
 
@@ -117,12 +115,6 @@ ServiceLayerNode::handleLiveConfigUpdate(const InitialGuard & initGuard)
                     oldC.nodeCapacity, newC.nodeCapacity);
                 ASSIGN(nodeCapacity);
                 ns.setCapacity(newC.nodeCapacity);
-            }
-            if (DIFFER(nodeReliability)) {
-                LOG(info, "Live config update: Node reliability changed from %u to %u.",
-                    oldC.nodeReliability, newC.nodeReliability);
-                ASSIGN(nodeReliability);
-                ns.setReliability(newC.nodeReliability);
             }
             if (updated) {
                 _serverConfig.reset(new vespa::config::content::core::StorServerConfig(oldC));

--- a/vdslib/src/tests/state/clusterstatetest.cpp
+++ b/vdslib/src/tests/state/clusterstatetest.cpp
@@ -87,8 +87,8 @@ TEST(ClusterStateTest, test_basic_functionality)
     // Test other storage node propertise
     // (Messages is excluded from system states to not make them too long as
     // most nodes have no use for them)
-    VERIFYNEW("storage:9 .3.c:2.3 .4.r:8 .7.m:foo\\x20bar",
-              "storage:9 .3.c:2.3 .4.r:8");
+    VERIFYNEW("storage:9 .3.c:2.3 .7.m:foo\\x20bar",
+              "storage:9 .3.c:2.3");
 
     // Test that messages are kept in verbose mode, even if last index
     {
@@ -159,7 +159,7 @@ TEST(ClusterStateTest, test_detailed)
     ClusterState state(
             "version:314 cluster:i "
             "distributor:8 .1.s:i .3.s:i .3.i:0.5 .5.s:d .7.m:foo\\x20bar "
-            "storage:10 .2.d:16 .2.d.3:d .4.s:d .5.c:1.3 .5.r:4"
+            "storage:10 .2.d:16 .2.d.3:d .4.s:d .5.c:1.3 "
             " .6.m:bar\\tfoo .7.s:m .8.d:10 .8.d.4.c:0.6 .8.d.4.m:small"
     );
     EXPECT_EQ(314u, state.getVersion());
@@ -170,7 +170,7 @@ TEST(ClusterStateTest, test_detailed)
     // Testing distributor node states
     for (uint16_t i = 0; i <= 20; ++i) {
         const NodeState& ns(state.getNodeState(Node(NodeType::DISTRIBUTOR, i)));
-            // Test node states
+        // Test node states
         if (i == 1 || i == 3) {
             EXPECT_EQ(State::INITIALIZING, ns.getState());
         } else if (i == 5 || i >= 8) {
@@ -178,7 +178,7 @@ TEST(ClusterStateTest, test_detailed)
         } else {
             EXPECT_EQ(State::UP, ns.getState());
         }
-            // Test initialize progress
+        // Test initialize progress
         if (i == 1) {
             EXPECT_EQ(vespalib::Double(0.0), ns.getInitProgress());
         } else if (i == 3) {
@@ -186,7 +186,7 @@ TEST(ClusterStateTest, test_detailed)
         } else {
             EXPECT_EQ(vespalib::Double(0.0), ns.getInitProgress());
         }
-            // Test message
+        // Test message
         if (i == 7) {
             EXPECT_EQ(string("foo bar"), ns.getDescription());
         } else {
@@ -197,7 +197,7 @@ TEST(ClusterStateTest, test_detailed)
     // Testing storage node states
     for (uint16_t i = 0; i <= 20; ++i) {
         const NodeState& ns(state.getNodeState(Node(NodeType::STORAGE, i)));
-            // Test node states
+        // Test node states
         if (i == 4 || i >= 10) {
             EXPECT_EQ(State::DOWN, ns.getState());
         } else if (i == 7) {
@@ -211,13 +211,7 @@ TEST(ClusterStateTest, test_detailed)
         } else {
             EXPECT_EQ(string(""), ns.getDescription());
         }
-            // Test reliability
-        if (i == 5) {
-            EXPECT_EQ(uint16_t(4), ns.getReliability());
-        } else {
-            EXPECT_EQ(uint16_t(1), ns.getReliability());
-        }
-            // Test capacity
+        // Test capacity
         if (i == 5) {
             EXPECT_EQ(vespalib::Double(1.3), ns.getCapacity());
         } else {

--- a/vdslib/src/tests/state/nodestatetest.cpp
+++ b/vdslib/src/tests/state/nodestatetest.cpp
@@ -11,13 +11,11 @@ TEST(NodeStateTest, test_parsing)
         NodeState ns = NodeState("s:u");
         EXPECT_EQ(std::string("s:u"), ns.toString());
         EXPECT_EQ(vespalib::Double(1.0), ns.getCapacity());
-        EXPECT_EQ(uint16_t(1), ns.getReliability());
     }
     {
         NodeState ns = NodeState("s:m");
         EXPECT_EQ(std::string("s:m"), ns.toString());
         EXPECT_EQ(vespalib::Double(1.0), ns.getCapacity());
-        EXPECT_EQ(uint16_t(1), ns.getReliability());
     }
     {
         NodeState ns = NodeState("t:4");
@@ -25,31 +23,27 @@ TEST(NodeStateTest, test_parsing)
         EXPECT_EQ(uint64_t(4), ns.getStartTimestamp());
     }
     {
-        NodeState ns = NodeState("s:u c:2.4 r:3 b:12");
-        EXPECT_EQ(std::string("s:u c:2.4 r:3 b:12"), ns.toString());
+        NodeState ns = NodeState("s:u c:2.4 b:12");
+        EXPECT_EQ(std::string("s:u c:2.4 b:12"), ns.toString());
         EXPECT_EQ(vespalib::Double(2.4), ns.getCapacity());
-        EXPECT_EQ(uint16_t(3), ns.getReliability());
         EXPECT_EQ(12, (int)ns.getMinUsedBits());
 
         EXPECT_NE(NodeState("s:u b:12"), NodeState("s:u b:13"));
     }
     {
-        NodeState ns = NodeState("c:2.4\ns:u\nr:5");
-        EXPECT_EQ(std::string("s:u c:2.4 r:5"), ns.toString());
-        EXPECT_EQ(vespalib::Double(2.4), ns.getCapacity());
-        EXPECT_EQ(uint16_t(5), ns.getReliability());
-    }
-    {
-        NodeState ns = NodeState("c:2.4 r:1");
+        NodeState ns = NodeState("c:2.4\ns:u");
         EXPECT_EQ(std::string("s:u c:2.4"), ns.toString());
         EXPECT_EQ(vespalib::Double(2.4), ns.getCapacity());
-        EXPECT_EQ(uint16_t(1), ns.getReliability());
+    }
+    {
+        NodeState ns = NodeState("c:2.4");
+        EXPECT_EQ(std::string("s:u c:2.4"), ns.toString());
+        EXPECT_EQ(vespalib::Double(2.4), ns.getCapacity());
     }
     {
         NodeState ns = NodeState("c:2.4 k:2.6");
         EXPECT_EQ(std::string("s:u c:2.4"), ns.toString());
         EXPECT_EQ(vespalib::Double(2.4), ns.getCapacity());
-        EXPECT_EQ(uint16_t(1), ns.getReliability());
     }
 }
 

--- a/vdslib/src/vespa/vdslib/state/nodestate.h
+++ b/vdslib/src/vespa/vdslib/state/nodestate.h
@@ -23,7 +23,6 @@ class NodeState : public document::Printable
     const State* _state;
     vespalib::string _description;
     vespalib::Double _capacity;
-    uint16_t _reliability;
     vespalib::Double _initProgress;
     uint32_t _minUsedBits;
     uint64_t _startTimestamp;
@@ -42,7 +41,7 @@ public:
     NodeState & operator = (NodeState &&) noexcept;
     NodeState(const NodeType& nodeType, const State&,
               vespalib::stringref description = "",
-              double capacity = 1.0, uint16_t reliability = 1);
+              double capacity = 1.0);
     /** Set type if you want to verify that content fit with the given type. */
     NodeState(vespalib::stringref serialized, const NodeType* nodeType = 0);
     ~NodeState();
@@ -58,7 +57,6 @@ public:
     const State& getState() const { return *_state; }
     vespalib::Double getCapacity() const { return _capacity; }
     uint32_t getMinUsedBits() const { return _minUsedBits; }
-    uint16_t getReliability() const { return _reliability; }
     vespalib::Double getInitProgress() const { return _initProgress; }
     const vespalib::string& getDescription() const { return _description; }
     uint64_t getStartTimestamp() const { return _startTimestamp; }
@@ -66,7 +64,6 @@ public:
     void setState(const State& state);
     void setCapacity(vespalib::Double capacity);
     void setMinUsedBits(uint32_t usedBits);
-    void setReliability(uint16_t reliability);
     void setInitProgress(vespalib::Double initProgress);
     void setStartTimestamp(uint64_t startTimestamp);
     void setDescription(vespalib::stringref desc) { _description = desc; }


### PR DESCRIPTION
@baldersheim @toregge please review

I have never seen this in use anywhere, and can find no code that ever
sets it (be it in the server config or in the cluster state itself).

Bonus is that node candidate trimming can be vastly simplified with this stuff removed.