### PR TITLE
Revert "Bjorncs/zk server client port tls only [run-systemtest]"

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -16,7 +16,6 @@ maxClientConnections int default=0
 dataDir string default="var/zookeeper"
 
 clientPort int default=2181
-# TODO(bjorncs): remove setting - no longer in use
 secureClientPort int default=2184
 
 snapshotCount int default=50000
@@ -43,9 +42,7 @@ server[].joining bool default=false
 trustEmptySnapshot bool default=true
 
 # TLS options
-# TODO(bjorncs): todo cleanup after migrating to unified Vespa TLS configuration
 tlsForQuorumCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
-# TODO(bjorncs): todo cleanup after migrating to unified Vespa TLS configuration
 tlsForClientServerCommunication enum { OFF, PORT_UNIFICATION, TLS_WITH_PORT_UNIFICATION, TLS_ONLY } default=OFF
 # TODO(bjorncs): remove setting - no longer in use
 jksKeyStoreFile string default="conf/zookeeper/zookeeper.jks"

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -182,12 +182,10 @@ public class ConfiguratorTest {
     private void validateConfigFileSingleHost(File cfgFile) {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 "sslQuorum=false\n" +
                 "portUnification=false\n" +
-                "client.portUnification=false\n" +
-                "clientPort=2181\n" +
-                "secureClientPort=0\n";
+                "client.portUnification=false\n";
         validateConfigFile(cfgFile, expected);
     }
 
@@ -200,7 +198,8 @@ public class ConfiguratorTest {
     }
 
     private String tlsClientServerConfig() {
-        return "ssl.context.supplier.class=com.yahoo.vespa.zookeeper.VespaSslContextProvider\n" +
+        return "secureClientPort=2184\n" +
+                "ssl.context.supplier.class=com.yahoo.vespa.zookeeper.VespaSslContextProvider\n" +
                 "ssl.ciphersuites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256," +
                 "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\n" +
                 "ssl.enabledProtocols=TLSv1.2\n" +
@@ -210,27 +209,23 @@ public class ConfiguratorTest {
     private void validateConfigFileMultipleHosts(File cfgFile) {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
-                "server.1=bar:432:234\n" +
-                "server.2=baz:543:345:observer\n" +
+                "server.0=foo:321:123;2181\n" +
+                "server.1=bar:432:234;2181\n" +
+                "server.2=baz:543:345:observer;2181\n" +
                 "sslQuorum=false\n" +
                 "portUnification=false\n" +
-                "client.portUnification=false\n" +
-                "clientPort=2181\n" +
-                "secureClientPort=0\n";
+                "client.portUnification=false\n";
         validateConfigFile(cfgFile, expected);
     }
 
     private void validateConfigFilePortUnification(File cfgFile) {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 "sslQuorum=false\n" +
                 "portUnification=true\n" +
                 tlsQuorumConfig() +
                 "client.portUnification=true\n" +
-                "clientPort=2181\n" +
-                "secureClientPort=0\n" +
                 tlsClientServerConfig();
         validateConfigFile(cfgFile, expected);
     }
@@ -238,13 +233,11 @@ public class ConfiguratorTest {
     private void validateConfigFileTlsWithPortUnification(File cfgFile) {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 "sslQuorum=true\n" +
                 "portUnification=true\n" +
                 tlsQuorumConfig() +
                 "client.portUnification=true\n" +
-                "clientPort=2181\n" +
-                "secureClientPort=0\n" +
                 tlsClientServerConfig();
         validateConfigFile(cfgFile, expected);
     }
@@ -252,13 +245,11 @@ public class ConfiguratorTest {
     private void validateConfigFileTlsOnly(File cfgFile) {
         String expected =
                 commonConfig() +
-                "server.0=foo:321:123\n" +
+                "server.0=foo:321:123;2181\n" +
                 "sslQuorum=true\n" +
                 "portUnification=false\n" +
                 tlsQuorumConfig() +
                 "client.portUnification=false\n" +
-                "clientPort=0\n" +
-                "secureClientPort=2181\n" +
                 tlsClientServerConfig();
         validateConfigFile(cfgFile, expected);
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#16962

Seems to have broken the tests/cloudconfig/configserver/configserver.rb system test.