### PR TITLE
Add node to system info

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
@@ -2,11 +2,13 @@
 package com.yahoo.container.jdisc;
 
 import ai.vespa.cloud.Environment;
+import ai.vespa.cloud.Node;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
+import com.yahoo.container.QrConfig;
 import com.yahoo.container.di.componentgraph.Provider;
 
 /**
@@ -20,8 +22,9 @@ public class SystemInfoProvider extends AbstractComponent implements Provider<Sy
     private final SystemInfo instance;
 
     @Inject
-    public SystemInfoProvider(ConfigserverConfig config) {
-        this.instance = new SystemInfo(new Zone(Environment.valueOf(config.environment()), config.region()));
+    public SystemInfoProvider(ConfigserverConfig csConfig, QrConfig qrConfig) {
+        this.instance = new SystemInfo(new Zone(Environment.valueOf(csConfig.environment()), csConfig.region()),
+                                       new Node(qrConfig.discriminator()));
     }
 
     @Override

--- a/hosted-zone-api/abi-spec.json
+++ b/hosted-zone-api/abi-spec.json
@@ -19,6 +19,20 @@
       "public static final enum ai.vespa.cloud.Environment prod"
     ]
   },
+  "ai.vespa.cloud.Node": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(java.lang.String)",
+      "public java.lang.String id()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()"
+    ],
+    "fields": []
+  },
   "ai.vespa.cloud.SystemInfo": {
     "superClass": "java.lang.Object",
     "interfaces": [],
@@ -26,8 +40,9 @@
       "public"
     ],
     "methods": [
-      "public void <init>(ai.vespa.cloud.Zone)",
-      "public ai.vespa.cloud.Zone zone()"
+      "public void <init>(ai.vespa.cloud.Zone, ai.vespa.cloud.Node)",
+      "public ai.vespa.cloud.Zone zone()",
+      "public ai.vespa.cloud.Node node()"
     ],
     "fields": []
   },

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/Node.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/Node.java
@@ -1,0 +1,35 @@
+package ai.vespa.cloud;
+
+import java.util.Objects;
+
+/**
+ * The node where this process (usually a Jdisc container) is running.
+ *
+ * @author gjoranv
+ */
+public class Node {
+
+    private final String id;
+
+    public Node(String id) {
+        if (id == null || id.isBlank()) throw new IllegalArgumentException("The 'id' field cannot be null or blank!");
+        this.id = id;
+    }
+
+    /** Returns a unique ID for this node. */
+    public String id() { return id; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node node = (Node) o;
+        return id.equals(node.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+}

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
@@ -10,12 +10,18 @@ package ai.vespa.cloud;
 public class SystemInfo {
 
     private final Zone zone;
+    private final Node node;
 
-    public SystemInfo(Zone zone) {
+    public SystemInfo(Zone zone, Node node) {
         this.zone = zone;
+        this.node = node;
     }
 
     /** Returns the zone this is running in */
     public Zone zone() { return zone; }
+
+
+    /** Returns the node this is running on */
+    public Node node() { return node; }
 
 }

--- a/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
+++ b/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
@@ -48,4 +48,11 @@ public class SystemInfoTest {
         }
     }
 
+    @Test
+    public void testNode() {
+        String id = "default.container.1";
+        Node node = new Node(id);
+        assertEquals(id, node.id());
+    }
+
 }

--- a/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
+++ b/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
@@ -14,8 +14,10 @@ public class SystemInfoTest {
     @Test
     public void testSystemInfo() {
         Zone zone = new Zone(Environment.dev, "us-west-1");
-        SystemInfo info = new SystemInfo(zone);
+        Node node = new Node("default.container.1");
+        SystemInfo info = new SystemInfo(zone, node);
         assertEquals(zone, info.zone());
+        assertEquals(node, info.node());
     }
 
     @Test


### PR DESCRIPTION
The new user api is `systemInfo.node().id()`, which is meant as a discriminator between Jdisc containers.
Node can be extended with other properties as we find appropriate.