### PR TITLE
Avoid noncompliant use of std::is_sorted (The comparison function did…

### DIFF
--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -552,6 +552,8 @@ EnumeratedSaveTest::checkMem(AttributeVector &v, const MemAttr &e)
         MemAttr m2;
         EXPECT_TRUE(v2->save(m2, v.getBaseFileName()));
         ASSERT_TRUE(m2 == e);
+        auto v3 = AttributeFactory::createAttribute("convert", v.getConfig());
+        EXPECT_TRUE(v3->load());
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/enum_store_loaders.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enum_store_loaders.cpp
@@ -43,7 +43,7 @@ EnumeratedLoaderBase::build_enum_value_remapping()
     }
     auto comp_up = _store.allocate_comparator();
     auto& comp = *comp_up;
-    if (std::is_sorted(_indexes.begin(), _indexes.end(), [&comp](Index lhs, Index rhs) { return !comp.less(rhs, lhs); })) {
+    if (std::adjacent_find(_indexes.begin(), _indexes.end(), [&comp](Index lhs, Index rhs) { return !comp.less(lhs, rhs); }) == _indexes.end()) {
         return; // Unique values are already sorted
     }
     vespalib::Array<std::pair<Index, uint32_t>> sortdata;
@@ -61,7 +61,7 @@ EnumeratedLoaderBase::build_enum_value_remapping()
         _enum_value_remapping[entry.second] = enum_value;
         ++enum_value;
     }
-    assert(std::is_sorted(_indexes.begin(), _indexes.end(), [&comp](Index lhs, Index rhs) { return !comp.less(rhs, lhs); }));
+    assert(std::adjacent_find(_indexes.begin(), _indexes.end(), [&comp](Index lhs, Index rhs) { return !comp.less(lhs, rhs); }) == _indexes.end());
 }
 
 void


### PR DESCRIPTION
… not satisfy the requirements for Compare.).  Use std::adjacent_find instead.

@baldersheim : please review
