### PR TITLE
Support nearest neighbor query in client's Field API

### DIFF
--- a/client/src/main/java/ai/vespa/client/dsl/Field.java
+++ b/client/src/main/java/ai/vespa/client/dsl/Field.java
@@ -550,6 +550,29 @@ public class Field extends QueryChain {
         return common("=", annotation, false);
     }
 
+    /**
+     * Nearest neighbor query.
+     * https://docs.vespa.ai/en/reference/query-language-reference.html#nearestneighbor
+     *
+     * @param rankFeature the rankfeature.
+     * @return the query
+     */
+    public Query nearestNeighbor(String rankFeature) {
+        return common("nearestNeighbor", annotation, (Object) rankFeature);
+    }
+
+    /**
+     * Nearest neighbor query.
+     * https://docs.vespa.ai/en/reference/query-language-reference.html#nearestneighbor
+     *
+     * @param annotation the annotation
+     * @param rankFeature the rankfeature.
+     * @return the query
+     */
+    public Query nearestNeighbor(Annotation annotation, String rankFeature) {
+        return common("nearestNeighbor", annotation, (Object) rankFeature);
+    }
+
     private Query common(String relation, Annotation annotation, Object value) {
         return common(relation, annotation, value, values.toArray());
     }
@@ -604,6 +627,12 @@ public class Field extends QueryChain {
             case "sameElement":
                 return String.format("%s contains %s(%s)", fieldName, relation,
                                      ((Query) values.get(0)).toCommaSeparatedAndQueries());
+            case "nearestNeighbor":
+                valuesStr = values.stream().map(i -> (String) i).collect(Collectors.joining(", "));
+
+                return hasAnnotation
+                    ? String.format("([%s]nearestNeighbor(%s, %s))", annotation, fieldName, valuesStr)
+                    : String.format("nearestNeighbor(%s, %s)", fieldName, valuesStr);
             default:
                 Object value = values.get(0);
                 valuesStr = value instanceof Long ? value.toString() + "L" : value.toString();

--- a/client/src/test/groovy/ai/vespa/client/dsl/QTest.groovy
+++ b/client/src/test/groovy/ai/vespa/client/dsl/QTest.groovy
@@ -424,6 +424,26 @@ class QTest extends Specification {
         q == """yql=select * from sources * where f1 contains ([{"key":"value"}]uri("https://test.uri"));"""
     }
 
+    def "nearestNeighbor"() {
+        given:
+        def q = Q.p("f1").nearestNeighbor("query_vector")
+                .semicolon()
+                .build()
+
+        expect:
+        q == """yql=select * from sources * where nearestNeighbor(f1, query_vector);"""
+    }
+
+    def "nearestNeighbor with annotation"() {
+        given:
+        def q = Q.p("f1").nearestNeighbor(A.a("targetHits", 10), "query_vector")
+                .semicolon()
+                .build()
+
+        expect:
+        q == """yql=select * from sources * where ([{"targetHits":10}]nearestNeighbor(f1, query_vector));"""
+    }
+
     def "use contains instead of contains equiv when input size is 1"() {
         def q = Q.p("f1").containsEquiv(["p1"])
             .semicolon()


### PR DESCRIPTION
Context:
While implementing transformers we noticed the java-client lacks an API to query nearest neighbors as described in https://docs.vespa.ai/en/reference/query-language-reference.html#nearestneighbor. This PR aims to extend the Field API to support it.

Pinging @bratseth ( the upward `OWNER` file is the root and it points to you )

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
