### PR TITLE
Compaction of B-tree can cause identity of nodes to change.

### DIFF
--- a/vespalib/src/vespa/vespalib/btree/btreeiterator.h
+++ b/vespalib/src/vespa/vespalib/btree/btreeiterator.h
@@ -531,7 +531,6 @@ public:
             uint32_t eidx;
             do {
                 --level;
-                assert(_path[level].getNode() == end_itr._path[level].getNode());
                 idx = _path[level].getIdx();
                 eidx = end_itr._path[level].getIdx();
                 if (idx > eidx) {
@@ -555,7 +554,6 @@ public:
                 return;
             } else {
                 // Lowest shared node is a leaf node.
-                assert(_leaf.getNode() == end_itr._leaf.getNode());
             }
         }
         uint32_t idx = _leaf.getIdx();

--- a/vespalib/src/vespa/vespalib/btree/btreeiterator.h
+++ b/vespalib/src/vespa/vespalib/btree/btreeiterator.h
@@ -348,9 +348,19 @@ public:
 
     bool
     operator==(const BTreeIteratorBase & rhs) const {
-        if (_leaf.getNode() != rhs._leaf.getNode() ||
-            _leaf.getIdx() != rhs._leaf.getIdx()) {
+        if (_leaf.getIdx() != rhs._leaf.getIdx()) {
             return false;
+        }
+        if (_leaf.getNode() == rhs._leaf.getNode()) {
+            return true;
+        }
+        if ((_leaf.getNode() == nullptr) || (rhs._leaf.getNode() == nullptr) || (_pathSize != rhs._pathSize)) {
+            return false;
+        }
+        for (uint32_t level = 0; level < _pathSize; ++level) {
+            if (_path[level].getIdx() != rhs._path[level].getIdx()) {
+                return false;
+            }
         }
         return true;
     }

--- a/vespalib/src/vespa/vespalib/btree/btreeiterator.hpp
+++ b/vespalib/src/vespa/vespalib/btree/btreeiterator.hpp
@@ -515,15 +515,12 @@ operator-(const BTreeIteratorBase &rhs) const
     if (_pathSize != 0) {
         uint32_t pidx = _pathSize;
         while (pidx > 0) {
-            assert(_path[pidx - 1].getNode() == rhs._path[pidx - 1].getNode());
             if (_path[pidx - 1].getIdx() != rhs._path[pidx - 1].getIdx())
                 break;
             --pidx;
         }
         return position(pidx) - rhs.position(pidx);
     } else {
-        assert(_leaf.getNode() == nullptr || rhs._leaf.getNode() == nullptr ||
-               _leaf.getNode() == rhs._leaf.getNode());
         return position(0) - rhs.position(0);
     }
 }


### PR DESCRIPTION
Change operator== for B-tree iterator accordingly.

@baldersheim : please review
