### PR TITLE
Balder/add swapable attribute option

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
@@ -222,6 +222,9 @@ public class AttributeFields extends Derived implements AttributesConfig.Produce
         if (attribute.isHuge()) {
             aaB.huge(true);
         }
+        if (attribute.isSwappable()) {
+            aaB.swappable(true);
+        }
         if (attribute.getSorting().isDescending()) {
             aaB.sortascending(false);
         }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
@@ -222,8 +222,8 @@ public class AttributeFields extends Derived implements AttributesConfig.Produce
         if (attribute.isHuge()) {
             aaB.huge(true);
         }
-        if (attribute.isSwappable()) {
-            aaB.swappable(true);
+        if (attribute.isPaged()) {
+            aaB.paged(true);
         }
         if (attribute.getSorting().isDescending()) {
             aaB.sortascending(false);

--- a/config-model/src/main/java/com/yahoo/searchdefinition/document/Attribute.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/document/Attribute.java
@@ -57,6 +57,7 @@ public final class Attribute implements Cloneable, Serializable {
     private boolean fastAccess = false;
     private boolean huge = false;
     private boolean mutable = false;
+    private boolean swappable = false;
     private int arity = BooleanIndexDefinition.DEFAULT_ARITY;
     private long lowerBound = BooleanIndexDefinition.DEFAULT_LOWER_BOUND;
     private long upperBound = BooleanIndexDefinition.DEFAULT_UPPER_BOUND;
@@ -194,6 +195,7 @@ public final class Attribute implements Cloneable, Serializable {
     public boolean isFastSearch()         { return fastSearch; }
     public boolean isFastAccess()         { return fastAccess; }
     public boolean isHuge()               { return huge; }
+    public boolean isSwappable()          { return swappable; }
     public boolean isPosition()           { return isPosition; }
     public boolean isMutable()            { return mutable; }
 
@@ -226,6 +228,7 @@ public final class Attribute implements Cloneable, Serializable {
     public void setEnableOnlyBitVector(boolean enableOnlyBitVector) { this.enableOnlyBitVector = enableOnlyBitVector; }
     public void setFastSearch(boolean fastSearch)                { this.fastSearch = fastSearch; }
     public void setHuge(boolean huge)                            { this.huge = huge; }
+    public void setSwappable(boolean swappable)                  { this.swappable = swappable; }
     public void setFastAccess(boolean fastAccess)                { this.fastAccess = fastAccess; }
     public void setPosition(boolean position)                    { this.isPosition = position; }
     public void setMutable(boolean mutable)                      { this.mutable = mutable; }
@@ -355,8 +358,9 @@ public final class Attribute implements Cloneable, Serializable {
     @Override
     public int hashCode() {
         return Objects.hash(
-                name, type, collectionType, sorting, dictionary, isPrefetch(), fastAccess, removeIfZero, createIfNonExistent,
-                isPosition, huge, enableBitVectors, enableOnlyBitVector, tensorType, referenceDocumentType, distanceMetric, hnswIndexParams);
+                name, type, collectionType, sorting, dictionary, isPrefetch(), fastAccess, removeIfZero,
+                createIfNonExistent, isPosition, huge, mutable, swappable, enableBitVectors, enableOnlyBitVector,
+                tensorType, referenceDocumentType, distanceMetric, hnswIndexParams);
     }
 
     @Override
@@ -379,6 +383,8 @@ public final class Attribute implements Cloneable, Serializable {
         if (this.enableOnlyBitVector != other.enableOnlyBitVector) return false;
         if (this.fastSearch != other.fastSearch) return false;
         if (this.huge != other.huge) return false;
+        if (this.mutable != other.mutable) return false;
+        if (this.swappable != other.swappable) return false;
         if (! this.sorting.equals(other.sorting)) return false;
         if (! Objects.equals(dictionary, other.dictionary)) return false;
         if (! Objects.equals(tensorType, other.tensorType)) return false;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/document/Attribute.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/document/Attribute.java
@@ -57,7 +57,7 @@ public final class Attribute implements Cloneable, Serializable {
     private boolean fastAccess = false;
     private boolean huge = false;
     private boolean mutable = false;
-    private boolean swappable = false;
+    private boolean paged = false;
     private int arity = BooleanIndexDefinition.DEFAULT_ARITY;
     private long lowerBound = BooleanIndexDefinition.DEFAULT_LOWER_BOUND;
     private long upperBound = BooleanIndexDefinition.DEFAULT_UPPER_BOUND;
@@ -188,22 +188,22 @@ public final class Attribute implements Cloneable, Serializable {
     /** Returns the prefetch value of this, null if the default is used. */
     public Boolean getPrefetchValue() { return prefetch; }
 
-    public boolean isRemoveIfZero()       { return removeIfZero; }
-    public boolean isCreateIfNonExistent(){ return createIfNonExistent; }
-    public boolean isEnabledBitVectors()  { return enableBitVectors; }
+    public boolean isRemoveIfZero()         { return removeIfZero; }
+    public boolean isCreateIfNonExistent()  { return createIfNonExistent; }
+    public boolean isEnabledBitVectors()    { return enableBitVectors; }
     public boolean isEnabledOnlyBitVector() { return enableOnlyBitVector; }
-    public boolean isFastSearch()         { return fastSearch; }
-    public boolean isFastAccess()         { return fastAccess; }
-    public boolean isHuge()               { return huge; }
-    public boolean isSwappable()          { return swappable; }
-    public boolean isPosition()           { return isPosition; }
-    public boolean isMutable()            { return mutable; }
+    public boolean isFastSearch()           { return fastSearch; }
+    public boolean isFastAccess()           { return fastAccess; }
+    public boolean isHuge()                 { return huge; }
+    public boolean isPaged()                { return paged; }
+    public boolean isPosition()             { return isPosition; }
+    public boolean isMutable()              { return mutable; }
 
-    public int arity() { return arity; }
+    public int arity()       { return arity; }
     public long lowerBound() { return lowerBound; }
     public long upperBound() { return upperBound; }
     public double densePostingListThreshold() { return densePostingListThreshold; }
-    public Optional<TensorType> tensorType() { return tensorType; }
+    public Optional<TensorType> tensorType()  { return tensorType; }
     public Optional<StructuredDataType> referenceDocumentType() { return referenceDocumentType; }
 
     public static final DistanceMetric DEFAULT_DISTANCE_METRIC = DistanceMetric.EUCLIDEAN;
@@ -228,7 +228,7 @@ public final class Attribute implements Cloneable, Serializable {
     public void setEnableOnlyBitVector(boolean enableOnlyBitVector) { this.enableOnlyBitVector = enableOnlyBitVector; }
     public void setFastSearch(boolean fastSearch)                { this.fastSearch = fastSearch; }
     public void setHuge(boolean huge)                            { this.huge = huge; }
-    public void setSwappable(boolean swappable)                  { this.swappable = swappable; }
+    public void setPaged(boolean paged)                  { this.paged = paged; }
     public void setFastAccess(boolean fastAccess)                { this.fastAccess = fastAccess; }
     public void setPosition(boolean position)                    { this.isPosition = position; }
     public void setMutable(boolean mutable)                      { this.mutable = mutable; }
@@ -359,7 +359,7 @@ public final class Attribute implements Cloneable, Serializable {
     public int hashCode() {
         return Objects.hash(
                 name, type, collectionType, sorting, dictionary, isPrefetch(), fastAccess, removeIfZero,
-                createIfNonExistent, isPosition, huge, mutable, swappable, enableBitVectors, enableOnlyBitVector,
+                createIfNonExistent, isPosition, huge, mutable, paged, enableBitVectors, enableOnlyBitVector,
                 tensorType, referenceDocumentType, distanceMetric, hnswIndexParams);
     }
 
@@ -384,7 +384,7 @@ public final class Attribute implements Cloneable, Serializable {
         if (this.fastSearch != other.fastSearch) return false;
         if (this.huge != other.huge) return false;
         if (this.mutable != other.mutable) return false;
-        if (this.swappable != other.swappable) return false;
+        if (this.paged != other.paged) return false;
         if (! this.sorting.equals(other.sorting)) return false;
         if (! Objects.equals(dictionary, other.dictionary)) return false;
         if (! Objects.equals(tensorType, other.tensorType)) return false;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/AttributeOperation.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/AttributeOperation.java
@@ -18,9 +18,10 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
     private Boolean fastSearch;
     private Boolean fastAccess;
     private Boolean mutable;
+    private Boolean swappable;
     private Boolean enableBitVectors;
     private Boolean enableOnlyBitVector;
-    //TODO: Husk sorting!!
+    //TODO: Remember sorting!!
     private boolean doAlias = false;
     private String alias;
     private String aliasedName;
@@ -72,6 +73,9 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
     }
     public void setMutable(Boolean mutable) {
         this.mutable = mutable;
+    }
+    public void setSwappable(Boolean swappable) {
+        this.swappable = swappable;
     }
 
     public Boolean getEnableBitVectors() {
@@ -130,6 +134,9 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
 
         if (huge != null) {
             attribute.setHuge(huge);
+        }
+        if (swappable != null) {
+            attribute.setSwappable(swappable);
         }
         if (fastSearch != null) {
             attribute.setFastSearch(fastSearch);

--- a/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/AttributeOperation.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/fieldoperation/AttributeOperation.java
@@ -18,7 +18,7 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
     private Boolean fastSearch;
     private Boolean fastAccess;
     private Boolean mutable;
-    private Boolean swappable;
+    private Boolean paged;
     private Boolean enableBitVectors;
     private Boolean enableOnlyBitVector;
     //TODO: Remember sorting!!
@@ -74,8 +74,8 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
     public void setMutable(Boolean mutable) {
         this.mutable = mutable;
     }
-    public void setSwappable(Boolean swappable) {
-        this.swappable = swappable;
+    public void setPaged(Boolean paged) {
+        this.paged = paged;
     }
 
     public Boolean getEnableBitVectors() {
@@ -135,8 +135,8 @@ public class AttributeOperation implements FieldOperation, FieldOperationContain
         if (huge != null) {
             attribute.setHuge(huge);
         }
-        if (swappable != null) {
-            attribute.setSwappable(swappable);
+        if (paged != null) {
+            attribute.setPaged(paged);
         }
         if (fastSearch != null) {
             attribute.setFastSearch(fastSearch);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
@@ -105,6 +105,7 @@ public class AttributeChangeValidator {
                 validateAttributeSetting(id, currAttr, nextAttr, AttributeChangeValidator::extractDictionaryType, "dictionary: btree/hash", result);
                 validateAttributeSetting(id, currAttr, nextAttr, AttributeChangeValidator::extractDictionaryCase, "dictionary: cased/uncased", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::isHuge, "huge", result);
+                validateAttributeSetting(id, currAttr, nextAttr, Attribute::isSwappable, "swappable", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::densePostingListThreshold, "dense-posting-list-threshold", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::isEnabledOnlyBitVector, "rank: filter", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::distanceMetric, "distance-metric", result);

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/search/AttributeChangeValidator.java
@@ -105,7 +105,7 @@ public class AttributeChangeValidator {
                 validateAttributeSetting(id, currAttr, nextAttr, AttributeChangeValidator::extractDictionaryType, "dictionary: btree/hash", result);
                 validateAttributeSetting(id, currAttr, nextAttr, AttributeChangeValidator::extractDictionaryCase, "dictionary: cased/uncased", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::isHuge, "huge", result);
-                validateAttributeSetting(id, currAttr, nextAttr, Attribute::isSwappable, "swappable", result);
+                validateAttributeSetting(id, currAttr, nextAttr, Attribute::isPaged, "paged", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::densePostingListThreshold, "dense-posting-list-threshold", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::isEnabledOnlyBitVector, "rank: filter", result);
                 validateAttributeSetting(id, currAttr, nextAttr, Attribute::distanceMetric, "distance-metric", result);

--- a/config-model/src/main/javacc/SDParser.jj
+++ b/config-model/src/main/javacc/SDParser.jj
@@ -299,6 +299,7 @@ TOKEN :
 | < ENABLEONLYBITVECTOR: "enable-only-bit-vector" >
 | < FASTACCESS: "fast-access" >
 | < MUTABLE: "mutable" >
+| < SWAPPABLE: "swappable" >
 | < FASTSEARCH: "fast-search" >
 | < HUGE: "huge" >
 | < TENSOR_TYPE: "tensor" ("<" (~["<",">"])+ ">")? "(" (~["(",")"])+ ")" >
@@ -1229,11 +1230,12 @@ Object attributeSetting(FieldOperationContainer field, AttributeOperation attrib
 }
 {
     (
-        <HUGE>                { attribute.setHuge(true); }
-      | <FASTSEARCH>          { attribute.setFastSearch(true); }
-      | <FASTACCESS>          { attribute.setFastAccess(true); }
-      | <MUTABLE>             { attribute.setMutable(true); }
-      | <ENABLEBITVECTORS>    { attribute.setEnableBitVectors(true); }
+        <HUGE>                   { attribute.setHuge(true); }
+      | <FASTSEARCH>            { attribute.setFastSearch(true); }
+      | <FASTACCESS>            { attribute.setFastAccess(true); }
+      | <MUTABLE>                { attribute.setMutable(true); }
+      | <SWAPPABLE>              { attribute.setSwappable(true); }
+      | <ENABLEBITVECTORS>       { attribute.setEnableBitVectors(true); }
       | <ENABLEONLYBITVECTOR> { attribute.setEnableOnlyBitVector(true); }
       | sorting(field, attributeName)
       | <ALIAS> { String alias; String aliasedName=attributeName; } [aliasedName = identifier()] <COLON> alias = identifierWithDash() {
@@ -2736,6 +2738,7 @@ String identifier() : { }
       | <SECONDPHASE>
       | <SORTING>
       | <SOURCE>
+      | <SWAPPABLE>
       | <SSCONTEXTUAL>
       | <SSOVERRIDE>
       | <SSTITLE>

--- a/config-model/src/main/javacc/SDParser.jj
+++ b/config-model/src/main/javacc/SDParser.jj
@@ -299,7 +299,7 @@ TOKEN :
 | < ENABLEONLYBITVECTOR: "enable-only-bit-vector" >
 | < FASTACCESS: "fast-access" >
 | < MUTABLE: "mutable" >
-| < SWAPPABLE: "swappable" >
+| < PAGED: "paged" >
 | < FASTSEARCH: "fast-search" >
 | < HUGE: "huge" >
 | < TENSOR_TYPE: "tensor" ("<" (~["<",">"])+ ">")? "(" (~["(",")"])+ ")" >
@@ -1230,13 +1230,13 @@ Object attributeSetting(FieldOperationContainer field, AttributeOperation attrib
 }
 {
     (
-        <HUGE>                   { attribute.setHuge(true); }
-      | <FASTSEARCH>            { attribute.setFastSearch(true); }
-      | <FASTACCESS>            { attribute.setFastAccess(true); }
-      | <MUTABLE>                { attribute.setMutable(true); }
-      | <SWAPPABLE>              { attribute.setSwappable(true); }
-      | <ENABLEBITVECTORS>       { attribute.setEnableBitVectors(true); }
-      | <ENABLEONLYBITVECTOR> { attribute.setEnableOnlyBitVector(true); }
+        <HUGE>                 { attribute.setHuge(true); }
+      | <FASTSEARCH>           { attribute.setFastSearch(true); }
+      | <FASTACCESS>           { attribute.setFastAccess(true); }
+      | <MUTABLE>              { attribute.setMutable(true); }
+      | <PAGED>                { attribute.setPaged(true); }
+      | <ENABLEBITVECTORS>     { attribute.setEnableBitVectors(true); }
+      | <ENABLEONLYBITVECTOR>  { attribute.setEnableOnlyBitVector(true); }
       | sorting(field, attributeName)
       | <ALIAS> { String alias; String aliasedName=attributeName; } [aliasedName = identifier()] <COLON> alias = identifierWithDash() {
           attribute.setDoAlias(true);
@@ -2738,7 +2738,7 @@ String identifier() : { }
       | <SECONDPHASE>
       | <SORTING>
       | <SOURCE>
-      | <SWAPPABLE>
+      | <PAGED>
       | <SSCONTEXTUAL>
       | <SSOVERRIDE>
       | <SSTITLE>

--- a/config-model/src/test/derived/advanced/attributes.cfg
+++ b/config-model/src/test/derived/advanced/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/advanced/attributes.cfg
+++ b/config-model/src/test/derived/advanced/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/array_of_struct_attribute/attributes.cfg
+++ b/config-model/src/test/derived/array_of_struct_attribute/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/array_of_struct_attribute/attributes.cfg
+++ b/config-model/src/test/derived/array_of_struct_attribute/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/attributeprefetch/attributes.cfg
+++ b/config-model/src/test/derived/attributeprefetch/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -287,7 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -318,7 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -349,7 +349,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -380,7 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -411,7 +411,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -442,7 +442,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -473,7 +473,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -504,7 +504,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -535,7 +535,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/attributeprefetch/attributes.cfg
+++ b/config-model/src/test/derived/attributeprefetch/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -278,6 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -308,6 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -338,6 +349,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -368,6 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -398,6 +411,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -428,6 +442,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -458,6 +473,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -488,6 +504,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -518,6 +535,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/attributes/attributes.cfg
+++ b/config-model/src/test/derived/attributes/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -278,6 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -308,6 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -338,6 +349,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -368,6 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -398,6 +411,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -428,6 +442,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -458,6 +473,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -488,6 +504,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -518,6 +535,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/attributes/attributes.cfg
+++ b/config-model/src/test/derived/attributes/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -287,7 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -318,7 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -349,7 +349,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -380,7 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -411,7 +411,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -442,7 +442,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -473,7 +473,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -504,7 +504,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -535,7 +535,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/complex/attributes.cfg
+++ b/config-model/src/test/derived/complex/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge true
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/complex/attributes.cfg
+++ b/config-model/src/test/derived/complex/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge true
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/hnsw_index/attributes.cfg
+++ b/config-model/src/test/derived/hnsw_index/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/hnsw_index/attributes.cfg
+++ b/config-model/src/test/derived/hnsw_index/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_fields_inherited_reference/attributes.cfg
+++ b/config-model/src/test/derived/imported_fields_inherited_reference/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_fields_inherited_reference/attributes.cfg
+++ b/config-model/src/test/derived/imported_fields_inherited_reference/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_position_field/attributes.cfg
+++ b/config-model/src/test/derived/imported_position_field/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_position_field/attributes.cfg
+++ b/config-model/src/test/derived/imported_position_field/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_struct_fields/attributes.cfg
+++ b/config-model/src/test/derived/imported_struct_fields/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/imported_struct_fields/attributes.cfg
+++ b/config-model/src/test/derived/imported_struct_fields/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/importedfields/attributes.cfg
+++ b/config-model/src/test/derived/importedfields/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/importedfields/attributes.cfg
+++ b/config-model/src/test/derived/importedfields/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/inheritance/attributes.cfg
+++ b/config-model/src/test/derived/inheritance/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/inheritance/attributes.cfg
+++ b/config-model/src/test/derived/inheritance/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/inheritfromparent/attributes.cfg
+++ b/config-model/src/test/derived/inheritfromparent/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/inheritfromparent/attributes.cfg
+++ b/config-model/src/test/derived/inheritfromparent/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/map_attribute/attributes.cfg
+++ b/config-model/src/test/derived/map_attribute/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/map_attribute/attributes.cfg
+++ b/config-model/src/test/derived/map_attribute/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/map_of_struct_attribute/attributes.cfg
+++ b/config-model/src/test/derived/map_of_struct_attribute/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/map_of_struct_attribute/attributes.cfg
+++ b/config-model/src/test/derived/map_of_struct_attribute/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/music/attributes.cfg
+++ b/config-model/src/test/derived/music/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -287,7 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -318,7 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/music/attributes.cfg
+++ b/config-model/src/test/derived/music/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -278,6 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -308,6 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/newrank/attributes.cfg
+++ b/config-model/src/test/derived/newrank/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -287,7 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/newrank/attributes.cfg
+++ b/config-model/src/test/derived/newrank/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -278,6 +287,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/predicate_attribute/attributes.cfg
+++ b/config-model/src/test/derived/predicate_attribute/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/predicate_attribute/attributes.cfg
+++ b/config-model/src/test/derived/predicate_attribute/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/prefixexactattribute/attributes.cfg
+++ b/config-model/src/test/derived/prefixexactattribute/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/prefixexactattribute/attributes.cfg
+++ b/config-model/src/test/derived/prefixexactattribute/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/reference_fields/attributes.cfg
+++ b/config-model/src/test/derived/reference_fields/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/reference_fields/attributes.cfg
+++ b/config-model/src/test/derived/reference_fields/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/sorting/attributes.cfg
+++ b/config-model/src/test/derived/sorting/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE

--- a/config-model/src/test/derived/sorting/attributes.cfg
+++ b/config-model/src/test/derived/sorting/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending false
 attribute[].sortfunction LOWERCASE

--- a/config-model/src/test/derived/tensor/attributes.cfg
+++ b/config-model/src/test/derived/tensor/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/tensor/attributes.cfg
+++ b/config-model/src/test/derived/tensor/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/types/attributes.cfg
+++ b/config-model/src/test/derived/types/attributes.cfg
@@ -8,7 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -39,7 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -70,7 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -101,7 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -132,7 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -163,7 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -194,7 +194,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -225,7 +225,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -256,7 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -287,7 +287,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -318,7 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -349,7 +349,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -380,7 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
-attribute[].swappable false
+attribute[].paged false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/derived/types/attributes.cfg
+++ b/config-model/src/test/derived/types/attributes.cfg
@@ -8,6 +8,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -38,6 +39,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -68,6 +70,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -98,6 +101,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -128,6 +132,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -158,6 +163,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -188,6 +194,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -218,6 +225,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -248,6 +256,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -278,6 +287,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -308,6 +318,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch true
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -338,6 +349,7 @@ attribute[].removeifzero true
 attribute[].createifnonexistent true
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA
@@ -368,6 +380,7 @@ attribute[].removeifzero false
 attribute[].createifnonexistent false
 attribute[].fastsearch false
 attribute[].huge false
+attribute[].swappable false
 attribute[].ismutable false
 attribute[].sortascending true
 attribute[].sortfunction UCA

--- a/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
@@ -35,7 +35,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         Search search = SearchBuilder.buildFromFile("src/test/examples/attributesettings.sd");
 
         SDField f1=(SDField) search.getDocument().getField("f1");
-        assertTrue(f1.getAttributes().size() == 1);
+        assertEquals(1, f1.getAttributes().size());
         Attribute a1 = f1.getAttributes().get(f1.getName());
         assertThat(a1.getType(), is(Attribute.Type.LONG));
         assertThat(a1.getCollectionType(), is(Attribute.CollectionType.SINGLE));
@@ -46,7 +46,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         assertFalse(a1.isCreateIfNonExistent());
 
         SDField f2=(SDField) search.getDocument().getField("f2");
-        assertTrue(f2.getAttributes().size() == 1);
+        assertEquals(1, f2.getAttributes().size());
         Attribute a2 = f2.getAttributes().get(f2.getName());
         assertThat(a2.getType(), is(Attribute.Type.LONG));
         assertThat(a2.getCollectionType(), is(Attribute.CollectionType.SINGLE));
@@ -57,7 +57,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         assertFalse(a2.isCreateIfNonExistent());
         assertThat(f2.getAliasToName().get("f2alias"), is("f2"));
         SDField f3=(SDField) search.getDocument().getField("f3");
-        assertTrue(f3.getAttributes().size() == 1);
+        assertEquals(1, f3.getAttributes().size());
         assertThat(f3.getAliasToName().get("f3alias"), is("f3"));
 
         Attribute a3 = f3.getAttributes().get(f3.getName());
@@ -80,7 +80,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
 
     private void assertWeightedSet(Search search, String name, boolean createIfNonExistent, boolean removeIfZero) {
         SDField f4 = (SDField) search.getDocument().getField(name);
-        assertTrue(f4.getAttributes().size() == 1);
+        assertEquals(1, f4.getAttributes().size());
         Attribute a4 = f4.getAttributes().get(f4.getName());
         assertThat(a4.getType(), is(Attribute.Type.STRING));
         assertThat(a4.getCollectionType(), is(Attribute.CollectionType.WEIGHTEDSET));
@@ -95,7 +95,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
     public void requireThatFastAccessCanBeSet() throws IOException, ParseException {
         Search search = SearchBuilder.buildFromFile("src/test/examples/attributesettings.sd");
         SDField field = (SDField) search.getDocument().getField("fast_access");
-        assertTrue(field.getAttributes().size() == 1);
+        assertEquals(1, field.getAttributes().size());
         Attribute attr = field.getAttributes().get(field.getName());
         assertTrue(attr.isFastAccess());
     }
@@ -136,7 +136,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
                         "    }\n" +
                         "  }\n" +
                         "}\n");
-        assertFalse(attr.isSwappable());
+        assertTrue(attr.isSwappable());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
@@ -123,7 +123,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
                         "    }\n" +
                         "  }\n" +
                         "}\n");
-        assertFalse(attr.isSwappable());
+        assertFalse(attr.isPaged());
     }
     @Test
     public void requireThatSwappableCanBeSet() throws ParseException {
@@ -132,11 +132,11 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
                         "  document test { \n" +
                         "    field f type int { \n" +
                         "      indexing: attribute \n" +
-                        "      attribute: swappable \n" +
+                        "      attribute: paged \n" +
                         "    }\n" +
                         "  }\n" +
                         "}\n");
-        assertTrue(attr.isSwappable());
+        assertTrue(attr.isPaged());
     }
 
     @Test
@@ -246,7 +246,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         single.setEnableOnlyBitVector(true);
         single.setFastSearch(true);
         single.setHuge(true);
-        single.setSwappable(true);
+        single.setPaged(true);
         single.setFastAccess(true);
         single.setPosition(true);
         single.setArity(5);
@@ -269,7 +269,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         assertTrue(array.isEnabledOnlyBitVector());
         assertTrue(array.isFastSearch());
         assertTrue(array.isHuge());
-        assertTrue(array.isSwappable());
+        assertTrue(array.isPaged());
         assertTrue(array.isFastAccess());
         assertTrue(array.isPosition());
         assertEquals(5, array.arity());

--- a/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
@@ -112,6 +112,33 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         SDField field = (SDField) search.getDocument().getField("f");
         return field.getAttributes().get(field.getName());
     }
+
+    @Test
+    public void requireThatSwappableIsDefaultOff() throws ParseException {
+        Attribute attr = getAttributeF(
+                "search test {\n" +
+                        "  document test { \n" +
+                        "    field f type int { \n" +
+                        "      indexing: attribute \n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}\n");
+        assertFalse(attr.isSwappable());
+    }
+    @Test
+    public void requireThatSwappableCanBeSet() throws ParseException {
+        Attribute attr = getAttributeF(
+                "search test {\n" +
+                        "  document test { \n" +
+                        "    field f type int { \n" +
+                        "      indexing: attribute \n" +
+                        "      attribute: swappable \n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}\n");
+        assertFalse(attr.isSwappable());
+    }
+
     @Test
     public void requireThatMutableIsDefaultOff() throws ParseException {
         Attribute attr = getAttributeF(
@@ -219,6 +246,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         single.setEnableOnlyBitVector(true);
         single.setFastSearch(true);
         single.setHuge(true);
+        single.setSwappable(true);
         single.setFastAccess(true);
         single.setPosition(true);
         single.setArity(5);
@@ -241,6 +269,7 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         assertTrue(array.isEnabledOnlyBitVector());
         assertTrue(array.isFastSearch());
         assertTrue(array.isHuge());
+        assertTrue(array.isSwappable());
         assertTrue(array.isFastAccess());
         assertTrue(array.isPosition());
         assertEquals(5, array.arity());

--- a/configdefinitions/src/vespa/attributes.def
+++ b/configdefinitions/src/vespa/attributes.def
@@ -11,7 +11,7 @@ attribute[].removeifzero        bool default=false
 attribute[].createifnonexistent bool default=false
 attribute[].fastsearch          bool default=false
 attribute[].huge                bool default=false
-attribute[].swapable            bool default=false
+attribute[].swappable           bool default=false
 # An attribute marked mutable can be updated by a query.
 attribute[].ismutable           bool default=false
 attribute[].sortascending       bool default=true

--- a/configdefinitions/src/vespa/attributes.def
+++ b/configdefinitions/src/vespa/attributes.def
@@ -11,7 +11,7 @@ attribute[].removeifzero        bool default=false
 attribute[].createifnonexistent bool default=false
 attribute[].fastsearch          bool default=false
 attribute[].huge                bool default=false
-attribute[].swappable           bool default=false
+attribute[].paged               bool default=false
 # An attribute marked mutable can be updated by a query.
 attribute[].ismutable           bool default=false
 attribute[].sortascending       bool default=true

--- a/configdefinitions/src/vespa/attributes.def
+++ b/configdefinitions/src/vespa/attributes.def
@@ -11,6 +11,7 @@ attribute[].removeifzero        bool default=false
 attribute[].createifnonexistent bool default=false
 attribute[].fastsearch          bool default=false
 attribute[].huge                bool default=false
+attribute[].swapable            bool default=false
 # An attribute marked mutable can be updated by a query.
 attribute[].ismutable           bool default=false
 attribute[].sortascending       bool default=true

--- a/searchcommon/src/vespa/searchcommon/attribute/config.cpp
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.cpp
@@ -14,6 +14,7 @@ Config::Config() noexcept :
     _isFilter(false),
     _fastAccess(false),
     _mutable(false),
+    _swapable(false),
     _match(Match::UNCASED),
     _dictionary(),
     _growStrategy(),
@@ -35,6 +36,7 @@ Config::Config(BasicType bt, CollectionType ct, bool fastSearch_, bool huge_) no
       _isFilter(false),
       _fastAccess(false),
       _mutable(false),
+      _swapable(false),
       _match(Match::UNCASED),
       _dictionary(),
       _growStrategy(),
@@ -64,6 +66,7 @@ Config::operator==(const Config &b) const
            _isFilter == b._isFilter &&
            _fastAccess == b._fastAccess &&
            _mutable == b._mutable &&
+           _swapable == b._swapable &&
            _match == b._match &&
            _dictionary == b._dictionary &&
            _growStrategy == b._growStrategy &&

--- a/searchcommon/src/vespa/searchcommon/attribute/config.cpp
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.cpp
@@ -14,7 +14,7 @@ Config::Config() noexcept :
         _isFilter(false),
         _fastAccess(false),
         _mutable(false),
-        _swappable(false),
+        _paged(false),
         _match(Match::UNCASED),
         _dictionary(),
         _growStrategy(),
@@ -36,7 +36,7 @@ Config::Config(BasicType bt, CollectionType ct, bool fastSearch_, bool huge_) no
       _isFilter(false),
       _fastAccess(false),
       _mutable(false),
-      _swappable(false),
+      _paged(false),
       _match(Match::UNCASED),
       _dictionary(),
       _growStrategy(),
@@ -66,7 +66,7 @@ Config::operator==(const Config &b) const
            _isFilter == b._isFilter &&
            _fastAccess == b._fastAccess &&
            _mutable == b._mutable &&
-           _swappable == b._swappable &&
+           _paged == b._paged &&
            _match == b._match &&
            _dictionary == b._dictionary &&
            _growStrategy == b._growStrategy &&

--- a/searchcommon/src/vespa/searchcommon/attribute/config.cpp
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.cpp
@@ -5,24 +5,24 @@
 namespace search::attribute {
 
 Config::Config() noexcept :
-    _basicType(BasicType::NONE),
-    _type(CollectionType::SINGLE),
-    _fastSearch(false),
-    _huge(false),
-    _enableBitVectors(false),
-    _enableOnlyBitVector(false),
-    _isFilter(false),
-    _fastAccess(false),
-    _mutable(false),
-    _swapable(false),
-    _match(Match::UNCASED),
-    _dictionary(),
-    _growStrategy(),
-    _compactionStrategy(),
-    _predicateParams(),
-    _tensorType(vespalib::eval::ValueType::error_type()),
-    _distance_metric(DistanceMetric::Euclidean),
-    _hnsw_index_params()
+        _basicType(BasicType::NONE),
+        _type(CollectionType::SINGLE),
+        _fastSearch(false),
+        _huge(false),
+        _enableBitVectors(false),
+        _enableOnlyBitVector(false),
+        _isFilter(false),
+        _fastAccess(false),
+        _mutable(false),
+        _swappable(false),
+        _match(Match::UNCASED),
+        _dictionary(),
+        _growStrategy(),
+        _compactionStrategy(),
+        _predicateParams(),
+        _tensorType(vespalib::eval::ValueType::error_type()),
+        _distance_metric(DistanceMetric::Euclidean),
+        _hnsw_index_params()
 {
 }
 
@@ -36,7 +36,7 @@ Config::Config(BasicType bt, CollectionType ct, bool fastSearch_, bool huge_) no
       _isFilter(false),
       _fastAccess(false),
       _mutable(false),
-      _swapable(false),
+      _swappable(false),
       _match(Match::UNCASED),
       _dictionary(),
       _growStrategy(),
@@ -66,7 +66,7 @@ Config::operator==(const Config &b) const
            _isFilter == b._isFilter &&
            _fastAccess == b._fastAccess &&
            _mutable == b._mutable &&
-           _swapable == b._swapable &&
+           _swappable == b._swappable &&
            _match == b._match &&
            _dictionary == b._dictionary &&
            _growStrategy == b._growStrategy &&

--- a/searchcommon/src/vespa/searchcommon/attribute/config.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.h
@@ -40,7 +40,7 @@ public:
     CollectionType collectionType()       const { return _type; }
     bool fastSearch()                     const { return _fastSearch; }
     bool huge()                           const { return _huge; }
-    bool swapable()                       const { return _swapable; }
+    bool swappable()                      const { return _swappable; }
     const PredicateParams &predicateParams() const { return _predicateParams; }
     const vespalib::eval::ValueType & tensorType() const { return _tensorType; }
     DistanceMetric distance_metric() const { return _distance_metric; }
@@ -117,7 +117,7 @@ public:
      */
     Config & setIsFilter(bool isFilter) { _isFilter = isFilter; return *this; }
     Config & setMutable(bool isMutable) { _mutable = isMutable; return *this; }
-    Config & setSwapable(bool isSwapable) { _swapable = isSwapable; return *this; }
+    Config & setSwappable(bool isSwappable) { _swappable = isSwappable; return *this; }
     Config & setFastAccess(bool v) { _fastAccess = v; return *this; }
     Config & setGrowStrategy(const GrowStrategy &gs) { _growStrategy = gs; return *this; }
     Config & setCompactionStrategy(const CompactionStrategy &compactionStrategy) {
@@ -139,7 +139,7 @@ private:
     bool           _isFilter;
     bool           _fastAccess;
     bool           _mutable;
-    bool           _swapable;
+    bool           _swappable;
     Match                          _match;
     DictionaryConfig               _dictionary;
     GrowStrategy                   _growStrategy;

--- a/searchcommon/src/vespa/searchcommon/attribute/config.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.h
@@ -40,7 +40,7 @@ public:
     CollectionType collectionType()       const { return _type; }
     bool fastSearch()                     const { return _fastSearch; }
     bool huge()                           const { return _huge; }
-    bool swappable()                      const { return _swappable; }
+    bool paged()                          const { return _paged; }
     const PredicateParams &predicateParams() const { return _predicateParams; }
     const vespalib::eval::ValueType & tensorType() const { return _tensorType; }
     DistanceMetric distance_metric() const { return _distance_metric; }
@@ -117,7 +117,7 @@ public:
      */
     Config & setIsFilter(bool isFilter) { _isFilter = isFilter; return *this; }
     Config & setMutable(bool isMutable) { _mutable = isMutable; return *this; }
-    Config & setSwappable(bool isSwappable) { _swappable = isSwappable; return *this; }
+    Config & setPaged(bool paged_in) { _paged = paged_in; return *this; }
     Config & setFastAccess(bool v) { _fastAccess = v; return *this; }
     Config & setGrowStrategy(const GrowStrategy &gs) { _growStrategy = gs; return *this; }
     Config & setCompactionStrategy(const CompactionStrategy &compactionStrategy) {
@@ -139,7 +139,7 @@ private:
     bool           _isFilter;
     bool           _fastAccess;
     bool           _mutable;
-    bool           _swappable;
+    bool           _paged;
     Match                          _match;
     DictionaryConfig               _dictionary;
     GrowStrategy                   _growStrategy;

--- a/searchcommon/src/vespa/searchcommon/attribute/config.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/config.h
@@ -40,6 +40,7 @@ public:
     CollectionType collectionType()       const { return _type; }
     bool fastSearch()                     const { return _fastSearch; }
     bool huge()                           const { return _huge; }
+    bool swapable()                       const { return _swapable; }
     const PredicateParams &predicateParams() const { return _predicateParams; }
     const vespalib::eval::ValueType & tensorType() const { return _tensorType; }
     DistanceMetric distance_metric() const { return _distance_metric; }
@@ -116,6 +117,7 @@ public:
      */
     Config & setIsFilter(bool isFilter) { _isFilter = isFilter; return *this; }
     Config & setMutable(bool isMutable) { _mutable = isMutable; return *this; }
+    Config & setSwapable(bool isSwapable) { _swapable = isSwapable; return *this; }
     Config & setFastAccess(bool v) { _fastAccess = v; return *this; }
     Config & setGrowStrategy(const GrowStrategy &gs) { _growStrategy = gs; return *this; }
     Config & setCompactionStrategy(const CompactionStrategy &compactionStrategy) {
@@ -137,6 +139,7 @@ private:
     bool           _isFilter;
     bool           _fastAccess;
     bool           _mutable;
+    bool           _swapable;
     Match                          _match;
     DictionaryConfig               _dictionary;
     GrowStrategy                   _growStrategy;

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -238,9 +238,9 @@ TEST("require that config can be converted")
     }
     {
         CACA a;
-        EXPECT_TRUE(!CC::convert(a).swappable());
-        a.swappable = true;
-        EXPECT_TRUE(CC::convert(a).swappable());
+        EXPECT_TRUE(!CC::convert(a).paged());
+        a.paged = true;
+        EXPECT_TRUE(CC::convert(a).paged());
     }
     { // tensor
         CACA a;

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -238,9 +238,9 @@ TEST("require that config can be converted")
     }
     {
         CACA a;
-        EXPECT_TRUE(!CC::convert(a).swapable());
+        EXPECT_TRUE(!CC::convert(a).swappable());
         a.swappable = true;
-        EXPECT_TRUE(CC::convert(a).swapable());
+        EXPECT_TRUE(CC::convert(a).swappable());
     }
     { // tensor
         CACA a;

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -20,43 +20,13 @@ using namespace search::attribute;
 using std::shared_ptr;
 using vespalib::stringref;
 
-typedef BasicType      BT;
-typedef CollectionType CT;
-typedef AttributeVector::SP             AVSP;
+using BT = BasicType;
+using CT = CollectionType;
+using AVSP = AttributeVector::SP;
 
 namespace search {
 
-class AttributeManagerTest : public vespalib::TestApp
-{
-private:
-    void verifyLoad(AttributeVector & v);
-    void testLoad();
-    void testGuards();
-    void testConfigConvert();
-    void testContext();
-    void can_get_readable_attribute_vector_by_name();
-
-    bool
-    assertDataType(BT::Type exp,
-                   AttributesConfig::Attribute::Datatype in);
-
-    bool
-    assertCollectionType(CollectionType exp,
-                         AttributesConfig::Attribute::Collectiontype in,
-                         bool removeIfZ = false,
-                         bool createIfNe = false);
-
-public:
-    AttributeManagerTest()
-    {
-    }
-    int Main() override;
-};
-
-
-typedef MultiValueNumericAttribute< IntegerAttributeTemplate<int32_t>,
-                                    multivalue::Value<int32_t> >
-TestAttributeBase;
+using TestAttributeBase = MultiValueNumericAttribute< IntegerAttributeTemplate<int32_t>, multivalue::Value<int32_t> >;
 
 class TestAttribute : public TestAttributeBase
 {
@@ -73,8 +43,7 @@ public:
 };
 
 
-void
-AttributeManagerTest::testGuards()
+TEST("Test attribute guards")
 {
     AttributeVector::SP vec(new TestAttribute("mvint") );
     TestAttribute * v = static_cast<TestAttribute *> (vec.get());
@@ -134,7 +103,7 @@ AttributeManagerTest::testGuards()
 
 
 void
-AttributeManagerTest::verifyLoad(AttributeVector & v)
+verifyLoad(AttributeVector & v)
 {
     EXPECT_TRUE( !v.isLoaded() );
     EXPECT_TRUE( v.load() );
@@ -143,8 +112,7 @@ AttributeManagerTest::verifyLoad(AttributeVector & v)
 }
 
 
-void
-AttributeManagerTest::testLoad()
+TEST("Test loading of attributes")
 {
     {
         TestAttributeBase v("mvint");
@@ -172,14 +140,14 @@ AttributeManagerTest::testLoad()
         verifyLoad(v);
     }
     {
-        AttributeVector::Config config(BT::INT32,
+        Config config(BT::INT32,
                                        CollectionType::ARRAY);
         TestAttributeBase v("mvint", config);
         verifyLoad(v);
     }
     {
         AttributeManager manager;
-        AttributeVector::Config config(BT::INT32,
+        Config config(BT::INT32,
                                        CollectionType::ARRAY);
         EXPECT_TRUE(manager.addVector("mvint", config));
         AttributeManager::AttributeList list;
@@ -193,7 +161,7 @@ AttributeManagerTest::testLoad()
 
 
 bool
-AttributeManagerTest::assertDataType(BT::Type exp, AttributesConfig::Attribute::Datatype in)
+assertDataType(BT::Type exp, AttributesConfig::Attribute::Datatype in)
 {
     AttributesConfig::Attribute a;
     a.datatype = in;
@@ -202,25 +170,22 @@ AttributeManagerTest::assertDataType(BT::Type exp, AttributesConfig::Attribute::
 
 
 bool
-AttributeManagerTest::
 assertCollectionType(CollectionType exp, AttributesConfig::Attribute::Collectiontype in,
-                     bool removeIfZ, bool createIfNe)
+                     bool removeIfZ = false, bool createIfNe = false)
 {
     AttributesConfig::Attribute a;
     a.collectiontype = in;
     a.removeifzero = removeIfZ;
     a.createifnonexistent = createIfNe;
-    AttributeVector::Config out = ConfigConverter::convert(a);
+    Config out = ConfigConverter::convert(a);
     return EXPECT_EQUAL(exp.type(), out.collectionType().type()) &&
         EXPECT_EQUAL(exp.removeIfZero(), out.collectionType().removeIfZero()) &&
         EXPECT_EQUAL(exp.createIfNonExistant(), out.collectionType().createIfNonExistant());
 }
 
 
-void
-AttributeManagerTest::testConfigConvert()
+TEST("require that config can be converted")
 {
-    // typedef AttributeVector::Config AVC;
     typedef BT AVBT;
     typedef CollectionType AVCT;
     using CACA = AttributesConfig::Attribute;
@@ -271,11 +236,17 @@ AttributeManagerTest::testConfigConvert()
         a.ismutable = true;
         EXPECT_TRUE(CC::convert(a).isMutable());
     }
+    {
+        CACA a;
+        EXPECT_TRUE(!CC::convert(a).swapable());
+        a.swapable = true;
+        EXPECT_TRUE(CC::convert(a).swapable());
+    }
     { // tensor
         CACA a;
         a.datatype = CACAD::TENSOR;
         a.tensortype = "tensor(x[5])";
-        AttributeVector::Config out = ConfigConverter::convert(a);
+        Config out = ConfigConverter::convert(a);
         EXPECT_EQUAL("tensor(x[5])", out.tensorType().to_spec());
     }
     { // distance metric (default)
@@ -334,8 +305,7 @@ bool gt_attribute(const attribute::IAttributeVector * a, const attribute::IAttri
     return a->getName() < b->getName();
 }
 
-void
-AttributeManagerTest::testContext()
+TEST("test the attribute context")
 {
     std::vector<AVSP> attrs;
     // create various attributes vectors
@@ -370,13 +340,13 @@ AttributeManagerTest::testContext()
         }
 
         for (uint32_t i = 0; i < 2; ++i) {
-            EXPECT_TRUE(first->getAttribute("sint32") != NULL);
-            EXPECT_TRUE(first->getAttribute("aint32") != NULL);
-            EXPECT_TRUE(first->getAttribute("wsint32") != NULL);
-            EXPECT_TRUE(first->getAttributeStableEnum("wsint32") != NULL);
+            EXPECT_TRUE(first->getAttribute("sint32") != nullptr);
+            EXPECT_TRUE(first->getAttribute("aint32") != nullptr);
+            EXPECT_TRUE(first->getAttribute("wsint32") != nullptr);
+            EXPECT_TRUE(first->getAttributeStableEnum("wsint32") != nullptr);
         }
-        EXPECT_TRUE(first->getAttribute("foo") == NULL);
-        EXPECT_TRUE(first->getAttribute("bar") == NULL);
+        EXPECT_TRUE(first->getAttribute("foo") == nullptr);
+        EXPECT_TRUE(first->getAttribute("bar") == nullptr);
 
         // one generation guard taken per attribute asked for
         for (uint32_t i = 0; i < attrs.size(); ++i) {
@@ -388,10 +358,10 @@ AttributeManagerTest::testContext()
         {
             IAttributeContext::UP second = manager.createContext();
 
-            EXPECT_TRUE(second->getAttribute("sint32") != NULL);
-            EXPECT_TRUE(second->getAttribute("aint32") != NULL);
-            EXPECT_TRUE(second->getAttribute("wsint32") != NULL);
-            EXPECT_TRUE(second->getAttributeStableEnum("wsint32") != NULL);
+            EXPECT_TRUE(second->getAttribute("sint32") != nullptr);
+            EXPECT_TRUE(second->getAttribute("aint32") != nullptr);
+            EXPECT_TRUE(second->getAttribute("wsint32") != nullptr);
+            EXPECT_TRUE(second->getAttributeStableEnum("wsint32") != nullptr);
 
             // two generation guards taken per attribute asked for
             for (uint32_t i = 0; i < attrs.size(); ++i) {
@@ -428,8 +398,7 @@ AttributeManagerTest::testContext()
     }
 }
 
-void
-AttributeManagerTest::can_get_readable_attribute_vector_by_name()
+TEST("require that we can get readable attribute by name")
 {
     auto attr = AttributeFactory::createAttribute("cool_attr", Config(BT::INT32, CT::SINGLE));
     // Ensure there's something to actually load, or fetching the attribute will throw.
@@ -443,20 +412,7 @@ AttributeManagerTest::can_get_readable_attribute_vector_by_name()
     EXPECT_TRUE(av.get() == nullptr);
 }
 
-int AttributeManagerTest::Main()
-{
-    TEST_INIT("attributemanager_test");
-
-    testLoad();
-    testGuards();
-    testConfigConvert();
-    testContext();
-    can_get_readable_attribute_vector_by_name();
-
-    TEST_DONE();
-}
-
 } // namespace search
 
 
-TEST_APPHOOK(search::AttributeManagerTest);
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
+++ b/searchlib/src/tests/attribute/attributemanager/attributemanager_test.cpp
@@ -239,7 +239,7 @@ TEST("require that config can be converted")
     {
         CACA a;
         EXPECT_TRUE(!CC::convert(a).swapable());
-        a.swapable = true;
+        a.swappable = true;
         EXPECT_TRUE(CC::convert(a).swapable());
     }
     { // tensor

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -335,7 +335,7 @@ struct Fixture {
             _denseTensors = true;
         }
         if (_traits.use_mmap_file_allocator) {
-            _cfg.setSwappable(true);
+            _cfg.setPaged(true);
         }
         if (_traits.use_mock_index) {
             _index_factory = std::make_unique<MockNearestNeighborIndexFactory>();
@@ -1010,7 +1010,7 @@ TEST_F("NN blueprint handles strong filter triggering brute force search", Neare
     EXPECT_FALSE(bp->may_approximate());
 }
 
-TEST("Dense tensor attribute with swappable flag uses mmap file allocator")
+TEST("Dense tensor attribute with paged flag uses mmap file allocator")
 {
     vespalib::string basedir("mmap-file-allocator-factory-dir");
     vespalib::alloc::MmapFileAllocatorFactory::instance().setup(basedir);

--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -26,6 +26,7 @@
 #include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/mmap_file_allocator_factory.h>
 #include <vespa/searchlib/util/bufferwriter.h>
 
 #include <vespa/log/log.h>
@@ -256,10 +257,16 @@ struct FixtureTraits {
     bool use_direct_tensor_attribute = false;
     bool enable_hnsw_index = false;
     bool use_mock_index = false;
+    bool use_mmap_file_allocator = false;
 
     FixtureTraits dense() && {
         use_dense_tensor_attribute = true;
         enable_hnsw_index = false;
+        return *this;
+    }
+
+    FixtureTraits mmap_file_allocator() && {
+        use_mmap_file_allocator = true;
         return *this;
     }
 
@@ -326,6 +333,9 @@ struct Fixture {
         _cfg.setTensorType(ValueType::from_spec(_typeSpec));
         if (_cfg.tensorType().is_dense()) {
             _denseTensors = true;
+        }
+        if (_traits.use_mmap_file_allocator) {
+            _cfg.setSwappable(true);
         }
         if (_traits.use_mock_index) {
             _index_factory = std::make_unique<MockNearestNeighborIndexFactory>();
@@ -998,6 +1008,19 @@ TEST_F("NN blueprint handles strong filter triggering brute force search", Neare
     bp->set_global_filter(*strong_filter);
     EXPECT_EQUAL(11u, bp->getState().estimate().estHits);
     EXPECT_FALSE(bp->may_approximate());
+}
+
+TEST("Dense tensor attribute with swappable flag uses mmap file allocator")
+{
+    vespalib::string basedir("mmap-file-allocator-factory-dir");
+    vespalib::alloc::MmapFileAllocatorFactory::instance().setup(basedir);
+    {
+        Fixture f(vec_2d_spec, FixtureTraits().dense().mmap_file_allocator());
+        vespalib::string allocator_dir(basedir + "/0.my_attr");
+        EXPECT_TRUE(vespalib::isDirectory(allocator_dir));
+    }
+    vespalib::alloc::MmapFileAllocatorFactory::instance().setup("");
+    vespalib::rmdir(basedir, true);
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/tensor/dense_tensor_store/dense_tensor_store_test.cpp
+++ b/searchlib/src/tests/tensor/dense_tensor_store/dense_tensor_store_test.cpp
@@ -1,14 +1,14 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include <vespa/log/log.h>
+LOG_SETUP("dense_tensor_store_test");
 #include <vespa/vespalib/testkit/test_kit.h>
+#include <vespa/vespalib/util/memory_allocator.h>
 #include <vespa/searchlib/tensor/dense_tensor_store.h>
 #include <vespa/eval/eval/simple_value.h>
 #include <vespa/eval/eval/tensor_spec.h>
 #include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/value_type.h>
 #include <vespa/eval/eval/test/value_compare.h>
-
-#include <vespa/log/log.h>
-LOG_SETUP("dense_tensor_store_test");
 
 using search::tensor::DenseTensorStore;
 using vespalib::eval::SimpleValue;
@@ -28,7 +28,7 @@ struct Fixture
 {
     DenseTensorStore store;
     Fixture(const vespalib::string &tensorType)
-        : store(ValueType::from_spec(tensorType))
+        : store(ValueType::from_spec(tensorType), {})
     {}
     void assertSetAndGetTensor(const TensorSpec &tensorSpec) {
         Value::UP expTensor = makeTensor(tensorSpec);

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -282,6 +282,14 @@ public:
 
     virtual IExtendAttribute * getExtendInterface();
 
+    /**
+     * Returns the number of readers holding a generation guard.
+     * Should be called by the writer thread.
+     **/
+    uint32_t getGenerationRefCount(generation_t gen) const {
+        return _genHandler.getGenerationRefCount(gen);
+    }
+
 protected:
     /**
      * Called when a new document has been added, but only for
@@ -290,14 +298,6 @@ protected:
      * Should return true if underlying structures were resized.
      **/
     virtual bool onAddDoc(DocId) { return false; }
-
-    /**
-     * Returns the number of readers holding a generation guard.
-     * Should be called by the writer thread.
-     */
-    uint32_t getGenerationRefCount(generation_t gen) const {
-        return _genHandler.getGenerationRefCount(gen);
-    }
 
     const GenerationHandler & getGenerationHandler() const {
         return _genHandler;

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -108,7 +108,7 @@ ConfigConverter::convert(const AttributesConfig::Attribute & cfg)
     retval.setIsFilter(cfg.enableonlybitvector);
     retval.setFastAccess(cfg.fastaccess);
     retval.setMutable(cfg.ismutable);
-    retval.setSwapable(cfg.swappable);
+    retval.setSwappable(cfg.swappable);
     predicateParams.setArity(cfg.arity);
     predicateParams.setBounds(cfg.lowerbound, cfg.upperbound);
     predicateParams.setDensePostingListThreshold(cfg.densepostinglistthreshold);

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -108,7 +108,7 @@ ConfigConverter::convert(const AttributesConfig::Attribute & cfg)
     retval.setIsFilter(cfg.enableonlybitvector);
     retval.setFastAccess(cfg.fastaccess);
     retval.setMutable(cfg.ismutable);
-    retval.setSwappable(cfg.swappable);
+    retval.setPaged(cfg.paged);
     predicateParams.setArity(cfg.arity);
     predicateParams.setBounds(cfg.lowerbound, cfg.upperbound);
     predicateParams.setDensePostingListThreshold(cfg.densepostinglistthreshold);

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -108,7 +108,7 @@ ConfigConverter::convert(const AttributesConfig::Attribute & cfg)
     retval.setIsFilter(cfg.enableonlybitvector);
     retval.setFastAccess(cfg.fastaccess);
     retval.setMutable(cfg.ismutable);
-    retval.setSwapable(cfg.swapable);
+    retval.setSwapable(cfg.swappable);
     predicateParams.setArity(cfg.arity);
     predicateParams.setBounds(cfg.lowerbound, cfg.upperbound);
     predicateParams.setDensePostingListThreshold(cfg.densepostinglistthreshold);

--- a/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/configconverter.cpp
@@ -108,6 +108,7 @@ ConfigConverter::convert(const AttributesConfig::Attribute & cfg)
     retval.setIsFilter(cfg.enableonlybitvector);
     retval.setFastAccess(cfg.fastaccess);
     retval.setMutable(cfg.ismutable);
+    retval.setSwapable(cfg.swapable);
     predicateParams.setArity(cfg.arity);
     predicateParams.setBounds(cfg.lowerbound, cfg.upperbound);
     predicateParams.setDensePostingListThreshold(cfg.densepostinglistthreshold);

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -10,6 +10,8 @@
 #include <vespa/searchlib/attribute/load_utils.h>
 #include <vespa/searchlib/attribute/readerbase.h>
 #include <vespa/vespalib/data/slime/inserter.h>
+#include <vespa/vespalib/util/memory_allocator.h>
+#include <vespa/vespalib/util/mmap_file_allocator_factory.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.tensor.dense_tensor_attribute");
@@ -72,6 +74,15 @@ can_use_index_save_file(const search::attribute::Config &config, const search::a
     return true;
 }
 
+std::unique_ptr<vespalib::alloc::MemoryAllocator>
+make_memory_allocator(const vespalib::string& name, bool swappable)
+{
+    if (swappable) {
+        return vespalib::alloc::MmapFileAllocatorFactory::instance().make_memory_allocator(name);
+    }
+    return {};
+}
+
 }
 
 void
@@ -114,7 +125,7 @@ DenseTensorAttribute::memory_usage() const
 DenseTensorAttribute::DenseTensorAttribute(vespalib::stringref baseFileName, const Config& cfg,
                                            const NearestNeighborIndexFactory& index_factory)
     : TensorAttribute(baseFileName, cfg, _denseTensorStore),
-      _denseTensorStore(cfg.tensorType()),
+      _denseTensorStore(cfg.tensorType(), make_memory_allocator(getName(), cfg.swappable())),
       _index()
 {
     if (cfg.hnsw_index_params().has_value()) {

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.cpp
@@ -125,7 +125,7 @@ DenseTensorAttribute::memory_usage() const
 DenseTensorAttribute::DenseTensorAttribute(vespalib::stringref baseFileName, const Config& cfg,
                                            const NearestNeighborIndexFactory& index_factory)
     : TensorAttribute(baseFileName, cfg, _denseTensorStore),
-      _denseTensorStore(cfg.tensorType(), make_memory_allocator(getName(), cfg.swappable())),
+      _denseTensorStore(cfg.tensorType(), make_memory_allocator(getName(), cfg.paged())),
       _index()
 {
     if (cfg.hnsw_index_params().has_value()) {

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.h
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_attribute.h
@@ -29,7 +29,7 @@ private:
 public:
     DenseTensorAttribute(vespalib::stringref baseFileName, const Config& cfg,
                          const NearestNeighborIndexFactory& index_factory = DefaultNearestNeighborIndexFactory());
-    virtual ~DenseTensorAttribute();
+    ~DenseTensorAttribute() override;
     // Implements AttributeVector and ITensorAttribute
     uint32_t clearDoc(DocId docId) override;
     void setTensor(DocId docId, const vespalib::eval::Value &tensor) override;

--- a/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/dense_tensor_store.h
@@ -36,10 +36,12 @@ public:
     class BufferType : public vespalib::datastore::BufferType<char>
     {
         using CleanContext = vespalib::datastore::BufferType<char>::CleanContext;
+        std::unique_ptr<vespalib::alloc::MemoryAllocator> _allocator;
     public:
-        BufferType(const TensorSizeCalc &tensorSizeCalc);
+        BufferType(const TensorSizeCalc &tensorSizeCalc, std::unique_ptr<vespalib::alloc::MemoryAllocator> allocator);
         ~BufferType() override;
         void cleanHold(void *buffer, size_t offset, ElemCount numElems, CleanContext cleanCtx) override;
+        const vespalib::alloc::MemoryAllocator* get_memory_allocator() const override;
     };
 private:
     DataStoreType _concreteStore;
@@ -55,7 +57,7 @@ private:
     setDenseTensor(const TensorType &tensor);
 
 public:
-    DenseTensorStore(const ValueType &type);
+    DenseTensorStore(const ValueType &type, std::unique_ptr<vespalib::alloc::MemoryAllocator> allocator);
     ~DenseTensorStore() override;
 
     const ValueType &type() const { return _type; }


### PR DESCRIPTION
@toregge PR
This reintroduces file backed memory allocator now controlled by `attribute::swappable`, as opposed to the ad-doc testing done earlier on with `attribute:huge`.
This relates to #18646 and includes a modified reversal of #17205