### PR TITLE
JAR with default classifier is no longer a fatjar

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -731,7 +731,7 @@ fi
 %{_prefix}/bin/vespa-feed-client
 %{_prefix}/conf/vespa-feed-client/logging.properties
 %{_prefix}/lib/jars/vespa-http-client-jar-with-dependencies.jar
-%{_prefix}/lib/jars/vespa-feed-client-cli.jar
+%{_prefix}/lib/jars/vespa-feed-client-cli-jar-with-dependencies.jar
 
 %files config-model-fat
 %if %{_defattr_is_vespa_vespa}

--- a/vespa-feed-client-cli/CMakeLists.txt
+++ b/vespa-feed-client-cli/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_java_artifact(vespa-feed-client-cli)
+install_fat_java_artifact(vespa-feed-client-cli)
 
 vespa_install_script(src/main/sh/vespa-feed-client.sh vespa-feed-client bin)
 install(FILES src/main/resources/logging.properties DESTINATION conf/vespa-feed-client)

--- a/vespa-feed-client-cli/src/main/sh/vespa-feed-client.sh
+++ b/vespa-feed-client-cli/src/main/sh/vespa-feed-client.sh
@@ -81,4 +81,4 @@ exec java \
 -Xms128m -Xmx2048m $(getJavaOptionsIPV46) \
 --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
 -Djava.util.logging.config.file=${VESPA_HOME}/conf/vespa-feed-client/logging.properties \
--cp ${VESPA_HOME}/lib/jars/vespa-feed-client-cli.jar ai.vespa.feed.client.CliClient "$@"
+-cp ${VESPA_HOME}/lib/jars/vespa-feed-client-cli-jar-with-dependencies.jar ai.vespa.feed.client.CliClient "$@"


### PR DESCRIPTION
Install and refer to 'jar-with-dependencies' artifact in wrapper script

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
