### PR TITLE
Transition directly to dirty in CD or non-PROD zones

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -236,13 +236,15 @@ public class Nodes {
      * transaction commits.
      */
     public List<Node> deactivate(List<Node> nodes, ApplicationTransaction transaction) {
+        if ( ! zone.environment().isProduction() || zone.system().isCd())
+            return deallocate(nodes, Agent.application, "Deactivated by application", transaction.nested());
+
         var stateless = NodeList.copyOf(nodes).stateless();
         var stateful  = NodeList.copyOf(nodes).stateful();
         List<Node> written = new ArrayList<>();
         written.addAll(deallocate(stateless.asList(), Agent.application, "Deactivated by application", transaction.nested()));
         written.addAll(db.writeTo(Node.State.inactive, stateful.asList(), Agent.application, Optional.empty(), transaction.nested()));
         return written;
-
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
@@ -89,12 +89,13 @@ public class RebalancerTest {
         tester.nodeRepository().nodes().deactivate(List.of(cpuSkewedNode),
                                                    new ApplicationTransaction(new ProvisionLock(cpuApp, () -> {}), tx));
         tx.commit();
+        assertEquals(1, tester.getNodes(Node.State.dirty).size());
 
         //     ... if activation fails when trying, we clean up the state
         tester.deployer().setFailActivate(true);
         tester.maintain();
         assertTrue("Want to retire is reset", tester.getNodes(Node.State.active).stream().noneMatch(node -> node.status().wantToRetire()));
-        assertEquals("Reserved node was moved to dirty", 1, tester.getNodes(Node.State.dirty).size());
+        assertEquals("Reserved node was moved to dirty", 2, tester.getNodes(Node.State.dirty).size());
         String reservedHostname = tester.getNodes(Node.State.dirty).first().get().hostname();
         tester.nodeRepository().nodes().setReady(reservedHostname, Agent.system, "Cleanup");
         tester.nodeRepository().nodes().removeRecursively(reservedHostname);
@@ -163,12 +164,12 @@ public class RebalancerTest {
 
     static class RebalancerTester {
 
-        static ApplicationId cpuApp = makeApplicationId("t1", "a1");
-        static ApplicationId memoryApp = makeApplicationId("t2", "a2");
-        private static NodeResources cpuResources = new NodeResources(8, 4, 10, 0.1);
-        private static NodeResources memResources = new NodeResources(4, 9, 10, 0.1);
-        private TestMetric metric = new TestMetric();
-        private ProvisioningTester tester = new ProvisioningTester.Builder()
+        static final ApplicationId cpuApp = makeApplicationId("t1", "a1");
+        static final ApplicationId memoryApp = makeApplicationId("t2", "a2");
+        private static final NodeResources cpuResources = new NodeResources(8, 4, 10, 0.1);
+        private static final NodeResources memResources = new NodeResources(4, 9, 10, 0.1);
+        private final TestMetric metric = new TestMetric();
+        private final ProvisioningTester tester = new ProvisioningTester.Builder()
                 .zone(new Zone(Environment.perf, RegionName.from("us-east")))
                 .flavorsConfig(flavorsConfig())
                 .build();


### PR DESCRIPTION
Fixes VESPA-21178. No need to go through `inactive` in these zones as they are expired in 1 minute anyway.