### PR TITLE
avoid crash on run-time onnx errors

### DIFF
--- a/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
+++ b/eval/src/tests/tensor/onnx_wrapper/onnx_wrapper_test.cpp
@@ -178,6 +178,9 @@ TEST(OnnxTest, simple_onnx_model_can_be_evaluated)
     ctx.eval();
     EXPECT_EQ(output.cells().typify<float>()[0], 80.0);
     //-------------------------------------------------------------------------
+    ctx.clear_results();
+    EXPECT_EQ(output.cells().typify<float>()[0], 0.0);
+    //-------------------------------------------------------------------------
 }
 
 TEST(OnnxTest, dynamic_onnx_model_can_be_evaluated)
@@ -223,6 +226,9 @@ TEST(OnnxTest, dynamic_onnx_model_can_be_evaluated)
     ctx.bind_param(2, new_bias);
     ctx.eval();
     EXPECT_EQ(output.cells().typify<float>()[0], 81.0);
+    //-------------------------------------------------------------------------
+    ctx.clear_results();
+    EXPECT_EQ(output.cells().typify<float>()[0], 0.0);
     //-------------------------------------------------------------------------
 }
 
@@ -270,6 +276,9 @@ TEST(OnnxTest, int_types_onnx_model_can_be_evaluated)
     ctx.eval();
     EXPECT_EQ(output.cells().typify<double>()[0], 80.0);
     //-------------------------------------------------------------------------
+    ctx.clear_results();
+    EXPECT_EQ(output.cells().typify<double>()[0], 0.0);
+    //-------------------------------------------------------------------------
 }
 
 TEST(OnnxTest, we_guess_batch_dimension_size_when_inference_fails) {    
@@ -310,6 +319,15 @@ TEST(OnnxTest, we_guess_batch_dimension_size_when_inference_fails) {
     auto expect_4 = TensorSpec::from_expr("tensor<float>(d0[4]):[2,4,6,8]");
     EXPECT_EQ(out_3, expect_3);
     EXPECT_EQ(out_4, expect_4);
+    //-------------------------------------------------------------------------
+    auto zero_3 = TensorSpec::from_expr("tensor<float>(d0[3]):[0,0,0]");
+    auto zero_4 = TensorSpec::from_expr("tensor<float>(d0[4]):[0,0,0,0]");
+    ctx_3.clear_results();
+    EXPECT_EQ(TensorSpec::from_value(ctx_3.get_result(0)), zero_3);
+    EXPECT_EQ(TensorSpec::from_value(ctx_4.get_result(0)), expect_4);
+    ctx_4.clear_results();
+    EXPECT_EQ(TensorSpec::from_value(ctx_3.get_result(0)), zero_3);
+    EXPECT_EQ(TensorSpec::from_value(ctx_4.get_result(0)), zero_4);
     //-------------------------------------------------------------------------
 }
 
@@ -356,6 +374,14 @@ TEST(OnnxTest, zero_copy_unstable_types) {
     EXPECT_EQ(cells16.typify<BFloat16>()[1], 2.0);
     EXPECT_EQ(cells16.typify<BFloat16>()[2], 3.0);
     //-------------------------------------------------------------------------
+    ctx.clear_results();
+    EXPECT_EQ(cells8.typify<Int8Float>()[0], 0.0);
+    EXPECT_EQ(cells8.typify<Int8Float>()[1], 0.0);
+    EXPECT_EQ(cells8.typify<Int8Float>()[2], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[0], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[1], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[2], 0.0);
+    //-------------------------------------------------------------------------
 }
 
 TEST(OnnxTest, converted_unstable_types) {
@@ -400,6 +426,14 @@ TEST(OnnxTest, converted_unstable_types) {
     EXPECT_EQ(cells16.typify<BFloat16>()[0], 1.0);
     EXPECT_EQ(cells16.typify<BFloat16>()[1], 2.0);
     EXPECT_EQ(cells16.typify<BFloat16>()[2], 3.0);
+    //-------------------------------------------------------------------------
+    ctx.clear_results();
+    EXPECT_EQ(cells8.typify<Int8Float>()[0], 0.0);
+    EXPECT_EQ(cells8.typify<Int8Float>()[1], 0.0);
+    EXPECT_EQ(cells8.typify<Int8Float>()[2], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[0], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[1], 0.0);
+    EXPECT_EQ(cells16.typify<BFloat16>()[2], 0.0);
     //-------------------------------------------------------------------------
 }
 

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
@@ -97,6 +97,17 @@ struct CreateVespaTensor {
     }
 };
 
+struct ClearVespaTensor {
+    template <typename CT> static void invoke(const Value &value) {
+        auto cells = unconstify(value.cells().typify<CT>());
+        std::fill(cells.begin(), cells.end(), CT{});
+    }
+    void operator()(const Value &value) {
+        return typify_invoke<1,TypifyCellType,ClearVespaTensor>(value.type().cell_type(), value);
+    }
+};
+ClearVespaTensor clear_vespa_tensor;
+
 //-----------------------------------------------------------------------------
 
 template <typename E> vespalib::string type_name(E enum_value) {
@@ -202,7 +213,7 @@ std::vector<int64_t> extract_sizes(const ValueType &type) {
     return sizes;
 }
 
-}
+} // <unnamed>
 
 vespalib::string
 Onnx::DimSize::as_string() const
