### PR TITLE
Shrink the size of the NodeState object by using float over double fo…

### DIFF
--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStateGeneratorTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterStateGeneratorTest.java
@@ -169,7 +169,7 @@ public class ClusterStateGeneratorTest {
     @Test
     public void storage_node_in_init_mode_while_listing_buckets_is_marked_down() {
         final NodeState initWhileListingBuckets = new NodeState(NodeType.STORAGE, State.INITIALIZING);
-        initWhileListingBuckets.setInitProgress(0.0);
+        initWhileListingBuckets.setInitProgress(0.0f);
 
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
                 .bringEntireClusterUp()
@@ -186,7 +186,7 @@ public class ClusterStateGeneratorTest {
     @Test
     public void implicit_down_while_listing_buckets_does_not_override_wanted_state() {
         final NodeState initWhileListingBuckets = new NodeState(NodeType.STORAGE, State.INITIALIZING);
-        initWhileListingBuckets.setInitProgress(0.0);
+        initWhileListingBuckets.setInitProgress(0.0f);
 
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
                 .bringEntireClusterUp()
@@ -200,7 +200,7 @@ public class ClusterStateGeneratorTest {
     @Test
     public void distributor_nodes_in_init_mode_are_not_mapped_to_down() {
         final NodeState initWhileListingBuckets = new NodeState(NodeType.DISTRIBUTOR, State.INITIALIZING);
-        initWhileListingBuckets.setInitProgress(0.0);
+        initWhileListingBuckets.setInitProgress(0.0f);
 
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
                 .bringEntireClusterUp()
@@ -821,7 +821,7 @@ public class ClusterStateGeneratorTest {
     private String do_test_storage_node_with_no_init_progress(State wantedState) {
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
                 .bringEntireClusterUp()
-                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5))
+                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5f))
                 .proposeStorageNodeWantedState(0, wantedState);
 
         final NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 0));
@@ -863,7 +863,7 @@ public class ClusterStateGeneratorTest {
                 .bringEntireClusterUp()
                 .reportStorageNodeState(0, State.INITIALIZING)
                 .reportStorageNodeState(0, State.DOWN) // Init -> Down triggers unstable init flag
-                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5));
+                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5f));
 
         final AnnotatedClusterState state = generateFromFixtureWithDefaultParams(fixture);
         assertThat(state.toString(), equalTo("distributor:5 storage:5 .0.s:d"));
@@ -873,7 +873,7 @@ public class ClusterStateGeneratorTest {
     public void storage_node_with_crashes_but_not_unstable_init_does_not_have_init_state_substituted_by_down() {
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(5)
                 .bringEntireClusterUp()
-                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5));
+                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5f));
         final NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 0));
         nodeInfo.setPrematureCrashCount(5);
 
@@ -926,7 +926,7 @@ public class ClusterStateGeneratorTest {
     public void configured_zero_init_progress_time_disables_auto_init_to_down_feature() {
         final ClusterFixture fixture = ClusterFixture.forFlatCluster(3)
                 .bringEntireClusterUp()
-                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5));
+                .reportStorageNodeState(0, new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.5f));
 
         final NodeInfo nodeInfo = fixture.cluster.getNodeInfo(new Node(NodeType.STORAGE, 0));
         nodeInfo.setInitProgressTime(10_000);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownTest.java
@@ -266,7 +266,7 @@ public class GroupAutoTakedownTest {
                 DistributionBuilder.withGroups(3).eachWithNodeCount(2), 0.51);
 
         final NodeState newState = new NodeState(NodeType.STORAGE, State.INITIALIZING);
