### PR TITLE
Retire all wanttoretire nodes with TypeNodeSpec

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeSpec.java
@@ -207,10 +207,8 @@ public interface NodeSpec {
 
         @Override
         public int idealRetiredCount(int acceptedCount, int currentRetiredCount) {
-             // All nodes marked with wantToRetire get marked as retired just before this function is called,
-             // the job of this function is to throttle the retired count. If no nodes are marked as retired
-             // then continue this way, otherwise allow only 1 node to be retired
-            return Math.min(1, currentRetiredCount);
+            // All nodes marked with wantToRetire get marked as retired just before this function is called
+            return currentRetiredCount;
         }
 
         @Override

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -190,11 +190,7 @@ public class RetiredExpirerTest {
 
         // Redeploy to retire all 3 config servers
         infraDeployer.activateAllSupportedInfraApplications(true);
-        List<Node> retiredNodes = tester.nodeRepository()
-                                        .nodes().list(() -> {})
-                                        .stream()
-                                        .filter(node -> node.allocation().map(allocation -> allocation.membership().retired()).orElse(false))
-                                        .collect(Collectors.toList());
+        List<Node> retiredNodes = tester.nodeRepository().nodes().list().retired().asList();
         assertEquals(3, retiredNodes.size());
 
         // The Orchestrator will allow only 1 to be removed, say cfg1


### PR DESCRIPTION
When wantToRetire is set on a set of infra nodes (any non-tenant application), at most 1 node is allowed to retire.

This causes a problem when wanting to reprovision all config servers:  Say cfg1 and cfghost2 is allowed to retire.  cfghost2 will not be allowed to exit retirement because cfg2 is not parked, which it cannot be because it isn't even retired yet.

Capping the number of retiring nodes seems unnecessary.  For instance RetiredExpirer ensures only one config server is allowed to complete retirement (be removed from application).

This may have an effect on proxy(host) retirement:  If >1 proxies are wantToRetire, and the orchestrator disallows removal, it used to be that first one proxy node would expire after 4 days, then another after 4 days, etc.  Now, all such proxies would expire after the first 4 day period.