### PR TITLE
Flag for enabling encryption during provisioning and dirty

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -163,6 +163,12 @@ public class Flags {
             "Allow migrating an unencrypted data partition to being encrypted.",
             "Takes effect on next host-admin tick.");
 
+    public static final UnboundBooleanFlag ENCRYPT_DIRTY_DISK = defineFeatureFlag(
+            "encrypt-dirty-disk", false,
+            List.of("hakonhall"), "2021-05-14", "2021-06-05",
+            "Allow migrating an unencrypted data partition to being encrypted when provisioned or dirty.",
+            "Takes effect on next host-admin tick.");
+
     public static final UnboundBooleanFlag ENABLE_FEED_BLOCK_IN_DISTRIBUTOR = defineFeatureFlag(
             "enable-feed-block-in-distributor", true,
             List.of("geirst"), "2021-01-27", "2021-07-01",


### PR DESCRIPTION
This allows us to enable disk encryption when new hosts are provisioned,
including when a rebuilt host is coming alive, without the need to also enable
encryption in parked which we have enabled on specific hosts under supervision.