### PR TITLE
Run single stripe in its own thread when not using legacy mode [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -40,8 +40,9 @@ class BucketDBUpdater;
 class DistributorBucketSpaceRepo;
 class DistributorStatus;
 class DistributorStripe;
+class DistributorStripePool;
+class StripeAccessor;
 class OperationSequencer;
-class LegacySingleStripeAccessor;
 class OwnershipTransferSafeTimePointCalculator;
 class SimpleMaintenanceScanner;
 class ThrottlingOperationStarter;
@@ -118,6 +119,10 @@ private:
     friend class DistributorTestUtil;
     friend class MetricUpdateHook;
 
+    // TODO STRIPE remove
+    DistributorStripe& first_stripe() noexcept;
+    const DistributorStripe& first_stripe() const noexcept;
+
     void setNodeStateUp();
     bool handleMessage(const std::shared_ptr<api::StorageMessage>& msg);
 
@@ -171,8 +176,10 @@ private:
     ChainedMessageSender*                 _messageSender;
     const bool                            _use_legacy_mode;
     // TODO STRIPE multiple stripes...! This is for proof of concept of wiring.
-    std::unique_ptr<DistributorStripe>   _stripe;
-    std::unique_ptr<LegacySingleStripeAccessor> _stripe_accessor;
+    std::unique_ptr<DistributorStripe>    _stripe;
+    std::unique_ptr<DistributorStripePool> _stripe_pool;
+    std::vector<std::unique_ptr<DistributorStripe>> _stripes;
+    std::unique_ptr<StripeAccessor>      _stripe_accessor;
     distributor::DistributorComponent    _component;
     std::shared_ptr<const DistributorConfiguration> _total_config;
     std::unique_ptr<BucketDBUpdater>     _bucket_db_updater;

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -22,6 +22,7 @@
 #include <vespa/storageapi/message/state.h>
 #include <vespa/storageframework/generic/metric/metricupdatehook.h>
 #include <vespa/storageframework/generic/thread/tickingthread.h>
+#include <mutex>
 #include <queue>
 #include <unordered_map>
 
@@ -298,6 +299,7 @@ private:
             std::vector<std::shared_ptr<api::StorageMessage>>,
             IndirectHigherPriority
     >;
+    mutable std::mutex _external_message_mutex;
     MessageQueue _messageQueue;
     ClientRequestPriorityQueue _client_request_priority_queue;
     MessageQueue _fetchedMessages;

--- a/storage/src/vespa/storage/distributor/distributor_stripe_pool.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_pool.h
@@ -62,10 +62,10 @@ public:
     void park_all_threads() noexcept;
     void unpark_all_threads() noexcept;
 
-    [[nodiscard]] const DistributorStripeThread& stripe(size_t idx) const noexcept {
+    [[nodiscard]] const DistributorStripeThread& stripe_thread(size_t idx) const noexcept {
         return *_stripes[idx];
     }
-    [[nodiscard]] DistributorStripeThread& stripe(size_t idx) noexcept {
+    [[nodiscard]] DistributorStripeThread& stripe_thread(size_t idx) noexcept {
         return *_stripes[idx];
     }
     [[nodiscard]] size_t stripe_count() const noexcept { return _stripes.size(); }

--- a/storage/src/vespa/storage/distributor/distributor_stripe_thread.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_thread.h
@@ -53,6 +53,9 @@ public:
 
     TickableStripe*       operator->() noexcept       { return &_stripe; }
     const TickableStripe* operator->() const noexcept { return &_stripe; }
+
+    TickableStripe& stripe() noexcept             { return _stripe; }
+    const TickableStripe& stripe() const noexcept { return _stripe; }
 private:
     [[nodiscard]] bool should_stop_thread_relaxed() const noexcept {
         return _should_stop.load(std::memory_order_relaxed);

--- a/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.cpp
+++ b/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.cpp
@@ -14,6 +14,10 @@ LegacySingleStripeAccessGuard::~LegacySingleStripeAccessGuard() {
     _accessor.mark_guard_released();
 }
 
+void LegacySingleStripeAccessGuard::flush_and_close() {
+    _stripe.flush_and_close();
+}
+
 void LegacySingleStripeAccessGuard::update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) {
     _stripe.update_total_distributor_config(std::move(config));
 }

--- a/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.h
+++ b/storage/src/vespa/storage/distributor/legacy_single_stripe_accessor.h
@@ -21,6 +21,8 @@ public:
                                   DistributorStripe& stripe);
     ~LegacySingleStripeAccessGuard() override;
 
+    void flush_and_close() override;
+
     void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) override;
 
     void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) override;

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
@@ -21,6 +21,10 @@ MultiThreadedStripeAccessGuard::~MultiThreadedStripeAccessGuard() {
     _accessor.mark_guard_released();
 }
 
+void MultiThreadedStripeAccessGuard::flush_and_close() {
+    first_stripe().flush_and_close();
+}
+
 void MultiThreadedStripeAccessGuard::update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) {
     // TODO STRIPE multiple stripes
     first_stripe().update_total_distributor_config(std::move(config));
@@ -95,7 +99,7 @@ void MultiThreadedStripeAccessGuard::clear_read_only_bucket_repo_databases() {
 }
 
 DistributorStripe& MultiThreadedStripeAccessGuard::first_stripe() noexcept {
-    return dynamic_cast<DistributorStripe&>(_stripe_pool.stripe(0));
+    return dynamic_cast<DistributorStripe&>(_stripe_pool.stripe_thread(0).stripe());
 }
 
 std::unique_ptr<StripeAccessGuard> MultiThreadedStripeAccessor::rendezvous_and_hold_all() {

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
@@ -27,6 +27,8 @@ public:
                                    DistributorStripePool& stripe_pool);
     ~MultiThreadedStripeAccessGuard() override;
 
+    void flush_and_close() override;
+
     void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) override;
 
     void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) override;
@@ -65,7 +67,7 @@ class MultiThreadedStripeAccessor : public StripeAccessor {
 
     friend class MultiThreadedStripeAccessGuard;
 public:
-    MultiThreadedStripeAccessor(DistributorStripePool& stripe_pool)
+    explicit MultiThreadedStripeAccessor(DistributorStripePool& stripe_pool)
         : _stripe_pool(stripe_pool),
           _guard_held(false)
     {}

--- a/storage/src/vespa/storage/distributor/stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/stripe_access_guard.h
@@ -28,6 +28,8 @@ class StripeAccessGuard {
 public:
     virtual ~StripeAccessGuard() = default;
 
+    virtual void flush_and_close() = 0;
+
     virtual void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) = 0;
 
     virtual void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) = 0;


### PR DESCRIPTION
@geirst please review

The (currently single) stripe is now run as part of the distributor
stripe pool instead of being transitively invoked by the main thread.

Introduce an explicit message mutex per stripe that is used for
external messages and status requests when not using legacy mode.
Use per-stripe wakeup mechanisms instead of the framework-global
mutex used in the legacy code path.

Additional work remains to bring back a dedicated message run-queue
for the top-level distributor, so this is not yet thread safe for
operations to the main `BucketDBUpdater`.
