### PR TITLE
- Prevent the rewrite that happens with equiv and phrase to handle fl…

### DIFF
--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -708,6 +708,24 @@ TEST("require that we do not break the stack on bad query") {
     EXPECT_FALSE(term.isValid());
 }
 
+TEST("a unhandled sameElement stack") {
+    const char * stack = "\022\002\026xyz_abcdefghij_xyzxyzxQ\001\vxxxxxx_name\034xxxxxx_xxxx_xxxxxxx_xxxxxxxxE\002\005delta\b<0.00393";
+    vespalib::stringref stackDump(stack);
+    EXPECT_EQUAL(85u, stackDump.size());
+    AllowRewrite empty;
+    const Query q(empty, stackDump);
+    EXPECT_TRUE(q.valid());
+    const QueryNode & root = q.getRoot();
+    auto sameElement = dynamic_cast<const SameElementQueryNode *>(&root);
+    EXPECT_TRUE(sameElement != nullptr);
+    EXPECT_EQUAL(2u, sameElement->size());
+    EXPECT_EQUAL("xyz_abcdefghij_xyzxyzx", sameElement->getIndex());
+    auto term0 = dynamic_cast<const QueryTerm *>((*sameElement)[0].get());
+    EXPECT_TRUE(term0 != nullptr);
+    auto term1 = dynamic_cast<const QueryTerm *>((*sameElement)[1].get());
+    EXPECT_TRUE(term1 != nullptr);
+}
+
 namespace {
     void verifyQueryTermNode(const vespalib::string & index, const QueryNode *node) {
         EXPECT_TRUE(dynamic_cast<const QueryTerm *>(node) != nullptr);

--- a/searchlib/src/vespa/searchlib/query/streaming/query.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/query.cpp
@@ -2,6 +2,7 @@
 #include "query.h"
 #include <vespa/searchlib/parsequery/stackdumpiterator.h>
 #include <vespa/vespalib/objects/visit.hpp>
+#include <cassert>
 
 namespace search::streaming {
 
@@ -155,6 +156,11 @@ bool SameElementQueryNode::evaluate() const {
 const HitList &
 SameElementQueryNode::evaluateHits(HitList & hl) const
 {
+    // TODO This should have been done in a different way, but there are currently no way for that.
+    //  Sanity check should be cheap enough that it does not matter.
+    for (const auto & child : *this) {
+        assert(dynamic_cast<const QueryTerm *>(child.get()) != nullptr);
+    }
     hl.clear();
     if ( !AndQueryNode::evaluate()) return hl;
 

--- a/searchlib/src/vespa/searchlib/query/streaming/querynode.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/querynode.cpp
@@ -10,8 +10,10 @@ namespace search::streaming {
 
 namespace {
     vespalib::stringref DEFAULT("default");
-    bool isPhraseOrNear(const QueryNode * qn) {
-        return dynamic_cast<const NearQueryNode *> (qn) || dynamic_cast<const PhraseQueryNode *> (qn);
+    bool disableRewrite(const QueryNode * qn) {
+        return dynamic_cast<const NearQueryNode *> (qn) ||
+               dynamic_cast<const PhraseQueryNode *> (qn) ||
+               dynamic_cast<const SameElementQueryNode *>(qn);
     }
 }
 
@@ -56,7 +58,7 @@ QueryNode::Build(const QueryNode * parent, const QueryNodeResultFactory & factor
                 if (qc->isFlattenable(queryRep.getType())) {
                     arity += queryRep.getArity();
                 } else {
-                    UP child = Build(qc, factory, queryRep, allowRewrite && !isPhraseOrNear(qn.get()));
+                    UP child = Build(qc, factory, queryRep, allowRewrite && !disableRewrite(qn.get()));
                     qc->push_back(std::move(child));
                 }
             }
@@ -128,7 +130,12 @@ QueryNode::Build(const QueryNode * parent, const QueryNodeResultFactory & factor
             auto qt = std::make_unique<QueryTerm>(factory.create(), ssTerm, ssIndex, sTerm);
             qt->setWeight(queryRep.GetWeight());
             qt->setUniqueId(queryRep.getUniqueId());
-            if ( qt->encoding().isBase10Integer() || ! qt->encoding().isFloat() || ! factory.getRewriteFloatTerms() || !allowRewrite || (ssTerm.find('.') == vespalib::string::npos)) {
+            if (qt->encoding().isBase10Integer() ||
+                ! qt->encoding().isFloat() ||
+                ! factory.getRewriteFloatTerms() ||
+                ! allowRewrite ||
+                (ssTerm.find('.') == vespalib::string::npos))
+            {
                 qn = std::move(qt);
             } else {
                 auto phrase = std::make_unique<PhraseQueryNode>();


### PR DESCRIPTION
…oating point queries in string fields, from happening in under a same-element node.

- Add raw stackdump from previously failing query.

@geirst PR