### PR TITLE
Revert "Close closeable http responses"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
@@ -4,9 +4,8 @@ package com.yahoo.vespa.config.server.http;
 import ai.vespa.util.http.hc4.VespaHttpClientBuilder;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.yolean.Exceptions;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 
@@ -15,12 +14,12 @@ import java.io.IOException;
  */
 public class LogRetriever {
 
-    private final CloseableHttpClient httpClient = VespaHttpClientBuilder.create().build();
+    private final HttpClient httpClient = VespaHttpClientBuilder.create().build();
 
     public HttpResponse getLogs(String logServerHostname) {
         HttpGet get = new HttpGet(logServerHostname);
-        try (CloseableHttpResponse response = httpClient.execute(get)) {
-            return new ProxyResponse(response);
+        try {
+            return new ProxyResponse(httpClient.execute(get));
         } catch (IOException e) {
             return HttpErrorResponse.internalServerError("Failed to get logs: " + Exceptions.toMessageString(e));
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SecretStoreValidator.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SecretStoreValidator.java
@@ -12,7 +12,6 @@ import com.yahoo.slime.SlimeUtils;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.tenant.SecretStoreExternalIdRetriever;
 import com.yahoo.yolean.Exceptions;
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -63,8 +62,8 @@ public class SecretStoreValidator {
         var data = uncheck(() -> SlimeUtils.toJsonBytes(slime));
         var entity = new ByteArrayEntity(data);
         postRequest.setEntity(entity);
-        try (CloseableHttpResponse response = httpClient.execute(postRequest)) {
-            return new ProxyResponse(response);
+        try {
+            return new ProxyResponse(httpClient.execute(postRequest));
         } catch (IOException e) {
             return HttpErrorResponse.internalServerError(
                     String.format("Failed to post request to %s: %s", uri, Exceptions.toMessageString(e))

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/TesterClient.java
@@ -4,13 +4,12 @@ package com.yahoo.vespa.config.server.http;
 import ai.vespa.util.http.hc4.VespaHttpClientBuilder;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.yolean.Exceptions;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.ByteArrayEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
 
 import java.io.IOException;
 import java.net.URI;
@@ -23,7 +22,7 @@ import java.util.logging.Logger;
  */
 public class TesterClient {
 
-    private final CloseableHttpClient httpClient = VespaHttpClientBuilder.create().build();
+    private final HttpClient httpClient = VespaHttpClientBuilder.create().build();
     private static final Logger logger = Logger.getLogger(TesterClient.class.getName());
 
     public HttpResponse getStatus(String testerHostname, int port) {
@@ -66,8 +65,8 @@ public class TesterClient {
 
     private HttpResponse execute(HttpUriRequest request, String messageIfRequestFails) {
         logger.log(Level.FINE, "Sending request to tester container " + request.getURI().toString());
-        try (CloseableHttpResponse response = httpClient.execute(request)) {
-            return new ProxyResponse(response);
+        try {
+            return new ProxyResponse(httpClient.execute(request));
         } catch (IOException e) {
             logger.warning(messageIfRequestFails + ": " + Exceptions.toMessageString(e));
             return HttpErrorResponse.internalServerError(Exceptions.toMessageString(e));


### PR DESCRIPTION
Reverts vespa-engine/vespa#17355

Unit test fails:

 08:55:10 [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.268 s <<< FAILURE! - in com.yahoo.vespa.config.server.http.SecretStoreValidatorTest
08:55:10 [ERROR] createsCorrectRequestData(com.yahoo.vespa.config.server.http.SecretStoreValidatorTest)  Time elapsed: 0.221 s  <<< ERROR!
08:55:10 org.apache.http.ConnectionClosedException: Premature end of chunk coded message body: closing chunk expected
08:55:10 	at org.apache.http.impl.io.ChunkedInputStream.getChunkSize(ChunkedInputStream.java:263) 