### PR TITLE
Use 4096 buffers for HNSW link array store.

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/hnsw_graph.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_graph.h
@@ -18,7 +18,10 @@ struct HnswGraph {
 
     // This uses 10 bits for buffer id -> 1024 buffers.
     // As we have very short arrays we get less fragmentation with fewer and larger buffers.
-    using EntryRefType = vespalib::datastore::EntryRefT<22>;
+    using LevelArrayEntryRefType = vespalib::datastore::EntryRefT<22>;
+
+    // This uses 12 bits for buffer id -> 4096 buffers.
+    using LinkArrayEntryRefType = vespalib::datastore::EntryRefT<20>;
 
     // Provides mapping from document id -> node reference.
     // The reference is used to lookup the node data in NodeStore.
@@ -27,13 +30,13 @@ struct HnswGraph {
 
     // This stores the level arrays for all nodes.
     // Each node consists of an array of levels (from level 0 to n) where each entry is a reference to the link array at that level.
-    using NodeStore = vespalib::datastore::ArrayStore<AtomicEntryRef, EntryRefType>;
+    using NodeStore = vespalib::datastore::ArrayStore<AtomicEntryRef, LevelArrayEntryRefType>;
     using StoreConfig = vespalib::datastore::ArrayStoreConfig;
     using LevelArrayRef = NodeStore::ConstArrayRef;
 
     // This stores all link arrays.
     // A link array consists of the document ids of the nodes a particular node is linked to.
-    using LinkStore = vespalib::datastore::ArrayStore<uint32_t, EntryRefType>;
+    using LinkStore = vespalib::datastore::ArrayStore<uint32_t, LinkArrayEntryRefType>;
     using LinkArrayRef = LinkStore::ConstArrayRef;
 
     NodeRefVector node_refs;

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -30,7 +30,7 @@ constexpr size_t min_num_arrays_for_new_buffer = 512_Ki;
 constexpr float alloc_grow_factor = 0.3;
 // TODO: Adjust these numbers to what we accept as max in config.
 constexpr size_t max_level_array_size = 16;
-constexpr size_t max_link_array_size = 64;
+constexpr size_t max_link_array_size = 193;
 constexpr vespalib::duration MAX_COUNT_DURATION(100ms);
 
 bool has_link_to(vespalib::ConstArrayRef<uint32_t> links, uint32_t id) {

--- a/vespalib/src/vespa/vespalib/datastore/entryref.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/entryref.cpp
@@ -8,6 +8,7 @@ namespace vespalib::datastore {
 template EntryRefT<24u, 8u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<31u, 1u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<22u,10u>::EntryRefT(size_t, uint32_t);
+template EntryRefT<20u,12u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<19u,13u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<18u, 6u>::EntryRefT(size_t, uint32_t);
 template EntryRefT<15u,17u>::EntryRefT(size_t, uint32_t);


### PR DESCRIPTION
Configure link array store to handle arrays of 193 elements or less without indirect storage.

This PR is related to issue #18153.

@baldersheim : please review
@geirst : FYI
