### PR TITLE
Read session status may fail

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -91,8 +91,8 @@ public class SessionZooKeeperClient {
 
     public Session.Status readStatus() {
         try {
-            String data = configCurator.getData(sessionStatusPath.getAbsolute());
-            return Session.Status.parse(data);
+            Optional<byte[]> data = curator.getData(sessionStatusPath);
+            return data.map(d -> Session.Status.parse(Utf8.toString(d))).orElse(Session.Status.NONE);
         } catch (Exception e) {
             log.log(Level.INFO, "Failed to read session status at " + sessionStatusPath.getAbsolute() +
                     ", will assume session has been removed: ", e);


### PR DESCRIPTION
When deleting expired sessions we delete many sessions at once,
watchers react to sessions being removed, but since this takes
some time handling a session being deleted may happen while other
sessions are deleted.

So make sure to handle the case where a session disappears while trying
to read its status.
