### PR TITLE
check extra field for change for reindexing

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexedSearchClusterChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexedSearchClusterChangeValidatorTest.java
@@ -41,7 +41,7 @@ public class IndexedSearchClusterChangeValidatorTest {
         public static VespaModel newOneDocModel(String sdContent) {
             return new ApplicationPackageBuilder().
                     addCluster(new ContentClusterBuilder().name("foo").docTypes("d1"))
-                                                  .addSchemas(new SchemaBuilder().name("d1").content(sdContent).build())
+                                                  .addSchemas(new SchemaBuilder().name("d1").documentFields(sdContent).build())
                                                   .buildCreator().create();
         }
 
@@ -52,8 +52,8 @@ public class IndexedSearchClusterChangeValidatorTest {
         public static VespaModel newTwoDocModel(String d1Content, String d2Content) {
             return new ApplicationPackageBuilder().
                     addCluster(new ContentClusterBuilder().name("foo").docTypes("d1", "d2"))
-                                                  .addSchemas(new SchemaBuilder().name("d1").content(d1Content).build())
-                                                  .addSchemas(new SchemaBuilder().name("d2").content(d2Content).build()).
+                                                  .addSchemas(new SchemaBuilder().name("d1").documentFields(d1Content).build())
+                                                  .addSchemas(new SchemaBuilder().name("d2").documentFields(d2Content).build()).
                     buildCreator().create();
         }
 
@@ -65,8 +65,8 @@ public class IndexedSearchClusterChangeValidatorTest {
             return new ApplicationPackageBuilder().
                     addCluster(new ContentClusterBuilder().name("foo").docTypes("d1")).
                     addCluster(new ContentClusterBuilder().name("bar").docTypes("d2"))
-                                                  .addSchemas(new SchemaBuilder().name("d1").content(d1Content).build())
-                                                  .addSchemas(new SchemaBuilder().name("d2").content(d2Content).build()).
+                                                  .addSchemas(new SchemaBuilder().name("d1").documentFields(d1Content).build())
+                                                  .addSchemas(new SchemaBuilder().name("d2").documentFields(d2Content).build()).
                     buildCreator().create();
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/StreamingSearchClusterChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/StreamingSearchClusterChangeValidatorTest.java
@@ -42,7 +42,7 @@ public class StreamingSearchClusterChangeValidatorTest {
         public static VespaModel createOneDocModel(String sdContent) {
             return new ApplicationPackageBuilder()
                     .addCluster(new ContentClusterBuilder().name("foo").docTypes(Arrays.asList(DocType.streaming("d1"))))
-                    .addSchemas(new SchemaBuilder().name("d1").content(sdContent).build())
+                    .addSchemas(new SchemaBuilder().name("d1").documentFields(sdContent).build())
                     .buildCreator().create();
         }
 
@@ -53,8 +53,8 @@ public class StreamingSearchClusterChangeValidatorTest {
         public static VespaModel createTwoDocModel(String d1Content, String d2Content) {
             return new ApplicationPackageBuilder()
                     .addCluster(new ContentClusterBuilder().name("foo").docTypes(Arrays.asList(DocType.streaming("d1"), DocType.streaming("d2"))))
-                    .addSchemas(new SchemaBuilder().name("d1").content(d1Content).build())
-                    .addSchemas(new SchemaBuilder().name("d2").content(d2Content).build())
+                    .addSchemas(new SchemaBuilder().name("d1").documentFields(d1Content).build())
+                    .addSchemas(new SchemaBuilder().name("d2").documentFields(d2Content).build())
                     .buildCreator().create();
         }
 
@@ -66,8 +66,8 @@ public class StreamingSearchClusterChangeValidatorTest {
             return new ApplicationPackageBuilder()
                     .addCluster(new ContentClusterBuilder().name("foo").docTypes(Arrays.asList(DocType.streaming("d1"))))
                     .addCluster(new ContentClusterBuilder().name("bar").docTypes(Arrays.asList(DocType.streaming("d2"))))
-                    .addSchemas(new SchemaBuilder().name("d1").content(d1Content).build())
-                    .addSchemas(new SchemaBuilder().name("d2").content(d2Content).build())
+                    .addSchemas(new SchemaBuilder().name("d1").documentFields(d1Content).build())
+                    .addSchemas(new SchemaBuilder().name("d2").documentFields(d2Content).build())
                     .buildCreator().create();
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/search/ContentClusterFixture.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/search/ContentClusterFixture.java
@@ -26,16 +26,28 @@ public abstract class ContentClusterFixture {
     protected ContentCluster currentCluster;
     protected ContentCluster nextCluster;
 
-    public ContentClusterFixture(String currentSd, String nextSd) throws Exception {
-        currentCluster = createCluster(currentSd);
-        nextCluster = createCluster(nextSd);
+    public ContentClusterFixture(String currentDocumentFields, String nextDocumentFields) throws Exception {
+        currentCluster = createCluster(currentDocumentFields);
+        nextCluster = createCluster(nextDocumentFields);
+    }
+
+    public ContentClusterFixture(String currentDocumentFields, String nextDocumentFields, String currentSchemaFields, String nextSchemaFields) throws Exception {
+        currentCluster = createCluster(currentDocumentFields, currentSchemaFields);
+        nextCluster = createCluster(nextDocumentFields, nextSchemaFields);
     }
 
     private static ContentCluster createCluster(String sdContent) throws Exception {
         return new ContentClusterBuilder().build(
                 ContentClusterUtils.createMockRoot(
-                        Arrays.asList(new SchemaBuilder().content(sdContent).build())));
+                        Arrays.asList(new SchemaBuilder().documentFields(sdContent).build())));
     }
+
+    private static ContentCluster createCluster(String documentFields, String schemaFields) throws Exception {
+        return new ContentClusterBuilder().build(
+                ContentClusterUtils.createMockRoot(
+                        Arrays.asList(new SchemaBuilder().documentFields(documentFields).schemaFields(schemaFields).build())));
+    }
+
 
     protected DocumentDatabase currentDb() {
         return currentCluster.getSearch().getIndexed().getDocumentDbs().get(0);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSearchClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSearchClusterTest.java
@@ -180,11 +180,11 @@ public class ContentSearchClusterTest {
     private static ContentCluster createClusterWithThreeDocumentTypes() throws Exception {
         List<String> schemas = new ArrayList<>();
         schemas.add(new SchemaBuilder().name("a")
-                                       .content(joinLines("field ref_to_b type reference<b> { indexing: attribute }",
+                                       .documentFields(joinLines("field ref_to_b type reference<b> { indexing: attribute }",
                                                           "field ref_to_c type reference<c> { indexing: attribute }"))
                                        .build());
         schemas.add(new SchemaBuilder().name("b")
-                                       .content("field ref_to_c type reference<c> { indexing: attribute }")
+                                       .documentFields("field ref_to_c type reference<c> { indexing: attribute }")
                                        .build());
         schemas.add(new SchemaBuilder().name("c").build());
         return createCluster(new ContentClusterBuilder().docTypes(List.of(DocType.index("a"),

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/utils/SchemaBuilder.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/utils/SchemaBuilder.java
@@ -15,7 +15,8 @@ import static com.yahoo.config.model.test.TestUtil.joinLines;
 public class SchemaBuilder {
 
     private String name = "test";
-    private String content = "";
+    private String documentFields = "";
+    private String schemaFields = "";
 
     public SchemaBuilder() {
     }
@@ -25,16 +26,21 @@ public class SchemaBuilder {
         return this;
     }
 
-    public SchemaBuilder content(String content) {
-        this.content = content;
+    public SchemaBuilder documentFields(String content) {
+        this.documentFields = content;
         return this;
     }
 
+    public SchemaBuilder schemaFields(String extra) {
+        this.schemaFields = extra;
+        return this;
+    }
     public String build() {
-        return joinLines("search " + name + " {",
+        return joinLines("schema " + name + " {",
                 "  document " + name + " {",
-                content,
+                documentFields,
                 "  }",
+                schemaFields,
                 "}");
     }
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/NormalizeExpression.java
@@ -81,7 +81,7 @@ public final class NormalizeExpression extends Expression {
     public boolean equals(Object o) {
         if (!(o instanceof NormalizeExpression)) return false;
         NormalizeExpression other = (NormalizeExpression)o;
-        if (linguistics != other.linguistics) return false;
+        if (linguistics.getClass() != other.linguistics.getClass()) return false;
         return true;
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This is an attempt to address the re-indexing issues seen by an application.

Issue was caused by comparing two SimpleLinguistics object, in testing at least, in the class NormalizeExpression

Changed to
`        if (linguistics.getClass() != other.linguistics.getClass()) return false;
`

Not sure if this is the best way to address this.
