### PR TITLE
Shorten provisioned expiry in dynamically provisioned zones

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -139,7 +139,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
             // Vespa upgrade frequency is higher in CD so (de)activate OS upgrades more frequently as well
             osUpgradeActivatorInterval = zone.system().isCd() ? Duration.ofSeconds(30) : Duration.ofMinutes(5);
             periodicRedeployInterval = Duration.ofMinutes(60);
-            provisionedExpiry = Duration.ofHours(4);
+            provisionedExpiry = zone.getCloud().dynamicProvisioning() ? Duration.ofMinutes(40) : Duration.ofHours(4);
             rebalancerInterval = Duration.ofMinutes(120);
             redeployMaintainerInterval = Duration.ofMinutes(1);
             // Need to be long enough for deployment to be finished for all config model versions


### PR DESCRIPTION
No point in waiting long for a host in dynamically provisioned zones, if a host is not up within `provisionExpiry`, it will be failed and application can trigger provisioning of another host instead. This could probably be lowered further, but at the same time there isn't much point in lowering to 20-30 minutes as deployment will probably time out (after 30 mins) before the second instance is ready.