### PR TITLE
Revert "Scale content clusters to minimum 3 nodes"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
@@ -16,8 +16,7 @@ import java.util.Optional;
 public class AllocationOptimizer {
 
     // The min and max nodes to consider when not using application supplied limits
-    private static final int minimumStatelessNodes = 2; // Since this number includes redundancy it cannot be lower than 2
-    private static final int minimumStatefulNodes = 3; // Leader election requires 3 nodes to have redundancy
+    private static final int minimumNodes = 2; // Since this number includes redundancy it cannot be lower than 2
     private static final int maximumNodes = 150;
 
     // When a query is issued on a node the cost is the sum of a fixed cost component and a cost component
@@ -41,7 +40,7 @@ public class AllocationOptimizer {
     public Optional<AllocatableClusterResources> findBestAllocation(ResourceTarget target,
                                                                     AllocatableClusterResources current,
                                                                     Limits limits) {
-        int minimumNodes = current.clusterSpec().isStateful() ? minimumStatefulNodes : minimumStatelessNodes;
+        int minimumNodes = AllocationOptimizer.minimumNodes;
         if (limits.isEmpty())
             limits = Limits.of(new ClusterResources(minimumNodes,    1, NodeResources.unspecified()),
                                new ClusterResources(maximumNodes, maximumNodes, NodeResources.unspecified()));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerProvisionTest.java
@@ -1,4 +1,4 @@
-// Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.component.Version;
@@ -247,14 +247,14 @@ public class DynamicDockerProvisionTest {
         tester.activate(app1, cluster1, Capacity.from(resources(2, 1, 2, 20, 40),
                                                       resources(4, 1, 2, 20, 40)));
         tester.assertNodes("Allocation specifies memory in the advertised amount",
-                           3, 1, 2, 20, 40,
+                           2, 1, 2, 20, 40,
                            app1, cluster1);
 
         // Redeploy the same
         tester.activate(app1, cluster1, Capacity.from(resources(2, 1, 2, 20, 40),
                                                       resources(4, 1, 2, 20, 40)));
         tester.assertNodes("Allocation specifies memory in the advertised amount",
-                           3, 1, 2, 20, 40,
+                           2, 1, 2, 20, 40,
                            app1, cluster1);
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.component.Version;
@@ -440,25 +440,7 @@ public class ProvisioningTest {
     }
 
     @Test
-    public void test_node_limits_only_container() {
-        Flavor hostFlavor = new Flavor(new NodeResources(20, 40, 100, 4));
-        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east")))
-                                                                    .flavors(List.of(hostFlavor))
-                                                                    .build();
-        tester.makeReadyHosts(4, hostFlavor.resources()).activateTenantHosts();
-
-        ApplicationId app1 = ProvisioningTester.applicationId("app1");
-        ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.container, new ClusterSpec.Id("cluster1")).vespaVersion("7").build();
-
-        tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, NodeResources.unspecified()),
-                                                      new ClusterResources(4, 1, NodeResources.unspecified())));
-        tester.assertNodes("Initial allocation at min with default resources",
-                           2, 1, 1.5, 8, 50, 0.3,
-                           app1, cluster1);
-    }
-
-    @Test
-    public void test_node_limits_only_content() {
+    public void test_node_limits() {
         Flavor hostFlavor = new Flavor(new NodeResources(20, 40, 100, 4));
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east")))
                                                                     .flavors(List.of(hostFlavor))
@@ -471,7 +453,7 @@ public class ProvisioningTest {
         tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, NodeResources.unspecified()),
                                                       new ClusterResources(4, 1, NodeResources.unspecified())));
         tester.assertNodes("Initial allocation at (allowable) min with default resources",
-                           3, 1, 1.5, 8, 50, 0.3,
+                           2, 1, 1.5, 8, 50, 0.3,
                            app1, cluster1);
     }
 


### PR DESCRIPTION
We now have dedicated cluster controllers in all zones, so this
is not needed anymore. Reverts most of #16378, but keeps the code
that increases to min only when it is within limits.

@jonmv FYI
