### PR TITLE
Avoid safe mutations in master moratorium and increase first cluster state broadcast deadline, try 2 [run-systemtest] 

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -79,8 +79,11 @@ public class ClusterControllerClusterConfigurer {
         options.minRatioOfDistributorNodesUp = config.min_distributor_up_ratio();
         options.minRatioOfStorageNodesUp = config.min_storage_up_ratio();
         options.cycleWaitTime = (int) (config.cycle_wait_time() * 1000);
+        options.minTimeBeforeFirstSystemStateBroadcast = (int) (config.min_time_before_first_system_state_broadcast() * 1000);
+        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
         options.showLocalSystemStatesInEventLog = config.show_local_systemstates_in_event_log();
         options.minTimeBetweenNewSystemStates = config.min_time_between_new_systemstates();
+        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
         options.distributionBits = config.ideal_distribution_bits();
         options.minNodeRatioPerGroup = config.min_node_ratio_per_group();
         options.setMaxDeferredTaskVersionWaitTime(Duration.ofMillis((int)(config.max_deferred_task_version_wait_time_sec() * 1000)));
@@ -90,20 +93,6 @@ public class ClusterControllerClusterConfigurer {
         options.clusterFeedBlockEnabled = config.enable_cluster_feed_block();
         options.clusterFeedBlockLimit = Map.copyOf(config.cluster_feed_block_limit());
         options.clusterFeedBlockNoiseLevel = config.cluster_feed_block_noise_level();
-
-        // minTimeBeforeFirstSystemStateBroadcast is the minimum time the CC will wait for the storage
-        // nodes and distributors being down in Slobrok and/or getnodestate, before being allowed to
-        // broadcast a cluster state.  We therefore force a longer timeout depending on related settings.
-        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
-        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
-        options.minTimeBeforeFirstSystemStateBroadcast = max(
-                options.maxSlobrokDisconnectGracePeriod,
-                options.nodeStateRequestTimeoutMS,
-                (int) (config.min_time_before_first_system_state_broadcast() * 1000));
-    }
-
-    private static int max(int a, int b, int c) {
-        return Math.max(a, Math.max(b, c));
     }
 
     private static void configure(FleetControllerOptions options, SlobroksConfig config) {

--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -79,11 +79,8 @@ public class ClusterControllerClusterConfigurer {
         options.minRatioOfDistributorNodesUp = config.min_distributor_up_ratio();
         options.minRatioOfStorageNodesUp = config.min_storage_up_ratio();
         options.cycleWaitTime = (int) (config.cycle_wait_time() * 1000);
-        options.minTimeBeforeFirstSystemStateBroadcast = (int) (config.min_time_before_first_system_state_broadcast() * 1000);
-        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
         options.showLocalSystemStatesInEventLog = config.show_local_systemstates_in_event_log();
         options.minTimeBetweenNewSystemStates = config.min_time_between_new_systemstates();
-        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
         options.distributionBits = config.ideal_distribution_bits();
         options.minNodeRatioPerGroup = config.min_node_ratio_per_group();
         options.setMaxDeferredTaskVersionWaitTime(Duration.ofMillis((int)(config.max_deferred_task_version_wait_time_sec() * 1000)));
@@ -93,6 +90,20 @@ public class ClusterControllerClusterConfigurer {
         options.clusterFeedBlockEnabled = config.enable_cluster_feed_block();
         options.clusterFeedBlockLimit = Map.copyOf(config.cluster_feed_block_limit());
         options.clusterFeedBlockNoiseLevel = config.cluster_feed_block_noise_level();
+
+        // minTimeBeforeFirstSystemStateBroadcast is the minimum time the CC will wait for the storage
+        // nodes and distributors being down in Slobrok and/or getnodestate, before being allowed to
+        // broadcast a cluster state.  We therefore force a longer timeout depending on related settings.
+        options.maxSlobrokDisconnectGracePeriod = (int) (config.max_slobrok_disconnect_grace_period() * 1000);
+        options.nodeStateRequestTimeoutMS = (int) (config.get_node_state_request_timeout() * 1000);
+        options.minTimeBeforeFirstSystemStateBroadcast = max(
+                options.maxSlobrokDisconnectGracePeriod,
+                options.nodeStateRequestTimeoutMS,
+                (int) (config.min_time_before_first_system_state_broadcast() * 1000));
+    }
+
+    private static int max(int a, int b, int c) {
+        return Math.max(a, Math.max(b, c));
     }
 
     private static void configure(FleetControllerOptions options, SlobroksConfig config) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -171,7 +171,8 @@ public class ContentCluster {
 
     /**
      * Checks if a node can be upgraded
-     *  @param node the node to be checked for upgrad
+     *
+     * @param node the node to be checked for upgrad
      * @param clusterState the current cluster state version
      * @param condition the upgrade condition
      * @param oldState the old/current wanted state

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ContentCluster.java
@@ -171,21 +171,22 @@ public class ContentCluster {
 
     /**
      * Checks if a node can be upgraded
-     *
-     * @param node the node to be checked for upgrad
+     *  @param node the node to be checked for upgrad
      * @param clusterState the current cluster state version
      * @param condition the upgrade condition
      * @param oldState the old/current wanted state
      * @param newState state wanted to be set  @return NodeUpgradePrechecker.Response
+     * @param inMoratorium whether the CC is in moratorium
      */
     public NodeStateChangeChecker.Result calculateEffectOfNewState(
             Node node, ClusterState clusterState, SetUnitStateRequest.Condition condition,
-            NodeState oldState, NodeState newState) {
+            NodeState oldState, NodeState newState, boolean inMoratorium) {
 
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
                 distribution.getRedundancy(),
                 new HierarchicalGroupVisitingAdapter(distribution),
-                clusterInfo
+                clusterInfo,
+                inMoratorium
         );
         return nodeStateChangeChecker.evaluateTransition(node, clusterState, condition, oldState, newState);
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -94,7 +94,9 @@ public class FleetControllerOptions implements Cloneable {
      * Minimum time to pass (in milliseconds) before broadcasting our first systemstate. Set small in unit tests,
      * but should be a few seconds in a real system to prevent new nodes taking over from disturbing the system by
      * putting out a different systemstate just because all nodes don't answer witihin a single cycle.
-     * If all nodes have reported before this time, the min time is ignored and system state is broadcasted.
+     * The cluster state is allowed to be broadcasted before this time if all nodes have successfully
+     * reported their state in Slobrok and getnodestate. This value should typically be at least
+     * maxSlobrokDisconnectGracePeriod and nodeStateRequestTimeoutMS.
      */
     public long minTimeBeforeFirstSystemStateBroadcast = 0;
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -95,7 +95,7 @@ public class FleetControllerOptions implements Cloneable {
      * but should be a few seconds in a real system to prevent new nodes taking over from disturbing the system by
      * putting out a different systemstate just because all nodes don't answer witihin a single cycle.
      * The cluster state is allowed to be broadcasted before this time if all nodes have successfully
-     * reported their state in Slobrok and getnodestate. This value should typically be at least
+     * reported their state in Slobrok and getnodestate. This value should typically be in the order of
      * maxSlobrokDisconnectGracePeriod and nodeStateRequestTimeoutMS.
      */
     public long minTimeBeforeFirstSystemStateBroadcast = 0;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterElectionHandler.java
@@ -1,10 +1,10 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
-import java.util.logging.Level;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
 
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -66,6 +66,11 @@ public class MasterElectionHandler implements MasterInterface {
     public boolean isMaster() {
         Integer master = getMaster();
         return (master != null && master == index);
+    }
+
+    @Override
+    public boolean inMasterMoratorium() {
+        return false;
     }
 
     @Override

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterInterface.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MasterInterface.java
@@ -5,5 +5,6 @@ public interface MasterInterface {
 
     boolean isMaster();
     Integer getMaster();
+    boolean inMasterMoratorium();
 
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -32,14 +32,17 @@ public class NodeStateChangeChecker {
     private final int requiredRedundancy;
     private final HierarchicalGroupVisiting groupVisiting;
     private final ClusterInfo clusterInfo;
+    private final boolean inMoratorium;
 
     public NodeStateChangeChecker(
             int requiredRedundancy,
             HierarchicalGroupVisiting groupVisiting,
-            ClusterInfo clusterInfo) {
+            ClusterInfo clusterInfo,
+            boolean inMoratorium) {
         this.requiredRedundancy = requiredRedundancy;
         this.groupVisiting = groupVisiting;
         this.clusterInfo = clusterInfo;
+        this.inMoratorium = inMoratorium;
     }
 
     public static class Result {
@@ -92,6 +95,10 @@ public class NodeStateChangeChecker {
             NodeState oldWantedState, NodeState newWantedState) {
         if (condition == SetUnitStateRequest.Condition.FORCE) {
             return Result.allowSettingOfWantedState();
+        }
+
+        if (inMoratorium) {
+            return Result.createDisallowed("Master cluster controller is bootstrapping and in moratorium");
         }
 
         if (condition != SetUnitStateRequest.Condition.SAFE) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequest.java
@@ -1,7 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.restapiv2.requests;
 
-import java.util.logging.Level;
 import com.yahoo.time.TimeBudget;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
@@ -26,6 +25,7 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SetNodeStateRequest extends Request<SetResponse> {
@@ -64,6 +64,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
                 id.getNode(),
                 context.nodeStateOrHostInfoChangeHandler,
                 context.currentConsolidatedState,
+                context.masterInfo.inMasterMoratorium(),
                 probe);
     }
 
@@ -104,6 +105,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
             Node node,
             NodeStateOrHostInfoChangeHandler stateListener,
             ClusterState currentClusterState,
+            boolean inMasterMoratorium,
             boolean probe) throws StateRestApiException {
         if ( ! cluster.hasConfiguredNode(node.getIndex())) {
             throw new MissingIdException(cluster.getName(), node);
@@ -115,7 +117,7 @@ public class SetNodeStateRequest extends Request<SetResponse> {
         NodeState wantedState = nodeInfo.getUserWantedState();
         NodeState newWantedState = getRequestedNodeState(newStates, node);
         NodeStateChangeChecker.Result result = cluster.calculateEffectOfNewState(
-                node, currentClusterState, condition, wantedState, newWantedState);
+                node, currentClusterState, condition, wantedState, newWantedState, inMasterMoratorium);
 
         log.log(Level.FINE, "node=" + node +
                 " current-cluster-state=" + currentClusterState + // Includes version in output format

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStatesForClusterRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStatesForClusterRequest.java
@@ -72,6 +72,7 @@ public class SetNodeStatesForClusterRequest extends Request<SetResponse> {
                     node,
                     context.nodeStateOrHostInfoChangeHandler,
                     context.currentConsolidatedState,
+                    context.masterInfo.inMasterMoratorium(),
                     probe);
 
             if (!setResponse.getWasModified()) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
@@ -23,5 +23,5 @@ public interface WantedStateSetter {
                     Node node,
                     NodeStateOrHostInfoChangeHandler stateListener,
                     ClusterState currentClusterState,
-                    boolean probe) throws StateRestApiException;
+                    boolean inMasterMoratorium, boolean probe) throws StateRestApiException;
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/WantedStateSetter.java
@@ -23,5 +23,6 @@ public interface WantedStateSetter {
                     Node node,
                     NodeStateOrHostInfoChangeHandler stateListener,
                     ClusterState currentClusterState,
-                    boolean inMasterMoratorium, boolean probe) throws StateRestApiException;
+                    boolean inMasterMoratorium,
+                    boolean probe) throws StateRestApiException;
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -57,7 +57,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     private NodeStateChangeChecker createChangeChecker(ContentCluster cluster) {
-        return new NodeStateChangeChecker(requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+        return new NodeStateChangeChecker(requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
     }
 
     private ContentCluster createCluster(Collection<ConfiguredNode> nodes) {
@@ -114,10 +114,23 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
+    public void testDeniedInMoratorium() {
+        ContentCluster cluster = createCluster(createNodes(4));
+        NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), true);
+        NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
+                new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
+                UP_NODE_STATE, MAINTENANCE_NODE_STATE);
+        assertFalse(result.settingWantedStateIsAllowed());
+        assertFalse(result.wantedStateAlreadySet());
+        assertThat(result.getReason(), is("Master cluster controller is bootstrapping and in moratorium"));
+    }
+
+    @Test
     public void testUnknownStorageNode() {
         ContentCluster cluster = createCluster(createNodes(4));
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 new Node(NodeType.STORAGE, 10), defaultAllUpClusterState(), SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);
@@ -149,7 +162,7 @@ public class NodeStateChangeCheckerTest {
 
         // We should then be denied setting storage node 1 safely to maintenance.
         NodeStateChangeChecker nodeStateChangeChecker = new NodeStateChangeChecker(
-                requiredRedundancy, visitor -> {}, cluster.clusterInfo());
+                requiredRedundancy, visitor -> {}, cluster.clusterInfo(), false);
         NodeStateChangeChecker.Result result = nodeStateChangeChecker.evaluateTransition(
                 nodeStorage, clusterStateWith3Down, SetUnitStateRequest.Condition.SAFE,
                 UP_NODE_STATE, MAINTENANCE_NODE_STATE);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
@@ -31,6 +31,11 @@ public class ClusterControllerMock implements RemoteClusterControllerTaskSchedul
             }
 
             @Override
+            public boolean inMasterMoratorium() {
+                return false;
+            }
+
+            @Override
             public Integer getMaster() {
                 return fleetControllerMaster;
             }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -572,7 +572,7 @@ public class SetNodeStateTest extends StateRestApiTest {
                 new SetUnitStateRequestImpl("music/storage/1").setNewState("user", "maintenance", "whatever reason."),
                 wantedStateSetter);
         SetResponse response = new SetResponse("some reason", wasModified);
-        when(wantedStateSetter.set(any(), any(), any(), any(), any(), any(), anyBoolean())).thenReturn(response);
+        when(wantedStateSetter.set(any(), any(), any(), any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(response);
 
         RemoteClusterControllerTask.Context context = mock(RemoteClusterControllerTask.Context.class);
         MasterInterface masterInterface = mock(MasterInterface.class);

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequestTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/SetNodeStateRequestTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -39,6 +40,7 @@ public class SetNodeStateRequestTest {
     private final Node storageNode = new Node(NodeType.STORAGE, NODE_INDEX);
     private final NodeStateOrHostInfoChangeHandler stateListener = mock(NodeStateOrHostInfoChangeHandler.class);
     private final ClusterState currentClusterState = mock(ClusterState.class);
+    private boolean inMasterMoratorium = false;
     private boolean probe = false;
 
     @Before
@@ -127,7 +129,7 @@ public class SetNodeStateRequestTest {
         when(unitState.getId()).thenReturn(wantedStateString);
         when(unitState.getReason()).thenReturn(REASON);
 
-        when(cluster.calculateEffectOfNewState(any(), any(), any(), any(), any())).thenReturn(result);
+        when(cluster.calculateEffectOfNewState(any(), any(), any(), any(), any(), anyBoolean())).thenReturn(result);
 
         when(storageNodeInfo.isStorage()).thenReturn(storageNode.getType() == NodeType.STORAGE);
         when(storageNodeInfo.getNodeIndex()).thenReturn(storageNode.getIndex());
@@ -173,6 +175,7 @@ public class SetNodeStateRequestTest {
                 storageNode,
                 stateListener,
                 currentClusterState,
+                inMasterMoratorium,
                 probe);
     }
 }

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -115,8 +115,11 @@ cycle_wait_time double default=0.1
 ## a new fleetcontroller. (Will broadcast earlier than this if we have gathered
 ## state from all before this). To prevent disturbance when taking over as
 ## fleetcontroller, give nodes a bit of time to answer so we dont temporarily
-## report nodes as down.
-min_time_before_first_system_state_broadcast double default=5.0
+## report nodes as down.  The time before the first broadcast may be increased
+## further by other settings like max_slobrok_disconnect_grace_period and
+## get_node_state_request_timeout, but may be shorter if all nodes have
+## reported their state.
+min_time_before_first_system_state_broadcast double default=120.0
 
 ## Request timeout of node state requests. Keeping a high timeout allows us to
 ## always have a pending operation with very low cost. Keeping a low timeout is

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -112,14 +112,12 @@ min_storage_up_ratio double default=0.01
 cycle_wait_time double default=0.1
 
 ## Minimum time to pass in seconds before broadcasting our first systemstate as
-## a new fleetcontroller. (Will broadcast earlier than this if we have gathered
-## state from all before this). To prevent disturbance when taking over as
+## a new fleetcontroller. Will broadcast earlier than this if we have gathered
+## state from all before this. To prevent disturbance when taking over as
 ## fleetcontroller, give nodes a bit of time to answer so we dont temporarily
-## report nodes as down.  The time before the first broadcast may be increased
-## further by other settings like max_slobrok_disconnect_grace_period and
-## get_node_state_request_timeout, but may be shorter if all nodes have
-## reported their state.
-min_time_before_first_system_state_broadcast double default=120.0
+## report nodes as down.  See also max_slobrok_disconnect_grace_period and
+## get_node_state_request_timeout.
+min_time_before_first_system_state_broadcast double default=30.0
 
 ## Request timeout of node state requests. Keeping a high timeout allows us to
 ## always have a pending operation with very low cost. Keeping a low timeout is


### PR DESCRIPTION
This PR will
 - Impose a master CC moratorium until it has broadcast its first cluster state
 - Deny the safe setting of node states in moratorium
 - Increase the default time to the first cluster state broadcast from 5s to 120s.

First commit is the double-revert of #17085 .