### PR TITLE
Don't fail nodes/v2 requests if QuestDb fails

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/ClusterData.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/ClusterData.java
@@ -56,9 +56,9 @@ public class ClusterData {
                            scalingEvents == null ? List.of()
                                                  : scalingEvents.stream().map(data -> data.toScalingEvent()).collect(Collectors.toList()),
                            autoscalingStatus,
-                           Duration.ofMillis(scalingDuration),
-                           maxQueryGrowthRate,
-                           currentQueryFractionOfMax);
+                           scalingDuration == null ? Duration.ofMillis(0) : Duration.ofMillis(scalingDuration),
+                           maxQueryGrowthRate == null ? -1 : maxQueryGrowthRate,
+                           currentQueryFractionOfMax == null ? -1 : currentQueryFractionOfMax);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationSerializer.java
@@ -15,6 +15,7 @@ import com.yahoo.vespa.hosted.provision.autoscale.MetricsDb;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Serializes application information for nodes/v2/application responses
@@ -61,8 +62,7 @@ public class ApplicationSerializer {
         NodeList nodes = applicationNodes.not().retired().cluster(cluster.id());
         if (nodes.isEmpty()) return;
         ClusterResources currentResources = nodes.toResources();
-        ClusterModel clusterModel = new ClusterModel(application, cluster, nodes.clusterSpec(), nodes, metricsDb, nodeRepository.clock());
-
+        Optional<ClusterModel> clusterModel = ClusterModel.create(application, cluster, nodes.clusterSpec(), nodes, metricsDb, nodeRepository.clock());
         Cursor clusterObject = clustersObject.setObject(cluster.id().value());
         clusterObject.setString("type", nodes.clusterSpec().type().name());
         toSlime(cluster.minResources(), clusterObject.setObject("min"));
@@ -71,12 +71,12 @@ public class ApplicationSerializer {
         if (cluster.shouldSuggestResources(currentResources))
             cluster.suggestedResources().ifPresent(suggested -> toSlime(suggested.resources(), clusterObject.setObject("suggested")));
         cluster.targetResources().ifPresent(target -> toSlime(target, clusterObject.setObject("target")));
-        clusterUtilizationToSlime(clusterModel, clusterObject.setObject("utilization"));
+        clusterModel.ifPresent(model -> clusterUtilizationToSlime(model, clusterObject.setObject("utilization")));
         scalingEventsToSlime(cluster.scalingEvents(), clusterObject.setArray("scalingEvents"));
         clusterObject.setString("autoscalingStatus", cluster.autoscalingStatus());
-        clusterObject.setLong("scalingDuration", clusterModel.scalingDuration().toMillis());
-        clusterObject.setDouble("maxQueryGrowthRate", clusterModel.maxQueryGrowthRate());
-        clusterObject.setDouble("currentQueryFractionOfMax", clusterModel.queryFractionOfMax());
+        clusterModel.ifPresent(model -> clusterObject.setLong("scalingDuration", model.scalingDuration().toMillis()));
+        clusterModel.ifPresent(model -> clusterObject.setDouble("maxQueryGrowthRate", model.maxQueryGrowthRate()));
+        clusterModel.ifPresent(model -> clusterObject.setDouble("currentQueryFractionOfMax", model.queryFractionOfMax()));
     }
 
     private static void toSlime(ClusterResources resources, Cursor clusterResourcesObject) {


### PR DESCRIPTION
Deployment jobs pools the application path, but does
not need information from QuestDb, so just return
without it if QuestDb fails.
