### PR TITLE
Remove generation of filereferences config, not used

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -459,10 +459,7 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
      * @param reference file reference (hash)
      */
     public void send(FileReference reference) {
-        Host host = null;
-        if (getHost() != null) // false when running application tests without hosts
-            host = getHost().getHost();
-        getRoot().getFileDistributor().sendFileReference(reference, host);
+        getRoot().getFileDistributor().sendFileReference(reference);
     }
 
     /** The service HTTP port for health status */

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -290,8 +290,7 @@ public class Admin extends AbstractConfigProducer<Admin> implements Serializable
     }
 
     private void addFileDistribution(HostResource host) {
-        FileDistributionConfigProvider configProvider =
-                new FileDistributionConfigProvider(fileDistribution, fileDistribution.getFileDistributor(), host.getHost());
+        FileDistributionConfigProvider configProvider = new FileDistributionConfigProvider(fileDistribution, host.getHost());
         fileDistribution.addFileDistributionConfigProducer(host.getHost(), configProvider);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
@@ -1,26 +1,18 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.filedistribution;
 
 import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
-import com.yahoo.cloud.config.filedistribution.FilereferencesConfig;
-import com.yahoo.config.FileReference;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.ConfigProxy;
 import com.yahoo.vespa.model.Host;
+import com.yahoo.vespa.model.HostSystem;
 
-import java.util.Collection;
+public class FileDistributionConfigProvider extends AbstractConfigProducer<AbstractConfigProducer<?>> implements FiledistributorrpcConfig.Producer {
 
-public class FileDistributionConfigProvider extends AbstractConfigProducer
-        implements FiledistributorrpcConfig.Producer, FilereferencesConfig.Producer {
-
-    private final FileDistributor fileDistributor;
     private final Host host;
 
-    public FileDistributionConfigProvider(AbstractConfigProducer parent,
-                                          FileDistributor fileDistributor,
-                                          Host host) {
+    public FileDistributionConfigProvider(AbstractConfigProducer<?> parent, Host host) {
         super(parent, host.getHostname());
-        this.fileDistributor = fileDistributor;
         this.host = host;
     }
 
@@ -29,10 +21,4 @@ public class FileDistributionConfigProvider extends AbstractConfigProducer
         builder.connectionspec("tcp/" + host.getHostname() + ":" + ConfigProxy.BASEPORT);
     }
 
-    @Override
-    public void getConfig(FilereferencesConfig.Builder builder) {
-        for (FileReference reference : fileDistributor.filesToSendToHost(host)) {
-            builder.filereferences(reference.value());
-        }
-    }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributor.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.filedistribution;
 
 import com.yahoo.config.FileReference;
@@ -6,51 +6,28 @@ import com.yahoo.vespa.model.Host;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 /**
- * Sends RPC requests to hosts (tenant hosts and config servers) asking them to start download of files. This is used
- * during prepare of an application. Services themselves will also request files, the methods in this class are used
- * so that hosts can start downloading files before services gets new config that needs these files. It also tries
- * to make sure that all config servers (not just the one where the application was deployed) have the files available.
+ * Keeps track of what files to send with file distribution
  *
  * @author Tony Vaagenes
  */
 public class FileDistributor {
 
-
     /** A map from file reference to the hosts to which that file reference should be distributed */
-    private final Map<FileReference, Set<Host>> filesToHosts = new LinkedHashMap<>();
+    private final Set<FileReference> fileReferences = new LinkedHashSet<>();
 
     public FileDistributor() { }
 
-    public void sendFileReference(FileReference reference, Host host) {
-        filesToHosts.computeIfAbsent(reference, k -> new HashSet<>()).add(host);
-    }
-
-    /** Returns the files which has been marked for distribution to the given host */
-    public Set<FileReference> filesToSendToHost(Host host) {
-        Set<FileReference> files = new HashSet<>();
-
-        for (Map.Entry<FileReference,Set<Host>> e : filesToHosts.entrySet()) {
-            if (e.getValue().contains(host)) {
-                files.add(e.getKey());
-            }
-        }
-        return files;
-    }
-
-    public Set<Host> getTargetHosts() {
-        Set<Host> hosts = new HashSet<>();
-        for (Set<Host> hostSubset: filesToHosts.values())
-            hosts.addAll(hostSubset);
-        return hosts;
+    public void sendFileReference(FileReference reference) {
+        fileReferences.add(reference);
     }
 
     public Set<FileReference> allFilesToSend() {
-        return Set.copyOf(filesToHosts.keySet());
+        return Set.copyOf(fileReferences);
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/FileDistributorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/FileDistributorTestCase.java
@@ -1,16 +1,11 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.filedistribution;
 
 import com.yahoo.config.FileReference;
 import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
-import com.yahoo.config.model.test.MockHosts;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -20,7 +15,6 @@ public class FileDistributorTestCase {
 
     @Test
     public void fileDistributor() {
-        MockHosts hosts = new MockHosts();
         FileRegistry fileRegistry = new MockFileRegistry();
         FileDistributor fileDistributor = new FileDistributor();
 
@@ -28,13 +22,10 @@ public class FileDistributorTestCase {
         String file2 = "component/path2";
         FileReference ref1 = fileRegistry.addFile(file1);
         FileReference ref2 = fileRegistry.addFile(file2);
-        fileDistributor.sendFileReference(ref1, hosts.host1);
-        fileDistributor.sendFileReference(ref2, hosts.host1);
-        fileDistributor.sendFileReference(ref1, hosts.host2); // same file reference as above
-        fileDistributor.sendFileReference(ref2, hosts.host3);
-
-        assertEquals(new HashSet<>(Arrays.asList(hosts.host1, hosts.host2, hosts.host3)),
-                fileDistributor.getTargetHosts());
+        fileDistributor.sendFileReference(ref1);
+        fileDistributor.sendFileReference(ref2);
+        fileDistributor.sendFileReference(ref1); // same file reference as above
+        fileDistributor.sendFileReference(ref2);
 
         assertNotNull(ref1);
         assertNotNull(ref2);


### PR DESCRIPTION
Filereferences config is not used anymore (has not been used for a long time), remove generation of config.

Please review only, will merge after 7.454 has been rolled out successfully.