### PR TITLE
we must now be prepared for multiple notifyOk calls

### DIFF
--- a/slobrok/src/vespa/slobrok/server/exchange_manager.cpp
+++ b/slobrok/src/vespa/slobrok/server/exchange_manager.cpp
@@ -108,9 +108,8 @@ ExchangeManager::lookupPartner(const std::string & name) const {
 void
 ExchangeManager::healthCheck()
 {
-    for (const auto & entry : _partners) {
-        RemoteSlobrok *partner = entry.second.get();
-        partner->healthCheck();
+    for (const auto & [ name, partner ] : _partners) {
+        partner->maybePushMine();
     }
     LOG(debug, "ExchangeManager::healthCheck for %ld partners", _partners.size());
 }

--- a/slobrok/src/vespa/slobrok/server/remote_slobrok.h
+++ b/slobrok/src/vespa/slobrok/server/remote_slobrok.h
@@ -66,7 +66,7 @@ public:
     void fail();
     bool isConnected() const { return (_remote != nullptr); }
     void tryConnect();
-    void healthCheck();
+    void maybePushMine();
     void invokeAsync(FRT_RPCRequest *req, double timeout, FRT_IRequestWait *rwaiter);
     const std::string & getName() const { return _rpcserver.getName(); }
     const std::string & getSpec() const { return _rpcserver.getSpec(); }


### PR DESCRIPTION
* ManagedRpcServer now schedules its own health checks,
  so we must handle repeated OK notifications.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
@havardpe FYI
