### PR TITLE
Jonmv/vespa feed client

### DIFF
--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/CliClient.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/CliClient.java
@@ -74,7 +74,7 @@ public class CliClient {
 
     private static FeedClient createFeedClient(CliArguments cliArgs) throws CliArguments.CliArgumentsException {
         FeedClientBuilder builder = FeedClientBuilder.create(cliArgs.endpoint());
-        cliArgs.connections().ifPresent(builder::setMaxConnections);
+        cliArgs.connections().ifPresent(builder::setConnectionsPerEndpoint);
         cliArgs.maxStreamsPerConnection().ifPresent(builder::setMaxStreamPerConnection);
         if (cliArgs.sslHostnameVerificationDisabled()) {
             builder.setHostnameVerifier(AcceptAllHostnameVerifier.INSTANCE);

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/FeedClient.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/FeedClient.java
@@ -10,10 +10,22 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface FeedClient extends Closeable {
 
+    /** Send a document put with the given parameters, returning a future with the result of the operation. */
     CompletableFuture<Result> put(DocumentId documentId, String documentJson, OperationParameters params);
+
+    /** Send a document update with the given parameters, returning a future with the result of the operation. */
     CompletableFuture<Result> update(DocumentId documentId, String updateJson, OperationParameters params);
+
+    /** Send a document remove with the given parameters, returning a future with the result of the operation. */
     CompletableFuture<Result> remove(DocumentId documentId, OperationParameters params);
 
+    /** Shut down, and reject new operations. Operations in flight are allowed to complete normally if graceful. */
+    void close(boolean graceful);
+
+    /** Initiates graceful shutdown. See {@link #close(boolean)}. */
+    default void close() { close(true); }
+
+    /** Controls what to retry, and how many times. */
     interface RetryStrategy {
 
         /** Whether to retry operations of the given type. */
@@ -24,10 +36,44 @@ public interface FeedClient extends Closeable {
 
     }
 
+    /** Allows slowing down or halting completely operations against the configured endpoint on high failure rates. */
+    interface CircuitBreaker {
+
+        /** Called by the client whenever a successful response is obtained. */
+        void success();
+
+        /** Called by the client whenever a transient or fatal error occurs. */
+        void failure();
+
+        /** The current state of the circuit breaker. */
+        State state();
+
+        enum State {
+
+            /** Circuit is closed: business as usual. */
+            CLOSED,
+
+            /** Circuit is half-open: something is wrong, perhaps it recovers? */
+            HALF_OPEN,
+
+            /** Circuit is open: we have given up. */
+            OPEN;
+
+        }
+
+    }
+
     enum OperationType {
-        put,
-        update,
-        remove;
+
+        /** A document put operation. This is idempotent. */
+        PUT,
+
+        /** A document update operation. This is idempotent if all its contained updates are. */
+        UPDATE,
+
+        /** A document remove operation. This is idempotent. */
+        REMOVE;
+
     }
 
 }

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
@@ -8,7 +8,11 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -22,38 +26,45 @@ import static java.util.Objects.requireNonNull;
  */
 public class FeedClientBuilder {
 
-    FeedClient.RetryStrategy defaultRetryStrategy = new FeedClient.RetryStrategy() { };
+    static final FeedClient.RetryStrategy defaultRetryStrategy = new FeedClient.RetryStrategy() { };
 
-    final URI endpoint;
+    final List<URI> endpoints;
     final Map<String, Supplier<String>> requestHeaders = new HashMap<>();
     SSLContext sslContext;
     HostnameVerifier hostnameVerifier;
-    int maxConnections = 4;
-    int maxStreamsPerConnection = 1024;
+    int connectionsPerEndpoint = 4;
+    int maxStreamsPerConnection = 128;
     FeedClient.RetryStrategy retryStrategy = defaultRetryStrategy;
+    FeedClient.CircuitBreaker circuitBreaker = new GracePeriodCircuitBreaker(Clock.systemUTC(), Duration.ofSeconds(1), Duration.ofMinutes(10));
     Path certificate;
     Path privateKey;
     Path caCertificates;
-    Clock clock;
 
-    public static FeedClientBuilder create(URI endpoint) { return new FeedClientBuilder(endpoint); }
+    public static FeedClientBuilder create(URI endpoint) { return new FeedClientBuilder(Collections.singletonList(endpoint)); }
 
-    private FeedClientBuilder(URI endpoint) {
-        requireNonNull(endpoint.getHost());
-        this.endpoint = endpoint;
+    public static FeedClientBuilder create(List<URI> endpoints) { return new FeedClientBuilder(endpoints); }
+
+    private FeedClientBuilder(List<URI> endpoints) {
+        if (endpoints.isEmpty())
+            throw new IllegalArgumentException("At least one endpoint must be provided");
+
+        for (URI endpoint : endpoints)
+            requireNonNull(endpoint.getHost());
+
+        this.endpoints = new ArrayList<>(endpoints);
     }
 
     /**
-     * Sets the maximum number of connections this client will use.
+     * Sets the number of connections this client will use per endpoint.
      *
      * A reasonable value here is a small multiple of the numbers of containers in the
      * cluster to feed, so load can be balanced across these.
      * In general, this value should be kept as low as possible, but poor connectivity
      * between feeder and cluster may also warrant a higher number of connections.
      */
-    public FeedClientBuilder setMaxConnections(int max) {
+    public FeedClientBuilder setConnectionsPerEndpoint(int max) {
         if (max < 1) throw new IllegalArgumentException("Max connections must be at least 1, but was " + max);
-        this.maxConnections = max;
+        this.connectionsPerEndpoint = max;
         return this;
     }
 
@@ -94,6 +105,11 @@ public class FeedClientBuilder {
 
     public FeedClientBuilder setRetryStrategy(FeedClient.RetryStrategy strategy) {
         this.retryStrategy = requireNonNull(strategy);
+        return this;
+    }
+
+    public FeedClientBuilder setCircuitBreaker(FeedClient.CircuitBreaker breaker) {
+        this.circuitBreaker = requireNonNull(breaker);
         return this;
     }
 

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/GracePeriodCircuitBreaker.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/GracePeriodCircuitBreaker.java
@@ -1,0 +1,62 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.feed.client;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.WARNING;
+
+/**
+ * Breaks the circuit when no successes have been recorded for a specified time.
+ */
+public class GracePeriodCircuitBreaker implements FeedClient.CircuitBreaker {
+
+    private static final Logger log = Logger.getLogger(GracePeriodCircuitBreaker.class.getName());
+
+    private final AtomicLong lastSuccessMillis = new AtomicLong(0); // Trigger if first response is a failure.
+    private final AtomicBoolean halfOpen = new AtomicBoolean(false);
+    private final AtomicBoolean open = new AtomicBoolean(false);
+    private final Clock clock;
+    private final long graceMillis;
+    private final long doomMillis;
+
+    GracePeriodCircuitBreaker(Clock clock, Duration grace, Duration doom) {
+        if (grace.isNegative())
+            throw new IllegalArgumentException("Grace delay must be non-negative");
+
+        if (doom.isNegative())
+            throw new IllegalArgumentException("Doom delay must be non-negative");
+
+        this.clock = requireNonNull(clock);
+        this.graceMillis = grace.toMillis();
+        this.doomMillis = doom.toMillis();
+    }
+
+    @Override
+    public void success() {
+        lastSuccessMillis.set(clock.millis());
+        if (halfOpen.compareAndSet(true, false))
+            log.log(INFO, "Circuit breaker is now closed");
+    }
+
+    @Override
+    public void failure() {
+        long nowMillis = clock.millis();
+        if (lastSuccessMillis.get() < nowMillis - doomMillis && open.compareAndSet(false, true))
+            log.log(WARNING, "Circuit breaker is now open");
+
+        if (lastSuccessMillis.get() < nowMillis - graceMillis && halfOpen.compareAndSet(false, true))
+            log.log(INFO, "Circuit breaker is now half-open");
+    }
+
+    @Override
+    public State state() {
+        return open.get() ? State.OPEN : halfOpen.get() ? State.HALF_OPEN : State.CLOSED;
+    }
+
+}

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/JsonStreamFeeder.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/JsonStreamFeeder.java
@@ -17,9 +17,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static ai.vespa.feed.client.FeedClient.OperationType.put;
-import static ai.vespa.feed.client.FeedClient.OperationType.remove;
-import static ai.vespa.feed.client.FeedClient.OperationType.update;
+import static ai.vespa.feed.client.FeedClient.OperationType.PUT;
+import static ai.vespa.feed.client.FeedClient.OperationType.REMOVE;
+import static ai.vespa.feed.client.FeedClient.OperationType.UPDATE;
 import static com.fasterxml.jackson.core.JsonToken.START_OBJECT;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_FALSE;
 import static com.fasterxml.jackson.core.JsonToken.VALUE_STRING;
@@ -187,9 +187,9 @@ public class JsonStreamFeeder implements Closeable {
                     case FIELD_NAME:
                         switch (parser.getText()) {
                             case "id":
-                            case "put":    type = put;    id = readId(); break;
-                            case "update": type = update; id = readId(); break;
-                            case "remove": type = remove; id = readId(); break;
+                            case "put":    type = PUT;    id = readId(); break;
+                            case "update": type = UPDATE; id = readId(); break;
+                            case "remove": type = REMOVE; id = readId(); break;
                             case "condition": parameters = parameters.testAndSetCondition(readString()); break;
                             case "create":    parameters = parameters.createIfNonExistent(readBoolean()); break;
                             case "fields": {
@@ -230,9 +230,9 @@ public class JsonStreamFeeder implements Closeable {
             }
 
             switch (type) {
-                case put:    return client.put   (id, payload, parameters);
-                case update: return client.update(id, payload, parameters);
-                case remove: return client.remove(id,          parameters);
+                case PUT:    return client.put   (id, payload, parameters);
+                case UPDATE: return client.update(id, payload, parameters);
+                case REMOVE: return client.remove(id, parameters);
                 default: throw new IllegalStateException("Unexpected operation type '" + type + "'");
             }
         }

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/RequestStrategy.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/RequestStrategy.java
@@ -4,6 +4,7 @@ package ai.vespa.feed.client;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 
+import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -16,6 +17,12 @@ public interface RequestStrategy {
 
     /** Whether this has failed fatally, and we should cease sending further operations. */
     boolean hasFailed();
+
+    /** Forcibly terminates this, causing all inflight operations to complete immediately. */
+    void destroy();
+
+    /** Wait for all inflight requests to complete. */
+    void await();
 
     /** Enqueue the given operation, returning its future result. This may block if the client send queue is full. */
     CompletableFuture<SimpleHttpResponse> enqueue(DocumentId documentId, SimpleHttpRequest request,

--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/JsonStreamFeederTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/JsonStreamFeederTest.java
@@ -57,9 +57,8 @@ class JsonStreamFeederTest {
             }
 
             @Override
-            public void close() throws IOException {
+            public void close(boolean graceful) { }
 
-            }
         }).build().feed(in, 1 << 7, false); // TODO: hangs on 1 << 6.
         assertEquals(docs + 1, ids.size());
     }


### PR DESCRIPTION
@bjorncs please review.

This got a bit jumbled up. The changes are:

1. Avoid locking.
2. Dispatch from a dedicated thread (or user thread).
3. Queue up excess inflight requests if throttled.
4. Add configurable circuit breaker, which allows client to go to ping mode, causes it to shut down if fully opened.
5. Add `await()` to wait until nothing is in flight. (May want to change semantics here, await/close meh)
6. Support multiple endpoints.
7. Parse JSON response from /document/v1