### PR TITLE
avoid using fill_insert

### DIFF
--- a/eval/src/vespa/eval/eval/array_array_map.h
+++ b/eval/src/vespa/eval/eval/array_array_map.h
@@ -116,7 +116,7 @@ private:
                 _keys.push_back(k);
             }
         }
-        _values.resize(_values.size() + _values_per_entry, V{});
+        _values.resize(_values.size() + _values_per_entry);
         auto [pos, was_inserted] = _map.insert(MyKey{{tag_id},hash});
         assert(was_inserted);
         return Tag{tag_id};


### PR DESCRIPTION
gcc 9.3 would use default_append here, but gcc 10.2 seems to be able
to inline it completely. (tested with godbolt)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@arnej27959 FYI