### PR TITLE
Revert "Add support for mallinfo2 with glibc 2.33"

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -767,15 +767,15 @@ Proton::updateMetrics(const metrics::MetricLockGuard &)
         metrics.resourceUsage.openFileDescriptors.set(FastOS_File::count_open_files());
         metrics.resourceUsage.feedingBlocked.set((usageFilter.acceptWriteOperation() ? 0.0 : 1.0));
 #ifdef __linux__
+#pragma GCC diagnostic push
 #if __GLIBC_PREREQ(2, 33)
-        struct mallinfo2 mallocInfo = mallinfo2();
-        metrics.resourceUsage.mallocArena.set(mallocInfo.arena);
-#else
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
         struct mallinfo mallocInfo = mallinfo();
+#pragma GCC diagnostic pop
         // Vespamalloc reports arena in 1M blocks as an 'int' is too small.
         // If we use something else than vespamalloc this must be changed.
         metrics.resourceUsage.mallocArena.set(uint64_t(mallocInfo.arena) * 1_Mi);
-#endif
 #else
         metrics.resourceUsage.mallocArena.set(UINT64_C(0));
 #endif

--- a/vespamalloc/src/tests/stacktrace/stacktrace.cpp
+++ b/vespamalloc/src/tests/stacktrace/stacktrace.cpp
@@ -17,22 +17,12 @@ void * run(void * arg)
 }
 
 void verify_that_vespamalloc_datasegment_size_exists() {
-#if __GLIBC_PREREQ(2, 33)
-    struct mallinfo2 info = mallinfo2();
-    printf("Malloc used %zdm of memory\n", info.arena);
-    assert(info.arena >= 10 * 0x100000ul);
-    assert(info.arena < 10000 * 0x100000ul);
-    assert(info.fordblks == 0);
-    assert(info.fsmblks == 0);
-    assert(info.hblkhd == 0);
-    assert(info.hblks == 0);
-    assert(info.keepcost == 0);
-    assert(info.ordblks == 0);
-    assert(info.smblks == 0);
-    assert(info.uordblks == 0);
-    assert(info.usmblks == 0);
-#else
+#pragma GCC diagnostic push
+#if __GNUC_PREREQ(2, 33)
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     struct mallinfo info = mallinfo();
+#pragma GCC diagnostic push
     printf("Malloc used %dm of memory\n",info.arena);
     assert(info.arena >= 10);
     assert(info.arena < 10000);
@@ -45,7 +35,6 @@ void verify_that_vespamalloc_datasegment_size_exists() {
     assert(info.smblks == 0);
     assert(info.uordblks == 0);
     assert(info.usmblks == 0);
-#endif
 }
 
 int main(int argc, char *argv[])

--- a/vespamalloc/src/tests/test1/new_test.cpp
+++ b/vespamalloc/src/tests/test1/new_test.cpp
@@ -95,23 +95,17 @@ TEST("verify new with alignment = 64 with single element") {
     LOG(info, "&s=%p", s.get());
 }
 
-#if __GLIBC_PREREQ(2, 26)
-TEST("verify realloarray") {
-    void *arr = calloc(5,5);
-    errno = 0;
-    void *arr2 = reallocarray(arr, 800, 5);
-    int myErrno = errno;
-    EXPECT_NOT_EQUAL(arr, arr2);
-    EXPECT_NOT_EQUAL(nullptr, arr2);
-    EXPECT_NOT_EQUAL(ENOMEM, myErrno);
-
-    errno = 0;
-    void *arr3 = reallocarray(arr2, 1ul << 33, 1ul << 33);
-    myErrno = errno;
-    EXPECT_EQUAL(nullptr, arr3);
-    EXPECT_EQUAL(ENOMEM, myErrno);
+TEST("verify new with alignment = 64 with single element") {
+    struct alignas(64) S {
+        long a;
+    };
+    static_assert(sizeof(S) == 64);
+    static_assert(alignof(S) == 64);
+    auto s = std::make_unique<S>();
+    verify_aligned(s.get());
+    cmp(s.get(), &s->a);
+    LOG(info, "&s=%p", s.get());
 }
-#endif
 
 void verify_vespamalloc_usable_size() {
     struct AllocInfo { size_t requested; size_t usable;};


### PR DESCRIPTION
Reverts vespa-engine/vespa#18468

Testing on rhel8 fails with:
 16:17:36 The following tests FAILED:
16:17:36 	802 - vespamalloc_new_test_app (Failed) 