### PR TITLE
Allow empty config

### DIFF
--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -45,7 +45,7 @@ GenericConfig = element config {
     attribute name { text },
     attribute namespace { text }?, # TODO: Remove in Vespa 8
     attribute version { text }?,
-    anyElement +
+    anyElement*
 }
 
 ComponentSpec =


### PR DESCRIPTION
If you have zone-dependent config it is convenient to be able
to end up with an empty body in zones where the defaults should apply.
