### PR TITLE
specify opset version to make sure we can evaluate the models

### DIFF
--- a/eval/src/tests/tensor/onnx_wrapper/dynamic.py
+++ b/eval/src/tests/tensor/onnx_wrapper/dynamic.py
@@ -35,5 +35,5 @@ graph_def = helper.make_graph(
     ],
     [OUTPUT],
 )
-model_def = helper.make_model(graph_def, producer_name='dynamic.py')
+model_def = helper.make_model(graph_def, producer_name='dynamic.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
 onnx.save(model_def, 'dynamic.onnx')

--- a/eval/src/tests/tensor/onnx_wrapper/guess_batch.py
+++ b/eval/src/tests/tensor/onnx_wrapper/guess_batch.py
@@ -22,5 +22,5 @@ graph_def = helper.make_graph(
     ],
     [OUT],
 )
-model_def = helper.make_model(graph_def, producer_name='guess_batch.py')
+model_def = helper.make_model(graph_def, producer_name='guess_batch.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
 onnx.save(model_def, 'guess_batch.onnx')

--- a/eval/src/tests/tensor/onnx_wrapper/int_types.py
+++ b/eval/src/tests/tensor/onnx_wrapper/int_types.py
@@ -29,5 +29,5 @@ graph_def = helper.make_graph(
     ],
     [OUTPUT],
 )
-model_def = helper.make_model(graph_def, producer_name='int_types.py')
+model_def = helper.make_model(graph_def, producer_name='int_types.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
 onnx.save(model_def, 'int_types.onnx')

--- a/eval/src/tests/tensor/onnx_wrapper/simple.py
+++ b/eval/src/tests/tensor/onnx_wrapper/simple.py
@@ -29,5 +29,6 @@ graph_def = helper.make_graph(
     ],
     [OUTPUT],
 )
-model_def = helper.make_model(graph_def, producer_name='simple.py')
+
+model_def = helper.make_model(graph_def, producer_name='simple.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
 onnx.save(model_def, 'simple.onnx')


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 FYI

we need a newer version of onnxruntime to be able to run a model that calculates on bfloat16/int8