### PR TITLE
Revert "Bjorncs/vespa feed client cli"

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -724,12 +724,9 @@ fi
 %defattr(-,%{_vespa_user},%{_vespa_group},-)
 %endif
 %dir %{_prefix}
-%dir %{_prefix}/conf
-%dir %{_prefix}/conf/vespa-feed-client
 %dir %{_prefix}/lib
 %dir %{_prefix}/lib/jars
 %{_prefix}/bin/vespa-feed-client
-%{_prefix}/conf/vespa-feed-client/logging.properties
 %{_prefix}/lib/jars/vespa-http-client-jar-with-dependencies.jar
 %{_prefix}/lib/jars/vespa-feed-client-cli.jar
 

--- a/vespa-feed-client-cli/CMakeLists.txt
+++ b/vespa-feed-client-cli/CMakeLists.txt
@@ -2,4 +2,3 @@
 install_java_artifact(vespa-feed-client-cli)
 
 vespa_install_script(src/main/sh/vespa-feed-client.sh vespa-feed-client bin)
-configure_file(src/main/resources/logging.properties conf/vespa-feed-client/logging.properties @ONLY)

--- a/vespa-feed-client-cli/src/main/resources/logging.properties
+++ b/vespa-feed-client-cli/src/main/resources/logging.properties
@@ -1,2 +1,0 @@
-# Disable verbose info logging from org.apache.hc.client5.http.impl.async.AsyncHttpRequestRetryExec
-org.apache.hc.client5.http.impl.async.level = WARNING

--- a/vespa-feed-client-cli/src/main/sh/vespa-feed-client.sh
+++ b/vespa-feed-client-cli/src/main/sh/vespa-feed-client.sh
@@ -79,6 +79,4 @@ exec java \
 -Djava.library.path=${VESPA_HOME}/libexec64/native:${VESPA_HOME}/lib64 \
 -Djava.awt.headless=true \
 -Xms128m -Xmx2048m $(getJavaOptionsIPV46) \
---add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
--Djava.util.logging.config.file=${VESPA_HOME}/conf/vespa-feed-client/logging.properties \
 -cp ${VESPA_HOME}/lib/jars/vespa-feed-client-cli.jar ai.vespa.feed.client.CliClient "$@"


### PR DESCRIPTION
Reverts vespa-engine/vespa#18043

Fails when packaging RPM:
 19:36:32 Processing files: vespa-clients-7.412.24-1.el7.x86_64
19:36:32 error: Directory not found: /sd/workspace/src/git.vzbuilders.com/vespa/vespa-rpmbuild/BUILDROOT/vespa-7.412.24-1.el7.x86_64/opt/vespa/conf/vespa-feed-client
19:36:32 error: File not found: /sd/workspace/src/git.vzbuilders.com/vespa/vespa-rpmbuild/BUILDROOT/vespa-7.412.24-1.el7.x86_64/opt/vespa/conf/vespa-feed-client/logging.properties 