### PR TITLE
added valgrind suppression for wchar strings

### DIFF
--- a/eval/src/tests/apps/eval_expr/CMakeLists.txt
+++ b/eval/src/tests/apps/eval_expr/CMakeLists.txt
@@ -3,7 +3,7 @@ vespa_add_executable(eval_eval_expr_test_app TEST
     SOURCES
     eval_expr_test.cpp
     DEPENDS
-    vespalib
+    vespaeval
 )
 vespa_add_test(NAME eval_eval_expr_test_app COMMAND eval_eval_expr_test_app
                DEPENDS eval_eval_expr_test_app eval_eval_expr_app)

--- a/eval/src/tests/apps/eval_expr/eval_expr_test.cpp
+++ b/eval/src/tests/apps/eval_expr/eval_expr_test.cpp
@@ -9,8 +9,10 @@
 #include <vespa/vespalib/data/output.h>
 #include <vespa/vespalib/data/simple_buffer.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include <vespa/eval/eval/test/test_io.h>
 
 using namespace vespalib;
+using namespace vespalib::eval::test;
 using vespalib::make_string_short::fmt;
 using vespalib::slime::JsonFormat;
 using vespalib::slime::Inspector;
@@ -25,24 +27,6 @@ void read_until_eof(Input &input) {
     for (auto mem = input.obtain(); mem.size > 0; mem = input.obtain()) {
         input.evict(mem.size);
     }
-}
-
-// copied from vespalib::eval::test
-//
-// It seems that linking with the eval library contaminates the
-// process proxy in such a way that valgrind will fail. The working
-// theory is that some static state gets initialized before the proxy
-// is forked. This test bypasses the issue by linking with vespalib
-// instead. A more robust solution would be to reverse the roles of
-// the process proxy and the program; letting the proxy start the
-// program. This could also be combined with the ability to send open
-// file descriptors on unix domain sockets to avoid indirection for
-// stdin/stdout streams.
-
-void write_compact(const Slime &slime, Output &out) {
-    JsonFormat::encode(slime, out, true);
-    out.reserve(1).data[0] = '\n';
-    out.commit(1);
 }
 
 // Output adapter used to write to stdin of a child process

--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -307,6 +307,16 @@
    ...
 }
 {
+   Needed to avoid leak errors on static wchar strings when using the fastos process proxy
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNSbIwSt11char_traitsIwESaIwEE4_Rep9_S_createEmmRKS1_
+   ...
+   fun:__static_initialization_and_destruction_0
+   ...
+}
+{
    Apparent memory leak on Fedora 28.
    Memcheck:Leak
    match-leak-kinds: possible


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@arnej27959 @toregge FYI

I have also been told that the process proxy does _exit (avoiding cleanup) and that the proxy is not used even when started. The config sentinel also does fork with threads in production. I had an idea about how to make things more robust by having the proxy start the program to avoid contamination, but maybe we can just ignore it altogether and remove a lot of clever code...?