### PR TITLE
Tweak colors and messages

### DIFF
--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -63,9 +63,9 @@ var deployCmd = &cobra.Command{
 		}
 		resolvedSrc, err := vespa.Deploy(d)
 		if err == nil {
-			log.Printf("Deployed %s successfully", color.Cyan(resolvedSrc))
+			log.Print(color.Green("Success: "), "Deployed ", color.Cyan(resolvedSrc))
 		} else {
-			log.Print(err)
+			log.Print(color.Red("Error:"), err)
 		}
 	},
 }
@@ -79,7 +79,7 @@ var prepareCmd = &cobra.Command{
 		if err == nil {
 			log.Printf("Prepared %s successfully", color.Cyan(resolvedSrc))
 		} else {
-			log.Print(color.Red(err))
+			log.Print(color.Red("Error: "), err)
 		}
 	},
 }
@@ -91,9 +91,9 @@ var activateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		resolvedSrc, err := vespa.Activate(vespa.Deployment{ApplicationSource: applicationSource(args)})
 		if err == nil {
-			log.Printf("Activated %s successfully", color.Cyan(resolvedSrc))
+			log.Print(color.Green("Success: "), "activated ", color.Cyan(resolvedSrc))
 		} else {
-			log.Print(color.Red(err))
+			log.Print(color.Red("Error: "), err)
 		}
 	},
 }

--- a/client/go/cmd/deploy_test.go
+++ b/client/go/cmd/deploy_test.go
@@ -22,7 +22,7 @@ func TestDeployZipWithURLTargetArgument(t *testing.T) {
 
 	client := &mockHttpClient{}
 	assert.Equal(t,
-		"Deployed "+applicationPackage+" successfully\n",
+		"Success: Deployed "+applicationPackage+"\n",
 		executeCommand(t, client, arguments, []string{}))
 	assertDeployRequestMade("http://target:19071", client, t)
 }
