### PR TITLE
Revert "Support loadbalancer/v1 and application/v2/tenant without trailing slash"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/TenantHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/TenantHandler.java
@@ -93,7 +93,6 @@ public class TenantHandler extends HttpHandler {
 
     private static BindingMatch<?> getBindingMatch(HttpRequest request) {
         return HttpConfigRequests.getBindingMatch(request,
-                "http://*/application/v2/tenant",
                 "http://*/application/v2/tenant/",
                 "http://*/application/v2/tenant/*");
     }
@@ -104,7 +103,7 @@ public class TenantHandler extends HttpHandler {
 
     private static boolean isListTenantsRequest(HttpRequest request) {
         return getBindingMatch(request).groupCount() == 2 &&
-                request.getUri().getPath().matches("/application/v2/tenant/?");
+                request.getUri().getPath().endsWith("/tenant/");
     }
 
     private static TenantName getTenantNameFromRequest(HttpRequest request) {

--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -102,7 +102,8 @@
       <binding>http://*/status</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.TenantHandler' bundle='configserver'>
-      <binding>http://*/application/v2/tenant*</binding>
+      <binding>http://*/application/v2/tenant/</binding>
+      <binding>http://*/application/v2/tenant/*</binding>
     </handler>
     <handler id='com.yahoo.vespa.config.server.http.v2.SessionCreateHandler' bundle='configserver'>
       <binding>http://*/application/v2/tenant/*/session</binding>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TenantHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/TenantHandlerTest.java
@@ -102,9 +102,6 @@ public class TenantHandlerTest {
         assertResponseEquals((ListTenantsResponse) handler.handleGET(
                 HttpRequest.createTestRequest("http://deploy.example.yahoo.com:80/application/v2/tenant/", Method.GET)),
                 "{\"tenants\":[\"default\",\"a\"]}");
-        assertResponseEquals((ListTenantsResponse) handler.handleGET(
-                HttpRequest.createTestRequest("http://deploy.example.yahoo.com:80/application/v2/tenant", Method.GET)),
-                             "{\"tenants\":[\"default\",\"a\"]}");
     }
 
     @Test(expected=BadRequestException.class)

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/application/BindingSetTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/application/BindingSetTestCase.java
@@ -249,7 +249,7 @@ public class BindingSetTestCase {
         handlers.put(new UriPattern("http://*/config/v1/*/"), foo1);
         handlers.put(new UriPattern("http://*/config/v1/*/*"), foo2);
         handlers.put(new UriPattern("http://*/config/v1/*/*/"), foo3);
-        handlers.put(new UriPattern("http://*/application/v2/tenant*"), foo4);
+        handlers.put(new UriPattern("http://*/application/v2/tenant/"), foo4);
         handlers.put(new UriPattern("http://*/application/v2/tenant/*"), foo5);
         handlers.put(new UriPattern("http://*/application/v2/tenant/*/session"), foo6);
         handlers.put(new UriPattern("http://*/application/v2/tenant/*/session/*/prepared"), foo7);
@@ -276,7 +276,7 @@ public class BindingSetTestCase {
         assertSame(foo3, bindings.resolve(URI.create("http://abcxyz.yahoo.com:19071" +
                 "/config/v1/cloud.config.log.logd/admin/")));
         assertSame(foo4, bindings.resolve(URI.create("http://abcxyz.yahoo.com:19071" +
-                "/application/v2/tenant")));
+                "/application/v2/tenant/")));
         assertSame(foo5, bindings.resolve(URI.create("http://abcxyz.yahoo.com:19071" +
                 "/application/v2/tenant/b")));
         assertSame(foo6, bindings.resolve(URI.create("http://abcxyz.yahoo.com:19071" +

--- a/node-repository/src/main/config/node-repository.xml
+++ b/node-repository/src/main/config/node-repository.xml
@@ -14,7 +14,6 @@
 </handler>
 
 <handler id="com.yahoo.vespa.hosted.provision.restapi.LoadBalancersV1ApiHandler" bundle="node-repository">
-    <binding>http://*/loadbalancers/v1</binding>
     <binding>http://*/loadbalancers/v1/*</binding>
 </handler>
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiHandler.java
@@ -1,37 +1,53 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.restapi;
 
+import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;
-import com.yahoo.restapi.RestApi;
-import com.yahoo.restapi.RestApiRequestHandler;
+import com.yahoo.restapi.ErrorResponse;
+import com.yahoo.vespa.hosted.provision.NoSuchNodeException;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.yolean.Exceptions;
 
 import javax.inject.Inject;
+import java.util.logging.Level;
 
 /**
  * @author mpolden
- * @author jonmv
  */
-public class LoadBalancersV1ApiHandler extends RestApiRequestHandler<LoadBalancersV1ApiHandler> {
+public class LoadBalancersV1ApiHandler extends LoggingRequestHandler {
 
     private final NodeRepository nodeRepository;
 
     @Inject
     public LoadBalancersV1ApiHandler(LoggingRequestHandler.Context parentCtx, NodeRepository nodeRepository) {
-        super(parentCtx, LoadBalancersV1ApiHandler::createRestApiDefinition);
+        super(parentCtx);
         this.nodeRepository = nodeRepository;
     }
 
-    private static RestApi createRestApiDefinition(LoadBalancersV1ApiHandler self) {
-        return RestApi.builder()
-                      .addRoute(RestApi.route("/loadbalancers/v1")
-                                       .get(self::getLoadBalancers))
-                      .build();
+    @Override
+    public HttpResponse handle(HttpRequest request) {
+        try {
+            switch (request.getMethod()) {
+                case GET: return handleGET(request);
+                default: return ErrorResponse.methodNotAllowed("Method '" + request.getMethod() + "' is not supported");
+            }
+        }
+        catch (NotFoundException | NoSuchNodeException e) {
+            return ErrorResponse.notFoundError(Exceptions.toMessageString(e));
+        }
+        catch (IllegalArgumentException e) {
+            return ErrorResponse.badRequest(Exceptions.toMessageString(e));
+        }
+        catch (RuntimeException e) {
+            log.log(Level.WARNING, "Unexpected error handling '" + request.getUri() + "'", e);
+            return ErrorResponse.internalServerError(Exceptions.toMessageString(e));
+        }
     }
 
-    private HttpResponse getLoadBalancers(RestApi.RequestContext context) {
-        return new LoadBalancersResponse(context.request(), nodeRepository);
+    private HttpResponse handleGET(HttpRequest request) {
+        String path = request.getUri().getPath();
+        if (path.equals("/loadbalancers/v1/")) return new LoadBalancersResponse(request, nodeRepository);
+        throw new NotFoundException("Nothing at path '" + path + "'");
     }
-
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
@@ -33,10 +33,10 @@ public class ContainerConfig {
                "  <component id='com.yahoo.vespa.flags.InMemoryFlagSource'/>\n" +
                "  <component id='com.yahoo.config.provision.Zone'/>\n" +
                "  <handler id='com.yahoo.vespa.hosted.provision.restapi.NodesV2ApiHandler'>\n" +
-               "    <binding>http://*/nodes/v2*</binding>\n" +
+               "    <binding>http://*/nodes/v2/*</binding>\n" +
                "  </handler>\n" +
                "  <handler id='com.yahoo.vespa.hosted.provision.restapi.LoadBalancersV1ApiHandler'>\n" +
-               "    <binding>http://*/loadbalancers/v1*</binding>\n" +
+               "    <binding>http://*/loadbalancers/v1/*</binding>\n" +
                "  </handler>\n" +
                "  <http>\n" +
                "    <server id='myServer' port='" + port + "'/>\n" +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiTest.java
@@ -22,7 +22,6 @@ public class LoadBalancersV1ApiTest {
 
     @Test
     public void test_load_balancers() throws Exception {
-        tester.assertFile(new Request("http://localhost:8080/loadbalancers/v1"), "load-balancers.json");
         tester.assertFile(new Request("http://localhost:8080/loadbalancers/v1/"), "load-balancers.json");
         tester.assertFile(new Request("http://localhost:8080/loadbalancers/v1/?application=tenant4.application4.instance4"), "load-balancers-single.json");
         tester.assertResponse(new Request("http://localhost:8080/loadbalancers/v1/?application=tenant.nonexistent.default"), "{\"loadBalancers\":[]}");


### PR DESCRIPTION
Reverts vespa-engine/vespa#17658

Lots of broken system tests:
[14:18:07.672] 3da3f02f$ vespa-deploy -e mergingmaxnodestest -a test_merge_max_nodes__proton prepare /tmp/vespa-systemtests/artifacts/tmp/systemtests/MergingMaxNodesTest/merge_max_nodes__PROTON/2021-04-29T14-14-26/pid.2899/generatedapp
[14:18:10.000] Uploading application '/tmp/vespa-systemtests/artifacts/tmp/systemtests/MergingMaxNodesTest/merge_max_nodes__PROTON/2021-04-29T14-14-26/pid.2899/generatedapp' using http://3d281049.systemtest.vespa-vespa-factory.gq2.ows.oath.cloud:19071/application/v2/tenant/mergingmaxnodestest/session
[14:18:10.000] HTTP request failed with curl exit code 0
[14:18:10.000] Retrying with another config server


I guess something should be done to expose the error in the system test framework as well...