### PR TITLE
Stop using metricsProxyMaxHeapSizeInMb()

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -88,7 +88,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxMergeQueueSize() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"geirst"}) default boolean enableFeedBlockInDistributor() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}, removeAfter = "7.406") default int clusterControllerMaxHeapSizeInMb() { return 128; }
-        @ModelFeatureFlag(owners = {"hmusum"}) default int metricsProxyMaxHeapSizeInMb(ClusterSpec.Type type) { return 256; }
+        @ModelFeatureFlag(owners = {"hmusum"}, removeAfter = "7.422") default int metricsProxyMaxHeapSizeInMb(ClusterSpec.Type type) { return 256; }
         @ModelFeatureFlag(owners = {"bjorncs", "tokle"}) default List<String> allowedAthenzProxyIdentities() { return List.of(); }
         @ModelFeatureFlag(owners = {"tokle"}) default boolean tenantIamRole() { return false; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -55,7 +55,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean enableFeedBlockInDistributor = true;
     private boolean useExternalRankExpression = false;
     private int clusterControllerMaxHeapSizeInMb = 128;
-    private int metricsProxyMaxHeapSizeInMb = 256;
     private int maxActivationInhibitedOutOfSyncGroups = 0;
     private List<TenantSecretStore> tenantSecretStores = Collections.emptyList();
     private String jvmOmitStackTraceInFastThrowOption;
@@ -97,7 +96,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public double feedConcurrency() { return feedConcurrency; }
     @Override public boolean enableFeedBlockInDistributor() { return enableFeedBlockInDistributor; }
     @Override public int clusterControllerMaxHeapSizeInMb() { return clusterControllerMaxHeapSizeInMb; }
-    @Override public int metricsProxyMaxHeapSizeInMb(ClusterSpec.Type type) { return metricsProxyMaxHeapSizeInMb; }
     @Override public int maxActivationInhibitedOutOfSyncGroups() { return maxActivationInhibitedOutOfSyncGroups; }
     @Override public List<TenantSecretStore> tenantSecretStores() { return tenantSecretStores; }
     @Override public String jvmOmitStackTraceInFastThrowOption(ClusterSpec.Type type) { return jvmOmitStackTraceInFastThrowOption; }
@@ -230,11 +228,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties clusterControllerMaxHeapSizeInMb(int heapSize) {
         clusterControllerMaxHeapSizeInMb = heapSize;
-        return this;
-    }
-
-    public TestProperties metricsProxyMaxHeapSizeInMb(int heapSize) {
-        metricsProxyMaxHeapSizeInMb = heapSize;
         return this;
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -1,8 +1,4 @@
-// Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/*
- * Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
- */
-
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin.metricsproxy;
 
 import ai.vespa.metricsproxy.http.application.ApplicationMetricsHandler;
@@ -13,14 +9,10 @@ import ai.vespa.metricsproxy.http.yamas.YamasHandler;
 import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import com.yahoo.component.ComponentSpecification;
-import com.yahoo.config.model.api.HostInfo;
-import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
-import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames;
 import com.yahoo.vespa.model.container.component.Component;
@@ -40,14 +32,11 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.T
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getApplicationDimensionsConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getMetricsNodesConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
-import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getQrStartConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.servicesWithAdminOnly;
-import static com.yahoo.vespa.model.container.ContainerCluster.G1GC;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -75,42 +64,6 @@ public class MetricsProxyContainerClusterTest {
         assertEquals(MockApplicationPackage.APPLICATION_GENERATION, config.generation());
         assertEquals(MockApplicationPackage.APPLICATION_NAME, config.name());
         assertEquals(MockApplicationPackage.DEPLOYED_BY_USER, config.user());
-    }
-
-    private void metrics_proxy_has_expected_qr_start_options(MetricsProxyModelTester.TestMode mode) {
-        metrics_proxy_has_expected_qr_start_options(mode, 0);
-    }
-
-    private void metrics_proxy_has_expected_qr_start_options(MetricsProxyModelTester.TestMode mode, int maxHeapForAdminClusterNodes) {
-        DeployState.Builder builder = new DeployState.Builder();
-        if (maxHeapForAdminClusterNodes > 0) {
-            builder.properties(new TestProperties().metricsProxyMaxHeapSizeInMb(maxHeapForAdminClusterNodes));
-        }
-
-        VespaModel model = getModel(servicesWithAdminOnly(), mode, builder);
-        for (HostInfo host : model.getHosts()) {
-            QrStartConfig qrStartConfig = getQrStartConfig(model, host.getHostname());
-            assertEquals(32, qrStartConfig.jvm().minHeapsize());
-            assertEquals(maxHeapForAdminClusterNodes > 0 ? maxHeapForAdminClusterNodes : 512, qrStartConfig.jvm().heapsize());
-            assertEquals(0, qrStartConfig.jvm().heapSizeAsPercentageOfPhysicalMemory());
-            assertEquals(2, qrStartConfig.jvm().availableProcessors());
-            assertFalse(qrStartConfig.jvm().verbosegc());
-            assertEquals(G1GC, qrStartConfig.jvm().gcopts());
-            assertEquals(512, qrStartConfig.jvm().stacksize());
-            assertEquals(0, qrStartConfig.jvm().directMemorySizeCache());
-            assertEquals(32, qrStartConfig.jvm().compressedClassSpaceSize());
-            assertEquals(75, qrStartConfig.jvm().baseMaxDirectMemorySize());
-        }
-    }
-
-    @Test
-    public void metrics_proxy_has_expected_qr_start_options() {
-        metrics_proxy_has_expected_qr_start_options(self_hosted);
-        metrics_proxy_has_expected_qr_start_options(hosted);
-
-        // With max heap from feature flag
-        metrics_proxy_has_expected_qr_start_options(self_hosted, 123);
-        metrics_proxy_has_expected_qr_start_options(hosted, 123);
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -15,8 +15,6 @@ import com.yahoo.vespa.model.admin.monitoring.Metric;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.test.VespaModelTester;
 
-import java.util.Optional;
-
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
 


### PR DESCRIPTION
Prepare for removing feature flag. Need to keep the rest of the code
until no config model uses it.
Remove test that did not actually test anything (always 0 hosts in test),
not needed anymore.
