### PR TITLE
Log model build errors to the deploy log

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeployLogger.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeployLogger.java
@@ -20,4 +20,5 @@ public interface DeployLogger {
     default void logApplicationPackage(Level level, String message) {
         log(level, message);
     }
+
 }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/OutOfCapacityException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/OutOfCapacityException.java
@@ -7,7 +7,6 @@ package com.yahoo.config.provision;
  * having too few nodes (of the specified flavor)
  * 
  * @author hmusum
- *
  */
 public class OutOfCapacityException extends RuntimeException {
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -838,15 +838,14 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     public void validateThatSessionIsNotActive(Tenant tenant, long sessionId) {
         Session session = getRemoteSession(tenant, sessionId);
-        if (Session.Status.ACTIVATE.equals(session.getStatus())) {
-            throw new IllegalStateException("Session is active: " + sessionId);
-        }
+        if (Session.Status.ACTIVATE == session.getStatus())
+            throw new IllegalArgumentException("Session is active: " + sessionId);
     }
 
     public void validateThatSessionIsPrepared(Tenant tenant, long sessionId) {
         Session session = getRemoteSession(tenant, sessionId);
-        if ( ! Session.Status.PREPARE.equals(session.getStatus()))
-            throw new IllegalStateException("Session not prepared: " + sessionId);
+        if ( Session.Status.PREPARE != session.getStatus())
+            throw new IllegalArgumentException("Session not prepared: " + sessionId);
     }
 
     public long createSessionFromExisting(ApplicationId applicationId, boolean internalRedeploy, TimeoutBudget timeoutBudget) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/BadRequestException.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/BadRequestException.java
@@ -5,11 +5,11 @@ package com.yahoo.vespa.config.server.http;
  * Exception that will create a http response with BAD_REQUEST response code (400)
  *
  * @author hmusum
- * @since 5.1.17
  */
-public class BadRequestException extends RuntimeException {
+public class BadRequestException extends IllegalArgumentException {
 
     public BadRequestException(String message) {
         super(message);
     }
+
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -50,12 +50,12 @@ public class HttpHandler extends LoggingRequestHandler {
             return HttpErrorResponse.notFoundError(getMessage(e, request));
         } catch (ActivationConflictException e) {
             return HttpErrorResponse.conflictWhenActivating(getMessage(e, request));
-        } catch (BadRequestException | IllegalArgumentException | IllegalStateException e) {
+        } catch (InvalidApplicationException e) {
+            return HttpErrorResponse.invalidApplicationPackage(getMessage(e, request));
+        } catch (IllegalArgumentException e) {
             return HttpErrorResponse.badRequest(getMessage(e, request));
         } catch (OutOfCapacityException e) {
             return HttpErrorResponse.outOfCapacity(getMessage(e, request));
-        } catch (InvalidApplicationException e) {
-            return HttpErrorResponse.invalidApplicationPackage(getMessage(e, request));
         } catch (InternalServerException e) {
             return HttpErrorResponse.internalServerError(getMessage(e, request));
         } catch (UnknownVespaVersionException e) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/InvalidApplicationException.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/InvalidApplicationException.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.config.server.http;
 /**
  * @author hmusum
  */
-public class InvalidApplicationException extends RuntimeException {
+public class InvalidApplicationException extends IllegalArgumentException {
 
     public InvalidApplicationException(String message) {
         super(message);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableSet;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ModelContext;
@@ -80,7 +81,8 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
         super(modelFactoryRegistry,
               configserverConfig,
               zone,
-              hostProvisionerProvider);
+              hostProvisionerProvider,
+              new SilentDeployLogger());
         this.tenant = tenant;
         this.applicationGeneration = applicationGeneration;
         this.zkClient = zkClient;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -52,7 +52,6 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
     private final PermanentApplicationPackage permanentApplicationPackage;
     private final ConfigDefinitionRepo configDefinitionRepo;
     private final HostValidator<ApplicationId> hostValidator;
-    private final DeployLogger logger;
     private final PrepareParams params;
     private final FileDistributionProvider fileDistributionProvider;
     private final Optional<ApplicationSet> currentActiveApplicationSet;
@@ -66,18 +65,17 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                                  HostProvisionerProvider hostProvisionerProvider,
                                  Curator curator,
                                  HostValidator<ApplicationId> hostValidator,
-                                 DeployLogger logger,
+                                 DeployLogger deployLogger,
                                  PrepareParams params,
                                  Optional<ApplicationSet> currentActiveApplicationSet,
                                  ModelContext.Properties properties,
                                  ConfigserverConfig configserverConfig) {
-        super(modelFactoryRegistry, configserverConfig, properties.zone(), hostProvisionerProvider);
+        super(modelFactoryRegistry, configserverConfig, properties.zone(), hostProvisionerProvider, deployLogger);
         this.permanentApplicationPackage = permanentApplicationPackage;
         this.configDefinitionRepo = configDefinitionRepo;
         this.fileDistributionProvider = fileDistributionProvider;
         this.hostValidator = hostValidator;
         this.curator = curator;
-        this.logger = logger;
         this.params = params;
         this.currentActiveApplicationSet = currentActiveApplicationSet;
         this.properties = properties;
@@ -99,7 +97,7 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                 applicationPackage,
                 modelOf(modelVersion),
                 permanentApplicationPackage.applicationPackage(),
-                logger,
+                deployLogger(),
                 configDefinitionRepo,
                 fileDistributionProvider.getFileRegistry(),
                 new ApplicationCuratorDatabase(applicationId.tenant(), curator).readReindexingStatus(applicationId),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -242,7 +242,7 @@ public class HostedDeployTest {
      * Tests that we create the minimal set of models and that version 7.x is created
      * if creating version 8.x fails (to support upgrades to new major version for applications
      * that are still using features that do not work on version 8.x)
-     **/
+     */
     @Test
     public void testCreateLatestMajorOnPreviousMajorIfItFailsOnMajorVersion8() throws IOException {
         deployWithModelForLatestMajorVersionFailing(8);
@@ -252,7 +252,7 @@ public class HostedDeployTest {
      * Tests that we fail deployment for version 7.x if creating version 7.x fails (i.e. that we do not skip
      * building 7.x and only build version 6.x). Skipping creation of models for a major version is only supported
      * for major version >= 8 (see test above) or when major-version=6 is set in application package.
-     **/
+     */
     @Test(expected = InvalidApplicationException.class)
     public void testFailingToCreateModelVersion7FailsDeployment() throws IOException {
         deployWithModelForLatestMajorVersionFailing(7);
@@ -286,7 +286,7 @@ public class HostedDeployTest {
 
     /**
      * Tests that we fail deployment if a needed model version fails to be created
-     **/
+     */
     @Test(expected = InvalidApplicationException.class)
     public void testDeploymentFailsIfNeededModelVersionFails() throws IOException {
         List<Host> hosts = createHosts(7, "7.0.0");
@@ -302,7 +302,7 @@ public class HostedDeployTest {
      * Test that deploying an application works when there are no allocated hosts in the system
      * (the bootstrap a new zone case, so deploying the routing app since that is the first deployment
      * that will be done)
-     **/
+     */
     @Test
     public void testCreateOnlyNeededModelVersionsWhenNoHostsAllocated() throws IOException {
         CountingModelFactory factory700 = createHostedModelFactory(Version.fromString("7.0.0"));


### PR DESCRIPTION
This is to achieve two things:
- Log IllegalArgumentExceptions from model building to the deploy log.
- Return them as application. package errors in the REST API. (Which I hope will cause no retry to happen.)

I also cleaned up the error classification a bit to reflect the common practice that all exceptions probably caused by incorrect input should be IllegalArgumentException instances.