### PR TITLE
Load of tensor attribute with nearest neighbor index enabled but no

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -207,7 +207,7 @@ DenseTensorAttribute::onLoad()
                 // This ensures that get_vector() (via getTensor()) is able to find the newly added tensor.
                 setCommittedDocIdLimit(lid + 1);
                 _index->add_document(lid);
-                if ((lid % (1u << 8)) == 0) {
+                if ((lid % 256) == 0) {
                     commit();
                 }
             }

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -207,6 +207,9 @@ DenseTensorAttribute::onLoad()
                 // This ensures that get_vector() (via getTensor()) is able to find the newly added tensor.
                 setCommittedDocIdLimit(lid + 1);
                 _index->add_document(lid);
+                if ((lid & ((1u << 8) - 1)) == 0) {
+                    commit();
+                }
             }
         } else {
             _refVector.push_back(EntryRef());

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -207,7 +207,7 @@ DenseTensorAttribute::onLoad()
                 // This ensures that get_vector() (via getTensor()) is able to find the newly added tensor.
                 setCommittedDocIdLimit(lid + 1);
                 _index->add_document(lid);
-                if ((lid & ((1u << 8) - 1)) == 0) {
+                if ((lid % (1u << 8)) == 0) {
                     commit();
                 }
             }


### PR DESCRIPTION
saved index will index documents during the load. Add occasional calls
to commit() to prevent excessive growth of hold lists.

@geirst : please review
