### PR TITLE
Use a hash map for specs. If the request is a point lookup then just …

### DIFF
--- a/slobrok/src/tests/mirrorapi/match_test.cpp
+++ b/slobrok/src/tests/mirrorapi/match_test.cpp
@@ -4,7 +4,7 @@
 
 class MatchTester : public slobrok::api::IMirrorAPI
 {
-    SpecList lookup(const std::string &) const override {
+    SpecList lookup(vespalib::stringref ) const override {
         return SpecList();
     }
     uint32_t updates() const override { return 0; }

--- a/slobrok/src/vespa/slobrok/backoff.h
+++ b/slobrok/src/vespa/slobrok/backoff.h
@@ -1,10 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <stdio.h>
+#include <cstdio>
 
-namespace slobrok {
-namespace api {
+namespace slobrok::api {
 
 class BackOff
 {
@@ -20,6 +19,4 @@ public:
     bool shouldWarn();
 };
 
-} // namespace api
-} // namespace slobrok
-
+}

--- a/slobrok/src/vespa/slobrok/imirrorapi.h
+++ b/slobrok/src/vespa/slobrok/imirrorapi.h
@@ -1,11 +1,10 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <string>
+#include <vespa/vespalib/stllike/string.h>
 #include <vector>
 
-namespace slobrok {
-namespace api {
+namespace slobrok::api {
 
 /**
  * @brief Defines an interface for the name server lookup.
@@ -48,7 +47,7 @@ public:
      * @return a list of all matching services, with corresponding connect specs
      * @param pattern The pattern used for matching
      **/
-    virtual SpecList lookup(const std::string & pattern) const = 0;
+    virtual SpecList lookup(vespalib::stringref pattern) const = 0;
 
     /**
      * Obtain the number of updates seen by this mirror. The value may wrap, but will never become 0 again. This can be
@@ -62,6 +61,4 @@ public:
     virtual bool ready() const = 0;
 };
 
-} // namespace api
-} // namespace slobrok
-
+}

--- a/slobrok/src/vespa/slobrok/sbmirror.cpp
+++ b/slobrok/src/vespa/slobrok/sbmirror.cpp
@@ -4,6 +4,7 @@
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/frt/target.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".slobrok.mirror");
@@ -53,14 +54,22 @@ MirrorAPI::~MirrorAPI()
 
 
 MirrorAPI::SpecList
-MirrorAPI::lookup(const std::string & pattern) const
+MirrorAPI::lookup(vespalib::stringref pattern) const
 {
     SpecList ret;
+    ret.reserve(1);
+    bool exact = pattern.find('*') == std::string::npos;
     std::lock_guard guard(_lock);
-    SpecList::const_iterator end = _specs.end();
-    for (SpecList::const_iterator it = _specs.begin(); it != end; ++it) {
-        if (match(it->first.c_str(), pattern.c_str())) {
-            ret.push_back(*it);
+    if (exact) {
+        auto found = _specs.find(pattern);
+        if (found != _specs.end()) {
+            ret.emplace_back(found->first, found->second);
+        }
+    } else {
+        for (const auto & spec : _specs) {
+            if (match(spec.first.c_str(), pattern.data())) {
+                ret.emplace_back(spec.first, spec.second);
+            }
         }
     }
     return ret;
@@ -77,8 +86,6 @@ MirrorAPI::lookup(const std::string & pattern) const
 bool
 IMirrorAPI::match(const char *name, const char *pattern)
 {
-    LOG_ASSERT(name != NULL);
-    LOG_ASSERT(pattern != NULL);
     while (*pattern != '\0') {
         if (*name == *pattern) {
             ++name;
@@ -102,11 +109,11 @@ IMirrorAPI::match(const char *name, const char *pattern)
 
 
 void
-MirrorAPI::updateTo(SpecList& newSpecs, uint32_t newGen)
+MirrorAPI::updateTo(SpecMap newSpecs, uint32_t newGen)
 {
     {
         std::lock_guard guard(_lock);
-        std::swap(newSpecs, _specs);
+         _specs = std::move(newSpecs);
         _updates.add();
     }
     _specsGen.setFromInt(newGen);
@@ -167,34 +174,26 @@ MirrorAPI::handleIncrementalFetch()
             LOG(spam, "incremental diff [%u;%u] full dump, but numRemove=%u, numNames=%u",
                 diff_from, diff_to, numRemove, numNames);
         }
-        SpecList specs;
+        SpecMap specs;
         for (uint32_t idx = 0; idx < numNames; idx++) {
-            specs.push_back(
-                    std::make_pair(std::string(n[idx]._str),
-                                   std::string(s[idx]._str)));
+            specs[n[idx]._str] = s[idx]._str;
         }
-        updateTo(specs, diff_to);
+        updateTo(std::move(specs), diff_to);
     } else if (_specsGen == diff_from) {
         // incremental update
-        SpecList specs;
-        SpecList::const_iterator end = _specs.end();
-        for (SpecList::const_iterator it = _specs.begin();
-             it != end;
-             ++it)
-        {
+        SpecMap specs;
+        for (const auto & spec : _specs) {
             bool keep = true;
             for (uint32_t idx = 0; idx < numRemove; idx++) {
-                if (it->first == r[idx]._str) keep = false;
+                if (spec.first == r[idx]._str) keep = false;
             }
             for (uint32_t idx = 0; idx < numNames; idx++) {
-                if (it->first == n[idx]._str) keep = false;
+                if (spec.first == n[idx]._str) keep = false;
             }
-            if (keep) specs.push_back(*it);
+            if (keep) specs[spec.first] = spec.second;
         }
         for (uint32_t idx = 0; idx < numNames; idx++) {
-            specs.push_back(
-                    std::make_pair(std::string(n[idx]._str),
-                                   std::string(s[idx]._str)));
+            specs[n[idx]._str] = s[idx]._str;
         }
         updateTo(specs, diff_to);
     }
@@ -222,13 +221,7 @@ MirrorAPI::handleReqDone()
     if (_reqDone) {
         _reqDone = false;
         _reqPending = false;
-        bool reconn = (_target == 0);
-
-        if (_req->IsError()) {
-            reconn = true;
-        } else {
-            reconn = handleIncrementalFetch();
-        }
+        bool reconn = _req->IsError() ? true : handleIncrementalFetch();
 
         if (reconn) {
             if (_target != 0) {

--- a/slobrok/src/vespa/slobrok/sbmirror.h
+++ b/slobrok/src/vespa/slobrok/sbmirror.h
@@ -5,6 +5,7 @@
 #include "backoff.h"
 #include "sblist.h"
 #include <vespa/vespalib/util/gencnt.h>
+#include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/fnet/frt/invoker.h>
 
 class FRT_Target;
@@ -40,6 +41,8 @@ public:
      * @param config   how to get the connect spec list
      **/
     MirrorAPI(FRT_Supervisor &orb, const ConfiguratorFactory & config);
+    MirrorAPI(const MirrorAPI &) = delete;
+    MirrorAPI &operator=(const MirrorAPI &) = delete;
 
     /**
      * @brief Clean up.
@@ -47,7 +50,7 @@ public:
     ~MirrorAPI();
 
     // Inherit doc from IMirrorAPI.
-    SpecList lookup(const std::string & pattern) const override;
+    SpecList lookup(vespalib::stringref pattern) const override;
 
     // Inherit doc from IMirrorAPI.
     uint32_t updates() const override { return _updates.getAsInt(); }
@@ -67,16 +70,14 @@ public:
     bool ready() const override;
 
 private:
-    MirrorAPI(const MirrorAPI &);
-    MirrorAPI &operator=(const MirrorAPI &);
-
+    using SpecMap = vespalib::hash_map<vespalib::string, vespalib::string>;
     /** from FNET_Task, polls slobrok **/
     void PerformTask() override;
 
     /** from FRT_IRequestWait **/
     void RequestDone(FRT_RPCRequest *req) override;
 
-    void updateTo(SpecList& newSpecs, uint32_t newGen);
+    void updateTo(SpecMap newSpecs, uint32_t newGen);
 
     bool handleIncrementalFetch();
 
@@ -93,7 +94,7 @@ private:
     bool                     _scheduled;
     bool                     _reqDone;
     bool                     _logOnSuccess;
-    SpecList                 _specs;
+    SpecMap                  _specs;
     vespalib::GenCnt         _specsGen;
     vespalib::GenCnt         _updates;
     SlobrokList              _slobrokSpecs;

--- a/slobrok/src/vespa/slobrok/sbregister.cpp
+++ b/slobrok/src/vespa/slobrok/sbregister.cpp
@@ -6,7 +6,6 @@
 #include <vespa/vespalib/util/host_name.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/exceptions.h>
-#include <sstream>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".slobrok.register");

--- a/storage/src/tests/storageserver/rpc/caching_rpc_target_resolver_test.cpp
+++ b/storage/src/tests/storageserver/rpc/caching_rpc_target_resolver_test.cpp
@@ -17,7 +17,7 @@ public:
     Mappings mappings;
     uint32_t gen;
     MockMirror() : mappings(), gen(1) {}
-    SpecList lookup(const std::string& pattern) const override {
+    SpecList lookup(vespalib::stringref pattern) const override {
         auto itr = mappings.find(pattern);
         if (itr != mappings.end()) {
             return itr->second;

--- a/storage/src/vespa/storage/storageserver/rpc/caching_rpc_target_resolver.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/caching_rpc_target_resolver.cpp
@@ -92,14 +92,13 @@ CachingRpcTargetResolver::insert_new_target_mapping(const api::StorageMessageAdd
 }
 
 std::shared_ptr<RpcTarget>
-CachingRpcTargetResolver::resolve_rpc_target(const api::StorageMessageAddress& address,
-                                             uint64_t bucket_id) {
+CachingRpcTargetResolver::resolve_rpc_target(const api::StorageMessageAddress& address, uint64_t bucket_id) {
     const uint32_t curr_slobrok_gen = _slobrok_mirror.updates();
     if (auto result = lookup_target(address, bucket_id, curr_slobrok_gen)) {
         return result;
     }
     auto slobrok_id = address_to_slobrok_id(address);
-    auto specs = _slobrok_mirror.lookup(slobrok_id); // FIXME string type mismatch; implicit conv!
+    auto specs = _slobrok_mirror.lookup(slobrok_id);
     if (specs.empty()) {
         LOG(debug, "Found no mapping for '%s'", slobrok_id.c_str());
         // TODO return potentially stale existing target if no longer existing in SB?


### PR DESCRIPTION
…use a hash lookup.

If it is a wildcard lookup iterate as earlier on.
Also use vespalib::stringref in interface to avoid conversion.
Use vespalib:string in the hash map to locate string in object aswe are still on old abi.

@havardpe and @arnej27959 PR