### PR TITLE
Use std::quick_exit instead of abort to avoid coredump when it will n…

### DIFF
--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -127,7 +127,7 @@ DistributorNode::generate_unique_timestamp()
                        "%u timestamps were generated within this time period.",
                 SanityCheckMaxWallClockSecondSkew, now_seconds,_timestamp_second_counter,
                 _intra_second_pseudo_usec_counter);
-            abort();
+            std::quick_exit(66);
         }
         assert(_intra_second_pseudo_usec_counter < 1'000'000);
         ++_intra_second_pseudo_usec_counter;


### PR DESCRIPTION
…ot provide any more information.

@arnej27959 or @jobergum or @bjormel or @kkraune PR
@vekterli and @geirst FYI