### PR TITLE
Remove last / from url when switching server when doing upload

### DIFF
--- a/config-model/src/main/perl/vespa-deploy
+++ b/config-model/src/main/perl/vespa-deploy
@@ -411,6 +411,7 @@ sub http_upload {
         debug("exitcode=$exitcode\n");
         debug("output=$output\n");
         $configsource_url = shift(@configsources);
+        $configsource_url =~ s/\/$//; # Remove last / from configsource_url
         if ($configsource_url) {
           $configsource_url_used = $configsource_url;
           $retry = 1;


### PR DESCRIPTION
Avoid empty segment in path, not conformant.

Hackish way to do it, but this is done only when uploading and this code is a can of worms...
