### PR TITLE
Decouple orchestrator resources into separate rest-api definitions

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -63,8 +63,30 @@
     <component id="com.yahoo.vespa.orchestrator.controller.RetryingClusterControllerClientFactory" bundle="orchestrator" />
     <component id="com.yahoo.vespa.orchestrator.OrchestratorImpl" bundle="orchestrator" />
     
-    <rest-api path="orchestrator" jersey2="true">      
-      <components bundle="orchestrator" />      
+    <rest-api path="orchestrator/v1/suspensions/applications" jersey2="true">
+      <components bundle="orchestrator">
+        <package>com.yahoo.vespa.orchestrator.resources.appsuspension</package>
+      </components>
+    </rest-api>
+    <rest-api path="orchestrator/v1/health" jersey2="true">
+      <components bundle="orchestrator">
+        <package>com.yahoo.vespa.orchestrator.resources.health</package>
+      </components>
+    </rest-api>
+    <rest-api path="orchestrator/v1/hosts" jersey2="true">
+      <components bundle="orchestrator">
+        <package>com.yahoo.vespa.orchestrator.resources.host</package>
+      </components>
+    </rest-api>
+    <rest-api path="orchestrator/v1/suspensions/hosts" jersey2="true">
+      <components bundle="orchestrator">
+        <package>com.yahoo.vespa.orchestrator.resources.hostsuspension</package>
+      </components>
+    </rest-api>
+    <rest-api path="orchestrator/v1/instances" jersey2="true">
+      <components bundle="orchestrator">
+        <package>com.yahoo.vespa.orchestrator.resources.instance</package>
+      </components>
     </rest-api>
 
     <handler id="com.yahoo.vespa.serviceview.StateRequestHandler" bundle="configserver">

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/appsuspension/ApplicationSuspensionResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/appsuspension/ApplicationSuspensionResource.java
@@ -1,9 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.appsuspension;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jaxrs.annotation.Component;
-import java.util.logging.Level;
 import com.yahoo.vespa.orchestrator.ApplicationIdNotFoundException;
 import com.yahoo.vespa.orchestrator.ApplicationStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.OrchestratorImpl;
@@ -18,13 +17,14 @@ import javax.ws.rs.Path;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
  * @author smorgrav
  */
