### PR TITLE
Change default max heap size for non-application containers

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -86,7 +86,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"geirst"}) default boolean enableFeedBlockInDistributor() { return false; }
         @ModelFeatureFlag(owners = {"baldersheim", "geirst", "toregge"}) default double maxDeadBytesRatio() { return 0.2; }
         @ModelFeatureFlag(owners = {"hmusum"}) default int clusterControllerMaxHeapSizeInMb() { return 256; }
-        @ModelFeatureFlag(owners = {"hmusum"}) default int metricsProxyMaxHeapSizeInMb(ClusterSpec.Type type) { return 512; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default int metricsProxyMaxHeapSizeInMb(ClusterSpec.Type type) { return 256; }
         @ModelFeatureFlag(owners = {"bjorncs", "tokle"}) default List<String> allowedAthenzProxyIdentities() { return List.of(); }
         @ModelFeatureFlag(owners = {"tokle"}) default boolean tenantIamRole() { return false; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -56,7 +56,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean enableFeedBlockInDistributor = false;
     private double maxDeadBytesRatio = 0.2;
     private int clusterControllerMaxHeapSizeInMb = 256;
-    private int metricsProxyMaxHeapSizeInMb = 512;
+    private int metricsProxyMaxHeapSizeInMb = 256;
     private int maxActivationInhibitedOutOfSyncGroups = 0;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -487,7 +487,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
                 .availableProcessors(2)
                 .compressedClassSpaceSize(32)
                 .minHeapsize(32)
-                .heapsize(512)
+                .heapsize(256)
                 .heapSizeAsPercentageOfPhysicalMemory(0)
                 .gcopts(Objects.requireNonNullElse(jvmGCOptions, G1GC));
         if (environmentVars != null) {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -233,7 +233,7 @@ public class Flags {
             "Takes effect when restarting cluster controller");
 
     public static final UnboundIntFlag METRICS_PROXY_MAX_HEAP_SIZE_IN_MB = defineIntFlag(
-            "metrics-proxy-max-heap-size-in-mb", 512,
+            "metrics-proxy-max-heap-size-in-mb", 256,
             List.of("hmusum"), "2021-03-01", "2021-05-01",
             "JVM max heap size for metrics proxy in Mb",
             "Takes effect when restarting metrics proxy");


### PR DESCRIPTION
Change default flag value for metrics proxy container max heap to 256 Mb.
