### PR TITLE
Using the jackson ObjectMapper directly at the rootlevel causes the w…

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/MetricsParser.java
@@ -1,0 +1,154 @@
+// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.service;
+
+import ai.vespa.metricsproxy.metric.Metric;
+import ai.vespa.metricsproxy.metric.Metrics;
+import ai.vespa.metricsproxy.metric.model.DimensionId;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
+
+/**
+ * Fetch metrics for a given vespa service
+ *
+ * @author Jo Kristian Bergum
+ */
+public class MetricsParser {
+
+    private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+    static Metrics parse(String data) throws IOException {
+        JsonParser parser = jsonMapper.createParser(data);
+
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of object, got " + parser.currentToken());
+        }
+
+        Metrics metrics  = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("metrics")) {
+                metrics = parseMetrics(parser);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return metrics;
+    }
+
+    static private Metrics parseSnapshot(JsonParser parser) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of 'snapshot' object, got " + parser.currentToken());
+        }
+        Metrics metrics = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("to")) {
+                long timestamp = parser.getLongValue();
+                long now = System.currentTimeMillis() / 1000;
+                timestamp = Metric.adjustTime(timestamp, now);
+                metrics = new Metrics(timestamp);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return metrics;
+    }
+
+    static private void parseValues(JsonParser parser, Metrics metrics) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
+            throw new IOException("Expected start of 'metrics:values' array, got " + parser.currentToken());
+        }
+
+        Map<String, Map<DimensionId, String>> uniqueDimensions = new HashMap<>();
+        while (parser.nextToken() == JsonToken.START_OBJECT) {
+            // read everything from this START_OBJECT to the matching END_OBJECT
+            // and return it as a tree model ObjectNode
+            JsonNode value = jsonMapper.readTree(parser);
+            handleValue(value, metrics.getTimeStamp(), metrics, uniqueDimensions);
+
+            // do whatever you need to do with this object
+        }
+    }
+
+    static private Metrics parseMetrics(JsonParser parser) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of 'metrics' object, got " + parser.currentToken());
+        }
+        Metrics metrics = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("snapshot")) {
+                metrics = parseSnapshot(parser);
+            } else if (fieldName.equals("values")) {
+                parseValues(parser, metrics);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return metrics;
+    }
+
+    static private void handleValue(JsonNode metric, long timestamp, Metrics metrics, Map<String, Map<DimensionId, String>> uniqueDimensions) {
+        String name = metric.get("name").textValue();
+        String description = "";
+
+        if (metric.has("description")) {
+            description = metric.get("description").textValue();
+        }
+
+        Map<DimensionId, String> dim = Collections.emptyMap();
+        if (metric.has("dimensions")) {
+            JsonNode dimensions = metric.get("dimensions");
+            StringBuilder sb = new StringBuilder();
+            for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
+                String k = (String) it.next();
+                String v = dimensions.get(k).asText();
+                sb.append(toDimensionId(k)).append(v);
+            }
+            if ( ! uniqueDimensions.containsKey(sb.toString())) {
+                dim = new HashMap<>();
+                for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
+                    String k = (String) it.next();
+                    String v = dimensions.get(k).textValue();
+                    dim.put(toDimensionId(k), v);
+                }
+                uniqueDimensions.put(sb.toString(), Collections.unmodifiableMap(dim));
+            }
+            dim = uniqueDimensions.get(sb.toString());
+        }
+
+        JsonNode aggregates = metric.get("values");
+        for (Iterator<?> it = aggregates.fieldNames(); it.hasNext(); ) {
+            String aggregator = (String) it.next();
+            JsonNode aggregatorValue = aggregates.get(aggregator);
+            if (aggregatorValue == null) {
+                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is missing");
+            }
+            Number value = aggregatorValue.numberValue();
+            if (value == null) {
+                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is not a number");
+            }
+            StringBuilder metricName = (new StringBuilder()).append(name).append(".").append(aggregator);
+            metrics.add(new Metric(metricName.toString(), value, timestamp, dim, description));
+        }
+    }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -1,21 +1,9 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.service;
 
-import ai.vespa.metricsproxy.metric.Metric;
 import ai.vespa.metricsproxy.metric.Metrics;
