### PR TITLE
Add groupId metric dimension.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -133,6 +133,7 @@ public class MetricsProxyContainer extends Container implements
             getHostResource().spec().membership().map(ClusterMembership::cluster).ifPresent(cluster -> {
                 dimensions.put(PublicDimensions.INTERNAL_CLUSTER_TYPE, cluster.type().name());
                 dimensions.put(PublicDimensions.INTERNAL_CLUSTER_ID, cluster.id().value());
+                cluster.group().ifPresent(group -> dimensions.put(PublicDimensions.GROUP_ID, group.toString()));
             });
 
             builder.dimensions(dimensions);

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/PublicDimensions.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/dimensions/PublicDimensions.java
@@ -25,6 +25,10 @@ public final class PublicDimensions {
     public static final String INTERNAL_CLUSTER_ID = "clusterid";
     public static final String CLUSTER_ID = "clusterId";
 
+    // This dimension is not currently (March 2021) added to the 'commonDimensions' allow-list below, due to the
+    // limit of 10 total dimensions in public http apis. See e.g. MetricsV2Handler#MAX_DIMENSIONS.
+    public static final String GROUP_ID = "groupId";
+
     // Internal name (instance) is confusing, so renamed to 'serviceId' for public use.
     // This is added by the metrics-proxy.
     public static final String INTERNAL_SERVICE_ID = "instance";


### PR DESCRIPTION
This should show up as `groupId: group 1` etc. for all metrics on content nodes.