### PR TITLE
Revert "Cluster controllers are not tied to content clusters anymore"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -177,7 +177,7 @@ public class Content extends ConfigModel {
                 s.setVespaMallocDebugStackTrace(cluster.getRootGroup().getVespaMallocDebugStackTrace().get());
             }
         }
-        cluster.prepare();
+        cluster.prepare(deployState);
     }
 
     private void setCpuSocketAffinity() {

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -38,6 +38,7 @@ import com.yahoo.yolean.Exceptions;
 import org.junit.Test;
 
 import java.io.StringReader;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -501,6 +502,7 @@ public class ModelProvisioningTest {
 
         // Check content clusters
         ContentCluster cluster = model.getContentClusters().get("bar");
+        assertNull("No own cluster controllers when hosted", cluster.getClusterControllers());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(9, cluster.getRootGroup().getSubgroups().size());
         assertEquals("0", cluster.getRootGroup().getSubgroups().get(0).getIndex());
@@ -534,6 +536,7 @@ public class ModelProvisioningTest {
         assertThat(cluster.getRootGroup().getSubgroups().get(8).getNodes().get(2).getConfigId(), is("bar/storage/26"));
 
         cluster = model.getContentClusters().get("baz");
+        assertNull("No own cluster controllers when hosted", cluster.getClusterControllers());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(27, cluster.getRootGroup().getSubgroups().size());
         assertThat(cluster.getRootGroup().getSubgroups().get(0).getIndex(), is("0"));
@@ -727,6 +730,7 @@ public class ModelProvisioningTest {
 
         // Check content cluster
         ContentCluster cluster = model.getContentClusters().get("bar");
+        assertNull(cluster.getClusterControllers());
         assertEquals(0, cluster.getRootGroup().getNodes().size());
         assertEquals(8, cluster.getRootGroup().getSubgroups().size());
         assertEquals(8, cluster.distributionBits());
@@ -861,6 +865,8 @@ public class ModelProvisioningTest {
         assertEquals(7, model.getRoot().hostSystem().getHosts().size());
 
         // Check cluster controllers
+        assertNull(model.getContentClusters().get("foo").getClusterControllers());
+        assertNull(model.getContentClusters().get("bar").getClusterControllers());
         ClusterControllerContainerCluster clusterControllers = model.getAdmin().getClusterControllers();
         assertEquals(3, clusterControllers.getContainers().size());
         assertEquals("cluster-controllers", clusterControllers.getName());

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -26,6 +26,7 @@ import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.clustercontroller.ClusterControllerContainer;
 import com.yahoo.vespa.model.admin.clustercontroller.ClusterControllerContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
 import com.yahoo.vespa.model.content.engines.ProtonEngine;
 import com.yahoo.vespa.model.content.utils.ContentClusterBuilder;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -531,7 +533,6 @@ public class ContentClusterTest extends ContentBaseTest {
         ContentCluster stagingNot16Bits = createWithZone(xml, new Zone(Environment.staging, RegionName.from("us-east-3")));
         assertDistributionBitsInConfig(stagingNot16Bits, 8);
     }
-
     @Test
     public void testGenerateSearchNodes()
     {
@@ -1075,6 +1076,7 @@ public class ContentClusterTest extends ContentBaseTest {
                                                           "    </documents>" +
                                                           "  </content>" +
                                                           " </services>");
+        assertNull("No own cluster controller for content", oneContentModel.getContentClusters().get("storage").getClusterControllers());
         assertNotNull("Shared cluster controller with content", oneContentModel.getAdmin().getClusterControllers());
 
         String twoContentServices = "<?xml version='1.0' encoding='UTF-8' ?>" +
@@ -1106,6 +1108,8 @@ public class ContentClusterTest extends ContentBaseTest {
         VespaModel twoContentModel = createEnd2EndOneNode(new TestProperties().setHostedVespa(true)
                                                                               .setMultitenant(true),
                                                           twoContentServices);
+        assertNull("No own cluster controller for content", twoContentModel.getContentClusters().get("storage").getClusterControllers());
+        assertNull("No own cluster controller for content", twoContentModel.getContentClusters().get("dev-null").getClusterControllers());
         assertNotNull("Shared cluster controller with content", twoContentModel.getAdmin().getClusterControllers());
 
         ClusterControllerContainerCluster clusterControllers = twoContentModel.getAdmin().getClusterControllers();


### PR DESCRIPTION
Reverts vespa-engine/vespa#18056
