### PR TITLE
Reduce scheduled OS upgrade cooldown

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -111,7 +111,7 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
 
         /** The cool-down period that must pass before a stable version can be used */
         private Duration cooldown() {
-            return system.isCd() ? Duration.ZERO : Duration.ofDays(14);
+            return system.isCd() ? Duration.ZERO : Duration.ofDays(7);
         }
 
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
@@ -116,7 +116,7 @@ public class OsUpgradeSchedulerTest {
                      tester.controller().osVersionTarget(cloud).get().osVersion().version());
 
         // Enough time passes since promotion of stable release
-        tester.clock().advance(Duration.ofDays(14).plus(Duration.ofSeconds(1)));
+        tester.clock().advance(Duration.ofDays(7).plus(Duration.ofSeconds(1)));
         scheduler.maintain();
         OsVersionTarget target0 = tester.controller().osVersionTarget(cloud).get();
         assertEquals(version1, target0.osVersion().version());
@@ -139,7 +139,7 @@ public class OsUpgradeSchedulerTest {
 
         // Enough time passes for stable version to be promoted. Nothing happens as stable is now before the manually
         // triggered version
-        tester.clock().advance(Duration.ofDays(14).plus(Duration.ofSeconds(1)));
+        tester.clock().advance(Duration.ofDays(7).plus(Duration.ofSeconds(1)));
         scheduler.maintain();
         assertEquals(version3, tester.controller().osVersionTarget(cloud).get().osVersion().version());
     }


### PR DESCRIPTION
The time it takes before a version is promoted to stable is already plenty
conservative.

@freva