### PR TITLE
Fix flag-config binding

### DIFF
--- a/client/go/cmd/cert.go
+++ b/client/go/cmd/cert.go
@@ -19,7 +19,6 @@ var overwriteCertificate bool
 func init() {
 	rootCmd.AddCommand(certCmd)
 	certCmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
-	addApplicationFlag(certCmd)
 	certCmd.MarkPersistentFlagRequired(applicationFlag)
 }
 

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -22,7 +22,7 @@ const (
 	configType = "yaml"
 )
 
-var flagToConfigBindings map[string][]*cobra.Command = make(map[string][]*cobra.Command)
+var flagToConfigBindings map[string]*cobra.Command = make(map[string]*cobra.Command)
 
 func init() {
 	rootCmd.AddCommand(configCmd)
@@ -92,7 +92,7 @@ func configDir(application string) (string, error) {
 }
 
 func bindFlagToConfig(option string, command *cobra.Command) {
-	flagToConfigBindings[option] = append(flagToConfigBindings[option], command)
+	flagToConfigBindings[option] = command
 }
 
 func readConfig() {
@@ -106,10 +106,8 @@ func readConfig() {
 	viper.SetConfigType(configType)
 	viper.AddConfigPath(configDir)
 	viper.AutomaticEnv()
-	for option, commands := range flagToConfigBindings {
-		for _, command := range commands {
-			viper.BindPFlag(option, command.PersistentFlags().Lookup(option))
-		}
+	for option, command := range flagToConfigBindings {
+		viper.BindPFlag(option, command.PersistentFlags().Lookup(option))
 	}
 	err = viper.ReadInConfig()
 	if _, ok := err.(viper.ConfigFileNotFoundError); ok {

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -25,11 +25,6 @@ func init() {
 	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(prepareCmd)
 	rootCmd.AddCommand(activateCmd)
-	addTargetFlag(deployCmd)
-	addApplicationFlag(deployCmd)
-	addTargetFlag(prepareCmd)
-	addTargetFlag(activateCmd)
-
 	deployCmd.PersistentFlags().StringVarP(&zoneArg, zoneFlag, "z", "dev.aws-us-east-1c", "The zone to use for deployment")
 }
 

--- a/client/go/cmd/document.go
+++ b/client/go/cmd/document.go
@@ -23,7 +23,6 @@ func init() {
 	rootCmd.AddCommand(documentCmd)
 	documentCmd.AddCommand(documentPostCmd)
 	documentCmd.AddCommand(documentGetCmd)
-	addTargetFlag(documentCmd)
 }
 
 var documentCmd = &cobra.Command{

--- a/client/go/cmd/query.go
+++ b/client/go/cmd/query.go
@@ -17,7 +17,6 @@ import (
 
 func init() {
 	rootCmd.AddCommand(queryCmd)
-	addTargetFlag(queryCmd)
 }
 
 var queryCmd = &cobra.Command{

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -22,7 +22,14 @@ var (
 		Use:   "vespa",
 		Short: "A command-line tool for working with Vespa instances",
 	}
-	color aurora.Aurora
+	color          aurora.Aurora
+	targetArg      string
+	applicationArg string
+)
+
+const (
+	applicationFlag = "application"
+	targetFlag      = "target"
 )
 
 func configureLogger() {
@@ -34,6 +41,10 @@ func configureLogger() {
 func init() {
 	configureLogger()
 	cobra.OnInitialize(readConfig)
+	rootCmd.PersistentFlags().StringVarP(&targetArg, targetFlag, "t", "local", "The name or URL of the recipient of this command")
+	rootCmd.PersistentFlags().StringVarP(&applicationArg, applicationFlag, "a", "", "The application to manage")
+	bindFlagToConfig(targetFlag, rootCmd)
+	bindFlagToConfig(applicationFlag, rootCmd)
 }
 
 // Execute executes the root command.

--- a/client/go/cmd/status.go
+++ b/client/go/cmd/status.go
@@ -16,7 +16,6 @@ func init() {
 	statusCmd.AddCommand(statusQueryCmd)
 	statusCmd.AddCommand(statusDocumentCmd)
 	statusCmd.AddCommand(statusDeployCmd)
-	addTargetFlag(statusCmd)
 }
 
 var statusCmd = &cobra.Command{

--- a/client/go/cmd/target.go
+++ b/client/go/cmd/target.go
@@ -7,19 +7,10 @@ package cmd
 import (
 	"log"
 	"strings"
-
-	"github.com/spf13/cobra"
 )
 
 const (
-	applicationFlag = "application"
-	targetFlag      = "target"
-	cloudApi        = "https://api.vespa-external.aws.oath.cloud:4443"
-)
-
-var (
-	targetArg      string
-	applicationArg string
+	cloudApi = "https://api.vespa-external.aws.oath.cloud:4443"
 )
 
 type target struct {
@@ -35,16 +26,6 @@ const (
 	queryContext    context = 1
 	documentContext context = 2
 )
-
-func addTargetFlag(command *cobra.Command) {
-	command.PersistentFlags().StringVarP(&targetArg, targetFlag, "t", "local", "The name or URL of the recipient of this command")
-	bindFlagToConfig(targetFlag, command)
-}
-
-func addApplicationFlag(command *cobra.Command) {
-	command.PersistentFlags().StringVarP(&applicationArg, applicationFlag, "a", "", "The application name to use for deployment")
-	bindFlagToConfig(applicationFlag, command)
-}
 
 func deployTarget() string {
 	return getTarget(deployContext).deploy


### PR DESCRIPTION
When binding flags to config, only one flag reference can be bound per flag
name. I.e. we have to choose between flags being inherited by sub-commands that
don't need them, and the ability to bind them to config.

@bratseth