### PR TITLE
Try to reduce test runtime for RoutingTestCase

### DIFF
--- a/messagebus/src/test/java/com/yahoo/messagebus/routing/RoutingTestCase.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/routing/RoutingTestCase.java
@@ -24,7 +24,9 @@ import com.yahoo.messagebus.test.Receptor;
 import com.yahoo.messagebus.test.SimpleMessage;
 import com.yahoo.messagebus.test.SimpleProtocol;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
@@ -44,24 +46,28 @@ import static org.junit.Assert.assertTrue;
  */
 public class RoutingTestCase {
 
-    Slobrok slobrok;
-    TestServer srcServer, dstServer;
+    static Slobrok slobrok;
+    static TestServer srcServer, dstServer;
+    static RetryTransientErrorsPolicy retryPolicy;
     SourceSession srcSession;
     DestinationSession dstSession;
-    RetryTransientErrorsPolicy retryPolicy;
 
-    @Before
-    public void setUp() throws ListenFailedException, UnknownHostException {
+    @BeforeClass
+    public static void setUpClass() throws ListenFailedException {
         slobrok = new Slobrok();
         dstServer = new TestServer(new MessageBusParams().addProtocol(new SimpleProtocol()),
                                    new RPCNetworkParams().setIdentity(new Identity("dst")).setSlobrokConfigId(
                                            TestServer.getSlobrokConfig(slobrok)));
-        dstSession = dstServer.mb.createDestinationSession(
-                new DestinationSessionParams().setName("session").setMessageHandler(new Receptor()));
         retryPolicy = new RetryTransientErrorsPolicy();
         retryPolicy.setBaseDelay(0);
         srcServer = new TestServer(new MessageBusParams().setRetryPolicy(retryPolicy).addProtocol(new SimpleProtocol()),
                                    new RPCNetworkParams().setSlobrokConfigId(TestServer.getSlobrokConfig(slobrok)));
+    }
+
+    @Before
+    public void setUp() throws UnknownHostException {
+        dstSession = dstServer.mb.createDestinationSession(
+                new DestinationSessionParams().setName("session").setMessageHandler(new Receptor()));
         srcSession = srcServer.mb.createSourceSession(
                 new SourceSessionParams().setTimeout(600.0).setThrottlePolicy(null).setReplyHandler(new Receptor()));
         assertTrue(srcServer.waitSlobrok("dst/session", 1));
@@ -69,10 +75,14 @@ public class RoutingTestCase {
 
     @After
     public void tearDown() {
-        slobrok.stop();
         dstSession.destroy();
-        dstServer.destroy();
         srcSession.destroy();
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        slobrok.stop();
+        dstServer.destroy();
         srcServer.destroy();
     }
 
@@ -238,7 +248,11 @@ public class RoutingTestCase {
     }
 
     @Test
-    public void requireThatTransientErrorsAreRetried() {
+    public void requireThatTransientErrorsAreRetried() throws Exception {
+        tearDownClass();
+        setUpClass();
+        setUp();
+
         assertTrue(srcSession.send(createMessage("msg"), Route.parse("dst/session")).isAccepted());
         Message msg = ((Receptor)dstSession.getMessageHandler()).getMessage(60);
         assertNotNull(msg);
@@ -264,7 +278,11 @@ public class RoutingTestCase {
     }
 
     @Test
-    public void requireThatTransientErrorsAreRetriedWithPolicy() {
+    public void requireThatTransientErrorsAreRetriedWithPolicy() throws Exception {
+        tearDownClass();
+        setUpClass();
+        setUp();
+
         SimpleProtocol protocol = new SimpleProtocol();
         protocol.addPolicyFactory("Custom", new CustomPolicyFactory());
         srcServer.mb.putProtocol(protocol);
@@ -755,7 +773,11 @@ public class RoutingTestCase {
     }
 
     @Test
-    public void requireThatOnlyActiveNodesAreAborted() {
+    public void requireThatOnlyActiveNodesAreAborted() throws Exception {
+        tearDownClass();
+        setUpClass();
+        setUp();
+
         SimpleProtocol protocol = new SimpleProtocol();
         protocol.addPolicyFactory("Custom", new CustomPolicyFactory(false));
         protocol.addPolicyFactory("SetReply", new SimpleProtocol.PolicyFactory() {


### PR DESCRIPTION
I don't really know this code, so please verify that these tests are still valid while reusing the server and messagebus instances. All tests passed except for the three where I had to add a manual teardown+setup. Runtime is reduced by approx 15 seconds.