### PR TITLE
Remove assert for a scenario that might occur in wait_until_unparked()

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor_stripe_thread.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_thread.cpp
@@ -70,7 +70,6 @@ void DistributorStripeThread::wait_until_event_notified_or_timed_out() noexcept 
 
 void DistributorStripeThread::wait_until_unparked() noexcept {
     std::unique_lock lock(_mutex);
-    assert(should_park_relaxed());
     // _should_park is always written within _mutex, relaxed load is safe.
     _park_cond.wait(lock, [this]{ return !should_park_relaxed(); });
 }


### PR DESCRIPTION
A stripe thread is parked as part of another thread calling DistributorStripePool::park_all_threads().
The stripe thread will then be inside DistributorStripePool::park_thread_until_released(),
just waiting to call DistributorStripeThread::wait_until_unparked().
Before this is called, the other thread can call DistributorStripePool::unpark_all_threads(),
and the _should_park variable in DistributorStripeThread is set to false again.
When the stripe thread calls DistributorStripeThread::wait_until_unparked(), it is already unparked.
This is a scenario that might occur when the parking / unparking loop is short.

@vekterli please review

