### PR TITLE
Look for pom when resolving application package

### DIFF
--- a/client/go/cmd/deploy_test.go
+++ b/client/go/cmd/deploy_test.go
@@ -62,7 +62,7 @@ func TestDeployApplicationDirectoryWithTarget(t *testing.T) {
 func TestDeployApplicationDirectoryWithEmptyTarget(t *testing.T) {
 	client := &mockHttpClient{}
 	assert.Equal(t,
-		"\x1b[31mno application package found in testdata/applications/withEmptyTarget\x1b[0m\n",
+		"\x1b[31mpom.xml exists but no target/application.zip. Run mvn package first\x1b[0m\n",
 		executeCommand(t, client, []string{"deploy", "testdata/applications/withEmptyTarget"}, []string{}))
 }
 

--- a/client/go/cmd/testdata/applications/withEmptyTarget/pom.xml
+++ b/client/go/cmd/testdata/applications/withEmptyTarget/pom.xml
@@ -1,0 +1,1 @@
+<services/>

--- a/client/go/cmd/testdata/applications/withTarget/pom.xml
+++ b/client/go/cmd/testdata/applications/withTarget/pom.xml
@@ -1,0 +1,1 @@
+<services/>

--- a/client/go/vespa/deploy_test.go
+++ b/client/go/vespa/deploy_test.go
@@ -18,7 +18,6 @@ func TestFindApplicationPackage(t *testing.T) {
 		{filepath.Join(dir, "foo"), "", true},
 		{filepath.Join(dir, "services.xml"), dir, false},
 		{filepath.Join(dir, "src", "main", "application", "services.xml"), filepath.Join(dir, "src", "main", "application"), false},
-		{filepath.Join(dir, "target", "application.zip"), filepath.Join(dir, "target", "application.zip"), false},
 	}
 
 	zipFile := filepath.Join(dir, "application.zip")


### PR DESCRIPTION
Check for existence of a pom when deciding whether or not to use target or source.
I reverted to the previous form of the function to make this work (the thing with candidates wasn't quite right anyway, because some were not candidates but evidence of where to look).

Could we please try to avoid encoding test cases as data you loop over as in deploy_test? It makes it harder to understand what is failing. For example, which test case fails here:
```
--- FAIL: TestFindApplicationPackage (0.00s)
    deploy_test.go:36: #3: FindApplicationPackage("/var/folders/97/srk32nhn027bscz9v43sxbrc0000gn/T/TestFindApplicationPackage2668587650/001") = ("/var/folders/97/srk32nhn027bscz9v43sxbrc0000gn/T/TestFindApplicationPackage2668587650/001/src/main/application", %!s(<nil>)), want ("/var/folders/97/srk32nhn027bscz9v43sxbrc0000gn/T/TestFindApplicationPackage2668587650/001/target/application.zip", nil)
```

I know you do it because it is a pattern in Go, but that pattern is just mistaken ... You can make it even shorter while avoiding the drawback of making test cases illegible by creating your own custom assert function.
