### PR TITLE
Make controller emit JSON from secret store validation

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -612,7 +612,7 @@ public class ApplicationApiHandler extends LoggingRequestHandler {
             SlimeUtils.copyObject(responseSlime.get(), responseResultCursor);
             return new SlimeJsonResponse(responseRoot);
         } catch (JsonParseException e) {
-            return new MessageResponse(response);
+            return ErrorResponse.internalServerError(response);
         }
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -577,7 +577,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
 
     @Override
     public String validateSecretStore(DeploymentId deployment, TenantSecretStore tenantSecretStore, String region, String parameterName) {
-        return deployment.toString() + " - " + tenantSecretStore.toString();
+        return "{\"settings\":{\"name\":\"foo\",\"role\":\"vespa-secretstore-access\",\"awsId\":\"892075328880\",\"externalId\":\"*****\",\"region\":\"us-east-1\"},\"status\":\"ok\"}";
     }
 
     public static class Application {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
@@ -177,9 +177,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
         secretStoreRequest =
                 request("/application/v4/tenant/scoober/secret-store/secret-foo/region/us-west-1/parameter-name/foo/validate", GET)
                         .roles(Set.of(Role.administrator(tenantName)));
-        tester.assertResponse(secretStoreRequest, "{" +
-                "\"message\":\"scoober.albums in prod.us-central-1 - TenantSecretStore{name='secret-foo', awsId='123', role='some-role'}\"" +
-                "}", 200);
+        tester.assertResponse(secretStoreRequest, "{\"target\":\"scoober.albums in prod.us-central-1\",\"result\":{\"settings\":{\"name\":\"foo\",\"role\":\"vespa-secretstore-access\",\"awsId\":\"892075328880\",\"externalId\":\"*****\",\"region\":\"us-east-1\"},\"status\":\"ok\"}}", 200);
     }
 
     @Test


### PR DESCRIPTION
FYI - @ldalves 

This changes the output from the API to be of the following format:
```json
{
  "target": "scoober.albums in prod.us-central-1",
  "result": {
    "settings": {
      "name": "foo",
      "role": "some-role-name-here",
      "awsId": "1234547899",
      "externalId": "*****",
      "region": "us-east-1"
    },
    "status": "ok"
  }
}
```

With an error:
```json
{
  "target": "scoober.albums in prod.us-central-1",
  "result": {
    "settings": {
      "name": "foo",
      "role": "some-role-name-here",
      "awsId": "1234547899",
      "externalId": "*****",
      "region": "us-east-1"
    },
    "status": "error",
    "errors": [
      {
        "type": "SecretNotFoundException",
        "message": "Could not find secret 'nalle' in any configured secret store"
      }
    ]
  }
}
```