### PR TITLE
ONNX: import rankingExpression input as function

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -855,10 +855,14 @@ public class RankProfile implements Cloneable {
     private Optional<TensorType> resolveOnnxInputType(String onnxInputName, OnnxModel model, MapEvaluationTypeContext context) {
         String source = model.getInputMap().get(onnxInputName);
         if (source != null) {
-            // Source is either a simple reference (query/attribute/constant)...
+            // Source is either a simple reference (query/attribute/constant/rankingExpression)...
             Optional<Reference> reference = Reference.simple(source);
             if (reference.isPresent()) {
-                return Optional.of(context.getType(reference.get()));
+                if (reference.get().name().equals("rankingExpression") && reference.get().simpleArgument().isPresent()) {
+                    source = reference.get().simpleArgument().get();  // look up function below
+                } else {
+                    return Optional.of(context.getType(reference.get()));
+                }
             }
             // ... or a function
             ExpressionFunction func = context.getFunction(source);

--- a/config-model/src/test/integration/onnx-model/schemas/test.sd
+++ b/config-model/src/test/integration/onnx-model/schemas/test.sd
@@ -117,4 +117,10 @@ search test {
         }
     }
 
+    rank-profile test_transformed_dynamic_model inherits test_dynamic_model {
+        first-phase {
+            expression: max(onnx(dynamic_model){d1:0},d0)
+        }
+    }
+
 }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
@@ -113,7 +113,7 @@ public class RankingExpressionWithOnnxModelTestCase {
         RankProfilesConfig.Builder builder = new RankProfilesConfig.Builder();
         ((RankProfilesConfig.Producer) db).getConfig(builder);
         RankProfilesConfig config = new RankProfilesConfig(builder);
-        assertEquals(9, config.rankprofile().size());
+        assertEquals(10, config.rankprofile().size());
 
         assertEquals("test_model_config", config.rankprofile(2).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(2).fef().property(0).name());


### PR DESCRIPTION
@bratseth Please review.

For context: during rank profile deriving, we modify `onnx-model` inputs to include `rankingExpression` if it refers to a function. This is for compatibility with the backend. For the first rank profile using the model, this works fine. For the next rank profile using the same model, the input function wasn't found due to the input now being enclosed in a `rankingExpression(...)`.

Since this modification only happens after type checking, this wasn't much of a problem. However, if a rank profile contains a `min` or `max` function for tensors (not numeric min/max, but tensor min/max), the type is checked again there which can cause type failure.