### PR TITLE
Redeploy applications when bootstrapping in random order

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -664,10 +664,10 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    public Set<ApplicationId> listApplications() {
+    public List<ApplicationId> listApplications() {
         return tenantRepository.getAllTenants().stream()
                 .flatMap(tenant -> tenant.getApplicationRepo().activeApplications().stream())
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList());
     }
 
     private boolean isFileLastModifiedBefore(File fileReference, Instant instant) {


### PR DESCRIPTION
Try to avoid e.g. all applications for one tenant being deployed at the same time. In some zones this might lead to contention when there are locks per tenant and e.g. deployments using a lot of resources will be clustered in time, which we want to avoid.