### PR TITLE
Split twice

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1679,7 +1679,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
         DeploymentId deploymentId = new DeploymentId(ApplicationId.from(tenantName, applicationName, instanceName), requireZone(environment, region));
 
         if (restPath.contains("/status/")) {
-            String[] parts = restPath.split("/status/");
+            String[] parts = restPath.split("/status/", 2);
             String result = controller.serviceRegistry().configServer().getServiceStatusPage(deploymentId, serviceName, parts[0], parts[1]);
             return new HtmlResponse(result);
         }


### PR DESCRIPTION
Since `/status/` at the end points to the root of the status page, it'll often be at the end of the path String. Empty string at the end are omitted, so specify explicitly that we want two matches:
```
String s = "/a/b/c/"
jshell> s.split("/a/") ==> String[2] { "", "b/c/" }
jshell> s.split("/c/") ==> String[1] { "/a/b" }
jshell> s.split("/a/", 2) ==> String[2] { "", "b/c/" }
jshell> s.split("/c/", 2) ==> String[2] { "/a/b", "" }
```