### PR TITLE
ensure that sending event to dispatch happens after updating internal…

### DIFF
--- a/document/src/vespa/document/fieldvalue/structuredfieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/structuredfieldvalue.cpp
@@ -118,7 +118,7 @@ StructuredFieldValue::onIterateNested(PathRange nested, IteratorHandler & handle
             const Field & field = fpe.getFieldRef();
             FieldValue::UP value = getValue(field, FieldValue::UP());
             LOG(spam, "fieldRef = %s", field.toString().c_str());
-            LOG(spam, "fieldValueToSet = %s", value->toString().c_str());
+            LOG(spam, "fieldValueToSet = %s", value ? value->toString().c_str() : "<null>");
             ModificationStatus status = ModificationStatus::NOT_MODIFIED;
             if (value) {
                 status = value->iterateNested(nested.next(), handler);

--- a/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
+++ b/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
@@ -84,6 +84,7 @@ void LocalRpcMonitorMap::add(const ServiceMapping &mapping) {
         if (removed.up) {
             _dispatcher.remove(removed.mapping());
         }
+        _delete.later(std::move(removed.srv));
     }
     auto [ iter, was_inserted ] =
         _map.try_emplace(mapping.name, globalService(mapping));
@@ -109,6 +110,7 @@ void LocalRpcMonitorMap::remove(const ServiceMapping &mapping) {
         if (removed.up) {
             _dispatcher.remove(removed.mapping());
         }
+        _delete.later(std::move(removed.srv));
     } else {
         LOG(debug, "tried to remove non-existing mapping %s->%s",
             mapping.name.c_str(), mapping.spec.c_str());

--- a/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
+++ b/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
@@ -2,6 +2,7 @@
 
 #include "local_rpc_monitor_map.h"
 #include "sbenv.h"
+#include <vespa/fnet/frt/supervisor.h>
 #include <vespa/log/log.h>
 LOG_SETUP(".slobrok.server.local_rpc_monitor_map");
 
@@ -10,7 +11,8 @@ namespace slobrok {
 #pragma GCC diagnostic ignored "-Winline"
 
 LocalRpcMonitorMap::LocalRpcMonitorMap(FRT_Supervisor &supervisor)
-  : _map(),
+  : _delete(supervisor.GetScheduler()),
+    _map(),
     _dispatcher(),
     _history(),
     _supervisor(supervisor),
@@ -40,7 +42,7 @@ void LocalRpcMonitorMap::addLocal(const ServiceMapping &mapping,
         mapping.name.c_str(), mapping.spec.c_str());
     auto old = _map.find(mapping.name);
     if (old != _map.end()) {
-        PerService & exists = old->second;
+        const PerService & exists = old->second;
         if (exists.spec() == mapping.spec) {
             LOG(debug, "added mapping %s->%s was already present",
                 mapping.name.c_str(), mapping.spec.c_str());
@@ -70,17 +72,19 @@ void LocalRpcMonitorMap::add(const ServiceMapping &mapping) {
             exists.localOnly = false;
             return;
         }
+        PerService removed = std::move(exists);
+        _map.erase(old);
         LOG(warning, "added mapping %s->%s, but already had conflicting mapping %s->%s",
             mapping.name.c_str(), mapping.spec.c_str(),
-            exists.name().c_str(), exists.spec().c_str());
-        if (exists.up) {
-            _dispatcher.remove(exists.mapping());
-        }
-        if (exists.inflight) {
-            auto target = std::move(exists.inflight);
+            removed.name().c_str(), removed.spec().c_str());
+        if (removed.inflight) {
+            auto target = std::move(removed.inflight);
             target->doneHandler(OkState(13, "conflict during initialization"));
         }
-        _map.erase(old);
+        if (removed.up) {
+            _dispatcher.remove(removed.mapping());
+        }
+        _delete.later(std::move(removed.srv));
     }
     auto [ iter, was_inserted ] =
         _map.try_emplace(mapping.name, globalService(mapping));
@@ -90,23 +94,23 @@ void LocalRpcMonitorMap::add(const ServiceMapping &mapping) {
 void LocalRpcMonitorMap::remove(const ServiceMapping &mapping) {
     auto iter = _map.find(mapping.name);
     if (iter != _map.end()) {
+        PerService removed = std::move(iter->second);
+        _map.erase(iter);
         LOG(debug, "remove: mapping %s->%s", mapping.name.c_str(), mapping.spec.c_str());
-        PerService & exists = iter->second;
-        if (mapping.spec != exists.spec()) {
+        if (mapping.spec != removed.spec()) {
             LOG(warning, "inconsistent specs for name '%s': had '%s', but was asked to remove '%s'",
                 mapping.name.c_str(),
-                exists.spec().c_str(),
+                removed.spec().c_str(),
                 mapping.spec.c_str());
-            return;
         }
-        if (exists.up) {
-            _dispatcher.remove(exists.mapping());
-        }
-        if (exists.inflight) {
-            auto target = std::move(exists.inflight);
+        if (removed.inflight) {
+            auto target = std::move(removed.inflight);
             target->doneHandler(OkState(13, "removed during initialization"));
         }
-        _map.erase(iter);
+        if (removed.up) {
+            _dispatcher.remove(removed.mapping());
+        }
+        _delete.later(std::move(removed.srv));
     } else {
         LOG(debug, "tried to remove non-existing mapping %s->%s",
             mapping.name.c_str(), mapping.spec.c_str());
@@ -120,13 +124,17 @@ void LocalRpcMonitorMap::notifyFailedRpcSrv(ManagedRpcServer *rpcsrv, std::strin
         auto target = std::move(psd.inflight);
         target->doneHandler(OkState(13, "failed check using listNames callback"));
     }
-    if (psd.up) {
+    if (psd.localOnly) {
+        PerService removed = std::move(psd);
+        auto iter = _map.find(removed.name());
+        _map.erase(iter);
+        if (removed.up) {
+            _dispatcher.remove(removed.mapping());
+        }
+        _delete.later(std::move(removed.srv));
+    } else if (psd.up) {
         psd.up = false;
         _dispatcher.remove(psd.mapping());
-    }
-    if (psd.localOnly) {
-        auto iter = _map.find(psd.name());
-        _map.erase(iter);
     }
 }
 

--- a/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
+++ b/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.cpp
@@ -84,7 +84,6 @@ void LocalRpcMonitorMap::add(const ServiceMapping &mapping) {
         if (removed.up) {
             _dispatcher.remove(removed.mapping());
         }
-        _delete.later(std::move(removed.srv));
     }
     auto [ iter, was_inserted ] =
         _map.try_emplace(mapping.name, globalService(mapping));
@@ -110,7 +109,6 @@ void LocalRpcMonitorMap::remove(const ServiceMapping &mapping) {
         if (removed.up) {
             _dispatcher.remove(removed.mapping());
         }
-        _delete.later(std::move(removed.srv));
     } else {
         LOG(debug, "tried to remove non-existing mapping %s->%s",
             mapping.name.c_str(), mapping.spec.c_str());

--- a/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.h
+++ b/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.h
@@ -93,7 +93,7 @@ private:
     FRT_Supervisor &_supervisor;
     std::unique_ptr<MapSubscription> _subscription;
     
-    PerService &lookup(ManagedRpcServer *rpcsrv);
+    PerService *lookup(ManagedRpcServer *rpcsrv);
     
 public:
     LocalRpcMonitorMap(FRT_Supervisor &_supervisor);

--- a/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.h
+++ b/slobrok/src/vespa/slobrok/server/local_rpc_monitor_map.h
@@ -29,15 +29,36 @@ class LocalRpcMonitorMap : public IRpcServerManager,
                            public MapListener
 {
 private:
+    class DeleteTask : public FNET_Task {
+        using MUP = std::unique_ptr<ManagedRpcServer>;
+        std::vector<MUP> _deleteList;
+    public:
+        void later(MUP rpcsrv) {
+            _deleteList.emplace_back(std::move(rpcsrv));
+            ScheduleNow();
+        }
+        void PerformTask() override {
+            std::vector<MUP> deleteAfterSwap;
+            std::swap(deleteAfterSwap, _deleteList);
+        }
+        DeleteTask(FNET_Scheduler *scheduler)
+          : FNET_Task(scheduler),
+            _deleteList()
+        {}
+        ~DeleteTask() { Kill(); }
+    };
+
+    DeleteTask _delete;
+
     struct PerService {
         bool up;
         bool localOnly;
         std::unique_ptr<ScriptCommand> inflight;
         std::unique_ptr<ManagedRpcServer> srv;
 
-        vespalib::string name() { return srv->getName(); }
-        vespalib::string spec() { return srv->getSpec(); }
-        ServiceMapping mapping() { return ServiceMapping{srv->getName(), srv->getSpec()}; }
+        vespalib::string name() const { return srv->getName(); }
+        vespalib::string spec() const { return srv->getSpec(); }
+        ServiceMapping mapping() const { return ServiceMapping{srv->getName(), srv->getSpec()}; }
     };
 
     std::unique_ptr<ManagedRpcServer> managedFor(const ServiceMapping &mapping) {

--- a/slobrok/src/vespa/slobrok/server/union_service_map.cpp
+++ b/slobrok/src/vespa/slobrok/server/union_service_map.cpp
@@ -16,8 +16,8 @@ void UnionServiceMap::add(const ServiceMapping &mapping)
     auto iter = _mappings.find(key);
     if (iter == _mappings.end()) {
         _mappings[key].emplace_back(mapping.spec, 1u);
-        ProxyMapSource::add(mapping);
         LOG(debug, "add new %s->%s", mapping.name.c_str(), mapping.spec.c_str());
+        ProxyMapSource::add(mapping);
     } else {
         Mappings &values = iter->second;
         for (CountedSpec &old : values) {
@@ -27,11 +27,13 @@ void UnionServiceMap::add(const ServiceMapping &mapping)
                 return;
             }
         }
-        if (values.size() == 1u) {
-            LOG(warning, "Multiple specs seen for name '%s', un-publishing", key.c_str());
-            ProxyMapSource::remove(ServiceMapping{key, values[0].spec});
-        }
         values.emplace_back(mapping.spec, 1u);
+        if (values.size() == 2u) {
+            ServiceMapping toRemove{key, values[0].spec};
+            LOG(warning, "Multiple specs seen for name '%s', un-publishing %s",
+                toRemove.name.c_str(), toRemove.spec.c_str());
+            ProxyMapSource::remove(toRemove);
+        }
     }
 }
 
@@ -61,16 +63,16 @@ void UnionServiceMap::remove(const ServiceMapping &mapping)
     std::erase_if(values, [] (const CountedSpec &v) { return v.count == 0; });
     if (values.size() == 1u) {
         LOG_ASSERT(old_size == 2u);
+        ServiceMapping toAdd{key, values[0].spec};
         LOG(info, "Had multiple mappings for %s, but now only %s remains",
-            key.c_str(), values[0].spec.c_str());
-        ProxyMapSource::add(ServiceMapping{key, values[0].spec});
-    }
-    if (values.size() == 0u) {
+            toAdd.name.c_str(), toAdd.spec.c_str());
+        ProxyMapSource::add(toAdd);
+    } else if (values.size() == 0u) {
         LOG_ASSERT(old_size == 1u);
         LOG(debug, "Last reference for %s -> %s removed",
             key.c_str(), mapping.spec.c_str());
-        ProxyMapSource::remove(mapping);
         _mappings.erase(iter);
+        ProxyMapSource::remove(mapping);
     }
 }
 
@@ -83,4 +85,3 @@ void UnionServiceMap::update(const ServiceMapping &old_mapping,
 }
 
 } // namespace slobrok
-


### PR DESCRIPTION
… state

* map.erase() invalidates reference to contents, move it to a local variable first
* cannot delete a ManagedRpcServer while we are in its callback

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review

this seems much more complicated than I hoped...