### PR TITLE
Use shared_ptr to lid space compaction job in order to ensure correct…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
@@ -56,11 +56,11 @@ JobTestBase::init(uint32_t allowedLidBloat,
         _singleExecutor = std::make_unique<vespalib::ThreadStackExecutor>(1, 0x10000);
         _master = std::make_unique<proton::ExecutorThreadService> (*_singleExecutor);
         _bucketExecutor = std::make_unique<storage::spi::dummy::DummyBucketExecutor>(4);
-        _job = std::make_unique<lidspace::CompactionJob>(compactCfg, _handler, _storer, *_master, *_bucketExecutor,
+        _job = std::make_shared<lidspace::CompactionJob>(compactCfg, _handler, _storer, *_master, *_bucketExecutor,
                                                          _diskMemUsageNotifier, blockableCfg, _clusterStateHandler, nodeRetired,
                                                          document::BucketSpace::placeHolder());
     } else {
-        _job = std::make_unique<LidSpaceCompactionJob>(compactCfg, _handler, _storer, _frozenHandler, _diskMemUsageNotifier,
+        _job = std::make_shared<LidSpaceCompactionJob>(compactCfg, _handler, _storer, _frozenHandler, _diskMemUsageNotifier,
                                                        blockableCfg, _clusterStateHandler, nodeRetired);
     }
 }

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
@@ -16,7 +16,7 @@ struct JobTestBase : public ::testing::TestWithParam<bool> {
     MyFrozenBucketHandler _frozenHandler;
     test::DiskMemUsageNotifier _diskMemUsageNotifier;
     test::ClusterStateHandler _clusterStateHandler;
-    std::unique_ptr<BlockableMaintenanceJob> _job;
+    std::shared_ptr<BlockableMaintenanceJob> _job;
     JobTestBase();
     ~JobTestBase() override;
     void init(uint32_t allowedLidBloat,

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.cpp
@@ -130,9 +130,6 @@ LidSpaceCompactionJobBase::run()
     }
 
     if (_scanItr && !_scanItr->valid()) {
-        if (!inSync()) {
-            return false;
-        }
         if (shouldRestartScanDocuments(_handler->getLidStatus())) {
             _scanItr = _handler->getIterator();
         } else {

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_base.h
@@ -50,7 +50,6 @@ private:
     void compactLidSpace(const search::LidUsageStats &stats);
     bool remove_batch_is_ongoing() const;
     bool remove_is_ongoing() const;
-    virtual bool inSync() const { return true; }
 protected:
     search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats, bool retryLastDocument);
 public:

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job_take2.h
@@ -31,16 +31,14 @@ private:
     BucketExecutor          &_bucketExecutor;
     document::BucketSpace    _bucketSpace;
     std::atomic<bool>        _stopped;
-    std::atomic<size_t>      _startedCount;
-    std::atomic<size_t>      _executedCount;
 
     bool scanDocuments(const search::LidUsageStats &stats) override;
-    void moveDocument(const search::DocumentMetaData & metaThen, std::shared_ptr<IDestructorCallback> onDone);
+    static void moveDocument(std::shared_ptr<CompactionJob> job, const search::DocumentMetaData & metaThen,
+                             std::shared_ptr<IDestructorCallback> onDone);
     void completeMove(const search::DocumentMetaData & metaThen, std::unique_ptr<MoveOperation> moveOp,
                       std::shared_ptr<IDestructorCallback> onDone);
     void onStop() override;
-    bool inSync() const override;
-    void failOperation();
+    class MoveTask;
 public:
     CompactionJob(const DocumentDBLidSpaceCompactionConfig &config,
                   std::shared_ptr<ILidSpaceCompactionHandler> handler,


### PR DESCRIPTION
… lifetime, and to avoid having to wait for pending operations

when reconfiguring or other events requiring move jobs to be stopped.

@toregge PR