### PR TITLE
reduce bandwidth allocation in dev

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -49,9 +49,9 @@ public class CapacityPolicies {
 
         if (capacity.isRequired()) return target;
 
-        // Dev does not cap the cpu of containers since usage is spotty: Allocate just a small amount exclusively
+        // Dev does not cap the cpu or network of containers since usage is spotty: Allocate just a small amount exclusively
         if (zone.environment() == Environment.dev && !zone.getCloud().dynamicProvisioning())
-            target = target.withVcpu(0.1);
+            target = target.withVcpu(0.1).withBandwidthGbps(0.1);
 
         // Allow slow storage in zones which are not performance sensitive
         if (zone.system().isCd() || zone.environment() == Environment.dev || zone.environment() == Environment.test)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicDockerAllocationTest.java
@@ -389,6 +389,7 @@ public class DynamicDockerAllocationTest {
         assertEquals(1, hosts.size());
         tester.activate(application, hosts);
         assertEquals(0.1, hosts.get(0).advertisedResources().vcpu(), 0.000001);
+        assertEquals(0.1, hosts.get(0).advertisedResources().bandwidthGbps(), 0.000001);
         assertEquals("Slow nodes are allowed in dev and preferred because they are cheaper",
                      NodeResources.DiskSpeed.slow, hosts.get(0).advertisedResources().diskSpeed());
     }


### PR DESCRIPTION
Network bandwidth is the resource currently blocking deployments to dev -
each host has a max of 33 containers each with 300mbit/s network bandwidth.