### PR TITLE
Do not use sudo when running vespa-zk* commands

### DIFF
--- a/zookeeper-command-line-client/src/main/sh/vespa-zkcli
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkcli
@@ -80,19 +80,15 @@ usage() {
     echo ""
 
     echo "-h|-help)              print this help text"
-    echo "-nosudo                do not use sudo when running command"
 }
 
-sudo="/usr/bin/sudo -u ${VESPA_USER}"
 while [ $# -gt 0 ]; do
     case $1 in
         -h|-help)        usage; exit 0;;
-        -nosudo)         shift; sudo="" ;;
         *)               echo "Unrecognized option '$1'" >&2; exit 1;;
     esac
 done
 
-$sudo java \
-	-cp $VESPA_HOME/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
-	-Dlog4j.configuration="log4j-vespa.properties" -Xms32m -Xmx512m \
-	com.yahoo.vespa.zookeeper.cli.Main "$@"
+java -cp $VESPA_HOME/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
+     -Dlog4j.configuration="log4j-vespa.properties" -Xms32m -Xmx512m \
+     com.yahoo.vespa.zookeeper.cli.Main "$@"


### PR DESCRIPTION
Try to remove sudo, causes issues when using environment variables.
Can't see why it should be needed by default either. Alternatively do as in https://github.com/vespa-engine/vespa/pull/16972
