### PR TITLE
Don't swallow exception when unable to find file references in use

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -578,16 +578,18 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return fileDistributionStatus.status(getApplication(applicationId), timeout);
     }
 
-    public List<String> deleteUnusedFiledistributionReferences(File fileReferencesPath, Duration keepFileReferences) {
-        log.log(Level.FINE, () -> "Keep unused file references for " + keepFileReferences);
+    public List<String> deleteUnusedFiledistributionReferences(File fileReferencesPath,
+                                                               Duration keepFileReferencesDuration,
+                                                               int numberToAlwaysKeep) {
+        log.log(Level.FINE, () -> "Keep unused file references for " + keepFileReferencesDuration);
         if (!fileReferencesPath.isDirectory()) throw new RuntimeException(fileReferencesPath + " is not a directory");
 
         Set<String> fileReferencesInUse = getFileReferencesInUse();
         log.log(Level.FINE, () -> "File references in use : " + fileReferencesInUse);
 
-        List<String> candidates = sortedUnusedFileReferences(fileReferencesPath, fileReferencesInUse, keepFileReferences);
+        List<String> candidates = sortedUnusedFileReferences(fileReferencesPath, fileReferencesInUse, keepFileReferencesDuration);
         // Do not delete the newest ones
-        List<String> fileReferencesToDelete = candidates.subList(0, Math.max(0, candidates.size() - 5));
+        List<String> fileReferencesToDelete = candidates.subList(0, Math.max(0, candidates.size() - numberToAlwaysKeep));
         if (fileReferencesToDelete.size() > 0) {
             log.log(Level.FINE, () -> "Will delete file references not in use: " + fileReferencesToDelete);
             fileReferencesToDelete.forEach(fileReference -> {
@@ -601,18 +603,12 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     private Set<String> getFileReferencesInUse() {
         Set<String> fileReferencesInUse = new HashSet<>();
-        // Intentionally skip applications that we for some reason do not find
-        // or that we fail to get file references for (they will be retried on the next run)
         for (var applicationId : listApplications()) {
-            try {
-                Optional<Application> app = getOptionalApplication(applicationId);
-                if (app.isEmpty()) continue;
-                fileReferencesInUse.addAll(app.get().getModel().fileReferences().stream()
-                                              .map(FileReference::value)
-                                              .collect(Collectors.toSet()));
-            } catch (Exception e) {
-                log.log(Level.WARNING, "Getting file references in use for '" + applicationId + "' failed", e);
-            }
+            Optional<Application> app = getOptionalApplication(applicationId);
+            if (app.isEmpty()) continue;
+            fileReferencesInUse.addAll(app.get().getModel().fileReferences().stream()
+                                          .map(FileReference::value)
+                                          .collect(Collectors.toSet()));
         }
         return fileReferencesInUse;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -604,9 +604,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     private Set<String> getFileReferencesInUse() {
         Set<String> fileReferencesInUse = new HashSet<>();
         for (var applicationId : listApplications()) {
-            Optional<Application> app = getOptionalApplication(applicationId);
-            if (app.isEmpty()) continue;
-            fileReferencesInUse.addAll(app.get().getModel().fileReferences().stream()
+            Application app = getApplication(applicationId);
+            fileReferencesInUse.addAll(app.getModel().fileReferences().stream()
                                           .map(FileReference::value)
                                           .collect(Collectors.toSet()));
         }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -300,7 +300,9 @@ public class ApplicationRepositoryTest {
         PrepareParams prepareParams = new PrepareParams.Builder().applicationId(applicationId()).ignoreValidationErrors(true).build();
         deployApp(new File("src/test/apps/app"), prepareParams);
 
-        List<String> toBeDeleted = applicationRepository.deleteUnusedFiledistributionReferences(fileReferencesDir, keepFileReferences);
+        List<String> toBeDeleted = applicationRepository.deleteUnusedFiledistributionReferences(fileReferencesDir,
+                                                                                                keepFileReferences,
+                                                                                                5);
         Collections.sort(toBeDeleted);
         assertEquals(List.of("bar0", "foo"), toBeDeleted);
         // bar0 and foo are the only ones that will be deleted (keeps 5 newest no matter how old they are)


### PR DESCRIPTION
Also keep up to 10 unused file references at all times.