-import ai.vespa.metricsproxy.metric.model.DimensionId;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
-import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
 
 /**
  * Fetch metrics for a given vespa service
@@ -23,8 +11,6 @@ import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
  * @author Jo Kristian Bergum
  */
 public class RemoteMetricsFetcher extends HttpMetricFetcher {
-
-    private static final ObjectMapper jsonMapper = new ObjectMapper();
 
     final static String METRICS_PATH = STATE_PATH + "metrics";
 
@@ -46,142 +32,14 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
         return createMetrics(data, fetchCount);
     }
 
-    /**
-     * Connect to remote service over http and fetch metrics
-     */
     Metrics createMetrics(String data, int fetchCount) {
         Metrics remoteMetrics = new Metrics();
         try {
-            remoteMetrics = parse(data);
+            remoteMetrics = MetricsParser.parse(data);
         } catch (Exception e) {
             handleException(e, data, fetchCount);
         }
 
         return remoteMetrics;
-    }
-
-    private Metrics parseSnapshot(JsonParser parser) throws IOException {
-        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
-            throw new IOException("Expected start of 'snapshot' object, got " + parser.currentToken());
-        }
-        Metrics metrics = new Metrics();
-        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
-            String fieldName = parser.getCurrentName();
-            JsonToken token = parser.nextToken();
-            if (fieldName.equals("to")) {
-                long timestamp = parser.getLongValue();
-                long now = System.currentTimeMillis() / 1000;
-                timestamp = Metric.adjustTime(timestamp, now);
-                metrics = new Metrics(timestamp);
-            } else {
-                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
-                    parser.skipChildren();
-                }
-            }
-        }
-        return metrics;
-    }
-
-    private void parseValues(JsonParser parser, Metrics metrics) throws IOException {
-        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
-            throw new IOException("Expected start of 'metrics:values' array, got " + parser.currentToken());
-        }
-
-        Map<String, Map<DimensionId, String>> uniqueDimensions = new HashMap<>();
-        while (parser.nextToken() == JsonToken.START_OBJECT) {
-            // read everything from this START_OBJECT to the matching END_OBJECT
-            // and return it as a tree model ObjectNode
-            JsonNode value = jsonMapper.readTree(parser);
-            handleValue(value, metrics.getTimeStamp(), metrics, uniqueDimensions);
-
-            // do whatever you need to do with this object
-        }
-    }
-
-    private Metrics parseMetrics(JsonParser parser) throws IOException {
-        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
-            throw new IOException("Expected start of 'metrics' object, got " + parser.currentToken());
-        }
-        Metrics metrics = new Metrics();
-        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
-            String fieldName = parser.getCurrentName();
-            JsonToken token = parser.nextToken();
-            if (fieldName.equals("snapshot")) {
-                metrics = parseSnapshot(parser);
-            } else if (fieldName.equals("values")) {
-                parseValues(parser, metrics);
-            } else {
-                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
-                    parser.skipChildren();
-                }
-            }
-        }
-        return metrics;
-    }
-    private Metrics parse(String data) throws IOException {
-        JsonParser parser = jsonMapper.createParser(data);
-
-        if (parser.nextToken() != JsonToken.START_OBJECT) {
-            throw new IOException("Expected start of object, got " + parser.currentToken());
-        }
-
-        Metrics metrics  = new Metrics();
-        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
-            String fieldName = parser.getCurrentName();
-            JsonToken token = parser.nextToken();
-            if (fieldName.equals("metrics")) {
-                metrics = parseMetrics(parser);
-            } else {
-                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
-                    parser.skipChildren();
-                }
-            }
-        }
-        return metrics;
-    }
-
-    private void handleValue(JsonNode metric, long timestamp, Metrics metrics, Map<String, Map<DimensionId, String>> uniqueDimensions) {
-        String name = metric.get("name").textValue();
-        String description = "";
-
-        if (metric.has("description")) {
-            description = metric.get("description").textValue();
-        }
-
-        Map<DimensionId, String> dim = Collections.emptyMap();
-        if (metric.has("dimensions")) {
-            JsonNode dimensions = metric.get("dimensions");
-            StringBuilder sb = new StringBuilder();
-            for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
-                String k = (String) it.next();
-                String v = dimensions.get(k).asText();
-                sb.append(toDimensionId(k)).append(v);
-            }
-            if ( ! uniqueDimensions.containsKey(sb.toString())) {
-                dim = new HashMap<>();
-                for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
-                    String k = (String) it.next();
-                    String v = dimensions.get(k).textValue();
-                    dim.put(toDimensionId(k), v);
-                }
-                uniqueDimensions.put(sb.toString(), Collections.unmodifiableMap(dim));
-            }
-            dim = uniqueDimensions.get(sb.toString());
-        }
-
-        JsonNode aggregates = metric.get("values");
-        for (Iterator<?> it = aggregates.fieldNames(); it.hasNext(); ) {
-            String aggregator = (String) it.next();
-            JsonNode aggregatorValue = aggregates.get(aggregator);
-            if (aggregatorValue == null) {
-                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is missing");
-            }
-            Number value = aggregatorValue.numberValue();
-            if (value == null) {
-                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is not a number");
-            }
-            StringBuilder metricName = (new StringBuilder()).append(name).append(".").append(aggregator);
-            metrics.add(new Metric(metricName.toString(), value, timestamp, dim, description));
-        }
     }
 }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -4,9 +4,10 @@ package ai.vespa.metricsproxy.service;
 import ai.vespa.metricsproxy.metric.Metric;
 import ai.vespa.metricsproxy.metric.Metrics;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -59,76 +60,128 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
         return remoteMetrics;
     }
 
