### PR TITLE
Lock less

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Cluster.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Cluster.java
@@ -125,6 +125,7 @@ public class Cluster {
     }
 
     public Cluster withAutoscalingStatus(String autoscalingStatus) {
+        if (autoscalingStatus.equals(this.autoscalingStatus)) return this;
         return new Cluster(id, exclusive, min, max, suggested, target, scalingEvents, autoscalingStatus);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ResourceTarget.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ResourceTarget.java
@@ -49,7 +49,7 @@ public class ResourceTarget {
     }
 
     /** Create a target of achieving ideal load given a current load */
-    public static ResourceTarget  idealLoad(ClusterTimeseries clusterTimeseries,
+    public static ResourceTarget idealLoad(ClusterTimeseries clusterTimeseries,
                                            ClusterNodesTimeseries clusterNodesTimeseries,
                                            AllocatableClusterResources current,
                                            Application application) {


### PR DESCRIPTION
- Only lock the application if a new autoscaling target is produced
  or cluster information should be updated.
- Only create a maintenance deployment if we should redeploy.
