### PR TITLE
Misc. VCMR changes

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/vcmr/VespaChangeRequest.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/vcmr/VespaChangeRequest.java
@@ -48,6 +48,10 @@ public class VespaChangeRequest extends ChangeRequest {
         return new VespaChangeRequest(getId(), source, getImpactedSwitches(), getImpactedHosts(), getApproval(), getImpact(), status, hostActionPlan, zoneId);
     }
 
+    public VespaChangeRequest withApproval(Approval approval) {
+        return new VespaChangeRequest(getId(), getChangeRequestSource(), getImpactedSwitches(), getImpactedHosts(), approval, getImpact(), status, hostActionPlan, zoneId);
+    }
+
     public VespaChangeRequest withActionPlan(List<HostAction> hostActionPlan) {
         return new VespaChangeRequest(getId(), getChangeRequestSource(), getImpactedSwitches(), getImpactedHosts(), getApproval(), getImpact(), status, hostActionPlan, zoneId);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ChangeRequestMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ChangeRequestMaintainer.java
@@ -49,6 +49,7 @@ public class ChangeRequestMaintainer extends ControllerMaintainer {
         var currentChangeRequests = pruneOldChangeRequests();
         var changeRequests = changeRequestClient.getChangeRequests(currentChangeRequests);
 
+        logger.fine(() -> "Found requests: " + changeRequests);
         storeChangeRequests(changeRequests);
         if (system.equals(SystemName.main)) {
             approveChanges(changeRequests);
@@ -63,6 +64,7 @@ public class ChangeRequestMaintainer extends ControllerMaintainer {
                 .filter(changeRequest -> changeRequest.getApproval() == ChangeRequest.Approval.REQUESTED)
                 .collect(Collectors.toList());
 
+        logger.fine(() -> "Approving " + unapprovedRequests);
         changeRequestClient.approveChangeRequests(unapprovedRequests);
     }
 
@@ -79,7 +81,9 @@ public class ChangeRequestMaintainer extends ControllerMaintainer {
                 optionalZone.ifPresent(zone -> {
                     var vcmr = existingChangeRequests
                             .getOrDefault(changeRequest.getId(), new VespaChangeRequest(changeRequest, zone))
-                            .withSource(changeRequest.getChangeRequestSource());
+                            .withSource(changeRequest.getChangeRequestSource())
+                            .withApproval(changeRequest.getApproval());
+                    logger.fine(() -> "Storing " + vcmr);
                     curator.writeChangeRequest(vcmr);
                 });
             });

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -155,7 +155,7 @@ public class ControllerMaintenance extends AbstractComponent {
             this.archiveUriUpdater = duration(5, MINUTES);
             this.archiveAccessMaintainer = duration(10, MINUTES);
             this.tenantRoleMaintainer = duration(5, MINUTES);
-            this.changeRequestMaintainer = duration(12, HOURS);
+            this.changeRequestMaintainer = duration(1, HOURS);
             this.vcmrMaintainer = duration(1, HOURS);
         }
 


### PR DESCRIPTION
- Add some fine-grained logging
- Add test to verify that updated source status is indeed stored in ZK
- Increase maintainer frequency, 12 hours is too rare
- Update approval status
- Re-read VCMR from ZK before writing assessment.  `VCMRMaintainer` could be keeping old data in memory while `ChangeRequestMaintainer` fetches updates
