### PR TITLE
add 'is_search' flag when creating match tools factory

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -299,7 +299,7 @@ struct MyWorld {
     void verify_diversity_filter(SearchRequest::SP req, bool expectDiverse) {
         Matcher::SP matcher = createMatcher();
         search::fef::Properties overrides;
-        auto mtf = matcher->create_match_tools_factory(*req, searchContext, attributeContext, metaStore, overrides);
+        auto mtf = matcher->create_match_tools_factory(*req, searchContext, attributeContext, metaStore, overrides, true);
         auto diversity = mtf->createDiversifier(HeapSize::lookup(config));
         EXPECT_EQUAL(expectDiverse, static_cast<bool>(diversity));
     }
@@ -309,7 +309,7 @@ struct MyWorld {
         SearchRequest::SP request = createSimpleRequest("f1", "spread");
         search::fef::Properties overrides;
         MatchToolsFactory::UP match_tools_factory = matcher->create_match_tools_factory(
-                *request, searchContext, attributeContext, metaStore, overrides);
+                *request, searchContext, attributeContext, metaStore, overrides, true);
         MatchTools::UP match_tools = match_tools_factory->createMatchTools();
         match_tools->setup_first_phase();
         return match_tools->match_data().get_termwise_limit();

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.cpp
@@ -167,7 +167,8 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
                   const IIndexEnvironment    & indexEnv,
                   const RankSetup            & rankSetup,
                   const Properties           & rankProperties,
-                  const Properties           & featureOverrides)
+                  const Properties           & featureOverrides,
+                  bool                         is_search)
     : _queryLimiter(queryLimiter),
       _requestContext(doom, attributeContext, rankProperties, extractAttributeBlueprintParams(rankSetup, rankProperties)),
       _query(),
@@ -193,9 +194,11 @@ MatchToolsFactory(QueryLimiter               & queryLimiter,
         _query.optimize();
         trace.addEvent(4, "MTF: Fetch Postings");
         _query.fetchPostings();
-        trace.addEvent(5, "MTF: Handle Global Filters");
-        double global_filter_limit = GlobalFilterLimit::lookup(rankProperties, rankSetup.get_global_filter_limit());
-        _query.handle_global_filters(searchContext.getDocIdLimit(), global_filter_limit);
+        if (is_search) {
+            trace.addEvent(5, "MTF: Handle Global Filters");
+            double global_filter_limit = GlobalFilterLimit::lookup(rankProperties, rankSetup.get_global_filter_limit());
+            _query.handle_global_filters(searchContext.getDocIdLimit(), global_filter_limit);
+        }
         _query.freeze();
         trace.addEvent(5, "MTF: prepareSharedState");
         _rankSetup.prepareSharedState(_queryEnv, _queryEnv.getObjectStore());

--- a/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_tools.h
@@ -119,7 +119,8 @@ public:
                       const search::fef::IIndexEnvironment &indexEnv,
                       const search::fef::RankSetup &rankSetup,
                       const search::fef::Properties &rankProperties,
-                      const search::fef::Properties &featureOverrides);
+                      const search::fef::Properties &featureOverrides,
+                      bool is_search);
     ~MatchToolsFactory();
     bool valid() const { return _valid; }
     const MaybeMatchPhaseLimiter &match_limiter() const { return *_match_limiter; }

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -136,7 +136,7 @@ using search::fef::indexproperties::softtimeout::Factor;
 std::unique_ptr<MatchToolsFactory>
 Matcher::create_match_tools_factory(const search::engine::Request &request, ISearchContext &searchContext,
                                     IAttributeContext &attrContext, const search::IDocumentMetaStore &metaStore,
-                                    const Properties &feature_overrides) const
+                                    const Properties &feature_overrides, bool is_search) const
 {
     const Properties & rankProperties = request.propertiesMap.rankProperties();
     bool softTimeoutEnabled = Enabled::lookup(rankProperties, _rankSetup->getSoftTimeoutEnabled());
@@ -156,7 +156,7 @@ Matcher::create_match_tools_factory(const search::engine::Request &request, ISea
     return std::make_unique<MatchToolsFactory>(_queryLimiter, doom, searchContext, attrContext,
                                                request.trace(), request.getStackRef(), request.location,
                                                _viewResolver, metaStore, _indexEnv, *_rankSetup,
-                                               rankProperties, feature_overrides);
+                                               rankProperties, feature_overrides, is_search);
 }
 
 size_t
@@ -216,7 +216,7 @@ Matcher::match(const SearchRequest &request, vespalib::ThreadBundle &threadBundl
         }
 
         MatchToolsFactory::UP mtf = create_match_tools_factory(request, searchContext, attrContext,
-                                                               metaStore, *feature_overrides);
+                metaStore, *feature_overrides, true);
         isDoomExplicit = mtf->getRequestContext().getDoom().isExplicitSoftDoom();
         traceQuery(6, request.trace(), mtf->query());
         if (!mtf->valid()) {
@@ -368,7 +368,7 @@ Matcher::create_docsum_matcher(const DocsumRequest &req, ISearchContext &search_
     }
     StupidMetaStore meta;
     MatchToolsFactory::UP mtf = create_match_tools_factory(req, search_ctx, attr_ctx, meta,
-            req.propertiesMap.featureOverrides());
+            req.propertiesMap.featureOverrides(), false);
     if (!mtf->valid()) {
         LOG(warning, "could not initialize docsum matching: %s",
             (expectedSessionCached) ? "session has expired" : "invalid query");

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.h
@@ -107,7 +107,7 @@ public:
     std::unique_ptr<MatchToolsFactory>
     create_match_tools_factory(const search::engine::Request &request, ISearchContext &searchContext,
                                IAttributeContext &attrContext, const search::IDocumentMetaStore &metaStore,
-                               const Properties &feature_overrides) const;
+                               const Properties &feature_overrides, bool is_search) const;
 
     /**
      * Perform a search against this matcher.


### PR DESCRIPTION
drop global filter handling for non-search setups

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 maybe something like this?