### PR TITLE
Propagate config to underlying bucket repos when storage distribution…

### DIFF
--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -57,6 +57,7 @@ public:
     void resend_delayed_messages();
     void storage_distribution_changed(const BucketSpaceDistributionConfigs& configs);
     void bootstrap_distribution_config(std::shared_ptr<const lib::Distribution>);
+    void propagate_distribution_config(const BucketSpaceDistributionConfigs& configs);
 
     vespalib::string report_xml_status(vespalib::xml::XmlOutputStream& xos, const framework::HttpUrlPath&) const;
 


### PR DESCRIPTION
… changes.

This fixes the following system tests when running with new distributor stripe mode:
Capacity::test_capacity
FlatToHierarchicTransitionTest::test_transition_implicitly_indexes_and_activates_docs_per_group
HierarchDistr::test_app_change__PROTON

@vekterli please review
