### PR TITLE
Store application package warning notification for direct deployments with deployment ID as source

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -394,10 +394,10 @@ public class ApplicationController {
             // Record the quota usage for this application
             var quotaUsage = deploymentQuotaUsage(zone, job.application());
 
-            // For direct deployments use the full application ID, but otherwise use just the tenant and application as
+            // For direct deployments use the full deployment ID, but otherwise use just the tenant and application as
             // the source since it's the same application, so it should have the same warnings
             NotificationSource source = zone.environment().isManuallyDeployed() ?
-                    NotificationSource.from(job.application()) : NotificationSource.from(applicationId);
+                    NotificationSource.from(new DeploymentId(job.application(), zone)) : NotificationSource.from(applicationId);
             List<String> warnings = Optional.ofNullable(result.prepareResponse().log)
                     .map(logs -> logs.stream()
                             .filter(log -> log.applicationPackage)

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/notification/NotificationSource.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/notification/NotificationSource.java
@@ -84,11 +84,10 @@ public class NotificationSource {
      * staging zone), or if this is at tenant or application level
      */
     public boolean isProduction() {
-        if (instance.isEmpty()) return true;
         return ! zoneId.map(ZoneId::environment)
                 .or(() -> jobType.map(JobType::environment))
                 .map(Environment::isManuallyDeployed)
-                .orElse(true); // Assume that notification with full application ID concern dev deployments
+                .orElse(false);
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDb.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.controller.notification;
 
 import com.yahoo.collections.Pair;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.ClusterMetrics;
@@ -38,6 +39,23 @@ public class NotificationsDb {
     NotificationsDb(Clock clock, CuratorDb curatorDb) {
         this.clock = clock;
         this.curatorDb = curatorDb;
+
+        removeApplicationPackageNotificationsWithInstanceSource();
+    }
+
+    // TODO (valerijf): Remove after 7.399
+    void removeApplicationPackageNotificationsWithInstanceSource() {
+        for (TenantName tenant : curatorDb.listNotifications()) {
+            try (Lock lock = curatorDb.lockNotifications(tenant)) {
+                List<Notification> initial = curatorDb.readNotifications(tenant);
+                List<Notification> filtered = initial.stream()
+                        .filter(notification -> notification.type() == Type.applicationPackage &&
+                                notification.source().instance().isPresent() && notification.source().zoneId().isEmpty())
+                        .collect(Collectors.toUnmodifiableList());
+                if (initial.size() > filtered.size())
+                    curatorDb.writeNotifications(tenant, filtered);
+            }
+        }
     }
 
     public List<Notification> listNotifications(NotificationSource source, boolean productionOnly) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -602,6 +602,13 @@ public class CuratorDb {
                 .map(slime -> NotificationsSerializer.fromSlime(tenantName, slime)).orElseGet(List::of);
     }
 
+
+    public List<TenantName> listNotifications() {
+        return curator.getChildren(notificationsRoot).stream()
+                .map(TenantName::from)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
     public void writeNotifications(TenantName tenantName, List<Notification> notifications) {
         curator.set(notificationsPath(tenantName), asJson(NotificationsSerializer.toSlime(notifications)));
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDbTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDbTest.java
@@ -52,7 +52,7 @@ public class NotificationsDbTest {
     @Test
     public void list_test() {
         assertEquals(notifications, notificationsDb.listNotifications(NotificationSource.from(tenant), false));
-        assertEquals(notificationIndices(0, 1, 3), notificationsDb.listNotifications(NotificationSource.from(tenant), true));
+        assertEquals(notificationIndices(0, 1, 2, 3), notificationsDb.listNotifications(NotificationSource.from(tenant), true));
         assertEquals(notificationIndices(2, 3), notificationsDb.listNotifications(NotificationSource.from(TenantAndApplicationId.from(tenant.value(), "app2")), false));
         assertEquals(notificationIndices(4, 5), notificationsDb.listNotifications(NotificationSource.from(ApplicationId.from(tenant.value(), "app1", "instance1")), false));
         assertEquals(notificationIndices(5), notificationsDb.listNotifications(NotificationSource.from(new RunId(ApplicationId.from(tenant.value(), "app1", "instance1"), JobType.devUsEast1, 5)), false));


### PR DESCRIPTION
Currently application package warnings have 2 different source types;
* For prod deployments they have tenant+application as source, the idea is that the warnings will be the same across the different instances and zones, since it is the same application package.
* For manual deployments, the source is the full application ID. This PR changes that to be the deployment ID because:
  - This simplifies the code in figuring out which notifications are related to dev/perf deployments so that we can hide those from the main views in the console
  - Allows for having different warnings if user deploys different application package, under the same application ID, to f.ex. dev vs perf.
  - Automatically cleans up notifications on deployment expiry: https://github.com/vespa-engine/vespa/blob/705b5fb3b553bebd279ad27838267d407533f0bb/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java#L706