### PR TITLE
Add back logging when resource-limits is specified and we do not throw

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
@@ -1,6 +1,7 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.cluster.DomResourceLimitsBuilder;
 
@@ -37,13 +38,16 @@ public class ClusterResourceLimits {
         private final boolean enableFeedBlockInDistributor;
         private final boolean hostedVespa;
         private final boolean throwIfSpecified;
+        private final DeployLogger deployLogger;
+
         private ResourceLimits.Builder ctrlBuilder = new ResourceLimits.Builder();
         private ResourceLimits.Builder nodeBuilder = new ResourceLimits.Builder();
 
-        public Builder(boolean enableFeedBlockInDistributor, boolean hostedVespa, boolean throwIfSpecified) {
+        public Builder(boolean enableFeedBlockInDistributor, boolean hostedVespa, boolean throwIfSpecified, DeployLogger deployLogger) {
             this.enableFeedBlockInDistributor = enableFeedBlockInDistributor;
             this.hostedVespa = hostedVespa;
             this.throwIfSpecified = throwIfSpecified;
+            this.deployLogger = deployLogger;
         }
 
         public ClusterResourceLimits build(ModelElement clusterElem) {
@@ -57,7 +61,7 @@ public class ClusterResourceLimits {
         private ResourceLimits.Builder createBuilder(ModelElement element) {
             return element == null
                     ? new ResourceLimits.Builder()
-                    : DomResourceLimitsBuilder.createBuilder(element, hostedVespa, throwIfSpecified);
+                    : DomResourceLimitsBuilder.createBuilder(element, hostedVespa, throwIfSpecified, deployLogger);
         }
 
         public void setClusterControllerBuilder(ResourceLimits.Builder builder) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -123,7 +123,8 @@ public class ContentCluster extends AbstractConfigProducer<AbstractConfigProduce
             boolean enableFeedBlockInDistributor = deployState.getProperties().featureFlags().enableFeedBlockInDistributor();
             var resourceLimits = new ClusterResourceLimits.Builder(enableFeedBlockInDistributor,
                                                                    stateIsHosted(deployState),
-                                                                   deployState.featureFlags().throwIfResourceLimitsSpecified())
+                                                                   deployState.featureFlags().throwIfResourceLimitsSpecified(),
+                                                                   deployState.getDeployLogger())
                     .build(contentElement);
             c.clusterControllerConfig = new ClusterControllerConfig.Builder(getClusterId(contentElement),
                     contentElement,

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/DomResourceLimitsBuilder.java
@@ -1,8 +1,11 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content.cluster;
 
+import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.ResourceLimits;
+
+import java.util.logging.Level;
 
 /**
  * Builder for feed block resource limits.
@@ -11,13 +14,21 @@ import com.yahoo.vespa.model.content.ResourceLimits;
  */
 public class DomResourceLimitsBuilder {
 
-    public static ResourceLimits.Builder createBuilder(ModelElement contentXml, boolean hostedVespa, boolean throwIfSpecified) {
+    public static ResourceLimits.Builder createBuilder(ModelElement contentXml,
+                                                       boolean hostedVespa,
+                                                       boolean throwIfSpecified,
+                                                       DeployLogger deployLogger) {
         ResourceLimits.Builder builder = new ResourceLimits.Builder();
         ModelElement resourceLimits = contentXml.child("resource-limits");
         if (resourceLimits == null) { return builder; }
 
-        if (hostedVespa && throwIfSpecified)
-            throw new IllegalArgumentException("Element '" + resourceLimits + "' is not allowed to be set");
+        if (hostedVespa) {
+            String message = "Element '" + resourceLimits + "' is not allowed to be set";
+            if (throwIfSpecified)
+                throw new IllegalArgumentException(message);
+            else
+                deployLogger.logApplicationPackage(Level.WARNING, message);
+        }
 
         if (resourceLimits.child("disk") != null) {
             builder.setDiskLimit(resourceLimits.childAsDouble("disk"));

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -1,6 +1,7 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
+import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockRoot;
@@ -23,7 +24,10 @@ public class FleetControllerClusterTest {
         var clusterElement = new ModelElement(doc.getDocumentElement());
         return new ClusterControllerConfig.Builder("storage",
                                                    clusterElement,
-                                                   new ClusterResourceLimits.Builder(enableFeedBlockInDistributor, false, false)
+                                                   new ClusterResourceLimits.Builder(enableFeedBlockInDistributor,
+                                                                                     false,
+                                                                                     false,
+                                                                                     new BaseDeployLogger())
                                                            .build(clusterElement).getClusterControllerLimits())
                 .build(root.getDeployState(), root, clusterElement.getXml());
     }


### PR DESCRIPTION
Add back logging so that apps that still have this setting get a
notification

Removing logging in https://github.com/vespa-engine/vespa/pull/18023 was premature.

@geirst please review