### PR TITLE
No CPU cap only in dev

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -405,7 +405,7 @@ public class NodeAgentImpl implements NodeAgent {
     }
 
     private boolean noCpuCap(ZoneApi zone) {
-        return zone.getEnvironment() == Environment.dev || zone.getSystemName().isCd();
+        return zone.getEnvironment() == Environment.dev;
     }
 
     private boolean downloadImageIfNeeded(NodeAgentContext context, Optional<Container> container) {


### PR DESCRIPTION
Cannot see why this should be needed in cd, it makes cd different
from other systems, which might hide bugs or show different behavior
