### PR TITLE
Limit host sharing to host node type

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeType.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeType.java
@@ -49,6 +49,11 @@ public enum NodeType {
         return !childNodeTypes.isEmpty();
     }
 
+    /** Returns whether this supports host sharing */
+    public boolean isSharable() {
+        return this == NodeType.host;
+    }
+
     public String description() {
         return description;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -105,8 +105,8 @@ public final class Node implements Nodelike {
         if (type != NodeType.host && reservedTo.isPresent())
             throw new IllegalArgumentException("Only tenant hosts can be reserved to a tenant");
 
-        if (!type.isHost() && exclusiveTo.isPresent())
-            throw new IllegalArgumentException("Only hosts can be exclusive to an application");
+        if (type != NodeType.host && exclusiveTo.isPresent())
+            throw new IllegalArgumentException("Only tenant hosts can be exclusive to an application");
     }
 
     /** Returns the IP config of this node */

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/ConfigServerLikeApplication.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/ConfigServerLikeApplication.java
@@ -21,7 +21,6 @@ public abstract class ConfigServerLikeApplication extends InfraApplication {
         return ClusterSpec.request(getClusterSpecType(), getClusterSpecId())
                           .vespaVersion(version)
                           .stateful(true)
-                          .exclusive(true)
                           .build();
     }
 

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/InfraApplication.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/InfraApplication.java
@@ -75,7 +75,7 @@ public abstract class InfraApplication implements InfraApplicationApi {
 
     @Override
     public ClusterSpec getClusterSpecWithVersion(Version version) {
-        return ClusterSpec.request(clusterSpecType, clusterSpecId).vespaVersion(version).exclusive(true).build();
+        return ClusterSpec.request(clusterSpecType, clusterSpecId).vespaVersion(version).build();
     }
 
     public ClusterSpec.Type getClusterSpecType() {


### PR DESCRIPTION
I think this is the right approach. Exclusive/sharing requirement only makes
sense for tenant hosts. For other node types we always allocate by type, which
is just another kind of exclusiveness, and we don't need both.

Merge with internal PR.

@hakonhall