### PR TITLE
Validate that schemas/ dir is used for schemas, warns otherwise

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/SchemasDirValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/SchemasDirValidator.java
@@ -1,0 +1,32 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.application.validation;
+
+import com.yahoo.config.application.api.ApplicationFile;
+import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.vespa.model.VespaModel;
+
+import java.util.logging.Level;
+
+/**
+ * Validates that correct directory is used for schemas
+ *
+ * @author hmusum
+ */
+public class SchemasDirValidator extends Validator {
+
+    public SchemasDirValidator() {
+    }
+
+    @Override
+    public void validate(VespaModel model, DeployState deployState) {
+        ApplicationPackage app = deployState.getApplicationPackage();
+        ApplicationFile sdDir = app.getFile(ApplicationPackage.SEARCH_DEFINITIONS_DIR);
+        if (sdDir.exists() && sdDir.isDirectory())
+            deployState.getDeployLogger().logApplicationPackage(
+                    Level.WARNING,
+                    "Directory " + ApplicationPackage.SEARCH_DEFINITIONS_DIR.getRelative() +
+                    "/ should not be used for schemas, use " + ApplicationPackage.SCHEMAS_DIR.getRelative() + "/ instead");
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ValidationParameters;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.container.QrConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.change.ChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.ClusterSizeReductionValidator;
@@ -25,8 +24,6 @@ import com.yahoo.vespa.model.application.validation.change.ResourcesReductionVal
 import com.yahoo.vespa.model.application.validation.change.StartupCommandChangeValidator;
 import com.yahoo.vespa.model.application.validation.change.StreamingSearchClusterChangeValidator;
 import com.yahoo.vespa.model.application.validation.first.AccessControlOnFirstDeploymentValidator;
-import com.yahoo.vespa.model.container.ApplicationContainerCluster;
-import com.yahoo.vespa.model.container.Container;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -43,7 +40,6 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * Executor of validators. This defines the right order of validator execution.
@@ -63,6 +59,7 @@ public class Validation {
             new RoutingValidator().validate(model, deployState);
             new RoutingSelectorValidator().validate(model, deployState);
         }
+        new SchemasDirValidator().validate(model, deployState);
         new ComponentValidator().validate(model, deployState);
         new SearchDataTypeValidator().validate(model, deployState);
         new ComplexAttributeFieldsValidator().validate(model, deployState);

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithFilePkg.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithFilePkg.java
@@ -24,9 +24,8 @@ import java.io.IOException;
  */
 public class VespaModelCreatorWithFilePkg {
 
-    private FilesApplicationPackage applicationPkg;
-
-    private ConfigModelRegistry configModelRegistry;
+    private final FilesApplicationPackage applicationPkg;
+    private final ConfigModelRegistry configModelRegistry;
 
     public VespaModelCreatorWithFilePkg(String directoryName) {
         this(new File(directoryName));


### PR DESCRIPTION
I'll try to do a cleanup of internal use of `searchdefinitions` dir later
