### PR TITLE
Revert "fix variable name typo"

### DIFF
--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -303,7 +303,7 @@ get_numa_ctl_cmd () {
                grep available |
                awk '$3 == "nodes" { print $2 }')
 
-    if [ -n "$numnodes" ]; then
+    if [ -n "$numanodes" ]; then
         # We are allowed to use numactl and have NUMA nodes
         if [ "$VESPA_AFFINITY_CPU_SOCKET" ] &&
            [ "$numnodes" -gt 1 ]


### PR DESCRIPTION
Reverts vespa-engine/vespa#18815

Will revert https://github.com/vespa-engine/vespa/pull/18808 after this to go back to old behaviour. Need to debug why the services are not starting with this change.