### PR TITLE
Correct dimension for JVM_OMIT_STACK_TRACE_IN_FAST_THROW, should be c…

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -143,7 +143,7 @@ public class PermanentFlags {
             "jvm-omit-stack-trace-in-fast-throw", true,
             "Controls JVM option OmitStackTraceInFastThrow (default feature flag value is true, which is the default JVM option value as well)",
             "takes effect on JVM restart",
-            NODE_TYPE, APPLICATION_ID);
+            CLUSTER_TYPE, APPLICATION_ID);
 
     public static final UnboundIntFlag MAX_TRIAL_TENANTS = defineIntFlag(
             "max-trial-tenants", -1,


### PR DESCRIPTION
…luster type.
