### PR TITLE
Use unique temp file, config may be created by more than service at a…

### DIFF
--- a/zookeeper-client-common/src/main/java/com/yahoo/vespa/zookeeper/client/ZkClientConfigBuilder.java
+++ b/zookeeper-client-common/src/main/java/com/yahoo/vespa/zookeeper/client/ZkClientConfigBuilder.java
@@ -46,7 +46,7 @@ public class ZkClientConfigBuilder {
     public ZKClientConfig toConfig(Path configFile) throws IOException, QuorumPeerConfig.ConfigException {
         String configString = toConfigString();
         Files.createDirectories(configFile.getParent());
-        Path tempFile = configFile.resolveSibling("." + configFile.getFileName() + ".tmp");
+        Path tempFile = Files.createTempFile(configFile.toAbsolutePath().getParent(), "." + configFile.getFileName(), ".tmp");
         Files.writeString(tempFile, configString);
         Files.move(tempFile, configFile, StandardCopyOption.ATOMIC_MOVE);
         return new ZKClientConfig(configFile.toString());


### PR DESCRIPTION
… time

Concurrent creation of client config might fail if we don't use unique temp file (seen in system tests)
