### PR TITLE
extend time span for REQUIRE_CONNECTIVITY_CHECK

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -225,7 +225,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag REQUIRE_CONNECTIVITY_CHECK = defineFeatureFlag(
             "require-connectivity-check", true,
-            List.of("arnej"), "2021-06-03", "2021-09-01",
+            List.of("arnej"), "2021-06-03", "2021-12-01",
             "Require that config-sentinel connectivity check passes with good quality before starting services",
             "Takes effect on next restart",
             ZONE_ID, APPLICATION_ID);


### PR DESCRIPTION
* this flag turned out to be useful at 2021-08-25.
  We have made fixes after that so hopefully we won't
  need it again, but let us extend its lifetime so
  we can observe that everything is OK for a longer
  period of time before removing support for the flag.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


@aressem please review and merge
@andreer FYI
