### PR TITLE
Use default metrics provider

### DIFF
--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -76,7 +76,6 @@ public class Configurator {
         sb.append("standaloneEnabled=false").append("\n");
         sb.append("reconfigEnabled=true").append("\n");
         sb.append("skipACL=yes").append("\n");
-        sb.append("metricsProvider.className=org.apache.zookeeper.metrics.impl.NullMetricsProvider\n");
         ensureThisServerIsRepresented(config.myid(), config.server());
         config.server().forEach(server -> addServerToCfg(sb, server));
         sb.append(new TlsQuorumConfig().createConfig(config, tlsContext));

--- a/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
+++ b/zookeeper-server/zookeeper-server-common/src/test/java/com/yahoo/vespa/zookeeper/ConfiguratorTest.java
@@ -175,8 +175,7 @@ public class ConfiguratorTest {
                "quorumListenOnAllIPs=true\n" +
                "standaloneEnabled=false\n" +
                "reconfigEnabled=true\n" +
-               "skipACL=yes\n" +
-               "metricsProvider.className=org.apache.zookeeper.metrics.impl.NullMetricsProvider\n";
+               "skipACL=yes\n";
     }
 
     private void validateConfigFileSingleHost(File cfgFile) {


### PR DESCRIPTION
This will make us able to get zookeeper metrics using four-letter word comman {{mntr}} (used by ZKMetricUpdater)