### PR TITLE
Print which tenant and session ID failed to load

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -94,8 +94,8 @@ public class SessionZooKeeperClient {
             String data = configCurator.getData(sessionStatusPath.getAbsolute());
             return Session.Status.parse(data);
         } catch (Exception e) {
-            log.log(Level.INFO, "Unable to read session status, assuming it was deleted: " +
-                                sessionStatusPath.getAbsolute());
+            log.log(Level.INFO, "Failed to read session status at " + sessionStatusPath.getAbsolute() +
+                    ", will assume session has been removed: " + e.getMessage());
             return Session.Status.NONE;
         }
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -94,7 +94,8 @@ public class SessionZooKeeperClient {
             String data = configCurator.getData(sessionStatusPath.getAbsolute());
             return Session.Status.parse(data);
         } catch (Exception e) {
-            log.log(Level.INFO, "Unable to read session status, assuming it was deleted");
+            log.log(Level.INFO, "Unable to read session status, assuming it was deleted: " +
+                                sessionStatusPath.getAbsolute());
             return Session.Status.NONE;
         }
     }


### PR DESCRIPTION
Getting a lot of 

```
[2021-07-01 15:25:02.904] configserver     Unable to read session status, assuming it was deleted
```

which doesn't say much.