### PR TITLE
Use same idle timeout for HTTP/2 stream and connections

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -75,7 +75,7 @@ public class ConnectorFactory {
         connector.setName(connectorConfig.name());
         connector.setAcceptQueueSize(connectorConfig.acceptQueueSize());
         connector.setReuseAddress(connectorConfig.reuseAddress());
-        connector.setIdleTimeout((long)(connectorConfig.idleTimeout() * 1000.0));
+        connector.setIdleTimeout(idleTimeoutInMillis());
         return connector;
     }
 
@@ -162,6 +162,7 @@ public class ConnectorFactory {
 
     private HTTP2ServerConnectionFactory newHttp2ConnectionFactory() {
         HTTP2ServerConnectionFactory factory = new HTTP2ServerConnectionFactory(newHttpConfiguration());
+        factory.setStreamIdleTimeout(idleTimeoutInMillis());
         factory.setMaxConcurrentStreams(4096);
         return factory;
     }
@@ -192,5 +193,7 @@ public class ConnectorFactory {
         return config.ssl().enabled()
                 || (config.implicitTlsEnabled() && TransportSecurityUtils.isTransportSecurityEnabled());
     }
+
+    private long idleTimeoutInMillis() { return (long) (connectorConfig.idleTimeout() * 1000.0); }
 
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
