### PR TITLE
Move nodes to 'failed' during activate

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -194,6 +194,17 @@ public final class Node implements Nodelike {
     }
 
     /**
+     * Returns a copy of this where wantToFail is set to true and history is updated to reflect this.
+     */
+    public Node withWantToFail(boolean wantToFail, Agent agent, String reason, Instant at) {
+        Node node = this.with(status.withWantToFail(wantToFail));
+        if (wantToFail)
+            node = node.with(history.with(new History.Event(History.Event.Type.wantToFail, agent, at)));
+        return node;
+
+    }
+
+    /**
      * Returns a copy of this node with wantToRetire and wantToDeprovision set to the given values and updated history.
      *
      * If both given wantToRetire and wantToDeprovision are equal to the current values, the method is no-op.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -91,9 +91,9 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
                                 !node.status().vespaVersion().get().equals(node.allocation().get().membership().cluster().vespaVersion()));
     }
 
-    /** Returns the subset of nodes with want to fail status matching the given value */
-    public NodeList wantToFail(boolean wantToFail) {
-        return matching(node -> node.status().wantToFail() == wantToFail);
+    /** Returns the subset of nodes with want to fail set to true */
+    public NodeList failing() {
+        return matching(node -> node.status().wantToFail());
     }
 
     /** Returns the subset of nodes that are currently changing their OS version to given version */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -91,6 +91,11 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
                                 !node.status().vespaVersion().get().equals(node.allocation().get().membership().cluster().vespaVersion()));
     }
 
