### PR TITLE
- Avoid inlining exchange_location_nodes to be able to see its execut…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
@@ -98,7 +98,7 @@ struct ProtonTermBase : public Base,
 };
 
 template <typename Base>
-struct ProtonTerm : public ProtonTermBase<Base> {
+struct ProtonTerm final : public ProtonTermBase<Base> {
     using ProtonTermBase<Base>::ProtonTermBase;
     ~ProtonTerm();
 };
@@ -116,8 +116,7 @@ typedef search::query::SimpleWeakAnd     ProtonWeakAnd;
 typedef search::query::SimpleSameElement ProtonSameElement;
 
 
-struct ProtonEquiv final : public ProtonTermBase<search::query::Equiv>
-{
+struct ProtonEquiv final : public ProtonTermBase<search::query::Equiv> {
     search::fef::MatchDataLayout children_mdl;
     using ProtonTermBase::ProtonTermBase;
 };

--- a/searchlib/src/vespa/searchlib/query/tree/intermediate.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediate.h
@@ -17,6 +17,7 @@ class Intermediate : public Node
 
     Intermediate() = default;
     virtual ~Intermediate() = 0;
+    bool isIntermediate() const override { return true; }
 
     const std::vector<Node *> &getChildren() const { return _children; }
     Intermediate &reserve(size_t sz) { _children.reserve(sz); return *this; }

--- a/searchlib/src/vespa/searchlib/query/tree/node.h
+++ b/searchlib/src/vespa/searchlib/query/tree/node.h
@@ -15,9 +15,10 @@ class Node {
  public:
     typedef std::unique_ptr<Node> UP;
 
-    virtual ~Node() {}
-
+    virtual ~Node() = default;
     virtual void accept(QueryVisitor &visitor) = 0;
+    virtual bool isIntermediate() const { return false; }
+    virtual bool isLocationTerm() const { return false; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -86,6 +86,7 @@ public:
                  int32_t id, Weight weight)
         : QueryNodeMixinType(term, view, id, weight)
     {}
+    bool isLocationTerm() const override { return true; }
     virtual ~LocationTerm() = 0;
 };
 


### PR DESCRIPTION
…ion cost with.

- Add isIntermediate, and isLocation virtual methods to avoid very expensive dynamic_cast.
- Use search::query::LocationTerm, instead of ProtonLocationTerm when possible.

@havardpe PR