### PR TITLE
More consistent cluster controller ZooKeeper and election handling [run-systemtest]

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -521,6 +521,7 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
 
         masterElectionHandler.setFleetControllerCount(options.fleetControllerCount);
         masterElectionHandler.setMasterZooKeeperCooldownPeriod(options.masterZooKeeperCooldownPeriod);
+        masterElectionHandler.setUsingZooKeeper(options.zooKeeperServerAddress != null && !options.zooKeeperServerAddress.isEmpty());
 
         if (rpcServer != null) {
             rpcServer.setMasterElectionHandler(masterElectionHandler);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -600,10 +600,6 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
     public void tick() throws Exception {
         synchronized (monitor) {
             boolean didWork;
-            // We defer ZooKeeper connections until our local Slobrok mirror is ready.
-            // Otherwise we risk winning an election without having any clue about the state of
-            // the nodes in the cluster, causing us to spuriously publish cluster down-states.
-            database.setConnectionEstablishmentIsAllowed(nodeLookup.isReady());
             didWork = database.doNextZooKeeperTask(databaseContext);
             didWork |= updateMasterElectionState();
             didWork |= handleLeadershipEdgeTransitions();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -597,6 +597,10 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
     public void tick() throws Exception {
         synchronized (monitor) {
             boolean didWork;
+            // We defer ZooKeeper connections until our local Slobrok mirror is ready.
+            // Otherwise we risk winning an election without having any clue about the state of
+            // the nodes in the cluster, causing us to spuriously publish cluster down-states.
+            database.setConnectionEstablishmentIsAllowed(nodeLookup.isReady());
             didWork = database.doNextZooKeeperTask(databaseContext);
             didWork |= updateMasterElectionState();
             didWork |= handleLeadershipEdgeTransitions();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
@@ -55,6 +55,10 @@ public class MasterElectionHandler implements MasterInterface {
     }
 
     public void setUsingZooKeeper(boolean usingZK) {
+        if (!usingZooKeeper && usingZK) {
+            // Reset any shortcuts taken by non-ZK election logic.
+            resetElectionProgress();
+        }
         usingZooKeeper = usingZK;
     }
 
@@ -224,13 +228,17 @@ public class MasterElectionHandler implements MasterInterface {
     }
 
     public void lostDatabaseConnection() {
-        if (totalCount > 1) {
+        if (totalCount > 1 || usingZooKeeper) {
             log.log(Level.INFO, "Cluster controller " + index + ": Clearing master data as we lost connection on node " + index);
-            masterData = null;
-            masterCandidate = null;
-            followers = 0;
-            nextMasterData = null;
+            resetElectionProgress();
         }
+    }
+
+    private void resetElectionProgress() {
+        masterData = null;
+        masterCandidate = null;
+        followers = 0;
+        nextMasterData = null;
     }
 
     public void writeHtmlState(StringBuilder sb, int stateGatherCount) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
@@ -25,6 +25,7 @@ public class MasterElectionHandler implements MasterInterface {
     private Map<Integer, Integer> nextMasterData;
     private long masterGoneFromZooKeeperTime; // Set to time master fleet controller disappears from zookeeper
     private long masterZooKeeperCooldownPeriod; // The period in ms that we won't take over unless master come back.
+    private boolean usingZooKeeper = false; // Unit tests may not use ZooKeeper at all.
 
     public MasterElectionHandler(int index, int totalCount, Object monitor, Timer timer) {
         this.monitor = monitor;
@@ -42,7 +43,7 @@ public class MasterElectionHandler implements MasterInterface {
 
     public void setFleetControllerCount(int count) {
         totalCount = count;
-        if (count == 1) {
+        if (count == 1 && !usingZooKeeper) {
             masterCandidate = 0;
             followers = 1;
             nextInLineCount = 0;
@@ -51,6 +52,10 @@ public class MasterElectionHandler implements MasterInterface {
 
     public void setMasterZooKeeperCooldownPeriod(int period) {
         masterZooKeeperCooldownPeriod = period;
+    }
+
+    public void setUsingZooKeeper(boolean usingZK) {
+        usingZooKeeper = usingZK;
     }
 
     @Override
@@ -106,7 +111,9 @@ public class MasterElectionHandler implements MasterInterface {
 
     public boolean watchMasterElection(DatabaseHandler database,
                                        DatabaseHandler.Context dbContext) throws InterruptedException {
-        if (totalCount == 1) return false; // No point in doing master election with only one node configured to be cluster controller
+        if (totalCount == 1 && !usingZooKeeper) {
+            return false; // Allow single configured node to become master implicitly if no ZK configured
+        }
         if (nextMasterData == null) {
             if (masterCandidate == null) {
                 log.log(Level.FINEST, "Cluster controller " + index + ": No current master candidate. Waiting for data to do master election.");

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeLookup.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeLookup.java
@@ -12,4 +12,11 @@ public interface NodeLookup {
 
     boolean updateCluster(ContentCluster cluster, NodeAddedOrRemovedListener listener);
 
+    /**
+     * Returns whether the lookup instance has been able to bootstrap itself with information about nodes.
+     *
+     * Calling updateCluster() _before_ isReady has returned true may not provide any useful data.
+     */
+    boolean isReady();
+
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
@@ -243,7 +243,7 @@ public class DatabaseHandler {
                 didWork = true;
             }
         }
-        if (isDatabaseClosedSafe() && zooKeeperIsConfigured() && connectionEstablishmentIsAllowed) {
+        if (isDatabaseClosedSafe() && zooKeeperIsConfigured()) {
             long currentTime = timer.getCurrentTimeInMillis();
             if (currentTime - lastZooKeeperConnectionAttempt < minimumWaitBetweenFailedConnectionAttempts) {
                 return false; // Not time to attempt connection yet.
@@ -266,10 +266,6 @@ public class DatabaseHandler {
             relinquishDatabaseConnectivity(context);
         }
         return didWork;
-    }
-
-    public void setConnectionEstablishmentIsAllowed(boolean allowed) {
-        connectionEstablishmentIsAllowed = allowed;
     }
 
     private boolean zooKeeperIsConfigured() {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseHandler.java
@@ -91,6 +91,7 @@ public class DatabaseHandler {
     private long lastZooKeeperConnectionAttempt = 0;
     private static final int minimumWaitBetweenFailedConnectionAttempts = 10000;
     private boolean lostZooKeeperConnectionEvent = false;
+    private boolean connectionEstablishmentIsAllowed = false;
     private Map<Integer, Integer> masterDataEvent = null;
 
     public DatabaseHandler(DatabaseFactory databaseFactory, Timer timer, String zooKeeperAddress, int ourIndex, Object monitor) throws InterruptedException
@@ -242,7 +243,7 @@ public class DatabaseHandler {
                 didWork = true;
             }
         }
-        if (isDatabaseClosedSafe() && zooKeeperIsConfigured()) {
+        if (isDatabaseClosedSafe() && zooKeeperIsConfigured() && connectionEstablishmentIsAllowed) {
             long currentTime = timer.getCurrentTimeInMillis();
             if (currentTime - lastZooKeeperConnectionAttempt < minimumWaitBetweenFailedConnectionAttempts) {
                 return false; // Not time to attempt connection yet.
@@ -265,6 +266,10 @@ public class DatabaseHandler {
             relinquishDatabaseConnectivity(context);
         }
         return didWork;
+    }
+
+    public void setConnectionEstablishmentIsAllowed(boolean allowed) {
+        connectionEstablishmentIsAllowed = allowed;
     }
 
     private boolean zooKeeperIsConfigured() {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/SlobrokClient.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/rpc/SlobrokClient.java
@@ -59,6 +59,7 @@ public class SlobrokClient implements NodeLookup {
         freshMirror = true;
     }
 
+    @Override
     public void shutdown() {
         if (supervisor != null) {
             supervisor.transport().shutdown().join();
@@ -67,6 +68,12 @@ public class SlobrokClient implements NodeLookup {
 
     public Mirror getMirror() { return mirror; }
 
+    @Override
+    public boolean isReady() {
+        return mirror != null && mirror.ready();
+    }
+
+    @Override
     public boolean updateCluster(ContentCluster cluster, NodeAddedOrRemovedListener listener) {
         if (mirror == null) return false;
         int mirrorVersion = mirror.updates();

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
@@ -66,19 +66,8 @@ public class DatabaseHandlerTest {
         }
 
         DatabaseHandler createHandler() throws Exception {
-            var handler = new DatabaseHandler(mockDbFactory, mockTimer, databaseAddress, 0, monitor);
-            handler.setConnectionEstablishmentIsAllowed(true);
-            return handler;
+            return new DatabaseHandler(mockDbFactory, mockTimer, databaseAddress, 0, monitor);
         }
-    }
-
-    @Test
-    public void can_not_connect_to_database_if_connectivity_is_not_allowed() throws Exception {
-        Fixture f = new Fixture();
-        DatabaseHandler handler = f.createHandler();
-        handler.setConnectionEstablishmentIsAllowed(false);
-        handler.doNextZooKeeperTask(f.createMockContext());
-        assertTrue(handler.isClosed()); // No connectivity allowed yet
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DatabaseHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -65,8 +66,19 @@ public class DatabaseHandlerTest {
         }
 
         DatabaseHandler createHandler() throws Exception {
-            return new DatabaseHandler(mockDbFactory, mockTimer, databaseAddress, 0, monitor);
+            var handler = new DatabaseHandler(mockDbFactory, mockTimer, databaseAddress, 0, monitor);
+            handler.setConnectionEstablishmentIsAllowed(true);
+            return handler;
         }
+    }
+
+    @Test
+    public void can_not_connect_to_database_if_connectivity_is_not_allowed() throws Exception {
+        Fixture f = new Fixture();
+        DatabaseHandler handler = f.createHandler();
+        handler.setConnectionEstablishmentIsAllowed(false);
+        handler.doNextZooKeeperTask(f.createMockContext());
+        assertTrue(handler.isClosed()); // No connectivity allowed yet
     }
 
     @Test

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyCommunicator.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DummyCommunicator.java
@@ -154,4 +154,8 @@ public class DummyCommunicator implements Communicator, NodeLookup {
         return false;
     }
 
+    @Override
+    public boolean isReady() {
+        return true;
+    }
 }


### PR DESCRIPTION
@hakonhall please review. This contains the changes in #17029 as well as some additional goodies:
* If we're running with ZooKeeper configured, do not allow short-circuiting election phase if only one node is configured. This strictly orders leadership edges to happen after ZK is connected.
* Be consistent in what election state the core `FleetController` logic consults. Instead of (mostly) checking the election handler, check our local state instead. The latter depends on the former, but will only be set _after_ we have fully processed the leadership edge. This strictly orders any state publishes to happen after we've read back from ZK, transitively after ZK connection establishment, transitively after Slobrok reports itself as ready. Note that there's still some auxiliary code sites related to node state change requests that consult the election handler; these should probably be changed to check the core controller state as well.

@geirst FYI