### PR TITLE
Generalize how address space usage is reported from attribute vectors.

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
@@ -1,10 +1,13 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/log/log.h>
-LOG_SETUP("attribute_usage_filter_test");
-#include <vespa/vespalib/testkit/testapp.h>
-#include <vespa/vespalib/util/size_literals.h>
+
 #include <vespa/searchcore/proton/attribute/attribute_usage_filter.h>
 #include <vespa/searchcore/proton/attribute/i_attribute_usage_listener.h>
+#include <vespa/searchlib/attribute/address_space_components.h>
+#include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/size_literals.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("attribute_usage_filter_test");
 
 using proton::AttributeUsageFilter;
 using proton::AttributeUsageStats;
@@ -24,15 +27,15 @@ class MyAttributeStats : public AttributeUsageStats
 {
 public:
     void triggerEnumStoreLimit() {
-        merge({        enumStoreOverLoad,
-                       search::AddressSpaceUsage::defaultMultiValueUsage() },
+        merge({ enumStoreOverLoad,
+                search::AddressSpaceComponents::default_multi_value_usage() },
               "enumeratedName",
               "ready");
     }
 
     void triggerMultiValueLimit() {
-        merge({         search::AddressSpaceUsage::defaultEnumStoreUsage(),
-                       multiValueOverLoad },
+        merge({ search::AddressSpaceComponents::default_enum_store_usage(),
+                multiValueOverLoad },
               "multiValueName",
               "ready");
     }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.cpp
@@ -1,13 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "attribute_usage_stats.h"
+#include <vespa/searchlib/attribute/address_space_components.h>
 #include <iostream>
 
 namespace proton {
 
 AttributeUsageStats::AttributeUsageStats()
-    : _enumStoreUsage(search::AddressSpaceUsage::defaultEnumStoreUsage()),
-      _multiValueUsage(search::AddressSpaceUsage::defaultMultiValueUsage())
+    : _enumStoreUsage(search::AddressSpaceComponents::default_enum_store_usage()),
+      _multiValueUsage(search::AddressSpaceComponents::default_multi_value_usage())
 {
 }
 
@@ -16,8 +17,8 @@ AttributeUsageStats::merge(const search::AddressSpaceUsage &usage,
                            const vespalib::string &attributeName,
                            const vespalib::string &subDbName)
 {
-    _enumStoreUsage.merge(usage.enumStoreUsage(), attributeName, subDbName);
-    _multiValueUsage.merge(usage.multiValueUsage(), attributeName, subDbName);
+    _enumStoreUsage.merge(usage.enum_store_usage(), attributeName, subDbName);
+    _multiValueUsage.merge(usage.multi_value_usage(), attributeName, subDbName);
 }
 
 std::ostream&

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_vector_explorer.cpp
@@ -63,8 +63,8 @@ convertAddressSpaceToSlime(const AddressSpace &addressSpace, Cursor &object)
 void
 convertAddressSpaceUsageToSlime(const AddressSpaceUsage &usage, Cursor &object)
 {
-    convertAddressSpaceToSlime(usage.enumStoreUsage(), object.setObject("enumStore"));
-    convertAddressSpaceToSlime(usage.multiValueUsage(), object.setObject("multiValue"));
+    convertAddressSpaceToSlime(usage.enum_store_usage(), object.setObject("enumStore"));
+    convertAddressSpaceToSlime(usage.multi_value_usage(), object.setObject("multiValue"));
 }
 
 void

--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -6,22 +6,23 @@
 #include <vespa/document/update/assignvalueupdate.h>
 #include <vespa/document/update/mapvalueupdate.h>
 #include <vespa/fastlib/io/bufferedfile.h>
+#include <vespa/searchlib/attribute/address_space_components.h>
 #include <vespa/searchlib/attribute/attribute.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/attributeguard.h>
 #include <vespa/searchlib/attribute/attributememorysavetarget.h>
 #include <vespa/searchlib/attribute/attributevector.hpp>
 #include <vespa/searchlib/attribute/attrvector.h>
+#include <vespa/searchlib/attribute/multienumattribute.hpp>
 #include <vespa/searchlib/attribute/multinumericattribute.h>
 #include <vespa/searchlib/attribute/multistringattribute.h>
+#include <vespa/searchlib/attribute/multivalueattribute.hpp>
 #include <vespa/searchlib/attribute/predicate_attribute.h>
 #include <vespa/searchlib/attribute/singlenumericpostattribute.h>
 #include <vespa/searchlib/attribute/singlestringattribute.h>
-#include <vespa/searchlib/attribute/multivalueattribute.hpp>
-#include <vespa/searchlib/attribute/multienumattribute.hpp>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/util/randomgenerator.h>
 #include <vespa/searchlib/test/weighted_type_test_utils.h>
+#include <vespa/searchlib/util/randomgenerator.h>
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <cmath>
@@ -2105,30 +2106,30 @@ AttributeTest::requireThatAddressSpaceUsageIsReported(const Config &config, bool
     AddressSpaceUsage after = attrPtr->getAddressSpaceUsage();
     if (attrPtr->hasEnum()) {
         LOG(info, "requireThatAddressSpaceUsageIsReported(%s): Has enum", attrName.c_str());
-        EXPECT_EQUAL(before.enumStoreUsage().used(), 1u);
-        EXPECT_EQUAL(before.enumStoreUsage().dead(), 1u);
-        EXPECT_GREATER(after.enumStoreUsage().used(), before.enumStoreUsage().used());
-        EXPECT_GREATER_EQUAL(after.enumStoreUsage().limit(), before.enumStoreUsage().limit());
-        EXPECT_GREATER(after.enumStoreUsage().limit(), 4200000000u);
+        EXPECT_EQUAL(before.enum_store_usage().used(), 1u);
+        EXPECT_EQUAL(before.enum_store_usage().dead(), 1u);
+        EXPECT_GREATER(after.enum_store_usage().used(), before.enum_store_usage().used());
+        EXPECT_GREATER_EQUAL(after.enum_store_usage().limit(), before.enum_store_usage().limit());
+        EXPECT_GREATER(after.enum_store_usage().limit(), 4200000000u);
     } else {
         LOG(info, "requireThatAddressSpaceUsageIsReported(%s): NOT enum", attrName.c_str());
-        EXPECT_EQUAL(before.enumStoreUsage().used(), 0u);
-        EXPECT_EQUAL(before.enumStoreUsage().dead(), 0u);
-        EXPECT_EQUAL(after.enumStoreUsage(), before.enumStoreUsage());
-        EXPECT_EQUAL(AddressSpaceUsage::defaultEnumStoreUsage(), after.enumStoreUsage());
+        EXPECT_EQUAL(before.enum_store_usage().used(), 0u);
+        EXPECT_EQUAL(before.enum_store_usage().dead(), 0u);
+        EXPECT_EQUAL(after.enum_store_usage(), before.enum_store_usage());
+        EXPECT_EQUAL(AddressSpaceComponents::default_enum_store_usage(), after.enum_store_usage());
     }
     if (attrPtr->hasMultiValue()) {
         LOG(info, "requireThatAddressSpaceUsageIsReported(%s): Has multi-value", attrName.c_str());
-        EXPECT_EQUAL(before.multiValueUsage().used(), 1u);
-        EXPECT_EQUAL(before.multiValueUsage().dead(), 1u);
-        EXPECT_GREATER_EQUAL(after.multiValueUsage().used(), before.multiValueUsage().used());
-        EXPECT_GREATER(after.multiValueUsage().limit(), before.multiValueUsage().limit());
-        EXPECT_GREATER((1ull << 32), after.multiValueUsage().limit());
+        EXPECT_EQUAL(before.multi_value_usage().used(), 1u);
+        EXPECT_EQUAL(before.multi_value_usage().dead(), 1u);
+        EXPECT_GREATER_EQUAL(after.multi_value_usage().used(), before.multi_value_usage().used());
+        EXPECT_GREATER(after.multi_value_usage().limit(), before.multi_value_usage().limit());
+        EXPECT_GREATER((1ull << 32), after.multi_value_usage().limit());
     } else {
         LOG(info, "requireThatAddressSpaceUsageIsReported(%s): NOT multi-value", attrName.c_str());
-        EXPECT_EQUAL(before.multiValueUsage().used(), 0u);
-        EXPECT_EQUAL(after.multiValueUsage(), before.multiValueUsage());
-        EXPECT_EQUAL(AddressSpaceUsage::defaultMultiValueUsage(), after.multiValueUsage());
+        EXPECT_EQUAL(before.multi_value_usage().used(), 0u);
+        EXPECT_EQUAL(after.multi_value_usage(), before.multi_value_usage());
+        EXPECT_EQUAL(AddressSpaceComponents::default_multi_value_usage(), after.multi_value_usage());
     }
 }
 

--- a/searchlib/src/tests/attribute/compaction/attribute_compaction_test.cpp
+++ b/searchlib/src/tests/attribute/compaction/attribute_compaction_test.cpp
@@ -154,7 +154,7 @@ public:
         return status;
     }
     const Config &getConfig() const { return _v->getConfig(); }
-    AddressSpace getMultiValueAddressSpaceUsage() const {return _v->getAddressSpaceUsage().multiValueUsage(); }
+    AddressSpace getMultiValueAddressSpaceUsage() const {return _v->getAddressSpaceUsage().multi_value_usage(); }
     AddressSpace getMultiValueAddressSpaceUsage(const vespalib::string &prefix) {
         AddressSpace usage(getMultiValueAddressSpaceUsage());
         LOG(info, "address space usage %s: used=%zu, dead=%zu, limit=%zu, usage=%12.8f",

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(searchlib_attribute OBJECT
     SOURCES
+    address_space_components.cpp
     address_space_usage.cpp
     attribute.cpp
     attribute_blueprint_factory.cpp

--- a/searchlib/src/vespa/searchlib/attribute/address_space_components.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_components.cpp
@@ -15,7 +15,7 @@ AddressSpace AddressSpaceComponents::default_multi_value_usage() {
     return AddressSpace(0, 0, (1ull << 32));
 }
 
-vespalib::string AddressSpaceComponents::enum_store = "enum-store";
-vespalib::string AddressSpaceComponents::multi_value = "multi-value";
+const vespalib::string AddressSpaceComponents::enum_store = "enum-store";
+const vespalib::string AddressSpaceComponents::multi_value = "multi-value";
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/address_space_components.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_components.cpp
@@ -1,0 +1,21 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "address_space_components.h"
+#include "i_enum_store.h"
+
+namespace search {
+
+using vespalib::AddressSpace;
+
+AddressSpace AddressSpaceComponents::default_enum_store_usage() {
+    return AddressSpace(0, 0, IEnumStore::InternalIndex::offsetSize());
+}
+
+AddressSpace AddressSpaceComponents::default_multi_value_usage() {
+    return AddressSpace(0, 0, (1ull << 32));
+}
+
+vespalib::string AddressSpaceComponents::enum_store = "enum-store";
+vespalib::string AddressSpaceComponents::multi_value = "multi-value";
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/address_space_components.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_components.h
@@ -1,0 +1,21 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/address_space.h>
+
+namespace search {
+
+/**
+ * A set of components in an attribute vector that use address space.
+ */
+class AddressSpaceComponents {
+public:
+    static vespalib::AddressSpace default_enum_store_usage();
+    static vespalib::AddressSpace default_multi_value_usage();
+    static vespalib::string enum_store;
+    static vespalib::string multi_value;
+};
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/address_space_components.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_components.h
@@ -14,8 +14,8 @@ class AddressSpaceComponents {
 public:
     static vespalib::AddressSpace default_enum_store_usage();
     static vespalib::AddressSpace default_multi_value_usage();
-    static vespalib::string enum_store;
-    static vespalib::string multi_value;
+    static const vespalib::string enum_store;
+    static const vespalib::string multi_value;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
@@ -17,12 +17,12 @@ AddressSpaceUsage::AddressSpaceUsage(const AddressSpace& enum_store_usage,
     : _map()
 {
     // TODO: Remove this constructor and instead add usage for each relevant component explicit.
-    add(AddressSpaceComponents::enum_store, enum_store_usage);
-    add(AddressSpaceComponents::multi_value, multi_value_usage);
+    set(AddressSpaceComponents::enum_store, enum_store_usage);
+    set(AddressSpaceComponents::multi_value, multi_value_usage);
 }
 
 void
-AddressSpaceUsage::add(const vespalib::string& component, const vespalib::AddressSpace& usage)
+AddressSpaceUsage::set(const vespalib::string& component, const vespalib::AddressSpace& usage)
 {
     _map[component] = usage;
 }

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
@@ -1,33 +1,52 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include "address_space_components.h"
 #include "address_space_usage.h"
-#include "i_enum_store.h"
 
 namespace search {
 
 using vespalib::AddressSpace;
 
 AddressSpaceUsage::AddressSpaceUsage()
-        : _enumStoreUsage(defaultEnumStoreUsage()),
-          _multiValueUsage(defaultMultiValueUsage()) {
+    : _map()
+{
 }
 
-AddressSpaceUsage::AddressSpaceUsage(const AddressSpace &enumStoreUsage_,
-                                     const AddressSpace &multiValueUsage_)
-        : _enumStoreUsage(enumStoreUsage_),
-          _multiValueUsage(multiValueUsage_) {
+AddressSpaceUsage::AddressSpaceUsage(const AddressSpace& enum_store_usage,
+                                     const AddressSpace& multi_value_usage)
+    : _map()
+{
+    // TODO: Remove this constructor and instead add usage for each relevant component explicit.
+    add(AddressSpaceComponents::enum_store, enum_store_usage);
+    add(AddressSpaceComponents::multi_value, multi_value_usage);
+}
+
+void
+AddressSpaceUsage::add(const vespalib::string& component, const vespalib::AddressSpace& usage)
+{
+    _map[component] = usage;
 }
 
 AddressSpace
-AddressSpaceUsage::defaultEnumStoreUsage()
+AddressSpaceUsage::get(const vespalib::string& component) const
 {
-    return AddressSpace(0, 0, IEnumStore::InternalIndex::offsetSize());
+    auto itr = _map.find(component);
+    if (itr != _map.end()) {
+        return itr->second;
+    }
+    return AddressSpace();
 }
 
 AddressSpace
-AddressSpaceUsage::defaultMultiValueUsage()
+AddressSpaceUsage::enum_store_usage() const
 {
-    return AddressSpace(0, 0, (1ull << 32));
+    return get(AddressSpaceComponents::enum_store);
 }
 
-} // namespace search
+AddressSpace
+AddressSpaceUsage::multi_value_usage() const
+{
+    return get(AddressSpaceComponents::multi_value);
+}
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
@@ -22,7 +22,7 @@ public:
     AddressSpaceUsage();
     AddressSpaceUsage(const vespalib::AddressSpace& enum_store_usage,
                       const vespalib::AddressSpace& multi_value_usage);
-    void add(const vespalib::string& component, const vespalib::AddressSpace& usage);
+    void set(const vespalib::string& component, const vespalib::AddressSpace& usage);
     vespalib::AddressSpace get(const vespalib::string& component) const;
     vespalib::AddressSpace enum_store_usage() const;
     vespalib::AddressSpace multi_value_usage() const;

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
@@ -2,28 +2,30 @@
 
 #pragma once
 
+#include <vespa/vespalib/stllike/hash_fun.h>
+#include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/util/address_space.h>
+#include <unordered_map>
 
 namespace search {
 
 /**
- * Represents the address space usage for enum store and multi value mapping.
+ * Represents the address space usage for a set of attribute vector components.
  */
 class AddressSpaceUsage
 {
 private:
-    vespalib::AddressSpace _enumStoreUsage;
-    vespalib::AddressSpace _multiValueUsage;
+    using AddressSpaceMap = std::unordered_map<vespalib::string, vespalib::AddressSpace, vespalib::hash<vespalib::string>>;
+    AddressSpaceMap _map;
 
 public:
     AddressSpaceUsage();
-    AddressSpaceUsage(const vespalib::AddressSpace &enumStoreUsage_,
-                      const vespalib::AddressSpace &multiValueUsage_);
-    static vespalib::AddressSpace defaultEnumStoreUsage();
-    static vespalib::AddressSpace defaultMultiValueUsage();
-    const vespalib::AddressSpace &enumStoreUsage() const { return _enumStoreUsage; }
-    const vespalib::AddressSpace &multiValueUsage() const { return _multiValueUsage; }
-
+    AddressSpaceUsage(const vespalib::AddressSpace& enum_store_usage,
+                      const vespalib::AddressSpace& multi_value_usage);
+    void add(const vespalib::string& component, const vespalib::AddressSpace& usage);
+    vespalib::AddressSpace get(const vespalib::string& component) const;
+    vespalib::AddressSpace enum_store_usage() const;
+    vespalib::AddressSpace multi_value_usage() const;
 };
 
-} // namespace search
+}

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -1,10 +1,11 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "attributevector.h"
+#include "address_space_components.h"
 #include "attribute_read_guard.h"
 #include "attributefilesavetarget.h"
 #include "attributeiterators.hpp"
 #include "attributesaver.h"
+#include "attributevector.h"
 #include "attributevector.hpp"
 #include "floatbase.h"
 #include "interlock.h"
@@ -14,14 +15,14 @@
 #include <vespa/document/update/assignvalueupdate.h>
 #include <vespa/document/update/mapvalueupdate.h>
 #include <vespa/fastlib/io/bufferedfile.h>
+#include <vespa/searchcommon/attribute/attribute_utils.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/query/query_term_decoder.h>
 #include <vespa/searchlib/queryeval/emptysearch.h>
+#include <vespa/searchlib/util/logutil.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/size_literals.h>
-#include <vespa/searchlib/util/logutil.h>
-#include <vespa/searchcommon/attribute/attribute_utils.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -222,22 +223,20 @@ AttributeVector::getEnumStoreValuesMemoryUsage() const
     return vespalib::MemoryUsage();
 }
 
-vespalib::AddressSpace
-AttributeVector::getEnumStoreAddressSpaceUsage() const
+void
+AttributeVector::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
-    return AddressSpaceUsage::defaultEnumStoreUsage();
-}
-
-vespalib::AddressSpace
-AttributeVector::getMultiValueAddressSpaceUsage() const
-{
-    return AddressSpaceUsage::defaultMultiValueUsage();
+    // TODO: Stop inserting defaults here when code using AddressSpaceUsage no longer require these two components.
+    usage.add(AddressSpaceComponents::enum_store, AddressSpaceComponents::default_enum_store_usage());
+    usage.add(AddressSpaceComponents::multi_value, AddressSpaceComponents::default_multi_value_usage());
 }
 
 AddressSpaceUsage
 AttributeVector::getAddressSpaceUsage() const
 {
-    return AddressSpaceUsage(getEnumStoreAddressSpaceUsage(), getMultiValueAddressSpaceUsage());
+    AddressSpaceUsage usage;
+    populate_address_space_usage(usage);
+    return usage;
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -227,8 +227,8 @@ void
 AttributeVector::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
     // TODO: Stop inserting defaults here when code using AddressSpaceUsage no longer require these two components.
-    usage.add(AddressSpaceComponents::enum_store, AddressSpaceComponents::default_enum_store_usage());
-    usage.add(AddressSpaceComponents::multi_value, AddressSpaceComponents::default_multi_value_usage());
+    usage.set(AddressSpaceComponents::enum_store, AddressSpaceComponents::default_enum_store_usage());
+    usage.set(AddressSpaceComponents::multi_value, AddressSpaceComponents::default_multi_value_usage());
 }
 
 AddressSpaceUsage

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -381,8 +381,7 @@ protected:
     }
 
     virtual vespalib::MemoryUsage getEnumStoreValuesMemoryUsage() const;
-    virtual vespalib::AddressSpace getEnumStoreAddressSpaceUsage() const;
-    virtual vespalib::AddressSpace getMultiValueAddressSpaceUsage() const;
+    virtual void populate_address_space_usage(AddressSpaceUsage& usage) const;
 
 public:
     DECLARE_IDENTIFIABLE_ABSTRACT(AttributeVector);

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -64,7 +64,7 @@ protected:
     void insertNewUniqueValues(EnumStoreBatchUpdater& updater);
     virtual void considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) = 0;
     vespalib::MemoryUsage getEnumStoreValuesMemoryUsage() const override;
-    vespalib::AddressSpace getEnumStoreAddressSpaceUsage() const override;
+    void populate_address_space_usage(AddressSpaceUsage& usage) const override;
 public:
     EnumAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);
     ~EnumAttribute();

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "address_space_components.h"
 #include <vespa/vespalib/util/hdr_abort.h>
 #include <vespa/searchlib/attribute/enumattribute.h>
 #include <vespa/searchlib/attribute/enumstore.hpp>
@@ -76,10 +77,11 @@ EnumAttribute<B>::getEnumStoreValuesMemoryUsage() const
 }
 
 template <typename B>
-vespalib::AddressSpace
-EnumAttribute<B>::getEnumStoreAddressSpaceUsage() const
+void
+EnumAttribute<B>::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
-    return _enumStore.get_address_space_usage();
+    B::populate_address_space_usage(usage);
+    usage.add(AddressSpaceComponents::enum_store, _enumStore.get_address_space_usage());
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -81,7 +81,7 @@ void
 EnumAttribute<B>::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
     B::populate_address_space_usage(usage);
-    usage.add(AddressSpaceComponents::enum_store, _enumStore.get_address_space_usage());
+    usage.set(AddressSpaceComponents::enum_store, _enumStore.get_address_space_usage());
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
@@ -48,7 +48,7 @@ protected:
      **/
     bool onAddDoc(DocId doc) override { (void) doc; return false; }
 
-    vespalib::AddressSpace getMultiValueAddressSpaceUsage() const override;
+    void populate_address_space_usage(AddressSpaceUsage& usage) const override;
 
 public:
     MultiValueAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -205,7 +205,7 @@ void
 MultiValueAttribute<B, M>::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
     B::populate_address_space_usage(usage);
-    usage.add(AddressSpaceComponents::multi_value, _mvMapping.getAddressSpaceUsage());
+    usage.set(AddressSpaceComponents::multi_value, _mvMapping.getAddressSpaceUsage());
 }
 
 template <typename B, typename M>

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "address_space_components.h"
 #include <vespa/searchlib/attribute/multivalueattribute.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
@@ -200,12 +201,12 @@ MultiValueAttribute<B, M>::apply_attribute_changes_to_wset(DocumentValues& docVa
 }
 
 template <typename B, typename M>
-vespalib::AddressSpace
-MultiValueAttribute<B, M>::getMultiValueAddressSpaceUsage() const
+void
+MultiValueAttribute<B, M>::populate_address_space_usage(AddressSpaceUsage& usage) const
 {
-    return _mvMapping.getAddressSpaceUsage();
+    B::populate_address_space_usage(usage);
+    usage.add(AddressSpaceComponents::multi_value, _mvMapping.getAddressSpaceUsage());
 }
-
 
 template <typename B, typename M>
 bool

--- a/vespalib/src/vespa/vespalib/util/address_space.cpp
+++ b/vespalib/src/vespa/vespalib/util/address_space.cpp
@@ -6,6 +6,13 @@
 
 namespace vespalib {
 
+AddressSpace::AddressSpace()
+    : _used(0),
+      _dead(0),
+      _limit(0)
+{
+}
+
 AddressSpace::AddressSpace(size_t used_, size_t dead_, size_t limit_)
     : _used(used_),
       _dead(dead_),

--- a/vespalib/src/vespa/vespalib/util/address_space.h
+++ b/vespalib/src/vespa/vespalib/util/address_space.h
@@ -18,6 +18,7 @@ private:
     size_t _limit;
 
 public:
+    AddressSpace();
     AddressSpace(size_t used_, size_t dead_, size_t limit_);
     size_t used() const { return _used; }
     size_t dead() const { return _dead; }


### PR DESCRIPTION
This prepares for reporting address space usage for more attribute vector components,
not only enum store and multi-value mapping.

@vekterli please review
@toregge FYI