-        newState.setInitProgress(0.5);
+        newState.setInitProgress(0.5f);
 
         fixture.reportStorageNodeState(4, newState);
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
@@ -186,7 +186,7 @@ public class RpcServerTest extends FleetControllerTest {
         waitForState("version:\\d+ distributor:10 .0.s:d .2.s:d storage:10 .1.s:d .2.s:d .7.s:m");
         timer.advanceTime(1000000);
         waitForCompleteCycle(); // Make fleet controller notice that time has changed before any disconnects
-        nodes.get(3).setNodeState(new NodeState(nodes.get(3).getType(), State.INITIALIZING).setInitProgress(0.2));
+        nodes.get(3).setNodeState(new NodeState(nodes.get(3).getType(), State.INITIALIZING).setInitProgress(0.2f));
         nodes.get(3).connect();
         waitForState("version:\\d+ distributor:10 .0.s:d .2.s:d storage:10 .1.s:i .1.i:0.2 .2.s:d .7.s:m");
 
@@ -305,7 +305,7 @@ public class RpcServerTest extends FleetControllerTest {
         waitForState("version:\\d+ distributor:10 .0.s:d .2.s:d storage:10 .1.s:d .2.s:d .7.s:m .9.s:r");
         timer.advanceTime(1000000);
         waitForCompleteCycle(); // Make fleet controller notice that time has changed before any disconnects
-        nodes.get(3).setNodeState(new NodeState(nodes.get(3).getType(), State.INITIALIZING).setInitProgress(0.2));
+        nodes.get(3).setNodeState(new NodeState(nodes.get(3).getType(), State.INITIALIZING).setInitProgress(0.2f));
         nodes.get(3).connect();
         waitForState("version:\\d+ distributor:10 .0.s:d .2.s:d storage:10 .1.s:i .1.i:0.2 .2.s:d .7.s:m .9.s:r");
     }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -111,14 +111,14 @@ public class StateChangeTest extends FleetControllerTest {
 
 
         for (int j = 0; j < 10; ++j) {
-            communicator.setNodeState(new Node(NodeType.DISTRIBUTOR, j), new NodeState(NodeType.DISTRIBUTOR, State.INITIALIZING).setInitProgress(0.0), "");
+            communicator.setNodeState(new Node(NodeType.DISTRIBUTOR, j), new NodeState(NodeType.DISTRIBUTOR, State.INITIALIZING).setInitProgress(0.0f), "");
         }
 
         for (int i=0; i<100; i += 10) {
             timer.advanceTime(options.maxInitProgressTime / 20);
             ctrl.tick();
             for (int j = 0; j < 10; ++j) {
-                communicator.setNodeState(new Node(NodeType.STORAGE, j), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(i / 100.0), "");
+                communicator.setNodeState(new Node(NodeType.STORAGE, j), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(i / 100.0f), "");
             }
         }
 
@@ -391,14 +391,14 @@ public class StateChangeTest extends FleetControllerTest {
 
         tick(1000);
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0f), "");
 
         ctrl.tick();
 
         // Still maintenance since .i progress 0.0 is really down.
         assertEquals("version:4 distributor:10 storage:10 .6.s:m", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.6), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.6f), "");
 
         ctrl.tick();
 
@@ -451,14 +451,14 @@ public class StateChangeTest extends FleetControllerTest {
 
         tick(1000);
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0f), "");
 
         ctrl.tick();
 
         // Still maintenance since .i progress 0.0 is really down.
         assertEquals("version:4 distributor:10 storage:10 .6.s:m", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.6), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.6f), "");
 
         ctrl.tick();
 
@@ -541,13 +541,13 @@ public class StateChangeTest extends FleetControllerTest {
 
         assertEquals("version:5 distributor:10 storage:10 .6.s:d", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.001), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.001f), "");
 
         ctrl.tick();
 
         assertEquals("version:5 distributor:10 storage:10 .6.s:d", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1f), "");
 
         ctrl.tick();
 
@@ -604,7 +604,7 @@ public class StateChangeTest extends FleetControllerTest {
 
         assertEquals("version:5 distributor:10 storage:10 .6.s:d", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1f), "");
 
         ctrl.tick();
 
@@ -625,11 +625,11 @@ public class StateChangeTest extends FleetControllerTest {
 
         tick(options.nodeStateRequestTimeoutMS + 1);
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0f), "");
 
         tick(1000);
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1f), "");
 
         tick(1000);
 
@@ -691,7 +691,7 @@ public class StateChangeTest extends FleetControllerTest {
 
         assertEquals("version:5 distributor:10 storage:10 .6.s:d", ctrl.getSystemState().toString());
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3f), "");
 
         ctrl.tick();
 
@@ -699,7 +699,7 @@ public class StateChangeTest extends FleetControllerTest {
 
         ctrl.tick();
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2f), "");
 
         ctrl.tick();
 
