### PR TITLE
Preserve wantToRebuild until host is readied

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -167,7 +167,7 @@ public class Nodes {
                     if (rebuilding) {
                         node = node.with(node.status().withWantToRetire(existing.get().status().wantToRetire(),
                                                                         false,
-                                                                        existing.get().status().wantToRebuild()));
+                                                                        rebuilding));
                     }
                     nodesToRemove.add(existing.get());
                 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -161,6 +161,14 @@ public class Nodes {
                     node = node.with(node.status().withFailCount(existing.get().status().failCount()));
                     if (existing.get().status().firmwareVerifiedAt().isPresent())
                         node = node.with(node.status().withFirmwareVerifiedAt(existing.get().status().firmwareVerifiedAt().get()));
+                    // Preserve wantToRebuild/wantToRetire when rebuilding as the fields shouldn't be cleared until the
+                    // host is readied (i.e. we know it is up and rebuild completed)
+                    boolean rebuilding = existing.get().status().wantToRebuild();
+                    if (rebuilding) {
+                        node = node.with(node.status().withWantToRetire(existing.get().status().wantToRetire(),
+                                                                        false,
+                                                                        existing.get().status().wantToRebuild()));
+                    }
                     nodesToRemove.add(existing.get());
                 }
 


### PR DESCRIPTION
This prevents starting too many rebuilds if hosts never transition out of
provisioned after rebuild.

This also ensures that we retry rebuilds until they succeed (host becomes
ready).

@hakonhall