### PR TITLE
As there are very few unique dimensions, normally in the rannge 5-30,…

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/DimensionId.java
@@ -1,6 +1,9 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.metric.model;
 
+import com.yahoo.yolean.concurrent.CopyOnWriteHashMap;
+
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -8,10 +11,13 @@ import java.util.Objects;
  */
 public final class DimensionId {
 
+    private static final Map<String, DimensionId> dictionary = new CopyOnWriteHashMap<>();
     public final String id;
     private DimensionId(String id) { this.id = id; }
 
-    public static DimensionId toDimensionId(String id) { return new DimensionId(id); }
+    public static DimensionId toDimensionId(String id) {
+        return dictionary.computeIfAbsent(id, key -> new DimensionId(key));
+    }
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
… a dictionary will significantly reduce memory bloat.

One large instance running OOM had 25 unique, but 500k DimensionId objects.

@gjoranv PR