### PR TITLE
Change the way we switch connection when the current one is not working

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription.impl;
 
 import com.yahoo.jrt.Request;
@@ -16,7 +16,7 @@ import com.yahoo.vespa.config.util.ConfigUtils;
  *
  * @author hmusum
  */
-public class MockConnection implements ConnectionPool, com.yahoo.vespa.config.Connection {
+public class MockConnection implements ConnectionPool, Connection {
 
     private Request lastRequest;
     private final ResponseHandler responseHandler;
@@ -87,9 +87,7 @@ public class MockConnection implements ConnectionPool, com.yahoo.vespa.config.Co
     }
 
     @Override
-    public Connection setNewCurrentConnection() {
-        return this;
-    }
+    public Connection switchConnection() { return this; }
 
     @Override
     public int getSize() {

--- a/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config;
 
 import com.yahoo.jrt.Supervisor;
@@ -10,13 +10,35 @@ public interface ConnectionPool extends AutoCloseable {
 
     void close();
 
+    /**
+     * Sets the supplied Connection to have an error, implementations are expected to call
+     * {@link #switchConnection()} after setting state for the supplied Connection.
+     *
+     */
     void setError(Connection connection, int i);
 
     Connection getCurrent();
 
-    Connection setNewCurrentConnection();
+    /**
+     * Switches to another (healthy, if one exists) Connection instance.
+     * Returns the resulting Connection. See also {@link #setError(Connection, int)}
+     *
+     * @return a Connection
+     */
+    Connection switchConnection();
+
+    /**
+     * Sets the current JRTConnection instance by randomly choosing
+     * from the available sources and returns the result.
+     *
+     * @return a Connection
+     */
+    @Deprecated
+    default Connection setNewCurrentConnection() { return switchConnection(); };
 
     int getSize();
 
+    // TODO: Exposes implementation, try to remove
     Supervisor getSupervisor();
+
 }

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnection.java
@@ -79,17 +79,14 @@ public class JRTConnection implements Connection {
 
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Address: ");
         sb.append(address);
-        sb.append("\n").append("Healthy: ").append(isHealthy());
+        sb.append(", ").append(isHealthy() ? "healthy" : "unhealthy");
         if (lastSuccess.isAfter(Instant.EPOCH)) {
-            sb.append("\n");
-            sb.append("Last success: ");
+            sb.append(", last success: ");
             sb.append(lastSuccess);
         }
         if (lastFailure.isAfter(Instant.EPOCH)) {
-            sb.append("\n");
-            sb.append("Last failure: ");
+            sb.append(", last failure: ");
             sb.append(lastFailure);
         }
         return sb.toString();

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -12,16 +12,14 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import static java.util.logging.Level.FINE;
+import java.util.stream.Collectors;
 
 /**
  * A pool of JRT connections to a config source (either a config server or a config proxy).
- * The current connection is chosen randomly when calling {#link #setNewCurrentConnection}
- * (since the connection is chosen randomly, it might end up using the same connection again,
- * and it will always do so if there is only one source).
+ * The current connection is chosen randomly when calling {#link {@link #switchConnection()}}
+ * (it will continue to use the same connection if there is only one source).
  * The current connection is available with {@link #getCurrent()}.
- * When calling {@link #setError(Connection, int)}, {#link #setNewCurrentConnection} will always be called.
+ * When calling {@link #setError(Connection, int)}, {#link {@link #switchConnection()}} will always be called.
  *
  * @author Gunnar Gauslaa Bergem
  * @author hmusum
@@ -55,7 +53,7 @@ public class JRTConnectionPool implements ConnectionPool {
                 connections.put(address, new JRTConnection(address, supervisor));
             }
         }
-        setNewCurrentConnection();
+        initialize();
     }
 
     /**
@@ -67,18 +65,32 @@ public class JRTConnectionPool implements ConnectionPool {
         return currentConnection;
     }
 
-    /**
-     * Returns and set the current JRTConnection instance by randomly choosing
-     * from the available sources (this means that you might end up using
-     * the same connection).
-     *
-     * @return a JRTConnection
-     */
-    public synchronized JRTConnection setNewCurrentConnection() {
+    @Override
+    public synchronized JRTConnection switchConnection() {
         List<JRTConnection> sources = getSources();
-        currentConnection = sources.get(ThreadLocalRandom.current().nextInt(0, sources.size()));
+        if (sources.size() <= 1) return currentConnection;
+
+        List<JRTConnection> healthySources = sources.stream()
+                                                    .filter(JRTConnection::isHealthy)
+                                                    .collect(Collectors.toList());
+        if (healthySources.size() == 0) {
+            log.log(Level.INFO, "No healthy sources, keep using " + currentConnection);
+            return currentConnection;
+        }
+        JRTConnection newConnection = pickNewConnectionRandomly(healthySources);
+        log.log(Level.INFO, () -> "Switching from " + currentConnection + " to " + newConnection);
+        return currentConnection = newConnection;
+    }
+
+    public synchronized JRTConnection initialize() {
+        List<JRTConnection> sources = getSources();
+        currentConnection = pickNewConnectionRandomly(sources);
         log.log(Level.INFO, () -> "Choosing new connection: " + currentConnection);
         return currentConnection;
+    }
+
+    private JRTConnection pickNewConnectionRandomly(List<JRTConnection> sources) {
+        return sources.get(ThreadLocalRandom.current().nextInt(0, sources.size()));
     }
 
     List<JRTConnection> getSources() {
@@ -96,7 +108,7 @@ public class JRTConnectionPool implements ConnectionPool {
     @Override
     public void setError(Connection connection, int errorCode) {
         connection.setError(errorCode);
-        setNewCurrentConnection();
+        switchConnection();
     }
 
     public JRTConnectionPool updateSources(List<String> addresses) {

--- a/config/src/test/java/com/yahoo/vespa/config/JRTConnectionPoolTest.java
+++ b/config/src/test/java/com/yahoo/vespa/config/JRTConnectionPoolTest.java
@@ -1,10 +1,11 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config;
 
 import com.yahoo.config.subscription.ConfigSourceSet;
 import org.junit.Test;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -25,11 +26,12 @@ public class JRTConnectionPoolTest {
     @Test
     public void test_random_selection_of_sourceBasicHashBasedSelection() {
         JRTConnectionPool sourcePool = new JRTConnectionPool(sources);
-        assertThat(sourcePool.toString(), is("Address: host0\nAddress: host1\nAddress: host2\n"));
+        assertEquals("host0,host1,host2",
+                     sourcePool.getSources().stream().map(JRTConnection::getAddress).collect(Collectors.joining(",")));
 
         Map<String, Integer> sourceOccurrences = new HashMap<>();
         for (int i = 0; i < 1000; i++) {
-            final String address = sourcePool.setNewCurrentConnection().getAddress();
+            final String address = sourcePool.switchConnection().getAddress();
             if (sourceOccurrences.containsKey(address)) {
                 sourceOccurrences.put(address, sourceOccurrences.get(address) + 1);
             } else {
@@ -57,7 +59,7 @@ public class JRTConnectionPoolTest {
 
         int count = 1000;
         for (int i = 0; i < count; i++) {
-            String address = sourcePool.setNewCurrentConnection().getAddress();
+            String address = sourcePool.switchConnection().getAddress();
             if (timesUsed.containsKey(address)) {
                 int times = timesUsed.get(address);
                 timesUsed.put(address, times + 1);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionUtil.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionUtil.java
@@ -79,7 +79,7 @@ public class FileDistributionUtil {
         public Connection getCurrent() { return null; }
 
         @Override
-        public Connection setNewCurrentConnection() { return null; }
+        public Connection switchConnection() { return null; }
 
         @Override
         public int getSize() { return 0; }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -127,7 +127,7 @@ public class FileReferenceDownloader {
                 return true;
             } else {
                 log.log(logLevel, "File reference '" + fileReference + "' not found at " + connection.getAddress());
-                connectionPool.setNewCurrentConnection();
+                connectionPool.switchConnection();
                 return false;
             }
         } else {

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -341,7 +341,7 @@ public class FileDownloaderTest {
         }
 
         @Override
-        public Connection setNewCurrentConnection() {
+        public Connection switchConnection() {
             return this;
         }
 


### PR DESCRIPTION
Consider only healthy sources (if there are any) when switching to
a new one due to failures.
Also log when connecting to a source.
