### PR TITLE
Only suspend active nodes when removing container

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.nodeagent;
 
 import com.yahoo.config.provision.ApplicationId;
@@ -357,7 +357,7 @@ public class NodeAgentImpl implements NodeAgent {
             }
 
             try {
-                if (context.node().state() != NodeState.dirty) {
+                if (context.node().state() == NodeState.active) {
                     suspend(context);
                 }
                 stopServices(context);


### PR DESCRIPTION
In other states vespa processes have already been stopped (for
nodes running vespa services and empty sentinel config means will be
received and vespa services stopped)

