### PR TITLE
- Use 256k buffer for connection log as it is low volume.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
@@ -6,6 +6,7 @@ import com.yahoo.container.core.AccessLogConfig.FileHandler.CompressionFormat;
 import com.yahoo.container.logging.JSONAccessLog;
 import com.yahoo.container.logging.VespaAccessLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 
 import java.util.OptionalInt;
@@ -27,6 +28,7 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
     private final String symlinkName;
     private final CompressionType compressionType;
     private final int queueSize;
+    private final Integer bufferSize;
 
     public AccessLogComponent(ContainerCluster<?> cluster, AccessLogType logType, CompressionType compressionType, String clusterName, boolean isHostedVespa)
     {
@@ -57,6 +59,9 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
         this.symlinkName = symlinkName;
         this.compressionType = compressionType;
         this.queueSize = queueSize(cluster).orElse(-1);
+        bufferSize = (cluster instanceof ApplicationContainerCluster)
+                ? 4*1024*1024
+                : null;
 
         if (fileNamePattern == null)
             throw new RuntimeException("File name pattern required when configuring access log.");
@@ -100,6 +105,9 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
         }
         if (queueSize >= 0) {
             builder.queueSize(queueSize);
+        }
+        if (bufferSize != null) {
+            builder.bufferSize(bufferSize);
         }
         switch (compressionType) {
             case GZIP:

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
@@ -86,6 +86,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
             assertEquals("pattern", fileHandlerConfig.pattern());
             assertEquals("interval", fileHandlerConfig.rotation());
             assertEquals(10000, fileHandlerConfig.queueSize());
+            assertEquals(4*1024*1024, fileHandlerConfig.bufferSize());
         }
 
         { // json
@@ -97,6 +98,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
             assertEquals("pattern", fileHandlerConfig.pattern());
             assertEquals("interval", fileHandlerConfig.rotation());
             assertEquals(10000, fileHandlerConfig.queueSize());
+            assertEquals(4*1024*1024, fileHandlerConfig.bufferSize());
         }
     }
 
@@ -116,6 +118,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
         ConnectionLogConfig config = root.getConfig(ConnectionLogConfig.class, "default/component/com.yahoo.container.logging.FileConnectionLog");
         assertEquals("default", config.cluster());
         assertEquals(10000, config.queueSize());
+        assertEquals(256*1024, config.bufferSize());
     }
 
     @Test

