### PR TITLE
Return 0.0 rather than nan for non-existing tensor cells in Java

### DIFF
--- a/vespajlib/src/main/java/com/yahoo/tensor/IndexedTensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/IndexedTensor.java
@@ -106,7 +106,7 @@ public abstract class IndexedTensor implements Tensor {
         return getFloat((int)toValueIndex(indexes, dimensionSizes));
     }
 
-    /** Returns the value at this address, or NaN if there is no value at this address */
+    /** Returns the value at this address, or 0.0 if there is no value at this address */
     @Override
     public double get(TensorAddress address) {
         // optimize for fast lookup within bounds:
@@ -114,7 +114,7 @@ public abstract class IndexedTensor implements Tensor {
             return get((int)toValueIndex(address, dimensionSizes, type));
         }
         catch (IllegalArgumentException e) {
-            return Double.NaN;
+            return 0.0;
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/MappedTensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/MappedTensor.java
@@ -32,7 +32,7 @@ public class MappedTensor implements Tensor {
     public long size() { return cells.size(); }
 
     @Override
-    public double get(TensorAddress address) { return cells.getOrDefault(address, Double.NaN); }
+    public double get(TensorAddress address) { return cells.getOrDefault(address, 0.0); }
 
     @Override
     public boolean has(TensorAddress address) { return cells.containsKey(address); }

--- a/vespajlib/src/main/java/com/yahoo/tensor/MixedTensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/MixedTensor.java
@@ -54,10 +54,10 @@ public class MixedTensor implements Tensor {
     public double get(TensorAddress address) {
         long cellIndex = index.indexOf(address);
         if (cellIndex < 0 || cellIndex >= cells.size())
-            return Double.NaN;
+            return 0.0;
         Cell cell = cells.get((int)cellIndex);
         if ( ! address.equals(cell.getKey()))
-            return Double.NaN;
+            return 0.0;
         return cell.getValue();
     }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/Tensor.java
@@ -67,7 +67,7 @@ public interface Tensor {
     /** Returns the number of cells in this */
     long size();
 
-    /** Returns the value of a cell, or NaN if this cell does not exist/have no value */
+    /** Returns the value of a cell, or 0.0 if this cell does not exist */
     double get(TensorAddress address);
 
     /** Returns true if this cell exists */

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
@@ -64,12 +64,7 @@ public class Slice<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETY
 
         PartialAddress subspaceAddress = subspaceToAddress(tensor.type(), context);
         if (resultType.rank() == 0) { // shortcut common case
-            var key = subspaceAddress.asAddress(tensor.type());
-            if (tensor.has(key)) {
-                return Tensor.from(tensor.get(key));
-            } else {
-                return Tensor.from(0.0);
-            }
+            return Tensor.from(tensor.get(subspaceAddress.asAddress(tensor.type())));
         }
 
         Tensor.Builder b = Tensor.Builder.of(resultType);


### PR DESCRIPTION
@bratseth Please review.
@arnej27959 FYI.
@havardpe FYI.

With https://github.com/vespa-engine/vespa/pull/17693 merged, I believe we can now switch to 0.0 as default.