### PR TITLE
Use int for FastOS_UNIX_Application::GetOpt() return value.

### DIFF
--- a/vespalib/src/tests/btree/iteratespeed.cpp
+++ b/vespalib/src/tests/btree/iteratespeed.cpp
@@ -136,7 +136,7 @@ int
 IterateSpeed::Main()
 {
     int argi;
-    char c;
+    int c;
     const char *optArg;
     argi = 1;
     int loops = 1;


### PR DESCRIPTION
@baldersheim : please review
