### PR TITLE
Allow file distribution rpc requests while bootstrapping

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -77,12 +77,14 @@ public class ConfigServerBootstrapTest {
         assertFalse(vipStatus.isInRotation());
         bootstrap.start();
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
+        assertTrue(rpcServer.isServingConfigRequests());
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");
         waitUntil(vipStatus::isInRotation, "failed waiting for server to be in rotation");
 
         bootstrap.deconstruct();
         assertEquals(StateMonitor.Status.down, bootstrap.status());
         assertFalse(rpcServer.isRunning());
+        assertTrue(rpcServer.isServingConfigRequests());
         assertFalse(vipStatus.isInRotation());
     }
 
@@ -108,6 +110,7 @@ public class ConfigServerBootstrapTest {
 
         bootstrap.start();
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
+        assertTrue(rpcServer.isServingConfigRequests());
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");
         waitUntil(vipStatus::isInRotation, "failed waiting for server to be in rotation");
         bootstrap.deconstruct();
@@ -140,7 +143,8 @@ public class ConfigServerBootstrapTest {
         // App is invalid, bootstrapping was unsuccessful. Status should be 'initializing',
         // rpc server should not be running and it should be out of rotation
         assertEquals(StateMonitor.Status.initializing, stateMonitor.status());
-        assertFalse(rpcServer.isRunning());
+        assertTrue(rpcServer.isRunning());
+        assertFalse(rpcServer.isServingConfigRequests());
         assertFalse(vipStatus.isInRotation());
 
         bootstrap.deconstruct();
@@ -179,6 +183,7 @@ public class ConfigServerBootstrapTest {
                                                                     stateMonitor, vipStatus, VIP_STATUS_PROGRAMMATICALLY);
         bootstrap.start();
         waitUntil(rpcServer::isRunning, "failed waiting for Rpc server running");
+        assertTrue(rpcServer.isServingConfigRequests());
         waitUntil(() -> bootstrap.status() == StateMonitor.Status.up, "failed waiting for status 'up'");
         waitUntil(vipStatus::isInRotation, "failed waiting for server to be in rotation");
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/RpcTester.java
@@ -114,7 +114,7 @@ public class RpcTester implements AutoCloseable {
     }
 
     RpcServer createRpcServer(ConfigserverConfig config) throws IOException {
-        return new RpcServer(config,
+        RpcServer rpcServer = new RpcServer(config,
                              new SuperModelRequestHandler(new TestConfigDefinitionRepo(),
                                                           configserverConfig,
                                                           new SuperModelManager(
@@ -128,6 +128,8 @@ public class RpcTester implements AutoCloseable {
                              new FileServer(temporaryFolder.newFolder()),
                              new NoopRpcAuthorizer(),
                              new RpcRequestHandlerProvider());
+        rpcServer.setUpGetConfigHandlers();
+        return rpcServer;
     }
 
     void startRpcServer()  {


### PR DESCRIPTION
We do not want to server config requests while bootstrapping, since we
have not finished deploying all applications yet and don't want to serve
stale or empty config. File distributuion requests should be OK, though,
if we cannot serve the requests (unknown file, host is not allowed to
get file etc.), the client will try another config server.

