### PR TITLE
Enable HTTP/2 by default in jdisc (assuming ALPN/TLS)

### DIFF
--- a/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -127,4 +127,4 @@ maxRequestsPerConnection       int     default=0
 maxConnectionLife              double  default=0.0
 
 # Enable HTTP/2 (in addition to HTTP/1.1 using ALPN)
-http2Enabled                   bool  default=false
+http2Enabled                   bool  default=true


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
