### PR TITLE
- Let DotProduct,Wand and WeightedSet be Term nodes in the query tree…

### DIFF
--- a/juniper/src/vespa/juniper/query.h
+++ b/juniper/src/vespa/juniper/query.h
@@ -155,17 +155,6 @@ public:
      */
     virtual bool VisitANDNOT(const QueryItem* item, int arity) = 0;
 
-    /** To be called upon by IQuery::Traverse visiting a THRESHOLD query item
-     * @param item The (opaque to IQueryVisitor) item that is visited
-     * @param arity The number of children of this item
-     * @param threshold The threshold value for which the sum of the individual
-     *   subexpressions' weights (as obtained by the IQueryVisitor::Weight function
-     *   should result in a hit for the THRESHOLD expression.
-     * @return if false, caller should skip calling this element's children visitors,
-     *   otherwise caller should proceed as normal
-     */
-    virtual bool VisitTHRESHOLD(const QueryItem* item, int arity, int threshold) = 0;
-
     /** To be called upon by IQuery::Traverse visiting any other query item
      *  than the ones handled by Juniper (to avoid inconsistency in the
      *  traversal wrt. arities)

--- a/juniper/src/vespa/juniper/queryvisitor.cpp
+++ b/juniper/src/vespa/juniper/queryvisitor.cpp
@@ -189,21 +189,11 @@ bool QueryVisitor::VisitANDNOT(const QueryItem*, int arity)
     return true;
 }
 
-bool QueryVisitor::VisitTHRESHOLD(const QueryItem*, int arity, int threshold)
-{
-    LOG(debug, "juniper: VisitTHRESHOLD[%d,%d]", arity, threshold);
-    QueryNode* node = new QueryNode(arity, threshold);
-    node->_options = _qhandle->_options;
-
-    insert(node);
-    return true;
-}
-
 
 bool QueryVisitor::VisitOther(const QueryItem*, int arity)
 {
     LOG(debug, "juniper: VisitOther[%d]", arity);
-    insert(NULL);
+    insert(nullptr);
     return false;
 }
 

--- a/juniper/src/vespa/juniper/queryvisitor.h
+++ b/juniper/src/vespa/juniper/queryvisitor.h
@@ -22,6 +22,8 @@ namespace juniper {
 class QueryVisitor : public juniper::IQueryVisitor
 {
 public:
+    QueryVisitor(QueryVisitor &) = delete;
+    QueryVisitor &operator=(QueryVisitor &) = delete;
     QueryVisitor(const IQuery& query, QueryHandle* qhandle, juniper::QueryModifier & queryModifier);
     ~QueryVisitor();
 
@@ -33,7 +35,6 @@ public:
     bool VisitRANK(const QueryItem* item, int arity) override;
     bool VisitPHRASE(const QueryItem* item, int arity) override;
     bool VisitANDNOT(const QueryItem* item, int arity) override;
-    bool VisitTHRESHOLD(const QueryItem* item, int arity, int threshold) override;
     bool VisitOther(const QueryItem* item, int arity) override;
     void VisitKeyword(const QueryItem* item, const char* keyword,
                       const size_t length = 0, bool prefix = false, bool specialToken = false) override;
@@ -49,7 +50,6 @@ protected:
     std::string get_index(const QueryItem* item);
 private:
     // Helper functions/members for use during construction only.
-    void update_parameters(const char* options);
     void insert(QueryExpr* expr);
     void postprocess_query();
     juniper::QueryModifier & _queryModifier;
@@ -62,9 +62,6 @@ private:
     QueryHandle* _qhandle;
     int _term_index;
     bool _got_stack; // Set when we have created a stack root
-
-    QueryVisitor(QueryVisitor &);
-    QueryVisitor &operator=(QueryVisitor &);
 };
 
 

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -164,6 +164,17 @@ fef_test::IndexEnvironment plain_index_env;
 fef_test::IndexEnvironment resolved_index_env;
 fef_test::IndexEnvironment attribute_index_env;
 
+vespalib::string
+termAsString(const search::query::Range &term) {
+    vespalib::asciistream os;
+    return (os << term).str();
+}
+
+const vespalib::string &
+termAsString(const vespalib::string & term) {
+    return term;
+}
+
 void setupIndexEnvironments()
 {
     FieldInfo field_info(FieldType::INDEX, CollectionType::SINGLE, field, field_id);

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -898,9 +898,9 @@ void Test::requireThatWeakAndBlueprintsAreCreatedCorrectly() {
 void Test::requireThatParallelWandBlueprintsAreCreatedCorrectly() {
     using search::queryeval::WeakAndBlueprint;
 
-    ProtonWandTerm wand(field, 42, Weight(100), 123, 9000, 1.25);
-    wand.append(Node::UP(new ProtonStringTerm("foo", field, 0, Weight(3))));
-    wand.append(Node::UP(new ProtonStringTerm("bar", field, 0, Weight(7))));
+    ProtonWandTerm wand(2, field, 42, Weight(100), 123, 9000, 1.25);
+    wand.addTerm("foo", Weight(3));
+    wand.addTerm("bar", Weight(7));
 
     ViewResolver viewResolver;
     ResolveViewVisitor resolve_visitor(viewResolver, attribute_index_env);

--- a/searchcore/src/tests/proton/matching/querynodes_test.cpp
+++ b/searchcore/src/tests/proton/matching/querynodes_test.cpp
@@ -518,6 +518,13 @@ TEST("requireThatSimpleIntermediatesGetProperBlending") {
     TEST_DO(checkProperBlendingWithParent<Rank>());
 }
 
+TEST("control query nodes size") {
+    EXPECT_EQUAL(160u, sizeof(search::query::NumberTerm));
+    EXPECT_EQUAL(192u, sizeof(ProtonNodeTypes::NumberTerm));
+    EXPECT_EQUAL(160u, sizeof(search::query::StringTerm));
+    EXPECT_EQUAL(192u, sizeof(ProtonNodeTypes::StringTerm));
+}
+
 }  // namespace
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchcore/src/tests/proton/matching/termdataextractor_test.cpp
+++ b/searchcore/src/tests/proton/matching/termdataextractor_test.cpp
@@ -39,31 +39,6 @@ namespace search { class AttributeManager; }
 
 namespace {
 
-class Test : public vespalib::TestApp {
-    void requireThatTermsAreAdded();
-    void requireThatAViewWithTwoFieldsGivesOneTermDataPerTerm();
-    void requireThatUnrankedTermsAreSkipped();
-    void requireThatNegativeTermsAreSkipped();
-    void requireThatSameElementIsSkipped();
-
-public:
-    int Main() override;
-};
-
-int
-Test::Main()
-{
-    TEST_INIT("termdataextractor_test");
-
-    TEST_DO(requireThatTermsAreAdded());
-    TEST_DO(requireThatAViewWithTwoFieldsGivesOneTermDataPerTerm());
-    TEST_DO(requireThatUnrankedTermsAreSkipped());
-    TEST_DO(requireThatNegativeTermsAreSkipped());
-    TEST_DO(requireThatSameElementIsSkipped());
-
-    TEST_DONE();
-}
-
 const string field = "field";
 const uint32_t id[] = { 10, 11, 12, 13, 14, 15, 16, 17, 18 };
 
@@ -77,14 +52,10 @@ Node::UP getQuery(const ViewResolver &resolver)
     query_builder.addSubstringTerm("baz", field, id[3], Weight(0));
     query_builder.addSuffixTerm("qux", field, id[4], Weight(0));
     query_builder.addRangeTerm(Range(), field, id[5], Weight(0));
-    query_builder.addWeightedSetTerm(1, field, id[6], Weight(0));
-    {
-        // weighted token
-        query_builder.addStringTerm("bar", field, id[3], Weight(0));
-    }
+    query_builder.addWeightedSetTerm(1, field, id[6], Weight(0))
+                 .addTerm("bar", Weight(0));
 
-    query_builder.addLocationTerm(Location(Point{10, 10}, 3, 0),
-                                  field, id[7], Weight(0));
+    query_builder.addLocationTerm(Location(Point{10, 10}, 3, 0), field, id[7], Weight(0));
     Node::UP node = query_builder.build();
 
     fef_test::IndexEnvironment index_environment;
@@ -98,7 +69,7 @@ Node::UP getQuery(const ViewResolver &resolver)
     return node;
 }
 
-void Test::requireThatTermsAreAdded() {
+TEST("requireThatTermsAreAdded") {
     Node::UP node = getQuery(ViewResolver());
 
     vector<const ITermData *> term_data;
@@ -110,7 +81,7 @@ void Test::requireThatTermsAreAdded() {
     }
 }
 
-void Test::requireThatAViewWithTwoFieldsGivesOneTermDataPerTerm() {
+TEST("requireThatAViewWithTwoFieldsGivesOneTermDataPerTerm") {
     ViewResolver resolver;
     resolver.add(field, "foo");
     resolver.add(field, "bar");
@@ -125,9 +96,7 @@ void Test::requireThatAViewWithTwoFieldsGivesOneTermDataPerTerm() {
     }
 }
 
-void
-Test::requireThatUnrankedTermsAreSkipped()
-{
+TEST("requireThatUnrankedTermsAreSkipped") {
     QueryBuilder<ProtonNodeTypes> query_builder;
     query_builder.addAnd(2);
     query_builder.addStringTerm("term1", field, id[0], Weight(0));
@@ -142,9 +111,7 @@ Test::requireThatUnrankedTermsAreSkipped()
     EXPECT_EQUAL(id[0], term_data[0]->getUniqueId());
 }
 
-void
-Test::requireThatNegativeTermsAreSkipped()
-{
+TEST("requireThatNegativeTermsAreSkipped") {
     QueryBuilder<ProtonNodeTypes> query_builder;
     query_builder.addAnd(2);
     query_builder.addStringTerm("term1", field, id[0], Weight(0));
@@ -163,8 +130,7 @@ Test::requireThatNegativeTermsAreSkipped()
     EXPECT_EQUAL(id[1], term_data[1]->getUniqueId());
 }
 
-void
-Test::requireThatSameElementIsSkipped()
+TEST("requireThatSameElementIsSkipped")
 {
     QueryBuilder<ProtonNodeTypes> query_builder;
     query_builder.addAnd(2);
@@ -183,4 +149,4 @@ Test::requireThatSameElementIsSkipped()
 
 }  // namespace
 
-TEST_APPHOOK(Test);
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.cpp
@@ -54,7 +54,7 @@ ProtonTermData::resolve(const ViewResolver &resolver,
     for (size_t i = 0; i < fields.size(); ++i) {
         const FieldInfo *info = idxEnv.getFieldByName(fields[i]);
         if (info != 0) {
-            _fields.push_back(FieldEntry(fields[i], info->id()));
+            _fields.emplace_back(fields[i], info->id());
             _fields.back().attribute_field =
                 (info->type() == FieldType::ATTRIBUTE) ||
                 (info->type() == FieldType::HIDDEN_ATTRIBUTE);
@@ -79,7 +79,7 @@ ProtonTermData::resolveFromChildren(const std::vector<Node *> &subterms)
             if (lookupField(subSpec.getFieldId()) == 0) {
                 // this must happen before handles are reserved
                 LOG_ASSERT(subSpec.getHandle() == search::fef::IllegalHandle);
-                _fields.push_back(FieldEntry(subSpec.getName(), subSpec.getFieldId()));
+                _fields.emplace_back(subSpec.getName(), subSpec.getFieldId());
             }
         }
     }

--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -474,20 +474,16 @@ BitVectorTest::test(BasicType bt,
                     bool filter)
 {
     Config cfg(bt, ct);
-    AttributePtr v = make(cfg, pref, fastSearch,
-                          enableBitVectors, enableOnlyBitVector, filter);
+    AttributePtr v = make(cfg, pref, fastSearch, enableBitVectors, enableOnlyBitVector, filter);
     addDocs(v, 1024);
     VectorType &tv = as<VectorType>(v);  
     populate(tv, 2, 1023, true);
 
     SearchContextPtr sc = getSearch<VectorType>(tv, true);
-    checkSearch(v, std::move(sc), 2, 1022, 205, !enableBitVectors && !filter,
-                true);
+    checkSearch(v, std::move(sc), 2, 1022, 205, !enableBitVectors && !filter, true);
     sc = getSearch<VectorType>(tv, false);
-    checkSearch(v, std::move(sc), 2, 1022, 205, !enableOnlyBitVector &&
-                !filter, true);
-    const search::IDocumentWeightAttribute *dwa =
-        v->asDocumentWeightAttribute();
+    checkSearch(v, std::move(sc), 2, 1022, 205, !enableOnlyBitVector && !filter, true);
+    const search::IDocumentWeightAttribute *dwa = v->asDocumentWeightAttribute();
     if (dwa != nullptr) {
         search::IDocumentWeightAttribute::LookupResult lres = 
             dwa->lookup(getSearchStr<VectorType>(), dwa->get_dictionary_snapshot());
@@ -504,21 +500,16 @@ BitVectorTest::test(BasicType bt,
     }
     populate(tv, 2, 973, false);
     sc = getSearch<VectorType>(tv, true);
-    checkSearch(v, std::move(sc), 977, 1022, 10, !enableOnlyBitVector &&
-                !filter, true);
+    checkSearch(v, std::move(sc), 977, 1022, 10, !enableOnlyBitVector &&!filter, true);
     populate(tv, 2, 973, true);
     sc = getSearch<VectorType>(tv, true);
-    checkSearch(v, std::move(sc), 2, 1022, 205, !enableBitVectors && !filter,
-                true);
+    checkSearch(v, std::move(sc), 2, 1022, 205, !enableBitVectors && !filter, true);
     addDocs(v, 15000);
     sc = getSearch<VectorType>(tv, true);
-    checkSearch(v, std::move(sc), 2, 1022, 205, !enableOnlyBitVector &&
-                !filter, true);
+    checkSearch(v, std::move(sc), 2, 1022, 205, !enableOnlyBitVector && !filter, true);
     populateAll(tv, 10, 15000, true);
     sc = getSearch<VectorType>(tv, true);
-    checkSearch(v, std::move(sc), 2, 14999, 14992,
-                !enableBitVectors && !filter,
-                false);
+    checkSearch(v, std::move(sc), 2, 14999, 14992, !enableBitVectors && !filter, false);
 }
 
 

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -425,11 +425,11 @@ TEST("require that attribute dot product works") {
         bool fast_search = ((i & 0x1) != 0);
         bool strict = ((i & 0x2) != 0);
         MyAttributeManager attribute_manager = make_weighted_string_attribute_manager(fast_search);
-        SimpleDotProduct node(field, 0, Weight(1));
-        node.append(Node::UP(new SimpleStringTerm("foo", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("bar", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("baz", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("fox", "", 0, Weight(1))));
+        SimpleDotProduct node(4, field, 0, Weight(1));
+        node.addTerm("foo", Weight(1));
+        node.addTerm("bar", Weight(1));
+        node.addTerm("baz", Weight(1));
+        node.addTerm("fox", Weight(1));
         Result result = do_search(attribute_manager, node, strict);
         ASSERT_EQUAL(5u, result.hits.size());
         if (fast_search) {
@@ -457,11 +457,11 @@ TEST("require that attribute dot product can produce no hits") {
         bool fast_search = ((i & 0x1) != 0);
         bool strict = ((i & 0x2) != 0);
         MyAttributeManager attribute_manager = make_weighted_string_attribute_manager(fast_search);
-        SimpleDotProduct node(field, 0, Weight(1));
-        node.append(Node::UP(new SimpleStringTerm("notfoo", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("notbar", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("notbaz", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("notfox", "", 0, Weight(1))));
+        SimpleDotProduct node(4, field, 0, Weight(1));
+        node.addTerm("notfoo", Weight(1));
+        node.addTerm("notbar", Weight(1));
+        node.addTerm("notbaz", Weight(1));
+        node.addTerm("notfox", Weight(1));
         Result result = do_search(attribute_manager, node, strict);
         ASSERT_EQUAL(0u, result.hits.size());
         EXPECT_EQUAL(0u, result.est_hits);
@@ -525,11 +525,11 @@ TEST("require that attribute parallel wand works") {
         bool fast_search = ((i & 0x1) != 0);
         bool strict = ((i & 0x2) != 0);
         MyAttributeManager attribute_manager = make_weighted_string_attribute_manager(fast_search);
-        SimpleWandTerm node(field, 0, Weight(1), 10, 500, 1.5);
-        node.append(Node::UP(new SimpleStringTerm("foo", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("bar", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("baz", "", 0, Weight(1))));
-        node.append(Node::UP(new SimpleStringTerm("fox", "", 0, Weight(1))));
+        SimpleWandTerm node(4, field, 0, Weight(1), 10, 500, 1.5);
+        node.addTerm("foo", Weight(1));
+        node.addTerm("bar", Weight(1));
+        node.addTerm("baz", Weight(1));
+        node.addTerm("fox", Weight(1));
         Result result = do_search(attribute_manager, node, strict);
         EXPECT_FALSE(result.est_empty);
         if (fast_search) {
@@ -561,11 +561,11 @@ TEST("require that attribute weighted set term works") {
         bool fast_search = ((i & 0x1) != 0);
         bool strict = ((i & 0x2) != 0);
         MyAttributeManager attribute_manager = make_weighted_string_attribute_manager(fast_search);
-        SimpleWeightedSetTerm node(field, 0, Weight(1));
-        node.append(Node::UP(new SimpleStringTerm("foo", "", 0, Weight(10))));
-        node.append(Node::UP(new SimpleStringTerm("bar", "", 0, Weight(20))));
-        node.append(Node::UP(new SimpleStringTerm("baz", "", 0, Weight(30))));
-        node.append(Node::UP(new SimpleStringTerm("fox", "", 0, Weight(40))));
+        SimpleWeightedSetTerm node(4, field, 0, Weight(1));
+        node.addTerm("foo", Weight(10));
+        node.addTerm("bar", Weight(20));
+        node.addTerm("baz", Weight(30));
+        node.addTerm("fox", Weight(40));
         Result result = do_search(attribute_manager, node, strict);
         EXPECT_FALSE(result.est_empty);
         ASSERT_EQUAL(5u, result.hits.size());

--- a/searchlib/src/tests/query/customtypevisitor_test.cpp
+++ b/searchlib/src/tests/query/customtypevisitor_test.cpp
@@ -15,18 +15,6 @@ using namespace search::query;
 
 namespace {
 
-class Test : public vespalib::TestApp {
-    const char *current_state;
-    virtual void DumpState(bool) {
-      fprintf(stderr, "%s: ERROR: in %s\n", GetName(), current_state);
-    }
-
-    template <class T> void requireThatNodeIsVisited();
-
-public:
-    int Main() override;
-};
-
 template <class Base>
 struct InitTerm : Base {
     InitTerm() : Base(typename Base::Type(), "view", 0, Weight(0)) {}
@@ -49,9 +37,9 @@ struct MyStringTerm : InitTerm<StringTerm>  {};
 struct MySubstrTerm : InitTerm<SubstringTerm>  {};
 struct MySuffixTerm : InitTerm<SuffixTerm>  {};
 struct MyWeakAnd : WeakAnd { MyWeakAnd() : WeakAnd(1234, "view") {} };
-struct MyWeightedSetTerm : WeightedSetTerm { MyWeightedSetTerm() : WeightedSetTerm("view", 0, Weight(42)) {} };
-struct MyDotProduct : DotProduct { MyDotProduct() : DotProduct("view", 0, Weight(42)) {} };
-struct MyWandTerm : WandTerm { MyWandTerm() : WandTerm("view", 0, Weight(42), 57, 67, 77.7) {} };
+struct MyWeightedSetTerm : WeightedSetTerm { MyWeightedSetTerm() : WeightedSetTerm(0, "view", 0, Weight(42)) {} };
+struct MyDotProduct : DotProduct { MyDotProduct() : DotProduct(0, "view", 0, Weight(42)) {} };
+struct MyWandTerm : WandTerm { MyWandTerm() : WandTerm(0, "view", 0, Weight(42), 57, 67, 77.7) {} };
 struct MyPredicateQuery : InitTerm<PredicateQuery> {};
 struct MyRegExpTerm : InitTerm<RegExpTerm>  {};
 struct MyNearestNeighborTerm : NearestNeighborTerm {};
@@ -119,7 +107,7 @@ public:
 };
 
 template <class T>
-void Test::requireThatNodeIsVisited() {
+void requireThatNodeIsVisited() {
     MyCustomVisitor visitor;
     Node::UP query(new T);
     visitor.isVisited<T>() = false;
@@ -127,37 +115,28 @@ void Test::requireThatNodeIsVisited() {
     ASSERT_TRUE(visitor.isVisited<T>());
 }
 
-#define TEST_CALL(func) \
-    current_state = #func; \
-    func();
+TEST("customtypevisitor_test") {
 
-int
-Test::Main()
-{
-    TEST_INIT("customtypevisitor_test");
-
-    TEST_CALL(requireThatNodeIsVisited<MyAnd>);
-    TEST_CALL(requireThatNodeIsVisited<MyAndNot>);
-    TEST_CALL(requireThatNodeIsVisited<MyNear>);
-    TEST_CALL(requireThatNodeIsVisited<MyONear>);
-    TEST_CALL(requireThatNodeIsVisited<MyOr>);
-    TEST_CALL(requireThatNodeIsVisited<MyPhrase>);
-    TEST_CALL(requireThatNodeIsVisited<MySameElement>);
-    TEST_CALL(requireThatNodeIsVisited<MyRangeTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyRank>);
-    TEST_CALL(requireThatNodeIsVisited<MyNumberTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyPrefixTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyStringTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MySubstrTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MySuffixTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyWeightedSetTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyDotProduct>);
-    TEST_CALL(requireThatNodeIsVisited<MyWandTerm>);
-    TEST_CALL(requireThatNodeIsVisited<MyPredicateQuery>);
-    TEST_CALL(requireThatNodeIsVisited<MyRegExpTerm>);
-
-    TEST_DONE();
+    requireThatNodeIsVisited<MyAnd>();
+    requireThatNodeIsVisited<MyAndNot>();
+    requireThatNodeIsVisited<MyNear>();
+    requireThatNodeIsVisited<MyONear>();
+    requireThatNodeIsVisited<MyOr>();
+    requireThatNodeIsVisited<MyPhrase>();
+    requireThatNodeIsVisited<MySameElement>();
+    requireThatNodeIsVisited<MyRangeTerm>();
+    requireThatNodeIsVisited<MyRank>();
+    requireThatNodeIsVisited<MyNumberTerm>();
+    requireThatNodeIsVisited<MyPrefixTerm>();
+    requireThatNodeIsVisited<MyStringTerm>();
+    requireThatNodeIsVisited<MySubstrTerm>();
+    requireThatNodeIsVisited<MySuffixTerm>();
+    requireThatNodeIsVisited<MyWeightedSetTerm>();
+    requireThatNodeIsVisited<MyDotProduct>();
+    requireThatNodeIsVisited<MyWandTerm>();
+    requireThatNodeIsVisited<MyPredicateQuery>();
+    requireThatNodeIsVisited<MyRegExpTerm>();
 }
 }  // namespace
 
-TEST_APPHOOK(Test);
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/query/query_visitor_test.cpp
+++ b/searchlib/src/tests/query/query_visitor_test.cpp
@@ -15,25 +15,6 @@ using namespace search::query;
 
 namespace {
 
-class Test : public vespalib::TestApp {
-    void requireThatAllNodesCanBeVisited();
-
-    template <class T> void checkVisit(T *node);
-
-public:
-    int Main() override;
-};
-
-int
-Test::Main()
-{
-    TEST_INIT("query_visitor_test");
-
-    TEST_DO(requireThatAllNodesCanBeVisited());
-
-    TEST_DONE();
-}
-
 class MyVisitor : public QueryVisitor
 {
 public:
@@ -69,7 +50,7 @@ public:
 };
 
 template <class T>
-void Test::checkVisit(T *node) {
+void checkVisit(T *node) {
     Node::UP query(node);
     MyVisitor visitor;
     visitor.isVisited<T>() = false;
@@ -77,7 +58,7 @@ void Test::checkVisit(T *node) {
     ASSERT_TRUE(visitor.isVisited<T>());
 }
 
-void Test::requireThatAllNodesCanBeVisited() {
+TEST("requireThatAllNodesCanBeVisited") {
     checkVisit<And>(new SimpleAnd);
     checkVisit<AndNot>(new SimpleAndNot);
     checkVisit<Near>(new SimpleNear(0));
@@ -85,9 +66,9 @@ void Test::requireThatAllNodesCanBeVisited() {
     checkVisit<Or>(new SimpleOr);
     checkVisit<Phrase>(new SimplePhrase("field", 0, Weight(42)));
     checkVisit<SameElement>(new SimpleSameElement("field"));
-    checkVisit<WeightedSetTerm>(new SimpleWeightedSetTerm("field", 0, Weight(42)));
-    checkVisit<DotProduct>(new SimpleDotProduct("field", 0, Weight(42)));
-    checkVisit<WandTerm>(new SimpleWandTerm("field", 0, Weight(42), 57, 67, 77.7));
+    checkVisit<WeightedSetTerm>(new SimpleWeightedSetTerm(0, "field", 0, Weight(42)));
+    checkVisit<DotProduct>(new SimpleDotProduct(0, "field", 0, Weight(42)));
+    checkVisit<WandTerm>(new SimpleWandTerm(0, "field", 0, Weight(42), 57, 67, 77.7));
     checkVisit<Rank>(new SimpleRank);
     checkVisit<NumberTerm>(new SimpleNumberTerm("0.42", "field", 0, Weight(0)));
     const Location location(Point{10, 10}, 20, 0);
@@ -104,4 +85,4 @@ void Test::requireThatAllNodesCanBeVisited() {
 
 }  // namespace
 
-TEST_APPHOOK(Test);
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
+++ b/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
@@ -45,9 +45,9 @@ struct DP {
     }
 
     Node::UP createNode() const {
-        SimpleDotProduct *node = new SimpleDotProduct("view", 0, Weight(0));
+        SimpleDotProduct *node = new SimpleDotProduct(tokens.size(), "view", 0, Weight(0));
         for (size_t i = 0; i < tokens.size(); ++i) {
-            node->append(Node::UP(new SimpleStringTerm(tokens[i].first, "view", 0, Weight(tokens[i].second))));
+            node->addTerm(tokens[i].first, Weight(tokens[i].second));
         }
         return Node::UP(node);
     }

--- a/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
@@ -156,9 +156,9 @@ TEST_F(FakeSearchableTest, require_that_weigheted_set_search_works) {
     source.addResult("fieldfoo", "friend3",
                      FakeResult().doc(5));
 
-    SimpleWeightedSetTerm weightedSet("fieldfoo", 1, w);
-    weightedSet.append(Node::UP(new SimpleStringTerm("friend1", "fieldfoo", 2, Weight(1))));
-    weightedSet.append(Node::UP(new SimpleStringTerm("friend2", "fieldfoo", 3, Weight(2))));
+    SimpleWeightedSetTerm weightedSet(2, "fieldfoo", 1, w);
+    weightedSet.addTerm("friend1", Weight(1));
+    weightedSet.addTerm("friend2", Weight(2));
 
     FieldSpecList fields;
     fields.add(FieldSpec("fieldfoo", 1, 1));

--- a/searchlib/src/tests/queryeval/getnodeweight/getnodeweight_test.cpp
+++ b/searchlib/src/tests/queryeval/getnodeweight/getnodeweight_test.cpp
@@ -34,9 +34,9 @@ TEST("test variations of getWeight")
     EXPECT_EQUAL(42, getWeight(SimpleStringTerm("foo", "bar", 1, Weight(42))));
     EXPECT_EQUAL(42, getWeight(SimpleSubstringTerm("foo", "bar", 1, Weight(42))));
     EXPECT_EQUAL(42, getWeight(SimpleSuffixTerm("foo", "bar", 1, Weight(42))));
-    EXPECT_EQUAL(42, getWeight(SimpleWeightedSetTerm("bar", 1, Weight(42))));
-    EXPECT_EQUAL(42, getWeight(SimpleDotProduct("bar", 1, Weight(42))));
-    EXPECT_EQUAL(42, getWeight(SimpleWandTerm("bar", 1, Weight(42), 57, 67, 77.7)));
+    EXPECT_EQUAL(42, getWeight(SimpleWeightedSetTerm(0, "bar", 1, Weight(42))));
+    EXPECT_EQUAL(42, getWeight(SimpleDotProduct(0, "bar", 1, Weight(42))));
+    EXPECT_EQUAL(42, getWeight(SimpleWandTerm(0, "bar", 1, Weight(42), 57, 67, 77.7)));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
@@ -158,11 +158,10 @@ struct WandBlueprintSpec
     Node::UP createNode(uint32_t scoresToTrack = 100,
                         score_t scoreThreshold = 0,
                         double thresholdBoostFactor = 1) const {
-        SimpleWandTerm *node = new SimpleWandTerm("view", 0, Weight(0),
+        SimpleWandTerm *node = new SimpleWandTerm(tokens.size(), "view", 0, Weight(0),
                                                   scoresToTrack, scoreThreshold, thresholdBoostFactor);
         for (size_t i = 0; i < tokens.size(); ++i) {
-            node->append(Node::UP(new SimpleStringTerm(tokens[i].first, "view", 0,
-                                                       Weight(tokens[i].second))));
+            node->addTerm(tokens[i].first, Weight(tokens[i].second));
         }
         return Node::UP(node);
     }

--- a/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
+++ b/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
@@ -53,9 +53,9 @@ struct WS {
     }
 
     Node::UP createNode() const {
-        SimpleWeightedSetTerm *node = new SimpleWeightedSetTerm("view", 0, Weight(0));
+        SimpleWeightedSetTerm *node = new SimpleWeightedSetTerm(tokens.size(), "view", 0, Weight(0));
         for (size_t i = 0; i < tokens.size(); ++i) {
-            node->append(Node::UP(new SimpleStringTerm(tokens[i].first, "view", 0, Weight(tokens[i].second))));
+            node->addTerm(tokens[i].first,Weight(tokens[i].second));
         }
         return Node::UP(node);
     }

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.cpp
@@ -13,7 +13,7 @@ public:
 
     vespalib::stringref asString() const override { return _key; }
 private:
-    vespalib::string _key;
+    vespalib::stringref _key;
 };
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.cpp
@@ -1,3 +1,32 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "i_document_weight_attribute.h"
+#include <charconv>
+
+namespace search {
+namespace {
+class StringAsKey final : public IDocumentWeightAttribute::LookupKey {
+public:
+    StringAsKey(vespalib::stringref key)
+            : _key(key)
+    { }
+
+    vespalib::stringref asString() const override { return _key; }
+private:
+    vespalib::string _key;
+};
+}
+
+bool
+IDocumentWeightAttribute::LookupKey::asInteger(int64_t &value) const {
+    vespalib::stringref str = asString();
+    const char *end = str.data() + str.size();
+    auto res = std::from_chars(str.data(), end, value);
+    return res.ptr == end;
+}
+
+IDocumentWeightAttribute::LookupResult
+IDocumentWeightAttribute::lookup(vespalib::stringref term, vespalib::datastore::EntryRef dictionary_snapshot) const {
+    return lookup(StringAsKey(term), dictionary_snapshot);
+}
+}

--- a/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_document_weight_attribute.h
@@ -3,17 +3,20 @@
 #pragma once
 
 #include "postinglisttraits.h"
-
 #include <functional>
 
 namespace search {
-
-namespace query { class Node; }
 
 using DocumentWeightIterator = attribute::PostingListTraits<int32_t>::const_iterator;
 
 struct IDocumentWeightAttribute
 {
+    struct LookupKey {
+        virtual ~LookupKey() = default;
+        virtual vespalib::stringref asString() const = 0;
+        virtual bool asInteger(int64_t &value) const;
+    };
+
     struct LookupResult {
         const vespalib::datastore::EntryRef posting_idx;
         const uint32_t posting_size;
@@ -25,7 +28,8 @@ struct IDocumentWeightAttribute
             : posting_idx(posting_idx_in), posting_size(posting_size_in), min_weight(min_weight_in), max_weight(max_weight_in), enum_idx(enum_idx_in) {}
     };
     virtual vespalib::datastore::EntryRef get_dictionary_snapshot() const = 0;
-    virtual LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const = 0;
+    virtual LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const = 0;
+    LookupResult lookup(vespalib::stringref term, vespalib::datastore::EntryRef dictionary_snapshot) const;
     /*
      * Collect enum indexes (via callback) where folded
      * (e.g. lowercased) value equals the folded value for enum_idx.

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -36,7 +36,7 @@ private:
         const MultiValueNumericPostingAttribute &self;
         DocumentWeightAttributeAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
-        LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override;
+        LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
         void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
         DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "multinumericpostattribute.h"
+#include <charconv>
 
 namespace search {
 
@@ -92,12 +93,11 @@ MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::get_dic
 
 template <typename B, typename M>
 IDocumentWeightAttribute::LookupResult
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const
+MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
-    char *end = nullptr;
-    int64_t int_term = strtoll(term.c_str(), &end, 10);
-    if (*end == '\0') {
+    int64_t int_term;
+    if (key.asInteger(int_term)) {
         auto comp = self._enumStore.make_comparator(int_term);
         auto find_result = dictionary.find_posting_list(comp, dictionary_snapshot);
         if (find_result.first.valid()) {

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -34,7 +34,7 @@ private:
         const MultiValueStringPostingAttributeT &self;
         DocumentWeightAttributeAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
-        LookupResult lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const override;
+        LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
         void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
         DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -108,10 +108,10 @@ MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::get_dic
 
 template <typename B, typename T>
 IDocumentWeightAttribute::LookupResult
-MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::lookup(const vespalib::string &term, vespalib::datastore::EntryRef dictionary_snapshot) const
+MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
-    auto comp = self._enumStore.make_folded_comparator(term.c_str());
+    auto comp = self._enumStore.make_folded_comparator(key.asString().data());
     auto find_result = dictionary.find_posting_list(comp, dictionary_snapshot);
     if (find_result.first.valid()) {
         auto pidx = find_result.second;

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -22,7 +22,7 @@ SimpleQueryStackDumpIterator::SimpleQueryStackDumpIterator(vespalib::stringref b
       _currArity(0),
       _curr_index_name(),
       _curr_term(),
-      _scratch(),
+      _curr_integer_term(0),
       _extraIntArg1(0),
       _extraIntArg2(0),
       _extraIntArg3(0),
@@ -152,9 +152,7 @@ bool SimpleQueryStackDumpIterator::readNext() {
     case ParseItem::ITEM_PURE_WEIGHTED_LONG:
         {
             if (p + sizeof(int64_t) > _bufEnd) return false;
-            int64_t value = vespalib::nbo::n2h(*reinterpret_cast<const int64_t *>(p));
-            auto res = std::to_chars(_scratch, _scratch + sizeof(_scratch), value, 10);
-            _curr_term = vespalib::stringref(_scratch, res.ptr - _scratch);
+            _curr_integer_term = vespalib::nbo::n2h(*reinterpret_cast<const int64_t *>(p));
             p += sizeof(int64_t);
             _currArity = 0;
         }

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -36,7 +36,7 @@ private:
     vespalib::stringref _curr_index_name;
     /** The term in the current item */
     vespalib::stringref _curr_term;
