### PR TITLE
Stop waiting until appliction has been removed

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -532,7 +532,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             } else {
                 transaction.commit();
             }
-            waitForApplicationRemoved(tenantApplications, applicationId);
             return true;
         } finally {
             applicationTransaction.ifPresent(ApplicationTransaction::close);
@@ -589,21 +588,6 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
             });
         }
         return fileReferencesToDelete;
-    }
-
-    private void waitForApplicationRemoved(TenantApplications applications, ApplicationId applicationId) {
-        log.log(Level.FINE, "Waiting for " + applicationId + " to be deleted");
-        Duration duration = Duration.ofSeconds(30);
-        Instant end = Instant.now().plus(duration);
-        do {
-            if ( ! (applications.hasApplication(applicationId)))
-                return;
-            log.log(Level.FINE, "Application " + applicationId + " not deleted yet, will retry");
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException interruptedException) {/* ignore */}
-        } while (Instant.now().isBefore(end));
-        log.log(Level.INFO, "Application " + applicationId + " not deleted after " + duration + ", giving up");
     }
 
     private Set<String> getFileReferencesInUse() {


### PR DESCRIPTION
Removing the application is done from another thread (that gets the event that the application node has been removed from ZooKeeper). That thread also needs the application lock, but will not get it before `delete()` releases the lock. The other servers also need to wait for the lock before they can remove the application. Need to come up with another solution to this.
