### PR TITLE
Remove notion of node-specific reliability from Java distribution code

### DIFF
--- a/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
@@ -77,7 +77,6 @@ public class NodeState implements Cloneable {
         NodeState ns = (NodeState) o;
         if (state != ns.state
             || Math.abs(capacity - ns.capacity)         > 0.0000000001
-            || Math.abs(reliability - ns.reliability)   > 0.0000000001
             || Math.abs(initProgress - ns.initProgress) > 0.0000000001
             || startTimestamp != ns.startTimestamp
             || minUsedBits != ns.minUsedBits)
@@ -105,7 +104,7 @@ public class NodeState implements Cloneable {
         return true;
     }
     public int hashCode() {
-        return state.hashCode() ^ diskStates.hashCode() ^ Double.valueOf(capacity).hashCode() ^ Double.valueOf(reliability).hashCode();
+        return state.hashCode() ^ diskStates.hashCode() ^ Double.valueOf(capacity).hashCode();
     }
 
     /**
@@ -127,7 +126,6 @@ public class NodeState implements Cloneable {
     private boolean similarToImpl(final NodeState other, boolean considerInitProgress) {
         if (state != other.state) return false;
         if (Math.abs(capacity - other.capacity) > 0.0000000001) return false;
-        if (Math.abs(reliability - other.reliability) > 0.0000000001) return false;
         if (startTimestamp != other.startTimestamp) return false;
 
         // Init progress on different sides of the init progress limit boundary is not similar.
@@ -168,9 +166,6 @@ public class NodeState implements Cloneable {
         if (Math.abs(capacity - other.capacity) > 0.000000001) {
             diff.add(new Diff.Entry("capacity", capacity, other.capacity));
         }
-        if (Math.abs(reliability - other.reliability) > 0.000000001) {
-            diff.add(new Diff.Entry("reliability", reliability, other.reliability));
-        }
         if (minUsedBits != other.minUsedBits) {
             diff.add(new Diff.Entry("minUsedBits", minUsedBits, other.minUsedBits));
         }
@@ -206,7 +201,6 @@ public class NodeState implements Cloneable {
     /** Capacity is set by deserializing a node state. This seems odd, as it is config */
     public NodeState setCapacity(double c) { this.capacity = c; return this; }
 
-    public NodeState setReliability(int r) { this.reliability = r; return this; }
     public NodeState setInitProgress(double p) { this.initProgress = p; return this; }
     public NodeState setDescription(String desc) { this.description = desc; return this; }
     public NodeState setMinUsedBits(int u) { this.minUsedBits = u; return this; }
@@ -214,7 +208,6 @@ public class NodeState implements Cloneable {
     public NodeState setStartTimestamp(long ts) { this.startTimestamp = ts; return this; }
 
     public double getCapacity() { return this.capacity; }
-    public int getReliability() { return this.reliability; }
     public double getInitProgress() { return this.initProgress; }
     public boolean hasDescription() { return (description.length() > 0); }
     public String getDescription() { return description; }
@@ -237,9 +230,6 @@ public class NodeState implements Cloneable {
         }
         if (Math.abs(capacity - 1.0) > 0.000000001) {
             sb.append(compact ? ", c " : ", capacity ").append(compact ? String.format(Locale.ENGLISH, "%.3g", capacity) : capacity);
-        }
-        if (Math.abs(reliability - 1.0) > 0.000000001) {
-            sb.append(compact ? ", r " : ", reliability ").append(reliability);
         }
         if (state.equals(State.INITIALIZING)) {
             sb.append(compact ? ", i " : ", init progress ").append(compact ? String.format(Locale.ENGLISH, "%.3g", initProgress) : initProgress);
@@ -323,10 +313,6 @@ public class NodeState implements Cloneable {
         if (Math.abs(capacity - 1.0) > 0.000000001) {
             if (empty) { empty = false; } else { sb.append(' '); }
             sb.append(prefix).append("c:").append(capacity);
-        }
-        if (Math.abs(reliability - 1.0) > 0.000000001) {
-            if (empty) { empty = false; } else { sb.append(' '); }
-            sb.append(prefix).append("r:").append(reliability);
         }
         if (state == State.INITIALIZING) {
             sb.append(' ');
@@ -416,15 +402,6 @@ public class NodeState implements Cloneable {
                     throw new ParseException("Illegal capacity '" + value + "'. Capacity must be a positive floating point number", 0);
                 }
                 continue;
-            case 'r':
-                if (key.length() > 1) break;
-                if (type != null && !type.equals(NodeType.STORAGE)) break;
-                try{
-                    newState.setReliability(Integer.valueOf(value));
-                } catch (Exception e) {
-                    throw new ParseException("Illegal reliability '" + value + "'. Reliability must be a positive integer number", 0);
-                }
-                continue;
             case 'i':
                 if (key.length() > 1) break;
                 try{
@@ -499,9 +476,6 @@ public class NodeState implements Cloneable {
         }
         if (type.equals(NodeType.DISTRIBUTOR) && Math.abs(capacity - 1.0) > 0.000000001) {
             throw new IllegalArgumentException("Capacity should not be set for a distributor node");
-        }
-        if (type.equals(NodeType.DISTRIBUTOR) && Math.abs(reliability - 1.0) > 0.000000001) {
-            throw new IllegalArgumentException("Reliability should not be set for a distributor node");
         }
         if (type.equals(NodeType.DISTRIBUTOR) && !diskStates.isEmpty()) {
             throw new IllegalArgumentException("Disk states should not be set for a distributor node");

--- a/vdslib/src/test/java/com/yahoo/vdslib/state/ClusterStateTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/state/ClusterStateTestCase.java
@@ -34,7 +34,7 @@ public class ClusterStateTestCase{
     public void testClone() throws ParseException {
         ClusterState state = new ClusterState("");
         state.setNodeState(new Node(NodeType.DISTRIBUTOR, 1), new NodeState(NodeType.DISTRIBUTOR, State.UP).setDescription("available"));
-        state.setNodeState(new Node(NodeType.STORAGE, 0), new NodeState(NodeType.STORAGE, State.UP).setCapacity(1.2).setReliability(2));
+        state.setNodeState(new Node(NodeType.STORAGE, 0), new NodeState(NodeType.STORAGE, State.UP).setCapacity(1.2));
         state.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.UP).setDiskCount(2).setDiskState(1, new DiskState(State.DOWN)));
         ClusterState other = state.clone();
         assertEquals(state.toString(true), other.toString(true));

--- a/vdslib/src/test/java/com/yahoo/vdslib/state/NodeStateTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/state/NodeStateTestCase.java
@@ -42,20 +42,6 @@ public class NodeStateTestCase {
     }
 
     @Test
-    public void testTrivialitiesToIncreaseCoverage() throws ParseException {
-        NodeState ns = new NodeState(NodeType.STORAGE, State.UP);
-        assertEquals(1, ns.getReliability());
-        assertEquals(false, ns.isAnyDiskDown());
-
-        assertEquals(ns.setReliability(2).serialize(), NodeState.deserialize(NodeType.STORAGE, "r:2").serialize());
-        assertEquals(ns.setDiskCount(1).serialize(), NodeState.deserialize(NodeType.STORAGE, "r:2 d:1").serialize());
-        assertEquals(ns.setReliability(1).serialize(), NodeState.deserialize(NodeType.STORAGE, "d:1").serialize());
-
-        assertEquals(ns.setDiskState(0, new DiskState(State.DOWN, "", 1)), NodeState.deserialize(NodeType.STORAGE, "s:u d:1 d.0.s:d"));
-        assertEquals(ns, NodeState.deserialize(NodeType.STORAGE, "s:u d:1 d.0:d"));
-    }
-
-    @Test
     public void testDiskState() throws ParseException {
         NodeState ns = NodeState.deserialize(NodeType.STORAGE, "s:m");
         assertEquals(new DiskState(State.UP, "", 1), ns.getDiskState(0));
@@ -110,10 +96,6 @@ public class NodeStateTestCase {
         } catch (Exception e) {}
         try {
             NodeState.deserialize(NodeType.STORAGE, "s:m c:badvalue");
-            assertTrue("Should fail", false);
-        } catch (Exception e) {}
-        try {
-            NodeState.deserialize(NodeType.STORAGE, "s:m r:badvalue");
             assertTrue("Should fail", false);
         } catch (Exception e) {}
         try {
@@ -222,12 +204,12 @@ public class NodeStateTestCase {
         String expected = "Maintenance => Up";
         assertEquals(expected, ns.getTextualDifference(new NodeState(NodeType.STORAGE, State.UP)).substring(0, expected.length()));
 
-        NodeState ns1 = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2).setReliability(2).setDiskCount(4)
+        NodeState ns1 = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2).setDiskCount(4)
                 .setMinUsedBits(12).setStartTimestamp(5).setDiskState(1, new DiskState(State.DOWN, "bad disk", 1))
                 .setDiskState(3, new DiskState(State.UP, "", 2));
         ns1.toString();
         ns1.toString(true);
-        expected = "Maintenance => Up, capacity: 1.2 => 1.0, reliability: 2 => 1, minUsedBits: 12 => 16, startTimestamp: 5 => 0, disks: 4 => 0, description: Foo bar => ";
+        expected = "Maintenance => Up, capacity: 1.2 => 1.0, minUsedBits: 12 => 16, startTimestamp: 5 => 0, disks: 4 => 0, description: Foo bar => ";
         assertEquals(expected, ns1.getTextualDifference(new NodeState(NodeType.STORAGE, State.UP)).substring(0, expected.length()));
     }
 
@@ -239,10 +221,6 @@ public class NodeStateTestCase {
         } catch (Exception e) {}
         try{
             new NodeState(NodeType.DISTRIBUTOR, State.UP).setCapacity(3).verifyValidInSystemState(NodeType.DISTRIBUTOR);
-            assertTrue("Should not be valid", false);
-        } catch (Exception e) {}
-        try{
-            new NodeState(NodeType.DISTRIBUTOR, State.UP).setReliability(3).verifyValidInSystemState(NodeType.DISTRIBUTOR);
             assertTrue("Should not be valid", false);
         } catch (Exception e) {}
         try{


### PR DESCRIPTION
@baldersheim please review. Follow-up of #16741.

Not used, and wasn't algorithmically in sync with the C++ code anyway.
Also add guard to avoid emitting invalid node indices for storage nodes
if the number of configured nodes is lower than the replication factor.
Looks like this particular code path is only called by cross-language
conformance tests, so hasn't been a problem in practice.