### PR TITLE
avoid deadlock on signal lock

### DIFF
--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -65,9 +65,7 @@ public:
     ~StorageApp() override;
 
     void handleSignal(int signal) {
-        LOG(info, "Got signal %d, waiting for lock", signal);
-        std::lock_guard sync(_signalLock);
-        LOG(info, "Got lock for signal %d", signal);
+        LOG(info, "Got signal %d", signal);
         _lastSignal = signal;
         _signalCond.notify_one();
     }


### PR DESCRIPTION
* a signal handler is not a thread
* if the main thread holds the lock when the signal handler is invoked
  in the same thread, it will deadlock
* holding the lock is not necessary for notify_one()

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim you were the last one to change this code
@vekterli @geirst FYI