### PR TITLE
make runnable not only from cwd

### DIFF
--- a/vespa-feed-client-cli/src/main/sh/vespa-feed-client-standalone.sh
+++ b/vespa-feed-client-cli/src/main/sh/vespa-feed-client-standalone.sh
@@ -5,5 +5,5 @@ exec java \
 -Djava.awt.headless=true \
 -Xms128m -Xmx2048m \
 --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
--Djava.util.logging.config.file=logging.properties \
--cp vespa-feed-client-cli-jar-with-dependencies.jar ai.vespa.feed.client.CliClient "$@"
+-Djava.util.logging.config.file=`dirname $0`/logging.properties \
+-cp `dirname $0`/vespa-feed-client-cli-jar-with-dependencies.jar ai.vespa.feed.client.CliClient "$@"


### PR DESCRIPTION
I am not sure if this is the best fix - when unzipping the artifact I get

````
$ ll
-rw-r--r--  1 xxx  staff      154 Aug  1 11:58 logging.properties
-rwxr-xr-x@ 1 xxx  staff      288 Aug  3 10:54 vespa-feed-client
-rw-r--r--  1 xxx  staff  8784885 Aug  1 12:00 vespa-feed-client-cli-jar-with-dependencies.jar
````

FYI @bjorncs / @jonmv 
