### PR TITLE
Resolve container-cpu-cap based on cluster type and ID

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/BooleanFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/BooleanFlag.java
@@ -12,6 +12,11 @@ public class BooleanFlag extends FlagImpl<Boolean, BooleanFlag> {
         super(id, defaultValue, vector, serializer, source, BooleanFlag::new);
     }
 
+    @Override
+    public BooleanFlag self() {
+        return this;
+    }
+
     public boolean value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/DoubleFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/DoubleFlag.java
@@ -12,6 +12,11 @@ public class DoubleFlag extends FlagImpl<Double, DoubleFlag> {
         super(id, defaultValue, vector, serializer, source, DoubleFlag::new);
     }
 
+    @Override
+    public DoubleFlag self() {
+        return this;
+    }
+
     public double value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/FetchVector.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/FetchVector.java
@@ -33,8 +33,11 @@ public class FetchVector {
         /** Node type from com.yahoo.config.provision.NodeType::name, e.g. tenant, host, confighost, controller, etc. */
         NODE_TYPE,
 
-        /** Cluster type from com.yahoo.config.provision.ClusterSpec.Type::name, e.g. content, container, admin */
+        /** Cluster type from com.yahoo.config.provision.ClusterSpec.Type::value, e.g. content, container, admin */
         CLUSTER_TYPE,
+
+        /** Cluster ID from com.yahoo.config.provision.ClusterSpec.Id::value, e.g. cluster-controllers, logserver. */
+        CLUSTER_ID,
 
         /**
          * Fully qualified hostname.

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flag.java
@@ -1,6 +1,8 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
+import java.util.Optional;
+
 /**
  * Interface for flag.
  *
@@ -12,11 +14,19 @@ public interface Flag<T, F> {
     /** The flag ID. */
     FlagId id();
 
+    /** A generic type-safe method for getting {@code this}. */
+    F self();
+
     /** Returns the flag serializer. */
     FlagSerializer<T> serializer();
 
     /** Returns an immutable clone of the current object, except with the dimension set accordingly. */
     F with(FetchVector.Dimension dimension, String dimensionValue);
+
+    /** Same as {@link #with(FetchVector.Dimension, String)} if value is present, and otherwise returns {@code this}. */
+    default F with(FetchVector.Dimension dimension, Optional<String> dimensionValue) {
+        return dimensionValue.map(value -> with(dimension, value)).orElse(self());
+    }
 
     /** Returns the value, boxed if the flag wraps a primitive type. */
     T boxedValue();

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
+import static com.yahoo.vespa.flags.FetchVector.Dimension.CLUSTER_ID;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.CLUSTER_TYPE;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
@@ -245,7 +246,7 @@ public class Flags {
             List.of("hmusum"), "2021-03-15", "2021-05-15",
             "JVM max heap size for config proxy in Mb",
             "Takes effect on restart of Docker container",
-            CLUSTER_TYPE);
+            CLUSTER_TYPE, CLUSTER_ID);
 
     public static final UnboundStringFlag DEDICATED_CLUSTER_CONTROLLER_FLAVOR = defineStringFlag(
             "dedicated-cluster-controller-flavor", "", List.of("jonmv"), "2021-02-25", "2021-04-25",

--- a/flags/src/main/java/com/yahoo/vespa/flags/IntFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/IntFlag.java
@@ -12,6 +12,11 @@ public class IntFlag extends FlagImpl<Integer, IntFlag> {
         super(id, defaultValue, vector, serializer, source, IntFlag::new);
     }
 
+    @Override
+    public IntFlag self() {
+        return this;
+    }
+
     public int value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/JacksonFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/JacksonFlag.java
@@ -12,6 +12,11 @@ public class JacksonFlag<T> extends FlagImpl<T, JacksonFlag<T>> {
         super(id, defaultValue, vector, serializer, source, JacksonFlag::new);
     }
 
+    @Override
+    public JacksonFlag<T> self() {
+        return this;
+    }
+
     public T value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/ListFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/ListFlag.java
@@ -13,6 +13,11 @@ public class ListFlag<T> extends FlagImpl<List<T>, ListFlag<T>> {
         super(id, defaultValue, vector, serializer, source, ListFlag::new);
     }
 
+    @Override
+    public ListFlag<T> self() {
+        return this;
+    }
+
     public List<T> value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/LongFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/LongFlag.java
@@ -12,6 +12,11 @@ public class LongFlag extends FlagImpl<Long, LongFlag> {
         super(id, defaultValue, vector, serializer, source, LongFlag::new);
     }
 
+    @Override
+    public LongFlag self() {
+        return this;
+    }
+
     public long value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -11,6 +11,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
+import static com.yahoo.vespa.flags.FetchVector.Dimension.CLUSTER_ID;
+import static com.yahoo.vespa.flags.FetchVector.Dimension.CLUSTER_TYPE;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.CONSOLE_USER_EMAIL;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.HOSTNAME;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.NODE_TYPE;
@@ -102,9 +104,9 @@ public class PermanentFlags {
     public static final UnboundDoubleFlag CONTAINER_CPU_CAP = defineDoubleFlag(
             "container-cpu-cap", 0,
             "Hard limit on how many CPUs a container may use. This value is multiplied by CPU allocated to node, so " +
-                    "to cap CPU at 200%, set this to 2, etc.",
+                    "to cap CPU at 200%, set this to 2, etc. 0 disables the cap to allow unlimited CPU.",
             "Takes effect on next node agent tick. Change is orchestrated, but does NOT require container restart",
-            HOSTNAME, APPLICATION_ID);
+            HOSTNAME, APPLICATION_ID, CLUSTER_ID, CLUSTER_TYPE);
 
     public static final UnboundListFlag<String> DISABLED_HOST_ADMIN_TASKS = defineListFlag(
             "disabled-host-admin-tasks", List.of(), String.class,

--- a/flags/src/main/java/com/yahoo/vespa/flags/StringFlag.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/StringFlag.java
@@ -12,6 +12,11 @@ public class StringFlag extends FlagImpl<String, StringFlag> {
         super(id, defaultValue, vector, serializer, source, StringFlag::new);
     }
 
+    @Override
+    public StringFlag self() {
+        return this;
+    }
+
     public String value() {
         return boxedValue();
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/DimensionHelper.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/DimensionHelper.java
@@ -17,6 +17,7 @@ public class DimensionHelper {
         serializedDimensions.put(FetchVector.Dimension.HOSTNAME, "hostname");
         serializedDimensions.put(FetchVector.Dimension.APPLICATION_ID, "application");
         serializedDimensions.put(FetchVector.Dimension.NODE_TYPE, "node-type");
+        serializedDimensions.put(FetchVector.Dimension.CLUSTER_ID, "cluster-id");
         serializedDimensions.put(FetchVector.Dimension.CLUSTER_TYPE, "cluster-type");
         serializedDimensions.put(FetchVector.Dimension.VESPA_VERSION, "vespa-version");
         serializedDimensions.put(FetchVector.Dimension.CONSOLE_USER_EMAIL, "console-user-email");


### PR DESCRIPTION
The goal is to enable higher cap for the cluster type "admin" and cluster ID "cluster-controllers".  If the cap is applied to cluster type "admin" it would also include "logserver" (which would probably be OK).