### PR TITLE
Stop all stripe threads before starting shutdown (and closing) of the…

### DIFF
--- a/storage/src/tests/distributor/distributortestutil.cpp
+++ b/storage/src/tests/distributor/distributortestutil.cpp
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/distributor_stripe.h>
 #include <vespa/storage/distributor/distributor_stripe_component.h>
+#include <vespa/storage/distributor/distributor_stripe_pool.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
 
@@ -28,10 +29,12 @@ DistributorTestUtil::createLinks()
 {
     _node.reset(new TestDistributorApp(_config.getConfigId()));
     _threadPool = framework::TickingThreadPool::createDefault("distributor");
+    _stripe_pool = std::make_unique<DistributorStripePool>();
     _distributor.reset(new Distributor(
             _node->getComponentRegister(),
             _node->node_identity(),
             *_threadPool,
+            *_stripe_pool,
             *this,
             _num_distributor_stripes,
             _hostInfo,

--- a/storage/src/tests/distributor/distributortestutil.h
+++ b/storage/src/tests/distributor/distributortestutil.h
@@ -17,16 +17,17 @@ namespace framework { struct TickingThreadPool; }
 
 namespace distributor {
 
-class StripeBucketDBUpdater;
 class Distributor;
 class DistributorBucketSpace;
 class DistributorBucketSpaceRepo;
-class DistributorStripeOperationContext;
 class DistributorStripe;
 class DistributorStripeComponent;
+class DistributorStripeOperationContext;
+class DistributorStripePool;
 class ExternalOperationHandler;
 class IdealStateManager;
 class Operation;
+class StripeBucketDBUpdater;
 
 // TODO STRIPE rename to DistributorStripeTestUtil?
 class DistributorTestUtil : private DoneInitializeHandler
@@ -206,6 +207,7 @@ protected:
     vdstestlib::DirConfig _config;
     std::unique_ptr<TestDistributorApp> _node;
     std::unique_ptr<framework::TickingThreadPool> _threadPool;
+    std::unique_ptr<DistributorStripePool> _stripe_pool;
     std::unique_ptr<Distributor> _distributor;
     std::unique_ptr<storage::DistributorComponent> _component;
     DistributorMessageSenderStub _sender;

--- a/storage/src/vespa/storage/distributor/distributor.h
+++ b/storage/src/vespa/storage/distributor/distributor.h
@@ -63,6 +63,7 @@ public:
     Distributor(DistributorComponentRegister&,
                 const NodeIdentity& node_identity,
                 framework::TickingThreadPool&,
+                DistributorStripePool& stripe_pool,
                 DoneInitializeHandler&,
                 uint32_t num_distributor_stripes,
                 HostInfo& hostInfoReporterRegistrar,
@@ -201,7 +202,7 @@ private:
     const bool                            _use_legacy_mode;
     // TODO STRIPE multiple stripes...! This is for proof of concept of wiring.
     std::unique_ptr<DistributorStripe>    _stripe;
-    std::unique_ptr<DistributorStripePool> _stripe_pool;
+    DistributorStripePool&                _stripe_pool;
     std::vector<std::unique_ptr<DistributorStripe>> _stripes;
     std::unique_ptr<StripeAccessor>      _stripe_accessor;
     MessageQueue                         _message_queue; // Queue for top-level ops

--- a/storage/src/vespa/storage/distributor/distributor_stripe_pool.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_pool.h
@@ -77,6 +77,7 @@ public:
         return *_stripes[idx];
     }
     [[nodiscard]] size_t stripe_count() const noexcept { return _stripes.size(); }
+    [[nodiscard]] bool is_stopped() const noexcept { return _stopped; }
 
     // Applies to all threads. May be called both before and after start(). Thread safe.
     void set_tick_wait_duration(vespalib::duration new_tick_wait_duration) noexcept;

--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -15,6 +15,8 @@
 
 namespace storage {
 
+namespace distributor { class DistributorStripePool; }
+
 class IStorageChainBuilder;
 
 class DistributorNode
@@ -22,6 +24,7 @@ class DistributorNode
         private UniqueTimeCalculator
 {
     framework::TickingThreadPool::UP _threadPool;
+    std::unique_ptr<distributor::DistributorStripePool> _stripe_pool;
     DistributorNodeContext& _context;
     uint64_t _lastUniqueTimestampRequested;
     uint32_t _uniqueTimestampCounter;


### PR DESCRIPTION
… storage link chain.

This is required to avoid stripe threads being able to send up messages
while the communication manager is being closed.
Such messages will fail at the RPC layer (already closed)
and an error reply is sent down from the communication manager.
This triggers an assert in StorageLink::sendDown() which is already CLOSED.

@vekterli please review
