### PR TITLE
Remove active queries metrics that are never set

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -272,10 +272,6 @@ public class VespaMetricSet {
         metrics.add(new Metric("search_connections.sum"));
         metrics.add(new Metric("search_connections.count"));
         metrics.add(new Metric("search_connections.average")); // TODO: Remove in Vespa 8
-        metrics.add(new Metric("active_queries.max"));
-        metrics.add(new Metric("active_queries.sum"));
-        metrics.add(new Metric("active_queries.count"));
-        metrics.add(new Metric("active_queries.average")); // TODO: Remove in Vespa 8
         metrics.add(new Metric("feed.latency.max"));
         metrics.add(new Metric("feed.latency.sum"));
         metrics.add(new Metric("feed.latency.count"));

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -57,7 +57,6 @@ public class StatisticsSearcher extends Searcher {
     private static final String QUERY_LATENCY_METRIC = "query_latency";
     private static final String QUERY_HIT_OFFSET_METRIC = "query_hit_offset";
     private static final String QUERIES_METRIC = "queries";
-    private static final String ACTIVE_QUERIES_METRIC = "active_queries";
     private static final String PEAK_QPS_METRIC = "peak_qps";
     private static final String DOCS_COVERED_METRIC = "documents_covered";
     private static final String DOCS_TOTAL_METRIC = "documents_total";
@@ -84,12 +83,12 @@ public class StatisticsSearcher extends Searcher {
     // Naming of enums are reflected directly in metric dimensions and should not be changed as they are public API
     private enum DegradedReason { match_phase, adaptive_timeout, timeout, non_ideal_state }
 
-    private Metric metric;
-    private Map<String, Metric.Context> chainContexts = new CopyOnWriteHashMap<>();
-    private Map<String, Metric.Context> statePageOnlyContexts = new CopyOnWriteHashMap<>();
-    private Map<String, Map<DegradedReason, Metric.Context>> degradedReasonContexts = new CopyOnWriteHashMap<>();
-    private Map<String, Map<String, Metric.Context>> relevanceContexts = new CopyOnWriteHashMap<>();
-    private java.util.Timer scheduler = new java.util.Timer(true);
+    private final Metric metric;
+    private final Map<String, Metric.Context> chainContexts = new CopyOnWriteHashMap<>();
+    private final Map<String, Metric.Context> statePageOnlyContexts = new CopyOnWriteHashMap<>();
+    private final Map<String, Map<DegradedReason, Metric.Context>> degradedReasonContexts = new CopyOnWriteHashMap<>();
+    private final Map<String, Map<String, Metric.Context>> relevanceContexts = new CopyOnWriteHashMap<>();
+    private final java.util.Timer scheduler = new java.util.Timer(true);
 
     private class PeakQpsReporter extends java.util.TimerTask {
         private long prevMaxQPSTime = System.currentTimeMillis();

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -123,6 +123,12 @@ public class YqlParserTestCase {
     }
 
     @Test
+    public void testHitLimit() {
+        assertParse("select artist_name, track_name, track_uri from sources * where (myField contains ([{\"prefix\":true}]\"m\") and ([{\"hitLimit\": 5000, \"descending\": true}]range(static_score,0,Infinity))) limit 30 offset 0;",
+                    "AND myField:m* static_score:[0;;-5000]");
+    }
+
+    @Test
     public void test() {
         assertParse("select foo from bar where title contains \"madonna\";",
                     "title:madonna");


### PR DESCRIPTION
I noticed we define these metrics but never set them. I guess they should be safe to remove then.