### PR TITLE
Add support for ignorable exceptions when building config model

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/IgnorableExceptionId.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/IgnorableExceptionId.java
@@ -1,0 +1,42 @@
+package com.yahoo.config.model.api;
+
+import java.util.Objects;
+
+/**
+ * Id used for retrying an operation that caused an {@link IgnorableIllegalArgumentException} as a signal to the
+ * caller that the original exception thrown with this id can be ignored (i.e. the
+ * operation should succeed).
+ *
+ * @author hmusum
+ */
+public class IgnorableExceptionId {
+
+    private final String id; // unique id for the exception, used to ignore exception on retries
+
+    public IgnorableExceptionId(String id) {
+        this.id = id;
+    }
+
+    /* No argument can be ignored if it is illegal */
+    public static IgnorableExceptionId none() {
+        return new IgnorableExceptionId("__none__");
+    }
+
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if ( ! (o instanceof IgnorableExceptionId)) return false;
+        IgnorableExceptionId other = (IgnorableExceptionId)o;
+        return this.id.equals(other.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+}

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/IgnorableIllegalArgumentException.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/IgnorableIllegalArgumentException.java
@@ -1,0 +1,18 @@
+package com.yahoo.config.model.api;
+
+public class IgnorableIllegalArgumentException extends IllegalArgumentException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final IgnorableExceptionId id; // unique id for the exception, used to ignore exception on retries
+
+    public IgnorableIllegalArgumentException(String s, IgnorableExceptionId id) {
+        super(s);
+        this.id = id;
+    }
+
+    public IgnorableExceptionId id() {
+        return id;
+    }
+
+}

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -140,6 +140,8 @@ public interface ModelContext {
         default boolean allowDisableMtls() { return true; }
 
         default List<X509Certificate> operatorCertificates() { return List.of(); }
+
+        default IgnorableExceptionId ignorableIllegalArgumentId() { return IgnorableExceptionId.none(); };
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
@@ -1,7 +1,7 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
-import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.cluster.DomResourceLimitsBuilder;
 
@@ -37,14 +37,14 @@ public class ClusterResourceLimits {
 
         private final boolean enableFeedBlockInDistributor;
         private final boolean hostedVespa;
-        private final DeployLogger deployLogger;
+        private final IgnorableExceptionId ignorableExceptionId;
         private ResourceLimits.Builder ctrlBuilder = new ResourceLimits.Builder();
         private ResourceLimits.Builder nodeBuilder = new ResourceLimits.Builder();
 
-        public Builder(boolean enableFeedBlockInDistributor, boolean hostedVespa, DeployLogger deployLogger) {
+        public Builder(boolean enableFeedBlockInDistributor, boolean hostedVespa, IgnorableExceptionId ignorableExceptionId) {
             this.enableFeedBlockInDistributor = enableFeedBlockInDistributor;
             this.hostedVespa = hostedVespa;
-            this.deployLogger = deployLogger;
+            this.ignorableExceptionId = ignorableExceptionId;
         }
 
         public ClusterResourceLimits build(ModelElement clusterElem) {
@@ -58,7 +58,7 @@ public class ClusterResourceLimits {
         private ResourceLimits.Builder createBuilder(ModelElement element) {
             return element == null
                     ? new ResourceLimits.Builder()
-                    : DomResourceLimitsBuilder.createBuilder(element, hostedVespa, deployLogger);
+                    : DomResourceLimitsBuilder.createBuilder(element, hostedVespa, ignorableExceptionId);
         }
 
         public void setClusterControllerBuilder(ResourceLimits.Builder builder) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -2,12 +2,10 @@
 package com.yahoo.vespa.model.content.cluster;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
-import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
@@ -47,7 +45,6 @@ import com.yahoo.vespa.model.content.IndexedHierarchicDistributionValidator;
 import com.yahoo.vespa.model.content.Redundancy;
 import com.yahoo.vespa.model.content.ReservedDocumentTypeNameValidator;
 import com.yahoo.vespa.model.content.StorageGroup;
-import com.yahoo.vespa.model.content.StorageNode;
 import com.yahoo.vespa.model.content.engines.PersistenceEngine;
 import com.yahoo.vespa.model.content.engines.ProtonEngine;
 import com.yahoo.vespa.model.content.storagecluster.StorageCluster;
@@ -64,7 +61,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -135,7 +131,7 @@ public class ContentCluster extends AbstractConfigProducer implements
             boolean enableFeedBlockInDistributor = deployState.getProperties().featureFlags().enableFeedBlockInDistributor();
             var resourceLimits = new ClusterResourceLimits.Builder(enableFeedBlockInDistributor,
                                                                    stateIsHosted(deployState),
-                                                                   deployState.getDeployLogger())
+                                                                   deployState.getProperties().ignorableIllegalArgumentId())
                     .build(contentElement);
             c.clusterControllerConfig = new ClusterControllerConfig.Builder(getClusterId(contentElement),
                     contentElement,

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
@@ -1,11 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content.cluster;
 
-import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.IgnorableExceptionId;
+import com.yahoo.config.model.api.IgnorableIllegalArgumentException;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.ResourceLimits;
-
-import java.util.logging.Level;
 
 /**
  * Builder for feed block resource limits.
@@ -14,18 +13,23 @@ import java.util.logging.Level;
  */
 public class DomResourceLimitsBuilder {
 
-    public static ResourceLimits.Builder createBuilder(ModelElement contentXml, boolean hostedVespa, DeployLogger deployLogger) {
+    public static final IgnorableExceptionId illegalArgumentId = new IgnorableExceptionId("resource-limits");
+
+    public static ResourceLimits.Builder createBuilder(ModelElement contentXml,
+                                                       boolean hostedVespa,
+                                                       IgnorableExceptionId ignorableExceptionId) {
         ResourceLimits.Builder builder = new ResourceLimits.Builder();
         ModelElement resourceLimits = contentXml.child("resource-limits");
         if (resourceLimits == null) { return builder; }
 
         if (hostedVespa) {
-            deployLogger.logApplicationPackage(Level.WARNING, "Element " + resourceLimits +
-                                                              " is not allowed, default limits will be used");
-            // TODO: Throw exception when we are sure nobody is using this
-            //throw new IllegalArgumentException("Element " + element + " is not allowed to be set, default limits will be used");
-            return builder;
+            // This exception is explicitly ignorable, so just return with default values (logging happens where id is created)
+            if (ignorableExceptionId.equals(illegalArgumentId)) return builder;
+
+            throw new IgnorableIllegalArgumentException("Element '" + resourceLimits + "' is not allowed in services.xml",
+                                                        illegalArgumentId);
         }
+
         if (resourceLimits.child("disk") != null) {
             builder.setDiskLimit(resourceLimits.childAsDouble("disk"));
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -1,15 +1,18 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
-import com.yahoo.config.application.api.DeployLogger;
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
-import com.yahoo.searchdefinition.derived.TestableDeployLogger;
+import com.yahoo.config.model.api.IgnorableExceptionId;
+import com.yahoo.config.model.api.IgnorableIllegalArgumentException;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
+import com.yahoo.vespa.model.content.cluster.DomResourceLimitsBuilder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -48,7 +51,9 @@ public class ClusterResourceLimitsTest {
             return this;
         }
         public ClusterResourceLimits build() {
-            var builder = new ClusterResourceLimits.Builder(enableFeedBlockInDistributor, false, new BaseDeployLogger());
+            var builder = new ClusterResourceLimits.Builder(enableFeedBlockInDistributor,
+                                                            false,
+                                                            IgnorableExceptionId.none());
             builder.setClusterControllerBuilder(ctrlBuilder);
             builder.setContentNodeBuilder(nodeBuilder);
             return builder.build();
@@ -120,26 +125,40 @@ public class ClusterResourceLimitsTest {
     }
 
     @Test
-    // TODO: Change to expect exception being thrown when no one uses this in hosted
-    public void default_resource_limits_when_hosted_and_warning_is_logged() {
-        TestableDeployLogger logger = new TestableDeployLogger();
-        final boolean hosted = true;
-
-        ClusterResourceLimits.Builder builder = new ClusterResourceLimits.Builder(true, hosted, logger);
-        ClusterResourceLimits limits = builder.build(new ModelElement(XML.getDocument("<cluster id=\"test\">" +
-                                                       "  <tuning>\n" +
-                                                       "    <resource-limits>\n" +
-                                                       "      <memory>0.92</memory>\n" +
-                                                       "    </resource-limits>\n" +
-                                                       "  </tuning>\n" +
-                                                       "</cluster>")
-                                          .getDocumentElement()));
+    // TODO: Remove when exception being thrown instead (see test below)
+    public void default_resource_limits_used_when_hosted() {
+        var builder = new ClusterResourceLimits.Builder(true,
+                                                        true,
+                                                        DomResourceLimitsBuilder.illegalArgumentId);
+        var limits = builder.build(clusterXml());
 
         assertLimits(0.8, 0.8, limits.getClusterControllerLimits());
         assertLimits(0.9, 0.9, limits.getContentNodeLimits());
+    }
 
-        assertEquals(1, logger.warnings.size());
-        assertEquals("Element resource-limits is not allowed, default limits will be used", logger.warnings.get(0));
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void exception_is_thrown_when_resource_limits_is_used() {
+        var builder = new ClusterResourceLimits.Builder(true,
+                                                        true,
+                                                        IgnorableExceptionId.none());
+
+        expectedException.expect(IgnorableIllegalArgumentException.class);
+        expectedException.expectMessage(containsString("Element 'resource-limits' is not allowed in services.xml"));
+        builder.build(clusterXml());
+    }
+
+    private ModelElement clusterXml() {
+        return new ModelElement(XML.getDocument("<cluster id=\"test\">" +
+                                                "  <tuning>\n" +
+                                                "    <resource-limits>\n" +
+                                                "      <memory>0.92</memory>\n" +
+                                                "    </resource-limits>\n" +
+                                                "  </tuning>\n" +
+                                                "</cluster>")
+                                   .getDocumentElement());
     }
 
     private void assertLimits(Double expCtrlDisk, Double expCtrlMemory, Double expNodeDisk, Double expNodeMemory, Fixture f) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -1,12 +1,12 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
-import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.text.XML;
+import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -26,7 +26,7 @@ public class FleetControllerClusterTest {
                                                    clusterElement,
                                                    new ClusterResourceLimits.Builder(enableFeedBlockInDistributor,
                                                                                      false,
-                                                                                     new BaseDeployLogger())
+                                                                                     IgnorableExceptionId.none())
                                                            .build(clusterElement).getClusterControllerLimits())
                 .build(root.getDeployState(), root, clusterElement.getXml());
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -12,6 +12,7 @@ import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.config.model.api.HostProvisioner;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.Provisioned;
@@ -289,6 +290,7 @@ public class ModelContextImpl implements ModelContext {
         private final StringFlag jvmGCOptionsFlag;
         private final boolean allowDisableMtls;
         private final List<X509Certificate> operatorCertificates;
+        private final IgnorableExceptionId ignorableExceptionId;
 
         public Properties(ApplicationId applicationId,
                           ConfigserverConfig configserverConfig,
@@ -303,7 +305,8 @@ public class ModelContextImpl implements ModelContext {
                           Optional<Quota> maybeQuota,
                           List<TenantSecretStore> tenantSecretStores,
                           SecretStore secretStore,
-                          List<X509Certificate> operatorCertificates) {
+                          List<X509Certificate> operatorCertificates,
+                          IgnorableExceptionId ignorableExceptionId) {
             this.featureFlags = new FeatureFlags(flagSource, applicationId);
             this.applicationId = applicationId;
             this.multitenant = configserverConfig.multitenant() || configserverConfig.hostedVespa() || Boolean.getBoolean("multitenant");
@@ -327,6 +330,7 @@ public class ModelContextImpl implements ModelContext {
             this.allowDisableMtls = PermanentFlags.ALLOW_DISABLE_MTLS.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.operatorCertificates = operatorCertificates;
+            this.ignorableExceptionId = ignorableExceptionId;
         }
 
         @Override public ModelContext.FeatureFlags featureFlags() { return featureFlags; }
@@ -399,6 +403,8 @@ public class ModelContextImpl implements ModelContext {
         public List<X509Certificate> operatorCertificates() {
             return operatorCertificates;
         }
+
+        public IgnorableExceptionId ignorableIllegalArgumentId() { return ignorableExceptionId; }
 
         public String flagValueForClusterType(StringFlag flag, Optional<ClusterSpec.Type> clusterType) {
             return clusterType.map(type -> flag.with(CLUSTER_TYPE, type.name()))

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/PreparedModelsBuilder.java
@@ -9,6 +9,7 @@ import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
 import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.HostProvisioner;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.ModelCreateResult;
@@ -87,7 +88,8 @@ public class PreparedModelsBuilder extends ModelsBuilder<PreparedModelsBuilder.P
                                                     ApplicationId applicationId,
                                                     Optional<DockerImage> wantedDockerImageRepository,
                                                     Version wantedNodeVespaVersion,
-                                                    Optional<AllocatedHosts> allocatedHosts) {
+                                                    Optional<AllocatedHosts> allocatedHosts,
+                                                    IgnorableExceptionId ignorableExceptionId) {
         Version modelVersion = modelFactory.version();
         log.log(Level.FINE, () -> "Building model " + modelVersion + " for " + applicationId);
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionPreparer.java
@@ -15,6 +15,7 @@ import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.EndpointCertificateMetadata;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.config.model.api.FileDistribution;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.Quota;
 import com.yahoo.config.model.api.TenantSecretStore;
@@ -204,7 +205,8 @@ public class SessionPreparer {
                                                               params.quota(),
                                                               params.tenantSecretStores(),
                                                               secretStore,
-                                                              params.operatorCertificates());
+                                                              params.operatorCertificates(),
+                                                              IgnorableExceptionId.none());
             this.fileDistributionProvider = fileDistributionFactory.createProvider(serverDbSessionDir);
             this.preparedModelsBuilder = new PreparedModelsBuilder(modelFactoryRegistry,
                                                                    permanentApplicationPackage,

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -36,7 +36,6 @@ import com.yahoo.vespa.config.server.modelfactory.ModelFactoryRegistry;
 import com.yahoo.vespa.config.server.monitoring.MetricUpdater;
 import com.yahoo.vespa.config.server.monitoring.Metrics;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
-import com.yahoo.vespa.config.server.tenant.TenantListener;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.zookeeper.ConfigCurator;
 import com.yahoo.vespa.config.server.zookeeper.SessionCounter;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ModelContextImplTest.java
@@ -6,6 +6,7 @@ import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.HostProvisioner;
+import com.yahoo.config.model.api.IgnorableExceptionId;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.Provisioned;
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
@@ -75,7 +76,8 @@ public class ModelContextImplTest {
                         Optional.empty(),
                         List.of(),
                         new SecretStoreProvider().get(),
-                        List.of()),
+                        List.of(),
+                        IgnorableExceptionId.none()),
                 Optional.empty(),
                 Optional.empty(),
                 new Version(7),


### PR DESCRIPTION
It's now possible to throw an exception that leads to a warning
being logged and visible for the customer, while the model will
be built again without throwing any exception.