-    private Metrics parse(String data) throws IOException {
-        JsonNode o = jsonMapper.readTree(data);
-        if (!(o.has("metrics"))) {
-            return new Metrics(); //empty
+    private Metrics parseSnapshot(JsonParser parser) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of 'snapshot' object, got " + parser.currentToken());
         }
-
-        JsonNode metrics = o.get("metrics");
-        ArrayNode values;
-        long timestamp;
-
-        try {
-            JsonNode snapshot = metrics.get("snapshot");
-            timestamp = snapshot.get("to").asLong();
-            values = (ArrayNode) metrics.get("values");
-        } catch (Exception e) {
-            // snapshot might not have been produced. Do not throw exception into log
-            return new Metrics();
-        }
-        long now = System.currentTimeMillis() / 1000;
-        timestamp = Metric.adjustTime(timestamp, now);
-        Metrics m = new Metrics(timestamp);
-
-        Map<DimensionId, String> noDims = Collections.emptyMap();
-        Map<String, Map<DimensionId, String>> uniqueDimensions = new HashMap<>();
-        for (int i = 0; i < values.size(); i++) {
-            JsonNode metric = values.get(i);
-            String name = metric.get("name").textValue();
-            String description = "";
-
-            if (metric.has("description")) {
-                description = metric.get("description").textValue();
+        Metrics metrics = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("to")) {
+                long timestamp = parser.getLongValue();
+                long now = System.currentTimeMillis() / 1000;
+                timestamp = Metric.adjustTime(timestamp, now);
+                metrics = new Metrics(timestamp);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
             }
+        }
+        return metrics;
+    }
 