-    char                _scratch[24];
+    int64_t             _curr_integer_term;
 
     /* extra arguments */
     uint32_t _extraIntArg1;
@@ -119,6 +119,7 @@ public:
 
     vespalib::stringref getIndexName() const { return _curr_index_name; }
     vespalib::stringref getTerm() const { return _curr_term; }
+    int64_t getIntergerTerm() const { return _curr_integer_term; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.cpp
@@ -13,8 +13,5 @@ Near::~Near() = default;
 ONear::~ONear() = default;
 Phrase::~Phrase() = default;
 SameElement::~SameElement() = default;
-WeightedSetTerm::~WeightedSetTerm() = default;
-DotProduct::~DotProduct() = default;
-WandTerm::~WandTerm() = default;
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
@@ -122,36 +122,4 @@ private:
     bool _expensive;
 };
 
-class WeightedSetTerm : public QueryNodeMixin<WeightedSetTerm, Intermediate>, public Term {
-public:
-    WeightedSetTerm(const vespalib::string &view, int32_t id, Weight weight)
-        : Term(view, id, weight) {}
-    virtual ~WeightedSetTerm() = 0;
-};
-
-class DotProduct : public QueryNodeMixin<DotProduct, Intermediate>, public Term {
-public:
-    DotProduct(const vespalib::string &view, int32_t id, Weight weight)
-        : Term(view, id, weight) {}
-    virtual ~DotProduct() = 0;
-};
-
-class WandTerm : public QueryNodeMixin<WandTerm, Intermediate>, public Term {
-private:
-    uint32_t _targetNumHits;
-    int64_t  _scoreThreshold;
-    double   _thresholdBoostFactor;
-public:
-    WandTerm(const vespalib::string &view, int32_t id, Weight weight,
-             uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor)
-        : Term(view, id, weight),
-          _targetNumHits(targetNumHits),
-          _scoreThreshold(scoreThreshold),
-          _thresholdBoostFactor(thresholdBoostFactor) {}
-    virtual ~WandTerm() = 0;
-    uint32_t getTargetNumHits() const { return _targetNumHits; }
-    int64_t getScoreThreshold() const { return _scoreThreshold; }
-    double getThresholdBoostFactor() const { return _thresholdBoostFactor; }
-};
-
 }

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -50,9 +50,6 @@ class QueryBuilderBase
     std::stack<NodeInfo> _nodes;
     vespalib::string _error_msg;
 
