### PR TITLE
Revert "Do not deploy or install jakarta jars."

### DIFF
--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -220,6 +220,8 @@
                 jackson-jaxrs-base-${jackson2.version}.jar,
                 jackson-jaxrs-json-provider-${jackson2.version}.jar,
                 jackson-module-jaxb-annotations-${jackson2.version}.jar,
+                jakarta.activation-api-1.2.1.jar,
+                jakarta.xml.bind-api-2.3.2.jar,
                 javassist-${javassist.version}.jar,
                 javax.ws.rs-api-${javax.ws.rs-api.version}.jar,
                 jersey-client-${jersey2.version}.jar,

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -721,6 +721,8 @@ fi
 %{_prefix}/lib/jars/hk2-*.jar
 %{_prefix}/lib/jars/hosted-zone-api-jar-with-dependencies.jar
 %{_prefix}/lib/jars/jackson-*.jar
+%{_prefix}/lib/jars/jakarta.activation-api-*.jar
+%{_prefix}/lib/jars/jakarta.xml.bind-api-*.jar
 %{_prefix}/lib/jars/javassist-*.jar
 %{_prefix}/lib/jars/javax.*.jar
 %{_prefix}/lib/jars/jdisc-cloud-aws-jar-with-dependencies.jar


### PR DESCRIPTION
Reverts vespa-engine/vespa#17774

```
13:34:23   RPM build errors:
13:34:23       File listed twice: /opt/vespa/lib/jars/zookeeper-server-common-jar-with-dependencies.jar
13:34:23       Installed (but unpackaged) file(s) found:
13:34:23      /opt/vespa/lib/jars/jakarta.activation-api-1.2.1.jar
13:34:23      /opt/vespa/lib/jars/jakarta.xml.bind-api-2.3.2.jar
```