### PR TITLE
Revert "Stop creating the classpath mappings file."

### DIFF
--- a/bundle-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/bundle-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -16,7 +16,8 @@
           <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
           <compile>org.apache.maven.plugins:maven-compiler-plugin:compile</compile>
           <process-test-resources>
-              org.apache.maven.plugins:maven-resources-plugin:testResources
+              org.apache.maven.plugins:maven-resources-plugin:testResources,
+              com.yahoo.vespa:bundle-plugin:generate-bundle-classpath-mappings
           </process-test-resources>
           <test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile</test-compile>
           <test>org.apache.maven.plugins:maven-surefire-plugin:test</test>


### PR DESCRIPTION
Reverts vespa-engine/vespa#18544

SecretStore integration tests started failing with:
[12:46:55.254] mvn -P  clean package --batch-mode --quiet -DskipTests -Dmaven.repo.local=/tmp/vespa/17/.m2/repository
[12:47:46.427] [ERROR] Failed to execute goal com.yahoo.vespa:vespa-maven-plugin:7.430.2:generateTestDescriptor (generate-test-descriptor) on project secret-store-test-app: Failed to analyze test classes: /tmp/vespa/17/workdir/target/test-classes -> [Help 1]