@@ -735,7 +735,7 @@ public class StateChangeTest extends FleetControllerTest {
 
         ctrl.tick();
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3f), "");
 
         ctrl.tick();
 
@@ -751,7 +751,7 @@ public class StateChangeTest extends FleetControllerTest {
 
         tick(1000);
 
-        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3), "");
+        communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.3f), "");
 
         ctrl.tick();
 
@@ -804,13 +804,13 @@ public class StateChangeTest extends FleetControllerTest {
 
             tick(options.nodeStateRequestTimeoutMS + 1);
 
-            communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0), "");
+            communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.0f), "");
 
             ctrl.tick();
 
             tick(options.nodeStateRequestTimeoutMS + 1);
 
-            communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1), "");
+            communicator.setNodeState(new Node(NodeType.STORAGE, 6), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.1f), "");
 
             tick(1000);
         }
@@ -1228,7 +1228,7 @@ public class StateChangeTest extends FleetControllerTest {
         communicator.setNodeState(
                 new Node(NodeType.STORAGE, 2),
                 new NodeState(NodeType.STORAGE, State.INITIALIZING)
-                        .setInitProgress(0.1).setMinUsedBits(16), "");
+                        .setInitProgress(0.1f).setMinUsedBits(16), "");
 
         ctrl.tick();
 
@@ -1245,7 +1245,7 @@ public class StateChangeTest extends FleetControllerTest {
             communicator.setNodeState(
                     new Node(NodeType.STORAGE, 2),
                     new NodeState(NodeType.STORAGE, State.INITIALIZING)
-                            .setInitProgress((i * 0.1) + 0.1).setMinUsedBits(17), "");
+                            .setInitProgress((i * 0.1f) + 0.1f).setMinUsedBits(17), "");
             timer.advanceTime(1000);
             ctrl.tick();
         }

