### PR TITLE
Print corresponding public key if API key already exists

### DIFF
--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -34,7 +34,7 @@ var apiKeyCmd = &cobra.Command{
 		}
 		app, err := vespa.ApplicationFromString(getApplication())
 		if err != nil {
-			printErr(err, "Could not parse application")
+			fatalErr(err, "Could not parse application")
 			return
 		}
 		apiKeyFile := filepath.Join(configDir, app.Tenant+".api-key.pem")
@@ -45,14 +45,14 @@ var apiKeyCmd = &cobra.Command{
 		}
 		apiKey, err := vespa.CreateAPIKey()
 		if err != nil {
-			printErr(err, "Could not create API key")
+			fatalErr(err, "Could not create API key")
 			return
 		}
 		if err := os.WriteFile(apiKeyFile, apiKey, 0600); err == nil {
 			printSuccess("API private key written to ", apiKeyFile)
 			printPublicKey(apiKeyFile, app.Tenant)
 		} else {
-			printErr(err, "Failed to write ", apiKeyFile)
+			fatalErr(err, "Failed to write ", apiKeyFile)
 		}
 	},
 }
@@ -60,22 +60,22 @@ var apiKeyCmd = &cobra.Command{
 func printPublicKey(apiKeyFile, tenant string) {
 	pemKeyData, err := os.ReadFile(apiKeyFile)
 	if err != nil {
-		printErr(err, "Failed to read ", apiKeyFile)
+		fatalErr(err, "Failed to read ", apiKeyFile)
 		return
 	}
 	key, err := vespa.ECPrivateKeyFrom(pemKeyData)
 	if err != nil {
-		printErr(err, "Failed to load key")
+		fatalErr(err, "Failed to load key")
 		return
 	}
 	pemPublicKey, err := vespa.PEMPublicKeyFrom(key)
 	if err != nil {
-		printErr(err, "Failed to extract public key")
+		fatalErr(err, "Failed to extract public key")
 		return
 	}
 	fingerprint, err := vespa.FingerprintMD5(pemPublicKey)
 	if err != nil {
-		printErr(err, "Failed to extract fingerprint")
+		fatalErr(err, "Failed to extract fingerprint")
 	}
 	log.Printf("\nThis is your public key:\n%s", color.Green(pemPublicKey))
 	log.Printf("Its fingerprint is:\n%s\n", color.Cyan(fingerprint))

--- a/client/go/cmd/api_key_test.go
+++ b/client/go/cmd/api_key_test.go
@@ -19,4 +19,5 @@ func TestAPIKey(t *testing.T) {
 
 	out = execute(command{args: []string{"api-key", "-a", "t1.a1.i1"}, configDir: configDir}, t, nil)
 	assert.True(t, strings.HasPrefix(out, "Error: File "+keyFile+" already exists\nHint: Use -f to overwrite it\n"))
+	assert.True(t, strings.Contains(out, "This is your public key"))
 }

--- a/client/go/cmd/cert.go
+++ b/client/go/cmd/cert.go
@@ -30,7 +30,7 @@ var certCmd = &cobra.Command{
 		app := getApplication()
 		pkg, err := vespa.ApplicationPackageFrom(applicationSource(args))
 		if err != nil {
-			printErr(err)
+			fatalErr(err)
 			return
 		}
 		configDir := configDir(app)
@@ -44,7 +44,7 @@ var certCmd = &cobra.Command{
 		if !overwriteCertificate {
 			for _, file := range []string{pkgCertificateFile, privateKeyFile, certificateFile} {
 				if util.PathExists(file) {
-					printErrHint(fmt.Errorf("Certificate or private key %s already exists", color.Cyan(file)), "Use -f flag to force overwriting")
+					fatalErrHint(fmt.Errorf("Certificate or private key %s already exists", color.Cyan(file)), "Use -f flag to force overwriting")
 					return
 				}
 			}
@@ -52,23 +52,23 @@ var certCmd = &cobra.Command{
 
 		keyPair, err := vespa.CreateKeyPair()
 		if err != nil {
-			printErr(err, "Could not create key pair")
+			fatalErr(err, "Could not create key pair")
 			return
 		}
 		if err := os.MkdirAll(securityDir, 0755); err != nil {
-			printErr(err, "Could not create security directory")
+			fatalErr(err, "Could not create security directory")
 			return
 		}
 		if err := keyPair.WriteCertificateFile(pkgCertificateFile, overwriteCertificate); err != nil {
-			printErr(err, "Could not write certificate")
+			fatalErr(err, "Could not write certificate")
 			return
 		}
 		if err := keyPair.WriteCertificateFile(certificateFile, overwriteCertificate); err != nil {
-			printErr(err, "Could not write certificate")
+			fatalErr(err, "Could not write certificate")
 			return
 		}
 		if err := keyPair.WritePrivateKeyFile(privateKeyFile, overwriteCertificate); err != nil {
-			printErr(err, "Could not write private key")
+			fatalErr(err, "Could not write private key")
 			return
 		}
 		printSuccess("Certificate written to ", color.Cyan(pkgCertificateFile))

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -86,13 +86,13 @@ func configDir(application string) string {
 		var err error
 		home, err = os.UserHomeDir()
 		if err != nil {
-			printErr(err, "Could not determine configuration directory")
+			fatalErr(err, "Could not determine configuration directory")
 			return ""
 		}
 	}
 	configDir := filepath.Join(home, ".vespa", application)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
-		printErr(err, "Could not create config directory")
+		fatalErr(err, "Could not create config directory")
 		return ""
 	}
 	return configDir
@@ -119,7 +119,7 @@ func readConfig() {
 		return // Fine
 	}
 	if err != nil {
-		printErr(err, "Could not read configuration")
+		fatalErr(err, "Could not read configuration")
 	}
 }
 
@@ -167,7 +167,7 @@ func writeConfig() {
 
 	if !util.PathExists(configDir) {
 		if err := os.MkdirAll(configDir, 0700); err != nil {
-			printErr(err, "Could not create ", color.Cyan(configDir))
+			fatalErr(err, "Could not create ", color.Cyan(configDir))
 			return
 		}
 	}
@@ -175,13 +175,13 @@ func writeConfig() {
 	configFile := filepath.Join(configDir, configName+"."+configType)
 	if !util.PathExists(configFile) {
 		if _, err := os.Create(configFile); err != nil {
-			printErr(err, "Could not create ", color.Cyan(configFile))
+			fatalErr(err, "Could not create ", color.Cyan(configFile))
 			return
 		}
 	}
 
 	if err := viper.WriteConfig(); err != nil {
-		printErr(err, "Could not write config")
+		fatalErr(err, "Could not write config")
 		return
 	}
 }

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -44,7 +44,7 @@ has started but may not have completed.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		pkg, err := vespa.ApplicationPackageFrom(applicationSource(args))
 		if err != nil {
-			printErr(nil, err.Error())
+			fatalErr(nil, err.Error())
 			return
 		}
 		target := getTarget()
@@ -52,7 +52,7 @@ has started but may not have completed.`,
 		if opts.IsCloud() {
 			deployment := deploymentFromArgs()
 			if !opts.ApplicationPackage.HasCertificate() {
-				printErrHint(fmt.Errorf("Missing certificate in application package"), "Applications in Vespa Cloud require a certificate", "Try 'vespa cert'")
+				fatalErrHint(fmt.Errorf("Missing certificate in application package"), "Applications in Vespa Cloud require a certificate", "Try 'vespa cert'")
 			}
 			opts.APIKey = readAPIKey(deployment.Application.Tenant)
 			opts.Deployment = deployment
@@ -65,7 +65,7 @@ has started but may not have completed.`,
 			}
 			waitForQueryService()
 		} else {
-			printErr(nil, err.Error())
+			fatalErr(nil, err.Error())
 		}
 	},
 }
@@ -77,7 +77,7 @@ var prepareCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pkg, err := vespa.ApplicationPackageFrom(applicationSource(args))
 		if err != nil {
-			printErr(err, "Could not find application package")
+			fatalErr(err, "Could not find application package")
 			return
 		}
 		configDir := configDir("default")
@@ -93,7 +93,7 @@ var prepareCmd = &cobra.Command{
 			writeSessionID(configDir, sessionID)
 			printSuccess("Prepared ", color.Cyan(pkg.Path), " with session ", sessionID)
 		} else {
-			printErr(nil, err.Error())
+			fatalErr(nil, err.Error())
 		}
 	},
 }
