### PR TITLE
Check feed metric value separately

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterDeploymentMetricsRetriever.java
@@ -127,8 +127,10 @@ public class ClusterDeploymentMetricsRetriever {
             case VESPA_CONTAINER:
                 optionalDouble(values.field("query_latency.sum")).ifPresent(qlSum ->
                         aggregator.get()
-                                .addContainerLatency(qlSum, values.field("query_latency.count").asDouble())
-                                .addFeedLatency(values.field("feed.latency.sum").asDouble(), values.field("feed.latency.count").asDouble()));
+                                .addContainerLatency(qlSum, values.field("query_latency.count").asDouble()));
+                optionalDouble(values.field("feed.latency.sum")).ifPresent(flSum ->
+                        aggregator.get()
+                                .addFeedLatency(flSum, values.field("feed.latency.count").asDouble()));
                 break;
             case VESPA_QRSERVER:
                 optionalDouble(values.field("query_latency.sum")).ifPresent(qlSum ->


### PR DESCRIPTION
`feed.latency` is not necessarily in the same `values` object as `query_latency` 