### PR TITLE
Use RestApiException instead of old JAX-RS equivalent

### DIFF
--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/InstanceRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/InstanceRequestHandler.java
@@ -30,8 +30,6 @@ import com.yahoo.vespa.service.manager.UnionMonitorManager;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
 import com.yahoo.vespa.service.monitor.SlobrokApi;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.List;
 import java.util.TreeMap;
@@ -101,7 +99,7 @@ public class InstanceRequestHandler extends RestApiRequestHandler<InstanceReques
 
         ApplicationInstance applicationInstance
                 = serviceMonitor.getApplication(instanceId)
-                .orElseThrow(() -> new WebApplicationException(Response.status(Response.Status.NOT_FOUND).build()));
+                .orElseThrow(RestApiException.NotFoundException::new);
 
         HostInfos hostInfos = statusService.getHostInfosByApplicationResolver().apply(applicationInstance.reference());
         TreeMap<HostName, WireHostInfo> hostStatusMap =


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
