### PR TITLE
set coredump limit before running pstack

### DIFF
--- a/configd/src/apps/sentinel/service.cpp
+++ b/configd/src/apps/sentinel/service.cpp
@@ -125,7 +125,7 @@ Service::terminate(bool catchable, bool dumpState)
             return 0;
         } else {
             if (dumpState && _state != KILLING) {
-                vespalib::string pstackCmd = make_string("pstack %d > %s/%s.pstack.%d 2>&1",
+                vespalib::string pstackCmd = make_string("ulimit -c 0; pstack %d > %s/%s.pstack.%d 2>&1",
                                                          _pid, getVespaTempDir().c_str(), name().c_str(), _pid);
                 LOG(info, "%s:%d failed to stop. Stack dumping with %s", name().c_str(), _pid, pstackCmd.c_str());
                 int pstackRet = system(pstackCmd.c_str());


### PR DESCRIPTION
* gdb has an issue that triggers when we run pstack, details in:
  https://sourceware.org/bugzilla/show_bug.cgi?id=25678
* getting a core dump from GDB isn't useful for us in this case.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review
