### PR TITLE
Do not block global merges to nodes tagged as busy [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
@@ -9,8 +9,8 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".distributor.operation");
 
-using namespace storage;
-using namespace storage::distributor;
+namespace storage::distributor {
+
 using document::BucketSpace;
 
 const uint32_t IdealStateOperation::MAINTENANCE_MESSAGE_TYPES[] =
@@ -85,7 +85,7 @@ IdealStateOperation::setIdealStateManager(IdealStateManager* manager) {
 void
 IdealStateOperation::done()
 {
-    if (_manager != NULL) {
+    if (_manager) {
         if (ok()) {
             _manager->getMetrics().operations[getType()]->ok.inc(1);
         } else {
@@ -105,35 +105,6 @@ IdealStateOperation::setCommandMeta(api::MaintenanceCommand& cmd) const
 {
     cmd.setPriority(_priority);
     cmd.setReason(_detailedReason);
-}
-
-std::string
-IdealStateOperation::toXML(framework::Clock& clock) const
-{
-    std::ostringstream ost;
-
-    ost << "<operation bucketid=\"" << getBucketId()
-        << "\" reason=\"" << _detailedReason << "\" operations=\"";
-
-    ost << getName() << "[";
-    for (uint32_t j = 0; j < getNodes().size(); j++) {
-        if (j != 0) {
-            ost << ",";
-        }
-        ost << getNodes()[j];
-    }
-    ost << "]";
-
-    if (getStartTime().isSet()) {
-        uint64_t timeSpent(
-                (clock.getTimeInMillis() - getStartTime()).getTime());
-        ost << "\" runtime_secs=\"" << timeSpent << "\"";
-    } else {
-        ost << "\"";
-    }
-
-    ost << "/>";
-    return ost.str();
 }
 
 namespace {
@@ -276,4 +247,6 @@ IdealStateOperation::shouldBlockThisOperation(uint32_t messageType,
     }
 
     return false;
+}
+
 }

--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
@@ -208,8 +208,6 @@ public:
      */
     void setCommandMeta(api::MaintenanceCommand& cmd) const;
 
-    std::string toXML(framework::Clock& clock) const;
-
     std::string toString() const override;
 
     /**

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -61,6 +61,7 @@ private:
 
     void deleteSourceOnlyNodes(const BucketDatabase::Entry& currentState,
                                DistributorStripeMessageSender& sender);
+    bool is_global_bucket_merge() const noexcept;
 };
 
 }


### PR DESCRIPTION
@geirst please review

To avoid starvation of high priority global bucket merges, we do not consider
these for blocking due to a node being "busy" (usually caused by a full merge
throttler queue).

This is for two reasons:
 1. When an ideal state op is blocked, it is still removed from the internal
    maintenance priority queue. This means a blocked high pri operation will
    not be retried until the next DB pass (at which point the node is likely
    to still be marked as busy when there's heavy merge traffic).
 2. Global bucket merges have high priority and will most likely be allowed
    to enter the merge throttler queues, displacing lower priority merges.

We may consider adding a separate busy-dimension for global merges at
some point if it's deemed worth the effort, but for now I think we'll go with
the simple solution.
