### PR TITLE
Remove implicit reboot of nodes moving to dirty

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -246,19 +246,7 @@ public class CuratorDatabaseClient {
     private Status newNodeStatus(Node node, Node.State toState) {
         if (node.state() != Node.State.failed && toState == Node.State.failed) return node.status().withIncreasedFailCount();
         if (node.state() == Node.State.failed && toState == Node.State.active) return node.status().withDecreasedFailCount(); // fail undo
-        if (rebootOnTransitionTo(toState, node)) {
-            return node.status().withReboot(node.status().reboot().withIncreasedWanted());
-        }
         return node.status();
-    }
-
-    /** Returns whether to reboot node as part of transition to given state. This is done to get rid of any lingering
-     * unwanted state (e.g. processes) on non-host nodes. */
-    private boolean rebootOnTransitionTo(Node.State state, Node node) {
-        if (node.type().isHost()) return false; // Reboot of host nodes is handled by NodeRebooter
-        if (zone.environment().isTest()) return false; // We want to reuse nodes quickly in test environments
-
-        return node.state() != Node.State.dirty && state == Node.State.dirty;
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -88,7 +88,7 @@ public class NodesV2ApiTest {
         assertReboot(19, new Request("http://localhost:8080/nodes/v2/command/reboot",
                         new byte[0], Request.Method.POST));
         tester.assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/host2.yahoo.com"),
-                                     "\"rebootGeneration\":4");
+                                     "\"rebootGeneration\":3");
 
         // POST new nodes
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
@@ -420,12 +420,12 @@ public class NodesV2ApiTest {
                         new byte[0], Request.Method.PUT),
                 "{\"message\":\"Moved foo.yahoo.com to dirty\"}");
         tester.assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/foo.yahoo.com"),
-                                      "\"rebootGeneration\":1");
+                                      "\"rebootGeneration\":0");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/foo.yahoo.com",
                         Utf8.toBytes("{\"currentRebootGeneration\": 42}"), Request.Method.PATCH),
                 "{\"message\":\"Updated foo.yahoo.com\"}");
         tester.assertResponseContains(new Request("http://localhost:8080/nodes/v2/node/foo.yahoo.com"),
-                                      "\"rebootGeneration\":1");
+                                      "\"rebootGeneration\":0");
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -9,7 +9,7 @@
   "cpuCores": 2.0,
   "resources":{"vcpu":2.0,"memoryGb":16.0,"diskGb":400.0,"bandwidthGbps":10.0,"diskSpeed":"fast","storageType":"remote"},
   "environment": "BARE_METAL",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
@@ -9,7 +9,7 @@
   "cpuCores": 2.0,
   "resources":{"vcpu":2.0,"memoryGb":16.0,"diskGb":400.0,"bandwidthGbps":10.0,"diskSpeed":"fast","storageType":"remote"},
   "environment": "BARE_METAL",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
@@ -26,7 +26,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":2.0, "memoryGb":8.0, "diskGb":50.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
@@ -27,7 +27,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":2.0, "memoryGb":8.0, "diskGb":50.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "vespaVersion": "5.104.142",
   "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:5.104.142",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
@@ -26,7 +26,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":2.0, "memoryGb":8.0, "diskGb":50.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
@@ -8,7 +8,7 @@
   "flavor": "[vcpu: 0.5, memory: 48.0 Gb, disk 500.0 Gb, bandwidth: 1.0 Gbps, storage type: local]",
   "resources":{"vcpu":0.5,"memoryGb":48.0,"diskGb":500.0,"bandwidthGbps":1.0,"diskSpeed":"fast","storageType":"local"},
   "environment": "DOCKER_CONTAINER",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
@@ -30,7 +30,7 @@
   "allowedToBeDown": true,
   "orchestratorStatus": "ALLOWED_TO_BE_DOWN",
   "suspendedSinceMillis": 0,
-  "rebootGeneration": 3,
+  "rebootGeneration": 2,
   "currentRebootGeneration": 1,
   "vespaVersion": "6.43.0",
   "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.45.0",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
@@ -27,7 +27,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":1.0, "memoryGb":4.0, "diskGb":100.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "vespaVersion": "6.41.0",
   "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.41.0",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
@@ -27,7 +27,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":1.0, "memoryGb":4.0, "diskGb":100.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "vespaVersion": "6.41.0",
   "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:6.41.0",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
@@ -9,7 +9,7 @@
   "flavor": "[vcpu: 1.0, memory: 8.0 Gb, disk 100.0 Gb, bandwidth: 1.0 Gbps, disk speed: slow, storage type: remote]",
   "resources":{"vcpu":1.0,"memoryGb":8.0,"diskGb":100.0,"bandwidthGbps":1.0,"diskSpeed":"slow","storageType":"remote"},
   "environment": "DOCKER_CONTAINER",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 1,
   "wantToRetire": false,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
@@ -9,7 +9,7 @@
   "flavor": "[vcpu: 1.0, memory: 8.0 Gb, disk 100.0 Gb, bandwidth: 1.0 Gbps, disk speed: slow, storage type: remote]",
   "resources":{"vcpu":1.0,"memoryGb":8.0,"diskGb":100.0,"bandwidthGbps":1.0,"diskSpeed":"slow","storageType":"remote"},
   "environment": "DOCKER_CONTAINER",
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "vespaVersion": "1.2.3",
   "currentDockerImage": "docker-registry.domain.tld:8080/dist/vespa:1.2.3",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
@@ -26,7 +26,7 @@
   "wantedVespaVersion": "6.42.0",
   "requestedResources": { "vcpu":2.0, "memoryGb":8.0, "diskGb":50.0, "bandwidthGbps":1.0, "diskSpeed":"fast", "storageType":"any" },
   "allowedToBeDown": false,
-  "rebootGeneration": 1,
+  "rebootGeneration": 0,
   "currentRebootGeneration": 0,
   "failCount": 0,
   "wantToRetire": false,


### PR DESCRIPTION
As far as I can tell this has no effect as node admin simply removes any
containers that are in dirty. The comment about "lingering processes" is from
the bare metal days.

@freva

FYI @hakonhall