-            Map<DimensionId, String> dim = noDims;
-            if (metric.has("dimensions")) {
-                JsonNode dimensions = metric.get("dimensions");
-                StringBuilder sb = new StringBuilder();
+    private void parseValues(JsonParser parser, Metrics metrics) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_ARRAY) {
+            throw new IOException("Expected start of 'metrics:values' array, got " + parser.currentToken());
+        }
+
+        Map<String, Map<DimensionId, String>> uniqueDimensions = new HashMap<>();
+        while (parser.nextToken() == JsonToken.START_OBJECT) {
+            // read everything from this START_OBJECT to the matching END_OBJECT
+            // and return it as a tree model ObjectNode
+            JsonNode value = jsonMapper.readTree(parser);
+            handleValue(value, metrics.getTimeStamp(), metrics, uniqueDimensions);
+
+            // do whatever you need to do with this object
+        }
+    }
+
+    private Metrics parseMetrics(JsonParser parser) throws IOException {
+        if (parser.getCurrentToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of 'metrics' object, got " + parser.currentToken());
+        }
+        Metrics metrics = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("snapshot")) {
+                metrics = parseSnapshot(parser);
+            } else if (fieldName.equals("values")) {
+                parseValues(parser, metrics);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return metrics;
+    }
+    private Metrics parse(String data) throws IOException {
+        JsonParser parser = jsonMapper.createParser(data);
+
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+            throw new IOException("Expected start of object, got " + parser.currentToken());
+        }
+
+        Metrics metrics  = new Metrics();
+        for (parser.nextToken(); parser.getCurrentToken() != JsonToken.END_OBJECT; parser.nextToken()) {
+            String fieldName = parser.getCurrentName();
+            JsonToken token = parser.nextToken();
+            if (fieldName.equals("metrics")) {
+                metrics = parseMetrics(parser);
+            } else {
+                if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
+                }
+            }
+        }
+        return metrics;
+    }
+
+    private void handleValue(JsonNode metric, long timestamp, Metrics metrics, Map<String, Map<DimensionId, String>> uniqueDimensions) {
+        String name = metric.get("name").textValue();
+        String description = "";
+
+        if (metric.has("description")) {
+            description = metric.get("description").textValue();
+        }
+
+        Map<DimensionId, String> dim = Collections.emptyMap();
+        if (metric.has("dimensions")) {
+            JsonNode dimensions = metric.get("dimensions");
+            StringBuilder sb = new StringBuilder();
+            for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
+                String k = (String) it.next();
+                String v = dimensions.get(k).asText();
+                sb.append(toDimensionId(k)).append(v);
+            }
+            if ( ! uniqueDimensions.containsKey(sb.toString())) {
+                dim = new HashMap<>();
                 for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
                     String k = (String) it.next();
-                    String v = dimensions.get(k).asText();
-                    sb.append(toDimensionId(k)).append(v);
+                    String v = dimensions.get(k).textValue();
+                    dim.put(toDimensionId(k), v);
                 }
-                if ( ! uniqueDimensions.containsKey(sb.toString())) {
-                    dim = new HashMap<>();
-                    for (Iterator<?> it = dimensions.fieldNames(); it.hasNext(); ) {
-                        String k = (String) it.next();
-                        String v = dimensions.get(k).textValue();
-                        dim.put(toDimensionId(k), v);
-                    }
-                    uniqueDimensions.put(sb.toString(), Collections.unmodifiableMap(dim));
-                }
-                dim = uniqueDimensions.get(sb.toString());
+                uniqueDimensions.put(sb.toString(), Collections.unmodifiableMap(dim));
             }
-
-            JsonNode aggregates = metric.get("values");
-            for (Iterator<?> it = aggregates.fieldNames(); it.hasNext(); ) {
-                String aggregator = (String) it.next();
-                JsonNode aggregatorValue = aggregates.get(aggregator);
-                if (aggregatorValue == null) {
-                    throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is missing");
-                }
-                Number value = aggregatorValue.numberValue();
-                if (value == null) {
-                    throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is not a number");
-                }
-                StringBuilder metricName = (new StringBuilder()).append(name).append(".").append(aggregator);
-                m.add(new Metric(metricName.toString(), value, timestamp, dim, description));
-            }
+            dim = uniqueDimensions.get(sb.toString());
         }
 
-        return m;
+        JsonNode aggregates = metric.get("values");
+        for (Iterator<?> it = aggregates.fieldNames(); it.hasNext(); ) {
+            String aggregator = (String) it.next();
+            JsonNode aggregatorValue = aggregates.get(aggregator);
+            if (aggregatorValue == null) {
+                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is missing");
+            }
+            Number value = aggregatorValue.numberValue();
+            if (value == null) {
+                throw new IllegalArgumentException("Value for aggregator '" + aggregator + "' is not a number");
+            }
+            StringBuilder metricName = (new StringBuilder()).append(name).append(".").append(aggregator);
+            metrics.add(new Metric(metricName.toString(), value, timestamp, dim, description));
+        }
     }
 }


### PR DESCRIPTION
…hole object structure to be build in memory.

A compromise here is to drive the parsing with the stream api and use an object mapper per entry in the array.

@bjorncs @gjoranv @jonmv @hmusum PR
Note that this rewrite currently requires 'snapshot' to appear ahead of 'values'.
Json does not guarantee any order as it is a map, but do we guarantee order in how we produce the metrics ?
If not I guess we need optional post processing of the metrics to update the timestamp.