### PR TITLE
Revert "Remove unnecessary interface and package exports"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/ArchiveBucketDb.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/ArchiveBucketDb.java
@@ -1,0 +1,16 @@
+// Copyright 2021 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.integration.archive;
+
+import com.yahoo.config.provision.TenantName;
+import com.yahoo.config.provision.zone.ZoneId;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
+
+public interface ArchiveBucketDb {
+
+    Optional<URI> archiveUriFor(ZoneId zoneId, TenantName tenant);
+
+    Set<ArchiveBucket> buckets(ZoneId zoneId);
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/package-info.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/package-info.java
@@ -1,0 +1,8 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+/**
+ * @author freva
+ */
+@ExportPackage
+package com.yahoo.vespa.hosted.controller.api.integration.archive;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -221,7 +221,8 @@ public class Controller extends AbstractComponent {
         if (version.isEmpty()) {
             throw new IllegalArgumentException("Invalid version '" + version.toFullString() + "'");
         }
-        if (!clouds().contains(cloudName)) {
+        Set<CloudName> clouds = clouds();
+        if (!clouds.contains(cloudName)) {
             throw new IllegalArgumentException("Cloud '" + cloudName + "' does not exist in this system");
         }
         try (Lock lock = curator.lockOsVersions()) {
@@ -305,5 +306,4 @@ public class Controller extends AbstractComponent {
     public NotificationsDb notificationsDb() {
         return notificationsDb;
     }
-
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/archive/package-info.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/archive/package-info.java
@@ -1,0 +1,5 @@
+// Copyright 2021 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+package com.yahoo.vespa.hosted.controller.archive;
+
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveAccessMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveAccessMaintainer.java
@@ -4,9 +4,9 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.google.common.collect.Maps;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.archive.ArchiveBucketDb;
 import com.yahoo.vespa.hosted.controller.api.integration.archive.ArchiveService;
 import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
-import com.yahoo.vespa.hosted.controller.archive.CuratorArchiveBucketDb;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
 import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 
@@ -23,7 +23,7 @@ public class ArchiveAccessMaintainer extends ControllerMaintainer {
 
     private static final String bucketCountMetricName = "archive.bucketCount";
 
-    private final CuratorArchiveBucketDb archiveBucketDb;
+    private final ArchiveBucketDb archiveBucketDb;
     private final ArchiveService archiveService;
     private final ZoneRegistry zoneRegistry;
     private final Metric metric;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
@@ -6,9 +6,9 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.ApplicationController;
 import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.archive.ArchiveBucketDb;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.NodeRepository;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
-import com.yahoo.vespa.hosted.controller.archive.CuratorArchiveBucketDb;
 
 import java.net.URI;
 import java.time.Duration;
@@ -28,7 +28,7 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
 
     private final ApplicationController applications;
     private final NodeRepository nodeRepository;
-    private final CuratorArchiveBucketDb archiveBucketDb;
+    private final ArchiveBucketDb archiveBucketDb;
 
     public ArchiveUriUpdater(Controller controller, Duration duration) {
         super(controller, duration, ArchiveUriUpdater.class.getSimpleName(), SystemName.all());


### PR DESCRIPTION
Reverts vespa-engine/vespa#17725

controller fails to start with:

	Caused by: java.lang.ClassNotFoundException: com.yahoo.vespa.hosted.controller.api.integration.archive.ArchiveService not found by controller-clients [99]