### PR TITLE
- Bring the BucketMover in along with the move keys and the move oper…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.cpp
@@ -151,19 +151,16 @@ BucketMoveJobV2::needMove(const ScanIterator &itr) const {
 class BucketMoveJobV2::StartMove : public storage::spi::BucketTask {
 public:
     using IDestructorCallbackSP = std::shared_ptr<vespalib::IDestructorCallback>;
-    StartMove(std::shared_ptr<BucketMoveJobV2> job, std::shared_ptr<BucketMover> mover,
-              std::vector<BucketMover::MoveKey> keys,
-              IDestructorCallbackSP opsTracker)
+    StartMove(std::shared_ptr<BucketMoveJobV2> job, BucketMover::MoveKeys keys, IDestructorCallbackSP opsTracker)
         : _job(job),
-          _mover(std::move(mover)),
           _keys(std::move(keys)),
           _opsTracker(std::move(opsTracker))
     {}
 
     void run(const Bucket &bucket, IDestructorCallbackSP onDone) override {
-        assert(_mover->getBucket() == bucket.getBucketId());
+        assert(_keys.mover().getBucket() == bucket.getBucketId());
         using DoneContext = vespalib::KeepAlive<std::pair<IDestructorCallbackSP, IDestructorCallbackSP>>;
-        BucketMoveJobV2::prepareMove(std::move(_job), std::move(_mover), std::move(_keys),
+        BucketMoveJobV2::prepareMove(std::move(_job), std::move(_keys),
                                      std::make_shared<DoneContext>(std::make_pair(std::move(_opsTracker), std::move(onDone))));
     }
 
@@ -172,10 +169,9 @@ public:
     }
 
 private:
-    std::shared_ptr<BucketMoveJobV2>    _job;
-    std::shared_ptr<BucketMover>        _mover;
-    std::vector<BucketMover::MoveKey>   _keys;
-    IDestructorCallbackSP               _opsTracker;
+    std::shared_ptr<BucketMoveJobV2>  _job;
+    BucketMover::MoveKeys             _keys;
+    IDestructorCallbackSP             _opsTracker;
 };
 
 void
@@ -189,37 +185,38 @@ BucketMoveJobV2::failOperation(std::shared_ptr<BucketMoveJobV2> job, BucketId bu
 }
 
 void
-BucketMoveJobV2::startMove(BucketMoverSP mover, size_t maxDocsToMove) {
-    auto [keys, done] = mover->getKeysToMove(maxDocsToMove);
+BucketMoveJobV2::startMove(BucketMover & mover, size_t maxDocsToMove) {
+    auto [keys, done] = mover.getKeysToMove(maxDocsToMove);
     if (done) {
-        mover->setAllScheduled();
+        mover.setAllScheduled();
     }
     if (keys.empty()) return;
-    mover->updateLastValidGid(keys.back()._gid);
-    Bucket spiBucket(document::Bucket(_bucketSpace, mover->getBucket()));
-    auto bucketTask = std::make_unique<StartMove>(shared_from_this(), std::move(mover), std::move(keys), getLimiter().beginOperation());
+    mover.updateLastValidGid(keys.back()._gid);
+    Bucket spiBucket(document::Bucket(_bucketSpace, mover.getBucket()));
+    auto bucketTask = std::make_unique<StartMove>(shared_from_this(), std::move(keys), getLimiter().beginOperation());
     _bucketExecutor.execute(spiBucket, std::move(bucketTask));
 }
 
 void
-BucketMoveJobV2::prepareMove(std::shared_ptr<BucketMoveJobV2> job, BucketMoverSP mover, std::vector<MoveKey> keys, IDestructorCallbackSP onDone)
+BucketMoveJobV2::prepareMove(std::shared_ptr<BucketMoveJobV2> job, BucketMover::MoveKeys keys, IDestructorCallbackSP onDone)
 {
     if (job->_stopped) return; //TODO Remove once lidtracker is no longer in use.
-    auto moveOps = mover->createMoveOperations(std::move(keys));
+    auto moveOps = keys.createMoveOperations();
     auto & master = job->_master;
     if (job->_stopped) return;
-    master.execute(makeLambdaTask([job=std::move(job), mover=std::move(mover), moveOps=std::move(moveOps), onDone=std::move(onDone)]() mutable {
+    master.execute(makeLambdaTask([job=std::move(job), moveOps=std::move(moveOps), onDone=std::move(onDone)]() mutable {
         if (job->_stopped.load(std::memory_order_relaxed)) return;
-        job->completeMove(std::move(mover), std::move(moveOps), std::move(onDone));
+        job->completeMove(std::move(moveOps), std::move(onDone));
     }));
 }
 
 void
-BucketMoveJobV2::completeMove(BucketMoverSP mover, GuardedMoveOps ops, IDestructorCallbackSP onDone) {
-    mover->moveDocuments(std::move(ops.success), std::move(onDone));
-    ops.failed.clear();
-    if (checkIfMoverComplete(*mover)) {
-        reconsiderBucket(_ready.meta_store()->getBucketDB().takeGuard(), mover->getBucket());
+BucketMoveJobV2::completeMove(GuardedMoveOps ops, IDestructorCallbackSP onDone) {
+    BucketMover & mover = ops.mover();
+    mover.moveDocuments(std::move(ops.success()), std::move(onDone));
+    ops.failed().clear();
+    if (checkIfMoverComplete(mover)) {
+        reconsiderBucket(_ready.meta_store()->getBucketDB().takeGuard(), mover.getBucket());
     }
 }
 
@@ -306,7 +303,7 @@ BucketMoveJobV2::createMover(BucketId bucket, bool wantReady) {
     const MaintenanceDocumentSubDB &target(wantReady ? _ready : _notReady);
     LOG(debug, "checkBucket(): mover.setupForBucket(%s, source:%u, target:%u)",
         bucket.toString().c_str(), source.sub_db_id(), target.sub_db_id());
-    return std::make_shared<BucketMover>(bucket, &source, target.sub_db_id(), _moveHandler);
+    return BucketMover::create(bucket, &source, target.sub_db_id(), _moveHandler);
 }
 
 std::shared_ptr<BucketMover>
@@ -327,12 +324,12 @@ BucketMoveJobV2::moveDocs(size_t maxDocsToMove) {
 
     // Select mover
     size_t index = _iterateCount++ % _movers.size();
-    const auto & mover = _movers[index];
+    auto & mover = *_movers[index];
 
     //Move, or reduce movers as we are tailing off
-    if (!mover->allScheduled()) {
+    if (!mover.allScheduled()) {
         startMove(mover, maxDocsToMove);
-        if (mover->allScheduled()) {
+        if (mover.allScheduled()) {
             _movers.erase(_movers.begin() + index);
         }
     }

--- a/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bucketmovejobv2.h
@@ -55,7 +55,6 @@ private:
     using BucketMoverSP = std::shared_ptr<BucketMover>;
     using Bucket2Mover = std::map<BucketId, BucketMoverSP>;
     using Movers = std::vector<BucketMoverSP>;
-    using MoveKey = BucketMover::MoveKey;
     using GuardedMoveOps = BucketMover::GuardedMoveOps;
     std::shared_ptr<IBucketStateCalculator>   _calc;
     IDocumentMoveHandler                     &_moveHandler;
@@ -93,10 +92,9 @@ private:
                     const vespalib::string &docTypeName,
                     document::BucketSpace bucketSpace);
 
-    void startMove(BucketMoverSP mover, size_t maxDocsToMove);
-    static void prepareMove(std::shared_ptr<BucketMoveJobV2> job, BucketMoverSP mover,
-                            std::vector<MoveKey> keysToMove, IDestructorCallbackSP context);
-    void completeMove(BucketMoverSP mover, GuardedMoveOps moveOps, IDestructorCallbackSP context);
+    void startMove(BucketMover & mover, size_t maxDocsToMove);
+    static void prepareMove(std::shared_ptr<BucketMoveJobV2> job, BucketMover::MoveKeys keys, IDestructorCallbackSP context);
+    void completeMove(GuardedMoveOps moveOps, IDestructorCallbackSP context);
     bool checkIfMoverComplete(const BucketMover & mover);
     void considerBucket(const bucketdb::Guard & guard, BucketId bucket);
     void reconsiderBucket(const bucketdb::Guard & guard, BucketId bucket);


### PR DESCRIPTION
…ations to ensure proper lifetime.

  It must outlive the keys and th emove operations to avoid refering random memory or trigger asserts.
- Enforce the BucketMover to be a shared_ptr.

@toregge PR