### PR TITLE
Counting executed task should happen in bucket executor once task has…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.cpp
@@ -46,7 +46,7 @@ isSameDocument(const search::DocumentMetaData & a, const search::DocumentMetaDat
 void
 CompactionJob::failOperation() {
     IncOnDestruct countGuard(_executedCount);
-    _master.execute(makeLambdaTask([this] { _scanItr.reset(); }
+    _master.execute(makeLambdaTask([this] { _scanItr.reset(); }));
 }
 
 bool


### PR DESCRIPTION
… been queued to master executor.

Since waiting for all to complete happens in master thread, countdown must happen in another thread.

@toregge PR