@@ -50,7 +50,7 @@ func TestDeployApplicationDirectoryWithPomAndTarget(t *testing.T) {
 func TestDeployApplicationDirectoryWithPomAndEmptyTarget(t *testing.T) {
 	client := &mockHttpClient{}
 	assert.Equal(t,
-		"pom.xml exists but no target/application.zip. Run mvn package first\n",
+		"Error: pom.xml exists but no target/application.zip. Run mvn package first\n",
 		executeCommand(t, client, []string{"deploy", "testdata/applications/withEmptyTarget"}, []string{}))
 }
 
@@ -65,7 +65,7 @@ func TestDeployError(t *testing.T) {
 func assertDeploy(applicationPackage string, arguments []string, t *testing.T) {
 	client := &mockHttpClient{}
 	assert.Equal(t,
-		"Deployed "+applicationPackage+" successfully\n",
+		"Success: Deployed "+applicationPackage+"\n",
 		executeCommand(t, client, arguments, []string{}))
 	assertDeployRequestMade("http://127.0.0.1:19071", client, t)
 }
@@ -84,13 +84,13 @@ func assertDeployRequestMade(target string, client *mockHttpClient, t *testing.T
 func assertApplicationPackageError(t *testing.T, status int, errorMessage string) {
 	client := &mockHttpClient{nextStatus: status, nextBody: errorMessage}
 	assert.Equal(t,
-		"Invalid application package (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
+		"Error: Invalid application package (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
 		executeCommand(t, client, []string{"deploy", "testdata/applications/withTarget/target/application.zip"}, []string{}))
 }
 
 func assertDeployServerError(t *testing.T, status int, errorMessage string) {
 	client := &mockHttpClient{nextStatus: status, nextBody: errorMessage}
 	assert.Equal(t,
-		"Error from deploy service at 127.0.0.1:19071 (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
+		"Error: Error from deploy service at 127.0.0.1:19071 (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
 		executeCommand(t, client, []string{"deploy", "testdata/applications/withTarget/target/application.zip"}, []string{}))
 }

--- a/client/go/cmd/query.go
+++ b/client/go/cmd/query.go
@@ -48,7 +48,7 @@ func query(arguments []string) {
 
 	response, err := util.HttpDo(&http.Request{URL: url}, time.Second*10, "Container")
 	if err != nil {
-		log.Print("Request failed: ", color.Red(err))
+		log.Print(color.Red("Error: "), "Request failed: ", err)
 		return
 	}
 	defer response.Body.Close()
@@ -56,10 +56,10 @@ func query(arguments []string) {
 	if response.StatusCode == 200 {
 		log.Print(util.ReaderToJSON(response.Body))
 	} else if response.StatusCode/100 == 4 {
-		log.Printf("Invalid query (%s):", color.Red(response.Status))
+		log.Print(color.Red("Error: "), "Invalid query: ", response.Status)
 		log.Print(util.ReaderToJSON(response.Body))
 	} else {
-		log.Printf("Error from container at %s (%s):", color.Cyan(url.Host), color.Red(response.Status))
+		log.Print(color.Red("Error: "), response.Status, " from container at ", color.Cyan(url.Host))
 		log.Print(util.ReaderToJSON(response.Body))
 	}
 }

--- a/client/go/cmd/query_test.go
+++ b/client/go/cmd/query_test.go
@@ -64,7 +64,7 @@ func assertQueryNonJsonResult(t *testing.T, expectedQuery string, query ...strin
 func assertQueryError(t *testing.T, status int, errorMessage string) {
 	client := &mockHttpClient{nextStatus: status, nextBody: errorMessage}
 	assert.Equal(t,
-		"Invalid query (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
+		"Error: Invalid query: Status "+strconv.Itoa(status)+"\n"+errorMessage+"\n",
 		executeCommand(t, client, []string{"query"}, []string{"yql=select from sources * where title contains 'foo'"}),
 		"error output")
 }
@@ -72,7 +72,7 @@ func assertQueryError(t *testing.T, status int, errorMessage string) {
 func assertQueryServiceError(t *testing.T, status int, errorMessage string) {
 	client := &mockHttpClient{nextStatus: status, nextBody: errorMessage}
 	assert.Equal(t,
-		"Error from container at 127.0.0.1:8080 (Status "+strconv.Itoa(status)+"):\n"+errorMessage+"\n",
+		"Error: Status "+strconv.Itoa(status)+" from container at 127.0.0.1:8080\n"+errorMessage+"\n",
 		executeCommand(t, client, []string{"query"}, []string{"yql=select from sources * where title contains 'foo'"}),
 		"error output")
 }

--- a/client/go/cmd/status.go
+++ b/client/go/cmd/status.go
@@ -59,14 +59,15 @@ func status(target string, description string) {
 	path := "/ApplicationStatus"
 	response, err := util.HttpGet(target, path, description)
 	if err != nil {
-		log.Print("Request failed: ", color.Red(err))
+		log.Print(description, " at ", color.Cyan(target), " is ", color.Red("not ready"))
+		log.Print(color.Brown(err))
 		return
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-		log.Print(description, " at ", color.Cyan(target), " is ", color.Yellow("not ready"))
-		log.Print(response.Status)
+		log.Print(description, " at ", color.Cyan(target), " is ", color.Red("not ready"))
+		log.Print(color.Brown(response.Status))
 	} else {
 		log.Print(description, " at ", color.Cyan(target), " is ", color.Green("ready"))
 	}

--- a/client/go/util/http.go
+++ b/client/go/util/http.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 )
 
@@ -48,7 +47,7 @@ func HttpGet(host string, path string, description string) (*http.Response, erro
 func HttpDo(request *http.Request, timeout time.Duration, description string) (*http.Response, error) {
 	response, err := ActiveHttpClient.Do(request, timeout)
 	if err != nil {
-		return nil, fmt.Errorf("Could not connect to %s at %s: %w", strings.ToLower(description), request.URL.Host, err)
+		return nil, err
 	}
 	return response, nil
 }


### PR DESCRIPTION
- Keep the red text short
- Mostly always indicate success or error by green or red
- Use brown for technical detail you don't need to look at most of the time