### PR TITLE
Fix module path

### DIFF
--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -10,8 +10,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/util"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 var overwriteKey bool

--- a/client/go/cmd/cert.go
+++ b/client/go/cmd/cert.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/util"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 var overwriteCertificate bool

--- a/client/go/cmd/clone.go
+++ b/client/go/cmd/clone.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 // Set this to test without downloading this file from github

--- a/client/go/cmd/clone_test.go
+++ b/client/go/cmd/clone_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 func TestClone(t *testing.T) {

--- a/client/go/cmd/command_tester.go
+++ b/client/go/cmd/command_tester.go
@@ -19,7 +19,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 type command struct {

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/vespa-engine/vespa/util"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 const (

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 const (

--- a/client/go/cmd/document.go
+++ b/client/go/cmd/document.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/util"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 func init() {

--- a/client/go/cmd/document_test.go
+++ b/client/go/cmd/document_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/vespa-engine/vespa/util"
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 func TestDocumentSendPut(t *testing.T) {

--- a/client/go/cmd/helpers.go
+++ b/client/go/cmd/helpers.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vespa-engine/vespa/vespa"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
 var exitFunc = os.Exit // To allow overriding Exit in tests

--- a/client/go/cmd/query.go
+++ b/client/go/cmd/query.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 func init() {

--- a/client/go/cmd/vespa/main.go
+++ b/client/go/cmd/vespa/main.go
@@ -5,7 +5,7 @@
 package main
 
 import (
-	"github.com/vespa-engine/vespa/cmd"
+	"github.com/vespa-engine/vespa/client/go/cmd"
 )
 
 func main() {

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/vespa-engine/vespa
+module github.com/vespa-engine/vespa/client/go
 
 go 1.16
 

--- a/client/go/vespa/deploy.go
+++ b/client/go/vespa/deploy.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 type ApplicationID struct {

--- a/client/go/vespa/document.go
+++ b/client/go/vespa/document.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 // Sends the operation given in the file

--- a/client/go/vespa/target.go
+++ b/client/go/vespa/target.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/vespa-engine/vespa/util"
+	"github.com/vespa-engine/vespa/client/go/util"
 )
 
 const (


### PR DESCRIPTION
This allows using `go install` to install Vespa CLI.

From https://golang.org/ref/mod#vcs-dir:

Modules are sometimes defined in repository subdirectories. This is typically
done for large repositories with multiple components that need to be released
and versioned independently. _Such a module is expected to be found in a
subdirectory that matches the part of the module’s path after the repository
root path._

@bratseth