### PR TITLE
Avoid copying map elements when iterating over map.

### DIFF
--- a/eval/src/apps/tensor_conformance/tensor_conformance.cpp
+++ b/eval/src/apps/tensor_conformance/tensor_conformance.cpp
@@ -161,7 +161,7 @@ public:
         Cursor &test = _writer.create();
         test.setString("expression", expression);
         Cursor &inputs = test.setObject("inputs");
-        for (const auto [name, spec]: inputs_in) {
+        for (const auto& [name, spec]: inputs_in) {
             insert_value(inputs, name, spec);
         }
         insert_value(test.setObject("result"), "expect", ref_eval(test));


### PR DESCRIPTION
@baldersheim : please review
