### PR TITLE
Warn instead of failing on validation errors in manual zones

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ValidationOverrides.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ValidationOverrides.java
@@ -177,6 +177,7 @@ public class ValidationOverrides {
 
     }
 
+    // TODO: Remove this class after June 2021
     public static class AllowAllValidationOverrides extends ValidationOverrides {
 
         private final DeployLogger logger;

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/ValidationOverrideTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/ValidationOverrideTest.java
@@ -4,16 +4,10 @@ package com.yahoo.config.application.api;
 import com.yahoo.test.ManualClock;
 import org.junit.Assert;
 import org.junit.Test;
-import org.xml.sax.SAXException;
-
-import java.io.IOException;
 import java.io.StringReader;
-import java.time.Clock;
 import java.time.Instant;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author bratseth
@@ -80,15 +74,6 @@ public class ValidationOverrideTest {
         ValidationOverrides empty = ValidationOverrides.empty;
         ValidationOverrides emptyReserialized = ValidationOverrides.fromXml(empty.xmlForm());
         assertEquals(empty.xmlForm(), emptyReserialized.xmlForm());
-    }
-
-    @Test
-    public void testAll() {
-        ValidationOverrides all = ValidationOverrides.all;
-        assertTrue(all.allows(ValidationId.deploymentRemoval, Clock.systemUTC().instant()));
-        assertTrue(all.allows(ValidationId.contentClusterRemoval, Clock.systemUTC().instant()));
-        assertTrue(all.allows(ValidationId.indexModeChange, Clock.systemUTC().instant()));
-        assertTrue(all.allows(ValidationId.fieldTypeChange, Clock.systemUTC().instant()));
     }
 
     private void assertOverridden(String validationId, ValidationOverrides overrides, Instant now) {

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -142,12 +142,8 @@ public class DeployState implements ConfigDefinitionStore {
         this.semanticRules = semanticRules; // TODO: Remove this by seeing how pagetemplates are propagated
         this.importedModels = importMlModels(applicationPackage, modelImporters, deployLogger);
 
-        ValidationOverrides suppliedValidationOverrides = applicationPackage.getValidationOverrides().map(ValidationOverrides::fromXml)
-                                                                            .orElse(ValidationOverrides.empty);
-        this.validationOverrides =
-                zone.environment().isManuallyDeployed() // // Warn but allow in manually deployed zones
-                ? new ValidationOverrides.AllowAllValidationOverrides(suppliedValidationOverrides, deployLogger)
-                : suppliedValidationOverrides;
+        this.validationOverrides = applicationPackage.getValidationOverrides().map(ValidationOverrides::fromXml)
+                                                     .orElse(ValidationOverrides.empty);
 
         this.wantedNodeVespaVersion = wantedNodeVespaVersion;
         this.now = now;

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -174,8 +175,9 @@ public class VespaModelFactory implements ModelFactory {
             return Validation.validate(model, validationParameters, deployState);
         } catch (ValidationOverrides.ValidationException e) {
             if (deployState.isHosted() && zone.environment().isManuallyDeployed())
-                log.warning("Auto-overriding validation which would be disallowed in production: " +
-                            Exceptions.toMessageString(e));
+                deployState.getDeployLogger().logApplicationPackage(Level.WARNING,
+                                                                    "Auto-overriding validation which would be disallowed in production: " +
+                                                                    Exceptions.toMessageString(e));
             else
                 rethrowUnlessIgnoreErrors(e, validationParameters.ignoreValidationErrors());
         } catch (IllegalArgumentException | TransientException e) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/Validation.java
@@ -55,6 +55,7 @@ public class Validation {
      * between the previous and current model
      *
      * @return a list of required changes needed to make this configuration live
+     * @throws ValidationOverrides.ValidationException if the change fails validation
      */
     public static List<ConfigChangeAction> validate(VespaModel model, ValidationParameters validationParameters, DeployState deployState) {
         if (validationParameters.checkRouting()) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/ChangeValidator.java
@@ -25,6 +25,7 @@ public interface ChangeValidator {
      * @param now the instant to use as now
      * @return a list of actions specifying what needs to be done in order to activate the new model.
      *         Return an empty list if nothing needs to be done
+     * @throws IllegalArgumentException if the change fails validation
      */
     List<ConfigChangeAction> validate(VespaModel current, VespaModel next, ValidationOverrides overrides, Instant now);
 

--- a/config-model/src/test/java/com/yahoo/config/model/MockModelContext.java
+++ b/config-model/src/test/java/com/yahoo/config/model/MockModelContext.java
@@ -20,8 +20,8 @@ import com.yahoo.config.model.test.MockApplicationPackage;
 import java.util.Optional;
 
 /**
-* @author hmusum
-*/
+ * @author hmusum
+ */
 public class MockModelContext implements ModelContext {
 
     private final ApplicationPackage applicationPackage;
@@ -82,4 +82,5 @@ public class MockModelContext implements ModelContext {
     public Properties properties() {
         return new TestProperties();
     }
+
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/VespaModelFactoryTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/VespaModelFactoryTest.java
@@ -19,7 +19,6 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.ProvisionLogger;
-import com.yahoo.vespa.model.builder.xml.dom.NodesSpecification;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
@@ -45,14 +45,6 @@ public class ContentTypeRemovalValidatorTest {
         tester.deploy(previous, getServices("book"), Environment.prod, removalOverride); // Allowed due to override
     }
 
-    @Test
-    public void testNoOverrideNeededinDev() {
-        ValidationTester tester = new ValidationTester();
-
-        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null).getFirst();
-        tester.deploy(previous, getServices("book"), Environment.dev, null);
-    }
-
     private static String getServices(String documentType) {
         return "<services version='1.0'>" +
                "  <content id='test' version='1.0'>" +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -208,10 +208,11 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
                 builtModelVersions.add(modelVersion);
             } catch (RuntimeException e) {
                 // allow failure to create old config models if there is a validation override that allow skipping old
-                // config models (which is always true for manually deployed zones)
-                if (builtModelVersions.size() > 0 && builtModelVersions.get(0).getModel().skipOldConfigModels(now))
+                // config models or we're manually deploying
+                if (builtModelVersions.size() > 0 &&
+                    ( builtModelVersions.get(0).getModel().skipOldConfigModels(now) || zone().environment().isManuallyDeployed()))
                     log.log(Level.INFO, applicationId + ": Failed to build version " + version +
-                                        ", but allow failure due to validation override ´skipOldConfigModels´");
+                                        ", but allow failure due to validation override or manual deployment");
                 else {
                     log.log(Level.SEVERE, applicationId + ": Failed to build version " + version);
                     throw e;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -209,7 +209,7 @@ public class DeployTester {
         @Override
         public ModelCreateResult createAndValidateModel(ModelContext modelContext, ValidationParameters validationParameters) {
             if ( ! validationParameters.ignoreValidationErrors())
-                throw new IllegalArgumentException("Validation fails");
+                throw new IllegalArgumentException("Model building fails");
             return new ModelCreateResult(createModel(modelContext), Collections.emptyList());
         }
 


### PR DESCRIPTION
The purpose of validation overrides is to protect production from
destructive changes by requiring a confirmation for such changes.
This is unnecessary in manuall deployed environments.