### PR TITLE
Stop maintenance jobs prior to draining references. Also remove a red…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -847,7 +847,7 @@ MaintenanceControllerFixture::injectMaintenanceJobs()
 {
     if (_injectDefaultJobs) {
         MaintenanceJobsInjector::injectJobs(_mc, *_mcCfg, _bucketExecutor, _fh, _gsp, _fh, _mc,
-                                            _bucketCreateNotifier, _docTypeName.getName(), makeBucketSpace(), _fh, _fh,
+                                            _bucketCreateNotifier, makeBucketSpace(), _fh, _fh,
                                             _bmc, _clusterStateHandler, _bucketHandler, _calc, _diskMemUsageNotifier,
                                             _jobTrackers, _readyAttributeManager, _notReadyAttributeManager,
                                             std::make_unique<const AttributeConfigInspector>(AttributesConfigBuilder()),

--- a/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
@@ -108,7 +108,6 @@ MaintenanceJobsInjector::injectJobs(MaintenanceController &controller,
                                     IOperationStorer &opStorer,
                                     IFrozenBucketHandler &fbHandler,
                                     bucketdb::IBucketCreateNotifier &bucketCreateNotifier,
-                                    const vespalib::string &docTypeName,
                                     document::BucketSpace bucketSpace,
                                     IPruneRemovedDocumentsHandler &prdHandler,
                                     IDocumentMoveHandler &moveHandler,
@@ -127,6 +126,7 @@ MaintenanceJobsInjector::injectJobs(MaintenanceController &controller,
     controller.registerJobInMasterThread(std::make_unique<HeartBeatJob>(hbHandler, config.getHeartBeatConfig()));
     controller.registerJobInDefaultPool(std::make_unique<PruneSessionCacheJob>(scPruner, config.getSessionCachePruneInterval()));
 
+    const auto & docTypeName = controller.getDocTypeName().getName();
     const MaintenanceDocumentSubDB &mRemSubDB(controller.getRemSubDB());
     auto pruneRDjob = std::make_unique<PruneRemovedDocumentsJob>(config.getPruneRemovedDocumentsConfig(), *mRemSubDB.meta_store(),
                                                                  mRemSubDB.sub_db_id(), docTypeName, prdHandler, fbHandler);

--- a/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.h
@@ -40,7 +40,6 @@ struct MaintenanceJobsInjector
                            IOperationStorer &opStorer,
                            IFrozenBucketHandler &fbHandler,
                            bucketdb::IBucketCreateNotifier &bucketCreateNotifier,
-                           const vespalib::string &docTypeName,
                            document::BucketSpace bucketSpace,
                            IPruneRemovedDocumentsHandler &prdHandler,
                            IDocumentMoveHandler &moveHandler,

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
@@ -72,6 +72,7 @@ public:
     const MaintenanceDocumentSubDB &      getRemSubDB() const { return _remSubDB; }
     const MaintenanceDocumentSubDB & getNotReadySubDB() const { return _notReadySubDB; }
     IThreadService & masterThread() { return _masterThread; }
+    const DocTypeName & getDocTypeName() const { return _docTypeName; }
 private:
     using Mutex = std::mutex;
     using Guard = std::lock_guard<Mutex>;


### PR DESCRIPTION
…undant docTypeName parameter.

@toregge PR