### PR TITLE
Use SSLContext supplier for ZK server configuration

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -44,6 +44,7 @@ trustEmptySnapshot bool default=true
 # TLS options
 tlsForQuorumCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
 tlsForClientServerCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
+# TODO(bjorncs): remove setting - no longer in use
 jksKeyStoreFile string default="conf/zookeeper/zookeeper.jks"
 
 dynamicReconfiguration bool default=false

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -3,22 +3,14 @@
 package com.yahoo.vespa.zookeeper;
 
 import com.yahoo.cloud.config.ZookeeperServerConfig;
-import com.yahoo.security.KeyStoreBuilder;
-import com.yahoo.security.KeyStoreType;
-import com.yahoo.security.KeyStoreUtils;
-import com.yahoo.security.KeyUtils;
-import com.yahoo.security.X509CertificateUtils;
-import com.yahoo.security.tls.TransportSecurityOptions;
-import com.yahoo.text.Utf8;
+import com.yahoo.security.tls.TlsContext;
 import com.yahoo.vespa.defaults.Defaults;
 
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.PrivateKey;
-import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -34,39 +26,35 @@ public class Configurator {
 
     private final ZookeeperServerConfig zookeeperServerConfig;
     private final Path configFilePath;
-    private final Path jksKeyStoreFilePath;
 
     public Configurator(ZookeeperServerConfig zookeeperServerConfig) {
         log.log(Level.FINE, zookeeperServerConfig.toString());
         this.zookeeperServerConfig = zookeeperServerConfig;
         this.configFilePath = makeAbsolutePath(zookeeperServerConfig.zooKeeperConfigFile());
-        this.jksKeyStoreFilePath = makeAbsolutePath(zookeeperServerConfig.jksKeyStoreFile());
         System.setProperty(ZOOKEEPER_JMX_LOG4J_DISABLE, "true");
         System.setProperty("zookeeper.snapshot.trust.empty", Boolean.valueOf(zookeeperServerConfig.trustEmptySnapshot()).toString());
         System.setProperty(ZOOKEEPER_JUTE_MAX_BUFFER, Integer.valueOf(zookeeperServerConfig.juteMaxBuffer()).toString());
     }
 
-    void writeConfigToDisk(Optional<TransportSecurityOptions> transportSecurityOptions) {
+    void writeConfigToDisk(Optional<TlsContext> tlsContext) {
         configFilePath.toFile().getParentFile().mkdirs();
 
         try {
-            writeZooKeeperConfigFile(zookeeperServerConfig, transportSecurityOptions);
+            writeZooKeeperConfigFile(zookeeperServerConfig, tlsContext);
             writeMyIdFile(zookeeperServerConfig);
-            transportSecurityOptions.ifPresent(this::writeJksKeystore);
         } catch (IOException e) {
             throw new RuntimeException("Error writing zookeeper config", e);
         }
     }
 
     private void writeZooKeeperConfigFile(ZookeeperServerConfig config,
-                                          Optional<TransportSecurityOptions> transportSecurityOptions) throws IOException {
+                                          Optional<TlsContext> tlsContext) throws IOException {
         try (FileWriter writer = new FileWriter(configFilePath.toFile())) {
-            writer.write(transformConfigToString(config, transportSecurityOptions));
+            writer.write(transformConfigToString(config, tlsContext));
         }
     }
 
-    private String transformConfigToString(ZookeeperServerConfig config,
-                                           Optional<TransportSecurityOptions> transportSecurityOptions) {
+    private String transformConfigToString(ZookeeperServerConfig config, Optional<TlsContext> tlsContext) {
         StringBuilder sb = new StringBuilder();
         sb.append("tickTime=").append(config.tickTime()).append("\n");
         sb.append("initLimit=").append(config.initLimit()).append("\n");
@@ -74,7 +62,6 @@ public class Configurator {
         sb.append("maxClientCnxns=").append(config.maxClientConnections()).append("\n");
         sb.append("snapCount=").append(config.snapshotCount()).append("\n");
         sb.append("dataDir=").append(getDefaults().underVespaHome(config.dataDir())).append("\n");
-        sb.append("secureClientPort=").append(config.secureClientPort()).append("\n");
         sb.append("autopurge.purgeInterval=").append(config.autopurge().purgeInterval()).append("\n");
         sb.append("autopurge.snapRetainCount=").append(config.autopurge().snapRetainCount()).append("\n");
         // See http://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_zkCommands
@@ -90,8 +77,8 @@ public class Configurator {
         sb.append("metricsProvider.className=org.apache.zookeeper.metrics.impl.NullMetricsProvider\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
         config.server().forEach(server -> addServerToCfg(sb, server, config.clientPort()));
-        sb.append(new TlsQuorumConfig(jksKeyStoreFilePath).createConfig(config, transportSecurityOptions));
-        sb.append(new TlsClientServerConfig(jksKeyStoreFilePath).createConfig(config, transportSecurityOptions));
+        sb.append(new TlsQuorumConfig().createConfig(config, tlsContext));
+        sb.append(new TlsClientServerConfig().createConfig(config, tlsContext));
         return sb.toString();
     }
 
@@ -99,25 +86,6 @@ public class Configurator {
         try (FileWriter writer = new FileWriter(getDefaults().underVespaHome(config.myidFile()))) {
             writer.write(config.myid() + "\n");
         }
-    }
-
-    private void writeJksKeystore(TransportSecurityOptions options) {
-        Path privateKeyFile = options.getPrivateKeyFile().orElseThrow(() -> new RuntimeException("Could not find private key file"));
-        Path certificatesFile = options.getCertificatesFile().orElseThrow(() -> new RuntimeException("Could not find certificates file"));
-
-        PrivateKey privateKey;
-        List<X509Certificate> certificates;
-        try {
-            privateKey = KeyUtils.fromPemEncodedPrivateKey(Utf8.toString(Files.readAllBytes(privateKeyFile)));
-            certificates = X509CertificateUtils.certificateListFromPem(Utf8.toString(Files.readAllBytes(certificatesFile)));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        KeyStoreBuilder keyStoreBuilder = KeyStoreBuilder
-                .withType(KeyStoreType.JKS)
-                .withKeyEntry("foo", privateKey, certificates);
-
-        KeyStoreUtils.writeKeyStoreToFile(keyStoreBuilder.build(), jksKeyStoreFilePath);
     }
 
     private void ensureThisServerIsRepresented(int myid, List<ZookeeperServerConfig.Server> servers) {
@@ -172,59 +140,41 @@ public class Configurator {
     }
 
     private interface TlsConfig {
+        String createConfig(ZookeeperServerConfig config, Optional<TlsContext> tlsContext);
+
         default Optional<String> getEnvironmentVariable(String variableName) {
             return Optional.ofNullable(System.getenv().get(variableName))
                     .filter(var -> !var.isEmpty());
         }
 
-        default void validateOptions(Optional<TransportSecurityOptions> transportSecurityOptions, String tlsSetting) {
-            if (transportSecurityOptions.isEmpty() && !tlsSetting.equals("OFF"))
+        default void validateOptions(Optional<TlsContext> tlsContext, String tlsSetting) {
+            if (tlsContext.isEmpty() && !tlsSetting.equals("OFF"))
                 throw new RuntimeException("Could not retrieve transport security options");
         }
 
         String configFieldPrefix();
 
-        Path jksKeyStoreFilePath();
-
-        default String createCommonKeyStoreTrustStoreOptions(Optional<TransportSecurityOptions> transportSecurityOptions) {
-            StringBuilder sb = new StringBuilder();
-            transportSecurityOptions.ifPresent(options -> {
-                sb.append(configFieldPrefix()).append(".keyStore.location=").append(jksKeyStoreFilePath()).append("\n");
-                sb.append(configFieldPrefix()).append(".keyStore.type=JKS\n");
-
-                Path caCertificatesFile = options.getCaCertificatesFile().orElseThrow(() -> new RuntimeException("Could not find ca certificates file"));
-                sb.append(configFieldPrefix()).append(".trustStore.location=").append(caCertificatesFile).append("\n");
-                sb.append(configFieldPrefix()).append(".trustStore.type=PEM\n");
+        default void appendTlsConfig(StringBuilder builder, ZookeeperServerConfig config, Optional<TlsContext> tlsContext) {
+            tlsContext.ifPresent(ctx -> {
+                builder.append(configFieldPrefix()).append(".context.supplier.class=").append(VespaSslContextProvider.class.getName()).append("\n");
+                String enabledCiphers = Arrays.stream(ctx.parameters().getCipherSuites()).sorted().collect(Collectors.joining(","));
+                builder.append(configFieldPrefix()).append(".ciphersuites=").append(enabledCiphers).append("\n");
+                String enabledProtocols = Arrays.stream(ctx.parameters().getProtocols()).sorted().collect(Collectors.joining(","));
+                builder.append(configFieldPrefix()).append(".enabledProtocols=").append(enabledProtocols).append("\n");
+                builder.append(configFieldPrefix()).append(".clientAuth=NEED\n");
             });
-            return sb.toString();
         }
-
-        default String createCommonConfig() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(configFieldPrefix()).append(".hostnameVerification=false\n");
-            sb.append(configFieldPrefix()).append(".clientAuth=NEED\n");
-            sb.append(configFieldPrefix()).append(".ciphersuites=").append(VespaSslContextProvider.enabledTlsCiphersConfigValue()).append("\n");
-            sb.append(configFieldPrefix()).append(".enabledProtocols=").append(VespaSslContextProvider.enabledTlsProtocolConfigValue()).append("\n");
-            sb.append(configFieldPrefix()).append(".protocol=").append(VespaSslContextProvider.sslContextVersion()).append("\n");
-            return sb.toString();
-        }
-
     }
 
     static class TlsClientServerConfig implements TlsConfig {
 
-        private final Path jksKeyStoreFilePath;
-
-        TlsClientServerConfig(Path jksKeyStoreFilePath) {
-            this.jksKeyStoreFilePath = jksKeyStoreFilePath;
-        }
-
-        String createConfig(ZookeeperServerConfig config, Optional<TransportSecurityOptions> transportSecurityOptions) {
+        @Override
+        public String createConfig(ZookeeperServerConfig config, Optional<TlsContext> tlsContext) {
             String tlsSetting = getEnvironmentVariable("VESPA_TLS_FOR_ZOOKEEPER_CLIENT_SERVER_COMMUNICATION")
                     .orElse(config.tlsForClientServerCommunication().name());
-            validateOptions(transportSecurityOptions, tlsSetting);
+            validateOptions(tlsContext, tlsSetting);
 
-            StringBuilder sb = new StringBuilder(createCommonConfig());
+            StringBuilder sb = new StringBuilder();
             boolean portUnification;
             switch (tlsSetting) {
                 case "OFF":
@@ -239,7 +189,9 @@ public class Configurator {
                     throw new IllegalArgumentException("Unknown value of config setting tlsForClientServerCommunication: " + tlsSetting);
             }
             sb.append("client.portUnification=").append(portUnification).append("\n");
-            sb.append(createCommonKeyStoreTrustStoreOptions(transportSecurityOptions));
+            // TODO This should override "clientPort" if TLS enabled without port unification);
+            tlsContext.ifPresent(ctx -> sb.append("secureClientPort=").append(config.secureClientPort()).append("\n"));
+            appendTlsConfig(sb, config, tlsContext);
 
             return sb.toString();
         }
@@ -248,28 +200,17 @@ public class Configurator {
         public String configFieldPrefix() {
             return "ssl";
         }
-
-        @Override
-        public Path jksKeyStoreFilePath() {
-            return jksKeyStoreFilePath;
-        }
-
     }
 
     static class TlsQuorumConfig implements TlsConfig {
 
-        private final Path jksKeyStoreFilePath;
-
-        TlsQuorumConfig(Path jksKeyStoreFilePath) {
-            this.jksKeyStoreFilePath = jksKeyStoreFilePath;
-        }
-
-        String createConfig(ZookeeperServerConfig config, Optional<TransportSecurityOptions> transportSecurityOptions) {
+        @Override
+        public String createConfig(ZookeeperServerConfig config, Optional<TlsContext> tlsContext) {
             String tlsSetting = getEnvironmentVariable("VESPA_TLS_FOR_ZOOKEEPER_QUORUM_COMMUNICATION")
                     .orElse(config.tlsForQuorumCommunication().name());
-            validateOptions(transportSecurityOptions, tlsSetting);
+            validateOptions(tlsContext, tlsSetting);
 
-            StringBuilder sb = new StringBuilder(createCommonConfig());
+            StringBuilder sb = new StringBuilder();
             boolean sslQuorum;
             boolean portUnification;
             switch (tlsSetting) {
@@ -293,7 +234,7 @@ public class Configurator {
             }
             sb.append("sslQuorum=").append(sslQuorum).append("\n");
             sb.append("portUnification=").append(portUnification).append("\n");
-            sb.append(createCommonKeyStoreTrustStoreOptions(transportSecurityOptions));
+            appendTlsConfig(sb, config, tlsContext);
 
             return sb.toString();
         }
@@ -302,12 +243,6 @@ public class Configurator {
         public String configFieldPrefix() {
             return "ssl.quorum";
         }
-
-        @Override
-        public Path jksKeyStoreFilePath() {
-            return jksKeyStoreFilePath;
-        }
-
     }
 
 }

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaSslContextProvider.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/VespaSslContextProvider.java
@@ -5,39 +5,21 @@ import com.yahoo.security.tls.TlsContext;
 import com.yahoo.security.tls.TransportSecurityUtils;
 
 import javax.net.ssl.SSLContext;
-import java.util.Collection;
-import java.util.List;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
- * Provider for Vespa {@link SSLContext} instance to Zookeeper + misc utility methods for providing Vespa TLS specific ZK configuration.
+ * Provider for Vespa {@link SSLContext} instance to Zookeeper.
  *
  * @author bjorncs
  */
 public class VespaSslContextProvider implements Supplier<SSLContext> {
 
-    private static final TlsContext tlsContext = TransportSecurityUtils.getSystemTlsContext().orElse(null);
+    private static final SSLContext sslContext = TransportSecurityUtils.getSystemTlsContext().map(TlsContext::context).orElse(null);
 
     @Override
     public SSLContext get() {
-        if (!tlsEnabled()) throw new IllegalStateException("Vespa TLS is not enabled");
-        return tlsContext.context();
+        if (sslContext == null) throw new IllegalStateException("Vespa TLS is not enabled");
+        return sslContext;
     }
 
-    public static boolean tlsEnabled() { return tlsContext != null; }
-
-    public static String enabledTlsProtocolConfigValue() {
-        // Fallback to all allowed protocols if we cannot determine which are actually supported by runtime
-        Collection<String> enabledProtocols = tlsEnabled() ? List.of(tlsContext.parameters().getProtocols()) : TlsContext.ALLOWED_PROTOCOLS;
-        return enabledProtocols.stream().sorted().collect(Collectors.joining(","));
-    }
-
-    public static String enabledTlsCiphersConfigValue() {
-        // Fallback to all allowed ciphers if we cannot determine which are actually supported by runtime
-        Collection<String> enabledCiphers = tlsEnabled() ? List.of(tlsContext.parameters().getCipherSuites()) : TlsContext.ALLOWED_CIPHER_SUITES;
-        return enabledCiphers.stream().sorted().collect(Collectors.joining(","));
-    }
-
-    public static String sslContextVersion() { return tlsEnabled() ? tlsContext.context().getProtocol() : TlsContext.SSL_CONTEXT_VERSION; }
 }

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/ZooKeeperRunner.java
@@ -39,7 +39,7 @@ public class ZooKeeperRunner implements Runnable {
     public ZooKeeperRunner(ZookeeperServerConfig zookeeperServerConfig, VespaZooKeeperServer server) {
         this.zookeeperServerConfig = zookeeperServerConfig;
         this.server = server;
-        new Configurator(zookeeperServerConfig).writeConfigToDisk(TransportSecurityUtils.getOptions());
+        new Configurator(zookeeperServerConfig).writeConfigToDisk(TransportSecurityUtils.getSystemTlsContext());
         executorService = Executors.newSingleThreadExecutor(new DaemonThreadFactory("zookeeper server"));
         executorService.submit(this);
     }


### PR DESCRIPTION
Remove use of keystore/truststore from disk.
Only configure client secure port if TLS is enabled.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
