### PR TITLE
Never throttle failing of children on failed hosts

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailTester.java
@@ -114,7 +114,7 @@ public class NodeFailTester {
         return tester;
     }
 
-    public static NodeFailTester withTwoApplicationsOnDocker(int numberOfHosts) {
+    public static NodeFailTester withTwoApplications(int numberOfHosts) {
         NodeFailTester tester = new NodeFailTester();
 
         int nodesPerHost = 3;


### PR DESCRIPTION
I think this can only happen when manually failing host, but it's right action
in any case.

@freva