### PR TITLE
Require 3 config server (and controller) hosts

### DIFF
--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceCluster.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/ServiceCluster.java
@@ -81,10 +81,24 @@ public class ServiceCluster {
                 Objects.equals(serviceType, ServiceType.HOST_ADMIN);
     }
 
+    public boolean isConfigServerHostLike() {
+        return isConfigServerHost() || isControllerHost();
+    }
+
     public boolean isTenantHost() {
         return isHostedVespaApplicationWithPredicate(ApplicationInstanceId::isTenantHost) &&
                 Objects.equals(clusterId, ClusterId.TENANT_HOST) &&
                 Objects.equals(serviceType, ServiceType.HOST_ADMIN);
+    }
+
+    public String nodeDescription(boolean plural) {
+        String pluralSuffix = plural ? "s" : "";
+        return isConfigServer() ? "config server" + pluralSuffix :
+               isConfigServerHost() ? "config server host" + pluralSuffix :
+               isController() ? "controller" + pluralSuffix :
+               isControllerHost() ? "controller host" + pluralSuffix :
+               isTenantHost() ? "tenant host" + pluralSuffix :
+               "node" + pluralSuffix + " of {" + serviceType + "," + clusterId + "}";
     }
 
     private boolean isHostedVespaApplicationWithId(ApplicationInstanceId id) {

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ClusterApiImpl.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/model/ClusterApiImpl.java
@@ -81,9 +81,10 @@ class ClusterApiImpl implements ClusterApi {
         servicesDownAndNotInGroup = servicesNotInGroup.stream().filter(this::serviceEffectivelyDown).collect(Collectors.toSet());
 
         int serviceInstances = serviceCluster.serviceInstances().size();
-        if (serviceCluster.isConfigServerLike() && serviceInstances < numberOfConfigServers) {
+        if ((serviceCluster.isConfigServerLike() || serviceCluster.isConfigServerHostLike()) &&
+                serviceInstances < numberOfConfigServers) {
             missingServices = numberOfConfigServers - serviceInstances;
-            descriptionOfMissingServices = missingServices + " missing config server" + (missingServices > 1 ? "s" : "");
+            descriptionOfMissingServices = missingServices + " missing " + serviceCluster.nodeDescription(missingServices > 1);
         } else {
             missingServices = 0;
             descriptionOfMissingServices = "NA";

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.orchestrator.policy;
 
+import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.FetchVector;
@@ -149,7 +150,11 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
                 return ConcurrentSuspensionLimitForCluster.ONE_NODE;
             }
 
-            if (clusterApi.serviceType().equals(ServiceType.HOST_ADMIN)) {
+            if (clusterApi.serviceType() == ServiceType.HOST_ADMIN) {
+                if (Set.of(ClusterId.CONFIG_SERVER_HOST, ClusterId.CONTROLLER_HOST).contains(clusterApi.clusterId())) {
+                    return ConcurrentSuspensionLimitForCluster.ONE_NODE;
+                }
+
                 return ConcurrentSuspensionLimitForCluster.TWENTY_PERCENT;
             }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -150,7 +150,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
                 return ConcurrentSuspensionLimitForCluster.ONE_NODE;
             }
 
-            if (clusterApi.serviceType() == ServiceType.HOST_ADMIN) {
+            if (clusterApi.serviceType().equals(ServiceType.HOST_ADMIN)) {
                 if (Set.of(ClusterId.CONFIG_SERVER_HOST, ClusterId.CONTROLLER_HOST).contains(clusterApi.clusterId())) {
                     return ConcurrentSuspensionLimitForCluster.ONE_NODE;
                 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/ConfigServerApplication.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/ConfigServerApplication.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.service.duper;
 
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.vespa.applicationmodel.ApplicationInstanceId;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 
 /**
@@ -14,6 +16,15 @@ public class ConfigServerApplication extends ConfigServerLikeApplication {
 
     public ConfigServerApplication() {
         super("zone-config-servers", NodeType.config, ClusterSpec.Type.admin, ServiceType.CONFIG_SERVER);
+    }
+
+    /**
+     * A config server application has a particularly simple ApplicationInstanceId.
+     *
+     * @see InfraApplication#getApplicationInstanceId(Zone)
+     */
+    public ApplicationInstanceId getApplicationInstanceId() {
+        return new ApplicationInstanceId(getApplicationId().application().value());
     }
 
 }

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/duper/InfraApplication.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/duper/InfraApplication.java
@@ -12,12 +12,14 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceId;
 import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.applicationmodel.TenantId;
 import com.yahoo.vespa.service.health.StateV1HealthModel;
+import com.yahoo.vespa.service.model.ApplicationInstanceGenerator;
 import com.yahoo.vespa.service.model.ModelGenerator;
 import com.yahoo.vespa.service.monitor.InfraApplicationApi;
 
@@ -94,8 +96,8 @@ public abstract class InfraApplication implements InfraApplicationApi {
         return serviceType;
     }
 
-    public ApplicationInstanceId getApplicationInstanceId() {
-        return new ApplicationInstanceId(applicationId.application().value());
+    public ApplicationInstanceId getApplicationInstanceId(Zone zone) {
+        return ApplicationInstanceGenerator.toApplicationInstanceId(applicationId, zone);
     }
 
     public TenantId getTenantId() {

--- a/service-monitor/src/main/java/com/yahoo/vespa/service/model/ApplicationInstanceGenerator.java
+++ b/service-monitor/src/main/java/com/yahoo/vespa/service/model/ApplicationInstanceGenerator.java
@@ -164,7 +164,7 @@ public class ApplicationInstanceGenerator {
         return new ServiceInstance(configId, hostName, status);
     }
 
-    private static ApplicationInstanceId toApplicationInstanceId(ApplicationId applicationId, Zone zone) {
+    public static ApplicationInstanceId toApplicationInstanceId(ApplicationId applicationId, Zone zone) {
         if (applicationId.equals(configServerApplicationId)) {
             // Removing this historical discrepancy would break orchestration during rollout.
             // An alternative may be to use a feature flag and flip it between releases,


### PR DESCRIPTION
We already require 3 config server (and controller) nodes, but it is not
sufficient to protect the hosts from being left with only 1 healthy host: Say
the config server host application contains 2 nodes.  An upgrade of host-admin
on one of those nodes is allowed, since only the host is suspended and none of
the 2 nodes are down.  This is fixed by handling config server hosts similar to
config servers: assume 3 nodes.