### PR TITLE
Use owner's dimensions in BackedOverridableQueryProfile

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/DeclaredQueryProfileVariants.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/DeclaredQueryProfileVariants.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 public class DeclaredQueryProfileVariants {
 
-    private final Map<String, VariantQueryProfile> variantQueryProfiles =new LinkedHashMap<>();
+    private final Map<String, VariantQueryProfile> variantQueryProfiles = new LinkedHashMap<>();
 
     public DeclaredQueryProfileVariants(QueryProfile profile) {
         // Recreates the declared view (settings per set of dimensions)
@@ -67,26 +67,26 @@ public class DeclaredQueryProfileVariants {
         // having the variants
         for (Map.Entry<String,Object> entry : profile.declaredContent().entrySet()) {
             if ( ! (entry.getValue() instanceof QueryProfile)) continue;
-            QueryProfile subProfile=(QueryProfile)entry.getValue();
+            QueryProfile subProfile = (QueryProfile)entry.getValue();
             // Export if defined implicitly in this, or if this contains overrides
             if (!subProfile.isExplicit() || subProfile instanceof OverridableQueryProfile) {
-                String entryPrefix=prefix + entry.getKey() + ".";
-                dereferenceCompoundedVariants(subProfile.getVariants(),entryPrefix);
-                dereferenceCompoundedVariants(subProfile,entryPrefix);
+                String entryPrefix = prefix + entry.getKey() + ".";
+                dereferenceCompoundedVariants(subProfile.getVariants(), entryPrefix);
+                dereferenceCompoundedVariants(subProfile, entryPrefix);
             }
         }
 
-        if (profile.getVariants()==null) return;
+        if (profile.getVariants() == null) return;
         // We need to do the same dereferencing to overridables pointed to by variants of this
         for (Map.Entry<String,QueryProfileVariants.FieldValues> fieldValueEntry : profile.getVariants().getFieldValues().entrySet()) {
             for (QueryProfileVariants.FieldValue fieldValue : fieldValueEntry.getValue().asList()) {
                 if ( ! (fieldValue.getValue() instanceof QueryProfile)) continue;
-                QueryProfile subProfile=(QueryProfile)fieldValue.getValue();
+                QueryProfile subProfile = (QueryProfile)fieldValue.getValue();
                 // Export if defined implicitly in this, or if this contains overrides
                 if (!subProfile.isExplicit() || subProfile instanceof OverridableQueryProfile) {
-                    String entryPrefix=prefix + fieldValueEntry.getKey() + ".";
-                    dereferenceCompoundedVariants(subProfile.getVariants(),entryPrefix);
-                    dereferenceCompoundedVariants(subProfile,entryPrefix);
+                    String entryPrefix = prefix + fieldValueEntry.getKey() + ".";
+                    dereferenceCompoundedVariants(subProfile.getVariants(), entryPrefix);
+                    dereferenceCompoundedVariants(subProfile, entryPrefix);
                 }
             }
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/QueryProfiles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/QueryProfiles.java
@@ -65,12 +65,13 @@ public class QueryProfiles implements Serializable, QueryProfilesConfig.Producer
 
         if ( registry.getTypeRegistry().hasApplicationTypes() && registry.allComponents().isEmpty()) {
             logger.logApplicationPackage(Level.WARNING, "This application define query profile types, but has " +
-                                      "no query profiles referencing them so they have no effect. "  +
-                                      (tensorFields.isEmpty()
-                                       ? ""
-                                       : "In particular, the tensors (" + String.join(", ", tensorFields) +
-                                         ") will be interpreted as strings, not tensors if sent in requests. ") +
-                                      "See https://docs.vespa.ai/en/query-profiles.html");
+                                                        "no query profiles referencing them so they have no effect. "  +
+                                                        (tensorFields.isEmpty() ? ""
+                                                                                : "In particular, the tensors (" +
+                                                                                  String.join(", ", tensorFields) +
+                                                                                  ") will be interpreted as strings, " +
+                                                                                  "not tensors if sent in requests. ") +
+                                                        "See https://docs.vespa.ai/en/query-profiles.html");
         }
 
     }
@@ -100,7 +101,7 @@ public class QueryProfiles implements Serializable, QueryProfilesConfig.Producer
         for (QueryProfile inherited : profile.inherited())
             qB.inherit(inherited.getId().stringValue());
 
-        if (profile.getVariants()!=null) {
+        if (profile.getVariants() != null) {
             for (String dimension : profile.getVariants().getDimensions())
                 qB.dimensions(dimension);            
         }
@@ -180,7 +181,7 @@ public class QueryProfiles implements Serializable, QueryProfilesConfig.Producer
                 QueryProfilesConfig.Queryprofile.Queryprofilevariant.Reference.Builder refB = new QueryProfilesConfig.Queryprofile.Queryprofilevariant.Reference.Builder();
                 createVariantReferenceFieldConfig(refB, fullName, ((BackedOverridableQueryProfile) subProfile).getBacking().getId().stringValue());
                 qpB.reference(refB);
-                addVariantFieldChildren(qpB, subProfile,fullName + ".");
+                addVariantFieldChildren(qpB, subProfile, fullName + ".");
             }
         }
         else { // a primitive
@@ -208,7 +209,7 @@ public class QueryProfiles implements Serializable, QueryProfilesConfig.Producer
             }
             qB.queryprofilevariant(varB);
         }