--- a/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/state/NodeState.java
@@ -21,18 +21,17 @@ public class NodeState implements Cloneable {
     public static final String ORCHESTRATOR_RESERVED_DESCRIPTION = "Orchestrator";
 
     private final NodeType type;
-    private State state = State.UP;
+    private State state;
     private String description = "";
-    private double capacity = 1.0;
-    private int reliability =  1;
-    private double initProgress = 1.0;
+    private float capacity = 1.0f;
+    private float initProgress = 1.0f;
     private int minUsedBits = 16;
     private List<DiskState> diskStates = new ArrayList<>();
     /** When generating ideal states, we want to cheaply check if any disks are down in the nodestate. */
     private boolean anyDiskDown = false;
     private long startTimestamp = 0;
 
-    public static double getListingBucketsInitProgressLimit() { return 0.01; }
+    public static float getListingBucketsInitProgressLimit() { return 0.01f; }
 
     public NodeState(NodeType type, State state) {
         this.type = type;
@@ -199,9 +198,9 @@ public class NodeState implements Cloneable {
     }
 
     /** Capacity is set by deserializing a node state. This seems odd, as it is config */
-    public NodeState setCapacity(double c) { this.capacity = c; return this; }
+    public NodeState setCapacity(float c) { this.capacity = c; return this; }
 
-    public NodeState setInitProgress(double p) { this.initProgress = p; return this; }
+    public NodeState setInitProgress(float p) { this.initProgress = p; return this; }
     public NodeState setDescription(String desc) { this.description = desc; return this; }
     public NodeState setMinUsedBits(int u) { this.minUsedBits = u; return this; }
     public NodeState setState(State state) { this.state = state; return this; }
@@ -397,7 +396,7 @@ public class NodeState implements Cloneable {
                 if (key.length() > 1) break;
                 if (type != null && !type.equals(NodeType.STORAGE)) break;
                 try{
-                    newState.setCapacity(Double.valueOf(value));
+                    newState.setCapacity(Float.valueOf(value));
                 } catch (Exception e) {
                     throw new ParseException("Illegal capacity '" + value + "'. Capacity must be a positive floating point number", 0);
                 }
@@ -405,7 +404,7 @@ public class NodeState implements Cloneable {
             case 'i':
                 if (key.length() > 1) break;
                 try{
-                    newState.setInitProgress(Double.valueOf(value));
+                    newState.setInitProgress(Float.valueOf(value));
                 } catch (Exception e) {
                     throw new ParseException("Illegal init progress '" + value + "'. Init progress must be a floating point number from 0.0 to 1.0", 0);
                 }

--- a/vdslib/src/test/java/com/yahoo/vdslib/state/ClusterStateTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/state/ClusterStateTestCase.java
@@ -34,7 +34,7 @@ public class ClusterStateTestCase{
     public void testClone() throws ParseException {
         ClusterState state = new ClusterState("");
         state.setNodeState(new Node(NodeType.DISTRIBUTOR, 1), new NodeState(NodeType.DISTRIBUTOR, State.UP).setDescription("available"));
-        state.setNodeState(new Node(NodeType.STORAGE, 0), new NodeState(NodeType.STORAGE, State.UP).setCapacity(1.2));
+        state.setNodeState(new Node(NodeType.STORAGE, 0), new NodeState(NodeType.STORAGE, State.UP).setCapacity(1.2f));
         state.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.UP).setDiskCount(2).setDiskState(1, new DiskState(State.DOWN)));
         ClusterState other = state.clone();
         assertEquals(state.toString(true), other.toString(true));
@@ -187,7 +187,7 @@ public class ClusterStateTestCase{
 
         state2.setDistributionBits(21);
         state1.setVersion(123);
-        state1.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2).setDiskCount(2).setDescription("Booting"));
+        state1.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2f).setDiskCount(2).setDescription("Booting"));
         state2.setOfficial(true);
 
         assertEquals("version: 123 => 0, bits: 16 => 21, official: false => true, storage: [2: [Initializing => Up, disks: 2 => 0, description: Booting => ], 4: Down => Up, 5: Down => Up], distributor: [7: Up => Down, 8: Up => Down]", state1.getTextualDifference(state2));
@@ -219,7 +219,7 @@ public class ClusterStateTestCase{
                 "]", state2.getHtmlDifference(state3));
 
         state1.setVersion(123);
-        state1.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2).setDiskCount(2).setDescription("Booting"));
+        state1.setNodeState(new Node(NodeType.STORAGE, 2), new NodeState(NodeType.STORAGE, State.INITIALIZING).setInitProgress(0.2f).setDiskCount(2).setDescription("Booting"));
         state2.setDistributionBits(21);
         state2.setOfficial(true);
         assertEquals("version: 123 => 0, bits: 16 => 21, official: false => true, storage: [2: [Initializing => Up, disks: 2 => 0, description: Booting => ], 4: Down => Up, 5: Down => Up], distributor: [7: Up => Down, 8: Up => Down]", state1.getTextualDifference(state2));

--- a/vdslib/src/test/java/com/yahoo/vdslib/state/NodeStateTestCase.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/state/NodeStateTestCase.java
@@ -128,7 +128,7 @@ public class NodeStateTestCase {
         assertEquals("m:Foo\\x20bar", ns.serialize(false));
         assertEquals("m:Foo\\x20bar", ns.serialize(true));
 
-        ns = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2).setDiskCount(4)
+        ns = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2f).setDiskCount(4)
                 .setMinUsedBits(12).setStartTimestamp(5).setDiskState(1, new DiskState(State.DOWN, "bad disk", 1))
                 .setDiskState(3, new DiskState(State.UP, "", 2));
         assertEquals(".2.s:m .2.c:1.2 .2.t:5 .2.d:4 .2.d.1.s:d .2.d.3.c:2.0", ns.serialize(2, false));
@@ -204,7 +204,7 @@ public class NodeStateTestCase {
         String expected = "Maintenance => Up";
         assertEquals(expected, ns.getTextualDifference(new NodeState(NodeType.STORAGE, State.UP)).substring(0, expected.length()));
 
-        NodeState ns1 = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2).setDiskCount(4)
+        NodeState ns1 = new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Foo bar").setCapacity(1.2f).setDiskCount(4)
                 .setMinUsedBits(12).setStartTimestamp(5).setDiskState(1, new DiskState(State.DOWN, "bad disk", 1))
                 .setDiskState(3, new DiskState(State.UP, "", 2));
         ns1.toString();


### PR DESCRIPTION
…r initProgress and capacity. Also gc unused 'reliability' member.

@vekterli PR