-@Path(ApplicationSuspensionApi.PATH_PREFIX)
+@Path("")
 public class ApplicationSuspensionResource implements ApplicationSuspensionApi {
 
     private static final Logger log = Logger.getLogger(ApplicationSuspensionResource.class.getName());

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/health/HealthResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/health/HealthResource.java
@@ -1,10 +1,12 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.health;
 
 import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jaxrs.annotation.Component;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
+import com.yahoo.vespa.orchestrator.resources.ApplicationServices;
+import com.yahoo.vespa.orchestrator.resources.ServiceResource;
 import com.yahoo.vespa.orchestrator.restapi.wire.ApplicationReferenceList;
 import com.yahoo.vespa.orchestrator.restapi.wire.UrlReference;
 import com.yahoo.vespa.service.manager.HealthMonitorApi;
@@ -26,7 +28,7 @@ import java.util.stream.Collectors;
 /**
  * @author hakonhall
  */
-@Path("/v1/health")
+@Path("")
 public class HealthResource {
     private final UriInfo uriInfo;
     private final HealthMonitorApi healthMonitorApi;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/host/HostResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/host/HostResource.java
@@ -1,9 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.host;
 
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.yahoo.container.jaxrs.annotation.Component;
-import java.util.logging.Level;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.Host;
 import com.yahoo.vespa.orchestrator.HostNameNotFoundException;
@@ -11,6 +10,7 @@ import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy;
+import com.yahoo.vespa.orchestrator.resources.instance.InstanceResource;
 import com.yahoo.vespa.orchestrator.restapi.HostApi;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.HostService;
@@ -33,13 +33,14 @@ import javax.ws.rs.core.UriInfo;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
  * @author oyving
  */
-@Path(HostApi.PATH_PREFIX)
+@Path("")
 public class HostResource implements HostApi {
     private static final Logger log = Logger.getLogger(HostResource.class.getName());
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/hostsuspension/HostSuspensionResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/hostsuspension/HostSuspensionResource.java
@@ -1,9 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.hostsuspension;
 
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.yahoo.container.jaxrs.annotation.Component;
-import java.util.logging.Level;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.BatchHostNameNotFoundException;
 import com.yahoo.vespa.orchestrator.BatchInternalErrorException;
@@ -18,13 +17,14 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
  * @author hakonhall
  */
-@Path(HostSuspensionApi.PATH_PREFIX)
+@Path("")
 public class HostSuspensionResource implements HostSuspensionApi {
 
     private static final Logger log = Logger.getLogger(HostSuspensionResource.class.getName());

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/instance/InstanceResource.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/instance/InstanceResource.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.instance;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jaxrs.annotation.Component;
@@ -12,6 +12,7 @@ import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.orchestrator.OrchestratorUtil;
+import com.yahoo.vespa.orchestrator.resources.InstanceStatusResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.SlobrokEntryResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.WireHostInfo;
 import com.yahoo.vespa.orchestrator.status.HostInfo;
@@ -46,7 +47,7 @@ import static com.yahoo.vespa.orchestrator.OrchestratorUtil.parseApplicationInst
  * @author andreer
  * @author bakksjo
  */
-@Path("/v1/instances")
+@Path("")
 public class InstanceResource {
 
     public static final String DEFAULT_SLOBROK_PATTERN = "**";

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/appsuspension/ApplicationSuspensionResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/appsuspension/ApplicationSuspensionResourceTest.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.appsuspension;
 
 import com.yahoo.application.Application;
 import com.yahoo.application.Networking;
@@ -152,8 +152,10 @@ public class ApplicationSuspensionResourceTest {
                 "        <component id=\"com.yahoo.vespa.orchestrator.OrchestratorImpl\" bundle=\"orchestrator\" />\n" +
                 "        <component id=\"com.yahoo.vespa.orchestrator.controller.ClusterControllerClientFactoryMock\" bundle=\"orchestrator\" />\n" +
                 "\n" +
-                "        <rest-api path=\"orchestrator\">\n" +
-                "            <components bundle=\"orchestrator\" />\n" +
+                "        <rest-api path=\"orchestrator/v1/suspensions/applications\" jersey2=\"true\">\n" +
+                "            <components bundle=\"orchestrator\">\n" +
+                "                <package>com.yahoo.vespa.orchestrator.resources.appsuspension</package>\n" +
+                "            </components>\n" +
                 "        </rest-api>\n" +
                 "\n" +
                 "        <http>\n" +

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/host/HostResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/host/HostResourceTest.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.host;
 
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import com.yahoo.jdisc.Metric;
@@ -33,6 +33,7 @@ import com.yahoo.vespa.orchestrator.policy.BatchHostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.HostStateChangeDeniedException;
 import com.yahoo.vespa.orchestrator.policy.Policy;
 import com.yahoo.vespa.orchestrator.policy.SuspensionReasons;
+import com.yahoo.vespa.orchestrator.resources.hostsuspension.HostSuspensionResource;
 import com.yahoo.vespa.orchestrator.restapi.wire.BatchOperationResult;
 import com.yahoo.vespa.orchestrator.restapi.wire.GetHostResponse;
 import com.yahoo.vespa.orchestrator.restapi.wire.PatchHostRequest;

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/instance/InstanceResourceTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/resources/instance/InstanceResourceTest.java
@@ -1,5 +1,5 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.orchestrator.resources;
+package com.yahoo.vespa.orchestrator.resources.instance;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.config.provision.ApplicationId;
@@ -9,6 +9,7 @@ import com.yahoo.vespa.applicationmodel.ConfigId;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
 import com.yahoo.vespa.applicationmodel.ServiceType;
+import com.yahoo.vespa.orchestrator.resources.instance.InstanceResource;
 import com.yahoo.vespa.orchestrator.restapi.wire.SlobrokEntryResponse;
 import com.yahoo.vespa.service.manager.UnionMonitorManager;
 import com.yahoo.vespa.service.monitor.SlobrokApi;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
