### PR TITLE
Avoid safe mutations in master moratorium and increase first cluster state broadcast deadline [run-systemtest]

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -79,11 +79,8 @@ public class ClusterControllerClusterConfigurer {
         options.minRatioOfDistributorNodesUp = config.min_distributor_up_ratio();
         options.minRatioOfStorageNodesUp = config.min_storage_up_ratio();
         options.cycleWaitTime = (int) (config.cycle_wait_time() * 1000);
-        options.minTimeBeforeFirstSystemStateBroadcast = (int) (config.min_time_before_first_system_state_broadcast() * 1000);
-        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
         options.showLocalSystemStatesInEventLog = config.show_local_systemstates_in_event_log();
         options.minTimeBetweenNewSystemStates = config.min_time_between_new_systemstates();
-        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
         options.distributionBits = config.ideal_distribution_bits();
         options.minNodeRatioPerGroup = config.min_node_ratio_per_group();
         options.setMaxDeferredTaskVersionWaitTime(Duration.ofMillis((int)(config.max_deferred_task_version_wait_time_sec() * 1000)));
@@ -93,6 +90,20 @@ public class ClusterControllerClusterConfigurer {
         options.clusterFeedBlockEnabled = config.enable_cluster_feed_block();
         options.clusterFeedBlockLimit = Map.copyOf(config.cluster_feed_block_limit());
         options.clusterFeedBlockNoiseLevel = config.cluster_feed_block_noise_level();
+
+        // minTimeBeforeFirstSystemStateBroadcast is the minimum time the CC will wait for the storage
+        // nodes and distributors being down in Slobrok and/or getnodestate, before being allowed to
+        // broadcast a cluster state.  We therefore force a longer timeout depending on related settings.
+        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
+        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
+        options.minTimeBeforeFirstSystemStateBroadcast = max(
+                options.maxSlobrokDisconnectGracePeriod,
+                options.nodeStateRequestTimeoutMS,
+                (int) (config.min_time_before_first_system_state_broadcast() * 1000));
+    }
+
+    private static int max(int a, int b, int c) {
+        return Math.max(a, Math.max(b, c));
     }
 
     private static void configure(FleetControllerOptions options, SlobroksConfig config) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -171,21 +171,22 @@ public class ContentCluster {
 
     /**
      * Checks if a node can be upgraded
-     *
-     * @param node the node to be checked for upgrad
+     *  @param node the node to be checked for upgrad
      * @param clusterState the current cluster state version
      * @param condition the upgrade condition
      * @param oldState the old/current wanted state
      * @param newState state wanted to be set  @return NodeUpgradePrechecker.Response
+     * @param inMoratorium whether the CC is in moratorium
      */
     public NodeStateChangeChecker.Result calculateEffectOfNewState(
             Node node, ClusterState clusterState, SetUnitStateRequest.Condition condition,
-            NodeState oldState, NodeState newState) {
+            NodeState oldState, NodeState newState, boolean inMoratorium) {
 
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
                 distribution.getRedundancy(),
                 new HierarchicalGroupVisitingAdapter(distribution),
-                clusterInfo
+                clusterInfo,
+                inMoratorium
         );
         return nodeStateChangeChecker.evaluateTransition(node, clusterState, condition, oldState, newState);
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -89,6 +89,7 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
     private final MetricUpdater metricUpdater;
 
     private boolean isMaster = false;
+    private boolean inMasterMoratorium = false;
     private boolean isStateGatherer = false;
     private long firstAllowedStateBroadcast = Long.MAX_VALUE;
     private long tickStartTime = Long.MAX_VALUE;
@@ -709,6 +710,12 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         if ((currentTime >= firstAllowedStateBroadcast || cluster.allStatesReported())
             && currentTime >= nextStateSendTime)
         {
+            if (inMasterMoratorium) {
+                log.fine(currentTime < firstAllowedStateBroadcast ?
+                         "Master moratorium complete: all nodes have reported in" :
+                         "Master moratorium complete: timed out waiting for all nodes to report in");
+                inMasterMoratorium = false;
+            }
             if (currentTime < firstAllowedStateBroadcast) {
                 log.log(Level.FINE, "Not set to broadcast states just yet, but as we have gotten info from all nodes we can do so safely.");
                 // Reset timer to only see warning once.
@@ -777,7 +784,12 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         context.cluster = cluster;
         context.currentConsolidatedState = consolidatedClusterState();
         context.publishedClusterStateBundle = stateVersionTracker.getVersionedClusterStateBundle();
-        context.masterInfo = masterElectionHandler;
+        context.masterInfo = new MasterInterface() {
+            @Override public boolean isMaster() { return isMaster; }
+            @Override public Integer getMaster() { return masterElectionHandler.getMaster(); }
+            @Override public boolean inMasterMoratorium() { return inMasterMoratorium; }
+        };
+
         context.nodeStateOrHostInfoChangeHandler = this;
         context.nodeAddedOrRemovedListener = this;
         return context;
@@ -1075,11 +1087,12 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
                         + stateVersionTracker.getCurrentVersion() + " to be in line.", timer.getCurrentTimeInMillis()));
                 long currentTime = timer.getCurrentTimeInMillis();
                 firstAllowedStateBroadcast = currentTime + options.minTimeBeforeFirstSystemStateBroadcast;
+                isMaster = true;
+                inMasterMoratorium = true;
                 log.log(Level.FINE, "At time " + currentTime + " we set first system state broadcast time to be "
                         + options.minTimeBeforeFirstSystemStateBroadcast + " ms after at time " + firstAllowedStateBroadcast + ".");
                 didWork = true;
             }
-            isMaster = true;
             if (wantedStateChanged) {
                 database.saveWantedStates(databaseContext);
                 wantedStateChanged = false;
@@ -1099,6 +1112,7 @@ public class FleetController implements NodeStateOrHostInfoChangeHandler, NodeAd
         }
         wantedStateChanged = false;
         isMaster = false;
+        inMasterMoratorium = false;
     }
 
     public void run() {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -94,7 +94,9 @@ public class FleetControllerOptions implements Cloneable {
      * Minimum time to pass (in milliseconds) before broadcasting our first systemstate. Set small in unit tests,
      * but should be a few seconds in a real system to prevent new nodes taking over from disturbing the system by
      * putting out a different systemstate just because all nodes don't answer witihin a single cycle.
-     * If all nodes have reported before this time, the min time is ignored and system state is broadcasted.
+     * The cluster state is allowed to be broadcasted before this time if all nodes have successfully
+     * reported their state in Slobrok and getnodestate. This value should typically be at least
+     * maxSlobrokDisconnectGracePeriod and nodeStateRequestTimeoutMS.
      */
     public long minTimeBeforeFirstSystemStateBroadcast = 0;
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
@@ -1,10 +1,10 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
-import java.util.logging.Level;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
 
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -57,6 +57,11 @@ public class MasterElectionHandler implements MasterInterface {
     public boolean isMaster() {
         Integer master = getMaster();
         return (master != null && master == index);
+    }
+
+    @Override
+    public boolean inMasterMoratorium() {
+        return false;
     }
 
     @Override

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterInterface.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterInterface.java
@@ -5,5 +5,6 @@ public interface MasterInterface {
 
     boolean isMaster();
     Integer getMaster();
+    boolean inMasterMoratorium();
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -32,14 +32,17 @@ public class NodeStateChangeChecker {
     private final int requiredRedundancy;
     private final HierarchicalGroupVisiting groupVisiting;
     private final ClusterInfo clusterInfo;
+    private final boolean inMoratorium;
 
     public NodeStateChangeChecker(
             int requiredRedundancy,
             HierarchicalGroupVisiting groupVisiting,
-            ClusterInfo clusterInfo) {
+            ClusterInfo clusterInfo,
+            boolean inMoratorium) {
         this.requiredRedundancy = requiredRedundancy;
         this.groupVisiting = groupVisiting;
         this.clusterInfo = clusterInfo;
+        this.inMoratorium = inMoratorium;
     }
 
     public static class Result {
@@ -92,6 +95,10 @@ public class NodeStateChangeChecker {
             NodeState oldWantedState, NodeState newWantedState) {
         if (condition == SetUnitStateRequest.Condition.FORCE) {
             return Result.allowSettingOfWantedState();
+        }
+
+        if (inMoratorium) {
+            return Result.createDisallowed("Master cluster controller is bootstrapping and in moratorium");
         }
 
         if (condition != SetUnitStateRequest.Condition.SAFE) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.restapiv2.requests;
 
-import java.util.logging.Level;
 import com.yahoo.time.TimeBudget;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
@@ -26,6 +25,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SetNodeStateRequest extends Request<SetResponse> {
@@ -64,6 +64,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
                 id.getNode(),
                 context.nodeStateOrHostInfoChangeHandler,
                 context.currentConsolidatedState,
+                context.masterInfo.inMasterMoratorium(),
                 probe);
     }
 
@@ -104,6 +105,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
             Node node,
             NodeStateOrHostInfoChangeHandler stateListener,
             ClusterState currentClusterState,
+            boolean inMasterMoratorium,
             boolean probe) throws StateRestApiException {
         if ( ! cluster.hasConfiguredNode(node.getIndex())) {
             throw new MissingIdException(cluster.getName(), node);
@@ -115,7 +117,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
         NodeState wantedState = nodeInfo.getUserWantedState();
         NodeState newWantedState = getRequestedNodeState(newStates, node);
         NodeStateChangeChecker.Result result = cluster.calculateEffectOfNewState(
-                node, currentClusterState, condition, wantedState, newWantedState);
+                node, currentClusterState, condition, wantedState, newWantedState, inMasterMoratorium);
 
         log.log(Level.FINE, "node=" + node +
                 " current-cluster-state=" + currentClusterState + // Includes version in output format

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStatesForClusterRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStatesForClusterRequest.java
@@ -72,6 +72,7 @@ public class SetNodeStatesForClusterRequest extends Request<SetResponse> {
                     node,
                     context.nodeStateOrHostInfoChangeHandler,
                     context.currentConsolidatedState,
+                    context.masterInfo.inMasterMoratorium(),
                     probe);
 
             if (!setResponse.getWasModified()) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
@@ -23,5 +23,5 @@ public interface WantedStateSetter {
                     Node node,
                     NodeStateOrHostInfoChangeHandler stateListener,
                     ClusterState currentClusterState,
-                    boolean probe) throws StateRestApiException;
+                    boolean inMasterMoratorium, boolean probe) throws StateRestApiException;
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -57,7 +57,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     private NodeStateChangeChecker createChangeChecker(ContentCluster cluster) {
-        return new NodeStateChangeChecker(requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+        return new NodeStateChangeChecker(requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
     }
 
     private ContentCluster createCluster(Collection<ConfiguredNode> nodes) {
@@ -114,10 +114,23 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
+    public void testDeniedInMoratorium() {
+        ContentCluster cluster = createCluster(createNodes(4));
+        NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), true);
+        NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
+                new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
+                UP_NODE_STATE, MAINTENANCE_NODE_STATE);
+        assertFalse(result.settingWantedStateIsAllowed());
+        assertFalse(result.wantedStateAlreadySet());
+        assertThat(result.getReason(), is("Master cluster controller is bootstrapping and in moratorium"));
+    }
+
+    @Test
     public void testUnknownStorageNode() {
         ContentCluster cluster = createCluster(createNodes(4));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -149,7 +162,7 @@ public class NodeStateChangeCheckerTest {
 
         // We should then be denied setting storage node 1 safely to maintenance.
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 nodeStorage, clusterStateWith3Down, SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
@@ -31,6 +31,11 @@ public class ClusterControllerMock implements RemoteClusterControllerTaskSchedul
             }
 
             @Override
+            public boolean inMasterMoratorium() {
+                return false;
+            }
+
+            @Override
             public Integer getMaster() {
                 return fleetControllerMaster;
             }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -572,7 +572,7 @@ public class SetNodeStateTest extends StateRestApiTest {
                 new SetUnitStateRequestImpl("music/storage/1").setNewState("user", "maintenance", "whatever reason."),
                 wantedStateSetter);
         SetResponse response = new SetResponse("some reason", wasModified);
-        when(wantedStateSetter.set(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(response);
+        when(wantedStateSetter.set(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(response);
 
         RemoteClusterControllerTask.Context context = mock(RemoteClusterControllerTask.Context.class);
         MasterInterface masterInterface = mock(MasterInterface.class);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequestTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequestTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,6 +40,7 @@ public class SetNodeStateRequestTest {
     private final Node storageNode = new Node(NodeType.STORAGE, NODE_INDEX);
     private final NodeStateOrHostInfoChangeHandler stateListener = mock(NodeStateOrHostInfoChangeHandler.class);
     private final ClusterState currentClusterState = mock(ClusterState.class);
+    private boolean inMasterMoratorium = false;
     private boolean probe = false;
 
     @Before
@@ -127,7 +129,7 @@ public class SetNodeStateRequestTest {
         when(unitState.getId()).thenReturn(wantedStateString);
         when(unitState.getReason()).thenReturn(REASON);
 
-        when(cluster.calculateEffectOfNewState(any(), any(), any(), any(), any())).thenReturn(result);
+        when(cluster.calculateEffectOfNewState(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(result);
 
         when(storageNodeInfo.isStorage()).thenReturn(storageNode.getType() == NodeType.STORAGE);
         when(storageNodeInfo.getNodeIndex()).thenReturn(storageNode.getIndex());
@@ -173,6 +175,7 @@ public class SetNodeStateRequestTest {
                 storageNode,
                 stateListener,
                 currentClusterState,
+                inMasterMoratorium,
                 probe);
     }
 }

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -115,8 +115,11 @@ cycle_wait_time double default=0.1
 ## a new fleetcontroller. (Will broadcast earlier than this if we have gathered
 ## state from all before this). To prevent disturbance when taking over as
 ## fleetcontroller, give nodes a bit of time to answer so we dont temporarily
-## report nodes as down.
-min_time_before_first_system_state_broadcast double default=5.0
+## report nodes as down.  The time before the first broadcast may be increased
+## further by other settings like max_slobrok_disconnect_grace_period and
+## get_node_state_request_timeout, but may be shorter if all nodes have
+## reported their state.
+min_time_before_first_system_state_broadcast double default=120.0
 
 ## Request timeout of node state requests. Keeping a high timeout allows us to
 ## always have a pending operation with very low cost. Keeping a low timeout is


### PR DESCRIPTION
This PR will
 - Designate the master CC as in "moratorium" until it has broadcast its first cluster state
 - Deny the safe setting of node states in moratorium
 - Increase the time to the first cluster state broadcast as described below.

The first cluster state broadcast by a new CC will increase from 5 to 120 seconds, by default.  The time from start to the first broadcast can be increased with config, but not decreased below either of the following two config settings:
 - `get_node_state_request_timeout` 
 - `max_slobrok_disconnect_grace_period`

The time to the first broadcast may happen before 120 seconds if all nodes have reported their getnodestate and Slobrok (they are not down).  In an upgrade scenario, all nodes will likely report within a reasonable short time period, except with hierarchical groups where >1 node is allowed to be suspended.  The increase from 5 to 120 seconds will then appear twice: Once when CC 0 goes down and CC 1 becomes master, and once when CC 0 resumes mastership.
