### PR TITLE
Bratseth/delay initial maintenance

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -81,7 +81,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
 
     private ContainerModelEvaluation modelEvaluation;
 
-    private Optional<String> tlsClientAuthority;
+    private final Optional<String> tlsClientAuthority;
 
     private MbusParams mbusParams;
     private boolean messageBusEnabled = true;

--- a/simplemetrics/src/main/java/com/yahoo/metrics/simple/MetricAggregator.java
+++ b/simplemetrics/src/main/java/com/yahoo/metrics/simple/MetricAggregator.java
@@ -10,7 +10,7 @@ import com.yahoo.metrics.ManagerConfig;
 /**
  * Worker thread to collect the data stored in worker threads and build
  * snapshots for external consumption. Using the correct executor gives the
- * necessary guarantuees for this being invoked from only a single thread.
+ * necessary guarantees for this being invoked from only a single thread.
  *
  * @author Steinar Knutsen
  */
@@ -26,9 +26,8 @@ class MetricAggregator implements Runnable {
     MetricAggregator(ThreadLocalDirectory<Bucket, Sample> metricsCollection, AtomicReference<Bucket> currentSnapshot,
             ManagerConfig settings) {
         if (settings.reportPeriodSeconds() < 10) {
-            throw new IllegalArgumentException(
-                    "Do not use this metrics implementation"
-                    + " if report periods of less than 10 seconds is desired.");
+            throw new IllegalArgumentException("Do not use this metrics implementation" +
+                                               " if report periods of less than 10 seconds is desired.");
         }
         buffer = new Bucket[settings.reportPeriodSeconds()];
         dimensions = new DimensionCache(settings.pointsToKeepPerMetric());

--- a/simplemetrics/src/main/java/com/yahoo/metrics/simple/MetricManager.java
+++ b/simplemetrics/src/main/java/com/yahoo/metrics/simple/MetricManager.java
@@ -33,8 +33,8 @@ public class MetricManager extends AbstractComponent implements Provider<MetricR
 
     private MetricManager(ManagerConfig settings, Updater<Bucket, Sample> updater) {
         log.log(Level.CONFIG, "setting up simple metrics gathering." +
-                    " reportPeriodSeconds=" + settings.reportPeriodSeconds() +
-                    ", pointsToKeepPerMetric=" + settings.pointsToKeepPerMetric());
+                              " reportPeriodSeconds=" + settings.reportPeriodSeconds() +
+                              ", pointsToKeepPerMetric=" + settings.pointsToKeepPerMetric());
         metricsCollection = new ThreadLocalDirectory<>(updater);
         final AtomicReference<Bucket> currentSnapshot = new AtomicReference<>(null);
         executor = new ScheduledThreadPoolExecutor(1);

--- a/vespajlib/src/main/java/com/yahoo/concurrent/maintenance/Maintainer.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/maintenance/Maintainer.java
@@ -43,7 +43,8 @@ public abstract class Maintainer implements Runnable {
         this.ignoreCollision = ignoreCollision;
         Objects.requireNonNull(startedAt);
         Objects.requireNonNull(clusterHostnames);
-        Duration initialDelay = staggeredDelay(interval, startedAt, HostName.getLocalhost(), clusterHostnames);
+        Duration initialDelay = staggeredDelay(interval, startedAt, HostName.getLocalhost(), clusterHostnames)
+                                .plus(Duration.ofSeconds(30));
         service = new ScheduledThreadPoolExecutor(1, r -> new Thread(r, name() + "-worker"));
         service.scheduleAtFixedRate(this, initialDelay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
         jobControl.started(name(), this);

--- a/vespajlib/src/main/java/com/yahoo/concurrent/maintenance/Maintainer.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/maintenance/Maintainer.java
@@ -44,7 +44,7 @@ public abstract class Maintainer implements Runnable {
         Objects.requireNonNull(startedAt);
         Objects.requireNonNull(clusterHostnames);
         Duration initialDelay = staggeredDelay(interval, startedAt, HostName.getLocalhost(), clusterHostnames)
-                                .plus(Duration.ofSeconds(30));
+                                .plus(Duration.ofSeconds(30)); // Let the system  stabilize before maintenance
         service = new ScheduledThreadPoolExecutor(1, r -> new Thread(r, name() + "-worker"));
         service.scheduleAtFixedRate(this, initialDelay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
         jobControl.started(name(), this);


### PR DESCRIPTION
Delay initial maintenance by 30 seconds.
If we're starting an entire system it's not helpful to start maintenance while things are still coming up.
