### PR TITLE
Lesters/use header host for base url in model eval

### DIFF
--- a/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
@@ -140,9 +140,14 @@ public class ModelsEvaluationHandler extends ThreadedHttpRequestHandler {
     private String baseUrl(HttpRequest request) {
        URI uri = request.getUri();
        StringBuilder sb = new StringBuilder();
-       sb.append(uri.getScheme()).append("://").append(uri.getHost());
-       if (uri.getPort() >= 0) {
-           sb.append(":").append(uri.getPort());
+       sb.append(uri.getScheme()).append("://");
+       if (request.getHeader("Host") != null) {
+           sb.append(request.getHeader("Host"));
+       } else {
+           sb.append(uri.getHost());
+           if (uri.getPort() >= 0) {
+               sb.append(":").append(uri.getPort());
+           }
        }
        sb.append("/").append(API_ROOT).append("/").append(VERSION_V1).append("/");
        return sb.toString();

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/HandlerTester.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/HandlerTester.java
@@ -32,9 +32,21 @@ class HandlerTester {
         assertResponse(url, Collections.emptyMap(), expectedCode, expectedResult);
     }
 
+    void assertResponse(String url, int expectedCode, String expectedResult, Map<String, String> headers) {
+        assertResponse(url, Collections.emptyMap(), expectedCode, expectedResult, headers);
+    }
+
     void assertResponse(String url, Map<String, String> properties, int expectedCode, String expectedResult) {
+        assertResponse(url, properties, expectedCode, expectedResult, Collections.emptyMap());
+    }
+
+    void assertResponse(String url, Map<String, String> properties, int expectedCode, String expectedResult, Map<String, String> headers) {
         HttpRequest getRequest = HttpRequest.createTestRequest(url, com.yahoo.jdisc.http.HttpRequest.Method.GET, null, properties);
         HttpRequest postRequest = HttpRequest.createTestRequest(url, com.yahoo.jdisc.http.HttpRequest.Method.POST, null, properties);
+        if (headers.size() > 0) {
+            headers.forEach((k,v) -> getRequest.getJDiscRequest().headers().add(k, v));
+            headers.forEach((k,v) -> postRequest.getJDiscRequest().headers().add(k, v));
+        }
         assertResponse(getRequest, expectedCode, expectedResult);
         assertResponse(postRequest, expectedCode, expectedResult);
     }

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
@@ -53,6 +53,15 @@ public class ModelsEvaluationHandlerTest {
     }
 
     @Test
+    public void testListModelsWithDifferentHost() {
+        String url = "http://localhost/model-evaluation/v1";
+        String expected =
+                "{\"mnist_softmax\":\"http://localhost:8088/model-evaluation/v1/mnist_softmax\",\"mnist_saved\":\"http://localhost:8088/model-evaluation/v1/mnist_saved\",\"mnist_softmax_saved\":\"http://localhost:8088/model-evaluation/v1/mnist_softmax_saved\",\"xgboost_2_2\":\"http://localhost:8088/model-evaluation/v1/xgboost_2_2\",\"lightgbm_regression\":\"http://localhost:8088/model-evaluation/v1/lightgbm_regression\"}";
+        handler.assertResponse(url, 200, expected, Map.of("Host", "localhost:8088"));
+    }
+
+
+    @Test
     public void testXgBoostEvaluationWithoutBindings() {
         String url = "http://localhost/model-evaluation/v1/xgboost_2_2/eval";  // only has a single function
         String expected = "{\"cells\":[{\"address\":{},\"value\":-4.376589999999999}]}";


### PR DESCRIPTION
@bjorncs Please review. If host header is not available, falls back to old behaviour (as this is not set in most unit tests).