### PR TITLE
Enable group-suspension with permanent suspension

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -126,8 +126,8 @@ public class Flags {
             "Whether the Orchestrator can assume any missing proxy services are down.",
             "Takes effect on first (re)start of config server");
 
-    public static final UnboundBooleanFlag GROUP_SUSPENSION_IN_PERMANENT_SUSPEND = defineFeatureFlag(
-            "group-suspension-in-permanent-suspend", true,
+    public static final UnboundBooleanFlag GROUP_PERMANENT_SUSPENSION = defineFeatureFlag(
+            "group-permanent-suspension", true,
             List.of("hakonhall"), "2021-09-11", "2021-11-11",
             "Allow all content nodes in a hierarchical group to suspend at the same time when" +
             "permanently suspending a host.",

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -126,12 +126,12 @@ public class Flags {
             "Whether the Orchestrator can assume any missing proxy services are down.",
             "Takes effect on first (re)start of config server");
 
-    public static final UnboundBooleanFlag GROUP_SUSPENSION = defineFeatureFlag(
-            "group-suspension", true,
-            List.of("hakon"), "2021-01-22", "2021-08-22",
-            "Allow all content nodes in a hierarchical group to suspend at the same time",
-            "Takes effect on the next suspension request to the Orchestrator.",
-            APPLICATION_ID);
+    public static final UnboundBooleanFlag GROUP_SUSPENSION_IN_PERMANENT_SUSPEND = defineFeatureFlag(
+            "group-suspension-in-permanent-suspend", true,
+            List.of("hakonhall"), "2021-09-11", "2021-11-11",
+            "Allow all content nodes in a hierarchical group to suspend at the same time when" +
+            "permanently suspending a host.",
+            "Takes effect on the next permanent suspension request to the Orchestrator.");
 
     public static final UnboundBooleanFlag ENCRYPT_DIRTY_DISK = defineFeatureFlag(
             "encrypt-dirty-disk", false,

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -22,7 +22,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
 
     public HostedVespaClusterPolicy(FlagSource flagSource, Zone zone) {
         // Note that the "group" in this flag refers to hierarchical groups of a content cluster.
-        this.groupSuspensionInPermanentSuspendFlag = Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.bindTo(flagSource);
+        this.groupSuspensionInPermanentSuspendFlag = Flags.GROUP_PERMANENT_SUSPENSION.bindTo(flagSource);
         this.zone = zone;
     }
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -5,7 +5,6 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.applicationmodel.ClusterId;
 import com.yahoo.vespa.applicationmodel.ServiceType;
 import com.yahoo.vespa.flags.BooleanFlag;
-import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.orchestrator.model.ClusterApi;
@@ -18,26 +17,22 @@ import static com.yahoo.vespa.orchestrator.policy.HostedVespaPolicy.ENOUGH_SERVI
 
 public class HostedVespaClusterPolicy implements ClusterPolicy {
 
-    private final BooleanFlag groupSuspensionFlag;
+    private final BooleanFlag groupSuspensionInPermanentSuspendFlag;
     private final Zone zone;
 
     public HostedVespaClusterPolicy(FlagSource flagSource, Zone zone) {
         // Note that the "group" in this flag refers to hierarchical groups of a content cluster.
-        this.groupSuspensionFlag = Flags.GROUP_SUSPENSION.bindTo(flagSource);
+        this.groupSuspensionInPermanentSuspendFlag = Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.bindTo(flagSource);
         this.zone = zone;
     }
 
     @Override
     public SuspensionReasons verifyGroupGoingDownIsFine(ClusterApi clusterApi) throws HostStateChangeDeniedException {
-        boolean enableContentGroupSuspension = groupSuspensionFlag
-                .with(FetchVector.Dimension.APPLICATION_ID, clusterApi.getApplication().applicationId().serializedForm())
-                .value();
-
         if (clusterApi.noServicesOutsideGroupIsDown()) {
             return SuspensionReasons.nothingNoteworthy();
         }
 
-        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi, enableContentGroupSuspension).asPercentage();
+        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi, true).asPercentage();
         if (clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown() <= percentageOfServicesAllowedToBeDown) {
             return SuspensionReasons.nothingNoteworthy();
         }
@@ -69,7 +64,10 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             return;
         }
 
-        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi, false).asPercentage();
+        boolean enableContentGroupSuspension = groupSuspensionInPermanentSuspendFlag.value();
+
+        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi, enableContentGroupSuspension)
+                .asPercentage();
         if (clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown() <= percentageOfServicesAllowedToBeDown) {
             return;
         }

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
@@ -124,7 +124,7 @@ public class ClusterApiImplTest {
                             "Services down on resumed hosts: [1 missing config server]."));
         }
 
-        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION.id(), true);
+        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.id(), true);
 
         try {
             policy.verifyGroupGoingDownIsFine(clusterApi);
@@ -156,7 +156,7 @@ public class ClusterApiImplTest {
                             "Services down on resumed hosts: [1 missing config server host]."));
         }
 
-        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION.id(), true);
+        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.id(), true);
 
         try {
             policy.verifyGroupGoingDownIsFine(clusterApi);

--- a/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
+++ b/orchestrator/src/test/java/com/yahoo/vespa/orchestrator/model/ClusterApiImplTest.java
@@ -124,7 +124,7 @@ public class ClusterApiImplTest {
                             "Services down on resumed hosts: [1 missing config server]."));
         }
 
-        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.id(), true);
+        flagSource.withBooleanFlag(Flags.GROUP_PERMANENT_SUSPENSION.id(), true);
 
         try {
             policy.verifyGroupGoingDownIsFine(clusterApi);
@@ -156,7 +156,7 @@ public class ClusterApiImplTest {
                             "Services down on resumed hosts: [1 missing config server host]."));
         }
 
-        flagSource.withBooleanFlag(Flags.GROUP_SUSPENSION_IN_PERMANENT_SUSPEND.id(), true);
+        flagSource.withBooleanFlag(Flags.GROUP_PERMANENT_SUSPENSION.id(), true);
 
         try {
             policy.verifyGroupGoingDownIsFine(clusterApi);


### PR DESCRIPTION
This will enable the same per-cluster policy for "permanently suspending" a
host (i.e. removing it from an application, typically because it is
wantToRetire and retired), as the policy for suspending a host (typically for
upgrade).  The major difference is that the new policy allows for permanently
remove >1 content node at a time, if they are within the same group.

Guarded by a new flag group-suspension-in-permanent-suspend, enabled by
default.  The old and unused flag group-suspension is removed.