### PR TITLE
Disallow >1 group to suspend

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisiting.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisiting.java
@@ -4,8 +4,10 @@ package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.vdslib.distribution.GroupVisitor;
 
-@FunctionalInterface
 public interface HierarchicalGroupVisiting {
+    /** Returns true if the group contains more than one (leaf) group. */
+    boolean isHierarchical();
+
     /**
      * Invoke the visitor for each leaf group of an implied group.  If the group is non-hierarchical
      * (flat), the visitor will not be invoked.

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisitingAdapter.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/HierarchicalGroupVisitingAdapter.java
@@ -18,18 +18,20 @@ public class HierarchicalGroupVisitingAdapter implements HierarchicalGroupVisiti
     }
 
     @Override
+    public boolean isHierarchical() {
+        return !distribution.getRootGroup().isLeafGroup();
+    }
+
+    @Override
     public void visit(GroupVisitor visitor) {
-        if (distribution.getRootGroup().isLeafGroup()) {
-            // A flat non-hierarchical cluster
-            return;
+        if (isHierarchical()) {
+            distribution.visitGroups(group -> {
+                if (group.isLeafGroup()) {
+                    return visitor.visitGroup(group);
+                }
+
+                return true;
+            });
         }
-
-        distribution.visitGroups(group -> {
-            if (group.isLeafGroup()) {
-                return visitor.visitGroup(group);
-            }
-
-            return true;
-        });
     }
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.clustercontroller.core;
 
 import com.yahoo.lang.MutableBoolean;
+import com.yahoo.lang.SettableOptional;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
 import com.yahoo.vdslib.distribution.Group;
 import com.yahoo.vdslib.state.ClusterState;
@@ -212,6 +213,11 @@ public class NodeStateChangeChecker {
                     oldWantedState.getState() + ": " + oldWantedState.getDescription());
         }
 
+        Result otherGroupCheck = anotherNodeInAnotherGroupHasWantedState(nodeInfo);
+        if (!otherGroupCheck.settingWantedStateIsAllowed()) {
+            return otherGroupCheck;
+        }
+
         if (clusterState.getNodeState(nodeInfo.getNode()).getState() == State.DOWN) {
             return Result.allowSettingOfWantedState();
         }
@@ -228,6 +234,85 @@ public class NodeStateChangeChecker {
         Result checkDistributorsResult = checkDistributors(nodeInfo.getNode(), clusterState.getVersion());
         if (!checkDistributorsResult.settingWantedStateIsAllowed()) {
             return checkDistributorsResult;
+        }
+
+        return Result.allowSettingOfWantedState();
+    }
+
+    /**
+     * Returns a disallow-result if there is another node (in another group, if hierarchical)
+     * that has a wanted state != UP.  We disallow more than 1 suspended node/group at a time.
+     */
+    private Result anotherNodeInAnotherGroupHasWantedState(StorageNodeInfo nodeInfo) {
+        if (groupVisiting.isHierarchical()) {
+            SettableOptional<Result> anotherNodeHasWantedState = new SettableOptional<>();
+
+            groupVisiting.visit(group -> {
+                if (!groupContainsNode(group, nodeInfo.getNode())) {
+                    Result result = otherNodeInGroupHasWantedState(group);
+                    if (!result.settingWantedStateIsAllowed()) {
+                        anotherNodeHasWantedState.set(result);
+                        // Have found a node that is suspended, halt the visiting
+                        return false;
+                    }
+                }
+
+                return true;
+            });
+
+            return anotherNodeHasWantedState.asOptional().orElseGet(Result::allowSettingOfWantedState);
+        } else {
+            // Return a disallow-result if there is another node with a wanted state
+            return otherNodeHasWantedState(nodeInfo);
+        }
+    }
+
+    /** Returns a disallow-result, if there is a node in the group with wanted state != UP. */
+    private Result otherNodeInGroupHasWantedState(Group group) {
+        for (var configuredNode : group.getNodes()) {
+            StorageNodeInfo storageNodeInfo = clusterInfo.getStorageNodeInfo(configuredNode.index());
+            if (storageNodeInfo == null) continue;  // needed for tests only
+            State storageNodeWantedState = storageNodeInfo
+                    .getUserWantedState().getState();
+            if (storageNodeWantedState != State.UP) {
+                return Result.createDisallowed(
+                        "At most one group can have wanted state: Other storage node " + configuredNode.index() +
+                        " in group " + group.getIndex() + " has wanted state " + storageNodeWantedState);
+            }
+
+            State distributorWantedState = clusterInfo.getDistributorNodeInfo(configuredNode.index())
+                    .getUserWantedState().getState();
+            if (distributorWantedState != State.UP) {
+                return Result.createDisallowed(
+                        "At most one group can have wanted state: Other distributor " + configuredNode.index() +
+                        " in group " + group.getIndex() + " has wanted state " + distributorWantedState);
+            }
+        }
+
+        return Result.allowSettingOfWantedState();
+    }
+
+    private Result otherNodeHasWantedState(StorageNodeInfo nodeInfo) {
+        for (var configuredNode : clusterInfo.getConfiguredNodes().values()) {
+            if (configuredNode.index() == nodeInfo.getNodeIndex()) {
+                continue;
+            }
+
+            State storageNodeWantedState = clusterInfo.getStorageNodeInfo(configuredNode.index())
+                    .getUserWantedState().getState();
+            if (storageNodeWantedState != State.UP) {
+                return Result.createDisallowed(
+                        "At most one node can have a wanted state when #groups = 1: Other storage node " +
+                                configuredNode.index() + " has wanted state " + storageNodeWantedState);
+            }
+
+            State distributorWantedState = clusterInfo.getDistributorNodeInfo(configuredNode.index())
+                    .getUserWantedState().getState();
+            if (distributorWantedState != State.UP) {
+                return Result.createDisallowed(
+                        "At most one node can have a wanted state when #groups = 1: Other distributor " +
+                                configuredNode.index() + " has wanted state " + distributorWantedState);
+            }
         }
 
         return Result.allowSettingOfWantedState();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -212,10 +212,8 @@ public class NodeStateChangeChecker {
                     oldWantedState.getState() + ": " + oldWantedState.getDescription());
         }
 
-        switch (clusterState.getNodeState(nodeInfo.getNode()).getState()) {
-            case MAINTENANCE:
-            case DOWN:
-                return Result.allowSettingOfWantedState();
+        if (clusterState.getNodeState(nodeInfo.getNode()).getState() == State.DOWN) {
+            return Result.allowSettingOfWantedState();
         }
 
         if (anotherNodeInGroupAlreadyAllowed(nodeInfo, newDescription)) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeCheckerTest.java
@@ -147,7 +147,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
-    public void testWhenOtherStorageNodeIsSuspended() {
+    public void testSafeMaintenanceDisallowedWhenOtherStorageNodeInFlatClusterIsSuspended() {
         // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
         ContentCluster cluster = createCluster(createNodes(4));
         cluster.clusterInfo().getStorageNodeInfo(0).setWantedState(new NodeState(NodeType.STORAGE, State.MAINTENANCE).setDescription("Orchestrator"));
@@ -167,7 +167,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
-    public void testWhenOtherDistributorIsDown() {
+    public void testSafeMaintenanceDisallowedWhenOtherDistributorInFlatClusterIsSuspended() {
         // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
         ContentCluster cluster = createCluster(createNodes(4));
         cluster.clusterInfo().getDistributorNodeInfo(0)
@@ -188,7 +188,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
-    public void testWhenOtherDistributorInOtherGroupIsDown() {
+    public void testSafeMaintenanceDisallowedWhenDistributorInGroupIsDown() {
         // Nodes 0-3, distributor 0 being in maintenance with "Orchestrator" description.
         // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
         ContentCluster cluster = createCluster(createNodes(4));
@@ -224,7 +224,7 @@ public class NodeStateChangeCheckerTest {
     }
 
     @Test
-    public void testWhenOtherStorageNodeInOtherGroupIsSuspended() {
+    public void testSafeMaintenanceWhenOtherStorageNodeInGroupIsSuspended() {
         // Nodes 0-3, storage node 0 being in maintenance with "Orchestrator" description.
         // 2 groups: nodes 0-1 is group 0, 2-3 is group 1.
         ContentCluster cluster = createCluster(createNodes(4));

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -223,28 +223,28 @@ public class SetNodeStateTest extends StateRestApiTest {
         assertSetUnitState(1, State.MAINTENANCE, null);  // sanity-check
 
         // Because 2 is in a different group maintenance should be denied
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(2, State.MAINTENANCE);
+        assertSetUnitStateCausesAtMostOneGroupError(2, State.MAINTENANCE);
 
         // Because 3 and 5 are in the same group as 1, these should be OK
         assertSetUnitState(3, State.MAINTENANCE, null);
         assertUnitState(1, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
         assertUnitState(3, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
         assertSetUnitState(5, State.MAINTENANCE, null);
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(2, State.MAINTENANCE);  // sanity-check
+        assertSetUnitStateCausesAtMostOneGroupError(2, State.MAINTENANCE);  // sanity-check
 
         // Set all to up
         assertSetUnitState(1, State.UP, null);
         assertSetUnitState(1, State.UP, null); // sanity-check
         assertSetUnitState(3, State.UP, null);
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(2, State.MAINTENANCE);  // sanity-check
+        assertSetUnitStateCausesAtMostOneGroupError(2, State.MAINTENANCE);  // sanity-check
         assertSetUnitState(5, State.UP, null);
 
         // Now we should be allowed to upgrade second group, while the first group will be denied
         assertSetUnitState(2, State.MAINTENANCE, null);
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(1, State.MAINTENANCE);  // sanity-check
+        assertSetUnitStateCausesAtMostOneGroupError(1, State.MAINTENANCE);  // sanity-check
         assertSetUnitState(0, State.MAINTENANCE, null);
         assertSetUnitState(4, State.MAINTENANCE, null);
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(1, State.MAINTENANCE);  // sanity-check
+        assertSetUnitStateCausesAtMostOneGroupError(1, State.MAINTENANCE);  // sanity-check
 
         // And set second group up again
         assertSetUnitState(0, State.MAINTENANCE, null);
@@ -264,14 +264,14 @@ public class SetNodeStateTest extends StateRestApiTest {
         assertSetUnitState(1, State.MAINTENANCE, null);  // sanity-check
 
         // Because 2 is in a different group maintenance should be denied
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(2, State.MAINTENANCE);
+        assertSetUnitStateCausesAtMostOneGroupError(2, State.MAINTENANCE);
 
         // Because 3 and 5 are in the same group as 1, these should be OK
         assertSetUnitState(3, State.MAINTENANCE, null);
         assertUnitState(1, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
         assertUnitState(3, "user", State.MAINTENANCE, "whatever reason.");  // sanity-check
         assertSetUnitState(5, State.MAINTENANCE, null);
-        assertSetUnitStateCausesAlreadyInWantedMaintenance(2, State.MAINTENANCE);  // sanity-check
+        assertSetUnitStateCausesAtMostOneGroupError(2, State.MAINTENANCE);  // sanity-check
 
         // Set all to up
         assertSetUnitState(1, State.UP, null);
@@ -306,12 +306,14 @@ public class SetNodeStateTest extends StateRestApiTest {
         }
     }
 
-    private void assertSetUnitStateCausesAlreadyInWantedMaintenance(int index, State state) throws StateRestApiException {
-        assertSetUnitStateFails(index, state, "^Another storage node wants state MAINTENANCE: ([0-9]+)$");
+    private void assertSetUnitStateCausesAtMostOneGroupError(int index, State state) throws StateRestApiException {
+        assertSetUnitStateFails(index, state, "^At most one group can have wanted state: " +
+                "Other storage node ([0-9]+) in group ([0-9]+) has wanted state Maintenance$");
     }
 
     private void assertSetUnitStateCausesAnotherNodeHasStateError(int index, State state) throws StateRestApiException {
-        assertSetUnitStateFails(index, state, "^Another storage node has state DOWN: ([0-9]+)$");
+        assertSetUnitStateFails(index, state, "^At most one group can have wanted state: " +
+                "Other storage node ([0-9]+) in group ([0-9]+) has wanted state Maintenance$");
     }
 
     private void assertSetUnitStateFails(int index, State state, String reasonRegex)

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/SetNodeStateTest.java
@@ -215,7 +215,7 @@ public class SetNodeStateTest extends StateRestApiTest {
     @Test
     public void testShouldModifyStorageSafeBlocked() throws Exception {
         // Sets up 2 groups: [0, 2, 4] and [1, 3, 5]
-        setUpMusicGroup(6, false);
+        setUpMusicGroup(6, "");
 
         assertUnitState(1, "user", State.UP, "");
         assertSetUnitState(1, State.MAINTENANCE, null);
@@ -253,10 +253,10 @@ public class SetNodeStateTest extends StateRestApiTest {
     }
 
     @Test
-    public void settingSafeMaintenanceWhenNodeAlreadyInMaintenance() throws Exception {
-        // Sets up 2 groups: [0, 2, 4] and [1, 3, 5], with 1 being in maintenance
-        setUpMusicGroup(6, true);
-        assertUnitState(1, "generated", State.MAINTENANCE, "");
+    public void settingSafeMaintenanceWhenNodeDown() throws Exception {
+        // Sets up 2 groups: [0, 2, 4] and [1, 3, 5], with 1 being down
+        setUpMusicGroup(6, " .1.s:d");
+        assertUnitState(1, "generated", State.DOWN, "");
 
         assertUnitState(1, "user", State.UP, "");
         assertSetUnitState(1, State.MAINTENANCE, null);
@@ -279,7 +279,7 @@ public class SetNodeStateTest extends StateRestApiTest {
         assertSetUnitState(3, State.UP, null);
         // Because 1 is in maintenance, even though user wanted state is UP, trying to set 2 to
         // maintenance will fail.
-        assertSetUnitStateCausesAlreadyInMaintenance(2, State.MAINTENANCE);
+        assertSetUnitStateCausesAnotherNodeHasStateError(2, State.MAINTENANCE);
         assertSetUnitState(5, State.UP, null);
     }
 
@@ -307,14 +307,14 @@ public class SetNodeStateTest extends StateRestApiTest {
     }
 
     private void assertSetUnitStateCausesAlreadyInWantedMaintenance(int index, State state) throws StateRestApiException {
-        assertSetUnitStateCausesAlreadyInMaintenance(index, state, "^Another storage node wants state MAINTENANCE: ([0-9]+)$");
+        assertSetUnitStateFails(index, state, "^Another storage node wants state MAINTENANCE: ([0-9]+)$");
     }
 
-    private void assertSetUnitStateCausesAlreadyInMaintenance(int index, State state) throws StateRestApiException {
-        assertSetUnitStateCausesAlreadyInMaintenance(index, state, "^Another storage node has state MAINTENANCE: ([0-9]+)$");
+    private void assertSetUnitStateCausesAnotherNodeHasStateError(int index, State state) throws StateRestApiException {
+        assertSetUnitStateFails(index, state, "^Another storage node has state DOWN: ([0-9]+)$");
     }
 
-    private void assertSetUnitStateCausesAlreadyInMaintenance(int index, State state, String reasonRegex)
+    private void assertSetUnitStateFails(int index, State state, String reasonRegex)
             throws StateRestApiException {
         SetResponse setResponse = restAPI.setUnitState(new SetUnitStateRequestImpl("music/storage/" + index)
                 .setNewState("user", state.toString().toLowerCase(), "whatever reason.")

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
@@ -92,15 +92,14 @@ public abstract class StateRestApiTest {
         }, ccSockets);
     }
 
-    protected void setUpMusicGroup(int nodeCount, boolean node1InMaintenance) {
+    protected void setUpMusicGroup(int nodeCount, String node1StateString) {
         books = null;
         Distribution distribution = new Distribution(Distribution.getSimpleGroupConfig(2, nodeCount));
         jsonWriter.setDefaultPathPrefix("/cluster/v2");
         ContentCluster cluster = new ContentCluster("music", distribution.getNodes(), distribution);
         initializeCluster(cluster, distribution.getNodes());
         AnnotatedClusterState baselineState = AnnotatedClusterState
-                .withoutAnnotations(ClusterState.stateFromString("distributor:" + nodeCount + " storage:" + nodeCount +
-                        (node1InMaintenance ? " .1.s:m" : "")));
+                .withoutAnnotations(ClusterState.stateFromString("distributor:" + nodeCount + " storage:" + nodeCount + node1StateString));
         Map<String, AnnotatedClusterState> bucketSpaceStates = new HashMap<>();
         bucketSpaceStates.put("default", AnnotatedClusterState
                 .withoutAnnotations(ClusterState.stateFromString("distributor:" + nodeCount + " storage:" + nodeCount)));


### PR DESCRIPTION
* If there is more than one group, disallow suspending a node if there is a node in another group that has a user wanted state != UP.
* If there is 1 group, disallow suspending more than 1 node.

In addition, we no longer allow suspension if a node is already in maintenance, as maintenance is used with grace period exactly to defer downing of node.