### PR TITLE
Add unit test for global rankprofile name collision from onnx models

### DIFF
--- a/config-model/src/test/cfg/application/onnx_name_collision/models/barfoo.onnx
+++ b/config-model/src/test/cfg/application/onnx_name_collision/models/barfoo.onnx
@@ -1,0 +1,16 @@
+	barfoo.py:T
+
+bar
+bazfoo"MulmulZ
+bar
+
+
+Z
+baz
+
+
+b
+foo
+
+
+B

--- a/config-model/src/test/cfg/application/onnx_name_collision/models/barfoo.py
+++ b/config-model/src/test/cfg/application/onnx_name_collision/models/barfoo.py
@@ -1,0 +1,26 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+import onnx
+from onnx import helper, TensorProto
+
+INPUT_1 = helper.make_tensor_value_info('bar', TensorProto.FLOAT, [1])
+INPUT_2 = helper.make_tensor_value_info('baz', TensorProto.FLOAT, [1])
+OUTPUT = helper.make_tensor_value_info('foo', TensorProto.FLOAT, [1])
+
+nodes = [
+    helper.make_node(
+        'Mul',
+        ['bar', 'baz'],
+        ['foo'],
+    ),
+]
+graph_def = helper.make_graph(
+    nodes,
+    'mul',
+    [
+        INPUT_1,
+        INPUT_2
+    ],
+    [OUTPUT],
+)
+model_def = helper.make_model(graph_def, producer_name='barfoo.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
+onnx.save(model_def, 'barfoo.onnx')

--- a/config-model/src/test/cfg/application/onnx_name_collision/models/foobar.onnx
+++ b/config-model/src/test/cfg/application/onnx_name_collision/models/foobar.onnx
@@ -1,0 +1,16 @@
+	foobar.py:T
+
+foo
+bazbat"MulmulZ
+foo
+
+
+Z
+baz
+
+
+b
+bar
+
+
+B

--- a/config-model/src/test/cfg/application/onnx_name_collision/models/foobar.py
+++ b/config-model/src/test/cfg/application/onnx_name_collision/models/foobar.py
@@ -1,0 +1,26 @@
+# Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+import onnx
+from onnx import helper, TensorProto
+
+INPUT_1 = helper.make_tensor_value_info('foo', TensorProto.FLOAT, [1])
+INPUT_2 = helper.make_tensor_value_info('baz', TensorProto.FLOAT, [1])
+OUTPUT = helper.make_tensor_value_info('bar', TensorProto.FLOAT, [1])
+
+nodes = [
+    helper.make_node(
+        'Mul',
+        ['foo', 'baz'],
+        ['bat'],
+    ),
+]
+graph_def = helper.make_graph(
+    nodes,
+    'mul',
+    [
+        INPUT_1,
+        INPUT_2
+    ],
+    [OUTPUT],
+)
+model_def = helper.make_model(graph_def, producer_name='foobar.py', opset_imports=[onnx.OperatorSetIdProto(version=12)])
+onnx.save(model_def, 'foobar.onnx')

--- a/config-model/src/test/cfg/application/onnx_name_collision/services.xml
+++ b/config-model/src/test/cfg/application/onnx_name_collision/services.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container version="1.0">
+    <model-evaluation/>
+    <nodes>
+      <node hostalias="node1" />
+    </nodes>
+  </container>
+
+</services>


### PR DESCRIPTION
@baldersheim Please review. The models have input and output names that collide. Test passes when rank profiles have their own `OnnxModels` - will fail with a single global one in VespaModel.