### PR TITLE
Revert "Bjorncs/tls cipher feature flag"

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -94,6 +94,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"tokle"}) default boolean tenantIamRole() { return false; }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }
         @ModelFeatureFlag(owners = {"hmusum"}) default String jvmOmitStackTraceInFastThrowOption(ClusterSpec.Type type) { return ""; }
+        @ModelFeatureFlag(owners = {"bjorncs", "jonmv"}, removeAfter = "7.409") default boolean enableJdiscHttp2() { return true; }
         @ModelFeatureFlag(owners = {"tokle", "bjorncs"}) default boolean enableCustomAclMapping() { return false; }
         @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default int numDistributorStripes() { return 0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean requireConnectivityCheck() { return false; }
@@ -141,8 +142,6 @@ public interface ModelContext {
         default boolean allowDisableMtls() { return true; }
 
         default List<X509Certificate> operatorCertificates() { return List.of(); }
-
-        default List<String> tlsCiphersOverride() { return List.of(); }
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/ssl/HostedSslConnectorFactory.java
@@ -8,7 +8,6 @@ import com.yahoo.security.tls.TlsContext;
 import com.yahoo.vespa.model.container.http.ConnectorFactory;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,43 +24,39 @@ public class HostedSslConnectorFactory extends ConnectorFactory {
 
     private final boolean enforceClientAuth;
     private final boolean enforceHandshakeClientAuth;
-    private final Collection<String> tlsCiphersOverride;
 
     /**
      * Create connector factory that uses a certificate provided by the config-model / configserver and default hosted Vespa truststore.
      */
     public static HostedSslConnectorFactory withProvidedCertificate(
-            String serverName, EndpointCertificateSecrets endpointCertificateSecrets, boolean enforceHandshakeClientAuth,
-            Collection<String> tlsCiphersOverride) {
+            String serverName, EndpointCertificateSecrets endpointCertificateSecrets, boolean enforceHandshakeClientAuth) {
         ConfiguredDirectSslProvider sslProvider = createConfiguredDirectSslProvider(
                 serverName, endpointCertificateSecrets, DEFAULT_HOSTED_TRUSTSTORE, /*tlsCaCertificates*/null, enforceHandshakeClientAuth);
-        return new HostedSslConnectorFactory(sslProvider, false, enforceHandshakeClientAuth, tlsCiphersOverride);
+        return new HostedSslConnectorFactory(sslProvider, false, enforceHandshakeClientAuth);
     }
 
     /**
      * Create connector factory that uses a certificate provided by the config-model / configserver and a truststore configured by the application.
      */
     public static HostedSslConnectorFactory withProvidedCertificateAndTruststore(
-            String serverName, EndpointCertificateSecrets endpointCertificateSecrets, String tlsCaCertificates,
-            Collection<String> tlsCiphersOverride) {
+            String serverName, EndpointCertificateSecrets endpointCertificateSecrets, String tlsCaCertificates) {
         ConfiguredDirectSslProvider sslProvider = createConfiguredDirectSslProvider(
                 serverName, endpointCertificateSecrets, /*tlsCaCertificatesPath*/null, tlsCaCertificates, false);
-        return new HostedSslConnectorFactory(sslProvider, true, false, tlsCiphersOverride);
+        return new HostedSslConnectorFactory(sslProvider, true, false);
     }
 
     /**
      * Create connector factory that uses the default certificate and truststore provided by Vespa (through Vespa-global TLS configuration).
      */
-    public static HostedSslConnectorFactory withDefaultCertificateAndTruststore(String serverName, Collection<String> tlsCiphersOverride) {
-        return new HostedSslConnectorFactory(new DefaultSslProvider(serverName), true, false, tlsCiphersOverride);
+    public static HostedSslConnectorFactory withDefaultCertificateAndTruststore(String serverName) {
+        return new HostedSslConnectorFactory(new DefaultSslProvider(serverName), true, false);
     }
 
     private HostedSslConnectorFactory(SslProvider sslProvider, boolean enforceClientAuth,
-                                      boolean enforceHandshakeClientAuth, Collection<String> tlsCiphersOverride) {
+                                      boolean enforceHandshakeClientAuth) {
         super(new Builder("tls4443", 4443).sslProvider(sslProvider));
         this.enforceClientAuth = enforceClientAuth;
         this.enforceHandshakeClientAuth = enforceHandshakeClientAuth;
-        this.tlsCiphersOverride = tlsCiphersOverride;
     }
 
     private static ConfiguredDirectSslProvider createConfiguredDirectSslProvider(
@@ -88,15 +83,10 @@ public class HostedSslConnectorFactory extends ConnectorFactory {
         // Disables TLSv1.3 as it causes some browsers to prompt user for client certificate (when connector has 'want' auth)
         connectorBuilder.ssl.enabledProtocols(List.of("TLSv1.2"));
 
-        if (!tlsCiphersOverride.isEmpty()) {
-            connectorBuilder.ssl.enabledCipherSuites(tlsCiphersOverride);
-        } else {
-            // Add TLS_RSA_WITH_AES_256_GCM_SHA384 cipher to list of default allowed ciphers
-            // TODO Remove TLS_RSA_WITH_AES_256_GCM_SHA384 as it's weak and incompatible with HTTP/2
-            Set<String> ciphers = new HashSet<>(TlsContext.ALLOWED_CIPHER_SUITES);
-            ciphers.add("TLS_RSA_WITH_AES_256_GCM_SHA384");
-            connectorBuilder.ssl.enabledCipherSuites(Set.copyOf(ciphers));
-        }
+        // Add TLS_RSA_WITH_AES_256_GCM_SHA384 cipher to list of defalt allowed ciphers
+        Set<String> ciphers = new HashSet<>(TlsContext.ALLOWED_CIPHER_SUITES);
+        ciphers.add("TLS_RSA_WITH_AES_256_GCM_SHA384");
+        connectorBuilder.ssl.enabledCipherSuites(Set.copyOf(ciphers));
 
         connectorBuilder
                 .proxyProtocol(new ConnectorConfig.ProxyProtocol.Builder().enabled(true).mixedMode(true))

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -301,7 +301,6 @@ public class ModelContextImpl implements ModelContext {
         private final StringFlag jvmGCOptionsFlag;
         private final boolean allowDisableMtls;
         private final List<X509Certificate> operatorCertificates;
-        private final List<String> tlsCiphersOverride;
 
         public Properties(ApplicationId applicationId,
                           ConfigserverConfig configserverConfig,
@@ -340,8 +339,6 @@ public class ModelContextImpl implements ModelContext {
             this.allowDisableMtls = PermanentFlags.ALLOW_DISABLE_MTLS.bindTo(flagSource)
                     .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
             this.operatorCertificates = operatorCertificates;
-            this.tlsCiphersOverride = PermanentFlags.TLS_CIPHERS_OVERRIDE.bindTo(flagSource)
-                    .with(FetchVector.Dimension.APPLICATION_ID, applicationId.serializedForm()).value();
         }
 
         @Override public ModelContext.FeatureFlags featureFlags() { return featureFlags; }
@@ -414,8 +411,6 @@ public class ModelContextImpl implements ModelContext {
         public List<X509Certificate> operatorCertificates() {
             return operatorCertificates;
         }
-
-        @Override public List<String> tlsCiphersOverride() { return tlsCiphersOverride; }
 
         public String flagValueForClusterType(StringFlag flag, Optional<ClusterSpec.Type> clusterType) {
             return clusterType.map(type -> flag.with(CLUSTER_TYPE, type.name()))

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -170,13 +170,6 @@ public class PermanentFlags {
             TENANT_ID
     );
 
-    public static final UnboundListFlag<String> TLS_CIPHERS_OVERRIDE = defineListFlag(
-            "tls-ciphers-override", List.of(), String.class,
-            "Override TLS ciphers enabled for port 4443 on hosted application containers",
-            "Takes effect on redeployment",
-            APPLICATION_ID
-    );
-
     private PermanentFlags() {}
 
     private static UnboundBooleanFlag defineFeatureFlag(


### PR DESCRIPTION
Reverts vespa-engine/vespa#18374

`enableJdiscHttp2()` cannot be removed, still in use:
  Caused by: java.lang.NoSuchMethodError: 'boolean com.yahoo.config.model.api.ModelContext$FeatureFlags.enableJdiscHttp2()'
        at com.yahoo.vespa.model.container.xml.ContainerModelBuilder.addAdditionalHostedConnector(ContainerModelBuilder.java:436)

Well, I guess this revert is not good either (since we cannot remove stuff from API), but `enableJdiscHttp2()` should be added back.