### PR TITLE
Don't allow subclasses to override release()

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/AbstractResource.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/AbstractResource.java
@@ -70,7 +70,7 @@ public abstract class AbstractResource implements SharedResource {
     }
 
     @Override
-    public void release() {
+    public final void release() {
         initialCreationReference.close();
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
