### PR TITLE
Avoid stack overflow for function inlining case

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -644,6 +644,10 @@ public class RankProfile implements Cloneable {
     /** Adds a function and returns it */
     public RankingExpressionFunction addFunction(ExpressionFunction function, boolean inline) {
         RankingExpressionFunction rankingExpressionFunction = new RankingExpressionFunction(function, inline);
+        if (functions.containsKey(function.getName())) {
+            deployLogger.log(Level.WARNING, "Function '" + function.getName() + "' replaces a previous function " +
+                    "with the same name in rank profile '" + this.name + "'");
+        }
         functions.put(function.getName(), rankingExpressionFunction);
         allFunctionsCached = null;
         return rankingExpressionFunction;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/FunctionInliner.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/FunctionInliner.java
@@ -24,6 +24,7 @@ public class FunctionInliner extends ExpressionTransformer<RankProfileTransformC
     }
 
     private ExpressionNode transformFeatureNode(ReferenceNode feature, RankProfileTransformContext context) {
+        if (feature.getArguments().size() > 0) return feature;  // From RankProfile: only inline no-arg functions
         RankProfile.RankingExpressionFunction rankingExpressionFunction = context.inlineFunctions().get(feature.getName());
         if (rankingExpressionFunction == null) return feature;
         return transform(rankingExpressionFunction.function().getBody().getRoot(), context); // inline recursively and return


### PR DESCRIPTION
@bratseth Please review.

The issue at hand is something like the following rank profile:

```
rank-profile test {
    first-phase {
        expression: foo
    }
    function foo(x) {
        expression: x + x
    }
    function inline foo() {
        expression: foo(2)
    }
}
```

The expectation of the user writing this is that `inline foo()` is different than `foo(x)`. However, Vespa does not support multiple functions with the same name - even with different signatures. So the last `foo` here replaces the first. Since this is probably not expected by the user, we add a deploy time warning.

More problematically, loop invocation is not detected when calling `foo(2)` here since this is not recognized as a function invocation (number of arguments differ). The code in `FunctionInliner` did not differentiate between arguments, and this would then cause an infinite recursion stack overflow error. A guard was put in there.