### PR TITLE
Test runner improvements

### DIFF
--- a/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/JunitRunner.java
+++ b/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/JunitRunner.java
@@ -19,7 +19,6 @@ import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
-import org.junit.platform.launcher.listeners.LoggingListener;
 import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -178,7 +177,7 @@ public class JunitRunner extends AbstractComponent implements TestRunner {
 
         // Create log listener:
         var logLines = new ArrayList<LogRecord>();
-        var logListener = LoggingListener.forBiConsumer((t, m) -> log(logLines, m.get(), t));
+        var logListener = VespaJunitLogListener.forBiConsumer((t, m) -> log(logLines, m.get(), t));
         // Create a summary listener:
         var summaryListener = new SummaryGeneratingListener();
         launcher.registerTestExecutionListeners(logListener, summaryListener);

--- a/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/VespaJunitLogListener.java
+++ b/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/VespaJunitLogListener.java
@@ -1,0 +1,59 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+package com.yahoo.vespa.testrunner;
+
+import org.junit.platform.commons.util.Preconditions;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.reporting.ReportEntry;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+public class VespaJunitLogListener implements TestExecutionListener {
+
+    public static VespaJunitLogListener forBiConsumer(BiConsumer<Throwable, Supplier<String>> logger) {
+        return new VespaJunitLogListener(logger);
+    }
+
+    private final BiConsumer<Throwable, Supplier<String>> logger;
+
+    private VespaJunitLogListener(BiConsumer<Throwable, Supplier<String>> logger) {
+        this.logger = Preconditions.notNull(logger, "logger must not be null");
+    }
+
+    @Override
+    public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+        log("Registered dynamic test: %s - %s", testIdentifier.getDisplayName(), testIdentifier.getUniqueId());
+    }
+
+    @Override
+    public void executionStarted(TestIdentifier testIdentifier) {
+        log("Test started: %s - %s", testIdentifier.getDisplayName(), testIdentifier.getUniqueId());
+    }
+
+    @Override
+    public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+        log("Test skipped: %s - %s - %s", testIdentifier.getDisplayName(), testIdentifier.getUniqueId(), reason);
+    }
+
+    @Override
+    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+        logWithThrowable("Test completed: %s - %s - %s", testExecutionResult.getThrowable().orElse(null),
+                         testIdentifier.getDisplayName(), testIdentifier.getUniqueId(), testExecutionResult);
+    }
+
+    @Override
+    public void reportingEntryPublished(TestIdentifier testIdentifier, ReportEntry entry) {
+        log("[" + testIdentifier.getDisplayName() + "]: " + entry.toString());
+    }
+
+    private void log(String message, Object... args) {
+        logWithThrowable(message, null, args);
+    }
+
+    private void logWithThrowable(String message, Throwable t, Object... args) {
+        this.logger.accept(t, () -> String.format(message, args));
+    }
+}


### PR DESCRIPTION
* Remove irrelevant "Test plan execution started" messages
* Log ReportEntry from tests
* Include errors when test bundle fails to start