### PR TITLE
The global filter is only needed when having a nearest neighbor index…

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -92,7 +92,7 @@ NearestNeighborBlueprint::NearestNeighborBlueprint(const queryeval::FieldSpec& f
     }
     uint32_t est_hits = _attr_tensor.get_num_docs();
     setEstimate(HitEstimate(est_hits, false));
-    set_want_global_filter(true);
+    set_want_global_filter(nns_index && _approximate);
 }
 
 NearestNeighborBlueprint::~NearestNeighborBlueprint() = default;


### PR DESCRIPTION
… (hnsw) and doing approximate calculation.

This avoids costly calculation of the global filter in cases it is not needed.

@baldersheim and @arnej27959 please review