### PR TITLE
Avoid taking lock which is not a dependency in this job

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Step.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Step.java
@@ -1,10 +1,12 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
@@ -72,24 +74,24 @@ public enum Step {
 
     private final boolean alwaysRun;
     private final List<Step> prerequisites;
-    private final List<Step> allPrerequisites;
 
     Step(boolean alwaysRun, Step... prerequisites) {
         this.alwaysRun = alwaysRun;
         this.prerequisites = List.of(prerequisites);
-        this.allPrerequisites = Stream.concat(Stream.of(prerequisites),
-                                              Stream.of(prerequisites).flatMap(pre -> pre.allPrerequisites().stream()))
-                                      .sorted()
-                                      .distinct()
-                                      .collect(toUnmodifiableList());
     }
 
     /** Returns whether this is a cleanup-step, and should always run, regardless of job outcome, when specified in a job. */
     public boolean alwaysRun() { return alwaysRun; }
 
-    /** Returns all prerequisite steps for this, recursively. */
-    public List<Step> allPrerequisites() {
-        return allPrerequisites;
+    /** Returns all prerequisite steps for this, including transient ones, in a job profile containing the given steps. */
+    public List<Step> allPrerequisites(Collection<Step> among) {
+        return prerequisites.stream()
+                            .filter(among::contains)
+                            .flatMap(pre -> Stream.concat(Stream.of(pre),
+                                                          pre.allPrerequisites(among).stream()))
+                            .sorted()
+                            .distinct()
+                            .collect(toList());
     }
 
 


### PR DESCRIPTION
@freva please review and merge.

Deploying real and tester didn't happen in parallel, because real deployment must happen after initial install, after staging setup, after install test, after deploy tester. This makes sense in staging tests, but not in the other jobs, where all the intermediaries are absent. This fixes that, by considering only the steps present in the relevant job. 