### PR TITLE
Sort nodes by hostname to get deterministic metric reporting order

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -27,6 +27,7 @@ import com.yahoo.vespa.service.monitor.ServiceModel;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
 
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -66,7 +67,9 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
 
     @Override
     public double maintain() {
-        NodeList nodes = nodeRepository().nodes().list();
+        // Sort by hostname to get deterministic metric reporting order (and hopefully avoid changes
+        // to metric reporting time so we get double reporting or no reporting within a minute)
+        NodeList nodes = nodeRepository().nodes().list().sortedBy(Comparator.comparing(Node::hostname));
         ServiceModel serviceModel = serviceMonitor.getServiceModelSnapshot();
 
         updateZoneMetrics();


### PR DESCRIPTION
(and hopefully avoid changes to metric reporting time so we get double
reporting or no reporting within a minute)
