### PR TITLE
Enable fastos backtrace for aarch64.

### DIFF
--- a/fastos/src/tests/backtracetest.cpp
+++ b/fastos/src/tests/backtracetest.cpp
@@ -6,7 +6,7 @@
 
 #include "tests.h"
 
-#if defined(__x86_64__) && defined(__linux__)
+#if (defined(__x86_64__) || defined(__aarch64__)) && defined(__linux__)
 class Tracker
 {
 private:

--- a/fastos/src/vespa/fastos/backtrace.c
+++ b/fastos/src/vespa/fastos/backtrace.c
@@ -1,7 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "backtrace.h"
 
-#if defined(__i386__) || defined(__clang__)
+#if defined(__i386__) || defined(__clang__) || defined(__aarch64__)
 // use GLIBC version, hope it works
 extern int backtrace(void **buffer, int size);
 #define HAVE_BACKTRACE


### PR DESCRIPTION
@baldersheim : please review
