### PR TITLE
Wait longer between automatic OS upgrades

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public class OsUpgradeScheduler extends ControllerMaintainer {
 
     /** Trigger a new upgrade when the current target version reaches this age */
-    private static final Duration MAX_VERSION_AGE = Duration.ofDays(30);
+    private static final Duration MAX_VERSION_AGE = Duration.ofDays(45);
 
     /**
      * The interval at which new versions become available. We use this to avoid scheduling upgrades to a version that

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
@@ -40,14 +40,14 @@ public class OsUpgradeSchedulerTest {
         tester.controller().upgradeOsIn(cloud, version0, Duration.ofDays(1), false);
 
         // Target remains unchanged as it hasn't expired yet
-        for (var interval : List.of(Duration.ZERO, Duration.ofDays(15))) {
+        for (var interval : List.of(Duration.ZERO, Duration.ofDays(30))) {
             tester.clock().advance(interval);
             scheduler.maintain();
             assertEquals(version0, tester.controller().osVersionTarget(cloud).get().osVersion().version());
         }
 
-        // Just over 30 days pass, and a new target replaces the expired one
-        Version version1 = Version.fromString("7.0.0.20210215");
+        // Just over 45 days pass, and a new target replaces the expired one
+        Version version1 = Version.fromString("7.0.0.20210302");
         tester.clock().advance(Duration.ofDays(15).plus(Duration.ofSeconds(1)));
         scheduler.maintain();
         assertEquals("New target set", version1, tester.controller().osVersionTarget(cloud).get().osVersion().version());


### PR DESCRIPTION
Reduces churn a bit. We'll still comply with the 90 day upgrade policy.

@aressem or @hmusum