### PR TITLE
Expose number of retiring nodes in deployment log

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/ConvergenceSummary.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/ConvergenceSummary.java
@@ -22,9 +22,10 @@ public class ConvergenceSummary {
     private final long restarting;
     private final long services;
     private final long needNewConfig;
+    private final long retiring;
 
     public ConvergenceSummary(long nodes, long down, long upgradingOs, long upgradingFirmware, long needPlatformUpgrade, long upgradingPlatform,
-                              long needReboot, long rebooting, long needRestart, long restarting, long services, long needNewConfig) {
+                              long needReboot, long rebooting, long needRestart, long restarting, long services, long needNewConfig, long retiring) {
         this.nodes = nodes;
         this.down = down;
         this.upgradingOs = upgradingOs;
@@ -37,6 +38,7 @@ public class ConvergenceSummary {
         this.restarting = restarting;
         this.services = services;
         this.needNewConfig = needNewConfig;
+        this.retiring = retiring;
     }
 
     /** Number of nodes in the application. */
@@ -99,6 +101,11 @@ public class ConvergenceSummary {
         return needNewConfig;
     }
 
+    /** Number of nodes that are retiring. */
+    public long retiring() {
+        return retiring;
+    }
+
     /** Whether the convergence is done. */
     public boolean converged() {
         return     nodes > 0
@@ -125,12 +132,13 @@ public class ConvergenceSummary {
                needRestart == that.needRestart &&
                restarting == that.restarting &&
                services == that.services &&
-               needNewConfig == that.needNewConfig;
+               needNewConfig == that.needNewConfig &&
+               retiring == that.retiring;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nodes, down, upgradingOs, upgradingFirmware, needPlatformUpgrade, upgradingPlatform, needReboot, rebooting, needRestart, restarting, services, needNewConfig);
+        return Objects.hash(nodes, down, upgradingOs, upgradingFirmware, needPlatformUpgrade, upgradingPlatform, needReboot, rebooting, needRestart, restarting, services, needNewConfig, retiring);
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/NodeList.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/NodeList.java
@@ -87,6 +87,12 @@ public class NodeList extends AbstractFilteringList<NodeWithServices, NodeList> 
         return matching(NodeWithServices::needsNewConfig);
     }
 
+    /** The nodes that are retiring. */
+    public NodeList retiring() {
+        return matching(node -> node.node().retired());
+    }
+
+
     /** Returns a summary of the convergence status of the nodes in this list. */
     public ConvergenceSummary summary() {
         NodeList allowedDown = expectedDown();
@@ -101,7 +107,8 @@ public class NodeList extends AbstractFilteringList<NodeWithServices, NodeList> 
                                       needsRestart().size(),
                                       allowedDown.needsRestart().size(),
                                       asList().stream().mapToLong(node -> node.services().size()).sum(),
-                                      asList().stream().mapToLong(node -> node.services().stream().filter(service -> wantedConfigGeneration > service.currentGeneration()).count()).sum());
+                                      asList().stream().mapToLong(node -> node.services().stream().filter(service -> wantedConfigGeneration > service.currentGeneration()).count()).sum(),
+                                      retiring().size());
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -213,6 +213,7 @@ class JobControllerApiHandlerHelper {
         summaryObject.setLong("upgradingFirmware", summary.upgradingFirmware());
         summaryObject.setLong("services", summary.services());
         summaryObject.setLong("needNewConfig", summary.needNewConfig());
+        summaryObject.setLong("retiring", summary.retiring());
     }
 
     private static void toSlime(Cursor entryArray, List<LogEntry> entries) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/run-status.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/run-status.json
@@ -8,7 +8,7 @@
     "lastTestRecord": 3,
     "lastVespaLogTimestamp": 1196676930000432,
     "noNodesDownSince": 321321321321,
-    "convergenceSummary": [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144],
+    "convergenceSummaryV2": [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233],
     "testerCertificate": "-----BEGIN CERTIFICATE-----\nMIIBEzCBu6ADAgECAgEBMAoGCCqGSM49BAMEMBQxEjAQBgNVBAMTCW15c2Vydmlj\nZTAeFw0xOTA5MDYwNzM3MDZaFw0xOTA5MDcwNzM3MDZaMBQxEjAQBgNVBAMTCW15\nc2VydmljZTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABM0JhD8fV2DlAkjQOGX3\nY50ryMBr3g2+v/uFiRoxJ1muuSOWYrW7HCQIGuzc04fa0QwtaX/voAZKCV51t6jF\n0fwwCgYIKoZIzj0EAwQDRwAwRAIgVbQ3Co1H4X0gmRrtXSyTU0HgBQu9PXHMmX20\n5MyyPSoCIBltOcmaPfdN03L3zqbqZ6PgUBWsvAHgiBzL3hrtJ+iy\n-----END CERTIFICATE-----",
     "steps": {
       "deployInitialReal": "unfinished",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1-log-first-part.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-us-east-1-log-first-part.json
@@ -70,7 +70,8 @@
         "upgradingOs": 0,
         "upgradingFirmware": 0,
         "services": 1,
-        "needNewConfig": 1
+        "needNewConfig": 1,
+        "retiring": 0
       }
     },
     "copyVespaLogs": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
@@ -149,7 +149,8 @@
         "upgradingOs": 0,
         "upgradingFirmware": 0,
         "services": 1,
-        "needNewConfig": 1
+        "needNewConfig": 1,
+        "retiring": 0
       }
     },
     "startStagingSetup": {


### PR DESCRIPTION
Needed for VESPA-19930: Want to give some indicator to the tenant that the deployment may take a while if there is an ongoing retirement.