### PR TITLE
Add explicit casts to char, to avoid warning when char is unsigned.

### DIFF
--- a/searchlib/src/tests/aggregator/perdocexpr.cpp
+++ b/searchlib/src/tests/aggregator/perdocexpr.cpp
@@ -319,7 +319,7 @@ TEST("testNegate") {
     testNegate(FloatResultNode(67.0), FloatResultNode(-67.0));
 
     char strnorm[4] = { 102, 111, 111, 0 };
-    char strneg[4] = { -102, -111, -111, 0 };
+    char strneg[4] = { (char)-102, (char)-111, (char)-111, 0 };
     testNegate(StringResultNode(strnorm), StringResultNode(strneg));
     testNegate(RawResultNode(strnorm, 3), RawResultNode(strneg, 3));
 }

--- a/searchlib/src/tests/groupingengine/groupingengine_test.cpp
+++ b/searchlib/src/tests/groupingengine/groupingengine_test.cpp
@@ -311,7 +311,7 @@ Test::testAggregationSimple()
     ctx.add(FloatAttrBuilder("float").add(3).add(7).add(15).sp());
     ctx.add(StringAttrBuilder("string").add("3").add("7").add("15").sp());
 
-    char strsum[3] = {-101, '5', 0};
+    char strsum[3] = {(char)-101, '5', 0};
     testAggregationSimpleSum(ctx, SumAggregationResult(), Int64ResultNode(25), FloatResultNode(25), StringResultNode(strsum));
     testAggregationSimpleSum(ctx, MinAggregationResult(), Int64ResultNode(3), FloatResultNode(3), StringResultNode("15"));
     testAggregationSimpleSum(ctx, MaxAggregationResult(), Int64ResultNode(15), FloatResultNode(15), StringResultNode("7"));


### PR DESCRIPTION
@baldersheim : please review