@@ -105,7 +105,7 @@ var activateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pkg, err := vespa.ApplicationPackageFrom(applicationSource(args))
 		if err != nil {
-			printErr(err, "Could not find application package")
+			fatalErr(err, "Could not find application package")
 			return
 		}
 		configDir := configDir("default")
@@ -119,7 +119,7 @@ var activateCmd = &cobra.Command{
 			printSuccess("Activated ", color.Cyan(pkg.Path), " with session ", sessionID)
 			waitForQueryService()
 		} else {
-			printErr(nil, err.Error())
+			fatalErr(nil, err.Error())
 		}
 	},
 }
@@ -133,21 +133,21 @@ func waitForQueryService() {
 
 func writeSessionID(appConfigDir string, sessionID int64) {
 	if err := os.MkdirAll(appConfigDir, 0755); err != nil {
-		printErr(err, "Could not create directory for session ID")
+		fatalErr(err, "Could not create directory for session ID")
 	}
 	if err := os.WriteFile(sessionIDFile(appConfigDir), []byte(fmt.Sprintf("%d\n", sessionID)), 0600); err != nil {
-		printErr(err, "Could not write session ID")
+		fatalErr(err, "Could not write session ID")
 	}
 }
 
 func readSessionID(appConfigDir string) int64 {
 	b, err := os.ReadFile(sessionIDFile(appConfigDir))
 	if err != nil {
-		printErr(err, "Could not read session ID")
+		fatalErr(err, "Could not read session ID")
 	}
 	id, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
 	if err != nil {
-		printErr(err, "Invalid session ID")
+		fatalErr(err, "Invalid session ID")
 	}
 	return id
 }


### PR DESCRIPTION
Split the helper functions a bit. `fatalXXX` triggers immediate exit, while
`printXXX` does not.

@bratseth