### PR TITLE
Add metrics for chained merge failures (total and node busy)

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -781,6 +781,8 @@ public class VespaMetricSet {
         metrics.add(new Metric("vds.mergethrottler.bounced_due_to_back_pressure.rate"));
         metrics.add(new Metric("vds.mergethrottler.locallyexecutedmerges.ok.rate"));
         metrics.add(new Metric("vds.mergethrottler.mergechains.ok.rate"));
+        metrics.add(new Metric("vds.mergethrottler.mergechains.failures.busy.rate"));
+        metrics.add(new Metric("vds.mergethrottler.mergechains.failures.total.rate"));
         return metrics;
     }
 


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Improves visibility into how many merges chains are unwound due to hitting queue limits in nodes further down the chain.
