### PR TITLE
Revert "Use exact Protobuf version as dependency"

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -69,11 +69,7 @@ BuildRequires: vespa-icu-devel >= 65.1.0-1
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
 BuildRequires: vespa-onnxruntime-devel = 1.7.1
 BuildRequires: vespa-openssl-devel >= 1.1.1k-1
-%if 0%{?centos}
-BuildRequires: vespa-protobuf-devel = 3.7.0-4
-%else
-BuildRequires: vespa-protobuf-devel = 3.7.0-5
-%endif
+BuildRequires: vespa-protobuf-devel >= 3.7.0-4
 BuildRequires: vespa-libzstd-devel >= 1.4.5-2
 %endif
 %if 0%{?el8}
@@ -88,7 +84,7 @@ BuildRequires: openssl-devel
 BuildRequires: vespa-gtest >= 1.8.1-1
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
 BuildRequires: vespa-onnxruntime-devel = 1.7.1
-BuildRequires: vespa-protobuf-devel = 3.7.0-5
+BuildRequires: vespa-protobuf-devel >= 3.7.0-4
 BuildRequires: vespa-libzstd-devel >= 1.4.5-2
 %endif
 %if 0%{?fedora}
@@ -191,11 +187,7 @@ Requires: vespa-icu >= 65.1.0-1
 Requires: vespa-lz4 >= 1.9.2-2
 Requires: vespa-onnxruntime = 1.7.1
 Requires: vespa-openssl >= 1.1.1k-1
-%if 0%{?centos}
-Requires: vespa-protobuf = 3.7.0-4
-%else
-Requires: vespa-protobuf = 3.7.0-5
-%endif
+Requires: vespa-protobuf >= 3.7.0-4
 Requires: vespa-telegraf >= 1.1.1-1
 Requires: vespa-valgrind >= 3.16.0-1
 Requires: vespa-zstd >= 1.4.5-2
@@ -214,7 +206,7 @@ Requires: llvm-libs >= 10.0.1
 Requires: openssl-libs
 Requires: vespa-lz4 >= 1.9.2-2
 Requires: vespa-onnxruntime = 1.7.1
-Requires: vespa-protobuf = 3.7.0-5
+Requires: vespa-protobuf >= 3.7.0-4
 Requires: vespa-zstd >= 1.4.5-2
 %define _extra_link_directory %{_vespa_deps_prefix}/lib64
 %define _extra_include_directory %{_vespa_deps_prefix}/include;/usr/include/openblas


### PR DESCRIPTION
Reverts vespa-engine/vespa#17636

Build fails with:
 09:46:06 + rpmbuild -bb '--define=_topdir /sd/workspace/src/git.vzbuilders.com/vespa/vespa-rpmbuild' '--define=installdir /sd/workspace/src/git.vzbuilders.com/vespa/vespa-installdir' '--define=_debugsource_template %{nil}' vespa-7.397.11.spec
09:46:06 error: Failed build dependencies:
09:46:06 	vespa-protobuf-devel = 3.7.0-5 is needed by vespa-7.397.11-1.el7.x86_64