### PR TITLE
Revert "Use SQL to gc"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/QuestMetricsDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/QuestMetricsDb.java
@@ -357,8 +357,29 @@ public class QuestMetricsDb extends AbstractComponent implements MetricsDb {
         }
 
         void gc() {
+            // We remove full days at once and we want to see at least three days to not every only see weekend data
+            Instant oldestToKeep = clock.instant().minus(Duration.ofDays(4));
+            SqlExecutionContext context = newContext();
+            int partitions = 0;
             try {
-                issue("alter table " + name + " drop partition where at < dateadd('d', -4, now());", newContext());
+                List<String> removeList = new ArrayList<>();
+                for (String dirEntry : dir.list()) {
+                    File partitionDir = new File(dir, dirEntry);
+                    if ( ! partitionDir.isDirectory()) continue;
+
+                    partitions++;
+                    DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.of("UTC"));
+                    Instant partitionDay = Instant.from(formatter.parse(dirEntry.substring(0, 10) + "T00:00:00"));
+                    if (partitionDay.isBefore(oldestToKeep))
+                        removeList.add(dirEntry);
+
+                }
+                // Remove unless all partitions are old: Removing all partitions "will be supported in the future"
+                if ( removeList.size() < partitions && ! removeList.isEmpty()) {
+                    issue("alter table " + name + " drop partition list " +
+                          removeList.stream().map(dir -> "'" + dir + "'").collect(Collectors.joining(",")),
+                          context);
+                }
             }
             catch (SqlException e) {
                 log.log(Level.WARNING, "Failed to gc old metrics data in " + dir + " table " + name, e);

--- a/testutil/src/main/java/com/yahoo/test/ManualClock.java
+++ b/testutil/src/main/java/com/yahoo/test/ManualClock.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ManualClock extends Clock {
 
-    private final AtomicReference<Instant> currentTime = new AtomicReference<>(Instant.now());
+    private AtomicReference<Instant> currentTime = new AtomicReference<>(Instant.now());
 
     @Inject
     public ManualClock() {}
@@ -33,11 +33,6 @@ public class ManualClock extends Clock {
 
     public void advance(TemporalAmount temporal) {
         currentTime.updateAndGet(time -> time.plus(temporal));
-    }
-
-    /** Move time backwards by the given amount */
-    public void retreat(TemporalAmount temporal) {
-        currentTime.updateAndGet(time -> time.minus(temporal));
     }
 
     public void setInstant(Instant time) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#18466

Looks like `now()` isn't supported:
[2021-06-29 18:40:11.383] WARNING : configserver     Container.com.yahoo.vespa.hosted.provision.autoscale.QuestMetricsDb
	Failed to gc old metrics data in /opt/vespa/var/db/vespa/autoscaling/clusterMetrics table clusterMetrics
	exception=
	io.questdb.griffin.SqlException: [70] unknown function name: now()
	at io.questdb.griffin.SqlException.position(SqlException.java:60)
	at io.questdb.griffin.FunctionParser.invalidFunction(FunctionParser.java:295)
	at io.questdb.griffin.FunctionParser.createFunction(FunctionParser.java:465)
	at io.questdb.griffin.FunctionParser.visit(FunctionParser.java:277)
	at io.questdb.griffin.PostOrderTreeTraversalAlgo.traverse(PostOrderTreeTraversalAlgo.java:82)
	at io.questdb.griffin.FunctionParser.parseFunction(FunctionParser.java:230)
	at io.questdb.griffin.SqlCompiler.alterTableDropOrAttachPartition(SqlCompiler.java:1094)
	at io.questdb.griffin.SqlCompiler.alterTable(SqlCompiler.java:769)