### PR TITLE
Avoid frequent dynamic_cast to check if a node is an intermediate.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -64,11 +64,14 @@ find_location_terms(Node *tree) {
     std::vector<ProtonLocationTerm *> retval;
     std::vector<Node *> nodes;
     nodes.push_back(tree);
+    // Note the nodes vector being iterated over is appended in the loop
     for (size_t i = 0; i < nodes.size(); ++i) {
-        if (auto loc = dynamic_cast<ProtonLocationTerm *>(nodes[i])) {
+        Node * node = nodes[i];
+        if (auto loc = dynamic_cast<ProtonLocationTerm *>(node)) {
             retval.push_back(loc);
         }
-        if (auto parent = dynamic_cast<const search::query::Intermediate *>(nodes[i])) {
+        if (node->isIntermediate()) {
+            auto parent = static_cast<const search::query::Intermediate *>(node);
             for (Node * child : parent->getChildren()) {
                 nodes.push_back(child);
             }

--- a/searchlib/src/vespa/searchlib/query/tree/intermediate.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediate.h
@@ -17,6 +17,7 @@ class Intermediate : public Node
 
     Intermediate() = default;
     virtual ~Intermediate() = 0;
+    bool isIntermediate() const override { return true; }
 
     const std::vector<Node *> &getChildren() const { return _children; }
     Intermediate &reserve(size_t sz) { _children.reserve(sz); return *this; }

--- a/searchlib/src/vespa/searchlib/query/tree/node.h
+++ b/searchlib/src/vespa/searchlib/query/tree/node.h
@@ -15,9 +15,9 @@ class Node {
  public:
     typedef std::unique_ptr<Node> UP;
 
-    virtual ~Node() {}
-
+    virtual ~Node() = default;
     virtual void accept(QueryVisitor &visitor) = 0;
+    virtual bool isIntermediate() const { return false; }
 };
 
 }


### PR DESCRIPTION
@havardpe or @arnej27959 PR
I will remove the cast one at a time as I suspect the remaining one is more expensive than the other.