### PR TITLE
The default implementation of SearchContext::onFind was danegrous and…

### DIFF
--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -8,7 +8,7 @@
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/attributevector.h>
 #include <vespa/searchlib/attribute/attribute_read_guard.h>
-#include <vespa/searchlib/attribute/extendableattributes.h>
+#include <vespa/searchlib/attribute/singlestringattribute.h>
 #include <vespa/searchlib/attribute/iattributemanager.h>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/attribute/singlenumericattribute.h>
@@ -35,7 +35,6 @@ using search::AttributeGuard;
 using search::AttributeVector;
 using search::IAttributeManager;
 using search::IntegerAttribute;
-using search::SingleStringExtAttribute;
 using search::attribute::IAttributeContext;
 using search::fef::MatchData;
 using search::fef::MatchDataLayout;
@@ -266,9 +265,11 @@ bool search(const string &term, IAttributeManager &attribute_manager,
 }
 
 template <typename T> struct AttributeVectorTypeFinder {
-    //typedef search::SingleValueStringAttribute Type;
-    typedef SingleStringExtAttribute Type;
-    static void add(Type & a, const T & v) { a.add(v, weight); }
+    typedef search::SingleValueStringAttribute Type;
+    static void add(Type & a, const T & v) {
+        a.update(a.getNumDocs()-1, v);
+        a.commit();
+    }
 };
 template <> struct AttributeVectorTypeFinder<int64_t> {
     typedef search::SingleValueNumericAttribute<search::IntegerAttributeTemplate<int64_t> > Type;

--- a/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
+++ b/searchlib/src/tests/attribute/stringattribute/stringattribute_test.cpp
@@ -386,7 +386,7 @@ testSingleValue(Attribute & svsa, Config &cfg)
 TEST("testSingleValue")
 {
     EXPECT_EQUAL(24u, sizeof(AttributeVector::SearchContext));
-    EXPECT_EQUAL(80u, sizeof(SingleValueStringAttribute::StringSingleImplSearchContext));
+    EXPECT_EQUAL(72u, sizeof(SingleValueStringAttribute::StringSingleImplSearchContext));
     {
         Config cfg(BasicType::STRING, CollectionType::SINGLE);
         SingleValueStringAttribute svsa("svsa", cfg);

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.cpp
@@ -22,6 +22,11 @@ StringDirectAttribute(const vespalib::string & baseFileName, const Config & c)
 
 StringDirectAttribute::~StringDirectAttribute() = default;
 
+AttributeVector::SearchContext::UP
+StringDirectAttribute::getSearch(QueryTermSimpleUP, const attribute::SearchContextParams &) const {
+    LOG_ABORT("StringDirectAttribute::getSearch is not implemented and should never be called.");
+}
+
 bool StringDirectAttribute::findEnum(const char * key, EnumHandle & e) const
 {
     if (_offsets.size() < 1) {

--- a/searchlib/src/vespa/searchlib/attribute/attrvector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attrvector.h
@@ -142,6 +142,7 @@ private:
     bool onLoad() override;
     const char * getFromEnum(EnumHandle e) const override { return &_buffer[e]; }
     const char * getStringFromEnum(EnumHandle e) const override { return &_buffer[e]; }
+    SearchContext::UP getSearch(QueryTermSimpleUP term, const attribute::SearchContextParams & params) const override;
 protected:
     StringDirectAttribute(const vespalib::string & baseFileName, const Config & c);
     ~StringDirectAttribute() override;

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -152,29 +152,16 @@ protected:
             return -1;
         }
 
-
-        int32_t onFind(DocId docId, int32_t elementId, int32_t &weight) const override;
-        int32_t onFind(DocId docId, int32_t elementId) const override;
-
         bool isPrefix() const { return _isPrefix; }
         bool  isRegex() const { return _isRegex; }
         const vespalib::Regex & getRegex() const { return _regex; }
     private:
-        WeightedConstChar * getBuffer() const {
-            if (_buffer == nullptr) {
-                _buffer = new WeightedConstChar[_bufferLen];
-            }
-            return _buffer;
-        }
         std::unique_ptr<QueryTermUCS4> _queryTerm;
         std::vector<ucs4_t>            _termUCS4;
-        mutable WeightedConstChar *    _buffer;
         vespalib::Regex                _regex;
-        unsigned                       _bufferLen;
         bool                           _isPrefix;
         bool                           _isRegex;
     };
-    SearchContext::UP getSearch(QueryTermSimpleUP term, const attribute::SearchContextParams & params) const override;
 };
 
 }


### PR DESCRIPTION
… not thread safe.

However it was luckily only used in test. Rewrote test and removed code.

@toregge PR