+    /** Returns the subset of nodes with want to fail status matching the given value */
+    public NodeList wantToFail(boolean wantToFail) {
+        return matching(node -> node.status().wantToFail() == wantToFail);
+    }
+
     /** Returns the subset of nodes that are currently changing their OS version to given version */
     public NodeList changingOsVersionTo(Version version) {
         return matching(node -> node.status().osVersion().changingTo(version));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -152,6 +152,8 @@ public class History {
             wantToRetire(false),
             // The node was scheduled for retirement (soft)
             preferToRetire(false),
+            // This node was scheduled for failing
+            wantToFail,
             // The active node was retired
             retired,
             // The active node went down according to the service monitor

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -237,6 +237,14 @@ public class Nodes {
 
     }
 
+    /**
+     * Fails these nodes in a transaction and returns the nodes in the new state which will hold if the
+     * transaction commits.
+     */
+    public List<Node> fail(List<Node> nodes, ApplicationTransaction transaction) {
+        return db.writeTo(Node.State.failed, nodes, Agent.application, Optional.of("Failed by application"), transaction.nested());
+    }
+
     /** Move nodes to the dirty state */
     public List<Node> deallocate(List<Node> nodes, Agent agent, String reason) {
         return performOn(NodeListFilter.from(nodes), (node, lock) -> deallocate(node, agent, reason));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Status.java
@@ -22,6 +22,7 @@ public class Status {
     private final boolean wantToRetire;
     private final boolean wantToDeprovision;
     private final boolean preferToRetire;
+    private final boolean wantToFail;
     private final OsVersion osVersion;
     private final Optional<Instant> firmwareVerifiedAt;
 
@@ -32,6 +33,7 @@ public class Status {
                   boolean wantToRetire,
                   boolean wantToDeprovision,
                   boolean preferToRetire,
+                  boolean wantToFail,
                   OsVersion osVersion,
                   Optional<Instant> firmwareVerifiedAt) {
         this.reboot = Objects.requireNonNull(generation, "Generation must be non-null");
@@ -44,73 +46,76 @@ public class Status {
         this.wantToRetire = wantToRetire;
         this.wantToDeprovision = wantToDeprovision;
         this.preferToRetire = preferToRetire;
+        this.wantToFail = wantToFail;
         this.osVersion = Objects.requireNonNull(osVersion, "OS version must be non-null");
         this.firmwareVerifiedAt = Objects.requireNonNull(firmwareVerifiedAt, "Firmware check instant must be non-null");
     }
 
     /** Returns a copy of this with the reboot generation changed */
-    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withReboot(Generation reboot) { return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
     /** Returns the reboot generation of this node */
     public Generation reboot() { return reboot; }
 
     /** Returns a copy of this with the vespa version changed */
-    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withVespaVersion(Version version) { return new Status(reboot, Optional.of(version), containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
     /** Returns the Vespa version installed on the node, if known */
     public Optional<Version> vespaVersion() { return vespaVersion; }
 
     /** Returns a copy of this with the container image changed */
-    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withContainerImage(DockerImage containerImage) { return new Status(reboot, vespaVersion, Optional.of(containerImage), failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
     /** Returns the container image the node is running, if any */
     public Optional<DockerImage> containerImage() { return containerImage; }
 
-    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withIncreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount + 1, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
-    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withDecreasedFailCount() { return new Status(reboot, vespaVersion, containerImage, failCount - 1, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
-    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt); }
+    public Status withFailCount(int value) { return new Status(reboot, vespaVersion, containerImage, value, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt); }
 
     /** Returns how many times this node has been moved to the failed state. */
     public int failCount() { return failCount; }
 
     /** Returns a copy of this with the want to retire/deprovision flags changed */
     public Status withWantToRetire(boolean wantToRetire, boolean wantToDeprovision) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt);
     }
 
     /**
      * Returns whether this node is requested to retire. This is a hard request to retire, which allows any replacement
      * to increase node skew in the cluster.
      */
-    public boolean wantToRetire() {
-        return wantToRetire;
-    }
+    public boolean wantToRetire() { return wantToRetire; }
 
     /**
      * Returns whether this node should be de-provisioned when possible.
      */
-    public boolean wantToDeprovision() {
-        return wantToDeprovision;
-    }
+    public boolean wantToDeprovision() { return wantToDeprovision; }
 
     /**
      * Returns whether this node is requested to retire. Unlike {@link Status#wantToRetire()}, this is a soft
      * request to retire, which will not allow any replacement to increase node skew in the cluster.
      */
-    public boolean preferToRetire() {
-        return preferToRetire;
+    public boolean preferToRetire() { return preferToRetire; }
+
+    /** Returns a copy of this with want to fail set to the given value */
+    public Status withWantToFail(boolean wantToFail) {
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt);
     }
+
+    /** Returns whether this node should be failed */
+    public boolean wantToFail() { return wantToFail; }
 
     /** Returns a copy of this with prefer-to-retire set to given value */
     public Status withPreferToRetire(boolean preferToRetire) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, firmwareVerifiedAt);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, firmwareVerifiedAt);
     }
 
     /** Returns a copy of this with the OS version set to given version */
     public Status withOsVersion(OsVersion version) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, version, firmwareVerifiedAt);
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, version, firmwareVerifiedAt);
     }
 
     /** Returns the OS version of this node */
@@ -120,7 +125,7 @@ public class Status {
 
     /** Returns a copy of this with the firmwareVerifiedAt set to the given instant. */
     public Status withFirmwareVerifiedAt(Instant instant) {
-        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, osVersion, Optional.of(instant));
+        return new Status(reboot, vespaVersion, containerImage, failCount, wantToRetire, wantToDeprovision, preferToRetire, wantToFail, osVersion, Optional.of(instant));
     }
 
     /** Returns the last time this node had firmware that was verified to be up to date. */
@@ -131,7 +136,7 @@ public class Status {
     /** Returns the initial status of a newly provisioned node */
     public static Status initial() {
         return new Status(Generation.initial(), Optional.empty(), Optional.empty(), 0, false,
-                          false, false, OsVersion.EMPTY, Optional.empty());
+                          false, false, false, OsVersion.EMPTY, Optional.empty());
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -83,6 +83,7 @@ public class NodeSerializer {
     private static final String wantToRetireKey = "wantToRetire";
     private static final String wantToDeprovisionKey = "wantToDeprovision";
     private static final String preferToRetireKey = "preferToRetire";
+    private static final String wantToFailKey = "wantToFailKey";
     private static final String osVersionKey = "osVersion";
     private static final String wantedOsVersionKey = "wantedOsVersion";
     private static final String firmwareCheckKey = "firmwareCheck";
@@ -164,6 +165,7 @@ public class NodeSerializer {
         object.setBool(wantToRetireKey, node.status().wantToRetire());
         object.setBool(preferToRetireKey, node.status().preferToRetire());
         object.setBool(wantToDeprovisionKey, node.status().wantToDeprovision());
+        object.setBool(wantToFailKey, node.status().wantToFail());
         node.allocation().ifPresent(allocation -> toSlime(allocation, object.setObject(instanceKey)));
         toSlime(node.history(), object.setArray(historyKey));
         object.setString(nodeTypeKey, toString(node.type()));
@@ -272,6 +274,7 @@ public class NodeSerializer {
                           object.field(wantToRetireKey).asBool(),
                           object.field(wantToDeprovisionKey).asBool(),
                           object.field(preferToRetireKey).asBool(),
+                          object.field(wantToFailKey).asBool(),
                           new OsVersion(versionFromSlime(object.field(osVersionKey)),
                                         versionFromSlime(object.field(wantedOsVersionKey))),
                           instantFromSlime(object.field(firmwareCheckKey)));
@@ -413,6 +416,7 @@ public class NodeSerializer {
             case "reserved" : return History.Event.Type.reserved;
             case "activated" : return History.Event.Type.activated;
             case "wantToRetire": return History.Event.Type.wantToRetire;
+            case "wantToFail": return History.Event.Type.wantToFail;
             case "retired" : return History.Event.Type.retired;
             case "deactivated" : return History.Event.Type.deactivated;
             case "parked" : return History.Event.Type.parked;
@@ -438,6 +442,7 @@ public class NodeSerializer {
             case reserved : return "reserved";
             case activated : return "activated";
             case wantToRetire: return "wantToRetire";
+            case wantToFail: return "wantToFail";
             case retired : return "retired";
             case deactivated : return "deactivated";
             case parked : return "parked";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -88,13 +88,19 @@ class Activator {
 
         List<Node> activeToRemove = removeHostsFromList(hostnames, oldActive);
         activeToRemove = activeToRemove.stream().map(Node::unretire).collect(Collectors.toList()); // only active nodes can be retired. TODO: Move this line to deactivate
-        nodeRepository.nodes().deactivate(activeToRemove, transaction); // TODO: Pass activation time in this call and next line
+        deactivate(activeToRemove, transaction); // TODO: Pass activation time in this call and next line
         nodeRepository.nodes().activate(newActive, transaction.nested()); // activate also continued active to update node state
 
         rememberResourceChange(transaction, generation, activationTime,
                                NodeList.copyOf(oldActive).not().retired(),
                                NodeList.copyOf(newActive).not().retired());
         unreserveParentsOf(reservedToActivate);
+    }
+
+    private void deactivate(List<Node> toDeactivateList, ApplicationTransaction transaction) {
+        NodeList toDeactivate = NodeList.copyOf(toDeactivateList);
+        nodeRepository.nodes().deactivate(toDeactivate.wantToFail(false).asList(), transaction);
+        nodeRepository.nodes().fail(toDeactivate.wantToFail(true).asList(), transaction);
     }
 
     private void rememberResourceChange(ApplicationTransaction transaction, long generation, Instant at,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -99,8 +99,8 @@ class Activator {
 
     private void deactivate(List<Node> toDeactivateList, ApplicationTransaction transaction) {
         NodeList toDeactivate = NodeList.copyOf(toDeactivateList);
-        nodeRepository.nodes().deactivate(toDeactivate.wantToFail(false).asList(), transaction);
-        nodeRepository.nodes().fail(toDeactivate.wantToFail(true).asList(), transaction);
+        nodeRepository.nodes().deactivate(toDeactivate.not().failing().asList(), transaction);
+        nodeRepository.nodes().fail(toDeactivate.failing().asList(), transaction);
     }
 
     private void rememberResourceChange(ApplicationTransaction transaction, long generation, Instant at,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -111,6 +111,7 @@ class NodeAllocation {
                 if ( ! membership.cluster().satisfies(cluster)) continue; // wrong cluster id/type
                 if ((! candidate.isSurplus || saturated()) && ! membership.cluster().group().equals(cluster.group())) continue; // wrong group and we can't or have no reason to change it
                 if ( candidate.state() == Node.State.active && allocation.isRemovable()) continue; // don't accept; causes removal
+                if ( candidate.state() == Node.State.active && candidate.wantToFail()) continue; // don't accept; causes failing
                 if ( indexes.contains(membership.index())) continue; // duplicate index (just to be sure)
 
                 boolean resizeable = requestedNodes.considerRetiring() && candidate.isResizable;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
@@ -57,7 +57,6 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
     /** This node can be resized to the new NodeResources */
     final boolean isResizable;
 
-
     private NodeCandidate(NodeResources freeParentCapacity, Optional<Node> parent, boolean violatesSpares, boolean exclusiveSwitch, boolean isSurplus, boolean isNew, boolean isResizeable) {
         if (isResizeable && isNew)
             throw new IllegalArgumentException("A new node cannot be resizable");
@@ -78,6 +77,8 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
     public abstract boolean wantToRetire();
 
     public abstract boolean preferToRetire();
+
+    public abstract boolean wantToFail();
 
     public abstract Flavor flavor();
 
@@ -301,6 +302,9 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
         public boolean preferToRetire() { return node.status().preferToRetire(); }
 
         @Override
+        public boolean wantToFail() { return node.status().wantToFail(); }
+
+        @Override
         public Flavor flavor() { return node.flavor(); }
 
         @Override
@@ -385,6 +389,9 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
 
         @Override
         public boolean preferToRetire() { return false; }
+
+        @Override
+        public boolean wantToFail() { return false; }
 
         @Override
         public Flavor flavor() { return new Flavor(resources); }
@@ -481,6 +488,9 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
 
         @Override
         public boolean preferToRetire() { return false; }
+
+        @Override
+        public boolean wantToFail() { return false; }
 
         @Override
         public Flavor flavor() { return new Flavor(resources); }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -206,7 +206,7 @@ public class NodePrioritizer {
 
     /** Returns whether we are allocating to replace a failed node */
     private boolean isReplacement(NodeList nodesInCluster) {
-        int failedNodesInCluster = nodesInCluster.wantToFail(true).size();
+        int failedNodesInCluster = nodesInCluster.failing().size();
         if (failedNodesInCluster == 0) return false;
         return ! requestedNodes.fulfilledBy(nodesInCluster.size() - failedNodesInCluster);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -206,7 +206,7 @@ public class NodePrioritizer {
 
     /** Returns whether we are allocating to replace a failed node */
     private boolean isReplacement(NodeList nodesInCluster) {
-        int failedNodesInCluster = nodesInCluster.state(Node.State.failed).size();
+        int failedNodesInCluster = nodesInCluster.wantToFail(true).size();
         if (failedNodesInCluster == 0) return false;
         return ! requestedNodes.fulfilledBy(nodesInCluster.size() - failedNodesInCluster);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -52,6 +52,7 @@ public class NodeFailTester {
     public static final ApplicationId tenantHostApp = ApplicationId.from("hosted-vespa", "tenant-host", "default");
     public static final ApplicationId app1 = ApplicationId.from("foo1", "bar", "fuz");
     public static final ApplicationId app2 = ApplicationId.from("foo2", "bar", "fuz");
+    public static final ClusterSpec.Id testCluster = ClusterSpec.Id.from("test");
     public static final NodeFlavors hostFlavors = FlavorConfigBuilder.createDummies("default", "docker");
     private static final Duration downtimeLimitOneHour = Duration.ofMinutes(60);
 
@@ -96,8 +97,8 @@ public class NodeFailTester {
         tester.createHostNodes(3);
 
         // Create applications
-        ClusterSpec clusterApp1 = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test")).vespaVersion("6.42").build();
-        ClusterSpec clusterApp2 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test")).vespaVersion("6.42").build();
+        ClusterSpec clusterApp1 = ClusterSpec.request(ClusterSpec.Type.container, testCluster).vespaVersion("6.42").build();
+        ClusterSpec clusterApp2 = ClusterSpec.request(ClusterSpec.Type.content, testCluster).vespaVersion("6.42").build();
         Capacity capacity1 = Capacity.from(new ClusterResources(5, 1, nodeResources), false, true);
         Capacity capacity2 = Capacity.from(new ClusterResources(7, 1, nodeResources), false, true);
 
@@ -125,8 +126,8 @@ public class NodeFailTester {
 
         // Create applications
         ClusterSpec clusterNodeAdminApp = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("node-admin")).vespaVersion("6.42").build();
-        ClusterSpec clusterApp1 = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test")).vespaVersion("6.75.0").build();
-        ClusterSpec clusterApp2 = ClusterSpec.request(ClusterSpec.Type.content, ClusterSpec.Id.from("test")).vespaVersion("6.75.0").build();
+        ClusterSpec clusterApp1 = ClusterSpec.request(ClusterSpec.Type.container, testCluster).vespaVersion("6.75.0").build();
+        ClusterSpec clusterApp2 = ClusterSpec.request(ClusterSpec.Type.content, testCluster).vespaVersion("6.75.0").build();
         Capacity allHosts = Capacity.fromRequiredNodeType(NodeType.host);
         Capacity capacity1 = Capacity.from(new ClusterResources(3, 1, new NodeResources(1, 4, 100, 0.3)), false, true);
         Capacity capacity2 = Capacity.from(new ClusterResources(5, 1, new NodeResources(1, 4, 100, 0.3)), false, true);
@@ -150,7 +151,7 @@ public class NodeFailTester {
         NodeFailTester tester = new NodeFailTester();
 
         // Create applications
-        ClusterSpec clusterApp = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("test")).vespaVersion("6.42").build();
+        ClusterSpec clusterApp = ClusterSpec.request(ClusterSpec.Type.container, testCluster).vespaVersion("6.42").build();
         Map<ApplicationId, MockDeployer.ApplicationContext> apps = Map.of(app1, new MockDeployer.ApplicationContext(app1, clusterApp, capacity));
         tester.initializeMaintainers(apps);
         return tester;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -42,7 +42,6 @@ import static org.mockito.Mockito.when;
  */
 public class NodeFailerTest {
 
-
     private static final Report badTotalMemorySizeReport = Report.basicReport(
             "badTotalMemorySize", HARD_FAIL, Instant.now(), "too low");
 
@@ -308,6 +307,10 @@ public class NodeFailerTest {
                    tester.highestIndex(tester.nodeRepository.nodes().list(Node.State.active).owner(NodeFailTester.app1)).allocation().get().membership().index()
                    >
                    lastNode.allocation().get().membership().index());
+
+        assertEquals("Node failing does not cause recording of scaling events",
+                     1,
+                     tester.nodeRepository.applications().get(NodeFailTester.app1).get().cluster(NodeFailTester.testCluster).get().scalingEvents().size());
     }
 
     @Test


### PR DESCRIPTION
Node failing was based on a quick hack where we made a change to active nodes outside deployment.
This fixes that by introducing a wantToFail setting.

That avoids the spurious scalingEvents entries @ldalves and @freva.