### PR TITLE
- Add benchmark for hashtable reconstruction.

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/hashtable.h
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.h
@@ -102,7 +102,9 @@ class hash_node {
 public:
     using next_t=hashtable_base::next_t;
     enum {npos=-1u, invalid=-2u};
-    hash_node() : _node(), _next(invalid) {}
+    hash_node()
+        : _next(invalid)
+    {}
     hash_node(const V & node, next_t next=npos)
         : _next(next)
     {

--- a/vespalib/src/vespa/vespalib/stllike/hashtable.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.hpp
@@ -146,6 +146,8 @@ hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::erase(const Key & key
 template< typename Key, typename Value, typename Hash, typename Equal, typename KeyExtract, typename Modulator >
 void
 hashtable<Key, Value, Hash, Equal, KeyExtract, Modulator>::clear() {
+    if (_count == 0) return; // Already empty and properly initialized
+
     _nodes.clear();
     _count = 0;
     _nodes.resize(getTableSize());


### PR DESCRIPTION
- Optimize by not initializing hash_node._node char array.
- Also skip reconstruction, if it is in initial state.

@havardpe or @vekterli PR