### PR TITLE
- Use the enum batch updater directly. This avoids a temporary map an…

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -6,7 +6,6 @@
 #include "loadedenumvalue.h"
 #include "enumstore.h"
 #include "no_loaded_vector.h"
-#include <set>
 
 namespace search {
 
@@ -24,25 +23,18 @@ class EnumAttribute : public B
 protected:
     using BaseClass = B;
     using Change = typename B::Change;
-    using ChangeDataType = typename B::Change::DataType;
     using ChangeVector = typename B::ChangeVector;
-    using ChangeVectorIterator = typename B::ChangeVector::const_iterator;
     using DocId = typename B::DocId;
     using EnumEntryType = typename B::EnumEntryType;  // Template argument for enum store
     using EnumHandle = typename B::EnumHandle;
-    using EnumModifier = typename B::EnumModifier;
     using ValueModifier = typename B::ValueModifier;
 
 public:
-    using EnumIndexVector = typename B::EnumIndexVector;
     using EnumVector = typename B::EnumVector;
-    using LoadedValueType = typename B::LoadedValueType;
     using LoadedVector = typename B::LoadedVector;
 
 protected:
     using generation_t = typename B::generation_t;
-    using UniqueSet = std::set<ChangeDataType>;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using B::getGenerationHolder;
     using B::getStatus;
 
@@ -52,7 +44,6 @@ public:
 
 protected:
     using EnumIndex = IEnumStore::Index;
-    using EnumIndexRemapper = IEnumStore::EnumIndexRemapper;
 
     EnumStore _enumStore;
 
@@ -71,7 +62,7 @@ protected:
      * Perform compaction if necessary and insert the new unique values into the EnumStore.
      */
     void insertNewUniqueValues(EnumStoreBatchUpdater& updater);
-    virtual void considerAttributeChange(const Change & c, UniqueSet & newUniques) = 0;
+    virtual void considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) = 0;
     vespalib::MemoryUsage getEnumStoreValuesMemoryUsage() const override;
     vespalib::AddressSpace getEnumStoreAddressSpaceUsage() const override;
 public:

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -28,7 +28,7 @@ void EnumAttribute<B>::load_enum_store(LoadedVector& loaded)
         auto loader = _enumStore.make_non_enumerated_loader();
         if (!loaded.empty()) {
             auto value = loaded.read();
-            LoadedValueType prev = value.getValue();
+            typename B::LoadedValueType prev = value.getValue();
             uint32_t prevRefCount(0);
             EnumIndex index = loader.insert(value.getValue(), value._pidx.ref());
             for (size_t i(0), m(loaded.size()); i < m; ++i, loaded.next()) {
@@ -62,16 +62,9 @@ template <typename B>
 void
 EnumAttribute<B>::insertNewUniqueValues(EnumStoreBatchUpdater& updater)
 {
-    UniqueSet newUniques;
-
-    // find new unique strings
+    // find and insert new unique strings
     for (const auto & data : this->_changes) {
-        considerAttributeChange(data, newUniques);
-    }
-
-    // insert new unique values in EnumStore
-    for (const auto & data : newUniques) {
-        updater.insert(data.raw());
+        considerAttributeChange(data, updater);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.h
@@ -43,21 +43,15 @@ protected:
     using Change = typename B::BaseClass::Change;
     using DocId = typename B::BaseClass::DocId;
     using EnumHandle = typename B::BaseClass::EnumHandle;
-    using EnumModifier = typename B::BaseClass::EnumModifier;
     using LoadedVector = typename B::BaseClass::LoadedVector;
-    using UniqueSet = typename B::UniqueSet;
     using ValueModifier = typename B::BaseClass::ValueModifier;
     using WeightedEnum = typename B::BaseClass::WeightedEnum;
     using generation_t = typename B::BaseClass::generation_t;
 
     using DocIndices = typename MultiValueAttribute<B, M>::DocumentValues;
     using EnumIndex = IEnumStore::Index;
-    using EnumIndexRemapper = IEnumStore::EnumIndexRemapper;
-    using EnumIndexVector = IEnumStore::IndexVector;
     using EnumStoreBatchUpdater = typename B::EnumStoreBatchUpdater;
     using EnumVector = IEnumStore::EnumVector;
-    using LoadedEnumAttribute = attribute::LoadedEnumAttribute;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using WeightedIndex = typename MultiValueAttribute<B, M>::MultiValueType;
     using WeightedIndexArrayRef = typename MultiValueAttribute<B, M>::MultiValueArrayRef;
     using WeightedIndexVector = typename MultiValueAttribute<B, M>::ValueVector;
@@ -66,7 +60,7 @@ protected:
     bool extractChangeData(const Change & c, EnumIndex & idx) override; // EnumIndex is ValueType. Use EnumStore
 
     // from EnumAttribute
-    void considerAttributeChange(const Change & c, UniqueSet & newUniques) override; // same for both string and numeric
+    void considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) override; // same for both string and numeric
 
     virtual void applyValueChanges(const DocIndices& docIndices, EnumStoreBatchUpdater& updater);
 

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@@ -34,7 +34,7 @@ MultiValueEnumAttribute<B, M>::extractChangeData(const Change & c, EnumIndex & i
 
 template <typename B, typename M>
 void
-MultiValueEnumAttribute<B, M>::considerAttributeChange(const Change & c, UniqueSet & newUniques)
+MultiValueEnumAttribute<B, M>::considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter)
 {
     if (c._type == ChangeBase::APPEND ||
         (this->getInternalCollectionType().createIfNonExistant() &&
@@ -42,7 +42,7 @@ MultiValueEnumAttribute<B, M>::considerAttributeChange(const Change & c, UniqueS
     {
         EnumIndex idx;
         if (!this->_enumStore.find_index(c._data.raw(), idx)) {
-            newUniques.insert(c._data);
+            c._enumScratchPad = inserter.insert(c._data.raw()).ref();
         } else {
             c._enumScratchPad = idx.ref();
         }

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
@@ -25,10 +25,7 @@ protected:
     using DocId = typename B::BaseClass::DocId;
     using EnumHandle = typename B::BaseClass::EnumHandle;
     using EnumIndex = IEnumStore::Index;
-    using EnumIndexVector = IEnumStore::IndexVector;
     using EnumVector = IEnumStore::EnumVector;
-    using LoadedEnumAttribute = attribute::LoadedEnumAttribute;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using LoadedNumericValueT = typename B::BaseClass::LoadedNumericValueT;
     using LoadedVector = typename B::BaseClass::LoadedVector;
     using LoadedVectorR = SequentialReadModifyWriteVector<LoadedNumericValueT>;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -61,7 +61,6 @@ private:
     using DocId = typename B::DocId;
     using DocIndices = typename MultiValueNumericEnumAttribute<B, M>::DocIndices;
     using FrozenDictionary = typename Dictionary::FrozenView;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using Posting = typename PostingParent::Posting;
     using PostingList = typename PostingParent::PostingList;
     using PostingMap = typename PostingParent::PostingMap;

--- a/searchlib/src/vespa/searchlib/attribute/multistringattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringattribute.h
@@ -26,7 +26,6 @@ template <typename B, typename M>
 class MultiValueStringAttributeT : public MultiValueEnumAttribute<B, M> {
 protected:
     using DocIndices = typename MultiValueAttribute<B, M>::DocumentValues;
-    using EnumHintSearchContext = attribute::EnumHintSearchContext;
     using EnumIndex = typename MultiValueAttribute<B, M>::ValueType;
     using EnumStore = typename B::EnumStore;
     using MultiValueMapping = typename MultiValueAttribute<B, M>::MultiValueMapping;
@@ -150,7 +149,7 @@ public:
 
     template <typename BT>
     class StringTemplSearchContext : public BT,
-                                     public EnumHintSearchContext
+                                     public attribute::EnumHintSearchContext
     {
         using BT::queryTerm;
         using AttrType = MultiValueStringAttributeT<B, M>;

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -50,7 +50,6 @@ private:
     using ComparatorType = typename EnumStore::ComparatorType;
     using DocId = typename MultiValueStringAttributeT<B, T>::DocId;
     using DocIndices = typename MultiValueStringAttributeT<B, T>::DocIndices;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using Posting = typename PostingParent::Posting;
     using PostingMap = typename PostingParent::PostingMap;
     using QueryTermSimpleUP = AttributeVector::QueryTermSimpleUP;

--- a/searchlib/src/vespa/searchlib/attribute/numericbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/numericbase.cpp
@@ -10,8 +10,6 @@ namespace search {
 
 IMPLEMENT_IDENTIFIABLE_ABSTRACT(NumericAttribute, AttributeVector);
 
-using attribute::LoadedEnumAttributeVector;
-
 void
 NumericAttribute::load_enumerated_data(ReaderBase&,
                                        enumstore::EnumeratedPostingsLoader&,

--- a/searchlib/src/vespa/searchlib/attribute/numericbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/numericbase.h
@@ -16,7 +16,6 @@ class NumericAttribute : public AttributeVector
 {
 protected:
     typedef IEnumStore::Index       EnumIndex;
-    typedef IEnumStore::IndexVector EnumIndexVector;
     typedef IEnumStore::EnumVector  EnumVector;
 
     NumericAttribute(const vespalib::string & name, const AttributeVector::Config & cfg)

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
@@ -43,7 +43,6 @@ protected:
     using DocId = AttributeVector::DocId;
     using EntryRef = vespalib::datastore::EntryRef;
     using EnumIndex = IEnumStore::Index;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using PostingList = typename AggregationTraits::PostingList;
     using PostingMap = std::map<EnumPostingPair, PostingChange<P> >;
 
@@ -87,7 +86,6 @@ public:
     using EnumIndex = IEnumStore::Index;
     using EnumStore = EnumStoreType;
     using ComparatorType = typename EnumStore::ComparatorType;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using PostingList = typename Parent::PostingList;
     using PostingMap = typename Parent::PostingMap;
 

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
@@ -45,16 +45,10 @@ class SingleValueEnumAttribute : public B, public SingleValueEnumAttributeBase {
 protected:
     using Change = typename B::Change;
     using ChangeVector = typename B::ChangeVector;
-    using ChangeVectorIterator = typename B::ChangeVector::const_iterator;
     using DocId = typename B::DocId;
-    using EnumIndexRemapper = IEnumStore::EnumIndexRemapper;
-    using EnumModifier = typename B::EnumModifier;
     using EnumStore = typename B::EnumStore;
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
-    using LoadedEnumAttribute = attribute::LoadedEnumAttribute;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using LoadedVector = typename B::LoadedVector;
-    using UniqueSet = typename B::UniqueSet;
     using ValueModifier = typename B::ValueModifier;
     using WeightedEnum = typename B::WeightedEnum;
     using generation_t = typename B::generation_t;
@@ -62,16 +56,16 @@ protected:
     using B::getGenerationHolder;
 
 private:
-    void considerUpdateAttributeChange(const Change & c, UniqueSet & newUniques);
+    void considerUpdateAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter);
     void applyUpdateValueChange(const Change& c, EnumStoreBatchUpdater& updater);
 
 protected:
     // from EnumAttribute
-    void considerAttributeChange(const Change & c, UniqueSet & newUniques) override;
+    void considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) override;
 
     // implemented by single value numeric enum attribute.
     virtual void considerUpdateAttributeChange(const Change & c) { (void) c; }
-    virtual void considerArithmeticAttributeChange(const Change & c, UniqueSet & newUniques) { (void) c; (void) newUniques; }
+    virtual void considerArithmeticAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) { (void) c; (void) inserter; }
 
     virtual void applyValueChanges(EnumStoreBatchUpdater& updater) ;
     virtual void applyArithmeticValueChange(const Change& c, EnumStoreBatchUpdater& updater) {

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -135,26 +135,28 @@ SingleValueEnumAttribute<B>::onUpdateStat()
 
 template <typename B>
 void
-SingleValueEnumAttribute<B>::considerUpdateAttributeChange(const Change & c, UniqueSet & newUniques)
+SingleValueEnumAttribute<B>::considerUpdateAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter)
 {
     EnumIndex idx;
     if (!this->_enumStore.find_index(c._data.raw(), idx)) {
-        newUniques.insert(c._data);
+        c._enumScratchPad = inserter.insert(c._data.raw()).ref();
+    } else {
+        c._enumScratchPad = idx.ref();
     }
     considerUpdateAttributeChange(c); // for numeric
 }
 
 template <typename B>
 void
-SingleValueEnumAttribute<B>::considerAttributeChange(const Change & c, UniqueSet & newUniques)
+SingleValueEnumAttribute<B>::considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter)
 {
     if (c._type == ChangeBase::UPDATE) {
-        considerUpdateAttributeChange(c, newUniques);
+        considerUpdateAttributeChange(c, inserter);
     } else if (c._type >= ChangeBase::ADD && c._type <= ChangeBase::DIV) {
-        considerArithmeticAttributeChange(c, newUniques); // for numeric
+        considerArithmeticAttributeChange(c, inserter); // for numeric
     } else if (c._type == ChangeBase::CLEARDOC) {
         this->_defaultValue._doc = c._doc;
-        considerUpdateAttributeChange(this->_defaultValue, newUniques);
+        considerUpdateAttributeChange(this->_defaultValue, inserter);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
@@ -22,16 +22,12 @@ protected:
     using DocId = typename B::BaseClass::DocId;
     using EnumHandle = typename B::BaseClass::EnumHandle;
     using EnumIndex = typename SingleValueEnumAttributeBase::EnumIndex;
-    using EnumIndexVector = IEnumStore::IndexVector;
     using EnumStore = typename SingleValueEnumAttribute<B>::EnumStore;
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
     using EnumVector = IEnumStore::EnumVector;
-    using LoadedEnumAttribute = attribute::LoadedEnumAttribute;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using LoadedNumericValueT = typename B::BaseClass::LoadedNumericValueT;
     using LoadedVector = typename B::BaseClass::LoadedVector;
     using QueryTermSimpleUP = AttributeVector::QueryTermSimpleUP;
-    using UniqueSet = typename SingleValueEnumAttribute<B>::UniqueSet;
     using Weighted = typename B::BaseClass::Weighted;
     using WeightedFloat = typename B::BaseClass::WeightedFloat;
     using WeightedInt = typename B::BaseClass::WeightedInt;
@@ -46,7 +42,7 @@ protected:
 
     // from SingleValueEnumAttribute
     void considerUpdateAttributeChange(const Change & c) override;
-    void considerArithmeticAttributeChange(const Change & c, UniqueSet & newUniques) override;
+    void considerArithmeticAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) override;
     void applyArithmeticValueChange(const Change& c, EnumStoreBatchUpdater& updater) override;
 
     /*

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.h
@@ -43,7 +43,6 @@ private:
     using ComparatorType = typename EnumStore::ComparatorType;
     using DocId = typename B::BaseClass::DocId;
     using EnumIndex = typename SingleValueEnumAttributeBase::EnumIndex;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using PostingMap = typename PostingParent::PostingMap;
     using QueryTermSimpleUP = AttributeVector::QueryTermSimpleUP;
     using SelfType = SingleValueNumericPostingAttribute<B>;

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.h
@@ -22,9 +22,7 @@ protected:
     using ChangeVector = StringAttribute::ChangeVector;
     using DocId = StringAttribute::DocId;
     using EnumHandle = StringAttribute::EnumHandle;
-    using EnumHintSearchContext = attribute::EnumHintSearchContext;
     using EnumIndex = typename SingleValueEnumAttributeBase::EnumIndex;
-    using EnumIndexVector = typename SingleValueEnumAttributeBase::EnumIndexVector;
     using EnumStore = typename SingleValueEnumAttribute<B>::EnumStore;
     using LoadedVector = StringAttribute::LoadedVector;
     using QueryTermSimpleUP = AttributeVector::QueryTermSimpleUP;
@@ -103,7 +101,7 @@ public:
     };
 
     class StringTemplSearchContext : public StringSingleImplSearchContext,
-                                     public EnumHintSearchContext
+                                     public attribute::EnumHintSearchContext
     {
         using AttrType = SingleValueStringAttributeT<B>;
         using StringSingleImplSearchContext::queryTerm;

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.h
@@ -37,7 +37,6 @@ private:
     using ComparatorType = typename EnumStore::ComparatorType;
     using DocId = typename SingleValueStringAttributeT<B>::DocId;
     using EnumIndex = typename SingleValueStringAttributeT<B>::EnumIndex;
-    using LoadedEnumAttributeVector = attribute::LoadedEnumAttributeVector;
     using PostingMap = typename PostingParent::PostingMap;
     using QueryTermSimpleUP = AttributeVector::QueryTermSimpleUP;
     using SelfType = SingleValueStringPostingAttributeT<B>;

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.cpp
@@ -68,9 +68,6 @@ StringSearchHelper::isMatch(const char *src) const {
 
 IMPLEMENT_IDENTIFIABLE_ABSTRACT(StringAttribute, AttributeVector);
 
-using attribute::LoadedEnumAttribute;
-using attribute::LoadedEnumAttributeVector;
-
 class SortDataChar {
 public:
     SortDataChar() { }

--- a/searchlib/src/vespa/searchlib/attribute/stringbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/stringbase.h
@@ -49,7 +49,6 @@ class StringAttribute : public AttributeVector
 {
 public:
     using EnumIndex = IEnumStore::Index;
-    using EnumIndexVector = IEnumStore::IndexVector;
     using EnumVector = IEnumStore::EnumVector;
     using LoadedValueType = const char*;
     using LoadedVector = NoLoadedVector;


### PR DESCRIPTION
…d you have everything already in the L1 cache.

- Remeber the enum in the scratchPad. This avoid a lookup later on during commit.

@toregge PR