### PR TITLE
Port additional DB updater tests and fix delayed sending regression

### DIFF
--- a/storage/src/tests/distributor/legacy_bucket_db_updater_test.cpp
+++ b/storage/src/tests/distributor/legacy_bucket_db_updater_test.cpp
@@ -1053,6 +1053,7 @@ TEST_F(LegacyBucketDBUpdaterTest, recheck_node) {
     EXPECT_EQ(api::BucketInfo(20,10,12, 50, 60, true, true), copy->getBucketInfo());
 }
 
+// TODO STRIPE migrated to TopLevelBucketDBUpdaterTest
 TEST_F(LegacyBucketDBUpdaterTest, notify_bucket_change) {
     enableDistributorClusterState("distributor:1 storage:1");
 
@@ -1116,6 +1117,7 @@ TEST_F(LegacyBucketDBUpdaterTest, notify_bucket_change) {
               dumpBucket(document::BucketId(16, 2)));
 }
 
+// TODO STRIPE migrated to TopLevelBucketDBUpdaterTest
 TEST_F(LegacyBucketDBUpdaterTest, notify_bucket_change_from_node_down) {
     enableDistributorClusterState("distributor:1 storage:2");
 
@@ -1162,6 +1164,7 @@ TEST_F(LegacyBucketDBUpdaterTest, notify_bucket_change_from_node_down) {
               dumpBucket(document::BucketId(16, 1)));
 }
 
+// TODO STRIPE migrated to TopLevelBucketDBUpdaterTest
 /**
  * Test that NotifyBucketChange received while there's a pending cluster state
  * waits until the cluster state has been enabled as current before it sends off

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -985,6 +985,7 @@ void
 DistributorStripe::enable_cluster_state_bundle(const lib::ClusterStateBundle& new_state,
                                                bool has_bucket_ownership_change)
 {
+    assert(!_use_legacy_mode);
     // TODO STRIPE replace legacy func
     enableClusterStateBundle(new_state);
     if (has_bucket_ownership_change) {
@@ -995,6 +996,7 @@ DistributorStripe::enable_cluster_state_bundle(const lib::ClusterStateBundle& ne
         const auto now = TimePoint(std::chrono::milliseconds(_component.getClock().getTimeInMillis().getTime()));
         _externalOperationHandler.rejectFeedBeforeTimeReached(_ownershipSafeTimeCalc->safeTimePoint(now));
     }
+    _bucketDBUpdater.handle_activated_cluster_state_bundle(); // Triggers resending of queued requests
 }
 
 void

--- a/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.cpp
+++ b/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.cpp
@@ -170,6 +170,12 @@ StripeBucketDBUpdater::recheckBucketInfo(uint32_t nodeIdx,
     sendRequestBucketInfo(nodeIdx, bucket, std::shared_ptr<MergeReplyGuard>());
 }
 
+void
+StripeBucketDBUpdater::handle_activated_cluster_state_bundle()
+{
+    sendAllQueuedBucketRechecks();
+}
+
 namespace {
 
 class ReadOnlyDbMergingInserter : public BucketDatabase::MergingProcessor {

--- a/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.h
@@ -46,6 +46,7 @@ public:
     void flush();
     const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const;
     void recheckBucketInfo(uint32_t nodeIdx, const document::Bucket& bucket);
+    void handle_activated_cluster_state_bundle();
 
     bool onSetSystemState(const std::shared_ptr<api::SetSystemStateCommand>& cmd) override;
     bool onActivateClusterStateVersion(const std::shared_ptr<api::ActivateClusterStateVersionCommand>& cmd) override;


### PR DESCRIPTION
@geirst please review

Addresses a missing piece of functionality in the new code path where
queued bucket rechecks during a pending cluster state time window would
not be sent as expected when the pending state has been completed and
activated.

