### PR TITLE
Add short form output option to model-evaluation REST API

### DIFF
--- a/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/handler/ModelsEvaluationHandler.java
@@ -10,6 +10,7 @@ import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
+import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.serialization.JsonFormat;
@@ -87,6 +88,11 @@ public class ModelsEvaluationHandler extends ThreadedHttpRequestHandler {
             }
         }
         Tensor result = evaluator.evaluate();
+
+        Optional<String> format = property(request, "format");
+        if (format.isPresent() && format.get().equalsIgnoreCase("short") && result instanceof IndexedTensor) {
+            return new Response(200, JsonFormat.encodeShortForm((IndexedTensor) result));
+        }
         return new Response(200, JsonFormat.encode(result));
     }
 

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
@@ -183,6 +183,16 @@ public class ModelsEvaluationHandlerTest {
     }
 
     @Test
+    public void testMnistSoftmaxEvaluateSpecificFunctionWithShortOutput() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("Placeholder", inputTensorShortForm());
+        properties.put("format", "short");
+        String url = "http://localhost/model-evaluation/v1/mnist_softmax/default.add/eval";
+        String expected = "{\"type\":\"tensor(d0[],d1[10])\",\"value\":[[-0.3546536862850189,0.3759574592113495,0.06054411828517914,-0.251544713973999,0.017951013520359993,1.2899067401885986,-0.10389615595340729,0.6367976665496826,-1.4136744737625122,-0.2573896050453186]]}";
+        handler.assertResponse(url, properties, 200, expected);
+    }
+
+    @Test
     public void testMnistSavedDetails() {
         String url = "http://localhost:8080/model-evaluation/v1/mnist_saved";
         String expected = "{\"model\":\"mnist_saved\",\"functions\":[{\"function\":\"serving_default.y\",\"info\":\"http://localhost:8080/model-evaluation/v1/mnist_saved/serving_default.y\",\"eval\":\"http://localhost:8080/model-evaluation/v1/mnist_saved/serving_default.y/eval\",\"arguments\":[{\"name\":\"input\",\"type\":\"tensor(d0[],d1[784])\"}]}]}";

--- a/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/serialization/JsonFormatTestCase.java
@@ -1,6 +1,7 @@
 // Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor.serialization;
 
+import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import org.junit.Test;
@@ -79,6 +80,30 @@ public class JsonFormatTestCase {
         String denseJson = "{\"values\":[2.0, 3.0, 4.0, 5.0, 6.0, 7.0]}";
         Tensor decoded = JsonFormat.decode(expected.type(), denseJson.getBytes(StandardCharsets.UTF_8));
         assertEquals(expected, decoded);
+    }
+
+    @Test
+    public void testDenseTensorShortForm() {
+        assertEncodeShortForm("tensor(x[]):[1.0, 2.0]",
+                              "{\"type\":\"tensor(x[])\",\"value\":[1.0,2.0]}");
+        assertEncodeShortForm("tensor<float>(x[]):[1.0, 2.0]",
+                              "{\"type\":\"tensor<float>(x[])\",\"value\":[1.0,2.0]}");
+        assertEncodeShortForm("tensor(x[],y[]):[[1,2,3,4]]",
+                              "{\"type\":\"tensor(x[],y[])\",\"value\":[[1.0,2.0,3.0,4.0]]}");
+        assertEncodeShortForm("tensor(x[],y[]):[[1,2],[3,4]]",
+                              "{\"type\":\"tensor(x[],y[])\",\"value\":[[1.0,2.0],[3.0,4.0]]}");
+        assertEncodeShortForm("tensor(x[],y[]):[[1],[2],[3],[4]]",
+                              "{\"type\":\"tensor(x[],y[])\",\"value\":[[1.0],[2.0],[3.0],[4.0]]}");
+        assertEncodeShortForm("tensor(x[],y[],z[]):[[[1,2],[3,4]]]",
+                              "{\"type\":\"tensor(x[],y[],z[])\",\"value\":[[[1.0,2.0],[3.0,4.0]]]}");
+        assertEncodeShortForm("tensor(x[],y[],z[]):[[[1],[2],[3],[4]]]",
+                              "{\"type\":\"tensor(x[],y[],z[])\",\"value\":[[[1.0],[2.0],[3.0],[4.0]]]}");
+        assertEncodeShortForm("tensor(x[],y[],z[]):[[[1,2,3,4]]]",
+                              "{\"type\":\"tensor(x[],y[],z[])\",\"value\":[[[1.0,2.0,3.0,4.0]]]}");
+        assertEncodeShortForm("tensor(x[],y[],z[]):[[[1]],[[2]],[[3]],[[4]]]",
+                              "{\"type\":\"tensor(x[],y[],z[])\",\"value\":[[[1.0]],[[2.0]],[[3.0]],[[4.0]]]}");
+        assertEncodeShortForm("tensor(x[],y[],z[2]):[[[1, 2]],[[3, 4]]]",
+                              "{\"type\":\"tensor(x[],y[],z[2])\",\"value\":[[[1.0,2.0]],[[3.0,4.0]]]}");
     }
 
     @Test
@@ -272,6 +297,11 @@ public class JsonFormatTestCase {
         assertEncodeDecode(Tensor.from("tensor<float>(x[2],y[2]):[2.0, 3.0, 5.0 ,8.0]"));
         assertEncodeDecode(Tensor.from("tensor<bfloat16>(x[2],y[2]):[2.0, 3.0, 5.0 ,8.0]"));
         assertEncodeDecode(Tensor.from("tensor<int8>(x[2],y[2]):[2,3,5,8]"));
+    }
+
+    private void assertEncodeShortForm(String tensor, String expected) {
+        byte[] json = JsonFormat.encodeShortForm((IndexedTensor) Tensor.from(tensor));
+        assertEquals(expected, new String(json, StandardCharsets.UTF_8));
     }
 
 }


### PR DESCRIPTION
@bratseth Please review. Adds option to output short format for indexed tensors to the model-evaluation REST API when the parameter `?format=short` is given. The name (and possibly output format) of this parameter should probably be discussed during an architect meeting.

As an example, the output for `tensor(x[3]):[1.0, 2.0, 3.0]` is

```
{
    "type":"tensor(x[3])",
    "value": [1.0, 2.0, 3.0]
}
```