### PR TITLE
Better handling of ZK connectivity issues concurrent with elections [run-systemtest]

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
@@ -147,7 +147,7 @@ public class DatabaseHandler {
         } else {
             // If we have pending cluster state writes we cannot drop these on the floor, as otherwise the
             // core CC logic may keep thinking it has persisted writes it really has not. Clearing pending
-            // state writes woudl also prevent the controller from detecting itself being out of sync by
+            // state writes would also prevent the controller from detecting itself being out of sync by
             // triggering CaS violations upon znode writes.
             pendingStore.clearNonClusterStateFields();
         }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/ZooKeeperDatabase.java
@@ -238,6 +238,9 @@ public class ZooKeeperDatabase extends Database {
         } catch (InterruptedException e) {
             throw (InterruptedException) new InterruptedException("Interrupted").initCause(e);
         } catch (Exception e) {
+            // If we return a default, empty version, writes dependent on this bundle should only
+            // succeed if the previous znode version is 0, i.e. not yet created.
+            lastKnownStateVersionZNodeVersion = 0;
             maybeLogExceptionWarning(e, "Failed to retrieve latest system state version used. Returning null");
             return null;
         }
@@ -390,6 +393,9 @@ public class ZooKeeperDatabase extends Database {
             maybeLogExceptionWarning(e, "Failed to retrieve last published cluster state bundle from " +
                     "ZooKeeper, will use an empty state as baseline");
         }
+        // If we return a default, empty bundle, writes dependent on this bundle should only
+        // succeed if the previous znode version is 0, i.e. not yet created.
+        lastKnownStateBundleZNodeVersion = 0;
         return ClusterStateBundle.ofBaselineOnly(AnnotatedClusterState.emptyState());
     }
 


### PR DESCRIPTION
@geirst @hakonhall please review. These are predominantly racing edge cases dependent on ZK behavior and therefore tricky to test explicitly.

Adds the following safeguards/improvements:
- Do not clear pending (non-persisted) writes over a `connect()` edge.
  Avoids having the controller eternally wait for a doomed pending
  write to be completed when it has no other events that can trigger
  a new write.
- Trigger `lostDatabaseConnection()` whenever ZK is reconfigured to
  ensure we reload the newest state before trying to compute/publish
  any new states.
- Explicitly drop leadership in `lostDatabaseConnection()` to immediately
  prevent controller from trying any funny leader-related business
  since it no longer can depend on ZK watches triggering.
- When falling back to default state/cluster bundle, ensure that any
  subsequent dependent znode write is predicated on the pre-existing
  znode version being 0, i.e. did not previously exist.

