### PR TITLE
Revert "Respect exclusive request when allocating by type"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -436,9 +436,9 @@ class NodeAllocation {
     }
 
     private static Integer parseIndex(String hostname) {
-        // Node index is the first number appearing in the hostname
+        // Node index is the first number appearing in the hostname, before the first dot
         try {
-            return Integer.parseInt(hostname.replaceFirst("^\\D+(\\d+).*", "$1"));
+            return Integer.parseInt(hostname.replaceFirst("^\\D+(\\d+)\\..*", "$1"));
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Could not parse index from hostname '" + hostname + "'", e);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -19,6 +19,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.applications.Application;
 import com.yahoo.vespa.hosted.provision.autoscale.AllocatableClusterResources;
@@ -104,7 +105,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
         else {
             groups = 1; // type request with multiple groups is not supported
             resources = requested.minResources().nodeResources();
-            nodeSpec = NodeSpec.from(requested.type(), cluster.isExclusive());
+            nodeSpec = NodeSpec.from(requested.type());
         }
         return asSortedHosts(preparer.prepare(application, cluster, nodeSpec, groups), resources);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
@@ -77,8 +77,8 @@ public interface NodeSpec {
         return new CountNodeSpec(nodeCount, resources, exclusive, canFail);
     }
 
-    static NodeSpec from(NodeType type, boolean exclusive) {
-        return new TypeNodeSpec(type, exclusive);
+    static NodeSpec from(NodeType type) {
+        return new TypeNodeSpec(type);
     }
 
     /** A node spec specifying a node count and a flavor */
@@ -174,18 +174,16 @@ public interface NodeSpec {
         private static final Map<NodeType, Integer> WANTED_NODE_COUNT = Map.of(NodeType.config, 3);
 
         private final NodeType type;
-        private final boolean exclusive;
 
-        public TypeNodeSpec(NodeType type, boolean exclusive) {
+        public TypeNodeSpec(NodeType type) {
             this.type = type;
-            this.exclusive = exclusive;
         }
 
         @Override
         public NodeType type() { return type; }
 
         @Override
-        public boolean isExclusive() { return exclusive; }
+        public boolean isExclusive() { return false; }
 
         @Override
         public boolean isCompatible(Flavor flavor, NodeFlavors flavors) { return true; }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -58,10 +58,6 @@ public class MockHostProvisioner implements HostProvisioner {
         Flavor hostFlavor = this.hostFlavor.orElseGet(() -> flavors.stream().filter(f -> compatible(f, resources))
                                                                    .findFirst()
                                                                    .orElseThrow(() -> new OutOfCapacityException("No host flavor matches " + resources)));
-        Optional<ApplicationId> exclusiveTo = Optional.empty();
-        if (sharing == HostSharing.exclusive) {
-            exclusiveTo = Optional.of(applicationId);
-        }
         List<ProvisionedHost> hosts = new ArrayList<>();
         for (int index : provisionIndices) {
             String hostHostname = hostType == NodeType.host ? "hostname" + index : hostType.name() + index;
@@ -69,7 +65,7 @@ public class MockHostProvisioner implements HostProvisioner {
                                           hostHostname,
                                           hostFlavor,
                                           hostType,
-                                          exclusiveTo,
+                                          Optional.empty(),
                                           createAddressesForHost(hostType, hostFlavor, index),
                                           resources,
                                           osVersion));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -230,7 +230,6 @@ public class ProvisioningTester {
         ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from(nodeType.toString()))
                                          .vespaVersion(version)
                                          .stateful(nodeType == NodeType.config || nodeType == NodeType.controller)
-                                         .exclusive(nodeType != NodeType.tenant)
                                          .build();
         Capacity capacity = Capacity.fromRequiredNodeType(nodeType);
         List<HostSpec> hostSpecs = prepare(application, cluster, capacity);


### PR DESCRIPTION
Reverts vespa-engine/vespa#16765

Existing hosts do not have `exclusiveTo` set...