### PR TITLE
Revert "Don't deploy or install container-jersey2 [run-systemtest]"

### DIFF
--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -170,6 +170,7 @@
                 configgen.jar,
                 config-bundle-jar-with-dependencies.jar,
                 configdefinitions-jar-with-dependencies.jar,
+                container-jersey2-jar-with-dependencies.jar,
                 container-search-and-docproc-jar-with-dependencies.jar,
                 container-search-gui-jar-with-dependencies.jar,
                 docprocs-jar-with-dependencies.jar,

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -794,6 +794,7 @@ fi
 %{_prefix}/lib/jars/config-provisioning-jar-with-dependencies.jar
 %{_prefix}/lib/jars/container-apache-http-client-bundle-jar-with-dependencies.jar
 %{_prefix}/lib/jars/container-disc-jar-with-dependencies.jar
+%{_prefix}/lib/jars/container-jersey2-jar-with-dependencies.jar
 %{_prefix}/lib/jars/container-search-and-docproc-jar-with-dependencies.jar
 %{_prefix}/lib/jars/container-search-gui-jar-with-dependencies.jar
 %{_prefix}/lib/jars/defaults-jar-with-dependencies.jar


### PR DESCRIPTION
Reverts vespa-engine/vespa#18570

Seems like a jar is installed but not packaged:
 19:18:33 error: Installed (but unpackaged) file(s) found:
19:18:33    /opt/vespa/lib/jars/container-jersey2-jar-with-dependencies.jar 