### PR TITLE
Disallow feeding empty indexed tensors

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
@@ -94,6 +94,8 @@ public class TensorReader {
         IndexedTensor.BoundBuilder indexedBuilder = (IndexedTensor.BoundBuilder)builder;
         if (buffer.currentToken() == JsonToken.VALUE_STRING) {
             double[] decoded = decodeHexString(buffer.currentText(), builder.type().valueType());
+            if (decoded.length == 0)
+                throw new IllegalArgumentException("The 'values' string does not contain any values");
             for (int i = 0; i < decoded.length; i++) {
                 indexedBuilder.cellByDirectIndex(i, decoded[i]);
             }
@@ -104,6 +106,8 @@ public class TensorReader {
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
             indexedBuilder.cellByDirectIndex(index++, readDouble(buffer));
         }
+        if (index == 0)
+            throw new IllegalArgumentException("The 'values' array does not contain any values");
         expectCompositeEnd(buffer.currentToken());
     }
 

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -1282,6 +1282,22 @@ public class JsonReaderTestCase {
     }
 
     @Test
+    public void testDisallowedDenseTensorShortFormWithoutValues() {
+        assertCreatePutFails(inputJson("{ 'values': [] }"), "dense_tensor",
+                "The 'values' array does not contain any values");
+        assertCreatePutFails(inputJson("{ 'values': '' }"), "dense_tensor",
+                "The 'values' string does not contain any values");
+    }
+
+    @Test
+    public void testDisallowedMixedTensorShortFormWithoutValues() {
+        assertCreatePutFails(inputJson("{\"blocks\":{ \"a\": [] } }"),
+                "mixed_tensor", "Expected 3 values, but got 0");
+        assertCreatePutFails(inputJson("{\"blocks\":[ {\"address\":{\"x\":\"a\"}, \"values\": [] } ] }"),
+                "mixed_tensor", "Expected 3 values, but got 0");
+    }
+
+    @Test
     public void testParsingOfSparseTensorWithCells() {
         Tensor tensor = assertSparseTensorField("{{x:a,y:b}:2.0,{x:c,y:b}:3.0}}",
                                 createPutWithSparseTensor(inputJson("{",
@@ -2027,6 +2043,15 @@ public class JsonReaderTestCase {
         exception.expectMessage(expectedError);
         String jsonData = inputJson(json);
         new JsonReader(types, jsonToInputStream(jsonData), parserFactory).next();
+    }
+
+    private void assertCreatePutFails(String tensor, String name, String msg) {
+        try {
+            createPutWithTensor(inputJson(tensor), name);
+            fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains(msg));
+        }
     }
 
 }


### PR DESCRIPTION
@bratseth Please review. Ref: https://github.com/vespa-engine/vespa/issues/18909

I guess this can break existing feeds currently doing this?