### PR TITLE
Take array size into account when resizing vector for remapping EntryRef

### DIFF
--- a/vespalib/src/vespa/vespalib/datastore/bufferstate.h
+++ b/vespalib/src/vespa/vespalib/datastore/bufferstate.h
@@ -166,6 +166,7 @@ public:
     size_t getExtraHoldBytes() const { return _extraHoldBytes; }
     bool getCompacting() const { return _compacting; }
     void setCompacting() { _compacting = true; }
+    uint32_t get_used_arrays() const noexcept { return _usedElems / _arraySize; }
     void fallbackResize(uint32_t bufferId, size_t elementsNeeded, void *&buffer, Alloc &holdBuffer);
 
     bool isActive(uint32_t typeId) const {

--- a/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
@@ -107,7 +107,7 @@ private:
         for (const auto bufferId : _bufferIdsToCompact) {
             BufferState &state = _dataStore.getBufferState(bufferId);
             _compacting_buffer[bufferId] = true;
-            _mapping[bufferId].resize(state.size());
+            _mapping[bufferId].resize(state.get_used_arrays());
         }
     }
 
@@ -116,8 +116,9 @@ private:
         assert(iRef.valid());
         uint32_t buffer_id = iRef.bufferId();
         if (_compacting_buffer[buffer_id]) {
-            assert(iRef.offset() < _mapping[buffer_id].size());
-            EntryRef &mappedRef = _mapping[buffer_id][iRef.offset()];
+            auto &inner_mapping = _mapping[buffer_id];
+            assert(iRef.unscaled_offset() < inner_mapping.size());
+            EntryRef &mappedRef = inner_mapping[iRef.unscaled_offset()];
             assert(!mappedRef.valid());
             EntryRef newRef = _store.move(oldRef);
             mappedRef = newRef;

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_enumerator.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_enumerator.hpp
@@ -46,7 +46,7 @@ UniqueStoreEnumerator<RefT>::allocate_enum_values()
     for (uint32_t bufferId = 0; bufferId < RefType::numBuffers(); ++bufferId) {
         const BufferState &state = _store.getBufferState(bufferId);
         if (state.isActive()) {
-            _enumValues[bufferId].resize(state.size() / state.getArraySize());
+            _enumValues[bufferId].resize(state.get_used_arrays());
         }
     }
 }

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_remapper.h
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_remapper.h
@@ -4,6 +4,7 @@
 
 #include "entryref.h"
 #include <vector>
+#include <vespa/vespalib/stllike/allocator.h>
 
 namespace vespalib::datastore {
 
@@ -18,7 +19,7 @@ public:
 
 protected:
     std::vector<bool> _compacting_buffer;
-    std::vector<std::vector<EntryRef>> _mapping;
+    std::vector<std::vector<EntryRef, allocator_large<EntryRef>>> _mapping;
 public:
     UniqueStoreRemapper()
         : _compacting_buffer(),


### PR DESCRIPTION
(i.e. when compacting unique store values).
Add get_used_arrays() method to buffer state.
Use unscaled_offset().
Use allocator_large for inner remapping vector.

@baldersheim : please review
