### PR TITLE
Reduce sleep time when redeploying fails

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -56,8 +56,9 @@ keepUnusedFileReferencesMinutes int default=300
 # Bootstrapping
 # How long bootstrapping can take before giving up (in seconds)
 maxDurationOfBootstrap long default=7200
-# How long to sleep before redeploying again if it fails (in seconds)
-sleepTimeWhenRedeployingFails long default=30
+# Initial time for how long to sleep before redeploying again if it fails (in seconds)
+# Code uses backoff, so wait time will increase for every iteration
+sleepTimeWhenRedeployingFails long default=15
 
 # Features (to be overridden in configserver-config.xml if needed)
 buildMinimalSetOfConfigModels bool default=true

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -204,23 +204,23 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
 
     private boolean redeployAllApplications() throws InterruptedException {
         Instant end = Instant.now().plus(maxDurationOfRedeployment);
-        List<ApplicationId> applicationsNotRedeployed = applicationRepository.listApplications();
-        Collections.shuffle(applicationsNotRedeployed);
+        List<ApplicationId> applicationsToRedeploy = applicationRepository.listApplications();
+        Collections.shuffle(applicationsToRedeploy);
         long failCount = 0;
         do {
-            applicationsNotRedeployed = redeployApplications(applicationsNotRedeployed);
-            if ( ! applicationsNotRedeployed.isEmpty() && ! sleepTimeWhenRedeployingFails.isZero()) {
+            applicationsToRedeploy = redeployApplications(applicationsToRedeploy);
+            if ( ! applicationsToRedeploy.isEmpty() && ! sleepTimeWhenRedeployingFails.isZero()) {
                 Duration sleepTime = sleepTimeWhenRedeployingFails.multipliedBy(++failCount);
                 if (sleepTime.compareTo(Duration.ofMinutes(10)) > 0)
                     sleepTime = Duration.ofMinutes(10);
-                log.log(Level.INFO, "Redeployment of " + applicationsNotRedeployed + " not finished, will retry in " + sleepTime);
+                log.log(Level.INFO, "Redeployment of " + applicationsToRedeploy + " not finished, will retry in " + sleepTime);
                 Thread.sleep(sleepTime.toMillis());
             }
-        } while ( ! applicationsNotRedeployed.isEmpty() && Instant.now().isBefore(end));
+        } while ( ! applicationsToRedeploy.isEmpty() && Instant.now().isBefore(end));
 
-        if ( ! applicationsNotRedeployed.isEmpty()) {
+        if ( ! applicationsToRedeploy.isEmpty()) {
             log.log(Level.SEVERE, "Redeploying applications not finished after " + maxDurationOfRedeployment +
-                    ", exiting, applications that failed redeployment: " + applicationsNotRedeployed);
+                    ", exiting, applications that failed redeployment: " + applicationsToRedeploy);
             return false;
         }
         return true;


### PR DESCRIPTION
We have backoff, so this is just to reduce the initial sleep time, things will work the same, but e.g. tests will redeploy faster