### PR TITLE
Havardpe/int8 cell cast

### DIFF
--- a/eval/src/apps/tensor_conformance/generate.cpp
+++ b/eval/src/apps/tensor_conformance/generate.cpp
@@ -342,7 +342,7 @@ void generate_lambda(TestBuilder &dst) {
 
 void generate_cell_cast(TestBuilder &dst) {
     for (const auto &layout: basic_layouts) {
-        GenSpec a = GenSpec::from_desc(layout).seq(N());
+        GenSpec a = GenSpec::from_desc(layout).seq(N(-100));
         auto from_cell_types = a.dims().empty() ? just_double : dst.full ? all_types : just_float;
         auto to_cell_types = a.dims().empty() ? just_double : all_types;
         for (auto a_ct: from_cell_types) {

--- a/eval/src/tests/tensor/onnx_wrapper/float_to_int8.onnx
+++ b/eval/src/tests/tensor/onnx_wrapper/float_to_int8.onnx
@@ -1,0 +1,12 @@
+float_to_int8.py:P
+
+inout"Cast*	
+to float_to_int8Z
+in
+
+
+b
+out
+
+
+B

--- a/eval/src/tests/tensor/onnx_wrapper/float_to_int8.py
+++ b/eval/src/tests/tensor/onnx_wrapper/float_to_int8.py
@@ -1,0 +1,23 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+import onnx
+from onnx import helper, TensorProto
+
+IN = helper.make_tensor_value_info('in', TensorProto.FLOAT, [7])
+OUT = helper.make_tensor_value_info('out', TensorProto.INT8, [7])
+
+nodes = [
+    helper.make_node(
+        'Cast',
+        ['in'],
+        ['out'],
+        to=getattr(TensorProto, 'INT8'),
+    ),
+]
+graph_def = helper.make_graph(
+    nodes,
+    'float_to_int8',
+    [IN],
+    [OUT],
+)
+model_def = helper.make_model(graph_def, producer_name='float_to_int8.py', opset_imports=[onnx.OperatorSetIdProto(version=13)])
+onnx.save(model_def, 'float_to_int8.onnx')


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
@arnej27959 FYI

It seems onnx runtime does the same as we do now; everything outside the int8 value range is undefined and may be assigned any value. Newer clang compilers also embrace this, but by auto-vectorizing using saturating instructions.

Current solution is to not enforce saturation on cell cast, but rather not test with values that are undefined and that may give different results based on compiler and optimization level.