### PR TITLE
Port remaining legacy distributor tests to top-level test suite

### DIFF
--- a/storage/src/tests/distributor/legacy_distributor_test.cpp
+++ b/storage/src/tests/distributor/legacy_distributor_test.cpp
@@ -701,7 +701,7 @@ TEST_F(LegacyDistributorTest, stats_generated_for_preempted_operations) {
     }
 }
 
-// TODO STRIPE -> distributor test
+// Migrated to TopLevelDistributorTest
 TEST_F(LegacyDistributorTest, host_info_reporter_config_is_propagated_to_reporter) {
     setupDistributor(Redundancy(2), NodeCount(2), "storage:2 distributor:1");
 
@@ -830,10 +830,7 @@ void LegacyDistributorTest::assertNoMessageBounced() {
     ASSERT_EQ(0, _sender.replies().size());
 }
 
-// TODO refactor this to set proper highest timestamp as part of bucket info
-// reply once we have the "highest timestamp across all owned buckets" feature
-// in place.
-// TODO STRIPE where does this truly belong?
+// Migrated to TopLevelDistributorTest
 TEST_F(LegacyDistributorTest, configured_safe_time_point_rejection_works_end_to_end) {
     setupDistributor(Redundancy(2), NodeCount(2),
                      "bits:1 storage:1 distributor:2");
@@ -1021,8 +1018,7 @@ void assert_invalid_stats_for_all_spaces(
 }
 
 // Migrated to DistributorStripeTest
-// TODO STRIPE must impl/test cross-stripe bucket space stats
-// TODO STRIPE cross-stripe recovery mode handling how?
+// Cross-stripe bucket stats test added in TopLevelDistributorTest::entering_recovery_mode_resets_bucket_space_stats_across_all_stripes
 TEST_F(LegacyDistributorTest, entering_recovery_mode_resets_bucket_space_stats) {
     // Set up a cluster state + DB contents which implies merge maintenance ops
     setupDistributor(Redundancy(2), NodeCount(2), "version:1 distributor:1 storage:2");
@@ -1044,7 +1040,7 @@ TEST_F(LegacyDistributorTest, entering_recovery_mode_resets_bucket_space_stats) 
     assert_invalid_stats_for_all_spaces(stats, 2);
 }
 
-// TODO: migrate to TopLevelDistributorTest
+// Migrated to TopLevelDistributorTest
 TEST_F(LegacyDistributorTest, leaving_recovery_mode_immediately_sends_getnodestate_replies) {
     setupDistributor(Redundancy(2), NodeCount(2), "version:1 distributor:1 storage:2");
     // Should not send explicit replies during init stage

--- a/storage/src/tests/distributor/mock_tickable_stripe.h
+++ b/storage/src/tests/distributor/mock_tickable_stripe.h
@@ -13,7 +13,7 @@ struct MockTickableStripe : TickableStripe {
     void update_distribution_config(const BucketSpaceDistributionConfigs&) override { abort(); }
     void set_pending_cluster_state_bundle(const lib::ClusterStateBundle&) override { abort(); }
     void clear_pending_cluster_state_bundle() override { abort(); }
-    void enable_cluster_state_bundle(const lib::ClusterStateBundle&) override { abort(); }
+    void enable_cluster_state_bundle(const lib::ClusterStateBundle&, bool) override { abort(); }
     void notify_distribution_change_enabled() override { abort(); }
     PotentialDataLossReport remove_superfluous_buckets(document::BucketSpace, const lib::ClusterState&, bool) override {
         abort();

--- a/storage/src/tests/distributor/simplemaintenancescannertest.cpp
+++ b/storage/src/tests/distributor/simplemaintenancescannertest.cpp
@@ -294,4 +294,12 @@ TEST_F(SimpleMaintenanceScannerTest, merge_pending_maintenance_stats) {
     EXPECT_EQ(exp.perNodeStats, result.perNodeStats);
 }
 
+TEST_F(SimpleMaintenanceScannerTest, empty_bucket_db_is_immediately_done_by_default) {
+    auto res = _scanner->scanNext();
+    EXPECT_TRUE(res.isDone());
+    _scanner->reset();
+    res = _scanner->scanNext();
+    EXPECT_TRUE(res.isDone());
+}
+
 }

--- a/storage/src/tests/distributor/top_level_distributor_test_util.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.cpp
@@ -305,10 +305,12 @@ TopLevelDistributorTestUtil::all_distributor_stripes_are_in_recovery_mode() cons
 }
 
 void
-TopLevelDistributorTestUtil::enable_distributor_cluster_state(vespalib::stringref state)
+TopLevelDistributorTestUtil::enable_distributor_cluster_state(vespalib::stringref state,
+                                                              bool has_bucket_ownership_transfer)
 {
     bucket_db_updater().simulate_cluster_state_bundle_activation(
-            lib::ClusterStateBundle(lib::ClusterState(state)));
+            lib::ClusterStateBundle(lib::ClusterState(state)),
+            has_bucket_ownership_transfer);
 }
 
 void

--- a/storage/src/tests/distributor/top_level_distributor_test_util.h
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.h
@@ -128,7 +128,7 @@ protected:
     MessageSenderImpl _message_sender;
     uint32_t _num_distributor_stripes;
 
-    void enable_distributor_cluster_state(vespalib::stringref state);
+    void enable_distributor_cluster_state(vespalib::stringref state, bool has_bucket_ownership_transfer = false);
     void enable_distributor_cluster_state(const lib::ClusterStateBundle& state);
 };
 

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.cpp
@@ -424,12 +424,14 @@ BucketDBUpdater::enable_current_cluster_state_bundle_in_distributor_and_stripes(
     LOG(debug, "BucketDBUpdater finished processing state %s",
         state.getBaselineClusterState()->toString().c_str());
 
-    guard.enable_cluster_state_bundle(state);
+    guard.enable_cluster_state_bundle(state, _pending_cluster_state->hasBucketOwnershipTransfer());
 }
 
-void BucketDBUpdater::simulate_cluster_state_bundle_activation(const lib::ClusterStateBundle& activated_state) {
+void BucketDBUpdater::simulate_cluster_state_bundle_activation(const lib::ClusterStateBundle& activated_state,
+                                                               bool has_bucket_ownership_transfer)
+{
     auto guard = _stripe_accessor.rendezvous_and_hold_all();
-    guard->enable_cluster_state_bundle(activated_state);
+    guard->enable_cluster_state_bundle(activated_state, has_bucket_ownership_transfer);
 
     _active_state_bundle = activated_state;
     propagate_active_state_bundle_internally();

--- a/storage/src/vespa/storage/distributor/bucketdbupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdbupdater.h
@@ -78,7 +78,8 @@ private:
     // Only to be used by tests that want to ensure both the BucketDBUpdater _and_ the Distributor
     // components agree on the currently active cluster state bundle.
     // Transitively invokes Distributor::enableClusterStateBundle
-    void simulate_cluster_state_bundle_activation(const lib::ClusterStateBundle& activated_state);
+    void simulate_cluster_state_bundle_activation(const lib::ClusterStateBundle& activated_state,
+                                                  bool has_bucket_ownership_transfer = false);
 
     bool should_defer_state_enabling() const noexcept;
     bool has_pending_cluster_state() const;

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -273,7 +273,8 @@ private:
     void update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config) override;
     void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) override;
     void clear_pending_cluster_state_bundle() override;
-    void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state) override;
+    void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
+                                     bool has_bucket_ownership_change) override;
     void notify_distribution_change_enabled() override;
     PotentialDataLossReport remove_superfluous_buckets(document::BucketSpace bucket_space,
                                                        const lib::ClusterState& new_state,

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
@@ -51,9 +51,11 @@ void MultiThreadedStripeAccessGuard::clear_pending_cluster_state_bundle() {
     });
 }
 
