### PR TITLE
The metrics proxy is very memory hungry.

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/ConfiguredMetric.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/ConfiguredMetric.java
@@ -1,0 +1,41 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.core;
+
+import ai.vespa.metricsproxy.metric.model.Dimension;
+import ai.vespa.metricsproxy.metric.model.DimensionId;
+import ai.vespa.metricsproxy.metric.model.MetricId;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ConfiguredMetric {
+    private final MetricId name;
+    private final String description;
+    private final String outputname;
+    private final List<Dimension> dimension;
+    public ConfiguredMetric(ConsumersConfig.Consumer.Metric m) {
+        name = MetricId.toMetricId(m.name());
+        outputname = m.outputname();
+        description = m.description();
+        dimension = new ArrayList<>(m.dimension().size());
+        m.dimension().forEach(d -> dimension.add(new Dimension(DimensionId.toDimensionId(d.key()), d.value())));
+    }
+    public MetricId id() { return name; }
+    public String outputname() { return outputname; }
+    public String description() { return description; }
+    public List<Dimension> dimension() { return dimension; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConfiguredMetric that = (ConfiguredMetric) o;
+        return name.equals(that.name) && description.equals(that.description) && outputname.equals(that.outputname) && dimension.equals(that.dimension);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, outputname, dimension);
+    }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/ExternalMetrics.java
@@ -1,8 +1,8 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.metric;
 
+import ai.vespa.metricsproxy.core.ConfiguredMetric;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
-import ai.vespa.metricsproxy.core.ConsumersConfig.Consumer;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.logging.Logger;
 
 import static ai.vespa.metricsproxy.metric.model.DimensionId.toDimensionId;
-import static ai.vespa.metricsproxy.metric.model.MetricId.toMetricId;
 import static ai.vespa.metricsproxy.metric.model.ServiceId.toServiceId;
 import static java.util.logging.Level.FINE;
 import static java.util.stream.Collectors.toCollection;
