### PR TITLE
Avoid race condition regression introduced in #18179 [run-systemtest].

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
@@ -223,6 +223,12 @@ IdealStateOperation::shouldBlockThisOperation(uint32_t messageType,
             return true;
         }
     }
+    // Also block on pending bucket-specific RequestBucketInfo since this usually
+    // means there's a semi-completed merge being processed for the bucket, but
+    // there will not be a pending merge command for it at the time.
+    if (messageType == api::MessageType::REQUESTBUCKETINFO_ID) {
+        return true;
+    }
 
     return false;
 }

--- a/storageapi/src/vespa/storageapi/message/bucket.cpp
+++ b/storageapi/src/vespa/storageapi/message/bucket.cpp
@@ -493,6 +493,8 @@ RequestBucketInfoCommand::print(std::ostream& out, bool verbose,
     if (hasSystemState()) {
         out << "distributor " << _distributor << " in ";
         _state->print(out, verbose, indent + "  ");
+    } else if (super_bucket_id().isSet()) {
+        out << ", super bucket " << super_bucket_id() << ". ";
     }
     if (verbose && !_buckets.empty()) {
         out << "\n" << indent << "  Specified buckets:\n" << indent << "    ";
@@ -529,6 +531,8 @@ RequestBucketInfoReply::print(std::ostream& out, bool verbose,
     out << "RequestBucketInfoReply(" << _buckets.size();
     if (_full_bucket_fetch) {
         out << ", full fetch";
+    } else if (super_bucket_id().isSet()) {
+        out << ", super bucket " << super_bucket_id();
     }
     if (verbose) {
         out << "\n" << indent << "  ";


### PR DESCRIPTION
@geirst please review

We would previously check for the presence of pending null-bucket
`RequestBucketInfoCommand`s to determine if a pending cluster state
was present. We would also attempt to block all bucket delete operations
from starting if _any_ operation was pending towards that bucket on
a given node, including bucket info requests. The former was rewritten
to instead explicitly consider pending cluster state checks instead,
as checking null buckets no longer works when using stripes.

Unfortunately, due to a long-standing bug with message tracking of
`RequestBucketInfoCommand`s, these would _always_ be marked as pending
towards the null bucket. Since all ideal state ops would be blocked
by null-bucket info requests, this would avoid starting any ideal
state op as long as _any_ other op had an info request pending for
the target node. This had the desirable (but not explicitly coded for)
side effect of inhibiting bucket deletions from racing with half-finished
merge operations. It also had the undesirable effect of needlessly
blocking ops for completely unrelated buckets.

With these changes, we now explicitly handle bucket info requests for
single buckets in the `PendingMessageTracker`, allowing inhibition
of deletions to work as expected. Also add an explicit check for
pending info requests for all ideal state ops to mirror the old
behavior (but now per-bucket instead of globally...!).
