### PR TITLE
Arnej/wire constant types

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -206,6 +206,14 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
                 return featureTypes.get(reference);
             }
 
+            // the name of a constant feature?
+            if (reference.isIdentifier()) {
+                Reference asConst = FeatureNames.asConstantFeature(reference.name());
+                if (featureTypes.containsKey(asConst)) {
+                    return featureTypes.get(asConst);
+                }
+            }
+
             // We do not know what this is - since we do not have complete knowledge about the match features
             // in Java we must assume this is a match feature and return the double type - which is the type of
             // all match features

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/ConstantTensorTransformer.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/ConstantTensorTransformer.java
@@ -59,7 +59,6 @@ public class ConstantTensorTransformer extends ExpressionTransformer<RankProfile
             return node;
         }
         Value value = context.constants().get(constantName);
-        System.err.println("lookup constant: "+constantName+" -> "+value);
         if (value == null || value.type().rank() == 0) return node;
 
         TensorValue tensorValue = (TensorValue)value;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/ConstantTensorTransformer.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/ConstantTensorTransformer.java
@@ -49,11 +49,17 @@ public class ConstantTensorTransformer extends ExpressionTransformer<RankProfile
     }
 
     private ExpressionNode transformConstantReference(ReferenceNode node, RankProfileTransformContext context) {
+        String constantName = node.getName();
         Reference constantReference = node.reference();
-        if ( ! FeatureNames.isConstantFeature(constantReference) && constantReference.isIdentifier())
-            constantReference = FeatureNames.asConstantFeature(node.getName());
-
-        Value value = context.constants().get(node.getName());
+        if (FeatureNames.isConstantFeature(constantReference)) {
+            constantName = constantReference.simpleArgument().orElse(null);
+        } else if (constantReference.isIdentifier()) {
+            constantReference = FeatureNames.asConstantFeature(constantName);
+        } else {
+            return node;
+        }
+        Value value = context.constants().get(constantName);
+        System.err.println("lookup constant: "+constantName+" -> "+value);
         if (value == null || value.type().rank() == 0) return node;
 
         TensorValue tensorValue = (TensorValue)value;

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithTensorTestCase.java
@@ -33,6 +33,26 @@ public class RankingExpressionWithTensorTestCase {
     }
 
     @Test
+    public void requireConstantTensorCanBeReferredViaConstantFeature() throws ParseException {
+        RankProfileSearchFixture f = new RankProfileSearchFixture(
+                "  rank-profile my_profile {\n" +
+                "    first-phase {\n" +
+                "      expression: sum(constant(my_tensor))\n" +
+                "    }\n" +
+                "    constants {\n" +
+                "      my_tensor {\n" +
+                "        value: { {x:1,y:2}:1, {x:2,y:1}:2 }\n" +
+                "        type: tensor(x{},y{})\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }");
+        f.compileRankProfile("my_profile");
+        f.assertFirstPhaseExpression("reduce(constant(my_tensor), sum)", "my_profile");
+        f.assertRankProperty("tensor(x{},y{}):{{x:1,y:2}:1.0,{x:2,y:1}:2.0}", "constant(my_tensor).value", "my_profile");
+        f.assertRankProperty("tensor(x{},y{})", "constant(my_tensor).type", "my_profile");
+    }
+
+    @Test
     public void requireThatMultiLineConstantTensorAndTypeCanBeParsed() throws ParseException {
         RankProfileSearchFixture f = new RankProfileSearchFixture(
                 "  rank-profile my_profile {\n" +


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

NOTE: this feature (tensor constants directly in the rank profile) isn't recognised by the back-end, but
after discussion with @havardpe we think this is easy to handle from the config produced by config-model.

The alternative is to deprecate this completely and remove various unit tests (and .sd parsing).

@bratseth please review
@lesters FYI
