### PR TITLE
Throw instead of returning null for getBytes()/getData()

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -154,10 +154,8 @@ public class SessionZooKeeperClient {
     }
 
     public Optional<ApplicationId> readApplicationId() {
-        String idString = configCurator.getData(applicationIdPath());
-        return (idString == null)
-                ? Optional.empty()
-                : Optional.of(ApplicationId.fromSerializedForm(idString));
+        if ( ! configCurator.exists(applicationIdPath())) return Optional.empty();
+        return Optional.of(ApplicationId.fromSerializedForm(configCurator.getData(applicationIdPath())));
     }
 
     void writeApplicationPackageReference(Optional<FileReference> applicationPackageReference) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ConfigCurator.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ConfigCurator.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.zookeeper;
 
 import com.google.inject.Inject;
@@ -93,12 +93,12 @@ public class ConfigCurator {
         }
     }
 
-    /** Returns the data at a path and node. Replaces / by # in node names. Returns null if the path doesn't exist. */
+    /** Returns the data at a path and node. Replaces / by # in node names. */
     public String getData(String path, String node) {
         return getData(createFullPath(path, node));
     }
 
-    /** Returns the data at a path. Returns null if the path doesn't exist. */
+    /** Returns the data at a path */
     public String getData(String path) {
         byte[] data = getBytes(path);
         return (data == null) ? null : Utf8.toString(data);
@@ -111,8 +111,9 @@ public class ConfigCurator {
      * @return a byte array with data.
      */
     public byte[] getBytes(String path) {
+        if ( ! exists(path)) throw new IllegalArgumentException("Cannot read data from path " + path + ", it does not exist");
+
         try {
-            if ( ! exists(path)) return null; // TODO: Ugh
             return curator.framework().getData().forPath(path);
         }
         catch (Exception e) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplication.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplication.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.zookeeper;
 
 import com.yahoo.io.reader.NamedReader;
@@ -9,7 +9,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Responsible for providing data from an application subtree in zookeeper.
@@ -75,18 +74,12 @@ public class ZKApplication {
      * @return a Reader that can be used to get the data
      */
     Reader getDataReader(String path, String node) {
-        String data = getData(path, node);
-        if (data == null) {
-            throw new IllegalArgumentException("No node for " + getFullPath(path) + "/" + node + " exists");
-        }
-        return reader(data);
-    }
-
-    Optional<Reader> getOptionalDataReader(String path, String node) {
-        return Optional.ofNullable(getData(path, node)).map(data -> reader(data));
+        return reader(getData(path, node));
     }
 
     public String getData(String path, String node) {
+        if ( ! exists(path, node)) throw new IllegalArgumentException("No node for " + getFullPath(path) + "/" + node + " exists");
+
         try {
             return zk.getData(getFullPath(path), node);
         } catch (Exception e) {
@@ -96,6 +89,8 @@ public class ZKApplication {
     }
 
     public String getData(String path) {
+        if ( ! exists(path)) throw new IllegalArgumentException("No node for " + getFullPath(path) + " exists");
+
         try {
             return zk.getData(getFullPath(path));
         } catch (RuntimeException e) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationFile.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationFile.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.zookeeper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,21 +61,17 @@ class ZKApplicationFile extends ApplicationFile {
     @Override
     public Reader createReader() throws FileNotFoundException {
         String zkPath = getZKPath(path);
-        String data = zkApp.getData(zkPath);
-        if (data == null) {
-            throw new FileNotFoundException("No such path: " + path);
-        }
-        return new StringReader(data);
+        if ( ! zkApp.exists(zkPath)) throw new FileNotFoundException("No such path: " + path);
+
+        return new StringReader(zkApp.getData(zkPath));
     }
 
     @Override
     public InputStream createInputStream() throws FileNotFoundException {
         String zkPath = getZKPath(path);
-        byte[] data = zkApp.getBytes(zkPath);
-        if (data == null) {
-            throw new FileNotFoundException("No such path: " + path);
-        }
-        return new ByteArrayInputStream(data);
+        if ( ! zkApp.exists(zkPath)) throw new FileNotFoundException("No such path: " + path);
+
+        return new ByteArrayInputStream(zkApp.getBytes(zkPath));
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationPackage.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/zookeeper/ZKApplicationPackage.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -257,9 +256,12 @@ public class ZKApplicationPackage implements ApplicationPackage {
 
     @Override
     public File getFileReference(Path pathRelativeToAppDir) {
-        String fileName = zkApplication.getData(ConfigCurator.USERAPP_ZK_SUBPATH + "/" + pathRelativeToAppDir.getRelative());
+        String path = ConfigCurator.USERAPP_ZK_SUBPATH + "/" + pathRelativeToAppDir.getRelative();
+
         // File does not exist: Manufacture a non-existing file
-        return new File(Objects.requireNonNullElseGet(fileName, pathRelativeToAppDir::getRelative));
+        if ( ! zkApplication.exists(path)) return new File(pathRelativeToAppDir.getRelative());
+
+        return new File(zkApplication.getData(path));
     }
 
     @Override


### PR DESCRIPTION
Update callers to handle exception or check path existence before
calling methods.