@@ -66,7 +65,7 @@ public class ExternalMetrics {
 
     private Set<MetricId> metricsToRetain() {
         return consumers.getConsumersByMetric().keySet().stream()
-                .map(configuredMetric -> toMetricId(configuredMetric.name()))
+                .map(configuredMetric -> configuredMetric.id())
                 .collect(toCollection(LinkedHashSet::new));
     }
 
@@ -76,9 +75,8 @@ public class ExternalMetrics {
      */
     private Map<MetricId, List<String>> outputNamesById() {
         Map<MetricId, List<String>> outputNamesById = new LinkedHashMap<>();
-        for (Consumer.Metric metric : consumers.getConsumersByMetric().keySet()) {
-            MetricId id = toMetricId(metric.name());
-            outputNamesById.computeIfAbsent(id, unused -> new ArrayList<>())
+        for (ConfiguredMetric metric : consumers.getConsumersByMetric().keySet()) {
+            outputNamesById.computeIfAbsent(metric.id(), unused -> new ArrayList<>())
                     .add(metric.outputname());
         }
         return outputNamesById;

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/Dimension.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/Dimension.java
@@ -1,0 +1,13 @@
+// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package ai.vespa.metricsproxy.metric.model;
+
+public final class Dimension {
+    private final DimensionId key;
+    private final String value;
+    public Dimension(DimensionId key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+    public DimensionId key() { return key; }
+    public String value() { return value; }
+}

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 /**
  * @author gjoranv
  */
-public class DimensionId {
+public final class DimensionId {
 
     public final String id;
     private DimensionId(String id) { this.id = id; }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricsPacket.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/MetricsPacket.java
@@ -6,6 +6,7 @@ import ai.vespa.metricsproxy.metric.Metric;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -90,7 +91,7 @@ public class MetricsPacket {
         private long timestamp = 0L;
         private Map<MetricId, Number> metrics = new LinkedHashMap<>();
         private final Map<DimensionId, String> dimensions = new LinkedHashMap<>();
-        private final Set<ConsumerId> consumers = new LinkedHashSet<>();
+        private Set<ConsumerId> consumers = Collections.emptySet();
 
         public Builder(ServiceId service) {
             Objects.requireNonNull(service, "Service cannot be null.");
@@ -177,7 +178,20 @@ public class MetricsPacket {
         }
 
         public Builder addConsumers(Set<ConsumerId> extraConsumers) {
-            if (extraConsumers != null) consumers.addAll(extraConsumers);
+            if ((extraConsumers != null) && !extraConsumers.isEmpty()) {
+                if (consumers.isEmpty()) {
+                    if (extraConsumers.size() == 1) {
+                        consumers = Collections.singleton(extraConsumers.iterator().next());
+                        return this;
+                    }
+                    consumers = new LinkedHashSet<>(extraConsumers.size());
+                } else if (consumers.size() == 1) {
+                    var copy = new LinkedHashSet<ConsumerId>(extraConsumers.size() + 1);
+                    copy.addAll(consumers);
+                    consumers = copy;
+                }
+                consumers.addAll(extraConsumers);
+            }
             return this;
         }
 

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/node/ServiceHealthGatherer.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/node/ServiceHealthGatherer.java
@@ -4,7 +4,6 @@ package ai.vespa.metricsproxy.node;
 import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricsPacket;
-import ai.vespa.metricsproxy.metric.model.ServiceId;
 import ai.vespa.metricsproxy.service.VespaServices;
 
 import java.time.Instant;
@@ -21,7 +20,7 @@ public class ServiceHealthGatherer {
         return vespaServices.getVespaServices()
                 .stream()
                 .map(service ->
-                     new MetricsPacket.Builder(ServiceId.toServiceId(service.getMonitoringName()))
+                     new MetricsPacket.Builder(service.getMonitoringName())
                             .timestamp(Instant.now().getEpochSecond())
                             .statusMessage(service.getHealth().getStatus().status)
                             .statusCode(service.getHealth().getStatus().code)

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
@@ -4,6 +4,7 @@ package ai.vespa.metricsproxy.service;
 import ai.vespa.metricsproxy.metric.HealthMetric;
 import ai.vespa.metricsproxy.metric.Metrics;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
+import ai.vespa.metricsproxy.metric.model.ServiceId;
 
 import java.util.Collections;
 import java.util.Map;
@@ -24,7 +25,7 @@ public class VespaService implements Comparable<VespaService> {
     private final String instanceName;
     private final String configId;
     private final String serviceName;
-    private final String monitoringPrefix;
+    private final ServiceId serviceId;
     private final Map<DimensionId, String> dimensions;
 
     private volatile int pid = -1;
@@ -67,7 +68,7 @@ public class VespaService implements Comparable<VespaService> {
                          Map<DimensionId, String> dimensions) {
         this.serviceName = serviceName;
         this.instanceName = instanceName;
-        this.monitoringPrefix = monitoringPrefix;
+        serviceId = ServiceId.toServiceId(monitoringPrefix + SEPARATOR + serviceName);
         this.configId = configId;
         this.statePort = statePort;
         this.dimensions = dimensions;
@@ -81,8 +82,8 @@ public class VespaService implements Comparable<VespaService> {
      * The name used for this service in the monitoring system:
      * monitoring-system-name.serviceName
      */
-    public String getMonitoringName() {
-        return monitoringPrefix + SEPARATOR + serviceName;
+    public ServiceId getMonitoringName() {
+        return serviceId;
     }
 
     @Override

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaServices.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaServices.java
@@ -105,7 +105,7 @@ public class VespaServices {
         List<VespaService> myServices = new ArrayList<>();
         for (VespaService s : services) {
             log.log(FINE, () -> "getMonitoringServices. service=" + service + ", checking against " + s + ", which has monitoring name " + s.getMonitoringName());
-            if (s.getMonitoringName().equalsIgnoreCase(service)) {
+            if (s.getMonitoringName().id.equalsIgnoreCase(service)) {
                 myServices.add(s);
             }
         }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcHealthMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcHealthMetricsTest.java
@@ -53,7 +53,7 @@ public class RpcHealthMetricsTest {
             assertThat("Status should be failed" + h.getMessage(), h.isOk(), is(false));
             assertThat(h.getMessage(), is("SOMETHING FAILED"));
 
-            String jsonRPCMessage = getHealthMetrics(tester, qrserver.getMonitoringName());
+            String jsonRPCMessage = getHealthMetrics(tester, qrserver.getMonitoringName().id);
             assertThat(jsonRPCMessage, is(WANTED_RPC_RESPONSE));
         }
     }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcMetricsTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/rpc/RpcMetricsTest.java
@@ -103,7 +103,7 @@ public class RpcMetricsTest {
             assertThat("#Services should be 1 for config id " + SERVICE_1_CONFIG_ID, services.size(), is(1));
 
             VespaService qrserver = services.get(0);
-            assertThat(qrserver.getMonitoringName(), is(MONITORING_SYSTEM + VespaService.SEPARATOR + "qrserver"));
+            assertThat(qrserver.getMonitoringName().id, is(MONITORING_SYSTEM + VespaService.SEPARATOR + "qrserver"));
 
             Metrics metrics = qrserver.getMetrics();
             assertThat("Fetched number of metrics is not correct", metrics.size(), is(2));
@@ -134,7 +134,7 @@ public class RpcMetricsTest {
     }
 
     private static void verifyMetricsFromRpcRequest(VespaService service, RpcClient client) throws IOException {
-        String jsonResponse = getMetricsForYamas(service.getMonitoringName(), client).trim();
+        String jsonResponse = getMetricsForYamas(service.getMonitoringName().id, client).trim();
         ArrayNode metrics = (ArrayNode) jsonMapper.readTree(jsonResponse).get("metrics");
         assertThat("Expected 3 metric messages", metrics.size(), is(3));
         for (int i = 0; i < metrics.size() - 1; i++) { // The last "metric message" contains only status code/message
@@ -193,7 +193,7 @@ public class RpcMetricsTest {
             assertNotNull("Did not find expected metric with name 'bar'", m2);
 
             try (RpcClient rpcClient = new RpcClient(tester.rpcPort())) {
-                String response = getAllMetricNamesForService(services.get(0).getMonitoringName(), vespaMetricsConsumerId, rpcClient);
+                String response = getAllMetricNamesForService(services.get(0).getMonitoringName().id, vespaMetricsConsumerId, rpcClient);
                 assertThat(response, is("foo.count=ON;output-name=foo_count,bar.count=OFF,"));
             }
         }


### PR DESCRIPTION
This will avoid creating many identical DimensionIds, ServiceIds.
It will also prefer using cheap singleton lists where possible.
In addition the code relies less on generated Config code.

@hmusum PR