### PR TITLE
Reduce to 7 vcpus to allow for better utilization on Screwdriver inst…

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -9,7 +9,7 @@ jobs:
     requires: [~pr, ~commit]
     image: vespaengine/vespa-build-centos7
     annotations:
-      screwdriver.cd/cpu: 8
+      screwdriver.cd/cpu: 7
       screwdriver.cd/ram: 16
       screwdriver.cd/disk: HIGH
       screwdriver.cd/timeout: 600


### PR DESCRIPTION
…ances.

We have been asked to reduce to 7 vcpus and will monitor our PR build times to see the effect of this.
