### PR TITLE
The moveDoneContext must must live longer than the PendingLidTracker:…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/operationdonecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/operationdonecontext.cpp
@@ -1,24 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "operationdonecontext.h"
-#include <vespa/searchcore/proton/common/feedtoken.h>
 
 namespace proton {
 
-OperationDoneContext::OperationDoneContext(FeedToken token)
+OperationDoneContext::OperationDoneContext(IDestructorCallback::SP token)
     : _token(std::move(token))
 {
 }
 
-OperationDoneContext::~OperationDoneContext()
-{
-    ack();
-}
-
-void
-OperationDoneContext::ack()
-{
-    _token.reset();
-}
+OperationDoneContext::~OperationDoneContext() = default;
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/operationdonecontext.h
+++ b/searchcore/src/vespa/searchcore/proton/server/operationdonecontext.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <vespa/vespalib/util/idestructorcallback.h>
-#include <vespa/searchcore/proton/common/feedtoken.h>
 
 namespace proton {
 
@@ -16,13 +15,14 @@ namespace proton {
  */
 class OperationDoneContext : public vespalib::IDestructorCallback
 {
-    FeedToken _token;
-    void ack();
 public:
-    OperationDoneContext(FeedToken token);
+    using IDestructorCallback = vespalib::IDestructorCallback;
+    OperationDoneContext(IDestructorCallback::SP token);
 
     ~OperationDoneContext() override;
     bool hasToken() const { return static_cast<bool>(_token); }
+private:
+    IDestructorCallback::SP _token;
 };
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/putdonecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/putdonecontext.cpp
@@ -9,9 +9,8 @@ using document::Document;
 
 namespace proton {
 
-PutDoneContext::PutDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted,
-                               std::shared_ptr<const Document> doc,
-                               uint32_t lid)
+PutDoneContext::PutDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted,
+                               std::shared_ptr<const Document> doc, uint32_t lid)
     : OperationDoneContext(std::move(token)),
       _uncommitted(std::move(uncommitted)),
       _lid(lid),

--- a/searchcore/src/vespa/searchcore/proton/server/putdonecontext.h
+++ b/searchcore/src/vespa/searchcore/proton/server/putdonecontext.h
@@ -28,9 +28,8 @@ class PutDoneContext : public OperationDoneContext
     std::shared_ptr<const document::Document> _doc;
 
 public:
-    PutDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted,
-                   std::shared_ptr<const document::Document> doc,
-                   uint32_t lid);
+    PutDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted,
+                   std::shared_ptr<const document::Document> doc, uint32_t lid);
     ~PutDoneContext() override;
 
     void registerPutLid(DocIdLimit *docIdLimit) { _docIdLimit = docIdLimit; }

--- a/searchcore/src/vespa/searchcore/proton/server/removedonecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/removedonecontext.cpp
@@ -7,9 +7,8 @@
 
 namespace proton {
 
-RemoveDoneContext::RemoveDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted, vespalib::Executor &executor,
-                                     IDocumentMetaStore &documentMetaStore,
-                                     uint32_t lid)
+RemoveDoneContext::RemoveDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted,
+                                     vespalib::Executor &executor, IDocumentMetaStore &documentMetaStore, uint32_t lid)
     : OperationDoneContext(std::move(token)),
       _executor(executor),
       _task(),

--- a/searchcore/src/vespa/searchcore/proton/server/removedonecontext.h
+++ b/searchcore/src/vespa/searchcore/proton/server/removedonecontext.h
@@ -5,8 +5,6 @@
 #include "operationdonecontext.h"
 #include <vespa/searchcore/proton/common/ipendinglidtracker.h>
 #include <vespa/vespalib/util/executor.h>
-#include <vespa/document/base/globalid.h>
-#include <vespa/searchlib/common/serialnum.h>
 
 namespace proton {
 
@@ -28,8 +26,8 @@ class RemoveDoneContext : public OperationDoneContext
     IPendingLidTracker::Token _uncommitted;
 
 public:
-    RemoveDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted, vespalib::Executor &executor, IDocumentMetaStore &documentMetaStore,
-                      uint32_t lid);
+    RemoveDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted, vespalib::Executor &executor,
+                      IDocumentMetaStore &documentMetaStore, uint32_t lid);
     ~RemoveDoneContext() override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.h
@@ -53,7 +53,7 @@ public:
     using LidVector = LidVectorContext::LidVector;
     using Document = document::Document;
     using DocumentUpdate = document::DocumentUpdate;
-    using OnWriteDoneType =const std::shared_ptr<vespalib::IDestructorCallback> &;
+    using OnWriteDoneType = const std::shared_ptr<vespalib::IDestructorCallback> &;
     using OnForceCommitDoneType =const std::shared_ptr<ForceCommitContext> &;
     using OnOperationDoneType = const std::shared_ptr<OperationDoneContext> &;
     using OnPutDoneType = const std::shared_ptr<PutDoneContext> &;
@@ -66,6 +66,7 @@ public:
     using DocumentSP = std::shared_ptr<Document>;
     using DocumentUpdateSP = std::shared_ptr<DocumentUpdate>;
     using LidReuseDelayer = documentmetastore::LidReuseDelayer;
+    using IDestructorCallbackSP = std::shared_ptr<vespalib::IDestructorCallback>;
 
     using Lid = search::DocumentIdT;
 
@@ -180,8 +181,7 @@ private:
     // returns the number of documents removed.
     size_t removeDocuments(const RemoveDocumentsOperation &op, bool remove_index_and_attribute_fields);
 
-    void internalRemove(FeedToken token, IPendingLidTracker::Token uncommitted, SerialNum serialNum,
-                        Lid lid, std::shared_ptr<vespalib::IDestructorCallback> moveDoneCtx);
+    void internalRemove(IDestructorCallbackSP token, IPendingLidTracker::Token uncommitted, SerialNum serialNum, Lid lid);
 
     IPendingLidTracker::Token get_pending_lid_token(const DocumentOperation &op);
 

--- a/searchcore/src/vespa/searchcore/proton/server/updatedonecontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/updatedonecontext.cpp
@@ -7,7 +7,7 @@ using document::Document;
 
 namespace proton {
 
-UpdateDoneContext::UpdateDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted, const document::DocumentUpdate::SP &upd)
+UpdateDoneContext::UpdateDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted, const document::DocumentUpdate::SP &upd)
     : OperationDoneContext(std::move(token)),
       _uncommitted(std::move(uncommitted)),
       _upd(upd),

--- a/searchcore/src/vespa/searchcore/proton/server/updatedonecontext.h
+++ b/searchcore/src/vespa/searchcore/proton/server/updatedonecontext.h
@@ -24,7 +24,7 @@ class UpdateDoneContext : public OperationDoneContext
     document::DocumentUpdate::SP _upd;
     std::shared_future<std::unique_ptr<const document::Document>> _doc;
 public:
-    UpdateDoneContext(FeedToken token, IPendingLidTracker::Token uncommitted, const document::DocumentUpdate::SP &upd);
+    UpdateDoneContext(IDestructorCallback::SP token, IPendingLidTracker::Token uncommitted, const document::DocumentUpdate::SP &upd);
     ~UpdateDoneContext() override;
 
     const document::DocumentUpdate &getUpdate() { return *_upd; }


### PR DESCRIPTION
…:Token.

Since you either have a FeedToken or a moveDoneContext, and as they share the same IDestructorCallback as base class,
it is enough with one token. This token is destructed after the PendingLidTracker::Token.

@toregge PR