### PR TITLE
- Use faster std::to_chars.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.cpp
@@ -25,7 +25,6 @@ LOG_SETUP(".proton.server.bucketmovejob");
 using document::BucketId;
 using storage::spi::BucketInfo;
 using storage::spi::Bucket;
-using storage::spi::makeBucketTask;
 using proton::bucketdb::BucketMover;
 using vespalib::makeLambdaTask;
 using vespalib::Trinary;

--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -488,7 +488,7 @@ BitVectorTest::test(BasicType bt,
                 !filter, true);
     const search::IDocumentWeightAttribute *dwa =
         v->asDocumentWeightAttribute();
-    if (dwa != NULL) {
+    if (dwa != nullptr) {
         search::IDocumentWeightAttribute::LookupResult lres = 
             dwa->lookup(getSearchStr<VectorType>(), dwa->get_dictionary_snapshot());
         typedef search::queryeval::DocumentWeightSearchIterator DWSI;

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -592,6 +592,10 @@ TEST("require that empty intermediate node can be added") {
     EXPECT_EQUAL(0u, and_node->getChildren().size());
 }
 
+TEST("control size of SimpleQueryStackDumpIterator") {
+    EXPECT_EQUAL(160u, sizeof(SimpleQueryStackDumpIterator));
+}
+
 TEST("test query parsing error") {
     const char * STACK =
          "\001\002\001\003\000\005\002\004\001\034F\001\002\004term\004\004term\002dx\004\004term\002ifD\002\004term\001xD\003\004term\002dxE\004\004term\001\060F\005\002\004term"

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -593,7 +593,7 @@ TEST("require that empty intermediate node can be added") {
 }
 
 TEST("control size of SimpleQueryStackDumpIterator") {
-    EXPECT_EQUAL(160u, sizeof(SimpleQueryStackDumpIterator));
+    EXPECT_EQUAL(152u, sizeof(SimpleQueryStackDumpIterator));
 }
 
 TEST("test query parsing error") {

--- a/searchlib/src/tests/query/stackdumpquerycreator_test.cpp
+++ b/searchlib/src/tests/query/stackdumpquerycreator_test.cpp
@@ -48,8 +48,7 @@ TEST("requireThatTooLargeNumTermIsTreatedAsFloat") {
     appendNumTerm(buf, term_string);
 
     SimpleQueryStackDumpIterator query_stack(vespalib::stringref(buf.GetDrainPos(), buf.GetUsedLen()));
-    Node::UP node =
-        StackDumpQueryCreator<SimpleQueryNodeTypes>::create(query_stack);
+    Node::UP node = StackDumpQueryCreator<SimpleQueryNodeTypes>::create(query_stack);
     ASSERT_TRUE(node.get());
     NumberTerm *term = dynamic_cast<NumberTerm *>(node.get());
     ASSERT_TRUE(term);

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
@@ -33,7 +33,7 @@ struct IDocumentWeightAttribute
     virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const = 0;
     virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
     virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
-    virtual ~IDocumentWeightAttribute() {}
+    virtual ~IDocumentWeightAttribute() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
@@ -2,6 +2,8 @@
 
 #include "diskindex.h"
 #include "disktermblueprint.h"
+#include "pagedict4randread.h"
+#include "fileheader.h"
 #include <vespa/searchlib/index/schemautil.h>
 #include <vespa/searchlib/queryeval/create_blueprint_visitor_helper.h>
 #include <vespa/searchlib/queryeval/leaf_blueprints.h>
@@ -10,8 +12,6 @@
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/stllike/cache.hpp>
-#include "pagedict4randread.h"
-#include "fileheader.h"
 
 #include <vespa/log/log.h>
 LOG_SETUP(".diskindex.diskindex");

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -10,27 +10,25 @@ using search::query::PredicateQueryTerm;
 
 namespace search {
 
-SimpleQueryStackDumpIterator::SimpleQueryStackDumpIterator(vespalib::stringref buf) :
-        _buf(buf.begin()),
-        _bufEnd(buf.end()),
-        _bufLen(buf.size()),
-        _currPos(_buf),
-        _currEnd(_buf),
-        _currType(ParseItem::ITEM_UNDEF),
-        _currCreator(ParseItem::CREA_ORIG),
-        _currWeight(100),
-        _currUniqueId(0),
-        _currFlags(0),
-        _currArity(0),
-        _curr_index_name(),
-        _curr_term(),
-        _scratch(),
-        _extraIntArg1(0),
-        _extraIntArg2(0),
-        _extraIntArg3(0),
-        _extraDoubleArg4(0),
-        _extraDoubleArg5(0),
-        _predicate_query_term()
+SimpleQueryStackDumpIterator::SimpleQueryStackDumpIterator(vespalib::stringref buf)
+    : _buf(buf.begin()),
+      _bufEnd(buf.end()),
+      _currPos(_buf),
+      _currEnd(_buf),
+      _currType(ParseItem::ITEM_UNDEF),
+      _currFlags(0),
+      _currWeight(100),
+      _currUniqueId(0),
+      _currArity(0),
+      _curr_index_name(),
+      _curr_term(),
+      _scratch(),
+      _extraIntArg1(0),
+      _extraIntArg2(0),
+      _extraIntArg3(0),
+      _extraDoubleArg4(0),
+      _extraDoubleArg5(0),
+      _predicate_query_term()
 {
 }
 
@@ -123,14 +121,11 @@ SimpleQueryStackDumpIterator::next()
         _currUniqueId = 0;
     }
     if (ParseItem::getFeature_Flags(typefield)) {
-        if ((p + sizeof(uint32_t)) > _bufEnd) {
-            return false;
-        }
+        if ((p + sizeof(uint8_t)) > _bufEnd) return false;
         _currFlags = (uint8_t)*p++;
     } else {
         _currFlags = 0;
     }
-    _currCreator = ParseItem::GetCreator(_currFlags);
 
     switch (_currType) {
     case ParseItem::ITEM_OR:

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -18,8 +18,6 @@ private:
     const char *_buf;
     /** Pointer to just past the input buffer */
     const char *_bufEnd;
-    /** Total length of the input buffer */
-    size_t _bufLen;
 
     /** Pointer to the position of the current item in the buffer */
     const char *_currPos;
@@ -27,15 +25,12 @@ private:
     const char *_currEnd;
     /** The type of the current item */
     ParseItem::ItemType _currType;
-    ParseItem::ItemCreator _currCreator;
+    /** flags of the current item **/
+    uint8_t _currFlags;
     /** Rank weight of current item **/
     query::Weight _currWeight;
     /** unique id of the current item **/
     uint32_t _currUniqueId;
-
-    /** flags of the current item **/
-    uint32_t _currFlags;
-
     /** The arity of the current item */
     uint32_t _currArity;
     /** The index name (field name) in the current item */
@@ -67,7 +62,7 @@ public:
     SimpleQueryStackDumpIterator& operator=(const SimpleQueryStackDumpIterator &) = delete;
     ~SimpleQueryStackDumpIterator();
 
-    vespalib::stringref getStack() const { return vespalib::stringref(_buf, _bufLen); }
+    vespalib::stringref getStack() const { return vespalib::stringref(_buf, _bufEnd - _buf); }
     size_t getPosition() const { return _currPos - _buf; }
 
     /**
@@ -87,7 +82,7 @@ public:
      * Get the type of the current item.
      * @return the type.
      */
-    ParseItem::ItemCreator getCreator() const { return _currCreator; }
+    ParseItem::ItemCreator getCreator() const { return ParseItem::GetCreator(_currFlags); }
 
     /**
      * Get the rank weight of the current item.

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -4,7 +4,6 @@
 
 #include <vespa/searchlib/parsequery/parse.h>
 #include <vespa/searchlib/query/tree/predicate_query_term.h>
-#include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/string.h>
 
 namespace search {
@@ -15,9 +14,6 @@ namespace search {
 class SimpleQueryStackDumpIterator
 {
 private:
-    SimpleQueryStackDumpIterator(const SimpleQueryStackDumpIterator &);
-    SimpleQueryStackDumpIterator& operator=(const SimpleQueryStackDumpIterator &);
-
     /** Pointer to the start of the input buffer */
     const char *_buf;
     /** Pointer to just past the input buffer */
@@ -42,36 +38,33 @@ private:
 
     /** The arity of the current item */
     uint32_t _currArity;
+    /** The index name (field name) in the current item */
+    vespalib::stringref _curr_index_name;
+    /** The term in the current item */
+    vespalib::stringref _curr_term;
+    char                _scratch[24];
 
     /* extra arguments */
     uint32_t _extraIntArg1;
     uint32_t _extraIntArg2;
     uint32_t _extraIntArg3;
-    double _extraDoubleArg4;
-    double _extraDoubleArg5;
+    double   _extraDoubleArg4;
+    double   _extraDoubleArg5;
     /** The predicate query specification */
     query::PredicateQueryTerm::UP _predicate_query_term;
-    /** The index name (field name) in the current item */
-    vespalib::stringref _curr_index_name;
-    /** The term in the current item */
-    vespalib::stringref _curr_term;
-    vespalib::asciistream _generatedTerm;
 
-    vespalib::string readString(const char *&p);
-    vespalib::stringref read_stringref(const char *&p);
-    uint64_t readUint64(const char *&p);
-    double read_double(const char *&p);
-    uint64_t readCompressedPositiveInt(const char *&p);
-
+    VESPA_DLL_LOCAL vespalib::string readString(const char *&p);
+    VESPA_DLL_LOCAL vespalib::stringref read_stringref(const char *&p);
+    VESPA_DLL_LOCAL uint64_t readUint64(const char *&p);
+    VESPA_DLL_LOCAL double read_double(const char *&p);
+    VESPA_DLL_LOCAL uint64_t readCompressedPositiveInt(const char *&p);
 public:
     /**
-     * Make an iterator on a buffer. To get the first item, next
-     * must be called.
-     *
-     * @param buf A pointer to the buffer holding the stackdump
-     * @param buflen The length of the buffer in bytes
+     * Make an iterator on a buffer. To get the first item, next must be called.
      */
     SimpleQueryStackDumpIterator(vespalib::stringref buf);
+    SimpleQueryStackDumpIterator(const SimpleQueryStackDumpIterator &) = delete;
+    SimpleQueryStackDumpIterator& operator=(const SimpleQueryStackDumpIterator &) = delete;
     ~SimpleQueryStackDumpIterator();
 
     vespalib::stringref getStack() const { return vespalib::stringref(_buf, _bufLen); }
@@ -125,12 +118,10 @@ public:
     bool getAllowApproximate() const { return (_extraIntArg2 != 0); }
     uint32_t getExploreAdditionalHits() const { return _extraIntArg3; }
 
-    query::PredicateQueryTerm::UP getPredicateQueryTerm()
-    { return std::move(_predicate_query_term); }
+    query::PredicateQueryTerm::UP getPredicateQueryTerm() { return std::move(_predicate_query_term); }
 
     vespalib::stringref getIndexName() const { return _curr_index_name; }
     vespalib::stringref getTerm() const { return _curr_term; }
 };
 
 }
-

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -50,7 +50,7 @@ private:
         uint32_t arity = queryStack.getArity();
         ParseItem::ItemType type = queryStack.getType();
         Node::UP node;
-        Term *t = 0;
+        Term *t = nullptr;
         if (type == ParseItem::ITEM_AND) {
             builder.addAnd(arity);
         } else if (type == ParseItem::ITEM_RANK) {

--- a/searchlib/src/vespa/searchlib/query/weight.h
+++ b/searchlib/src/vespa/searchlib/query/weight.h
@@ -19,7 +19,7 @@ public:
      * constructor.
      * @param value The initial weight in percent; should be 100 unless a specific value is set.
      **/
-    explicit Weight(int32_t value) : _weight(value) {}
+    explicit Weight(int32_t value) noexcept : _weight(value) {}
 
     /**
      * change the weight value.
@@ -40,7 +40,7 @@ public:
     double multiplier() const { return 0.01 * _weight; }
 
     /** compare two weights */
-    bool operator== (const Weight& other) const { return _weight == other._weight; }
+    bool operator== (const Weight& other) const noexcept { return _weight == other._weight; }
 };
 
 }


### PR DESCRIPTION
- Reorganize stackdumpitertor so members accesses frequently are colocated.
- Add test to keep iteratorsize under control.

@havardpe or @toregge or @geirst or @arnej27959 PR