@@ -485,6 +496,14 @@ Onnx::EvalContext::eval()
                 _model._output_name_refs.data(), _result_values.data(), _result_values.size());
     for (const auto &entry: _result_converters) {
         entry.second(*this, entry.first);
+    }
+}
+
+void
+Onnx::EvalContext::clear_results()
+{
+    for (const Value::UP &result: _results) {
+        clear_vespa_tensor(*result);
     }
 }
 

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.h
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.h
@@ -134,6 +134,7 @@ public:
         size_t num_results() const { return _result_values.size(); }
         void bind_param(size_t i, const Value &param);
         void eval();
+        void clear_results();
         const Value &get_result(size_t i) const;
     };
 

--- a/searchlib/src/tests/features/onnx_feature/fragile.onnx
+++ b/searchlib/src/tests/features/onnx_feature/fragile.onnx
@@ -1,5 +1,5 @@
 
-fragile.py:b
+fragile.py:]
 
 in1
 in2out"AddfragileZ
@@ -9,7 +9,8 @@ fragile.py:b
 Z
 in2
 	
-batchb
-out
-	
-batchB
+batchb
+out
+
+
+B

--- a/searchlib/src/tests/features/onnx_feature/fragile.py
+++ b/searchlib/src/tests/features/onnx_feature/fragile.py
@@ -6,7 +6,7 @@ from onnx import helper, TensorProto
 INPUT1 = helper.make_tensor_value_info('in1', TensorProto.FLOAT, [2])
 INPUT2 = helper.make_tensor_value_info('in2', TensorProto.FLOAT, ['batch'])
 
-OUTPUT = helper.make_tensor_value_info('out', TensorProto.FLOAT, ['batch'])
+OUTPUT = helper.make_tensor_value_info('out', TensorProto.FLOAT, [2])
 
 nodes = [
     helper.make_node(

--- a/searchlib/src/tests/features/onnx_feature/onnx_feature_test.cpp
+++ b/searchlib/src/tests/features/onnx_feature/onnx_feature_test.cpp
@@ -147,20 +147,22 @@ TEST_F(OnnxFeatureTest, input_features_and_output_names_can_be_specified) {
 TEST_F(OnnxFeatureTest, fragile_model_can_be_evaluated) {
     add_expr("in1", "tensor<float>(x[2]):[docid,5]");
     add_expr("in2", "tensor<float>(x[2]):[docid,10]");
-    add_onnx(OnnxModel("fragile", fragile_model));
+    add_onnx(OnnxModel("fragile", fragile_model).dry_run_on_setup(true));
     EXPECT_TRUE(try_compile(onnx_feature("fragile")));
     EXPECT_EQ(get(1), TensorSpec::from_expr("tensor<float>(d0[2]):[2,15]"));
     EXPECT_EQ(get(3), TensorSpec::from_expr("tensor<float>(d0[2]):[6,15]"));
 }
 
-TEST_F(OnnxFeatureTest, runtime_broken_model_can_be_set_up_without_dry_run) {
+TEST_F(OnnxFeatureTest, broken_model_evaluates_to_all_zeros) {
     add_expr("in1", "tensor<float>(x[2]):[docid,5]");
     add_expr("in2", "tensor<float>(x[3]):[docid,10,31515]");
     add_onnx(OnnxModel("fragile", fragile_model).dry_run_on_setup(false));
     EXPECT_TRUE(try_compile(onnx_feature("fragile")));
+    EXPECT_EQ(get(1), TensorSpec::from_expr("tensor<float>(d0[2]):[0,0]"));
+    EXPECT_EQ(get(3), TensorSpec::from_expr("tensor<float>(d0[2]):[0,0]"));
 }
 
-TEST_F(OnnxFeatureTest, runtime_broken_model_fails_with_dry_run) {
+TEST_F(OnnxFeatureTest, broken_model_fails_with_dry_run) {
     add_expr("in1", "tensor<float>(x[2]):[docid,5]");
     add_expr("in2", "tensor<float>(x[3]):[docid,10,31515]");
     add_onnx(OnnxModel("fragile", fragile_model).dry_run_on_setup(true));

--- a/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
@@ -89,7 +89,12 @@ public:
         for (size_t i = 0; i < _eval_context.num_params(); ++i) {
             _eval_context.bind_param(i, inputs().get_object(i).get());
         }
-        _eval_context.eval();
+        try {
+            _eval_context.eval();
+        } catch (const Ort::Exception &ex) {
+            LOG(warning, "onnx model evaluation failed: %s", ex.what());
+            _eval_context.clear_results();
+        }
     }
 };
 
@@ -162,6 +167,8 @@ OnnxBlueprint::setup(const IIndexEnvironment &env,
         if (!error_msg.empty()) {
             return fail("onnx model dry-run failed: %s", error_msg.c_str());
         }
+    } else {
+        LOG(warning, "dry-run disabled for onnx model '%s'", model_cfg->name().c_str());
     }
     return true;
 }


### PR DESCRIPTION
- warn about onnx model dry-run being disabled
- catch and report onnx errors during ranking
- zero-fill failed results to avoid re-using previous results
- use explicit output size in fragile model
  (output became float[2] instead of float[batch] anyways)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@lesters FYI