### PR TITLE
Wire in executor in deploystate that can be use to speed up deploymen…

### DIFF
--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -11,7 +11,11 @@ import com.google.common.annotations.Beta;
 import com.yahoo.application.container.JDisc;
 import com.yahoo.application.container.impl.StandaloneContainerRunner;
 import com.yahoo.application.content.ContentCluster;
-import com.yahoo.config.*;
+import com.yahoo.config.ConfigInstance;
+import com.yahoo.config.InnerNode;
+import com.yahoo.config.InnerNodeVector;
+import com.yahoo.config.LeafNode;
+import com.yahoo.config.LeafNodeVector;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
@@ -37,7 +41,13 @@ import java.net.BindException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
 
 /**
  * Contains one or more containers built from services.xml.

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/DeployState.java
@@ -5,6 +5,7 @@ import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import ai.vespa.rankingexpression.importer.configmodelview.MlModelImporter;
 import com.yahoo.component.Version;
 import com.yahoo.component.Vtag;
+import com.yahoo.concurrent.InThreadExecutorService;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
@@ -55,6 +56,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 
 /**
@@ -87,6 +89,7 @@ public class DeployState implements ConfigDefinitionStore {
     private final HostProvisioner provisioner;
     private final Provisioned provisioned;
     private final Reindexing reindexing;
+    private final ExecutorService executor;
 
     public static DeployState createTestState() {
         return new Builder().build();
@@ -104,6 +107,7 @@ public class DeployState implements ConfigDefinitionStore {
                         SearchDocumentModel searchDocumentModel,
                         RankProfileRegistry rankProfileRegistry,
                         FileRegistry fileRegistry,
+                        ExecutorService executor,
                         DeployLogger deployLogger,
                         Optional<HostProvisioner> hostProvisioner,
                         Provisioned provisioned,
@@ -124,6 +128,7 @@ public class DeployState implements ConfigDefinitionStore {
                         Reindexing reindexing) {
         this.logger = deployLogger;
         this.fileRegistry = fileRegistry;
+        this.executor = executor;
         this.rankProfileRegistry = rankProfileRegistry;
         this.applicationPackage = applicationPackage;
         this.properties = properties;
@@ -282,6 +287,8 @@ public class DeployState implements ConfigDefinitionStore {
     /** The (machine learned) models imported from the models/ directory, as an unmodifiable map indexed by model name */
     public ImportedMlModels getImportedModels() { return importedModels; }
 
+    public ExecutorService getExecutor() { return executor; }
+
     public Version getWantedNodeVespaVersion() { return wantedNodeVespaVersion; }
 
     public Optional<DockerImage> getWantedDockerImageRepo() { return wantedDockerImageRepo; }
