### PR TITLE
Use local sessions from file system when deleting expired sessions

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -107,7 +107,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.LOGSERVER_CONTAINER;
 import static com.yahoo.vespa.config.server.filedistribution.FileDistributionUtil.fileReferenceExistsOnDisk;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -465,12 +465,13 @@ public class ApplicationRepositoryTest {
         // Create a local session without any data in zookeeper (corner case seen in production occasionally)
         // and check that expiring local sessions still work
         int sessionId = 6;
-        Files.createDirectory(new TenantFileSystemDirs(serverdb, tenant1).getUserApplicationDir(sessionId).toPath());
+        TenantName tenantName = tester.tenant().getName();
+        Files.createDirectory(new TenantFileSystemDirs(serverdb, tenantName).getUserApplicationDir(sessionId).toPath());
         LocalSession localSession2 = new LocalSession(tenant1,
                                                       sessionId,
                                                       FilesApplicationPackage.fromFile(testApp),
                                                       new SessionZooKeeperClient(curator,
-                                                                                 tenant1,
+                                                                                 tenantName,
                                                                                  sessionId,
                                                                                  ConfigUtils.getCanonicalHostName()));
         sessionRepository.addLocalSession(localSession2);


### PR DESCRIPTION
Earlier we loaded all local sessions at startup time and added to
a cache, that was used when deleting expired sessions.

We don't load local sessions at startup that anymore, but sessions are
still added to cache as they are created. Local sessions that were
leftover for some other reason (crash, failure in logic, whatnot) should
still be deleted, which is fixed with this.
