### PR TITLE
Propagate distributor config via internal snapshots [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/common/distributorcomponent.cpp
+++ b/storage/src/vespa/storage/common/distributorcomponent.cpp
@@ -8,12 +8,23 @@ DistributorComponent::DistributorComponent(DistributorComponentRegister& compReg
                                            vespalib::stringref name)
     : StorageComponent(compReg, name),
       _timeCalculator(0),
-      _totalConfig(*this)
+      _internal_config_generation(0),
+      _config_snapshot(std::make_shared<DistributorConfiguration>(*this))
 {
     compReg.registerDistributorComponent(*this);
 }
 
-DistributorComponent::~DistributorComponent() { }
+DistributorComponent::~DistributorComponent() = default;
+
+void DistributorComponent::update_config_snapshot() {
+    auto new_snapshot = std::make_shared<DistributorConfiguration>(*this);
+    new_snapshot->configure(_visitorConfig);
+    new_snapshot->configure(_distributorConfig);
+    // TODO make thread safe if necessary; access currently synchronized by config updates
+    // and checks all being routed through the same "critical tick" global lock.
+    ++_internal_config_generation;
+    _config_snapshot = std::move(new_snapshot);
+}
 
 } // storage
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -96,18 +96,18 @@ DistributorConfiguration::configureMaintenancePriorities(
         const vespa::config::content::core::StorDistributormanagerConfig& cfg)
 {
     MaintenancePriorities& mp(_maintenancePriorities);
-    mp.mergeMoveToIdealNode = cfg.priorityMergeMoveToIdealNode;
-    mp.mergeOutOfSyncCopies = cfg.priorityMergeOutOfSyncCopies;
-    mp.mergeTooFewCopies = cfg.priorityMergeTooFewCopies;
-    mp.mergeGlobalBuckets = cfg.priorityMergeGlobalBuckets;
-    mp.activateNoExistingActive = cfg.priorityActivateNoExistingActive;
+    mp.mergeMoveToIdealNode       = cfg.priorityMergeMoveToIdealNode;
+    mp.mergeOutOfSyncCopies       = cfg.priorityMergeOutOfSyncCopies;
+    mp.mergeTooFewCopies          = cfg.priorityMergeTooFewCopies;
+    mp.mergeGlobalBuckets         = cfg.priorityMergeGlobalBuckets;
+    mp.activateNoExistingActive   = cfg.priorityActivateNoExistingActive;
     mp.activateWithExistingActive = cfg.priorityActivateWithExistingActive;
-    mp.deleteBucketCopy = cfg.priorityDeleteBucketCopy;
-    mp.joinBuckets = cfg.priorityJoinBuckets;
-    mp.splitDistributionBits = cfg.prioritySplitDistributionBits;
-    mp.splitLargeBucket = cfg.prioritySplitLargeBucket;
-    mp.splitInconsistentBucket = cfg.prioritySplitInconsistentBucket;
-    mp.garbageCollection = cfg.priorityGarbageCollection;
+    mp.deleteBucketCopy           = cfg.priorityDeleteBucketCopy;
+    mp.joinBuckets                = cfg.priorityJoinBuckets;
+    mp.splitDistributionBits      = cfg.prioritySplitDistributionBits;
+    mp.splitLargeBucket           = cfg.prioritySplitLargeBucket;
+    mp.splitInconsistentBucket    = cfg.prioritySplitInconsistentBucket;
+    mp.garbageCollection          = cfg.priorityGarbageCollection;
 }
 
 void 

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -181,6 +181,8 @@ private:
 
     std::shared_ptr<lib::Distribution>   _distribution;
     std::shared_ptr<lib::Distribution>   _next_distribution;
+
+    uint64_t                             _current_internal_config_generation;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.cpp
+++ b/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.cpp
@@ -14,6 +14,10 @@ LegacySingleStripeAccessGuard::~LegacySingleStripeAccessGuard() {
     _accessor.mark_guard_released();
 }
 
+void LegacySingleStripeAccessGuard::update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) {
+    _stripe.update_total_distributor_config(std::move(config));
+}
+
 void LegacySingleStripeAccessGuard::update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) {
     _stripe.update_distribution_config(new_configs);
 }

--- a/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.h
+++ b/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.h
@@ -21,6 +21,8 @@ public:
                                   DistributorStripe& stripe);
     ~LegacySingleStripeAccessGuard() override;
 
+    void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) override;
+
     void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) override;
     void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) override;
     void clear_pending_cluster_state_bundle() override;

--- a/storage/src/vespa/storage/distributor/stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/stripe_access_guard.h
@@ -14,8 +14,9 @@ class ClusterStateBundle;
 class Distribution;
 }
 
-namespace storage::distributor {
+namespace storage { class DistributorConfiguration; }
 
+namespace storage::distributor {
 
 /**
  * A stripe access guard guarantees that the holder of a guard can access underlying
@@ -26,6 +27,8 @@ namespace storage::distributor {
 class StripeAccessGuard {
 public:
     virtual ~StripeAccessGuard() = default;
+
+    virtual void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) = 0;
 
     virtual void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) = 0;
     virtual void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) = 0;


### PR DESCRIPTION
@geirst please review.

Add functionality for updating config for stripes via accessor guard
interface. Stripes will now keep an explicit, immutable config snapshot
internally (and get explicit knowledge of when this changes) instead
of accessing config via magical component interface.

Introduce notion of internal config generation (not directly related
to generations received from underlying config system) to be able to
cheaply know if new config should be propagated. Since a lot of unit
tests use dirty "modify in place" tricks to alter config for tests,
have to do some extra work per tick to ensure non-generational config
changes are applied to the distributor code. This should be fixed as
a later follow-up.

Also remove `TickingThread` inheritance from `DistributorStripe` to begin
preparing for redesign of stripe threading model.