@@ -312,6 +319,7 @@ public class DeployState implements ConfigDefinitionStore {
 
         private ApplicationPackage applicationPackage = MockApplicationPackage.createEmpty();
         private FileRegistry fileRegistry = new MockFileRegistry();
+        private ExecutorService executor = new InThreadExecutorService();
         private DeployLogger logger = new BaseDeployLogger();
         private Optional<HostProvisioner> hostProvisioner = Optional.empty();
         private Provisioned provisioned = new Provisioned();
@@ -329,6 +337,8 @@ public class DeployState implements ConfigDefinitionStore {
         private Optional<DockerImage> wantedDockerImageRepo = Optional.empty();
         private Reindexing reindexing = null;
 
+        public Builder() {}
+
         public Builder applicationPackage(ApplicationPackage applicationPackage) {
             this.applicationPackage = applicationPackage;
             return this;
@@ -336,6 +346,11 @@ public class DeployState implements ConfigDefinitionStore {
 
         public Builder fileRegistry(FileRegistry fileRegistry) {
             this.fileRegistry = fileRegistry;
+            return this;
+        }
+
+        public Builder executor(ExecutorService executor) {
+            this.executor = executor;
             return this;
         }
 
@@ -433,6 +448,7 @@ public class DeployState implements ConfigDefinitionStore {
                                    searchDocumentModel,
                                    rankProfileRegistry,
                                    fileRegistry,
+                                   executor,
                                    logger,
                                    hostProvisioner,
                                    provisioned,

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
@@ -194,7 +194,8 @@ public final class VespaModel extends AbstractConfigProducerRoot implements Seri
                                               deployState.rankProfileRegistry(),
                                               deployState.getQueryProfiles().getRegistry(),
                                               deployState.getImportedModels(),
-                                              deployState.getProperties());
+                                              deployState.getProperties(),
+                                              deployState.getExecutor());
 
         HostSystem hostSystem = root.hostSystem();
         if (complete) { // create a completed, frozen model

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -153,7 +153,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
                                                String clusterName, ContentSearchCluster search) {
             List<ModelElement> indexedDefs = getIndexedSchemas(clusterElem);
             if (!indexedDefs.isEmpty()) {
-                IndexedSearchCluster isc = new IndexedSearchCluster(search, clusterName, 0, deployState);
+                IndexedSearchCluster isc = new IndexedSearchCluster(search, clusterName, 0);
                 isc.setRoutingSelector(clusterElem.childAsString("documents.selection"));
 
                 Double visibilityDelay = clusterElem.childAsDouble("engine.proton.visibility-delay");

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -17,7 +17,6 @@ import com.yahoo.vespa.model.container.docproc.DocprocChain;
 import com.yahoo.vespa.model.content.DispatchSpec;
 import com.yahoo.vespa.model.content.SearchCoverage;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -63,7 +62,7 @@ public class IndexedSearchCluster extends SearchCluster
         return routingSelector;
     }
 
-    public IndexedSearchCluster(AbstractConfigProducer<SearchCluster> parent, String clusterName, int index, DeployState deployState) {
+    public IndexedSearchCluster(AbstractConfigProducer<SearchCluster> parent, String clusterName, int index) {
         super(parent, clusterName, index);
         unionCfg = new UnionConfiguration(this, documentDbs);
         rootDispatch =  new DispatchGroup(this);
@@ -204,7 +203,8 @@ public class IndexedSearchCluster extends SearchCluster
                                                                                     deployState.getProperties(),
                                                                                     deployState.rankProfileRegistry(),
                                                                                     deployState.getQueryProfiles().getRegistry(),
-                                                                                    deployState.getImportedModels()));
+                                                                                    deployState.getImportedModels(),
+                                                                                    deployState.getExecutor()));
                 // TODO: remove explicit adding of user configs when the complete content model is built using builders.
                 db.mergeUserConfigs(spec.getUserConfigs());
                 documentDbs.add(db);

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
@@ -12,8 +12,6 @@ import com.yahoo.vespa.config.search.SummaryConfig;
 import com.yahoo.vespa.config.search.SummarymapConfig;
 import com.yahoo.vespa.config.search.vsm.VsmfieldsConfig;
 import com.yahoo.vespa.config.search.vsm.VsmsummaryConfig;
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 /**
@@ -99,7 +97,8 @@ public class StreamingSearchCluster extends SearchCluster implements
                                                  deployState.getProperties(),
                                                  deployState.rankProfileRegistry(),
                                                  deployState.getQueryProfiles().getRegistry(),
-                                                 deployState.getImportedModels());
+                                                 deployState.getImportedModels(),
+                                                 deployState.getExecutor());
     }
     @Override
     public DerivedConfiguration getSdConfig() {

--- a/config-model/src/test/java/com/yahoo/searchdefinition/IncorrectRankingExpressionFileRefTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/IncorrectRankingExpressionFileRefTestCase.java
@@ -1,12 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition;
 
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
-import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.derived.DerivedConfiguration;
 import com.yahoo.searchdefinition.parser.ParseException;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import com.yahoo.yolean.Exceptions;
 import org.junit.Test;
 
@@ -27,7 +24,7 @@ public class IncorrectRankingExpressionFileRefTestCase extends SchemaTestCase {
             Search search = SearchBuilder.buildFromFile("src/test/examples/incorrectrankingexpressionfileref.sd",
                                                         registry,
                                                         new QueryProfileRegistry());
-            new DerivedConfiguration(search, new BaseDeployLogger(), new TestProperties(), registry, new QueryProfileRegistry(), new ImportedMlModels()); // cause rank profile parsing
+            new DerivedConfiguration(search, registry); // cause rank profile parsing
             fail("parsing should have failed");
         } catch (IllegalArgumentException e) {
             String message = Exceptions.toMessageString(e);

--- a/config-model/src/test/java/com/yahoo/searchdefinition/RankingExpressionValidationTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/RankingExpressionValidationTestCase.java
@@ -1,12 +1,8 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition;
 
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
-import com.yahoo.config.model.deploy.TestProperties;
-import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.derived.DerivedConfiguration;
 import com.yahoo.searchdefinition.parser.ParseException;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import com.yahoo.yolean.Exceptions;
 import org.junit.Test;
 
@@ -27,7 +23,7 @@ public class RankingExpressionValidationTestCase extends SchemaTestCase {
         try {
             RankProfileRegistry registry = new RankProfileRegistry();
             Search search = importWithExpression(expression, registry);
-            new DerivedConfiguration(search, new BaseDeployLogger(), new TestProperties(), registry, new QueryProfileRegistry(), new ImportedMlModels()); // cause rank profile parsing
+            new DerivedConfiguration(search, registry); // cause rank profile parsing
             fail("No exception on incorrect ranking expression " + expression);
         } catch (IllegalArgumentException e) {
             // Success

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/AbstractExportingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/AbstractExportingTestCase.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition.derived;
 
+import com.yahoo.concurrent.InThreadExecutorService;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -49,15 +50,14 @@ public abstract class AbstractExportingTestCase extends SchemaTestCase {
                                                                properties,
                                                                builder.getRankProfileRegistry(),
                                                                builder.getQueryProfileRegistry(),
-                                                               new ImportedMlModels());
+                                                               new ImportedMlModels(), new InThreadExecutorService());
         return export(dirName, builder, config);
     }
 
     DerivedConfiguration derive(String dirName, SearchBuilder builder, Search search) throws IOException {
         DerivedConfiguration config = new DerivedConfiguration(search,
                                                                builder.getRankProfileRegistry(),
-                                                               builder.getQueryProfileRegistry(),
-                                                               new ImportedMlModels());
+                                                               builder.getQueryProfileRegistry());
         return export(dirName, builder, config);
     }
 

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/EmptyRankProfileTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/EmptyRankProfileTestCase.java
@@ -9,7 +9,6 @@ import com.yahoo.searchdefinition.SearchBuilder;
 import com.yahoo.searchdefinition.SchemaTestCase;
 import com.yahoo.searchdefinition.document.SDDocumentType;
 import com.yahoo.searchdefinition.document.SDField;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import org.junit.Test;
 
 /**
@@ -32,7 +31,7 @@ public class EmptyRankProfileTestCase extends SchemaTestCase {
         doc.addField(new SDField("c", DataType.STRING));
 
         search = SearchBuilder.buildFromRawSearch(search, rankProfileRegistry, new QueryProfileRegistry());
-        new DerivedConfiguration(search, rankProfileRegistry, new QueryProfileRegistry(), new ImportedMlModels());
+        new DerivedConfiguration(search, rankProfileRegistry);
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/LiteralBoostTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/LiteralBoostTestCase.java
@@ -11,7 +11,6 @@ import com.yahoo.searchdefinition.SearchBuilder;
 import com.yahoo.searchdefinition.document.SDDocumentType;
 import com.yahoo.searchdefinition.document.SDField;
 import com.yahoo.searchdefinition.processing.Processing;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 import org.junit.Test;
 
@@ -42,7 +41,7 @@ public class LiteralBoostTestCase extends AbstractExportingTestCase {
         other.addRankSetting(new RankProfile.RankSetting("a", RankProfile.RankSetting.Type.LITERALBOOST, 333));
 
         new Processing().process(search, new BaseDeployLogger(), rankProfileRegistry, new QueryProfiles(), true, false);
-        DerivedConfiguration derived=new DerivedConfiguration(search, rankProfileRegistry, new QueryProfileRegistry(), new ImportedMlModels());
+        DerivedConfiguration derived=new DerivedConfiguration(search, rankProfileRegistry);
 
         // Check attribute fields
         derived.getAttributeFields(); // TODO: assert content
@@ -73,7 +72,7 @@ public class LiteralBoostTestCase extends AbstractExportingTestCase {
         other.addRankSetting(new RankProfile.RankSetting("a", RankProfile.RankSetting.Type.LITERALBOOST, 333));
 
         search = SearchBuilder.buildFromRawSearch(search, rankProfileRegistry, new QueryProfileRegistry());
-        DerivedConfiguration derived = new DerivedConfiguration(search, rankProfileRegistry, new QueryProfileRegistry(),new ImportedMlModels());
+        DerivedConfiguration derived = new DerivedConfiguration(search, rankProfileRegistry);
 
         // Check il script addition
         assertIndexing(Arrays.asList("clear_state | guard { input a | tokenize normalize stem:\"BEST\" | index a; }",
@@ -100,7 +99,7 @@ public class LiteralBoostTestCase extends AbstractExportingTestCase {
         field2.setLiteralBoost(20);
 
         search = SearchBuilder.buildFromRawSearch(search, rankProfileRegistry, new QueryProfileRegistry());
-        new DerivedConfiguration(search, rankProfileRegistry, new QueryProfileRegistry(), new ImportedMlModels());
+        new DerivedConfiguration(search, rankProfileRegistry);
         assertIndexing(Arrays.asList("clear_state | guard { input title | tokenize normalize stem:\"BEST\" | summary title | index title; }",
                                      "clear_state | guard { input body | tokenize normalize stem:\"BEST\" | summary body | index body; }",
                                      "clear_state | guard { input title | tokenize | index title_literal; }",

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/SimpleInheritTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/SimpleInheritTestCase.java
@@ -1,11 +1,9 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition.derived;
 
-import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.Search;
 import com.yahoo.searchdefinition.SearchBuilder;
 import com.yahoo.searchdefinition.parser.ParseException;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import org.junit.Test;
 
 import java.io.File;
@@ -33,10 +31,7 @@ public class SimpleInheritTestCase extends AbstractExportingTestCase {
         toDir.mkdirs();
         deleteContent(toDir);
 
-        DerivedConfiguration config = new DerivedConfiguration(search,
-                                                               builder.getRankProfileRegistry(),
-                                                               new QueryProfileRegistry(),
-                                                               new ImportedMlModels());
+        DerivedConfiguration config = new DerivedConfiguration(search, builder.getRankProfileRegistry());
         config.export(toDirName);
 
         checkDir(toDirName, expectedResultsDirName);

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/TypeConversionTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/TypeConversionTestCase.java
@@ -3,14 +3,12 @@ package com.yahoo.searchdefinition.derived;
 
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.document.DataType;
-import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.RankProfileRegistry;
 import com.yahoo.searchdefinition.Search;
 import com.yahoo.searchdefinition.SchemaTestCase;
 import com.yahoo.searchdefinition.document.SDDocumentType;
 import com.yahoo.searchdefinition.document.SDField;
 import com.yahoo.searchdefinition.processing.Processing;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import com.yahoo.vespa.model.container.search.QueryProfiles;
 import org.junit.Test;
 
@@ -34,7 +32,7 @@ public class TypeConversionTestCase extends SchemaTestCase {
         document.addField(a);
 
         new Processing().process(search, new BaseDeployLogger(), rankProfileRegistry, new QueryProfiles(), true, false);
-        DerivedConfiguration derived = new DerivedConfiguration(search, rankProfileRegistry, new QueryProfileRegistry(), new ImportedMlModels());
+        DerivedConfiguration derived = new DerivedConfiguration(search, rankProfileRegistry);
         IndexInfo indexInfo = derived.getIndexInfo();
         assertFalse(indexInfo.hasCommand("default", "compact-to-term"));
     }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/ImplicitSearchFieldsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/ImplicitSearchFieldsTestCase.java
@@ -1,16 +1,12 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition.processing;
 
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
-import com.yahoo.config.model.deploy.TestProperties;
-import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.searchdefinition.Search;
 import com.yahoo.searchdefinition.SearchBuilder;
 import com.yahoo.searchdefinition.SchemaTestCase;
 import com.yahoo.searchdefinition.derived.DerivedConfiguration;
 import com.yahoo.searchdefinition.document.SDDocumentType;
 import com.yahoo.searchdefinition.parser.ParseException;
-import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -90,7 +86,7 @@ public class ImplicitSearchFieldsTestCase extends SchemaTestCase {
         sb.importFile("src/test/examples/nextgen/simple.sd");
         sb.build();
         assertNotNull(sb.getSearch());
-        new DerivedConfiguration(sb.getSearch(), new BaseDeployLogger(), new TestProperties(), sb.getRankProfileRegistry(), new QueryProfileRegistry(), new ImportedMlModels());
+        new DerivedConfiguration(sb.getSearch(), sb.getRankProfileRegistry());
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionsTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.searchdefinition.processing;
 
 import com.yahoo.collections.Pair;
 import com.yahoo.config.model.api.ModelContext;
-import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
@@ -77,7 +76,7 @@ public class RankingExpressionsTestCase extends SchemaTestCase {
     public void testThatIncludingFileInSubdirFails() throws IOException, ParseException {
         RankProfileRegistry registry = new RankProfileRegistry();
         Search search = createSearch("src/test/examples/rankingexpressioninfile", new TestProperties(), registry);
-        new DerivedConfiguration(search, new BaseDeployLogger(), new TestProperties(), registry, new QueryProfileRegistry(), new ImportedMlModels()); // rank profile parsing happens during deriving
+        new DerivedConfiguration(search, registry); // rank profile parsing happens during deriving
     }
 
     private void verifyProfile(RankProfile profile, List<String> expectedFunctions, List<Pair<String, String>> rankProperties,
@@ -100,7 +99,6 @@ public class RankingExpressionsTestCase extends SchemaTestCase {
     private void verifySearch(Search search, RankProfileRegistry rankProfileRegistry, LargeRankExpressions largeExpressions,
                               QueryProfileRegistry queryProfiles, ImportedMlModels models, ModelContext.Properties properties)
     {
-        ;
         AttributeFields attributes = new AttributeFields(search);
 
         verifyProfile(rankProfileRegistry.get(search, "base"), Arrays.asList("large_f", "large_m"),


### PR DESCRIPTION
…ts. Fx compile rankprofiles in parallell.

Currently only uses a foreground executor giving no semantic difference compared to normal single threaded execution.

@hmusum PR