### PR TITLE
Add messagetype policy "defaultroute" for non-indexed clusters

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/routing/DocumentProtocol.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/routing/DocumentProtocol.java
@@ -111,6 +111,8 @@ public final class DocumentProtocol implements Protocol,
             addSelector(cluster.getConfigId(), cluster.getRoutingSelector(), clusterBuilder);
             if (cluster.getSearch().hasIndexedCluster())
                 addRoutes(getDirectRouteName(cluster.getConfigId()), getIndexedRouteName(cluster.getConfigId()), clusterBuilder);
+            else
+                clusterBuilder.defaultRoute(cluster.getConfigId());
 
             builder.cluster(cluster.getConfigId(), clusterBuilder);
         }


### PR DESCRIPTION
@baldersheim please review and merge.

This will allow using a messagetype policy when there is no indexed cluster, and fixes a current issue. 
(We don't use the messagetype policy (in our routing table) unless there _is_ an indexed cluster, but someone may do it using the route spec directly.)