### PR TITLE
Don't setup metrics proxy container for tester instances

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -29,7 +29,6 @@ import com.yahoo.vespa.model.filedistribution.FileDistributor;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -212,7 +211,8 @@ public class Admin extends AbstractConfigProducer<Admin> implements Serializable
         if (slobroks.isEmpty()) // TODO: Move to caller
             slobroks.addAll(createDefaultSlobrokSetup(deployState.getDeployLogger()));
 
-        addMetricsProxyCluster(hosts, deployState);
+        if (! deployState.isHosted() || ! deployState.getProperties().applicationId().instance().value().equals("default-t"))
+            addMetricsProxyCluster(hosts, deployState);
 
         for (HostResource host : hosts) {
             if (!host.getHost().runsConfigServer()) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -211,7 +211,7 @@ public class Admin extends AbstractConfigProducer<Admin> implements Serializable
         if (slobroks.isEmpty()) // TODO: Move to caller
             slobroks.addAll(createDefaultSlobrokSetup(deployState.getDeployLogger()));
 
-        if (! deployState.isHosted() || ! deployState.getProperties().applicationId().instance().value().equals("default-t"))
+        if (! deployState.isHosted() || ! deployState.getProperties().applicationId().instance().isTester())
             addMetricsProxyCluster(hosts, deployState);
 
         for (HostResource host : hosts) {


### PR DESCRIPTION
I guess we don't need metrics proxy for tester instances? They are shortlived and I'm not sure if anyone ever look at metrics for them? Removing it will save some time starting Vespa on the node, since this is run on a node with few resources and starting a container requires some CPU seconds
