### PR TITLE
Revert "Add support for mallinfo2 with glibc 2.33"

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -767,15 +767,15 @@ Proton::updateMetrics(const metrics::MetricLockGuard &)
         metrics.resourceUsage.openFileDescriptors.set(FastOS_File::count_open_files());
         metrics.resourceUsage.feedingBlocked.set((usageFilter.acceptWriteOperation() ? 0.0 : 1.0));
 #ifdef __linux__
+#pragma GCC diagnostic push
 #if __GLIBC_PREREQ(2, 33)
-        struct mallinfo2 mallocInfo = mallinfo2();
-        metrics.resourceUsage.mallocArena.set(mallocInfo.arena);
-#else
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         struct mallinfo mallocInfo = mallinfo();
+#pragma GCC diagnostic pop
         // Vespamalloc reports arena in 1M blocks as an 'int' is too small.
         // If we use something else than vespamalloc this must be changed.
         metrics.resourceUsage.mallocArena.set(uint64_t(mallocInfo.arena) * 1_Mi);
-#endif
 #else
         metrics.resourceUsage.mallocArena.set(UINT64_C(0));
 #endif

--- a/vespamalloc/src/tests/stacktrace/stacktrace.cpp
+++ b/vespamalloc/src/tests/stacktrace/stacktrace.cpp
@@ -17,22 +17,12 @@ void * run(void * arg)
 }
 
 void verify_that_vespamalloc_datasegment_size_exists() {
-#if __GLIBC_PREREQ(2, 33)
-    struct mallinfo2 info = mallinfo2();
-    printf("Malloc used %zdm of memory\n", info.arena);
-    assert(info.arena >= 10 * 0x100000ul);
-    assert(info.arena < 10000 * 0x100000ul);
-    assert(info.fordblks == 0);
-    assert(info.fsmblks == 0);
-    assert(info.hblkhd == 0);
-    assert(info.hblks == 0);
-    assert(info.keepcost == 0);
-    assert(info.ordblks == 0);
-    assert(info.smblks == 0);
-    assert(info.uordblks == 0);
-    assert(info.usmblks == 0);
-#else
+#pragma GCC diagnostic push
+#if __GNUC_PREREQ(2, 33)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     struct mallinfo info = mallinfo();
+#pragma GCC diagnostic push
     printf("Malloc used %dm of memory\n",info.arena);
     assert(info.arena >= 10);
     assert(info.arena < 10000);
@@ -45,7 +35,6 @@ void verify_that_vespamalloc_datasegment_size_exists() {
     assert(info.smblks == 0);
     assert(info.uordblks == 0);
     assert(info.usmblks == 0);
-#endif
 }
 
 int main(int argc, char *argv[])

--- a/vespamalloc/src/tests/test1/new_test.cpp
+++ b/vespamalloc/src/tests/test1/new_test.cpp
@@ -95,19 +95,17 @@ TEST("verify new with alignment = 64 with single element") {
     LOG(info, "&s=%p", s.get());
 }
 
-#if __GLIBC_PREREQ(2, 26)
-TEST("verify realloarray") {
-    void *arr = calloc(5,5);
-    void *arr2 = reallocarray(arr, 800, 5);
-    EXPECT_NOT_EQUAL(arr, arr2);
-    EXPECT_NOT_EQUAL(nullptr, arr2);
-    EXPECT_NOT_EQUAL(ENOMEM, errno);
-
-    void *arr3 = reallocarray(arr2, 1u << 33, 1u << 33);
-    EXPECT_EQUAL(nullptr, arr3);
-    EXPECT_EQUAL(ENOMEM, errno);
+TEST("verify new with alignment = 64 with single element") {
+    struct alignas(64) S {
+        long a;
+    };
+    static_assert(sizeof(S) == 64);
+    static_assert(alignof(S) == 64);
+    auto s = std::make_unique<S>();
+    verify_aligned(s.get());
+    cmp(s.get(), &s->a);
+    LOG(info, "&s=%p", s.get());
 }
-#endif
 
 void verify_vespamalloc_usable_size() {
     struct AllocInfo { size_t requested; size_t usable;};


### PR DESCRIPTION
Reverts vespa-engine/vespa#18451

Building on rhel8 fails with:
 13:58:01 [ 15%] Building CXX object vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_app_object.dir/new_test.cpp.o
13:58:01 cd /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1 && /usr/bin/ccache /opt/rh/gcc-toolset-10/root/usr/bin/c++  -DPARANOID_LEVEL=0 -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/configdefinitions/src -isystem /opt/vespa-deps/include -isystem /usr/include/openblas -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/fastos/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespalib/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespalog/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/defaults/src  -g -O3 -fno-omit-frame-pointer -Winline -Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fPIC  -DXXH_INLINE_ALL -DBOOST_DISABLE_ASSERTS -march=sandybridge -mtune=skylake  -Wnoexcept -Wsuggest-override -Wnon-virtual-dtor -Wformat-security -std=c++2a -fdiagnostics-color=auto  -fvisibility-inlines-hidden    -fvisibility=hidden -o CMakeFiles/vespamalloc_new_test_app_object.dir/new_test.cpp.o -c /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp
13:58:01 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp: In member function ‘virtual void {anonymous}::TestKitHook99::Test::test_entry_point()’:
13:58:01 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:106:40: error: left shift count >= width of type [-Werror=shift-count-overflow]
13:58:01   106 |     void *arr3 = reallocarray(arr2, 1u << 33, 1u << 33);
13:58:01       |                                     ~~~^~~~~
13:58:01 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:106:50: error: left shift count >= width of type [-Werror=shift-count-overflow]
13:58:01   106 |     void *arr3 = reallocarray(arr2, 1u << 33, 1u << 33);
13:58:01       |                                               ~~~^~~~~
13:58:01 cc1plus: all warnings being treated as errors
13:58:01 make[3]: *** [vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_app_object.dir/build.make:63: vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_app_object.dir/new_test.cpp.o] Error 1 