### PR TITLE
support functional constants

### DIFF
--- a/eval/src/vespa/eval/eval/call_nodes.h
+++ b/eval/src/vespa/eval/eval/call_nodes.h
@@ -25,12 +25,12 @@ private:
     vespalib::string     _name;
     size_t               _num_params;
     std::vector<Node_UP> _args;
-    bool                 _is_const;
+    bool                 _is_const_double;
 public:
     Call(const vespalib::string &name_in, size_t num_params_in)
-        : _name(name_in), _num_params(num_params_in), _is_const(false) {}
+        : _name(name_in), _num_params(num_params_in), _is_const_double(false) {}
     ~Call();
-    bool is_const() const override { return _is_const; }
+    bool is_const_double() const override { return _is_const_double; }
     const vespalib::string &name() const { return _name; }
     size_t num_params() const { return _num_params; }
     size_t num_args() const { return _args.size(); }
@@ -45,9 +45,9 @@ public:
     }
     virtual void bind_next(Node_UP arg_in) {
         if (_args.empty()) {
-            _is_const = arg_in->is_const();
+            _is_const_double = arg_in->is_const_double();
         } else {
-            _is_const = (_is_const && arg_in->is_const());
+            _is_const_double = (_is_const_double && arg_in->is_const_double());
         }
         _args.push_back(std::move(arg_in));
     }

--- a/eval/src/vespa/eval/eval/fast_forest.cpp
+++ b/eval/src/vespa/eval/eval/fast_forest.cpp
@@ -85,26 +85,26 @@ State::encode_node(uint32_t tree_id, const nodes::Node &node)
         if (less) {
             auto symbol = nodes::as<nodes::Symbol>(less->lhs());
             assert(symbol);
-            assert(less->rhs().is_const());
+            assert(less->rhs().is_const_double());
             size_t feature = symbol->id();
             assert(feature < cmp_nodes.size());
-            cmp_nodes[feature].emplace_back(less->rhs().get_const_value(), tree_id, true_leafs, true);
+            cmp_nodes[feature].emplace_back(less->rhs().get_const_double_value(), tree_id, true_leafs, true);
         } else {
             assert(inverted);
             auto ge = nodes::as<nodes::GreaterEqual>(inverted->child());
             assert(ge);
             auto symbol = nodes::as<nodes::Symbol>(ge->lhs());
             assert(symbol);
-            assert(ge->rhs().is_const());
+            assert(ge->rhs().is_const_double());
             size_t feature = symbol->id();
             assert(feature < cmp_nodes.size());
-            cmp_nodes[feature].emplace_back(ge->rhs().get_const_value(), tree_id, true_leafs, false);
+            cmp_nodes[feature].emplace_back(ge->rhs().get_const_double_value(), tree_id, true_leafs, false);
         }
         return BitRange::join(true_leafs, false_leafs);
     } else {
-        assert(node.is_const());
+        assert(node.is_const_double());
         BitRange leaf_range(leafs[tree_id].size());
-        leafs[tree_id].push_back(node.get_const_value());
+        leafs[tree_id].push_back(node.get_const_double_value());
         return leaf_range;
     }
 }

