### PR TITLE
Different log level for different errors

### DIFF
--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/HttpRequestStrategy.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/HttpRequestStrategy.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static ai.vespa.feed.client.FeedClient.CircuitBreaker.State.CLOSED;
@@ -23,6 +24,8 @@ import static ai.vespa.feed.client.FeedClient.CircuitBreaker.State.HALF_OPEN;
 import static ai.vespa.feed.client.FeedClient.CircuitBreaker.State.OPEN;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
 // TODO: update doc
@@ -133,37 +136,48 @@ class HttpRequestStrategy implements RequestStrategy {
      */
     private boolean retry(HttpRequest request, Throwable thrown, int attempt) {
         breaker.failure();
-        log.log(FINE, thrown, () -> "Failed attempt " + attempt + " at " + request);
-
         if (   (thrown instanceof IOException)               // General IO problems.
             || (thrown instanceof CancellationException)     // TLS session disconnect.
-            || (thrown instanceof CancelledKeyException))    // Selection cancelled.
+            || (thrown instanceof CancelledKeyException)) {  // Selection cancelled.
+            log.log(INFO, thrown, () -> "Failed attempt " + attempt + " at " + request);
             return retry(request, attempt);
+        }
 
+        log.log(WARNING, thrown, () -> "Failed attempt " + attempt + " at " + request);
         return false;
     }
 
     /** Retries throttled requests (429, 503), adjusting the target inflight count, and server errors (500, 502). */
     private boolean retry(HttpRequest request, HttpResponse response, int attempt) {
-        if (response.code() / 100 == 2) {
+        if (response.code() / 100 == 2 || response.code() == 404 || response.code() == 412) {
+            logResponse(FINEST, response, request, attempt);
             breaker.success();
             throttler.success();
             return false;
         }
 
-        log.log(FINE, () -> "Status code " + response.code() + " (" + new String(response.body(), UTF_8) +
-                            ") on attempt " + attempt + " at " + request);
 
         if (response.code() == 429 || response.code() == 503) { // Throttling; reduce target inflight.
+            logResponse(FINE, response, request, attempt);
             throttler.throttled((inflight.get() - delayedCount.get()));
             return true;
         }
 
         breaker.failure();
-        if (response.code() == 500 || response.code() == 502 || response.code() == 504) // Hopefully temporary errors.
+        if (response.code() == 500 || response.code() == 502 || response.code() == 504) { // Hopefully temporary errors.
+            logResponse(INFO, response, request, attempt);
             return retry(request, attempt);
+        }
 
+        logResponse(WARNING, response, request, attempt);
         return false;
+    }
+
+    static void logResponse(Level level, HttpResponse response, HttpRequest request, int attempt) {
+        if (log.isLoggable(level))
+            log.log(level, "Status code " + response.code() +
+                           " (" + (response.body() == null ? "no body" : new String(response.body(), UTF_8)) +
+                           ") on attempt " + attempt + " at " + request);
     }
 
     private void acquireSlot() {

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/JsonFeeder.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/JsonFeeder.java
@@ -359,16 +359,14 @@ public class JsonFeeder implements Closeable {
         abstract String getDocumentJson(long start, long end);
 
         CompletableFuture<Result> next() throws IOException {
-            if (multipleOperations && !arrayPrefixParsed){
-                expect(START_ARRAY);
-                arrayPrefixParsed = true;
-            }
-
             JsonToken token = parser.nextToken();
+            if (multipleOperations && ! arrayPrefixParsed && token == START_ARRAY) {
+                arrayPrefixParsed = true;
+                token = parser.nextToken();
+            }
             if (token == END_ARRAY && multipleOperations) return null;
-            else if (token == null && !multipleOperations) return null;
-            else if (token == START_OBJECT);
-            else throw new OperationParseException("Unexpected token '" + parser.currentToken() + "' at offset " + parser.getTokenLocation().getByteOffset());
+            else if (token == null && ! arrayPrefixParsed) return null;
+            else if (token != START_OBJECT) throw new OperationParseException("Unexpected token '" + parser.currentToken() + "' at offset " + parser.getTokenLocation().getByteOffset());
             long start = 0, end = -1;
             OperationType type = null;
             DocumentId id = null;

--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/JsonFeederTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/JsonFeederTest.java
@@ -3,11 +3,13 @@ package ai.vespa.feed.client;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -73,6 +75,48 @@ class JsonFeederTest {
             assertEquals(docs + 1, resultsReceived.get());
             assertTrue(completedSuccessfully.get());
             assertNull(exceptionThrow.get());
+        }
+    }
+
+    @Test
+    public void multipleJsonArrayOperationsAreDispatchedToFeedClient() throws IOException, ExecutionException, InterruptedException {
+        SimpleClient client = new SimpleClient();
+        try (JsonFeeder feeder = JsonFeeder.builder(client).build()) {
+            String json = "[{" +
+                          "  \"put\": \"id:ns:type::abc1\",\n" +
+                          "  \"fields\": {\n" +
+                          "    \"lul\":\"lal\"\n" +
+                          "  }\n" +
+                          "},\n" +
+                          "{" +
+                          "  \"put\": \"id:ns:type::abc2\",\n" +
+                          "  \"fields\": {\n" +
+                          "    \"lul\":\"lal\"\n" +
+                          "  }\n" +
+                          "}]\n";
+            feeder.feedMany(new ByteArrayInputStream(json.getBytes(UTF_8))).get();
+            assertEquals(new HashSet<>(Arrays.asList("abc1", "abc2")), client.ids);
+        }
+    }
+
+    @Test
+    public void multipleJsonLOperationsAreDispatchedToFeedClient() throws IOException, ExecutionException, InterruptedException {
+        SimpleClient client = new SimpleClient();
+        try (JsonFeeder feeder = JsonFeeder.builder(client).build()) {
+            String json = "{" +
+                          "  \"put\": \"id:ns:type::abc1\",\n" +
+                          "  \"fields\": {\n" +
+                          "    \"lul\":\"lal\"\n" +
+                          "  }\n" +
+                          "}\n" +
+                          "{" +
+                          "  \"put\": \"id:ns:type::abc2\",\n" +
+                          "  \"fields\": {\n" +
+                          "    \"lul\":\"lal\"\n" +
+                          "  }\n" +
+                          "}\n";
+            feeder.feedMany(new ByteArrayInputStream(json.getBytes(UTF_8))).get();
+            assertEquals(new HashSet<>(Arrays.asList("abc1", "abc2")), client.ids);
         }
     }
 


### PR DESCRIPTION
@bjorncs please review and merge. This is hopefully enough. It's also possible to keep older errors per request, and return these when a request is cancelled, but that seems too messy, and these requests _were_ cancelled, in the end ... 