### PR TITLE
Always account for available IP addresses when checking capacity

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeResources.java
@@ -16,7 +16,7 @@ public class NodeResources {
     private static final double memoryUnitCost = 0.009;
     private static final double diskUnitCost =   0.0003;
 
-    private static final NodeResources unspecified = new NodeResources(0, 0, 0, 0);
+    private static final NodeResources zero = new NodeResources(0, 0, 0, 0);
 
     public enum DiskSpeed {
 
@@ -276,9 +276,9 @@ public class NodeResources {
         return true;
     }
 
-    public static NodeResources unspecified() { return unspecified; }
+    public static NodeResources unspecified() { return zero; }
 
-    public boolean isUnspecified() { return this.equals(unspecified); }
+    public boolean isUnspecified() { return this.equals(zero); }
 
     // Returns squared euclidean distance of the relevant numerical values of two node resources
     public double distanceTo(NodeResources other) {
@@ -327,6 +327,6 @@ public class NodeResources {
         return value;
     }
 
-    public static NodeResources zero() { return new NodeResources(0, 0, 0, 0); }
+    public static NodeResources zero() { return zero; }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMover.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMover.java
@@ -56,7 +56,7 @@ public abstract class NodeMover<MOVE> extends NodeRepositoryMaintainer {
             for (Node toHost : allNodes.matching(nodeRepository().nodes()::canAllocateTenantNodeTo)) {
                 if (toHost.hostname().equals(node.parentHostname().get())) continue;
                 if (spares.contains(toHost)) continue; // Do not offer spares as a valid move as they are reserved for replacement of failed nodes
-                if ( ! capacity.freeCapacityOf(toHost).satisfies(node.resources())) continue;
+                if ( ! capacity.hasCapacity(toHost, node.resources())) continue;
 
                 MOVE suggestedMove = suggestedMove(node, allNodes.parentOf(node).get(), toHost, allNodes);
                 bestMove = bestMoveOf(bestMove, suggestedMove);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Rebalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Rebalancer.java
@@ -69,20 +69,20 @@ public class Rebalancer extends NodeMover<Rebalancer.Move> {
         int hostCount = 0;
         for (Node host : allNodes.nodeType(NodeType.host).state(Node.State.active)) {
             hostCount++;
-            totalSkew += Node.skew(host.flavor().resources(), capacity.freeCapacityOf(host));
+            totalSkew += Node.skew(host.flavor().resources(), capacity.unusedCapacityOf(host));
         }
         metric.set("hostedVespa.docker.skew", totalSkew/hostCount, null);
     }
 
     private double skewReductionByRemoving(Node node, Node fromHost, HostCapacity capacity) {
-        NodeResources freeHostCapacity = capacity.freeCapacityOf(fromHost);
+        NodeResources freeHostCapacity = capacity.unusedCapacityOf(fromHost);
         double skewBefore = Node.skew(fromHost.flavor().resources(), freeHostCapacity);
         double skewAfter = Node.skew(fromHost.flavor().resources(), freeHostCapacity.add(node.flavor().resources().justNumbers()));
         return skewBefore - skewAfter;
     }
 
     private double skewReductionByAdding(Node node, Node toHost, HostCapacity capacity) {
-        NodeResources freeHostCapacity = capacity.freeCapacityOf(toHost);
+        NodeResources freeHostCapacity = capacity.unusedCapacityOf(toHost);
         double skewBefore = Node.skew(toHost.flavor().resources(), freeHostCapacity);
         double skewAfter = Node.skew(toHost.flavor().resources(), freeHostCapacity.subtract(node.resources().justNumbers()));
         return skewBefore - skewAfter;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainer.java
@@ -220,7 +220,7 @@ public class SpareCapacityMaintainer extends NodeRepositoryMaintainer {
                 return null;
 
             if ( ! host.resources().satisfies(node.resources())) return null;
-            NodeResources freeCapacity = freeCapacityWith(movesMade, host);
+            NodeResources freeCapacity = availableCapacityWith(movesMade, host);
             if (freeCapacity.satisfies(node.resources())) return List.of();
 
             List<Move> shortest = null;
@@ -291,8 +291,8 @@ public class SpareCapacityMaintainer extends NodeRepositoryMaintainer {
             return list;
         }
 
-        private NodeResources freeCapacityWith(List<Move> moves, Node host) {
-            NodeResources resources = hostCapacity.freeCapacityOf(host);
+        private NodeResources availableCapacityWith(List<Move> moves, Node host) {
+            NodeResources resources = hostCapacity.availableCapacityOf(host);
             for (Move move : moves) {
                 if ( ! move.toHost().equals(host)) continue;
                 resources = resources.subtract(move.node().resources());


### PR DESCRIPTION
This triggered unnecessary node moves in SwitchRebalancer.

@bratseth