### PR TITLE
Include legacy endpoint in certificate in public

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMetadata.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMetadata.java
@@ -18,18 +18,18 @@ public class EndpointCertificateMetadata {
     private final String certName;
     private final int version;
     private final long lastRequested;
-    private final String request_id;
+    private final String requestId;
     private final List<String> requestedDnsSans;
     private final String issuer;
     private final Optional<Long> expiry;
     private final Optional<Long> lastRefreshed;
 
-    public EndpointCertificateMetadata(String keyName, String certName, int version, long lastRequested, String request_id, List<String> requestedDnsSans, String issuer, Optional<Long> expiry, Optional<Long> lastRefreshed) {
+    public EndpointCertificateMetadata(String keyName, String certName, int version, long lastRequested, String requestId, List<String> requestedDnsSans, String issuer, Optional<Long> expiry, Optional<Long> lastRefreshed) {
         this.keyName = keyName;
         this.certName = certName;
         this.version = version;
         this.lastRequested = lastRequested;
-        this.request_id = request_id;
+        this.requestId = requestId;
         this.requestedDnsSans = requestedDnsSans;
         this.issuer = issuer;
         this.expiry = expiry;
@@ -52,8 +52,8 @@ public class EndpointCertificateMetadata {
         return lastRequested;
     }
 
-    public String request_id() {
-        return request_id;
+    public String requestId() {
+        return requestId;
     }
 
     public List<String> requestedDnsSans() {
@@ -78,7 +78,7 @@ public class EndpointCertificateMetadata {
                 this.certName,
                 version,
                 this.lastRequested,
-                this.request_id,
+                this.requestId,
                 this.requestedDnsSans,
                 this.issuer,
                 this.expiry,
@@ -91,7 +91,7 @@ public class EndpointCertificateMetadata {
                 this.certName,
                 this.version,
                 lastRequested,
-                this.request_id,
+                this.requestId,
                 this.requestedDnsSans,
                 this.issuer,
                 this.expiry,
@@ -104,7 +104,7 @@ public class EndpointCertificateMetadata {
                 this.certName,
                 this.version,
                 this.lastRequested,
-                this.request_id,
+                this.requestId,
                 this.requestedDnsSans,
                 this.issuer,
                 this.expiry,
@@ -127,16 +127,16 @@ public class EndpointCertificateMetadata {
     @Override
     public String toString() {
         return "EndpointCertificateMetadata{" +
-                "keyName='" + keyName + '\'' +
-                ", certName='" + certName + '\'' +
-                ", version=" + version +
-                ", lastRequested=" + lastRequested +
-                ", request_id=" + request_id +
-                ", requestedDnsSans=" + requestedDnsSans +
-                ", issuer=" + issuer +
-                ", expiry=" + expiry +
-                ", lastRefreshed=" + lastRefreshed +
-                '}';
+               "keyName='" + keyName + '\'' +
+               ", certName='" + certName + '\'' +
+               ", version=" + version +
+               ", lastRequested=" + lastRequested +
+               ", requestId=" + requestId +
+               ", requestedDnsSans=" + requestedDnsSans +
+               ", issuer=" + issuer +
+               ", expiry=" + expiry +
+               ", lastRefreshed=" + lastRefreshed +
+               '}';
     }
 
     @Override
@@ -146,17 +146,18 @@ public class EndpointCertificateMetadata {
         EndpointCertificateMetadata that = (EndpointCertificateMetadata) o;
         return version == that.version &&
                 lastRequested == that.lastRequested &&
-                keyName.equals(that.keyName) &&
-                certName.equals(that.certName) &&
-                request_id.equals(that.request_id) &&
-                requestedDnsSans.equals(that.requestedDnsSans) &&
-                issuer.equals(that.issuer) &&
-                expiry.equals(that.expiry) &&
-                lastRefreshed.equals(that.lastRefreshed);
+               keyName.equals(that.keyName) &&
+               certName.equals(that.certName) &&
+               requestId.equals(that.requestId) &&
+               requestedDnsSans.equals(that.requestedDnsSans) &&
+               issuer.equals(that.issuer) &&
+               expiry.equals(that.expiry) &&
+               lastRefreshed.equals(that.lastRefreshed);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(keyName, certName, version, lastRequested, request_id, requestedDnsSans, issuer, expiry, lastRefreshed);
+        return Objects.hash(keyName, certName, version, lastRequested, requestId, requestedDnsSans, issuer, expiry, lastRefreshed);
     }
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMock.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateMock.java
@@ -34,11 +34,12 @@ public class EndpointCertificateMock implements EndpointCertificateProvider {
 
     @Override
     public List<EndpointCertificateMetadata> listCertificates() {
-        return Collections.emptyList();
+        return List.of();
     }
 
     @Override
     public void deleteCertificate(ApplicationId applicationId, EndpointCertificateMetadata endpointCertificateMetadata) {
         dnsNames.remove(applicationId);
     }
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateValidatorImpl.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateValidatorImpl.java
@@ -16,6 +16,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/**
+ * @author andreer
+ */
 public class EndpointCertificateValidatorImpl implements EndpointCertificateValidator {
     private final SecretStore secretStore;
     private final Clock clock;

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateValidatorMock.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/certificates/EndpointCertificateValidatorMock.java
@@ -5,7 +5,11 @@ import com.yahoo.config.provision.zone.ZoneId;
 
 import java.util.List;
 
+/**
+ * @author andreer
+ */
 public class EndpointCertificateValidatorMock implements EndpointCertificateValidator {
+
     @Override
     public void validate(
             EndpointCertificateMetadata endpointCertificateMetadata,
@@ -14,4 +18,5 @@ public class EndpointCertificateValidatorMock implements EndpointCertificateVali
             List<String> requiredNamesForZone) {
         // Mock does no validation - for unit tests only!
     }
+
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -52,7 +52,7 @@ import com.yahoo.vespa.hosted.controller.application.QuotaUsage;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
 import com.yahoo.vespa.hosted.controller.athenz.impl.AthenzFacade;
-import com.yahoo.vespa.hosted.controller.certificate.EndpointCertificateManager;
+import com.yahoo.vespa.hosted.controller.certificate.EndpointCertificates;
 import com.yahoo.vespa.hosted.controller.concurrent.Once;
 import com.yahoo.vespa.hosted.controller.deployment.DeploymentTrigger;
 import com.yahoo.vespa.hosted.controller.deployment.JobStatus;
@@ -118,7 +118,7 @@ public class ApplicationController {
     private final Clock clock;
     private final DeploymentTrigger deploymentTrigger;
     private final ApplicationPackageValidator applicationPackageValidator;
-    private final EndpointCertificateManager endpointCertificateManager;
+    private final EndpointCertificates endpointCertificates;
     private final StringFlag dockerImageRepoFlag;
     private final BillingController billingController;
 
@@ -137,9 +137,9 @@ public class ApplicationController {
 
         deploymentTrigger = new DeploymentTrigger(controller, clock);
         applicationPackageValidator = new ApplicationPackageValidator(controller);
-        endpointCertificateManager = new EndpointCertificateManager(controller,
-                                                                    controller.serviceRegistry().endpointCertificateProvider(),
-                                                                    controller.serviceRegistry().endpointCertificateValidator());
+        endpointCertificates = new EndpointCertificates(controller,
+                                                        controller.serviceRegistry().endpointCertificateProvider(),
+                                                        controller.serviceRegistry().endpointCertificateValidator());
 
         // Update serialization format of all applications
         Once.after(Duration.ofMinutes(1), () -> {
@@ -379,7 +379,7 @@ public class ApplicationController {
                     &&   run.testerCertificate().isPresent())
                     applicationPackage = applicationPackage.withTrustedCertificate(run.testerCertificate().get());
 
-                endpointCertificateMetadata = endpointCertificateManager.getEndpointCertificateMetadata(instance, zone, applicationPackage.deploymentSpec().instance(instance.name()));
+                endpointCertificateMetadata = endpointCertificates.getMetadata(instance, zone, applicationPackage.deploymentSpec().instance(instance.name()));
 
                 containerEndpoints = controller.routing().containerEndpointsOf(application.get(), job.application().instance(), zone);
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -137,12 +137,9 @@ public class ApplicationController {
 
         deploymentTrigger = new DeploymentTrigger(controller, clock);
         applicationPackageValidator = new ApplicationPackageValidator(controller);
-        endpointCertificateManager = new EndpointCertificateManager(
-                controller.zoneRegistry(),
-                curator,
-                controller.serviceRegistry().endpointCertificateProvider(),
-                controller.serviceRegistry().endpointCertificateValidator(),
-                clock);
+        endpointCertificateManager = new EndpointCertificateManager(controller,
+                                                                    controller.serviceRegistry().endpointCertificateProvider(),
+                                                                    controller.serviceRegistry().endpointCertificateValidator());
 
         // Update serialization format of all applications
         Once.after(Duration.ofMinutes(1), () -> {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -72,6 +72,7 @@ public class RoutingController {
     private final RoutingPolicies routingPolicies;
     private final RotationRepository rotationRepository;
     private final BooleanFlag hideSharedRoutingEndpoint;
+    private final BooleanFlag vespaAppDomainInCertificate;
 
     public RoutingController(Controller controller, RotationsConfig rotationsConfig) {
         this.controller = Objects.requireNonNull(controller, "controller must be non-null");
@@ -79,6 +80,7 @@ public class RoutingController {
         this.rotationRepository = new RotationRepository(rotationsConfig, controller.applications(),
                                                          controller.curator());
         this.hideSharedRoutingEndpoint = Flags.HIDE_SHARED_ROUTING_ENDPOINT.bindTo(controller.flagSource());
+        this.vespaAppDomainInCertificate = Flags.VESPA_APP_DOMAIN_IN_CERTIFICATE.bindTo(controller.flagSource());
     }
 
     public RoutingPolicies policies() {
@@ -179,7 +181,7 @@ public class RoutingController {
                              .on(Port.tls());
             Endpoint endpoint = builder.in(controller.system());
             endpointDnsNames.add(endpoint.dnsName());
-            if (controller.system().isPublic()) {
+            if (controller.system().isPublic() && vespaAppDomainInCertificate.value()) {
                 Endpoint legacyEndpoint = builder.legacy().in(controller.system());
                 endpointDnsNames.add(legacyEndpoint.dnsName());
             }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -173,11 +173,16 @@ public class RoutingController {
         builders.add(Endpoint.of(deployment.applicationId()).target(ClusterSpec.Id.from("default"), deployment.zoneId()));
         builders.add(Endpoint.of(deployment.applicationId()).wildcard(deployment.zoneId()));
 
+        // Build all endpoints
         for (var builder : builders) {
-            Endpoint endpoint = builder.routingMethod(RoutingMethod.exclusive)
-                                       .on(Port.tls())
-                                       .in(controller.system());
+            builder = builder.routingMethod(RoutingMethod.exclusive)
+                             .on(Port.tls());
+            Endpoint endpoint = builder.in(controller.system());
             endpointDnsNames.add(endpoint.dnsName());
+            if (controller.system().isPublic()) {
+                Endpoint legacyEndpoint = builder.legacy().in(controller.system());
+                endpointDnsNames.add(legacyEndpoint.dnsName());
+            }
         }
         return Collections.unmodifiableList(endpointDnsNames);
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -154,8 +154,8 @@ public class RoutingController {
         return Collections.unmodifiableMap(endpoints);
     }
 
-    /** Returns the wildcard endpoints for given deployment */
-    public List<String> wildcardEndpoints(DeploymentId deployment) {
+    /** Returns certificate DNS names (CN and SAN values) for given deployment */
+    public List<String> certificateDnsNames(DeploymentId deployment) {
         List<String> endpointDnsNames = new ArrayList<>();
 
         // We add first an endpoint name based on a hash of the application ID,

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -3,12 +3,16 @@ package com.yahoo.vespa.hosted.controller;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.DeploymentInstanceSpec;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
+import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.flags.BooleanFlag;
@@ -34,6 +38,7 @@ import com.yahoo.vespa.hosted.controller.routing.RoutingId;
 import com.yahoo.vespa.hosted.controller.routing.RoutingPolicies;
 import com.yahoo.vespa.hosted.rotation.config.RotationsConfig;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -147,6 +152,34 @@ public class RoutingController {
             }
         }
         return Collections.unmodifiableMap(endpoints);
+    }
+
+    /** Returns the wildcard endpoints for given deployment */
+    public List<String> wildcardEndpoints(DeploymentId deployment) {
+        List<String> endpointDnsNames = new ArrayList<>();
+
+        // We add first an endpoint name based on a hash of the application ID,
+        // as the certificate provider requires the first CN to be < 64 characters long.
+        endpointDnsNames.add(commonNameHashOf(deployment.applicationId(), controller.system()));
+
+        // Add wildcard names for global endpoints when deploying to production
+        List<Endpoint.EndpointBuilder> builders = new ArrayList<>();
+        if (deployment.zoneId().environment().isProduction()) {
+            builders.add(Endpoint.of(deployment.applicationId()).target(EndpointId.defaultId()));
+            builders.add(Endpoint.of(deployment.applicationId()).wildcard());
+        }
+
+        // Add wildcard names for zone endpoints
+        builders.add(Endpoint.of(deployment.applicationId()).target(ClusterSpec.Id.from("default"), deployment.zoneId()));
+        builders.add(Endpoint.of(deployment.applicationId()).wildcard(deployment.zoneId()));
+
+        for (var builder : builders) {
+            Endpoint endpoint = builder.routingMethod(RoutingMethod.exclusive)
+                                       .on(Port.tls())
+                                       .in(controller.system());
+            endpointDnsNames.add(endpoint.dnsName());
+        }
+        return Collections.unmodifiableList(endpointDnsNames);
     }
 
     /** Change status of all global endpoints for given deployment */
@@ -347,6 +380,13 @@ public class RoutingController {
         return application.deploymentSpec().instance(instanceName)
                           .flatMap(DeploymentInstanceSpec::globalServiceId)
                           .isPresent();
+    }
+
+    /** Create a common name based on a hash of given application. This must be less than 64 characters long. */
+    private static String commonNameHashOf(ApplicationId application, SystemName system) {
+        HashCode sha1 = Hashing.sha1().hashString(application.serializedForm(), StandardCharsets.UTF_8);
+        String base32 = BaseEncoding.base32().omitPadding().lowerCase().encode(sha1.asBytes());
+        return 'v' + base32 + Endpoint.dnsSuffix(system);
     }
 
     /** Returns direct routing endpoints if any exist and feature flag is set for given application */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificateManager.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificateManager.java
@@ -1,30 +1,20 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.certificate;
 
-import com.google.common.hash.Hashing;
-import com.google.common.io.BaseEncoding;
 import com.yahoo.config.application.api.DeploymentInstanceSpec;
-import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.SystemName;
-import com.yahoo.config.provision.zone.RoutingMethod;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.config.provision.zone.ZoneId;
+import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.Instance;
+import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata;
 import com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateProvider;
 import com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateValidator;
-import com.yahoo.vespa.hosted.controller.api.integration.zone.ZoneRegistry;
-import com.yahoo.vespa.hosted.controller.application.Endpoint;
-import com.yahoo.vespa.hosted.controller.application.EndpointId;
 import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
-import org.jetbrains.annotations.NotNull;
 
-import java.nio.charset.Charset;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * Looks up stored endpoint certificate metadata, provisions new certificates if none is found,
  * re-provisions if zone is not covered, and uses refreshed certificates if a newer version is available.
- * <p>
+ *
  * See also EndpointCertificateMaintainer, which handles refreshes, deletions and triggers deployments
  *
  * @author andreer
@@ -46,40 +36,38 @@ public class EndpointCertificateManager {
 
     private static final Logger log = Logger.getLogger(EndpointCertificateManager.class.getName());
 
-    private final ZoneRegistry zoneRegistry;
+    private final Controller controller;
     private final CuratorDb curator;
-    private final EndpointCertificateProvider endpointCertificateProvider;
     private final Clock clock;
-    private final EndpointCertificateValidator endpointCertificateValidator;
+    private final EndpointCertificateProvider certificateProvider;
+    private final EndpointCertificateValidator certificateValidator;
 
-    public EndpointCertificateManager(ZoneRegistry zoneRegistry,
-                                      CuratorDb curator,
-                                      EndpointCertificateProvider endpointCertificateProvider,
-                                      EndpointCertificateValidator endpointCertificateValidator,
-                                      Clock clock) {
-        this.zoneRegistry = zoneRegistry;
-        this.curator = curator;
-        this.endpointCertificateProvider = endpointCertificateProvider;
-        this.clock = clock;
-        this.endpointCertificateValidator = endpointCertificateValidator;
+    public EndpointCertificateManager(Controller controller, EndpointCertificateProvider certificateProvider,
+                                      EndpointCertificateValidator certificateValidator) {
+        this.controller = controller;
+        this.curator = controller.curator();
+        this.clock = controller.clock();
+        this.certificateProvider = certificateProvider;
+        this.certificateValidator = certificateValidator;
     }
 
     public Optional<EndpointCertificateMetadata> getEndpointCertificateMetadata(Instance instance, ZoneId zone, Optional<DeploymentInstanceSpec> instanceSpec) {
-        var t0 = Instant.now();
+        Instant start = clock.instant();
         Optional<EndpointCertificateMetadata> metadata = getOrProvision(instance, zone, instanceSpec);
         metadata.ifPresent(m -> curator.writeEndpointCertificateMetadata(instance.id(), m.withLastRequested(clock.instant().getEpochSecond())));
-        Duration duration = Duration.between(t0, Instant.now());
+        Duration duration = Duration.between(start, clock.instant());
         if (duration.toSeconds() > 30)
             log.log(Level.INFO, String.format("Getting endpoint certificate metadata for %s took %d seconds!", instance.id().serializedForm(), duration.toSeconds()));
         return metadata;
     }
 
-    @NotNull
     private Optional<EndpointCertificateMetadata> getOrProvision(Instance instance, ZoneId zone, Optional<DeploymentInstanceSpec> instanceSpec) {
         final var currentCertificateMetadata = curator.readEndpointCertificateMetadata(instance.id());
 
+        DeploymentId deployment = new DeploymentId(instance.id(), zone);
+
         if (currentCertificateMetadata.isEmpty()) {
-            var provisionedCertificateMetadata = provisionEndpointCertificate(instance, Optional.empty(), zone, instanceSpec);
+            var provisionedCertificateMetadata = provisionEndpointCertificate(deployment, Optional.empty(), instanceSpec);
             // We do not verify the certificate if one has never existed before - because we do not want to
             // wait for it to be available before we deploy. This allows the config server to start
             // provisioning nodes ASAP, and the risk is small for a new deployment.
@@ -88,89 +76,55 @@ public class EndpointCertificateManager {
         }
 
         // Re-provision certificate if it is missing SANs for the zone we are deploying to
-        var requiredSansForZone = dnsNamesOf(instance.id(), zone);
+        var requiredSansForZone = controller.routing().wildcardEndpoints(deployment);
         if (!currentCertificateMetadata.get().requestedDnsSans().containsAll(requiredSansForZone)) {
             var reprovisionedCertificateMetadata =
-                    provisionEndpointCertificate(instance, currentCertificateMetadata, zone, instanceSpec)
-                    .withRequestId(currentCertificateMetadata.get().request_id()); // We're required to keep the original request_id
+                    provisionEndpointCertificate(deployment, currentCertificateMetadata, instanceSpec)
+                            .withRequestId(currentCertificateMetadata.get().request_id()); // We're required to keep the original request_id
             curator.writeEndpointCertificateMetadata(instance.id(), reprovisionedCertificateMetadata);
             // Verification is unlikely to succeed in this case, as certificate must be available first - controller will retry
-            endpointCertificateValidator.validate(reprovisionedCertificateMetadata, instance.id().serializedForm(), zone, requiredSansForZone);
+            certificateValidator.validate(reprovisionedCertificateMetadata, instance.id().serializedForm(), zone, requiredSansForZone);
             return Optional.of(reprovisionedCertificateMetadata);
         }
 
-        endpointCertificateValidator.validate(currentCertificateMetadata.get(), instance.id().serializedForm(), zone, requiredSansForZone);
+        certificateValidator.validate(currentCertificateMetadata.get(), instance.id().serializedForm(), zone, requiredSansForZone);
         return currentCertificateMetadata;
     }
 
-    private EndpointCertificateMetadata provisionEndpointCertificate(Instance instance, Optional<EndpointCertificateMetadata> currentMetadata, ZoneId deploymentZone, Optional<DeploymentInstanceSpec> instanceSpec) {
+    private EndpointCertificateMetadata provisionEndpointCertificate(DeploymentId deployment, Optional<EndpointCertificateMetadata> currentMetadata, Optional<DeploymentInstanceSpec> instanceSpec) {
 
         List<String> currentlyPresentNames = currentMetadata.isPresent() ?
                 currentMetadata.get().requestedDnsSans() : Collections.emptyList();
 
-        var requiredZones = new LinkedHashSet<>(Set.of(deploymentZone));
+        var requiredZones = new LinkedHashSet<>(Set.of(deployment.zoneId()));
 
-        var zoneCandidateList = zoneRegistry.zones().controllerUpgraded().zones().stream().map(ZoneApi::getId).collect(Collectors.toList());
+        var zoneCandidateList = controller.zoneRegistry().zones().controllerUpgraded().zones().stream().map(ZoneApi::getId).collect(Collectors.toList());
 
         // If not deploying to a dev or perf zone, require all prod zones in deployment spec + test and staging
-        if (!deploymentZone.environment().isManuallyDeployed()) {
+        if (!deployment.zoneId().environment().isManuallyDeployed()) {
             zoneCandidateList.stream()
-                    .filter(z -> z.environment().isTest() || instanceSpec.isPresent() && instanceSpec.get().deploysTo(z.environment(), z.region()))
-                    .forEach(requiredZones::add);
+                             .filter(z -> z.environment().isTest() || instanceSpec.isPresent() && instanceSpec.get().deploysTo(z.environment(), z.region()))
+                             .forEach(requiredZones::add);
         }
 
         var requiredNames = requiredZones.stream()
-                .flatMap(zone -> dnsNamesOf(instance.id(), zone).stream())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                                         .flatMap(zone -> controller.routing().wildcardEndpoints(new DeploymentId(deployment.applicationId(), zone)).stream())
+                                         .collect(Collectors.toCollection(LinkedHashSet::new));
 
         // Make sure all currently present names will remain present.
         // Instead of just adding "currently present names", we regenerate them in case the names for a zone have changed.
         zoneCandidateList.stream()
-                .map(zone -> dnsNamesOf(instance.id(), zone))
-                .filter(zoneNames -> zoneNames.stream().anyMatch(currentlyPresentNames::contains))
-                .filter(currentlyPresentNames::containsAll)
-                .forEach(requiredNames::addAll);
+                         .map(zone -> controller.routing().wildcardEndpoints(new DeploymentId(deployment.applicationId(), zone)))
+                         .filter(zoneNames -> zoneNames.stream().anyMatch(currentlyPresentNames::contains))
+                         .filter(currentlyPresentNames::containsAll)
+                         .forEach(requiredNames::addAll);
 
         // This check must be relaxed if we ever remove from the set of names generated.
         if (!requiredNames.containsAll(currentlyPresentNames))
             throw new RuntimeException("SANs to be requested do not cover all existing names! Missing names: "
-                    + currentlyPresentNames.stream().filter(s -> !requiredNames.contains(s)).collect(Collectors.joining(", ")));
+                                       + currentlyPresentNames.stream().filter(s -> !requiredNames.contains(s)).collect(Collectors.joining(", ")));
 
-        return endpointCertificateProvider.requestCaSignedCertificate(instance.id(), List.copyOf(requiredNames), currentMetadata);
+        return certificateProvider.requestCaSignedCertificate(deployment.applicationId(), List.copyOf(requiredNames), currentMetadata);
     }
 
-
-    private List<String> dnsNamesOf(ApplicationId applicationId, ZoneId zone) {
-        List<String> endpointDnsNames = new ArrayList<>();
-
-        // We add first an endpoint name based on a hash of the applicationId,
-        // as the certificate provider requires the first CN to be < 64 characters long.
-        endpointDnsNames.add(commonNameHashOf(applicationId, zoneRegistry.system()));
-
-        List<Endpoint.EndpointBuilder> endpoints = new ArrayList<>();
-
-        if (zone.environment().isProduction()) {
-            endpoints.add(Endpoint.of(applicationId).target(EndpointId.defaultId()));
-            endpoints.add(Endpoint.of(applicationId).wildcard());
-        }
-
-        endpoints.add(Endpoint.of(applicationId).target(ClusterSpec.Id.from("default"), zone));
-        endpoints.add(Endpoint.of(applicationId).wildcard(zone));
-
-        endpoints.stream()
-                .map(endpoint -> endpoint.routingMethod(RoutingMethod.exclusive))
-                .map(endpoint -> endpoint.on(Endpoint.Port.tls()))
-                .map(endpointBuilder -> endpointBuilder.in(zoneRegistry.system()))
-                .map(Endpoint::dnsName).forEach(endpointDnsNames::add);
-
-        return Collections.unmodifiableList(endpointDnsNames);
-    }
-
-    /** Create a common name based on a hash of the ApplicationId. This should always be less than 64 characters long. */
-    @SuppressWarnings("UnstableApiUsage")
-    private static String commonNameHashOf(ApplicationId application, SystemName system) {
-        var hashCode = Hashing.sha1().hashString(application.serializedForm(), Charset.defaultCharset());
-        var base32encoded = BaseEncoding.base32().omitPadding().lowerCase().encode(hashCode.asBytes());
-        return 'v' + base32encoded + Endpoint.dnsSuffix(system);
-    }
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
@@ -117,11 +117,6 @@ public class EndpointCertificates {
                      .filter(currentNames::containsAll)
                      .forEach(requiredNames::addAll);
 
-        // This check must be relaxed if we ever remove from the set of names generated.
-        if (!requiredNames.containsAll(currentNames))
-            throw new RuntimeException("SANs to be requested do not cover all existing names! Missing names: "
-                                       + currentNames.stream().filter(s -> !requiredNames.contains(s)).collect(Collectors.joining(", ")));
-
         return certificateProvider.requestCaSignedCertificate(deployment.applicationId(), List.copyOf(requiredNames), currentMetadata);
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
@@ -28,13 +28,14 @@ import java.util.stream.Collectors;
  * Looks up stored endpoint certificate metadata, provisions new certificates if none is found,
  * re-provisions if zone is not covered, and uses refreshed certificates if a newer version is available.
  *
- * See also EndpointCertificateMaintainer, which handles refreshes, deletions and triggers deployments
+ * See also {@link com.yahoo.vespa.hosted.controller.maintenance.EndpointCertificateMaintainer}, which handles
+ * refreshes, deletions and triggers deployments.
  *
  * @author andreer
  */
-public class EndpointCertificateManager {
+public class EndpointCertificates {
 
-    private static final Logger log = Logger.getLogger(EndpointCertificateManager.class.getName());
+    private static final Logger log = Logger.getLogger(EndpointCertificates.class.getName());
 
     private final Controller controller;
     private final CuratorDb curator;
@@ -42,8 +43,8 @@ public class EndpointCertificateManager {
     private final EndpointCertificateProvider certificateProvider;
     private final EndpointCertificateValidator certificateValidator;
 
-    public EndpointCertificateManager(Controller controller, EndpointCertificateProvider certificateProvider,
-                                      EndpointCertificateValidator certificateValidator) {
+    public EndpointCertificates(Controller controller, EndpointCertificateProvider certificateProvider,
+                                EndpointCertificateValidator certificateValidator) {
         this.controller = controller;
         this.curator = controller.curator();
         this.clock = controller.clock();
@@ -51,7 +52,8 @@ public class EndpointCertificateManager {
         this.certificateValidator = certificateValidator;
     }
 
-    public Optional<EndpointCertificateMetadata> getEndpointCertificateMetadata(Instance instance, ZoneId zone, Optional<DeploymentInstanceSpec> instanceSpec) {
+    /** Returns certificate metadata for endpoints of given instance and zone */
+    public Optional<EndpointCertificateMetadata> getMetadata(Instance instance, ZoneId zone, Optional<DeploymentInstanceSpec> instanceSpec) {
         Instant start = clock.instant();
         Optional<EndpointCertificateMetadata> metadata = getOrProvision(instance, zone, instanceSpec);
         metadata.ifPresent(m -> curator.writeEndpointCertificateMetadata(instance.id(), m.withLastRequested(clock.instant().getEpochSecond())));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificates.java
@@ -82,7 +82,7 @@ public class EndpointCertificates {
         if (!currentCertificateMetadata.get().requestedDnsSans().containsAll(requiredSansForZone)) {
             var reprovisionedCertificateMetadata =
                     provisionEndpointCertificate(deployment, currentCertificateMetadata, instanceSpec)
-                            .withRequestId(currentCertificateMetadata.get().request_id()); // We're required to keep the original request_id
+                            .withRequestId(currentCertificateMetadata.get().requestId()); // We're required to keep the original request ID
             curator.writeEndpointCertificateMetadata(instance.id(), reprovisionedCertificateMetadata);
             // Verification is unlikely to succeed in this case, as certificate must be available first - controller will retry
             certificateValidator.validate(reprovisionedCertificateMetadata, instance.id().serializedForm(), zone, requiredSansForZone);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/EndpointCertificateMetadataSerializer.java
@@ -46,7 +46,7 @@ public class EndpointCertificateMetadataSerializer {
         object.setString(certNameField, metadata.certName());
         object.setLong(versionField, metadata.version());
         object.setLong(lastRequestedField, metadata.lastRequested());
-        object.setString(requestIdField, metadata.request_id());
+        object.setString(requestIdField, metadata.requestId());
         var cursor = object.setArray(requestedDnsSansField);
         metadata.requestedDnsSans().forEach(cursor::addString);
         object.setString(issuerField, metadata.issuer());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificatesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificatesTest.java
@@ -204,7 +204,7 @@ public class EndpointCertificatesTest {
         assertTrue(endpointCertificateMetadata.isPresent());
         assertEquals(0, endpointCertificateMetadata.get().version());
         assertEquals(endpointCertificateMetadata, mockCuratorDb.readEndpointCertificateMetadata(testInstance.id()));
-        assertEquals("original-request-uuid", endpointCertificateMetadata.get().request_id());
+        assertEquals("original-request-uuid", endpointCertificateMetadata.get().requestId());
         assertEquals(Set.copyOf(expectedCombinedSans), Set.copyOf(endpointCertificateMetadata.get().requestedDnsSans()));
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificatesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/certificate/EndpointCertificatesTest.java
@@ -13,6 +13,8 @@ import com.yahoo.security.SignatureAlgorithm;
 import com.yahoo.security.X509CertificateBuilder;
 import com.yahoo.security.X509CertificateUtils;
 import com.yahoo.test.ManualClock;
+import com.yahoo.vespa.flags.Flags;
+import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.api.integration.certificates.EndpointCertificateMetadata;
@@ -131,6 +133,7 @@ public class EndpointCertificatesTest {
     @Test
     public void provisions_new_certificate_in_public_prod() {
         ControllerTester tester = new ControllerTester(SystemName.Public);
+        ((InMemoryFlagSource) tester.controller().flagSource()).withBooleanFlag(Flags.VESPA_APP_DOMAIN_IN_CERTIFICATE.id(), true);
         EndpointCertificateValidatorImpl endpointCertificateValidator = new EndpointCertificateValidatorImpl(secretStore, clock);
         EndpointCertificates endpointCertificates = new EndpointCertificates(tester.controller(), endpointCertificateMock, endpointCertificateValidator);
         List<String> expectedSans = List.of(

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -241,8 +241,15 @@ public class Flags {
     public static final UnboundBooleanFlag CFG_DEPLOY_MULTIPART = defineFeatureFlag(
             "cfg-deploy-multipart", false,
             List.of("tokle"), "2021-05-19", "2021-08-01",
-            "Wheter to deploy applications using multipart form data (instead of url params)",
+            "Whether to deploy applications using multipart form data (instead of url params)",
             "Takes effect immediately",
+            APPLICATION_ID);
+
+    public static final UnboundBooleanFlag VESPA_APP_DOMAIN_IN_CERTIFICATE = defineFeatureFlag(
+            "new-domain-in-certificate", false,
+            List.of("mpolden"), "2021-05-25", "2021-09-01",
+            "Whether to include the vespa-app.cloud names in certificate requests",
+            "Takes effect on next deployment through controller",
             APPLICATION_ID);
 
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */


### PR DESCRIPTION
Some applications, both in public CD and public systems, have dev endpoints in
the certificate issued for production instances.

Due to the check (now) removed in 8d64ba3dd4, any attempts to change DNS names
for these deployments will fail because we no longer include dev endpoints when
deploying a production instance. We probably did at some point?

In any case I don't see why we need this check. Both unit and integration tests
verify that we request certificates for the correct names.

Same as #17801 + two last commits.

@andreer