### PR TITLE
Log instead of throwing on identical redefinition of rank-expressions.

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
@@ -12,7 +12,7 @@ import java.util.logging.Level;
 public class RankExpressionFiles {
     private final Map<String, RankExpressionFile> expressions = new HashMap<>();
 
-    //TODO Deploy logger should not be necessary, as redefinition is illegal, but legacy prevents enforment starting now.
+    //TODO Deploy logger should not be necessary, as redefinition is illegal, but legacy prevents enforcement starting now.
     public void add(RankExpressionFile expression, DeployLogger deployLogger) {
         expression.validate();
         String name = expression.getName();

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
@@ -20,7 +20,7 @@ public class RankExpressionFiles {
             if ( expressions.get(name).getFileName().equals(expression.getFileName()) ) {
                 //TODO Throw instead, No later than Vespa 8
                 deployLogger.logApplicationPackage(Level.WARNING, "Rank expression file '" + name +
-                        "' defined twice with identical expression (illegal and will be enfoced soon) '" + expression.getFileName() + "'.");
+                        "' defined twice with identical expression (illegal and will be enforced soon) '" + expression.getFileName() + "'.");
             } else {
                 throw new IllegalArgumentException("Rank expression file '" + name +
                         "' defined twice (illegal but not enforced), but redefinition is not matching (illegal and enforced), " +

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
@@ -1,20 +1,32 @@
 package com.yahoo.searchdefinition;
 
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.vespa.model.AbstractService;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
 
 public class RankExpressionFiles {
     private final Map<String, RankExpressionFile> expressions = new HashMap<>();
 
-    public void add(RankExpressionFile expression) {
+    //TODO Deploy logger should not be necessary, as redefinition is illegal, but legacy prevents enforment starting now.
+    public void add(RankExpressionFile expression, DeployLogger deployLogger) {
         expression.validate();
         String name = expression.getName();
-        if (expressions.containsKey(name))
-            throw new IllegalArgumentException("Rank expression file '" + name + "' defined twice");
+        if (expressions.containsKey(name)) {
+            if ( expressions.get(name).getFileName().equals(expression.getFileName()) ) {
+                //TODO Throw instead, No later than Vespa 8
+                deployLogger.logApplicationPackage(Level.WARNING, "Rank expression file '" + name +
+                        "' defined twice with identical expression '" + expression.getFileName() + "'.");
+            } else {
+                throw new IllegalArgumentException("Rank expression file '" + name +
+                        "' defined twice (illegal but not enforced), but redefining is not matching (illegal and enforced)" +
+                        "previous = '" + expressions.get(name).getFileName() + "', new = '" + expression.getFileName() + "'.");
+            }
+        }
         expressions.put(name, expression);
     }
 

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankExpressionFiles.java
@@ -20,10 +20,10 @@ public class RankExpressionFiles {
             if ( expressions.get(name).getFileName().equals(expression.getFileName()) ) {
                 //TODO Throw instead, No later than Vespa 8
                 deployLogger.logApplicationPackage(Level.WARNING, "Rank expression file '" + name +
-                        "' defined twice with identical expression '" + expression.getFileName() + "'.");
+                        "' defined twice with identical expression (illegal and will be enfoced soon) '" + expression.getFileName() + "'.");
             } else {
                 throw new IllegalArgumentException("Rank expression file '" + name +
-                        "' defined twice (illegal but not enforced), but redefining is not matching (illegal and enforced)" +
+                        "' defined twice (illegal but not enforced), but redefinition is not matching (illegal and enforced), " +
                         "previous = '" + expressions.get(name).getFileName() + "', new = '" + expression.getFileName() + "'.");
             }
         }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -722,7 +722,7 @@ public class RankProfile implements Cloneable {
                     "' in subdirectory, which is not supported.");
 
         if (search.getDeployProperties().featureFlags().distributeExternalRankExpressions()) {
-            rankExpressionFiles().add(new RankExpressionFile(getUniqueExpressionName(expName), fileName));
+            rankExpressionFiles().add(new RankExpressionFile(getUniqueExpressionName(expName), fileName), search.getDeployLogger());
             externalFileExpressions.add(expName);
         }
         return search.getRankingExpression(fileName);


### PR DESCRIPTION
Redefinition to something else is still enforced.

@bratseth or @hmusum PR