### PR TITLE
Return request origin when wildcard is allowed

### DIFF
--- a/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
+++ b/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cors/CorsLogic.java
@@ -27,27 +27,20 @@ class CorsLogic {
     static Map<String, String> createCorsResponseHeaders(String requestOriginHeader,
                                                          Set<String> allowedOrigins) {
         if (requestOriginHeader == null) return Map.of();
+
         TreeMap<String, String> headers = new TreeMap<>();
-        allowedOrigins.stream()
-                .filter(allowedUrl -> matchesRequestOrigin(requestOriginHeader, allowedUrl))
-                .findAny()
-                .ifPresent(allowedOrigin -> headers.put(ALLOW_ORIGIN_HEADER, allowedOrigin));
-        ACCESS_CONTROL_HEADERS.forEach(headers::put);
+        if (requestOriginMatchesAnyAllowed(requestOriginHeader, allowedOrigins))
+            headers.put(ALLOW_ORIGIN_HEADER, requestOriginHeader);
+        headers.putAll(ACCESS_CONTROL_HEADERS);
         return headers;
     }
 
     static Map<String, String> createCorsPreflightResponseHeaders(String requestOriginHeader,
                                                                   Set<String> allowedOrigins) {
-        if (requestOriginHeader == null) return ACCESS_CONTROL_HEADERS;
-
-        TreeMap<String, String> headers = new TreeMap<>();
-        if (allowedOrigins.stream().anyMatch(allowedUrl -> matchesRequestOrigin(requestOriginHeader, allowedUrl)))
-            headers.put(ALLOW_ORIGIN_HEADER, requestOriginHeader);
-        ACCESS_CONTROL_HEADERS.forEach(headers::put);
-        return headers;
+        return createCorsResponseHeaders(requestOriginHeader, allowedOrigins);
     }
 
-    private static boolean matchesRequestOrigin(String requestOrigin, String allowedUrl) {
-        return allowedUrl.equals("*") || requestOrigin.startsWith(allowedUrl);
+    private static boolean requestOriginMatchesAnyAllowed(String requestOrigin, Set<String> allowedUrls) {
+        return allowedUrls.stream().anyMatch(requestOrigin::startsWith) || allowedUrls.contains("*");
     }
 }

--- a/jdisc-security-filters/src/test/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilterTest.java
+++ b/jdisc-security-filters/src/test/java/com/yahoo/jdisc/http/filter/security/cors/CorsResponseFilterTest.java
@@ -53,7 +53,7 @@ public class CorsResponseFilterTest {
     @Test
     public void any_request_origin_yields_allow_origin_header_in_response_when_wildcard_is_allowed() {
         Map<String, String> headers = doFilterRequest(newResponseFilter("*"), "http://any.origin");
-        assertEquals("*", headers.get(ALLOW_ORIGIN_HEADER));
+        assertEquals("http://any.origin", headers.get(ALLOW_ORIGIN_HEADER));
     }
 
     private static Map<String, String> doFilterRequest(SecurityResponseFilter filter, String originUrl) {


### PR DESCRIPTION
Credentials are not supported with `Access-Control-Allow-Origin` is `*`: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials