### PR TITLE
Move dependency management for spifly to parent pom

### DIFF
--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -430,12 +430,6 @@
                 <artifactId>jetty-jmx</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
-            <dependency>
-                <!-- Installed in jdisc runtime, but should only be used internally and not leaked as maven dep to users -->
-                <groupId>org.apache.aries.spifly</groupId>
-                <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
-                <version>${spifly.version}</version>
-            </dependency>
             <!-- Please don't add deps here, but instead above the NOTE. -->
 
         </dependencies>
@@ -481,7 +475,6 @@
         <org.lz4.version>1.7.1</org.lz4.version>
         <org.json.version>20090211</org.json.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <spifly.version>1.3.3</spifly.version>
         <xml-apis.version>1.4.01</xml-apis.version>
 
         <!-- These must be kept in sync with version used by current jersey2.version. -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -547,6 +547,11 @@
                 <version>${antlr4.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.aries.spifly</groupId>
+                <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
+                <version>${spifly.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>1.19</version>
@@ -809,6 +814,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <prometheus.client.version>0.6.0</prometheus.client.version>
         <protobuf.version>3.7.0</protobuf.version>
+        <spifly.version>1.3.3</spifly.version>
         <surefire.version>2.22.0</surefire.version>
         <tensorflow.version>1.12.0</tensorflow.version>
         <zookeeper.client.version>3.6.2</zookeeper.client.version>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
