### PR TITLE
Prepare all applications before activating when bootstrapping config server, take 2 [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ConfigServerBootstrap.java
@@ -13,7 +13,6 @@ import com.yahoo.container.jdisc.state.StateMonitor;
 import com.yahoo.vespa.config.server.rpc.RpcServer;
 import com.yahoo.vespa.config.server.version.VersionState;
 import com.yahoo.vespa.flags.BooleanFlag;
-import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.Flags;
 import com.yahoo.yolean.Exceptions;
@@ -129,8 +128,7 @@ public class ConfigServerBootstrap extends AbstractComponent implements Runnable
         this.sleepTimeWhenRedeployingFails = Duration.ofSeconds(configserverConfig.sleepTimeWhenRedeployingFails());
         this.exitIfRedeployingApplicationsFails = exitIfRedeployingApplicationsFails;
         rpcServerExecutor = Executors.newSingleThreadExecutor(new DaemonThreadFactory("config server RPC server"));
-        prepareAllAppsBeforeActivating = Flags.PREPARE_ALL_APPS_BEFORE_ACTIVATING_AT_BOOTSTRAP
-                .bindTo(flagSource).with(FetchVector.Dimension.ZONE_ID, applicationRepository.zone().toString());
+        prepareAllAppsBeforeActivating = Flags.PREPARE_ALL_APPS_BEFORE_ACTIVATING_AT_BOOTSTRAP.bindTo(flagSource);
 
         log.log(Level.FINE, () -> "Bootstrap mode: " + mode + ", VIP status mode: " + vipStatusMode);
         initializing(vipStatusMode);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -41,7 +41,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
 
 import static com.yahoo.vespa.config.server.ConfigServerBootstrap.VipStatusMode.VIP_STATUS_FILE;
 import static com.yahoo.vespa.config.server.ConfigServerBootstrap.VipStatusMode.VIP_STATUS_PROGRAMMATICALLY;

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -275,6 +275,13 @@ public class Flags {
             "Takes effect on redeploy",
             TENANT_ID);
 
+    public static final UnboundBooleanFlag PREPARE_ALL_APPS_BEFORE_ACTIVATING_AT_BOOTSTRAP = defineFeatureFlag(
+            "prepare-all-apps-before-activating-at-bootstrap", false,
+            List.of("hmusum"), "2021-08-17", "2021-10-17",
+            "Prepare all apps before activating when doing config server bootstrap",
+            "Takes effect on restart of config server",
+            ZONE_ID);
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,


### PR DESCRIPTION
Same changes as in https://github.com/vespa-engine/vespa/pull/18720, but add back old code and use feature flag to switch between old and new way of redeploying applications. 

https://github.com/vespa-engine/vespa/pull/18737 will hopefull help with the issues seen when https://github.com/vespa-engine/vespa/pull/18720 was tried.

Please review only.