-    void reportError(const vespalib::string &msg);
-    void reportError(const vespalib::string &msg, const Node & incomming, const Node & root);
-
 protected:
     QueryBuilderBase();
     ~QueryBuilderBase();
@@ -91,6 +88,9 @@ public:
      * build a new query tree with the same builder.
      */
     void reset();
+
+    void reportError(const vespalib::string &msg);
+    void reportError(const vespalib::string &msg, const Node & incomming, const Node & root);
 };
 
 
@@ -126,17 +126,17 @@ typename NodeTypes::SameElement *createSameElement(vespalib::stringref view) {
     return new typename NodeTypes::SameElement(view);
 }
 template <class NodeTypes>
-typename NodeTypes::WeightedSetTerm *createWeightedSetTerm(vespalib::stringref view, int32_t id, Weight weight) {
-    return new typename NodeTypes::WeightedSetTerm(view, id, weight);
+typename NodeTypes::WeightedSetTerm *createWeightedSetTerm(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight) {
+    return new typename NodeTypes::WeightedSetTerm(num_terms, view, id, weight);
 }
 template <class NodeTypes>
-typename NodeTypes::DotProduct *createDotProduct(vespalib::stringref view, int32_t id, Weight weight) {
-    return new typename NodeTypes::DotProduct(view, id, weight);
+typename NodeTypes::DotProduct *createDotProduct(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight) {
+    return new typename NodeTypes::DotProduct(num_terms, view, id, weight);
 }
 template <class NodeTypes>
 typename NodeTypes::WandTerm *
-createWandTerm(vespalib::stringref view, int32_t id, Weight weight, uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor) {
-    return new typename NodeTypes::WandTerm(view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor);
+createWandTerm(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight, uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor) {
+    return new typename NodeTypes::WandTerm(num_terms, view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor);
 }
 template <class NodeTypes>
 typename NodeTypes::Rank *createRank() {
@@ -262,12 +262,12 @@ public:
     }
     typename NodeTypes::WeightedSetTerm &addWeightedSetTerm( int child_count, stringref view, int32_t id, Weight weight) {
         adjustWeight(weight);
-        typename NodeTypes::WeightedSetTerm &node = addIntermediate(createWeightedSetTerm<NodeTypes>(view, id, weight), child_count);
+        typename NodeTypes::WeightedSetTerm &node = addTerm(createWeightedSetTerm<NodeTypes>(child_count, view, id, weight));
         return node;
     }
     typename NodeTypes::DotProduct &addDotProduct( int child_count, stringref view, int32_t id, Weight weight) {
         adjustWeight(weight);
-        typename NodeTypes::DotProduct &node = addIntermediate( createDotProduct<NodeTypes>(view, id, weight), child_count);
+        typename NodeTypes::DotProduct &node = addTerm( createDotProduct<NodeTypes>(child_count, view, id, weight));
         return node;
     }
     typename NodeTypes::WandTerm &addWandTerm(
@@ -276,9 +276,8 @@ public:
             int64_t scoreThreshold, double thresholdBoostFactor)
     {
         adjustWeight(weight);
-        typename NodeTypes::WandTerm &node = addIntermediate(
-                createWandTerm<NodeTypes>(view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor),
-                child_count);
+        typename NodeTypes::WandTerm &node = addTerm(
+                createWandTerm<NodeTypes>(child_count, view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor));
         return node;
     }
     typename NodeTypes::Rank &addRank(int child_count) {

--- a/searchlib/src/vespa/searchlib/query/tree/querynodemixin.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querynodemixin.h
@@ -8,7 +8,7 @@ namespace search::query {
 
 template <typename T, typename Base>
 struct QueryNodeMixin : Base {
-    typedef QueryNodeMixin<T, Base> QueryNodeMixinType;
+    using QueryNodeMixinType = QueryNodeMixin<T, Base>;
 
     ~QueryNodeMixin() = 0;
     void accept(QueryVisitor &visitor) override {

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -78,26 +78,32 @@ private:
         visitNodes(node.getChildren());
     }
 
+    void replicateMultiTerm(const MultiTerm &original, MultiTerm & replica) {
+        for (uint32_t i(0); i < original.getNumTerms(); i++) {
+            auto v = original.getAsString(i);
+            replica.addTerm(v.first, v.second);
+        }
+    }
+
     void visit(WeightedSetTerm &node) override {
-        replicate(node, _builder.addWeightedSetTerm(node.getChildren().size(), node.getView(),
-                                                    node.getId(), node.getWeight()));
-        visitNodes(node.getChildren());
+        auto & replica = _builder.addWeightedSetTerm(node.getNumTerms(), node.getView(), node.getId(), node.getWeight());
+        replicate(node, replica);
+        replicateMultiTerm(node, replica);
     }
 
     void visit(DotProduct &node) override {
-        replicate(node, _builder.addDotProduct(node.getChildren().size(), node.getView(),
-                                               node.getId(), node.getWeight()));
-        visitNodes(node.getChildren());
+        auto & replica = _builder.addDotProduct(node.getNumTerms(), node.getView(), node.getId(), node.getWeight());
+        replicate(node, replica);
+        replicateMultiTerm(node, replica);
     }
 
     void visit(WandTerm &node) override {
-        replicate(node, _builder.addWandTerm(node.getChildren().size(),
-                                             node.getView(),
-                                             node.getId(), node.getWeight(),
-                                             node.getTargetNumHits(),
-                                             node.getScoreThreshold(),
-                                             node.getThresholdBoostFactor()));
-        visitNodes(node.getChildren());
+        auto & replica = _builder.addWandTerm(node.getNumTerms(), node.getView(), node.getId(), node.getWeight(),
+                                              node.getTargetNumHits(),
+                                              node.getScoreThreshold(),
+                                              node.getThresholdBoostFactor());
+        replicate(node, replica);
+        replicateMultiTerm(node, replica);
     }
 
     void visit(Rank &node) override {

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -79,9 +79,19 @@ private:
     }
 
     void replicateMultiTerm(const MultiTerm &original, MultiTerm & replica) {
-        for (uint32_t i(0); i < original.getNumTerms(); i++) {
-            auto v = original.getAsString(i);
-            replica.addTerm(v.first, v.second);
+        if (original.getType() == MultiTerm::Type::STRING) {
+            for (uint32_t i(0); i < original.getNumTerms(); i++) {
+                auto v = original.getAsString(i);
+                replica.addTerm(v.first, v.second);
+            }
+        } else if (original.getType() == MultiTerm::Type::INTEGER) {
+            for (uint32_t i(0); i < original.getNumTerms(); i++) {
+                auto v = original.getAsInteger(i);
+                replica.addTerm(v.first, v.second);
+            }
+        } else {
+            assert (original.getType() == MultiTerm::Type::UNKNOWN);
+            assert (original.getNumTerms() == 0);
         }
     }
 

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -35,17 +35,17 @@ struct SimpleSameElement : SameElement {
     SimpleSameElement(vespalib::stringref view) : SameElement(view) {}
 };
 struct SimpleWeightedSetTerm : WeightedSetTerm {
-    SimpleWeightedSetTerm(vespalib::stringref view, int32_t id, Weight weight)
-        : WeightedSetTerm(view, id, weight) {}
+    SimpleWeightedSetTerm(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight)
+        : WeightedSetTerm(num_terms, view, id, weight) {}
 };
 struct SimpleDotProduct : DotProduct {
-    SimpleDotProduct(vespalib::stringref view, int32_t id, Weight weight)
-        : DotProduct(view, id, weight) {}
+    SimpleDotProduct(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight)
+        : DotProduct(num_terms, view, id, weight) {}
 };
 struct SimpleWandTerm : WandTerm {
-    SimpleWandTerm(vespalib::stringref view, int32_t id, Weight weight,
+    SimpleWandTerm(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight,
                    uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor)
-        : WandTerm(view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor) {}
+        : WandTerm(num_terms, view, id, weight, targetNumHits, scoreThreshold, thresholdBoostFactor) {}
 };
 struct SimpleRank : Rank {};
 struct SimpleNumberTerm : NumberTerm {

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -49,8 +49,8 @@ public:
 
 private:
     static void populateMultiTerm(search::SimpleQueryStackDumpIterator &queryStack, QueryBuilderBase & builder, MultiTerm & mt) {
-        for (uint32_t i(0); i < mt.getNumTerms(); i++) {
-            queryStack.next();
+        uint32_t added(0);
+        for (added = 0; (added < mt.getNumTerms()) && queryStack.next(); added++) {
             ParseItem::ItemType type = queryStack.getType();
             switch (type) {
                 case ParseItem::ITEM_PURE_WEIGHTED_LONG:
@@ -60,9 +60,12 @@ private:
                     mt.addTerm(queryStack.getTerm(), queryStack.GetWeight());
                     break;
                 default:
-                    builder.reportError(vespalib::make_string("Got unexpected node %d for multiterm node at child term %d", type, i));
+                    builder.reportError(vespalib::make_string("Got unexpected node %d for multiterm node at child term %d", type, added));
                     return;
             }
+        }
+        if (added < mt.getNumTerms()) {
+            builder.reportError(vespalib::make_string("Too few nodes(%d) for multiterm(%d)", added, mt.getNumTerms()));
         }
     }
     static Term *

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
@@ -69,7 +69,8 @@ public:
     }
     StringAndWeight getAsString(uint32_t index) const override {
         const auto & v = _terms[index];
-        auto res = std::to_chars(_scratchPad, _scratchPad + sizeof(_scratchPad), v.first, 10);
+        auto res = std::to_chars(_scratchPad, _scratchPad + sizeof(_scratchPad)-1, v.first, 10);
+        res.ptr[0] = '\0';
         return StringAndWeight(stringref(_scratchPad, res.ptr - _scratchPad), v.second);
     }
     IntegerAndWeight getAsInteger(uint32_t index) const override {
@@ -87,7 +88,8 @@ private:
 
 MultiTerm::MultiTerm(uint32_t num_terms)
     : _terms(),
-      _num_terms(num_terms)
+      _num_terms(num_terms),
+      _type(Type::UNKNOWN)
 {}
 
 MultiTerm::~MultiTerm() = default;
@@ -96,6 +98,7 @@ void
 MultiTerm::addTerm(vespalib::stringref term, Weight weight) {
     if ( ! _terms) {
         _terms = std::make_unique<StringTermVector>(_num_terms);
+        _type = Type::STRING;
     }
     _terms->addTerm(term, weight);
 }
@@ -104,6 +107,7 @@ void
 MultiTerm::addTerm(int64_t term, Weight weight) {
     if ( ! _terms) {
         _terms = std::make_unique<IntegerTermVector>(_num_terms);
+        _type = Type::INTEGER;
     }
     _terms->addTerm(term, weight);
 }

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
@@ -51,6 +51,9 @@ public:
         std::from_chars(v.first.c_str(), v.first.c_str() + v.first.size(), value);
         return IntegerAndWeight(value, v.second);
     }
+    Weight getWeight(uint32_t index) const override {
+        return _terms[index].second;
+    }
 private:
     std::vector<std::pair<vespalib::string, Weight>> _terms;
 };
@@ -71,6 +74,9 @@ public:
     }
     IntegerAndWeight getAsInteger(uint32_t index) const override {
         return _terms[index];
+    }
+    Weight getWeight(uint32_t index) const override {
+        return _terms[index].second;
     }
 private:
     std::vector<IntegerAndWeight> _terms;

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.cpp
@@ -1,26 +1,105 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "termnodes.h"
+#include <vespa/vespalib/util/exceptions.h>
+#include <charconv>
 
+using vespalib::IllegalArgumentException;
+using vespalib::stringref;
+using vespalib::make_string_short::fmt;
 namespace search::query {
-
-NumberTerm::~NumberTerm() = default;
-
-PrefixTerm::~PrefixTerm() = default;
-
-RangeTerm::~RangeTerm() = default;
 
 StringTerm::StringTerm(const Type &term, vespalib::stringref view, int32_t id, Weight weight)
     : QueryNodeMixinType(term, view, id, weight)
 {}
+
+NumberTerm::~NumberTerm() = default;
+PrefixTerm::~PrefixTerm() = default;
+RangeTerm::~RangeTerm() = default;
 StringTerm::~StringTerm() = default;
-
 SubstringTerm::~SubstringTerm() = default;
-
 SuffixTerm::~SuffixTerm() = default;
-
 LocationTerm::~LocationTerm() = default;
-
 RegExpTerm::~RegExpTerm() = default;
+WeightedSetTerm::~WeightedSetTerm() = default;
+DotProduct::~DotProduct() = default;
+WandTerm::~WandTerm() = default;
+
+namespace {
+
+void badType(const char *expected, const char *got) __attribute__((noinline));
+void badType(const char *expected, const char *got) {
+    throw IllegalArgumentException(fmt("Expected '%s' type, got '%s'", expected, got), VESPA_STRLOC);
+}
+
+class StringTermVector final : public MultiTerm::TermVector {
+public:
+    StringTermVector(uint32_t sz) : _terms() { _terms.reserve(sz); }
+    void addTerm(stringref term, Weight weight) override {
+        _terms.emplace_back(term, weight);
+    }
+    void addTerm(int64_t, Weight) override {
+        badType("string", "int64_t");
+    }
+    StringAndWeight getAsString(uint32_t index) const override {
+        const auto & v = _terms[index];
+        return StringAndWeight(v.first, v.second);
+    }
+    IntegerAndWeight getAsInteger(uint32_t index) const override {
+        const auto & v = _terms[index];
+        int64_t value(0);
+        std::from_chars(v.first.c_str(), v.first.c_str() + v.first.size(), value);
+        return IntegerAndWeight(value, v.second);
+    }
+private:
+    std::vector<std::pair<vespalib::string, Weight>> _terms;
+};
+
+class IntegerTermVector final : public MultiTerm::TermVector {
+public:
+    IntegerTermVector(uint32_t sz) : _terms() { _terms.reserve(sz); }
+    void addTerm(stringref, Weight) override {
+        badType("int64_t", "string");
+    }
+    void addTerm(int64_t term, Weight weight) override {
+        _terms.emplace_back(term, weight);
+    }
+    StringAndWeight getAsString(uint32_t index) const override {
+        const auto & v = _terms[index];
+        auto res = std::to_chars(_scratchPad, _scratchPad + sizeof(_scratchPad), v.first, 10);
+        return StringAndWeight(stringref(_scratchPad, res.ptr - _scratchPad), v.second);
+    }
+    IntegerAndWeight getAsInteger(uint32_t index) const override {
+        return _terms[index];
+    }
+private:
+    std::vector<IntegerAndWeight> _terms;
+    mutable char                  _scratchPad[24];
+};
+
+}
+
+MultiTerm::MultiTerm(uint32_t num_terms)
+    : _terms(),
+      _num_terms(num_terms)
+{}
+
+MultiTerm::~MultiTerm() = default;
+
+void
+MultiTerm::addTerm(vespalib::stringref term, Weight weight) {
+    if ( ! _terms) {
+        _terms = std::make_unique<StringTermVector>(_num_terms);
+    }
+    _terms->addTerm(term, weight);
+}
+
+void
+MultiTerm::addTerm(int64_t term, Weight weight) {
+    if ( ! _terms) {
+        _terms = std::make_unique<IntegerTermVector>(_num_terms);
+    }
+    _terms->addTerm(term, weight);
+}
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -155,6 +155,7 @@ public:
 
 class MultiTerm : public Node {
 public:
+    enum class Type {STRING, INTEGER, UNKNOWN};
     using StringAndWeight = std::pair<vespalib::stringref, Weight>;
     using IntegerAndWeight = std::pair<int64_t, Weight>;
     struct TermVector {
@@ -170,15 +171,19 @@ public:
     ~MultiTerm() override;
     void addTerm(vespalib::stringref term, Weight weight);
     void addTerm(int64_t term, Weight weight);
+    // Note that the first refers to a zero terminated string.
+    // That is required as the comparator for the enum store requires it.
     StringAndWeight getAsString(uint32_t index) const { return _terms->getAsString(index); }
     IntegerAndWeight getAsInteger(uint32_t index) const { return _terms->getAsInteger(index); }
     Weight weight(uint32_t index) const { return _terms->getWeight(index); }
     uint32_t getNumTerms() const { return _num_terms; }
+    Type getType() const { return _type; }
 protected:
     MultiTerm(uint32_t num_terms);
 private:
     std::unique_ptr<TermVector> _terms;
     uint32_t _num_terms;
+    Type _type;
 };
 
 class WeightedSetTerm : public QueryNodeMixin<WeightedSetTerm, MultiTerm>, public Term {

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -153,5 +153,67 @@ public:
     double get_distance_threshold() const { return _distance_threshold; }
 };
 
+class MultiTerm : public Node {
+public:
+    using StringAndWeight = std::pair<vespalib::stringref, Weight>;
+    using IntegerAndWeight = std::pair<int64_t, Weight>;
+    struct TermVector {
+        using StringAndWeight = MultiTerm::StringAndWeight;
+        using IntegerAndWeight = MultiTerm::IntegerAndWeight;
+        virtual ~TermVector() = default;
+        virtual void addTerm(vespalib::stringref term, Weight weight) = 0;
+        virtual void addTerm(int64_t term, Weight weight) = 0;
+        virtual StringAndWeight getAsString(uint32_t index) const = 0;
+        virtual IntegerAndWeight getAsInteger(uint32_t index) const = 0;
+    };
+    ~MultiTerm() override;
+    void addTerm(vespalib::stringref term, Weight weight);
+    void addTerm(int64_t term, Weight weight);
+    StringAndWeight getAsString(uint32_t index) const { return _terms->getAsString(index); }
+    IntegerAndWeight getAsInteger(uint32_t index) const { return _terms->getAsInteger(index); }
+    uint32_t getNumTerms() const { return _num_terms; }
+protected:
+    MultiTerm(uint32_t num_terms);
+private:
+    std::unique_ptr<TermVector> _terms;
+    uint32_t _num_terms;
+};
+
+class WeightedSetTerm : public QueryNodeMixin<WeightedSetTerm, MultiTerm>, public Term {
+public:
+    WeightedSetTerm(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight)
+            : QueryNodeMixinType(num_terms),
+              Term(view, id, weight)
+    {}
+    virtual ~WeightedSetTerm() = 0;
+};
+
+class DotProduct : public QueryNodeMixin<DotProduct, MultiTerm>, public Term {
+public:
+    DotProduct(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight)
+            : QueryNodeMixinType(num_terms),
+              Term(view, id, weight)
+    {}
+    virtual ~DotProduct() = 0;
+};
+
+class WandTerm : public QueryNodeMixin<WandTerm, MultiTerm>, public Term {
+private:
+    uint32_t _targetNumHits;
+    int64_t  _scoreThreshold;
+    double   _thresholdBoostFactor;
+public:
+    WandTerm(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight,
+             uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor)
+            : QueryNodeMixinType(num_terms),
+              Term(view, id, weight),
+              _targetNumHits(targetNumHits),
+              _scoreThreshold(scoreThreshold),
+              _thresholdBoostFactor(thresholdBoostFactor) {}
+    virtual ~WandTerm() = 0;
+    uint32_t getTargetNumHits() const { return _targetNumHits; }
+    int64_t getScoreThreshold() const { return _scoreThreshold; }
+    double getThresholdBoostFactor() const { return _thresholdBoostFactor; }
+};
 
 }

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -165,12 +165,14 @@ public:
         virtual void addTerm(int64_t term, Weight weight) = 0;
         virtual StringAndWeight getAsString(uint32_t index) const = 0;
         virtual IntegerAndWeight getAsInteger(uint32_t index) const = 0;
+        virtual Weight getWeight(uint32_t index) const = 0;
     };
     ~MultiTerm() override;
     void addTerm(vespalib::stringref term, Weight weight);
     void addTerm(int64_t term, Weight weight);
     StringAndWeight getAsString(uint32_t index) const { return _terms->getAsString(index); }
     IntegerAndWeight getAsInteger(uint32_t index) const { return _terms->getAsInteger(index); }
+    Weight weight(uint32_t index) const { return _terms->getWeight(index); }
     uint32_t getNumTerms() const { return _num_terms; }
 protected:
     MultiTerm(uint32_t num_terms);
@@ -182,8 +184,8 @@ private:
 class WeightedSetTerm : public QueryNodeMixin<WeightedSetTerm, MultiTerm>, public Term {
 public:
     WeightedSetTerm(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight)
-            : QueryNodeMixinType(num_terms),
-              Term(view, id, weight)
+        : QueryNodeMixinType(num_terms),
+          Term(view, id, weight)
     {}
     virtual ~WeightedSetTerm() = 0;
 };
@@ -191,8 +193,8 @@ public:
 class DotProduct : public QueryNodeMixin<DotProduct, MultiTerm>, public Term {
 public:
     DotProduct(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight)
-            : QueryNodeMixinType(num_terms),
-              Term(view, id, weight)
+        : QueryNodeMixinType(num_terms),
+          Term(view, id, weight)
     {}
     virtual ~DotProduct() = 0;
 };
@@ -205,11 +207,12 @@ private:
 public:
     WandTerm(uint32_t num_terms, const vespalib::string &view, int32_t id, Weight weight,
              uint32_t targetNumHits, int64_t scoreThreshold, double thresholdBoostFactor)
-            : QueryNodeMixinType(num_terms),
-              Term(view, id, weight),
-              _targetNumHits(targetNumHits),
-              _scoreThreshold(scoreThreshold),
-              _thresholdBoostFactor(thresholdBoostFactor) {}
+        : QueryNodeMixinType(num_terms),
+          Term(view, id, weight),
+          _targetNumHits(targetNumHits),
+          _scoreThreshold(scoreThreshold),
+          _thresholdBoostFactor(thresholdBoostFactor)
+    {}
     virtual ~WandTerm() = 0;
     uint32_t getTargetNumHits() const { return _targetNumHits; }
     int64_t getScoreThreshold() const { return _scoreThreshold; }

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.cpp
@@ -66,12 +66,12 @@ template <typename WS, typename NODE>
 void
 CreateBlueprintVisitorHelper::createWeightedSet(std::unique_ptr<WS> bp, NODE &n) {
     FieldSpecList fields;
-    for (size_t i = 0; i < n.getChildren().size(); ++i) {
+    for (size_t i = 0; i < n.getNumTerms(); ++i) {
         fields.clear();
         fields.add(bp->getNextChildField(_field));
-        const query::Node &node = *n.getChildren()[i];
-        uint32_t weight = getWeightFromNode(node).percent();
-        bp->addTerm(_searchable.createBlueprint(_requestContext, fields, node), weight);
+        const auto & term = n.getAsString(i);
+        query::SimpleStringTerm node(term.first, n.getView(), 0, term.second); // TODO Temporary
+        bp->addTerm(_searchable.createBlueprint(_requestContext, fields, node), term.second.percent());
     }
     setResult(std::move(bp));
 }

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.cpp
@@ -69,7 +69,7 @@ CreateBlueprintVisitorHelper::createWeightedSet(std::unique_ptr<WS> bp, NODE &n)
     for (size_t i = 0; i < n.getNumTerms(); ++i) {
         fields.clear();
         fields.add(bp->getNextChildField(_field));
-        const auto & term = n.getAsString(i);
+        auto term = n.getAsString(i);
         query::SimpleStringTerm node(term.first, n.getView(), 0, term.second); // TODO Temporary
         bp->addTerm(_searchable.createBlueprint(_requestContext, fields, node), term.second.percent());
     }

--- a/searchlib/src/vespa/searchlib/queryeval/termasstring.h
+++ b/searchlib/src/vespa/searchlib/queryeval/termasstring.h
@@ -2,26 +2,13 @@
 
 #pragma once
 
-#include <vespa/searchlib/query/tree/location.h>
-#include <vespa/searchlib/query/tree/range.h>
-#include <string>
+#include <vespa/vespalib/stllike/string.h>
 
 namespace search::query { class Node; }
 
 namespace search::queryeval {
 
-inline const vespalib::string &termAsString(const vespalib::string &term) {
-    return term;
-}
-
-vespalib::string termAsString(double float_term);
-
-vespalib::string termAsString(int64_t int_term);
-
-vespalib::string termAsString(const search::query::Range &term);
-
-vespalib::string termAsString(const search::query::Location &term);
-
 vespalib::string termAsString(const search::query::Node &term_node);
+vespalib::stringref termAsString(const search::query::Node &term_node, vespalib::string & scratchPad);
 
 }


### PR DESCRIPTION
… as they really are.

  That restricts the nodes to what they can really do and makes them significantly cheaper.
- In addition type conversion of numeric terms is delayed to when it is necessary.
   And as next step they can be avoided completely.

@havardpe PR