### PR TITLE
Don't consider number of working nodes in coverage

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
@@ -82,7 +82,7 @@ public abstract class InvokerFactory {
             if ( ! searchCluster.isPartialGroupCoverageSufficient(success) && !acceptIncompleteCoverage) {
                 return Optional.empty();
             }
-            if (invokers.size() == 0) {
+            if (invokers.isEmpty()) {
                 return Optional.of(createCoverageErrorInvoker(nodes, failed));
             }
         }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
@@ -74,7 +74,21 @@ public class SearchClusterCoverageTest {
 
     @Test
     public void three_groups_one_has_a_node_down() {
-        var tester =  new SearchClusterTester(3, 3);
+        var tester = new SearchClusterTester(3, 3);
+
+        tester.setDocsPerNode(100, 0);
+        tester.setDocsPerNode(100, 1);
+        tester.setDocsPerNode(100, 2);
+        tester.setWorking(1, 1, false);
+        tester.pingIterationCompleted();
+        assertTrue(tester.group(0).hasSufficientCoverage());
+        assertFalse(tester.group(1).hasSufficientCoverage());
+        assertTrue(tester.group(2).hasSufficientCoverage());
+    }
+
+    @Test
+    public void three_groups_one_has_a_node_down_but_remaining_has_enough_docs() {
+        var tester = new SearchClusterTester(3, 3);
 
         tester.setDocsPerNode(100, 0);
         tester.setDocsPerNode(150, 1);
@@ -82,7 +96,7 @@ public class SearchClusterCoverageTest {
         tester.setWorking(1, 1, false);
         tester.pingIterationCompleted();
         assertTrue(tester.group(0).hasSufficientCoverage());
-        assertFalse(tester.group(1).hasSufficientCoverage());
+        assertTrue("Sufficient documents on remaining two nodes", tester.group(1).hasSufficientCoverage());
         assertTrue(tester.group(2).hasSufficientCoverage());
     }
 


### PR DESCRIPTION
Trying to figure out the right groups to send queries to based
on the number of nodes in the group has many potential issues
at times of topology changes.

Since we could the number of documents available in each group
by summing documents in working nodes, we do not need to also
separately consider the number of working nodes in the group for
correctness.

Since we use adaptive dispatching by default we also do not need
to consider it to avoid overloading groups with less resources
available but enough documents.
