### PR TITLE
Remove call to remove unsued applications for every child event

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/TenantApplications.java
@@ -196,8 +196,6 @@ public class TenantApplications implements RequestHandler, HostValidator<Applica
                 default:
                     break;
             }
-            // We may have lost events and may need to remove applications.
-            removeUnusedApplications();
         });
     }
 


### PR DESCRIPTION
There is already a background job to remove unused applications,
there should be no need to do it here. It looks like deleting many
applications for the same tenant in a short time frame takes a long
time, this might help.
