### PR TITLE
Use 0.1 Gbps as bandwidth for cluster controllers

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -417,7 +417,7 @@ public class ModelContextImpl implements ModelContext {
         return new NodeResources(Double.parseDouble(parts[0]),
                                  Double.parseDouble(parts[1]),
                                  Double.parseDouble(parts[2]),
-                                 0.3,
+                                 0.1,
                                  NodeResources.DiskSpeed.any,
                                  NodeResources.StorageType.any);
     }


### PR DESCRIPTION
Not much traffic to cluster controllers, 0.1 Gbps should be enough.
Will help with getting more nodes on hosts with e.g. 1 Gbps bandwidth.

@jonmv FYI
