### PR TITLE
Revert "Metric for last successful update of IP tables"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainer.java
@@ -2,10 +2,7 @@
 package com.yahoo.vespa.hosted.node.admin.maintenance.acl;
 
 import com.google.common.net.InetAddresses;
-import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.NodeSpec;
 import com.yahoo.vespa.hosted.node.admin.container.ContainerOperations;
-import com.yahoo.vespa.hosted.node.admin.container.metrics.Dimensions;
-import com.yahoo.vespa.hosted.node.admin.container.metrics.Metrics;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentTask;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.Editor;
@@ -18,9 +15,7 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -48,17 +43,10 @@ public class AclMaintainer {
 
     private final ContainerOperations containerOperations;
     private final IPAddresses ipAddresses;
-    private final Metrics metrics;
-    private final Map<String, Long> lastSuccess;
-    private static final String METRIC_NAME_POSTFIX = ".acl.age";
 
-    public AclMaintainer(ContainerOperations containerOperations, IPAddresses ipAddresses, Metrics metrics) {
+    public AclMaintainer(ContainerOperations containerOperations, IPAddresses ipAddresses) {
         this.containerOperations = containerOperations;
         this.ipAddresses = ipAddresses;
-        this.metrics = metrics;
-        long timestamp = System.currentTimeMillis() / 1_000;
-        this.lastSuccess = new HashMap<>(Map.of(IPVersion.IPv4.id(), timestamp,
-                                                IPVersion.IPv6.id(), timestamp));
     }
 
     // ip(6)tables operate while having the xtables lock, run with synchronized to prevent multiple NodeAgents
@@ -67,13 +55,8 @@ public class AclMaintainer {
         if (context.isDisabled(NodeAgentTask.AclMaintainer)) return;
 
         // Apply acl to the filter table
-        boolean updatedIPv4 = editFlushOnError(context, IPVersion.IPv4, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv4));
-        boolean updatedIPv6 = editFlushOnError(context, IPVersion.IPv6, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv6));
-
-        Dimensions dimensions = generateDimensions(context);
-
-        updateMetric(dimensions, updatedIPv4, IPVersion.IPv4.id());
-        updateMetric(dimensions, updatedIPv6, IPVersion.IPv6.id());
+        editFlushOnError(context, IPVersion.IPv4, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv4));
+        editFlushOnError(context, IPVersion.IPv6, "filter", FilterTableLineEditor.from(context.acl(), IPVersion.IPv6));
 
         ipAddresses.getAddress(context.hostname().value(), IPVersion.IPv4).ifPresent(addr -> applyRedirect(context, addr));
         ipAddresses.getAddress(context.hostname().value(), IPVersion.IPv6).ifPresent(addr -> applyRedirect(context, addr));
@@ -130,32 +113,6 @@ public class AclMaintainer {
                 }
             }
         };
-    }
-
-    void updateMetric(Dimensions dimensions, boolean updated, String ipVersion) {
-        long updateAgeInSec;
-        long timestamp = System.currentTimeMillis() / 1_000;
-        if (updated) {
-            updateAgeInSec = 0;
-            lastSuccess.put(ipVersion, timestamp);
-        } else {
-            updateAgeInSec = timestamp - lastSuccess.get(ipVersion);
-        }
-
-        metrics.declareGauge(Metrics.APPLICATION_NODE, ipVersion + METRIC_NAME_POSTFIX, dimensions, Metrics.DimensionType.PRETAGGED)
-                .sample(updateAgeInSec);
-
-    }
-
-    private Dimensions generateDimensions(NodeAgentContext context) {
-        NodeSpec node = context.node();
-        Dimensions.Builder dimensionsBuilder = new Dimensions.Builder()
-                .add("host", node.hostname())
-                .add("zone", context.zone().getId().value());
-
-        node.currentVespaVersion().ifPresent(vespaVersion -> dimensionsBuilder.add("vespaVersion", vespaVersion.toFullString()));
-
-        return dimensionsBuilder.build();
     }
 
     private static class TemporaryIpTablesFileHandler implements AutoCloseable {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/acl/AclMaintainerTest.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.node.admin.maintenance.acl;
 
 import com.yahoo.vespa.hosted.node.admin.configserver.noderepository.Acl;
 import com.yahoo.vespa.hosted.node.admin.container.ContainerOperations;
-import com.yahoo.vespa.hosted.node.admin.container.metrics.Metrics;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContextImpl;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
@@ -38,8 +37,7 @@ public class AclMaintainerTest {
 
     private final ContainerOperations containerOperations = mock(ContainerOperations.class);
     private final IPAddressesMock ipAddresses = new IPAddressesMock();
-    private final Metrics metrics = new Metrics();
-    private final AclMaintainer aclMaintainer = new AclMaintainer(containerOperations, ipAddresses, metrics);
+    private final AclMaintainer aclMaintainer = new AclMaintainer(containerOperations, ipAddresses);
 
     private final FileSystem fileSystem = TestFileSystem.create();
     private final Function<Acl, NodeAgentContext> contextGenerator =


### PR DESCRIPTION
FYI: @mpolden 

Fails when building `vespa-yahoo:hosted/host-admin`:
```
14:25:11 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/hosted/host-admin/src/main/java/com/yahoo/vespa/hosted/hostadmin/task/container/NodeAdminTask.java:[243,29] constructor AclMaintainer in class com.yahoo.vespa.hosted.node.admin.maintenance.acl.AclMaintainer cannot be applied to given types;
14:25:11 [ERROR]   required: com.yahoo.vespa.hosted.node.admin.container.ContainerOperations,com.yahoo.vespa.hosted.node.admin.task.util.network.IPAddresses,com.yahoo.vespa.hosted.node.admin.container.metrics.Metrics
14:25:11 [ERROR]   found: com.yahoo.vespa.hosted.node.admin.container.ContainerOperations,com.yahoo.vespa.hosted.node.admin.task.util.network.IPAddresses
14:25:11 [ERROR]   reason: actual and formal argument lists differ in length
```