### PR TITLE
Revert "Add query.rate to the autoscaling metrics"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/AutoscalingMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/AutoscalingMetrics.java
@@ -20,8 +20,7 @@ public class AutoscalingMetrics {
                                      "mem.util",
                                      "disk.util",
                                      "application_generation",
-                                     "in_service",
-                                     "queries.rate"));
+                                     "in_service"));
     }
 
     private static Set<Metric> metrics(String ... metrics) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricSnapshot.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricSnapshot.java
@@ -18,11 +18,9 @@ public class MetricSnapshot implements Comparable<MetricSnapshot> {
     private final long generation;
     private final boolean inService;
     private final boolean stable;
-    private final double queryRate;
 
-    public MetricSnapshot(Instant at, double cpu, double memory, double disk,
-                          long generation, boolean inService, boolean stable,
-                          double queryRate) {
+    public MetricSnapshot(Instant at, double cpu, double memory, double disk, long generation,
+                          boolean inService, boolean stable) {
         this.at = at;
         this.cpu = cpu;
         this.memory = memory;
@@ -30,16 +28,12 @@ public class MetricSnapshot implements Comparable<MetricSnapshot> {
         this.generation = generation;
         this.inService = inService;
         this.stable = stable;
-        this.queryRate = queryRate;
     }
 
     public Instant at() { return at; }
     public double cpu() { return cpu; }
     public double memory() { return memory; }
     public double disk() { return disk; }
-
-    /** Queries per second */
-    public double queryRate() { return queryRate; }
 
     /** The configuration generation at the time of this measurement, or -1 if not known */
     public long generation() { return generation; }
@@ -59,8 +53,7 @@ public class MetricSnapshot implements Comparable<MetricSnapshot> {
                                       " disk: " + disk +
                                       " generation: " + generation +
                                       " inService: " + inService +
-                                      " stable: " + stable +
-                                      " queryRate: " + queryRate;
+                                      " stable: " + stable;
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsResponse.java
@@ -65,8 +65,7 @@ public class MetricsResponse {
                                                                 Metric.disk.from(values),
                                                                 (long)Metric.generation.from(values),
                                                                 Metric.inService.from(values) > 0,
-                                                                clusterIsStable(node.get(), applicationNodes, nodeRepository),
-                                                                Metric.queryRate.from(values))));
+                                                                 clusterIsStable(node.get(), applicationNodes, nodeRepository))));
     }
 
     private boolean clusterIsStable(Node node, NodeList applicationNodes, NodeRepository nodeRepository) {
@@ -116,11 +115,6 @@ public class MetricsResponse {
             public String metricResponseName() { return "in_service"; }
             double convertValue(double metricValue) { return (float)metricValue; } // Really a boolean
             double defaultValue() { return 1.0; }
-        },
-        queryRate { // queries per second
-            public String metricResponseName() { return "queries.rate"; }
-            double convertValue(double metricValue) { return (float)metricValue; }
-            double defaultValue() { return 0.0; }
         };
 
         /** The name of this metric as emitted from its source */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
@@ -146,8 +146,7 @@ class AutoscalingTester {
                                                                               disk,
                                                                               0,
                                                                               true,
-                                                                              true,
-                                                                              0.0))));
+                                                                              true))));
             }
         }
     }
@@ -178,8 +177,7 @@ class AutoscalingTester {
                                                                               disk,
                                                                               0,
                                                                               true,
-                                                                              true,
-                                                                              0.0))));
+                                                                              true))));
             }
         }
     }
@@ -200,8 +198,7 @@ class AutoscalingTester {
                                                                               disk,
                                                                               generation,
                                                                               inService,
-                                                                              stable,
-                                                                              0.0))));
+                                                                              stable))));
             }
         }
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsDbTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/NodeMetricsDbTest.java
@@ -40,14 +40,7 @@ public class NodeMetricsDbTest {
         MetricsDb db = MetricsDb.createTestInstance(tester.nodeRepository());
         Collection<Pair<String, MetricSnapshot>> values = new ArrayList<>();
         for (int i = 0; i < 40; i++) {
-            values.add(new Pair<>(node0, new MetricSnapshot(clock.instant(),
-                                                            0.9f,
-                                                            0.6f,
-                                                            0.6f,
-                                                            0,
-                                                            true,
-                                                            false,
-                                                            0.0)));
+            values.add(new Pair<>(node0, new MetricSnapshot(clock.instant(), 0.9f, 0.6f, 0.6f, 0, true, false)));
             clock.advance(Duration.ofMinutes(120));
         }
         db.add(values);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/QuestMetricsDbTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/QuestMetricsDbTest.java
@@ -54,7 +54,6 @@ public class QuestMetricsDbTest {
         assertEquals(0.2, snapshot.memory(), delta);
         assertEquals(0.4, snapshot.disk(), delta);
         assertEquals(1, snapshot.generation(), delta);
-        assertEquals(30, snapshot.queryRate(), delta);
 
         // Read all from 2 hosts
         List<NodeTimeseries> nodeTimeSeries2 = db.getNodeTimeseries(Duration.between(startTime, clock.instant()),
@@ -182,8 +181,7 @@ public class QuestMetricsDbTest {
                                                                    i * 0.4,
                                                                    i % 100,
                                                                    true,
-                                                                   true,
-                                                                   30.0)));
+                                                                   true)));
             clock.advance(sampleRate);
         }
         return timeseries;
@@ -199,8 +197,7 @@ public class QuestMetricsDbTest {
                                                                    i * 0.4,
                                                                    i % 100,
                                                                    true,
-                                                                   false,
-                                                                   0.0)));
+                                                                   false)));
         }
         return timeseries;
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTester.java
@@ -81,8 +81,7 @@ public class AutoscalingMaintainerTester {
                                                                                      disk,
                                                                                      generation,
                                                                                      true,
-                                                                                     true,
-                                                                                     0.0))));
+                                                                                     true))));
         }
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainerTest.java
@@ -131,8 +131,7 @@ public class ScalingSuggestionsMaintainerTest {
                                                                               disk,
                                                                               generation,
                                                                               true,
-                                                                              true,
-                                                                              0.0))));
+                                                                              true))));
         }
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#16745

For some awkward reason this seems to have made the queries.rate gone missing in a system test here:
https://git.vzbuilders.com/vespa/systemtests/blob/2619415f7e7a41abd344731791d7e7ae3bd8fb2f/tests-internal/search/metricsproxyyamas/metricsend2end.rb#L84