### PR TITLE
Use larger buffers for link arrays (and level arrays).

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -25,7 +25,7 @@ namespace {
 
 // TODO: Move this to MemoryAllocator, with name PAGE_SIZE.
 constexpr size_t small_page_size = 4_Ki;
-constexpr size_t min_num_arrays_for_new_buffer = 8_Ki;
+constexpr size_t min_num_arrays_for_new_buffer = 64_Ki;
 constexpr float alloc_grow_factor = 0.2;
 // TODO: Adjust these numbers to what we accept as max in config.
 constexpr size_t max_level_array_size = 16;


### PR DESCRIPTION
@baldersheim : please review
@geirst : FYI

This should delay running out of address space for link arrays (issue #18124) until about 8 times as many documents are present.

