### PR TITLE
If a document was removed or moved between th emove started and the d…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/documentbucketmover/documentmover_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentbucketmover/documentmover_test.cpp
@@ -35,6 +35,7 @@ struct DocumentMoverTest : ::testing::Test
     test::UserDocumentsBuilder _builder;
     std::shared_ptr<bucketdb::BucketDBOwner> _bucketDB;
     MyMoveOperationLimiter     _limiter;
+    //TODO When we retire old bucket move job me must make rewrite this test to use the BucketMover directly.
     DocumentBucketMover        _mover;
     MySubDbTwoBuckets          _source;
     bucketdb::BucketDBOwner    _bucketDb;
@@ -71,8 +72,10 @@ TEST_F(DocumentMoverTest, require_that_initial_bucket_mover_is_done)
     MyMoveOperationLimiter limiter;
     DocumentBucketMover mover(limiter, _bucketDb);
     EXPECT_TRUE(mover.bucketDone());
+    EXPECT_FALSE(mover.needReschedule());
     mover.moveDocuments(2);
     EXPECT_TRUE(mover.bucketDone());
+    EXPECT_FALSE(mover.needReschedule());
 }
 
 TEST_F(DocumentMoverTest, require_that_we_can_move_all_documents)
@@ -134,6 +137,18 @@ TEST_F(DocumentMoverTest, require_that_we_can_move_documents_in_several_steps)
     EXPECT_TRUE(moveDocuments(2));
     EXPECT_TRUE(_mover.bucketDone());
     EXPECT_EQ(5u, _handler._moves.size());
+}
+
+TEST_F(DocumentMoverTest, require_that_cancel_signal_rescheduling_need) {
+    setupForBucket(_source.bucket(1), 6, 9);
+    EXPECT_FALSE(_mover.bucketDone());
+    EXPECT_FALSE(_mover.needReschedule());
+    EXPECT_TRUE(moveDocuments(2));
+    EXPECT_FALSE(_mover.bucketDone());
+    EXPECT_FALSE(_mover.needReschedule());
+    _mover.cancel();
+    EXPECT_TRUE(_mover.bucketDone());
+    EXPECT_TRUE(_mover.needReschedule());
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
@@ -82,10 +82,11 @@ public:
     void moveDocument(MoveOperationUP moveOp, IDestructorCallbackSP onDone);
 
     const document::BucketId &getBucket() const { return _bucket; }
-    void cancel() { setBucketDone(); }
-    void setBucketDone() { _bucketDone = true; }
+    void cancel();
+    void setAllScheduled() { _allScheduled = true; }
     /// Signals all documents have been scheduled for move
-    bool bucketDone() const { return _bucketDone; }
+    bool allScheduled() const { return _allScheduled; }
+    bool needReschedule() const { return _needReschedule.load(std::memory_order_relaxed); }
     const MaintenanceDocumentSubDB * getSource() const { return _source; }
     /// Must be called in master thread
     void updateLastValidGid(const document::GlobalId &gid) {
@@ -103,7 +104,8 @@ private:
 
     std::atomic<uint32_t>           _started;
     std::atomic<uint32_t>           _completed;
-    bool                            _bucketDone; // All moves started, or operation has been cancelled
+    std::atomic<bool>               _needReschedule;
+    bool                            _allScheduled; // All moves started, or operation has been cancelled
     bool                            _lastGidValid;
     document::GlobalId              _lastGid;
     GuardedMoveOp createMoveOperation(MoveKey & key);
@@ -139,8 +141,9 @@ public:
     const document::BucketId &getBucket() const { return _impl->getBucket(); }
     bool moveDocuments(size_t maxDocsToMove);
     void cancel() { _impl->cancel(); }
+    bool needReschedule() { return _impl && _impl->needReschedule(); }
     bool bucketDone() const {
-        return !_impl || _impl->bucketDone();
+        return !_impl || _impl->allScheduled();
     }
     const MaintenanceDocumentSubDB * getSource() const { return _impl->getSource(); }
 };


### PR DESCRIPTION
…ocument was retrieved

there would be a racewith state change or othe bucket changes requiring the bucket to be reconsidered.
The mover would appear in sync prior to completing the move in the master thread.
This should now be accounted by accounting the failed state in the mover.

@toregge PR