### PR TITLE
add some configurable limits in sentinel config

### DIFF
--- a/configdefinitions/src/vespa/sentinel.def
+++ b/configdefinitions/src/vespa/sentinel.def
@@ -17,6 +17,20 @@ application.environment string default="default"
 application.instance string default="default"
 application.region string default="default"
 
+# Connectivity checks run before starting services and measure how
+# many nodes in the Vespa cluster we can connect to and how many of
+# those that can connect back to us. We delay starting services
+# if we have more problems than the following limits allow:
+
+## Percentage we fail to talk to, maximum
+connectivity.allowedBadOutPercent int default=100
+
+## Percentage that fails to talk back to us, maximum
+connectivity.allowedBadReversePercent int default=100
+
+## Absolute number of nodes that fail to talk back to us, maximum
+connectivity.allowedBadReverseCount int default=999999999
+
 ## The command to run. This will be run by sh -c, and the following
 ## environment variables are defined: $ROOT, $VESPA_SERVICE_NAME,
 ## $VESPA_CONFIG_ID

--- a/configdefinitions/src/vespa/sentinel.def
+++ b/configdefinitions/src/vespa/sentinel.def
@@ -23,13 +23,10 @@ application.region string default="default"
 # if we have more problems than the following limits allow:
 
 ## Percentage we fail to talk to, maximum
-connectivity.allowedBadOutPercent int default=100
-
-## Percentage that fails to talk back to us, maximum
-connectivity.allowedBadReversePercent int default=100
+connectivity.maxBadOutPercent int default=100
 
 ## Absolute number of nodes that fail to talk back to us, maximum
-connectivity.allowedBadReverseCount int default=999999999
+connectivity.maxBadReverseCount int default=999999999
 
 ## The command to run. This will be run by sh -c, and the following
 ## environment variables are defined: $ROOT, $VESPA_SERVICE_NAME,


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

here is a proposal for new configurable limits for the connectivity check.
I think we want an absolute limit for reverse fails; even for large applications having more than one or two nodes with one-way connectivity is probably bad.

@havardpe please review
