### PR TITLE
Make distributor timestamp generation thread safe [run-systemtest]

### DIFF
--- a/storage/src/tests/common/teststorageapp.cpp
+++ b/storage/src/tests/common/teststorageapp.cpp
@@ -226,7 +226,7 @@ TestDistributorApp::TestDistributorApp(NodeIndex index, vespalib::stringref conf
 TestDistributorApp::~TestDistributorApp() = default;
 
 api::Timestamp
-TestDistributorApp::getUniqueTimestamp()
+TestDistributorApp::generate_unique_timestamp()
 {
     std::lock_guard guard(_accessLock);
     uint64_t timeNow(getClock().getTimeInSeconds().getTime());

--- a/storage/src/tests/common/teststorageapp.h
+++ b/storage/src/tests/common/teststorageapp.h
@@ -101,7 +101,7 @@ public:
 
 private:
     // Storage server interface implementation (until we can remove it)
-    virtual api::Timestamp getUniqueTimestamp() { abort(); }
+    virtual api::Timestamp generate_unique_timestamp() { abort(); }
     [[nodiscard]] virtual StorBucketDatabase& content_bucket_db(document::BucketSpace) { abort(); }
     virtual StorBucketDatabase& getStorageBucketDatabase() { abort(); }
     virtual BucketDatabase& getBucketDatabase() { abort(); }
@@ -157,7 +157,7 @@ public:
         return _compReg;
     }
 
-    api::Timestamp getUniqueTimestamp() override;
+    api::Timestamp generate_unique_timestamp() override;
 };
 
 } // storageo

--- a/storage/src/vespa/storage/common/distributorcomponent.h
+++ b/storage/src/vespa/storage/common/distributorcomponent.h
@@ -46,7 +46,7 @@ typedef vespa::config::content::core::internal::InternalStorVisitordispatcherTyp
 
 struct UniqueTimeCalculator {
     virtual ~UniqueTimeCalculator() {}
-    virtual api::Timestamp getUniqueTimestamp() = 0;
+    [[nodiscard]] virtual api::Timestamp generate_unique_timestamp() = 0;
 };
 
 struct DistributorManagedComponent
@@ -90,8 +90,8 @@ public:
     DistributorComponent(DistributorComponentRegister& compReg, vespalib::stringref name);
     ~DistributorComponent() override;
 
-    api::Timestamp getUniqueTimestamp() const {
-        return _timeCalculator->getUniqueTimestamp();
+    [[nodiscard]] api::Timestamp getUniqueTimestamp() const {
+        return _timeCalculator->generate_unique_timestamp();
     }
     const DistributorConfig& getDistributorConfig() const {
         return _distributorConfig;

--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -12,6 +12,7 @@
 #include "storagenode.h"
 #include <vespa/storage/common/distributorcomponent.h>
 #include <vespa/storageframework/generic/thread/tickingthread.h>
+#include <mutex>
 
 namespace storage {
 
@@ -26,10 +27,18 @@ class DistributorNode
     framework::TickingThreadPool::UP _threadPool;
     std::unique_ptr<distributor::DistributorStripePool> _stripe_pool;
     DistributorNodeContext& _context;
-    uint64_t _lastUniqueTimestampRequested;
-    uint32_t _uniqueTimestampCounter;
+    std::mutex _timestamp_mutex;
+    uint64_t _timestamp_second_counter;
+    uint32_t _intra_second_pseudo_usec_counter;
     uint32_t _num_distributor_stripes;
     std::unique_ptr<StorageLink> _retrievedCommunicationManager;
+
+    // If the current wall clock is more than the below number of seconds into the
+    // past when compared to the highest recorded wall clock second time stamp, abort
+    // the process. This is a sanity checking measure to prevent a process running
+    // on a wall clock that transiently is set far into the future from (hopefully)
+    // generating a massive amount of broken future timestamps.
+    constexpr static uint32_t SanityCheckMaxWallClockSecondSkew = 120;
 
 public:
     typedef std::unique_ptr<DistributorNode> UP;
@@ -52,7 +61,7 @@ private:
     void initializeNodeSpecific() override;
     void perform_post_chain_creation_init_steps() override { /* no-op */ }
     void createChain(IStorageChainBuilder &builder) override;
-    api::Timestamp getUniqueTimestamp() override;
+    api::Timestamp generate_unique_timestamp() override;
 
     /**
      * Shut down necessary distributor-specific components before shutting


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

New behavior:
- Only allow time to travel forwards within a given distributor process'
  lifetime. This is a change from the old behavior, which would emit a
  warning to the logs and happily continue from a previously used second,
  possibly causing the distributor to reuse timestamps.
- Try to detect cases where the wall clock has been transiently set far
  into the future--only to bounce back--by aborting the process if the
  current observed time is more than 120 seconds older than the highest
  observed wall clock time. This is an attempt to avoid generating _too_
  many bogus future timestamps, as the distributor would otherwise continue
  generating timestamps within the highest observed second.
