### PR TITLE
Try to run steps again if we bail out due to status change

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunner.java
@@ -113,8 +113,10 @@ public class JobRunner extends ControllerMaintainer {
             jobs.locked(id.application(), id.type(), step, lockedStep -> {
                 jobs.locked(id, run -> run); // Memory visibility.
                 jobs.active(id).ifPresent(run -> { // The run may have become inactive, so we bail out.
-                    if ( ! run.readySteps().contains(step))
+                    if ( ! run.readySteps().contains(step)) {
+                        changed.set(true);
                         return; // Someone may have updated the run status, making this step obsolete, so we bail out.
+                    }
 
                     StepInfo stepInfo = run.stepInfo(lockedStep.get()).orElseThrow();
                     if (stepInfo.startTime().isEmpty()) {


### PR DESCRIPTION
If someone completes a step we are trying to run, we will bail out. Meanwhile, that other thread will attempt the next step, but fails to acquire the lock, since we hold it (for the prerequisite), so that thread gives up. When it is our turn again, and we bail out, we should try again to run any ready steps, otherwise we may lose the fact that _someone_ ought to do _something_. This is absolutely not a practical issue, but makes one unit test slightly unstable :)

@bjorncs please review.