### PR TITLE
correct heuristic for -(N)

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/AllParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/AllParser.java
@@ -112,6 +112,7 @@ public class AllParser extends SimpleParser {
     protected Item negativeItem() {
         int position = tokens.getPosition();
         Item item = null;
+        boolean isComposited = false;
         try {
             if ( ! tokens.skip(MINUS)) return null;
             if (tokens.currentIsNoIgnore(SPACE)) return null;
@@ -121,6 +122,7 @@ public class AllParser extends SimpleParser {
                 item = compositeItem();
 
                 if (item != null) {
+                    isComposited = true;
                     if (item instanceof OrItem) { // Turn into And
                         AndItem and = new AndItem();
 
@@ -137,9 +139,11 @@ public class AllParser extends SimpleParser {
             // Heuristic overdrive engaged!
             // Interpret -N as a positive item matching a negative number (by backtracking out of this)
             // but not if there is an explicit index (such as -a:b)
+            // but interpret -(N) as a negative item matching a positive number
             // but interpret --N as a negative item matching a negative number
             if (item instanceof IntItem &&
                 ((IntItem)item).getIndexName().isEmpty() &&
+                ! isComposited &&
                 ! ((IntItem)item).getNumber().startsWith(("-")))
                 item = null;
 

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
@@ -1970,6 +1970,13 @@ public class ParseTestCase {
     }
 
     @Test
+    public void testNegativeTermPositiveNumberInParentheses() {
+        tester.assertParsed("+a -12", "a -(12)", Query.Type.ALL);
+        tester.assertParsed("+a -(AND 12 15)", "a -(12 15)", Query.Type.ALL);
+        tester.assertParsed("+a -12 -15", "a -(12) -(15)", Query.Type.ALL);
+    }
+
+    @Test
     public void testSingleNegativeNumberLikeTerm() {
         tester.assertParsed("-12", "-12", Query.Type.ALL);
     }


### PR DESCRIPTION
interpret "-(N)" as a negative term searching a positive number.