### PR TITLE
Revert "Set allowedlidbloat to 1 instead of 1000"

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -363,7 +363,7 @@ lidspacecompaction.interval double default=10.0
 ##
 ## When considering compaction the lid bloat is calculated as (docIdLimit - numDocs).
 ## The lid bloat must be >= allowedlidbloat before considering compaction.
-lidspacecompaction.allowedlidbloat int default=1
+lidspacecompaction.allowedlidbloat int default=1000
 
 ## The allowed lid bloat factor (relative) before considering lid space compaction.
 ##


### PR DESCRIPTION
Reverts vespa-engine/vespa#16749
Broke LidSpaceCompactionTest::test_lid_usage_metrics test.