### PR TITLE
Retire any kind of host on cloud maintenance event

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/CloudEvent.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/CloudEvent.java
@@ -5,27 +5,32 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
 
-public final class CloudEvent {
+/**
+ * A maintenance event in a cloud service.
+ *
+ * @author freva
+ */
+public class CloudEvent {
+
     public final String instanceEventId;
     public final String code;
     public final String description;
     public final Optional<Date> notBefore;
     public final Optional<Date> notBeforeDeadline;
     public final Optional<Date> notAfter;
+    public final String awsRegionName;
+    public final Set<String> affectedInstances;
 
-    public String awsRegionName;
-    public Set<String> affectedInstances;
-
-    public CloudEvent(String instanceEventId, String code, String description, Date notAfter, Date notBefore, Date notBeforeDeadline,
-                      String awsRegionName, Set<String> affectedInstances) {
+    public CloudEvent(String instanceEventId, String code, String description, Date notAfter, Date notBefore,
+                      Date notBeforeDeadline, String awsRegionName, Set<String> affectedInstances) {
         this.instanceEventId = instanceEventId;
         this.code = code;
         this.description = description;
         this.notBefore = Optional.ofNullable(notBefore);
         this.notBeforeDeadline = Optional.ofNullable(notBeforeDeadline);
         this.notAfter = Optional.ofNullable(notAfter);
-
         this.awsRegionName = awsRegionName;
-        this.affectedInstances = affectedInstances;
+        this.affectedInstances = Set.copyOf(affectedInstances);
     }
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/MockAwsEventFetcher.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/MockAwsEventFetcher.java
@@ -10,9 +10,12 @@ import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Optional;
 
+/**
+ * @author freva
+ */
 public class MockAwsEventFetcher implements AwsEventFetcher {
 
-    private Map<String, List<CloudEvent>> mockedEvents = new HashMap<>();
+    private final Map<String, List<CloudEvent>> mockedEvents = new HashMap<>();
 
     @Override
     public List<CloudEvent> getEvents(String awsRegionName) {
@@ -27,4 +30,5 @@ public class MockAwsEventFetcher implements AwsEventFetcher {
     public void addEvent(String awsRegionName, CloudEvent cloudEvent) {
         mockedEvents.computeIfAbsent(awsRegionName, i -> new ArrayList<>()).add(cloudEvent);
     }
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CloudEventReporter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CloudEventReporter.java
@@ -2,23 +2,16 @@
 package com.yahoo.vespa.hosted.controller.maintenance;
 
 import com.yahoo.config.provision.CloudName;
-import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.zone.ZoneApi;
-import com.yahoo.jdisc.Metric;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.aws.AwsEventFetcher;
 import com.yahoo.vespa.hosted.controller.api.integration.aws.CloudEvent;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.NodeRepository;
-import com.yahoo.vespa.hosted.controller.api.integration.organization.Issue;
-import com.yahoo.vespa.hosted.controller.api.integration.organization.IssueHandler;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -33,79 +26,45 @@ public class CloudEventReporter extends ControllerMaintainer {
 
     private static final Logger log = Logger.getLogger(CloudEventReporter.class.getName());
 
-    private final IssueHandler issueHandler;
     private final AwsEventFetcher eventFetcher;
     private final Map<String, List<ZoneApi>> zonesByCloudNativeRegion;
     private final NodeRepository nodeRepository;
-    private final Metric metric;
 
-    private static final String INFRASTRUCTURE_INSTANCE_EVENTS = "infrastructure_instance_events";
-
-    CloudEventReporter(Controller controller, Duration interval, Metric metric) {
+    CloudEventReporter(Controller controller, Duration interval) {
         super(controller, interval);
-        this.issueHandler = controller.serviceRegistry().issueHandler();
         this.eventFetcher = controller.serviceRegistry().eventFetcherService();
         this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.zonesByCloudNativeRegion = supportedZonesByRegion();
-        this.metric = metric;
     }
 
     @Override
     protected boolean maintain() {
-        int numberOfInfrastructureEvents = 0;
         for (var region : zonesByCloudNativeRegion.keySet()) {
             List<CloudEvent> events = eventFetcher.getEvents(region);
             for (var event : events) {
                 log.info(String.format("Retrieved event %s, affecting the following instances: %s",
                                        event.instanceEventId,
                                        event.affectedInstances));
-                List<Node> needsManualIntervention = handleInstances(region, event);
-                if (!needsManualIntervention.isEmpty()) {
-                    numberOfInfrastructureEvents += needsManualIntervention.size();
-                    submitIssue(event);
-                }
+                deprovisionAffectedHosts(region, event);
             }
         }
-        metric.set(INFRASTRUCTURE_INSTANCE_EVENTS, numberOfInfrastructureEvents, metric.createContext(Collections.emptyMap()));
         return true;
     }
 
-    /**
-     * Handles affected instances in the following way:
-     *
-     *  1. Ignore if unknown instance, presumably belongs to different system
-     *  2. Retire and deprovision if tenant host
-     *  3. Submit issue if infrastructure host, as it requires manual intervention
-     */
-    private List<Node> handleInstances(String region, CloudEvent event) {
-        List<Node> needsManualIntervention = new ArrayList<>();
+    /** Deprovision any host affected by given event */
+    private void deprovisionAffectedHosts(String region, CloudEvent event) {
         for (var zone : zonesByCloudNativeRegion.get(region)) {
             for (var node : nodeRepository.list(zone.getId())) {
-                if (!affects(node, event)){
-                    continue;
-                }
-                if (node.type() == NodeType.host) {
-                    log.info(String.format("Setting host %s to wantToRetire and wantToDeprovision", node.hostname().value()));
-                    nodeRepository.retireAndDeprovision(zone.getId(), node.hostname().value());
-                } else {
-                    needsManualIntervention.add(node);
-                }
+                if (!affects(node, event)) continue;
+                log.info("Retiring and deprovisioning " + node.hostname().value() + " in " + zone.getId() +
+                         ": Affected by maintenance event " + event.instanceEventId);
+                nodeRepository.retireAndDeprovision(zone.getId(), node.hostname().value());
             }
-        }
-        return needsManualIntervention;
-    }
-
-    private void submitIssue(CloudEvent event) {
-        if (controller().system().isPublic())
-            return;
-        Issue issue = eventFetcher.createIssue(event);
-        if (!issueHandler.issueExists(issue)) {
-            issueHandler.file(issue);
-            log.log(Level.INFO, String.format("Filed an issue with the title '%s'", issue.summary()));
         }
     }
 
     private static boolean affects(Node node, CloudEvent event) {
+        if (!node.type().isHost()) return false; // Non-hosts are never affected
         return event.affectedInstances.stream()
                                       .anyMatch(instance -> node.hostname().value().contains(instance));
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -56,7 +56,7 @@ public class ControllerMaintenance extends AbstractComponent {
         maintainers.add(new NameServiceDispatcher(controller, intervals.nameServiceDispatcher));
         maintainers.add(new CostReportMaintainer(controller, intervals.costReportMaintainer, controller.serviceRegistry().costReportConsumer()));
         maintainers.add(new ResourceMeterMaintainer(controller, intervals.resourceMeterMaintainer, metric, controller.serviceRegistry().meteringService()));
-        maintainers.add(new CloudEventReporter(controller, intervals.cloudEventReporter, metric));
+        maintainers.add(new CloudEventReporter(controller, intervals.cloudEventReporter));
         maintainers.add(new ResourceTagMaintainer(controller, intervals.resourceTagMaintainer, controller.serviceRegistry().resourceTagger()));
         maintainers.add(new SystemRoutingPolicyMaintainer(controller, intervals.systemRoutingPolicyMaintainer));
         maintainers.add(new ApplicationMetaDataGarbageCollector(controller, intervals.applicationMetaDataGarbageCollector));


### PR DESCRIPTION
We now support retiring/deprovisioning config hosts, so we no longer need to
file tickets.

@olaaun

FYI @hakonhall