### PR TITLE
Revert "Consume and process metrics as they are parsed."

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/DummyMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/DummyMetricsFetcher.java
@@ -1,6 +1,8 @@
 // Copyright 2020 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.service;
 
+import ai.vespa.metricsproxy.metric.Metrics;
+
 /**
  * Dummy class used for getting health status for a vespa service that has no HTTP service
  * for getting metrics
@@ -19,6 +21,7 @@ public class DummyMetricsFetcher extends RemoteMetricsFetcher {
     /**
      * Connect to remote service over http and fetch metrics
      */
-    public void getMetrics(MetricsParser.Consumer consumer, int fetchCount) {
+    public Metrics getMetrics(int fetchCount) {
+        return new Metrics();
     }
 }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/RemoteMetricsFetcher.java
@@ -23,25 +23,32 @@ public class RemoteMetricsFetcher extends HttpMetricFetcher {
     /**
      * Connect to remote service over http and fetch metrics
      */
-    public void getMetrics(MetricsParser.Consumer consumer, int fetchCount) {
+    public Metrics getMetrics(int fetchCount) {
         try {
-            createMetrics(getJson(), consumer, fetchCount);
+            return createMetrics(getJson(), fetchCount);
         } catch (IOException | InterruptedException | ExecutionException e) {
+            return new Metrics();
         }
     }
 
-    void createMetrics(String data, MetricsParser.Consumer consumer, int fetchCount) {
+    Metrics createMetrics(String data, int fetchCount) {
+        Metrics remoteMetrics = new Metrics();
         try {
-            MetricsParser.parse(data, consumer);
+            remoteMetrics = MetricsParser.parse(data);
         } catch (Exception e) {
             handleException(e, data, fetchCount);
         }
+
+        return remoteMetrics;
     }
-    private void createMetrics(InputStream data, MetricsParser.Consumer consumer, int fetchCount) {
+    Metrics createMetrics(InputStream data, int fetchCount) {
+        Metrics remoteMetrics = new Metrics();
         try {
-            MetricsParser.parse(data, consumer);
+            remoteMetrics = MetricsParser.parse(data);
         } catch (Exception e) {
             handleException(e, data, fetchCount);
         }
+
+        return remoteMetrics;
     }
 }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java
@@ -2,7 +2,6 @@
 package ai.vespa.metricsproxy.service;
 
 import ai.vespa.metricsproxy.metric.HealthMetric;
-import ai.vespa.metricsproxy.metric.Metric;
 import ai.vespa.metricsproxy.metric.Metrics;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.ServiceId;
@@ -138,22 +137,10 @@ public class VespaService implements Comparable<VespaService> {
      *
      * @return the non-system metrics
      */
-    public void consumeMetrics(MetricsParser.Consumer consumer) {
-        remoteMetricsFetcher.getMetrics(consumer, metricsFetchCount.get());
+    public Metrics getMetrics() {
+        Metrics remoteMetrics = remoteMetricsFetcher.getMetrics(metricsFetchCount.get());
         metricsFetchCount.getAndIncrement();
-    }
-
-    private static class CollectMetrics implements MetricsParser.Consumer {
-        private final Metrics metrics = new Metrics();
-        @Override
-        public void consume(Metric metric) {
-            metrics.add(metric);
-        }
-    }
-    public final Metrics getMetrics() {
-        CollectMetrics collector = new CollectMetrics();
-        consumeMetrics(collector);
-        return collector.metrics;
+        return remoteMetrics;
     }
 
     /**

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/DownService.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/DownService.java
@@ -18,7 +18,8 @@ public class DownService extends VespaService {
     }
 
     @Override
-    public void consumeMetrics(MetricsParser.Consumer consumer) {
+    public Metrics getMetrics() {
+        return new Metrics();
     }
 
    @Override

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/DummyService.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/DummyService.java
@@ -2,6 +2,7 @@
 package ai.vespa.metricsproxy.service;
 
 import ai.vespa.metricsproxy.metric.Metric;
+import ai.vespa.metricsproxy.metric.Metrics;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 
 /**
@@ -20,10 +21,14 @@ public class DummyService extends VespaService {
     }
 
     @Override
-    public void consumeMetrics(MetricsParser.Consumer consumer) {
+    public Metrics getMetrics() {
+        Metrics m = new Metrics();
+
         long timestamp = System.currentTimeMillis() / 1000;
-        consumer.consume(new Metric(MetricId.toMetricId(METRIC_1), 5 * num + 1, timestamp));
-        consumer.consume(new Metric(MetricId.toMetricId(METRIC_2), 1.3 * num + 1.05, timestamp));
+        m.add(new Metric(MetricId.toMetricId(METRIC_1), 5 * num + 1, timestamp));
+        m.add(new Metric(MetricId.toMetricId(METRIC_2), 1.3 * num + 1.05, timestamp));
+
+        return m;
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#19038

Opensource build fails with:

13:15:45 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.0.1:javadoc-no-fork (generate-
javadoc) on project metrics-proxy: An error has occurred in Javadoc report generation:
13:15:45 [ERROR] Exit code: 1 - /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/factory/pipelines/opensource-release-trigger/vespa/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/VespaService.java:139: error: invalid use of @return
13:15:45 [ERROR] * @return the non-system metrics
13:15:45 [ERROR] ^