### PR TITLE
turn up the logging level

### DIFF
--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
@@ -54,6 +54,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @author Simon Thoresen Hult
@@ -118,6 +120,7 @@ public class SimpleFeeder implements ReplyHandler {
 
 
     public static void main(String[] args) throws Throwable {
+        Logger.getLogger("").setLevel(Level.WARNING);
         new SimpleFeeder(new FeederParams().parseArgs(args)).run().close();
     }
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
@@ -1,9 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespaget;
 
-
 import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.vespaclient.ClusterList;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * The vespa-get tool retrieves documents from a Vespa Document Storage cluster, and prints them to stdout as XML.
@@ -14,6 +16,7 @@ public class Main {
 
     public static void main(String[] args) {
         try {
+            Logger.getLogger("").setLevel(Level.WARNING);
             CommandLineOptions options = new CommandLineOptions();
             ClientParameters params = options.parseCommandLineArguments(args);
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespastat/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespastat/Main.java
@@ -1,6 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespastat;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Main application class
  *
@@ -12,6 +15,7 @@ public class Main {
     }
 
     public static void main(String[] args) {
+        Logger.getLogger("").setLevel(Level.WARNING);
         CommandLineOptions options = new CommandLineOptions();
         try {
             ClientParameters params = options.parseCommandLineArguments(args);


### PR DESCRIPTION
* these tools are also in the category where users
  will consider any INFO level message noise.
  Since they don't use the vespa LogSetup, just
  increase the threshold programmatically.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli please review
@baldersheim @bjorncs FYI
