### PR TITLE
Revert "Compute percentage of zero hit queries."

### DIFF
--- a/eval/src/vespa/eval/eval/aggr.h
+++ b/eval/src/vespa/eval/eval/aggr.h
@@ -10,10 +10,13 @@
 #include <algorithm>
 #include <cmath>
 
-namespace vespalib { class Stash; }
+namespace vespalib {
 
-namespace vespalib::eval {
+class Stash;
 
+namespace eval {
+
+struct BinaryOperation;
 
 /**
  * Enumeration of all different aggregators that are allowed to be
@@ -234,3 +237,4 @@ struct TypifyAggr {
 };
 
 } // namespace vespalib::eval
+} // namespace vespalib

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -5,32 +5,38 @@
 #include <util/clientstatus.h>
 #include <httpclient/httpclient.h>
 #include <util/filereader.h>
+#include <cassert>
 #include <cstring>
 #include <iostream>
 #include <vespa/vespalib/encoding/base64.h>
 
 using namespace vespalib;
 
-Client::Client(vespalib::CryptoEngine::SP engine, std::unique_ptr<ClientArguments> args)
-    : _args(std::move(args)),
-      _status(std::make_unique<ClientStatus>()),
-      _reqTimer(std::make_unique<Timer>()),
-      _cycleTimer(std::make_unique<Timer>()),
-      _masterTimer(std::make_unique<Timer>()),
-      _http(std::make_unique<HTTPClient>(std::move(engine), _args->_hostname, _args->_port, _args->_keepAlive,
-                                         _args->_headerBenchmarkdataCoverage, _args->_extraHeaders, _args->_authority)),
-      _reader(std::make_unique<FileReader>()),
+Client::Client(vespalib::CryptoEngine::SP engine, ClientArguments *args)
+    : _args(args),
+      _status(new ClientStatus()),
+      _reqTimer(new Timer()),
+      _cycleTimer(new Timer()),
+      _masterTimer(new Timer()),
+      _http(new HTTPClient(std::move(engine), _args->_hostname, _args->_port,
+                           _args->_keepAlive, _args->_headerBenchmarkdataCoverage,
+                           _args->_extraHeaders, _args->_authority)),
+      _reader(new FileReader()),
       _output(),
       _linebufsize(args->_maxLineSize),
-      _linebuf(std::make_unique<char[]>(_linebufsize)),
+      _linebuf(new char[_linebufsize]),
       _stop(false),
       _done(false),
       _thread()
 {
+    assert(args != NULL);
     _cycleTimer->SetMax(_args->_cycle);
 }
 
-Client::~Client() = default;
+Client::~Client()
+{
+    delete [] _linebuf;
+}
 
 void Client::runMe(Client * me) {
     me->run();
@@ -167,15 +173,15 @@ Client::run()
     std::this_thread::sleep_for(std::chrono::milliseconds(_args->_delay));
 
     // open query file
-    snprintf(inputFilename, 1024, _args->_filenamePattern.c_str(), _args->_myNum);
+    snprintf(inputFilename, 1024, _args->_filenamePattern, _args->_myNum);
     if (!_reader->Open(inputFilename)) {
         printf("Client %d: ERROR: could not open file '%s' [read mode]\n",
                _args->_myNum, inputFilename);
         _status->SetError("Could not open query file.");
         return;
     }
-    if ( ! _args->_outputPattern.empty()) {
-        snprintf(outputFilename, 1024, _args->_outputPattern.c_str(), _args->_myNum);
+    if (_args->_outputPattern != NULL) {
+        snprintf(outputFilename, 1024, _args->_outputPattern, _args->_myNum);
         _output = std::make_unique<std::ofstream>(outputFilename, std::ofstream::out | std::ofstream::binary);
         if (_output->fail()) {
             printf("Client %d: ERROR: could not open file '%s' [write mode]\n",
@@ -202,7 +208,7 @@ Client::run()
 
         _cycleTimer->Start();
 
-        linelen = urlSource.nextUrl(_linebuf.get(), _linebufsize);
+        linelen = urlSource.nextUrl(_linebuf, _linebufsize);
         if (linelen > 0) {
             ++urlNumber;
         } else {
@@ -216,11 +222,11 @@ Client::run()
         if (linelen < _linebufsize) {
             if (_output) {
                 _output->write("URL: ", strlen("URL: "));
-                _output->write(_linebuf.get(), linelen);
+                _output->write(_linebuf, linelen);
                 _output->write("\n\n", 2);
             }
             if (linelen + (int)_args->_queryStringToAppend.length() < _linebufsize) {
-                strcat(_linebuf.get(), _args->_queryStringToAppend.c_str());
+                strcat(_linebuf, _args->_queryStringToAppend.c_str());
             }
             int cLen = _args->_usePostMode ? urlSource.nextContent() : 0;
             
@@ -233,7 +239,7 @@ Client::run()
             }
                         
             _reqTimer->Start();
-            auto fetch_status = _http->Fetch(_linebuf.get(), _output.get(), _args->_usePostMode, content, cLen);
+            auto fetch_status = _http->Fetch(_linebuf, _output.get(), _args->_usePostMode, content, cLen);
             _reqTimer->Stop();
             _status->AddRequestStatus(fetch_status.RequestStatus());
             if (fetch_status.Ok() && fetch_status.TotalHitCount() == 0)

--- a/fbench/src/fbench/client.h
+++ b/fbench/src/fbench/client.h
@@ -21,17 +21,23 @@ struct ClientArguments
     int         _myNum;
 
     /**
+     * The total number of clients controlled by the parent fbench
+     * application
+     **/
+    int         _totNum;
+
+    /**
      * Pattern that combined with the client number will become the name
      * of the file containing the urls this client should request.
      **/
-    std::string _filenamePattern;
+    const char *_filenamePattern;
 
     /**
      * Pattern that combined with the client number will become the name
      * of the file this client should dump url content to. If this
      * pattern is set to NULL no output file is generated.
      **/
-    std::string _outputPattern;
+    const char *_outputPattern;
 
     /**
      * The server the client should fetch urls from.
@@ -110,9 +116,9 @@ struct ClientArguments
     std::string _extraHeaders;
     std::string _authority;
 
-    ClientArguments(int myNum,
-                    const std::string & filenamePattern,
-                    const std::string & outputPattern,
+    ClientArguments(int myNum, int totNum,
+                    const char *filenamePattern,
+                    const char *outputPattern,
                     const char *hostname, int port,
                     long cycle, long delay,
                     int ignoreCount, int byteLimit,
@@ -123,6 +129,7 @@ struct ClientArguments
                     const std::string & queryStringToAppend, const std::string & extraHeaders,
                     const std::string &authority, bool postMode)
         : _myNum(myNum),
+          _totNum(totNum),
           _filenamePattern(filenamePattern),
           _outputPattern(outputPattern),
           _hostname(hostname),
@@ -174,11 +181,13 @@ private:
     std::unique_ptr<FileReader>      _reader;
     std::unique_ptr<std::ofstream>   _output;
     int                              _linebufsize;
-    std::unique_ptr<char[]>          _linebuf;
+    char                            *_linebuf;
     std::atomic<bool>                _stop;
     std::atomic<bool>                _done;
     std::thread                      _thread;
 
+    Client(const Client &);
+    Client &operator=(const Client &);
     static void runMe(Client * client);
     void run();
 
@@ -188,9 +197,7 @@ public:
      * The client arguments given to this method becomes the
      * responsibility of the client.
      **/
-    Client(vespalib::CryptoEngine::SP engine, std::unique_ptr<ClientArguments> args);
-    Client(const Client &) = delete;
-    Client &operator=(const Client &) = delete;
+    Client(vespalib::CryptoEngine::SP engine, ClientArguments *args);
 
     /**
      * Delete objects owned by this client, including the client arguments.

--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -1,8 +1,4 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
-#include "fbench.h"
-#include "client.h"
-
 #include <util/timer.h>
 #include <httpclient/httpclient.h>
 #include <util/filereader.h>
@@ -13,6 +9,8 @@
 #include <vespa/vespalib/net/tls/tls_crypto_engine.h>
 #include <vespa/vespalib/io/mapped_file_input.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include "client.h"
+#include "fbench.h"
 #include <cstring>
 #include <cmath>
 #include <csignal>
@@ -21,8 +19,7 @@
 
 namespace {
 
-std::string
-maybe_load(const std::string &file_name, bool &failed) {
+std::string maybe_load(const std::string &file_name, bool &failed) {
     std::string content;
     if (!file_name.empty()) {
         vespalib::MappedFileInput file(file_name);
@@ -45,8 +42,8 @@ FBench::FBench()
       _clients(),
       _ignoreCount(0),
       _cycle(0),
-      _filenamePattern(),
-      _outputPattern(),
+      _filenamePattern(NULL),
+      _outputPattern(NULL),
       _byteLimit(0),
       _restartLimit(0),
       _maxLineSize(0),
@@ -61,6 +58,8 @@ FBench::FBench()
 FBench::~FBench()
 {
     _clients.clear();
+    free(_filenamePattern);
+    free(_outputPattern);
 }
 
 bool
@@ -122,13 +121,11 @@ FBench::InitBenchmark(int numClients, int ignoreCount, int cycle,
     _ignoreCount     = ignoreCount;
     _cycle           = cycle;
 
-    _filenamePattern = filenamePattern;
-    if (outputPattern != nullptr) {
-        _outputPattern = outputPattern;
-    } else {
-        _outputPattern.clear();
-    }
-
+    free(_filenamePattern);
+    _filenamePattern = strdup(filenamePattern);
+    free(_outputPattern);
+    _outputPattern   = (outputPattern == NULL) ?
+                       NULL : strdup(outputPattern);
     _queryStringToAppend = queryStringToAppend;
     _extraHeaders    = extraHeaders;
     _authority       = authority;
@@ -157,12 +154,15 @@ FBench::CreateClients()
             off_end = _queryfileOffset[i+1];
         }
         client = std::make_unique<Client>(_crypto_engine,
-            std::make_unique<ClientArguments>(i, _filenamePattern, _outputPattern,
-                                              _hostnames[i % _hostnames.size()].c_str(),
-                                              _ports[i % _ports.size()], _cycle,random() % spread,
-                                              _ignoreCount, _byteLimit, _restartLimit, _maxLineSize, _keepAlive,
-                                              _base64Decode, _headerBenchmarkdataCoverage, off_beg, off_end,
-                                              _singleQueryFile, _queryStringToAppend, _extraHeaders, _authority, _usePostMode));
+            new ClientArguments(i, _clients.size(), _filenamePattern,
+                                _outputPattern, _hostnames[i % _hostnames.size()].c_str(),
+                                _ports[i % _ports.size()], _cycle,
+                                random() % spread, _ignoreCount,
+                                _byteLimit, _restartLimit, _maxLineSize,
+                                _keepAlive, _base64Decode,
+                                _headerBenchmarkdataCoverage,
+                                off_beg, off_end,
+                                _singleQueryFile, _queryStringToAppend, _extraHeaders, _authority, _usePostMode));
         ++i;
     }
 }
@@ -278,8 +278,6 @@ FBench::PrintSummary()
     printf("utilization:            %8.2f %%\n",
            (maxRate > 0) ? 100 * (actualRate / maxRate) : 0);
     printf("zero hit queries:       %8ld\n", status._zeroHitQueries);
-    printf("zero hit percentage:    %8.2f %%\n",
-           (status._requestCnt > 0) ? 100.0*(double(status._zeroHitQueries)/status._requestCnt) : 0.0);
     printf("http request status breakdown:\n");
     for (const auto& entry : status._requestStatusDistribution)
         printf("  %8u : %8u \n", entry.first, entry.second);
@@ -347,7 +345,7 @@ FBench::Main(int argc, char *argv[])
     const int minLineSize = 1024;
 
     const char *queryFilePattern  = "query%03d.txt";
-    const char *outputFilePattern = nullptr;
+    const char *outputFilePattern = NULL;
     std::string queryStringToAppend;
     std::string extraHeaders;
     std::string ca_certs_file_name; // -T
@@ -601,8 +599,8 @@ main(int argc, char** argv)
     sigemptyset(&act.sa_mask);
     act.sa_flags = 0;
 
-    sigaction(SIGINT, &act, nullptr);
-    sigaction(SIGPIPE, &act, nullptr);
+    sigaction(SIGINT, &act, NULL);
+    sigaction(SIGPIPE, &act, NULL);
 
     FBench myApp;
     return myApp.Main(argc, argv);

--- a/fbench/src/fbench/fbench.h
+++ b/fbench/src/fbench/fbench.h
@@ -1,14 +1,6 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vector>
-#include <string>
-#include <memory>
-
-class Client;
-
-namespace vespalib { class CryptoEngine; }
-
 /**
  * This is the application class of the fbench program. It controls
  * the operation of the test clients and collects overall results.
@@ -18,27 +10,29 @@ namespace vespalib { class CryptoEngine; }
 class FBench
 {
 private:
-    std::shared_ptr<vespalib::CryptoEngine> _crypto_engine;
-    std::vector<std::unique_ptr<Client>> _clients;
-    int                      _ignoreCount;
-    int                      _cycle;
+    vespalib::CryptoEngine::SP _crypto_engine;
+    std::vector<Client::UP> _clients;
+    int                 _numClients;
+    int                 _ignoreCount;
+    int                 _cycle;
     std::vector<std::string> _hostnames;
-    std::vector<int>         _ports;
-    std::string              _filenamePattern;
-    std::string              _outputPattern;
-    int                      _byteLimit;
-    int                      _restartLimit;
-    int                      _maxLineSize;
-    bool                     _keepAlive;
-    bool                     _base64Decode;
-    bool                     _usePostMode;
-    bool                     _headerBenchmarkdataCoverage;
-    int                      _seconds;
-    std::vector<uint64_t>    _queryfileOffset;
-    bool                     _singleQueryFile;
-    std::string              _queryStringToAppend;
-    std::string              _extraHeaders;
-    std::string              _authority;
+    std::vector<int>    _ports;
+    char               *_filenamePattern;
+    char               *_outputPattern;
+    int                 _byteLimit;
+    int                 _restartLimit;
+    int                 _maxLineSize;
+    bool                _keepAlive;
+    bool                _base64Decode;
+    bool                _usePostMode;
+    bool                _headerBenchmarkdataCoverage;
+    int                 _seconds;
+    std::vector<uint64_t> _queryfileOffset;
+    int                 _numberOfQueries;
+    bool                _singleQueryFile;
+    std::string         _queryStringToAppend;
+    std::string         _extraHeaders;
+    std::string         _authority;
 
     bool init_crypto_engine(const std::string &ca_certs_file_name,
                             const std::string &cert_chain_file_name,


### PR DESCRIPTION
Reverts vespa-engine/vespa#18333

Seems to have caused core dumps in some performance tests:
[New LWP 5736]
[New LWP 5738]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Core was generated by `/opt/vespa/bin/vespa-fbench -c 0 -s 30 -n 8 -q /opt/vespa/tmp/systemtests/trans'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00000000004079ad in Client::Client(std::shared_ptr<vespalib::CryptoEngine>, std::unique_ptr<ClientArguments, std::default_delete<ClientArguments> >) ()
[Current thread is 1 (Thread 0x7f7df0119780 (LWP 5736))]
#0  0x00000000004079ad in Client::Client(std::shared_ptr<vespalib::CryptoEngine>, std::unique_ptr<ClientArguments, std::default_delete<ClientArguments> >) ()
#1  0x0000000000409b81 in FBench::CreateClients() ()
#2  0x000000000040d30a in FBench::Main(int, char**) ()
#3  0x000000000040708d in main ()

@baldersheim or @havardpe or @aressem 