### PR TITLE
Increase tick wait duration for main distributor thread when running …

### DIFF
--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -26,7 +26,9 @@ DistributorNode::DistributorNode(
     : StorageNode(configUri, context, generationFetcher,
                   std::make_unique<HostInfo>(),
                   !communicationManager ? NORMAL : SINGLE_THREADED_TEST_MODE),
-      _threadPool(framework::TickingThreadPool::createDefault("distributor")),
+      // TODO STRIPE: Change waitTime default to 100ms when legacy mode is removed.
+      _threadPool(framework::TickingThreadPool::createDefault("distributor",
+                                                              (num_distributor_stripes > 0) ? 100ms : 5ms)),
       _stripe_pool(std::make_unique<distributor::DistributorStripePool>()),
       _context(context),
       _timestamp_mutex(),

--- a/storageframework/src/vespa/storageframework/generic/thread/tickingthread.h
+++ b/storageframework/src/vespa/storageframework/generic/thread/tickingthread.h
@@ -78,6 +78,7 @@ struct ThreadLock {
 struct TickingThreadPool : public ThreadLock {
     using UP = std::unique_ptr<TickingThreadPool>;
 
+    // TODO STRIPE: Change waitTime default to 100ms when legacy mode is removed.
     static TickingThreadPool::UP createDefault(
             vespalib::stringref name,
             vespalib::duration waitTime = 5ms,


### PR DESCRIPTION
…with multiple stripes.

This because it will no longer be running background maintenance jobs
(non-event tick will instead be used primarily for resending full bucket fetches etc).

@vekterli please review