### PR TITLE
Use self-subscription for slobroks config in container messagebus

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
@@ -22,10 +22,10 @@ public class DocumentAccessProvider extends AbstractComponent implements Provide
 
     @Inject
     public DocumentAccessProvider(DocumentmanagerConfig documentmanagerConfig, LoadTypeConfig loadTypeConfig,
-                                  SlobroksConfig slobroksConfig, MessagebusConfig messagebusConfig,
-                                  DocumentProtocolPoliciesConfig policiesConfig, DistributionConfig distributionConfig) {
-        this.access = new VespaDocumentAccess(documentmanagerConfig, loadTypeConfig, slobroksConfig, messagebusConfig,
-                                              policiesConfig, distributionConfig);
+                                  MessagebusConfig messagebusConfig, DocumentProtocolPoliciesConfig policiesConfig,
+                                  DistributionConfig distributionConfig) {
+        this.access = new VespaDocumentAccess(documentmanagerConfig, loadTypeConfig, System.getProperty("config.id"),
+                                              messagebusConfig, policiesConfig, distributionConfig);
     }
 
     @Override

--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
@@ -41,7 +41,7 @@ public class VespaDocumentAccess extends DocumentAccess {
 
     VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig,
                         LoadTypeConfig loadTypeConfig,
-                        SlobroksConfig slobroksConfig,
+                        String slobroksConfigId,
                         MessagebusConfig messagebusConfig,
                         DocumentProtocolPoliciesConfig policiesConfig,
                         DistributionConfig distributionConfig) {
@@ -49,7 +49,7 @@ public class VespaDocumentAccess extends DocumentAccess {
         this.parameters = new MessageBusParams(new LoadTypeSet(loadTypeConfig))
                 .setDocumentProtocolPoliciesConfig(policiesConfig, distributionConfig);
         this.parameters.setDocumentmanagerConfig(documentmanagerConfig);
-        this.parameters.getRPCNetworkParams().setSlobroksConfig(slobroksConfig);
+        this.parameters.getRPCNetworkParams().setSlobrokConfigId(slobroksConfigId);
         this.parameters.getMessageBusParams().setMessageBusConfig(messagebusConfig);
     }
 

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerHolder.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerHolder.java
@@ -30,7 +30,9 @@ public class NetworkMultiplexerHolder extends AbstractComponent {
     }
 
     private Network newNetwork(RPCNetworkParams params) {
-        return params.getSlobroksConfig().slobrok().isEmpty() ? new NullNetwork() : new RPCNetwork(params);
+        return params.getSlobroksConfig() != null && params.getSlobroksConfig().slobrok().isEmpty()
+               ? new NullNetwork() // For LocalApplication, test setup.
+               : new RPCNetwork(params);
     }
 
     @Override

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
@@ -26,10 +26,14 @@ public class NetworkMultiplexerProvider {
     }
 
     public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig, String identity) {
-        this.net = net.get(asParameters(mbusConfig, identity));
+        this.net = net.get(asParameters(mbusConfig, identity).setSlobrokConfigId(identity));
     }
 
-    public static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, String identity) {
+    public static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, SlobroksConfig slobroksConfig, String identity) {
+        return asParameters(mbusConfig, identity).setSlobroksConfig(slobroksConfig);
+    }
+
+    private static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, String identity) {
         return new RPCNetworkParams().setSlobrokConfigId(identity)
                                      .setIdentity(new Identity(identity))
                                      .setListenPort(mbusConfig.port())

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
@@ -21,16 +21,16 @@ public class NetworkMultiplexerProvider {
     private final NetworkMultiplexer net;
 
     @Inject
-    public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig, SlobroksConfig slobroksConfig) {
-        this(net, mbusConfig, slobroksConfig, System.getProperty("config.id")); //:
+    public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig) {
+        this(net, mbusConfig, System.getProperty("config.id")); //:
     }
 
-    public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig, SlobroksConfig slobroksConfig, String identity) {
-        this.net = net.get(asParameters(mbusConfig, slobroksConfig, identity));
+    public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig, String identity) {
+        this.net = net.get(asParameters(mbusConfig, identity));
     }
 
-    public static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, SlobroksConfig slobroksConfig, String identity) {
-        return new RPCNetworkParams().setSlobroksConfig(slobroksConfig)
+    public static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, String identity) {
+        return new RPCNetworkParams().setSlobrokConfigId(identity)
                                      .setIdentity(new Identity(identity))
                                      .setListenPort(mbusConfig.port())
                                      .setNumTargetsPerSpec(mbusConfig.numconnectionspertarget())

--- a/container-messagebus/src/test/java/com/yahoo/container/jdisc/messagebus/MbusClientProviderTest.java
+++ b/container-messagebus/src/test/java/com/yahoo/container/jdisc/messagebus/MbusClientProviderTest.java
@@ -36,7 +36,7 @@ public class MbusClientProviderTest {
     }
 
     private void testClient(SessionConfig config) {
-        SessionCache cache = new SessionCache(NetworkMultiplexer.dedicated(new NullNetwork()),
+        SessionCache cache = new SessionCache(() -> NetworkMultiplexer.dedicated(new NullNetwork()),
                                               new ContainerMbusConfig.Builder().build(),
                                               new DocumentmanagerConfig.Builder().build(),
                                               new LoadTypeConfig.Builder().build(),

--- a/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
@@ -65,7 +65,7 @@ public abstract class DocumentProcessingHandlerTestBase {
         RPCNetwork net = new RPCNetwork(NetworkMultiplexerProvider.asParameters(new ContainerMbusConfig.Builder().build(),
                                                                                 driver.client().slobroksConfig(),
                                                                                 "test"));
-        sessionCache = new SessionCache(NetworkMultiplexer.dedicated(net),
+        sessionCache = new SessionCache(() -> NetworkMultiplexer.dedicated(net),
                                         new ContainerMbusConfig.Builder().build(),
                                         new MessagebusConfig.Builder().build(),
                                         protocol);


### PR DESCRIPTION
@baldersheim please review. This reverts the move from subscription to fixed config for the RPCNetwork used by the container messagebus. 