### PR TITLE
Use grow factor when considering switching to a new buffer.

### DIFF
--- a/vespalib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/vespalib/src/tests/datastore/datastore/datastore_test.cpp
@@ -563,16 +563,16 @@ TEST(DataStoreTest, require_that_buffer_growth_works)
     assertGrowStats({ 4, 4, 4, 4, 8, 16, 16, 32, 64, 64 },
                     { 4 }, 20, 4, 0);
     // Resize if buffer size is less than 4, min size 0
-    assertGrowStats({ 4, 4, 4, 4, 8, 16, 16, 32, 64, 64 },
+    assertGrowStats({ 4, 4, 8, 16, 16, 32, 32, 64, 128, 128 },
                     { 0, 1, 2, 4 }, 4, 0, 4);
     // Always switch to new buffer, min size 16
     assertGrowStats({ 16, 16, 16, 32, 32, 64, 128, 128, 128 },
                     { 16 }, 68, 16, 0);
     // Resize if buffer size is less than 16, min size 0
-    assertGrowStats({ 16, 16, 16, 32, 32, 64, 128, 128, 128 },
+    assertGrowStats({ 16, 32, 32, 64, 64, 128, 128, 128, 128 },
                     { 0, 1, 2, 4, 8, 16 }, 4, 0, 16);
     // Resize if buffer size is less than 16, min size 4
-    assertGrowStats({ 16, 16, 16, 32, 32, 64, 128, 128, 128 },
+    assertGrowStats({ 16, 32, 32, 64, 64, 128, 128, 128, 128 },
                     { 4, 8, 16 }, 20, 4, 16);
     // Always switch to new buffer, min size 0
     assertGrowStats({ 1, 1, 1, 1, 1, 2, 2, 4, 8, 8, 16, 32 },
@@ -580,7 +580,7 @@ TEST(DataStoreTest, require_that_buffer_growth_works)
 
     // Buffers with sizes larger than the huge page size of the mmap allocator.
     ASSERT_EQ(524288u, HUGE_PAGE_ARRAY_SIZE);
-    assertGrowStats({ 262144, 262144, 262144, 524288, 524288, 524288 * 2, 524288 * 3, 524288 * 4, 524288 * 5, 524288 * 5 },
+    assertGrowStats({ 262144, 524288, 524288, 524288 * 2, 524288 * 2, 524288 * 3, 524288 * 4, 524288 * 5, 524288 * 5, 524288 * 5 },
                     { 0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144 },
                     4, 0, HUGE_PAGE_ARRAY_SIZE / 2, HUGE_PAGE_ARRAY_SIZE * 5);
 }
@@ -614,12 +614,12 @@ TEST(DataStoreTest, require_that_offset_in_EntryRefT_is_within_bounds_when_alloc
      *   4) Cap bytes to alloc to the max offset EntryRef can handle.
      *      The max bytes to alloc is: maxArrays * arraySize * elementSize.
      */
-    assertGrowStats<uint8_t>({8192,8192,8192,16384,16384,32768,65536,65536,98304,98304,98304,98304}, 3);
-    assertGrowStats<uint8_t>({16384,16384,16384,32768,32768,65536,131072,131072,163840,163840,163840,163840}, 5);
-    assertGrowStats<uint8_t>({16384,16384,16384,32768,32768,65536,131072,131072,229376,229376,229376,229376}, 7);
-    assertGrowStats<uint32_t>({8192,8192,8192,16384,16384,32768,65536,65536,98304,98304,98304,98304}, 3);
-    assertGrowStats<uint32_t>({16384,16384,16384,32768,32768,65536,131072,131072,163840,163840,163840,163840}, 5);
-    assertGrowStats<uint32_t>({16384,16384,16384,32768,32768,65536,131072,131072,229376,229376,229376,229376}, 7);
+    assertGrowStats<uint8_t>({8192,16384,16384,32768,32768,65536,98304,98304,98304,98304,98304,98304}, 3);
+    assertGrowStats<uint8_t>({16384,16384,32768,32768,65536,65536,131072,163840,163840,163840,163840,163840}, 5);
+    assertGrowStats<uint8_t>({16384,32768,32768,65536,65536,131072,229376,229376,229376,229376,229376,229376}, 7);
+    assertGrowStats<uint32_t>({8192,16384,16384,32768,32768,65536,98304,98304,98304,98304,98304,98304}, 3);
+    assertGrowStats<uint32_t>({16384,16384,32768,32768,65536,65536,131072,163840,163840,163840,163840,163840}, 5);
+    assertGrowStats<uint32_t>({16384,32768,32768,65536,65536,131072,229376,229376,229376,229376,229376,229376}, 7);
 }
 
 namespace {

--- a/vespalib/src/vespa/vespalib/datastore/buffer_type.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_type.cpp
@@ -3,6 +3,7 @@
 #include "atomic_entry_ref.h"
 #include "buffer_type.hpp"
 #include <cassert>
+#include <cmath>
 
 namespace vespalib::datastore {
 
@@ -135,6 +136,20 @@ BufferTypeBase::calcArraysToAlloc(uint32_t bufferId, ElemCount elemsNeeded, bool
     }
     assert(result >= neededArrays);
     return result;
+}
+
+uint32_t
+BufferTypeBase::get_scaled_num_arrays_for_new_buffer() const
+{
+    if (_activeBuffers <= 1u || _numArraysForNewBuffer == 0u) {
+        return _numArraysForNewBuffer;
+    }
+    double scale_factor = std::pow(1.0 + _allocGrowFactor, _activeBuffers - 1);
+    double scaled_result = _numArraysForNewBuffer * scale_factor;
+    if (scaled_result >= _maxArrays) {
+        return _maxArrays;
+    }
+    return scaled_result;
 }
 
 BufferTypeBase::AggregatedBufferCounts::AggregatedBufferCounts()

--- a/vespalib/src/vespa/vespalib/datastore/buffer_type.h
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_type.h
@@ -74,7 +74,7 @@ public:
 
     uint32_t getActiveBuffers() const { return _activeBuffers; }
     size_t getMaxArrays() const { return _maxArrays; }
-    uint32_t getNumArraysForNewBuffer() const { return _numArraysForNewBuffer; }
+    uint32_t get_scaled_num_arrays_for_new_buffer() const;
 protected:
 
     struct BufferCounts {

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
@@ -125,7 +125,7 @@ DataStoreBase::switch_or_grow_primary_buffer(uint32_t typeId, size_t elemsNeeded
 {
     auto typeHandler = _typeHandlers[typeId];
     uint32_t arraySize = typeHandler->getArraySize();
-    size_t numArraysForNewBuffer = typeHandler->getNumArraysForNewBuffer();
+    size_t numArraysForNewBuffer = typeHandler->get_scaled_num_arrays_for_new_buffer();
     size_t numEntriesForNewBuffer = numArraysForNewBuffer * arraySize;
     uint32_t bufferId = _primary_buffer_ids[typeId];
     if (elemsNeeded + _states[bufferId].size() >= numEntriesForNewBuffer) {


### PR DESCRIPTION
This enables earlier ramp-up of buffer sizes.

This PR is related to issue #18153.
