### PR TITLE
Do not log warning when exact-terminator is not specified

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/ExactMatch.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/ExactMatch.java
@@ -62,9 +62,9 @@ public class ExactMatch extends Processor {
                 && ! field.getMatching().getExactMatchTerminator().equals("")) {
                 exactTerminator = field.getMatching().getExactMatchTerminator();
             } else {
-                warn(search, field,
-                     "With 'exact' matching, an exact-terminator is needed " +
-                     "(using '" + exactTerminator +"' as terminator)");
+                info(search, field,
+                     "With 'exact' matching, an exact-terminator is needed," +
+                     " using default value '" + exactTerminator +"' as terminator");
             }
             field.addQueryCommand("exact " + exactTerminator);
 


### PR DESCRIPTION
'@@' is default value according to doc, so no need to warn
