### PR TITLE
Revert "Log load balancer state transitions"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -65,7 +65,7 @@ public class LoadBalancerExpirer extends NodeRepositoryMaintainer {
         Instant now = nodeRepository().clock().instant();
         Instant expiry = now.minus(reservedExpiry);
         patchLoadBalancers(lb -> lb.state() == State.reserved && lb.changedAt().isBefore(expiry),
-                           lb -> db.writeLoadBalancer(lb.with(State.inactive, now), lb.state()));
+                           lb -> db.writeLoadBalancer(lb.with(State.inactive, now)));
     }
 
     /** Deprovision inactive load balancers that have expired */
@@ -114,7 +114,7 @@ public class LoadBalancerExpirer extends NodeRepositoryMaintainer {
                 attempts.add(1);
                 LOG.log(Level.INFO, () -> "Removing reals from inactive load balancer " + lb.id() + ": " + Sets.difference(lb.instance().get().reals(), reals));
                 service.create(new LoadBalancerSpec(lb.id().application(), lb.id().cluster(), reals), true);
-                db.writeLoadBalancer(lb.with(lb.instance().map(instance -> instance.withReals(reals))), lb.state());
+                db.writeLoadBalancer(lb.with(lb.instance().map(instance -> instance.withReals(reals))));
             } catch (Exception e) {
                 failed.add(lb.id());
                 lastException.set(e);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -482,28 +482,17 @@ public class CuratorDatabaseClient {
         return read(loadBalancerPath(id), LoadBalancerSerializer::fromJson);
     }
 
-    public void writeLoadBalancer(LoadBalancer loadBalancer, LoadBalancer.State fromState) {
+    public void writeLoadBalancer(LoadBalancer loadBalancer) {
         NestedTransaction transaction = new NestedTransaction();
-        writeLoadBalancers(List.of(loadBalancer), fromState, transaction);
+        writeLoadBalancers(List.of(loadBalancer), transaction);
         transaction.commit();
     }
 
-    public void writeLoadBalancers(Collection<LoadBalancer> loadBalancers, LoadBalancer.State fromState, NestedTransaction transaction) {
+    public void writeLoadBalancers(Collection<LoadBalancer> loadBalancers, NestedTransaction transaction) {
         CuratorTransaction curatorTransaction = db.newCuratorTransactionIn(transaction);
         loadBalancers.forEach(loadBalancer -> {
             curatorTransaction.add(createOrSet(loadBalancerPath(loadBalancer.id()),
                                                LoadBalancerSerializer.toJson(loadBalancer)));
-        });
-        transaction.onCommitted(() -> {
-            for (var lb : loadBalancers) {
-                if (lb.state() == fromState) continue;
-                if (fromState == null) {
-                    log.log(Level.INFO, () -> "Creating " + lb.id() + " in " + lb.state());
-                } else {
-                    log.log(Level.INFO, () -> "Moving " + lb.id() + " from " + fromState +
-                                              " to " + lb.state());
-                }
-            }
         });
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#18207

First config server in several cd zones fail to start:
[2021-06-11 12:58:51.183] INFO    : configserver     Container.com.yahoo.vespa.hosted.provision.provisioning.InfraDeployerImpl
        Failed to activate hosted-vespa.zone-config-servers
        exception=
        java.lang.IllegalArgumentException: Could not active load balancer that was never prepared: load balancer hosted-vespa:zone-config-servers:default:zone-config-servers
        at com.yahoo.vespa.hosted.provision.provisioning.LoadBalancerProvisioner.activate(LoadBalancerProvisioner.java:187)
        at com.yahoo.vespa.hosted.provision.provisioning.LoadBalancerProvisioner.activate(LoadBalancerProvisioner.java:105)
        at com.yahoo.vespa.hosted.provision.provisioning.Activator.lambda$activateLoadBalancers$4(Activator.java:152)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at com.yahoo.vespa.hosted.provision.provisioning.Activator.activateLoadBalancers(Activator.java:152)
        at com.yahoo.vespa.hosted.provision.provisioning.Activator.activate(Activator.java:49)