### PR TITLE
Use system default trust/key managers if no credentials provided

### DIFF
--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/SslContextBuilderTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/SslContextBuilderTest.java
@@ -59,6 +59,30 @@ class SslContextBuilderTest {
         assertEquals("TLS", sslContext.getProtocol());
     }
 
+    @Test
+    void successfully_constructs_sslcontext_when_no_builder_parameter_given() {
+        SSLContext sslContext = assertDoesNotThrow(() -> new SslContextBuilder().build());
+        assertEquals("TLS", sslContext.getProtocol());
+    }
+
+    @Test
+    void successfully_constructs_sslcontext_with_only_certificate_file() {
+        SSLContext sslContext = assertDoesNotThrow(() ->
+                new SslContextBuilder()
+                        .withCertificateAndKey(certificateFile, privateKeyFile)
+                        .build());
+        assertEquals("TLS", sslContext.getProtocol());
+    }
+
+    @Test
+    void successfully_constructs_sslcontext_with_only_ca_certificate_file() {
+        SSLContext sslContext = assertDoesNotThrow(() ->
+                new SslContextBuilder()
+                        .withCaCertificates(certificateFile)
+                        .build());
+        assertEquals("TLS", sslContext.getProtocol());
+    }
+
     private static void writePem(Path file, String type, byte[] asn1DerEncodedObject) throws IOException {
         try (BufferedWriter fileWriter = Files.newBufferedWriter(file);
              JcaPEMWriter pemWriter = new JcaPEMWriter(fileWriter)) {


### PR DESCRIPTION
Previously it initialized custom managers that trusted no-one if no CA certificates where provided.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
