### PR TITLE
As doSeek is called alot more frequent than doUnpack just use locking…

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_distance_heap.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_distance_heap.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/priority_queue.h>
 #include <mutex>
 #include <limits>
-#include <vespa/vespalib/util/priority_queue.h>
+#include <atomic>
 
 namespace search::queryeval {
 
@@ -15,7 +16,7 @@ class NearestNeighborDistanceHeap {
 private:
     std::mutex _lock;
     size_t _size;
-    double _distance_threshold;
+    std::atomic<double> _distance_threshold;
     vespalib::PriorityQueue<double, std::greater<double>> _priQ;
 public:
     explicit NearestNeighborDistanceHeap(size_t maxSize)
@@ -25,14 +26,10 @@ public:
         _priQ.reserve(maxSize);
     }
     void set_distance_threshold(double distance_threshold) {
-        _distance_threshold = distance_threshold;
+        _distance_threshold.store(distance_threshold, std::memory_order_relaxed);
     }
     double distanceLimit() {
-        std::lock_guard<std::mutex> guard(_lock);
-        if (_priQ.size() < _size) {
-            return _distance_threshold;
-        }
-        return _priQ.front();
+        return _distance_threshold.load(std::memory_order_relaxed);
     }
     void used(double distance) {
         std::lock_guard<std::mutex> guard(_lock);
@@ -41,6 +38,7 @@ public:
         } else if (distance < _priQ.front()) {
             _priQ.front() = distance;
             _priQ.adjust();
+            _distance_threshold.store(_priQ.front(), std::memory_order_relaxed);
         }
     }
 };

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_distance_heap.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_distance_heap.h
@@ -38,7 +38,11 @@ public:
         } else if (distance < _priQ.front()) {
             _priQ.front() = distance;
             _priQ.adjust();
-            _distance_threshold.store(_priQ.front(), std::memory_order_relaxed);
+        }
+        if (_priQ.size() >= _size) {
+            if (_distance_threshold.load(std::memory_order_relaxed) > _priQ.front()) {
+                _distance_threshold.store(_priQ.front(), std::memory_order_relaxed);
+            }
         }
     }
 };


### PR DESCRIPTION
… of the heap in unpack.

In addition to adjusting the priority Q also update the distance_threshold with a relaxed store to an atomic variable.
On read the distance threshold can be read cheaply with a relaxed load.

@geirst PR
@jobergum FYI