-void MultiThreadedStripeAccessGuard::enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state) {
+void MultiThreadedStripeAccessGuard::enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
+                                                                 bool has_bucket_ownership_change)
+{
     for_each_stripe([&](TickableStripe& stripe) {
-        stripe.enable_cluster_state_bundle(new_state);
+        stripe.enable_cluster_state_bundle(new_state, has_bucket_ownership_change);
     });
 }
 

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
@@ -34,7 +34,8 @@ public:
     void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) override;
     void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) override;
     void clear_pending_cluster_state_bundle() override;
-    void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state) override;
+    void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
+                                     bool has_bucket_ownership_change) override;
     void notify_distribution_change_enabled() override;
 
     PotentialDataLossReport remove_superfluous_buckets(document::BucketSpace bucket_space,

--- a/storage/src/vespa/storage/distributor/stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/stripe_access_guard.h
@@ -37,7 +37,8 @@ public:
     virtual void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) = 0;
     virtual void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) = 0;
     virtual void clear_pending_cluster_state_bundle() = 0;
-    virtual void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state) = 0;
+    virtual void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
+                                             bool has_bucket_ownership_change) = 0;
     virtual void notify_distribution_change_enabled() = 0;
 
     virtual PotentialDataLossReport remove_superfluous_buckets(document::BucketSpace bucket_space,

--- a/storage/src/vespa/storage/distributor/tickable_stripe.h
+++ b/storage/src/vespa/storage/distributor/tickable_stripe.h
@@ -39,7 +39,8 @@ public:
     virtual void update_distribution_config(const BucketSpaceDistributionConfigs& new_configs) = 0;
     virtual void set_pending_cluster_state_bundle(const lib::ClusterStateBundle& pending_state) = 0;
     virtual void clear_pending_cluster_state_bundle() = 0;
-    virtual void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state) = 0;
+    virtual void enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
+                                             bool has_bucket_ownership_change) = 0;
     virtual void notify_distribution_change_enabled() = 0;
 
     virtual PotentialDataLossReport remove_superfluous_buckets(document::BucketSpace bucket_space,


### PR DESCRIPTION
@geirst please review

Also fix a minor regression caused by the stripe cluster state change
code path consulting a now unused part of the `StripeBucketDBUpdater`
on whether a cluster state change implies bucket ownership change.
This was used for adding a configurable safe period for client mutations
to ensure distributors can't step on each others toes. The responsibility
for telling stripes that state changes imply ownership changes has
now been moved to the top-level DB updater and happens through the
stripe guard interface instead.
