### PR TITLE
let the sentinel run the RPC call for prepare-restart on content nodes.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -121,7 +121,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
             if (flushOnShutdownElem != null) {
                 return flushOnShutdownElem;
             }
-            return ! stateIsHosted(deployState);
+            return true;
         }
 
         private Double getQueryTimeout(ModelElement clusterElem) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -790,8 +790,8 @@ public class ContentClusterTest extends ContentBaseTest {
     }
 
     @Test
-    public void flush_on_shutdown_is_default_off_for_hosted() throws Exception {
-        assertNoPreShutdownCommand(createOneNodeCluster(true));
+    public void flush_on_shutdown_is_default_on_for_hosted() throws Exception {
+        assertPrepareRestartCommand(createOneNodeCluster(true));
     }
 
     @Test


### PR DESCRIPTION
* skipping this has created lots of operational problems
* if we end up running it two times, that's usually not a large extra cost

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@toregge please review
@hakonhall FYI
