### PR TITLE
Wire in tensor cell type resolving for concat in Java

### DIFF
--- a/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/rankingexpression/evaluation/EvaluationTestCase.java
@@ -409,8 +409,8 @@ public class EvaluationTestCase {
         tester.assertEvaluates("tensor<float>(x[3]):[1.0, 2.0, 3.0]",
                                "cell_cast(tensor0, float)",
                                "tensor<double>(x[3]):[1, 2, 3]");
-        tester.assertEvaluates("tensor<float>():{1}",
-                               "cell_cast(tensor0{x:1}, float)",
+        tester.assertEvaluates("tensor<float>(x[2]):[1.0, 2.0]",
+                               "cell_cast(tensor(x[2]):[tensor0{x:1}, tensor0{x:2}], float)",
                                "tensor<double>(x{}):{1:1, 2:2, 3:3}");
         tester.assertEvaluates("tensor<float>(x[2]):[3,8]",
                                "cell_cast(tensor0 * tensor1, float)",

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/CellCast.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/CellCast.java
@@ -3,6 +3,7 @@ package com.yahoo.tensor.functions;
 
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
+import com.yahoo.tensor.TypeResolver;
 import com.yahoo.tensor.evaluation.EvaluationContext;
 import com.yahoo.tensor.evaluation.Name;
 import com.yahoo.tensor.evaluation.TypeContext;
@@ -47,7 +48,7 @@ public class CellCast<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAM
 
     @Override
     public TensorType type(TypeContext<NAMETYPE> context) {
-        return new TensorType(valueType, argument.type(context).dimensions());
+        return TypeResolver.cell_cast(argument.type(context), valueType);
     }
 
     @Override
@@ -56,12 +57,11 @@ public class CellCast<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAM
         if (tensor.type().valueType() == valueType) {
             return tensor;
         }
-        TensorType type = new TensorType(valueType, tensor.type().dimensions());
+        TensorType type = TypeResolver.cell_cast(tensor.type(), valueType);
         return cast(tensor, type);
     }
 
     private Tensor cast(Tensor tensor, TensorType type) {
-        Tensor.Builder builder = Tensor.Builder.of(type);
         TensorType.Value fromValueType = tensor.type().valueType();
         switch (fromValueType) {
             case DOUBLE:

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
@@ -68,14 +68,13 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
     public Tensor evaluate(EvaluationContext<NAMETYPE> context) {
         Tensor a = argumentA.evaluate(context);
         Tensor b = argumentB.evaluate(context);
-        TensorType.Value combinedValueType = TensorType.combinedValueType(a.type(), b.type());
-        a = ensureIndexedDimension(dimension, a, combinedValueType);
-        b = ensureIndexedDimension(dimension, b, combinedValueType);
+        TensorType concatType = TypeResolver.concat(a.type(), b.type(), dimension);
+
+        a = ensureIndexedDimension(dimension, a, concatType.valueType());
+        b = ensureIndexedDimension(dimension, b, concatType.valueType());
 
         IndexedTensor aIndexed = (IndexedTensor) a; // If you get an exception here you have implemented a mixed tensor
         IndexedTensor bIndexed = (IndexedTensor) b;
-
-        TensorType concatType = TypeResolver.concat(a.type(), b.type(), dimension);
         DimensionSizes concatSize = concatSize(concatType, aIndexed, bIndexed, dimension);
 
         Tensor.Builder builder = Tensor.Builder.of(concatType, concatSize);

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Merge.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Merge.java
@@ -9,6 +9,7 @@ import com.yahoo.tensor.PartialAddress;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
+import com.yahoo.tensor.TypeResolver;
 import com.yahoo.tensor.evaluation.EvaluationContext;
 import com.yahoo.tensor.evaluation.Name;
 import com.yahoo.tensor.evaluation.TypeContext;
@@ -48,9 +49,7 @@ public class Merge<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETY
 
     /** Returns the type resulting from applying Merge to the two given types */
     public static TensorType outputType(TensorType a, TensorType b) {
-        Optional<TensorType> outputType = a.dimensionwiseGeneralizationWith(b);
-        if (outputType.isPresent()) return outputType.get();
-        throw new IllegalArgumentException("Cannot merge " + a + " and " + b + ": Arguments must have compatible types");
+        return TypeResolver.merge(a, b);
     }
 
     public DoubleBinaryOperator merger() { return merger; }

--- a/vespajlib/src/test/java/com/yahoo/tensor/TypeResolverTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/TypeResolverTestCase.java
@@ -225,11 +225,14 @@ public class TypeResolverTestCase {
         checkConcat("tensor<float>(x[3])",    "tensor()", "x", "tensor<float>(x[4])");
         checkConcat("tensor<bfloat16>(x[3])", "tensor()", "x", "tensor<bfloat16>(x[4])");
         checkConcat("tensor<int8>(x[3])",     "tensor()", "x", "tensor<int8>(x[4])");
+        // specific for Java
+        checkConcat("tensor(x[])",            "tensor(x[2])", "x", "tensor(x[])");
+        checkConcat("tensor(x[])",            "tensor(x[2])", "y", "tensor(x[],y[2])");
+        checkConcat("tensor(x[3])",           "tensor(x[2])", "y", "tensor(x[2],y[2])");
         // invalid combinations must fail
         checkConcatFails("tensor(x{})",       "tensor(x[2])", "x");
         checkConcatFails("tensor(x{})",       "tensor(x{})",  "x");
         checkConcatFails("tensor(x{})",       "tensor()",     "x");
-        checkConcatFails("tensor(x[3])",      "tensor(x[2])", "y");
     }
 
     @Test


### PR DESCRIPTION
@arnej27959 Please review. Like with `join` - I modified the rules a bit in `TypeResolver` to be conservative and fit existing behavior regarding unbound and mapped dimension.