--- a/eval/src/vespa/eval/eval/key_gen.cpp
+++ b/eval/src/vespa/eval/eval/key_gen.cpp
@@ -28,7 +28,7 @@ struct KeyGen : public NodeVisitor, public NodeTraverser {
     void visit(const In       &node) override { add_byte( 4);
         add_size(node.num_entries());
         for (size_t i = 0; i < node.num_entries(); ++i) {
-            add_double(node.get_entry(i).get_const_value());
+            add_double(node.get_entry(i).get_const_double_value());
         }
     }
     void visit(const Neg            &) override { add_byte( 5); }

--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
@@ -61,7 +61,7 @@ struct SetMemberHash : PluginState {
     vespalib::hash_set<double> members;
     explicit SetMemberHash(const In &in) : members(in.num_entries() * 3) {
         for (size_t i = 0; i < in.num_entries(); ++i) {
-            members.insert(in.get_entry(i).get_const_value());
+            members.insert(in.get_entry(i).get_const_double_value());
         }
     }
     static bool check_membership(const PluginState *state, double value) {
@@ -260,8 +260,8 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
     //-------------------------------------------------------------------------
 
     bool open(const Node &node) override {
-        if (node.is_const()) {
-            push_double(node.get_const_value());
+        if (node.is_const_double()) {
+            push_double(node.get_const_double_value());
             return false;
         }
         if (!inside_forest && (pass_params != PassParams::SEPARATE) && node.is_forest()) {
@@ -412,7 +412,7 @@ struct FunctionBuilder : public NodeVisitor, public NodeTraverser {
             // build explicit code to check all set members
             llvm::Value *found = builder.getFalse();
             for (size_t i = 0; i < item.num_entries(); ++i) {
-                llvm::Value *elem = llvm::ConstantFP::get(builder.getDoubleTy(), item.get_entry(i).get_const_value());
+                llvm::Value *elem = llvm::ConstantFP::get(builder.getDoubleTy(), item.get_entry(i).get_const_double_value());
                 llvm::Value *elem_eq = builder.CreateFCmpOEQ(lhs, elem, "elem_eq");
                 found = builder.CreateOr(found, elem_eq, "found");
             }

--- a/eval/src/vespa/eval/eval/make_tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/make_tensor_function.cpp
@@ -83,14 +83,14 @@ struct TensorFunctionBuilder : public NodeVisitor, public NodeTraverser {
 
     bool maybe_make_const(const Node &node) {
         if (auto create = as<TensorCreate>(node)) {
-            bool is_const = true;
+            bool is_const_double = true;
             for (size_t i = 0; i < create->num_children(); ++i) {
-                is_const &= create->get_child(i).is_const();
+                is_const_double &= create->get_child(i).is_const_double();
             }
-            if (is_const) {
+            if (is_const_double) {
                 TensorSpec spec(create->type().to_spec());
                 for (size_t i = 0; i < create->num_children(); ++i) {
-                    spec.add(create->get_child_address(i), create->get_child(i).get_const_value());
+                    spec.add(create->get_child_address(i), create->get_child(i).get_const_double_value());
                 }
                 make_const(node, *stash.create<Value::UP>(value_from_spec(spec, factory)));
                 return true;
@@ -172,7 +172,7 @@ struct TensorFunctionBuilder : public NodeVisitor, public NodeTraverser {
     void visit(const In &node) override {
         auto my_in = std::make_unique<In>(std::make_unique<Symbol>(0));
         for (size_t i = 0; i < node.num_entries(); ++i) {
-            my_in->add_entry(std::make_unique<Number>(node.get_entry(i).get_const_value()));
+            my_in->add_entry(std::make_unique<Number>(node.get_entry(i).get_const_double_value()));
         }
         auto my_fun = Function::create(std::move(my_in), {"x"});
         const auto &token = stash.create<CompileCache::Token::UP>(CompileCache::compile(*my_fun, PassParams::SEPARATE));

--- a/eval/src/vespa/eval/eval/operator_nodes.cpp
+++ b/eval/src/vespa/eval/eval/operator_nodes.cpp
@@ -13,7 +13,7 @@ Operator::Operator(const vespalib::string &op_str_in, int priority_in, Order ord
       _order(order_in),
       _lhs(),
       _rhs(),
-      _is_const(false)
+      _is_const_double(false)
 {}
 
 Operator::~Operator() { }

--- a/eval/src/vespa/eval/eval/operator_nodes.h
+++ b/eval/src/vespa/eval/eval/operator_nodes.h
@@ -32,7 +32,7 @@ private:
     Order            _order;
     Node_UP          _lhs;
     Node_UP          _rhs;
-    bool             _is_const;
+    bool             _is_const_double;
 
 public:
     Operator(const vespalib::string &op_str_in, int priority_in, Order order_in);
@@ -42,7 +42,7 @@ public:
     Order order() const { return _order; }
     const Node &lhs() const { return *_lhs; }
     const Node &rhs() const { return *_rhs; }
-    bool is_const() const override { return _is_const; }
+    bool is_const_double() const override { return _is_const_double; }
     size_t num_children() const override { return (_lhs && _rhs) ? 2 : 0; }
     const Node &get_child(size_t idx) const override {
         assert(idx < 2);
@@ -67,7 +67,7 @@ public:
     virtual void bind(Node_UP lhs_in, Node_UP rhs_in) {
         _lhs = std::move(lhs_in);
         _rhs = std::move(rhs_in);
-        _is_const = (_lhs->is_const() && _rhs->is_const());
+        _is_const_double = (_lhs->is_const_double() && _rhs->is_const_double());
     }
 
     vespalib::string dump(DumpContext &ctx) const override {

--- a/eval/src/vespa/eval/eval/vm_forest.cpp
+++ b/eval/src/vespa/eval/eval/vm_forest.cpp
@@ -136,8 +136,8 @@ void encode_less(const nodes::Less &less,
     auto symbol = nodes::as<nodes::Symbol>(less.lhs());
     assert(symbol);
     model_out.push_back(uint32_t(symbol->id()) << 12);
-    assert(less.rhs().is_const());
-    encode_const(less.rhs().get_const_value(), model_out);
+    assert(less.rhs().is_const_double());
+    encode_const(less.rhs().get_const_double_value(), model_out);
     size_t skip_idx = model_out.size();
     model_out.push_back(0); // left child size placeholder
     uint32_t left_type = encode_node(left_child, model_out);
@@ -157,7 +157,7 @@ void encode_in(const nodes::In &in,
     size_t set_size_idx = model_out.size();
     model_out.push_back(in.num_entries());
     for (size_t i = 0; i < in.num_entries(); ++i) {
-        encode_large_const(in.get_entry(i).get_const_value(), model_out);
+        encode_large_const(in.get_entry(i).get_const_double_value(), model_out);
     }
     size_t left_idx = model_out.size();
     uint32_t left_type = encode_node(left_child, model_out);
@@ -176,8 +176,8 @@ void encode_inverted(const nodes::Not &inverted,
     auto symbol = nodes::as<nodes::Symbol>(ge->lhs());
     assert(symbol);
     model_out.push_back(uint32_t(symbol->id()) << 12);
-    assert(ge->rhs().is_const());
-    encode_const(ge->rhs().get_const_value(), model_out);
+    assert(ge->rhs().is_const_double());
+    encode_const(ge->rhs().get_const_double_value(), model_out);
     size_t skip_idx = model_out.size();
     model_out.push_back(0); // left child size placeholder
     uint32_t left_type = encode_node(left_child, model_out);
@@ -204,8 +204,8 @@ uint32_t encode_node(const nodes::Node &node_in, std::vector<uint32_t> &model_ou
             return INVERTED;
         }
     } else {
-        assert(node_in.is_const());
-        encode_const(node_in.get_const_value(), model_out);
+        assert(node_in.is_const_double());
+        encode_const(node_in.get_const_double_value(), model_out);
         return LEAF;
     }
 }

--- a/searchlib/src/apps/vespa-ranking-expression-analyzer/vespa-ranking-expression-analyzer.cpp
+++ b/searchlib/src/apps/vespa-ranking-expression-analyzer/vespa-ranking-expression-analyzer.cpp
@@ -95,11 +95,11 @@ struct FunctionInfo {
         if (node) {
             auto lhs_symbol = as<Symbol>(node->lhs());
             auto rhs_symbol = as<Symbol>(node->rhs());
-            if (lhs_symbol && node->rhs().is_const()) {
-                inputs[lhs_symbol->id()].cmp_with.push_back(node->rhs().get_const_value());
+            if (lhs_symbol && node->rhs().is_const_double()) {
+                inputs[lhs_symbol->id()].cmp_with.push_back(node->rhs().get_const_double_value());
             }
-            if (node->lhs().is_const() && rhs_symbol) {
-                inputs[rhs_symbol->id()].cmp_with.push_back(node->lhs().get_const_value());
+            if (node->lhs().is_const_double() && rhs_symbol) {
+                inputs[rhs_symbol->id()].cmp_with.push_back(node->lhs().get_const_double_value());
             }
         }
     }
@@ -108,7 +108,7 @@ struct FunctionInfo {
         if (node) {
             if (auto symbol = as<Symbol>(node->child())) {
                 for (size_t i = 0; i < node->num_entries(); ++i) {
-                    inputs[symbol->id()].cmp_with.push_back(node->get_entry(i).get_const_value());
+                    inputs[symbol->id()].cmp_with.push_back(node->get_entry(i).get_const_double_value());
                 }
             }
         }


### PR DESCRIPTION
be more specific about const number values (GDBT trees):

is_const -> is_const_double
get_const_value -> get_const_double_value

Add more generic 'get_const_value' that can also be used for tensor
values. Allow it to be called even in the case of parse error, in
which case it does not produce a value (same as for non-const
sub-expressions).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review