-    }    
+    }
 
     private void createReferenceFieldConfig(QueryProfilesConfig.Queryprofile.Reference.Builder refB, QueryProfile profile,
             String fullName, String localName, String stringValue) {

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -947,10 +947,6 @@ public class ModelProvisioningTest {
         assertEquals("1|*", cluster.getRootGroup().getPartitions().get());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(2, cluster.getRootGroup().getSubgroups().size());
-        System.out.println("Nodes in group 0: ");
-        cluster.getRootGroup().getSubgroups().get(0).getNodes().forEach(n -> System.out.println("  " + n));
-        System.out.println("Nodes in group 1: ");
-        cluster.getRootGroup().getSubgroups().get(1).getNodes().forEach(n -> System.out.println("  " + n));
     }
 
     @Test
@@ -980,10 +976,6 @@ public class ModelProvisioningTest {
         assertEquals("1|*", cluster.getRootGroup().getPartitions().get());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(2, cluster.getRootGroup().getSubgroups().size());
-        System.out.println("Nodes in group 0: ");
-        cluster.getRootGroup().getSubgroups().get(0).getNodes().forEach(n -> System.out.println("  " + n));
-        System.out.println("Nodes in group 1: ");
-        cluster.getRootGroup().getSubgroups().get(1).getNodes().forEach(n -> System.out.println("  " + n));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/TensorFieldTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/TensorFieldTestCase.java
@@ -143,7 +143,6 @@ public class TensorFieldTestCase {
 
     private void assertHnswIndexParams(String indexSpec, int maxLinksPerNode, int neighborsToExploreAtInsert) throws ParseException {
         var sd = getSdWithIndexSpec(indexSpec);
-        System.out.println(sd);
         var search = createFromString(sd).getSearch();
         var attr = search.getAttribute("t1");
         var params = attr.hnswIndexParams();

--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
@@ -90,7 +90,6 @@ public class ModelEvaluationTest {
         RankProfilesConfig.Builder b = new RankProfilesConfig.Builder();
         cluster.getConfig(b);
         RankProfilesConfig config = new RankProfilesConfig(b);
-        // System.out.println(config);
 
         RankingConstantsConfig.Builder cb = new RankingConstantsConfig.Builder();
         cluster.getConfig(cb);

--- a/container-search/src/main/java/com/yahoo/search/federation/FederationSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/federation/FederationSearcher.java
@@ -303,7 +303,6 @@ public class FederationSearcher extends ForkingSearcher {
                 Object value = getSourceOrProviderProperty(original, key, sourceName, providerName, window.get(key));
                 if (value != null)
                     outgoing.properties().set(key, value);
-                if (value != null) System.out.println("Setting " + key + " = " + value);
             }
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/BackedOverridableQueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/BackedOverridableQueryProfile.java
@@ -31,7 +31,7 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
      * @param backingProfile the backing profile, which is assumed read only, never null
      */
     public BackedOverridableQueryProfile(QueryProfile backingProfile) {
-        Validator.ensureNotNull("An overridable query profile must be backed by a real query profile",backingProfile);
+        Validator.ensureNotNull("An overridable query profile must be backed by a real query profile", backingProfile);
         setType(backingProfile.getType());
         this.backingProfile = backingProfile;
     }
@@ -49,7 +49,7 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
     protected Object localLookup(String localName, DimensionBinding dimensionBinding) {
         Object valueInThis = super.localLookup(localName, dimensionBinding);
         if (valueInThis != null) return valueInThis;
-        return backingProfile.localLookup(localName, dimensionBinding);
+        return backingProfile.localLookup(localName, dimensionBinding.createFor(backingProfile.getDimensions()));
     }
 
     protected Boolean isLocalInstanceOverridable(String localName) {
@@ -88,17 +88,17 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
     }
 
     @Override
-    protected void visitVariants(boolean allowContent,QueryProfileVisitor visitor,DimensionBinding dimensionBinding) {
+    protected void visitVariants(boolean allowContent, QueryProfileVisitor visitor, DimensionBinding dimensionBinding) {
         super.visitVariants(allowContent, visitor, dimensionBinding);
         if (visitor.isDone()) return;
-        backingProfile.visitVariants(allowContent, visitor, dimensionBinding);
+        backingProfile.visitVariants(allowContent, visitor, dimensionBinding.createFor(backingProfile.getDimensions()));
     }
 
     @Override
     protected void visitInherited(boolean allowContent, QueryProfileVisitor visitor, DimensionBinding dimensionBinding, QueryProfile owner) {
         super.visitInherited(allowContent, visitor, dimensionBinding, owner);
         if (visitor.isDone()) return;
-        backingProfile.visitInherited(allowContent, visitor, dimensionBinding,owner);
+        backingProfile.visitInherited(allowContent, visitor, dimensionBinding.createFor(backingProfile.getDimensions()), owner);
     }
 
     /** Returns a value from the content of this: The value in this, or the value from the backing if not set in this */
@@ -113,12 +113,12 @@ public class BackedOverridableQueryProfile extends OverridableQueryProfile imple
      * All the values in this, and all values in the backing where an overriding value is not set in this
      */
     @Override
-    protected Map<String,Object> getContent() {
-        Map<String,Object> thisContent=super.getContent();
-        Map<String,Object> backingContent=backingProfile.getContent();
+    protected Map<String, Object> getContent() {
+        Map<String,Object> thisContent = super.getContent();
+        Map<String,Object> backingContent = backingProfile.getContent();
         if (thisContent.isEmpty()) return backingContent; // Shortcut
         if (backingContent.isEmpty()) return thisContent; // Shortcut
-        Map<String,Object> content=new HashMap<>(backingContent);
+        Map<String, Object> content = new HashMap<>(backingContent);
         content.putAll(thisContent);
         return content;
     }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfile.java
@@ -604,7 +604,7 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
     }
 
     /** Sets the value of a node in <i>this</i> profile - the local name given must not be nested (contain dots) */
-    protected QueryProfile setLocalNode(String localName, Object value,QueryProfileType parentType,
+    protected QueryProfile setLocalNode(String localName, Object value, QueryProfileType parentType,
                                         DimensionBinding dimensionBinding, QueryProfileRegistry registry) {
         if (parentType != null && type == null && ! isFrozen())
             type = parentType;
@@ -622,9 +622,10 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
     static Object combineValues(Object newValue, Object existingValue) {
         if (newValue instanceof QueryProfile) {
             QueryProfile newProfile = (QueryProfile)newValue;
-            if ( existingValue == null || ! (existingValue instanceof QueryProfile)) {
-                if (!isModifiable(newProfile))
+            if ( ! (existingValue instanceof QueryProfile)) {
+                if ( ! isModifiable(newProfile)) {
                     newProfile = new BackedOverridableQueryProfile(newProfile); // Make the query profile reference overridable
+                }
                 newProfile.value = existingValue;
                 return newProfile;
             }
@@ -829,7 +830,6 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
         validateName(localName);
         value = convertToSubstitutionString(value);
 
-
         if (dimensionBinding.isNull()) {
             Object combinedValue = value instanceof QueryProfile
                                    ? combineValues(value, content == null ? null : content.get(localName))
@@ -838,9 +838,8 @@ public class QueryProfile extends FreezableSimpleComponent implements Cloneable 
                 content.put(localName, combinedValue);
         }
         else {
-            if (variants == null) {
+            if (variants == null)
                 variants = new QueryProfileVariants(dimensionBinding.getDimensions(), this);
-            }
             variants.set(localName, dimensionBinding.getValues(), value);
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileVariant.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileVariant.java
@@ -37,7 +37,7 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
      * Returns the live reference to the values of this. This may be modified
      * if this is not frozen.
      */
-    public Map<String,Object> values() {
+    public Map<String, Object> values() {
         if (values == null) {
             if (frozen)
                 return Collections.emptyMap();
@@ -68,6 +68,8 @@ public class QueryProfileVariant implements Cloneable, Comparable<QueryProfileVa
         Object oldValue = values.get(key);
 
         Object combinedOrNull = QueryProfile.combineValues(newValue, oldValue);
+        if (combinedOrNull instanceof BackedOverridableQueryProfile) // Use the owner's, not the referenced dimensions
+            ((QueryProfile) combinedOrNull).setDimensions(owner.getDimensions().toArray(new String[0]));
         if (combinedOrNull != null)
             values.put(key, combinedOrNull);
         return combinedOrNull;


### PR DESCRIPTION
Use owner's dimensions rather than the backed's in
BackedObverridableQueryProfile. This matters when a profile
references a profile with different but overlapping dimensions
and both the owner and referred profile assigns values for
the same paths, within their respective dimension spaces.