--- a/container-core/src/main/java/com/yahoo/container/logging/AccessLogHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/logging/AccessLogHandler.java
@@ -12,7 +12,7 @@ class AccessLogHandler {
 
     AccessLogHandler(AccessLogConfig.FileHandler config, LogWriter<RequestLogEntry> logWriter) {
         logFileHandler = new LogFileHandler<>(
-                toCompression(config), config.pattern(), config.rotation(),
+                toCompression(config), config.bufferSize(), config.pattern(), config.rotation(),
                 config.symlink(), config.queueSize(), "request-logger", logWriter);
     }
 

--- a/container-core/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
@@ -8,9 +8,11 @@ package com.yahoo.container.logging;
 class ConnectionLogHandler {
     private final LogFileHandler<ConnectionLogEntry> logFileHandler;
 
-    public ConnectionLogHandler(String logDirectoryName, String clusterName, int queueSize, LogWriter<ConnectionLogEntry> logWriter) {
+    public ConnectionLogHandler(String logDirectoryName, int bufferSize, String clusterName,
+                                int queueSize, LogWriter<ConnectionLogEntry> logWriter) {
         logFileHandler = new LogFileHandler<>(
                 LogFileHandler.Compression.ZSTD,
+                bufferSize,
                 String.format("logs/vespa/%s/ConnectionLog.%s.%s", logDirectoryName, clusterName, "%Y%m%d%H%M%S"),
                 "0 60 ...",
                 String.format("ConnectionLog.%s", clusterName),

--- a/container-core/src/main/java/com/yahoo/container/logging/FileConnectionLog.java
+++ b/container-core/src/main/java/com/yahoo/container/logging/FileConnectionLog.java
@@ -14,7 +14,7 @@ public class FileConnectionLog extends AbstractComponent implements ConnectionLo
 
     @Inject
     public FileConnectionLog(ConnectionLogConfig config) {
-        logHandler = new ConnectionLogHandler(config.logDirectoryName(), config.cluster(), config.queueSize(), new JsonConnectionLogWriter());
+        logHandler = new ConnectionLogHandler(config.logDirectoryName(), config.bufferSize(), config.cluster(), config.queueSize(), new JsonConnectionLogWriter());
     }
 
     @Override

--- a/container-core/src/main/resources/configdefinitions/container.core.access-log.def
+++ b/container-core/src/main/resources/configdefinitions/container.core.access-log.def
@@ -21,3 +21,6 @@ fileHandler.compressionFormat enum {GZIP, ZSTD} default=GZIP
 
 # Max queue length of file handler
 fileHandler.queueSize int default=10000
+
+# Buffer size for the output stream has a default of 256k
+fileHandler.bufferSize int default=262144

--- a/container-core/src/main/resources/configdefinitions/container.logging.connection-log.def
+++ b/container-core/src/main/resources/configdefinitions/container.logging.connection-log.def
@@ -9,3 +9,6 @@ logDirectoryName string default="qrs"
 
 # Max queue length of file handler
 queueSize int default=10000
+
+# Buffer size for the output stream has a default of 256k
+bufferSize int default=262144

--- a/container-core/src/test/java/com/yahoo/container/logging/LogFileHandlerTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/logging/LogFileHandlerTestCase.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotEquals;
  * @author bjorncs
  */
 public class LogFileHandlerTestCase {
+    private static final int BUFFER_SIZE = 0x10000;
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -43,7 +44,7 @@ public class LogFileHandlerTestCase {
 
         String pattern = root.getAbsolutePath() + "/logfilehandlertest.%Y%m%d%H%M%S";
         long[] rTimes = {1000, 2000, 10000};
-        LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, pattern, rTimes, null, 2048, "thread-name", new StringLogWriter());
+        LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, BUFFER_SIZE, pattern, rTimes, null, 2048, "thread-name", new StringLogWriter());
         long now = System.currentTimeMillis();
         long millisPerDay = 60*60*24*1000;
         long tomorrowDays = (now / millisPerDay) +1;
@@ -65,7 +66,7 @@ public class LogFileHandlerTestCase {
         File logFile = temporaryFolder.newFile("testLogFileG1.txt");
 
       //create logfilehandler
-      LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, logFile.getAbsolutePath(), "0 5 ...", null, 2048, "thread-name", new StringLogWriter());
+      LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, BUFFER_SIZE, logFile.getAbsolutePath(), "0 5 ...", null, 2048, "thread-name", new StringLogWriter());
 
       //write log
       h.publish("testDeleteFileFirst1");
@@ -78,7 +79,7 @@ public class LogFileHandlerTestCase {
       File logFile = temporaryFolder.newFile("testLogFileG2.txt");
 
       //create logfilehandler
-       LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, logFile.getAbsolutePath(), "0 5 ...", null, 2048, "thread-name", new StringLogWriter());
+       LogFileHandler<String> h = new LogFileHandler<>(Compression.NONE, BUFFER_SIZE, logFile.getAbsolutePath(), "0 5 ...", null, 2048, "thread-name", new StringLogWriter());
 
       //write log
       h.publish("testDeleteFileDuringLogging1");
@@ -104,7 +105,7 @@ public class LogFileHandlerTestCase {
             }
         };
         LogFileHandler<String> handler = new LogFileHandler<>(
-                Compression.NONE, root.getAbsolutePath() + "/logfilehandlertest.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
+                Compression.NONE, BUFFER_SIZE, root.getAbsolutePath() + "/logfilehandlertest.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
 
         String message = formatter.format(new LogRecord(Level.INFO, "test"));
         handler.publishAndWait(message);
@@ -128,7 +129,7 @@ public class LogFileHandlerTestCase {
     public void compresses_previous_log_file() throws InterruptedException, IOException {
         File root = temporaryFolder.newFolder("compressespreviouslogfile");
         LogFileHandler<String> firstHandler = new LogFileHandler<>(
-                Compression.ZSTD, root.getAbsolutePath() + "/compressespreviouslogfile.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
+                Compression.ZSTD, BUFFER_SIZE, root.getAbsolutePath() + "/compressespreviouslogfile.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
         firstHandler.publishAndWait("test");
         firstHandler.shutdown();
 
@@ -136,7 +137,7 @@ public class LogFileHandlerTestCase {
         assertThat(root.toPath().resolve("symlink").toRealPath().toString()).isEqualTo(firstHandler.getFileName());
 
         LogFileHandler<String> secondHandler = new LogFileHandler<>(
-                Compression.ZSTD, root.getAbsolutePath() + "/compressespreviouslogfile.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
+                Compression.ZSTD, BUFFER_SIZE, root.getAbsolutePath() + "/compressespreviouslogfile.%Y%m%d%H%M%S%s", new long[]{0}, "symlink", 2048, "thread-name", new StringLogWriter());
         secondHandler.publishAndWait("test");
         secondHandler.rotateNow();
 
@@ -174,7 +175,7 @@ public class LogFileHandlerTestCase {
         File root = temporaryFolder.newFolder("testcompression" + compression.name());
 
         LogFileHandler<String> h = new LogFileHandler<>(
-                compression, root.getAbsolutePath() + "/logfilehandlertest.%Y%m%d%H%M%S%s", new long[]{0}, null, 2048, "thread-name", new StringLogWriter());
+                compression, BUFFER_SIZE, root.getAbsolutePath() + "/logfilehandlertest.%Y%m%d%H%M%S%s", new long[]{0}, null, 2048, "thread-name", new StringLogWriter());
         int logEntries = 10000;
         for (int i = 0; i < logEntries; i++) {
             h.publish("test");


### PR DESCRIPTION
- Used 256k buffer accesslog, but 4m for application containers.

@bjorncs PR