### PR TITLE
- Use a unitialized buffer to store hash keys and values.

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/hashtable.h
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.h
@@ -144,7 +144,7 @@ public:
         return *this;
     }
     ~hash_node() {
-        if (can_skip_destruction<V>::value) {
+        if (!can_skip_destruction<V>::value) {
             if (valid()) {
                 getValue().~V();
             }
@@ -164,7 +164,7 @@ public:
 private:
     void destruct() {
         if (valid()) {
-            if (can_skip_destruction<V>::value) {
+            if (!can_skip_destruction<V>::value) {
                 getValue().~V();
             }
             _next = invalid;

--- a/vespalib/src/vespa/vespalib/stllike/hashtable.h
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.h
@@ -166,7 +166,7 @@ public:
     bool hasNext()       const { return valid() && (_next != npos); }
 private:
     void destruct() {
-        if (!can_skip_destruction<V>::value) {
+        if constexpr (!can_skip_destruction<V>::value) {
             if (valid()) {
                 getValue().~V();
             }


### PR DESCRIPTION
- Use placement new and explicit destructor calls to not take the cost before necessary.
- This removes the need for a default constructor and unnecessary initialization.

@havardpe PR