### PR TITLE
Rename org.bouncycastle packages to avoid classpath conflict 

### DIFF
--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -135,6 +135,10 @@
                                     <shadedPattern>shaded.vespa</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>org.bouncycastle</pattern>
+                                    <shadedPattern>shaded.vespa.bouncycastle</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>commons-codec</pattern>
                                     <shadedPattern>shaded.vespa</shadedPattern>
                                 </relocation>


### PR DESCRIPTION
Other JARs on the same classpath on Hadoop may use non-compatible version of BouncyCastle.

FYI @lesters 