### PR TITLE
Upgrade slf4j dependencies to 1.7.30 [run-systemtest]

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -35,7 +35,7 @@
         <junit5.platform.version>1.7.0</junit5.platform.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version><!-- TODO Vespa 8: remove as provided dependency -->
-        <slf4j.version>1.7.5</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <tensorflow.version>1.12.0</tensorflow.version>
         <xml-apis.version>1.4.01</xml-apis.version>
 

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -461,7 +461,7 @@
         <jetty.version>9.4.38.v20210224</jetty.version>
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
-        <slf4j.version>1.7.5</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <xml-apis.version>1.4.01</xml-apis.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->

--- a/zkfacade/pom.xml
+++ b/zkfacade/pom.xml
@@ -64,7 +64,7 @@
       <!-- Needed to have the same version as slf4j-api -->
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.5</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>

--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
        <groupId>org.slf4j</groupId>
        <artifactId>slf4j-api</artifactId>
-       <version>1.7.25</version>
+       <scope>compile</scope>
     </dependency>
   </dependencies>
   <build>

--- a/zookeeper-server/zookeeper-server-3.6.2/pom.xml
+++ b/zookeeper-server/zookeeper-server-3.6.2/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.5</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <!-- snappy-java and metrics-core are included here
          to be able to work with ZooKeeper 3.6.2 due to


### PR DESCRIPTION
Upgrade jcl-over-slf4j to a version that exports common-logging 1.1.3 or newer (1.2 for 1.7.30).
Previous version exported 1.1.1 which is older than the version visible through container-dev Maven dependency tree.

FYI @gjoranv 