### PR TITLE
Revert "Revert "Revert "Don't write to standard err"""

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionValidator.java
@@ -97,10 +97,10 @@ public class IndexedHierarchicDistributionValidator {
         }
         if (totalReadyCopies % groupCount != 0) {
             throw new IllegalArgumentException(getErrorMsgPrefix(clusterName) + "Expected equal amount of ready copies per group, but " +
-                                               totalReadyCopies + " ready copies is specified with " + groupCount + " groups");
+                                totalReadyCopies + " ready copies is specified with " + groupCount + " groups");
         }
         if (totalReadyCopies == 0) {
-            throw new IllegalArgumentException(getErrorMsgPrefix(clusterName) + "Warning. No ready copies configured. At least one is required.");
+            System.err.println(getErrorMsgPrefix(clusterName) + "Warning. No ready copies configured. At least one is recommended.");
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/IndexedHierarchicDistributionTest.java
@@ -254,4 +254,10 @@ public class IndexedHierarchicDistributionTest {
         getTwoGroupsCluster(4, 2, "2|*");
     }
 
+    @Test
+    public void allowNoReadyCopies() throws Exception {
+        // The active one should be indexed anyhow. Setting up no ready copies
+        getTwoGroupsCluster(4, 0, "2|*");
+    }
+
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#17095

HierarchicDistributionTest::test_no_ready_copies started failing after this went in. Test could be annotated or fixed instead if that makes sense, haven't looked at test