### PR TITLE
Add a couple of stripe work TODOs

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
@@ -185,6 +185,9 @@ public:
     }
 };
 
+// TODO STRIPE replace with check for pending cluster state transition.
+//   Null-bucket messages are not intercepted nor observeable by stripes,
+//   only by the top-level distributor.
 bool
 checkNullBucketRequestBucketInfoMessage(uint16_t node,
                                         document::BucketSpace bucketSpace,

--- a/storage/src/vespa/storage/distributor/statechecker.cpp
+++ b/storage/src/vespa/storage/distributor/statechecker.cpp
@@ -79,6 +79,7 @@ StateChecker::Context::Context(const DistributorNodeContext& node_ctx_in,
       db(distributorBucketSpace.getBucketDatabase()),
       stats(statsTracker)
 {
+    // TODO STRIPE use existing cache for computing ideal storage nodes for bucket
     idealState = distribution.getIdealStorageNodes(systemState, bucket.getBucketId());
     unorderedIdealState.insert(idealState.begin(), idealState.end());
 }


### PR DESCRIPTION
@geirst please review

- Ideal state ops cannot look at null-bucket messages for determining
  if full bucket checks are pending when running in striped mode, as
  these are not handled by stripes when not in legacy mode.
- State checker context should use ideal state cache instead of recomputing
  for every checked bucket (observed via `perf` in production).

