### PR TITLE
Fix man usage

### DIFF
--- a/client/go/cmd/clone.go
+++ b/client/go/cmd/clone.go
@@ -30,7 +30,7 @@ func init() {
 
 var cloneCmd = &cobra.Command{
 	// TODO: "application" and "list" subcommands?
-	Use:   "clone <sample-application-path> <target-directory>",
+	Use:   "clone sample-application-path target-directory",
 	Short: "Create files and directory structure for a new Vespa application from a sample application",
 	Long: `Creates an application package file structure.
 	Example: "$ vespa clone vespa-cloud/album-recommendation my-app",

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -43,7 +43,7 @@ var configCmd = &cobra.Command{
 }
 
 var setConfigCmd = &cobra.Command{
-	Use:               "set <option> <value>",
+	Use:               "set option-name value",
 	Short:             "Set a configuration option.",
 	Example:           "$ vespa config set target cloud",
 	DisableAutoGenTag: true,
@@ -58,7 +58,7 @@ var setConfigCmd = &cobra.Command{
 }
 
 var getConfigCmd = &cobra.Command{
-	Use:               "get [<option>]",
+	Use:               "get option-name",
 	Short:             "Get a configuration option",
 	Example:           "$ vespa config get target",
 	Args:              cobra.MaximumNArgs(1),

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 var deployCmd = &cobra.Command{
-	Use:   "deploy [<application-directory>]",
+	Use:   "deploy [application-directory]",
 	Short: "Deploy (prepare and activate) an application package",
 	Long: `Deploy (prepare and activate) an application package.
 
@@ -83,7 +83,7 @@ If application directory is not specified, it defaults to working directory.`,
 }
 
 var prepareCmd = &cobra.Command{
-	Use:               "prepare <application-directory>",
+	Use:               "prepare application-directory",
 	Short:             "Prepare an application package for activation",
 	Args:              cobra.MaximumNArgs(1),
 	DisableAutoGenTag: true,

--- a/client/go/cmd/document.go
+++ b/client/go/cmd/document.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 var documentCmd = &cobra.Command{
-	Use:   "document <json-file>",
+	Use:   "document json-file",
 	Short: "Issue a document operation to Vespa",
 	Long: `Issue a document operation to Vespa.
 
@@ -43,7 +43,7 @@ should be used instead of this.`,
 }
 
 var documentPutCmd = &cobra.Command{
-	Use:   "put [<id>] <json-file>",
+	Use:   "put [id] json-file",
 	Short: "Writes a document to Vespa",
 	Long: `Writes the document in the given file to Vespa.
 If the document already exists, all its values will be replaced by this document.
@@ -62,7 +62,7 @@ $ vespa document put id:mynamespace:music::a-head-full-of-dreams src/test/resour
 }
 
 var documentUpdateCmd = &cobra.Command{
-	Use:   "update [<id>] <json-file>",
+	Use:   "update [id] json-file",
 	Short: "Modifies some fields of an existing document",
 	Long: `Updates the values of the fields given in a json file as specified in the file.
 If the document id is specified both as an argument and in the file the argument takes precedence.`,
@@ -80,7 +80,7 @@ $ vespa document update id:mynamespace:music::a-head-full-of-dreams src/test/res
 }
 
 var documentRemoveCmd = &cobra.Command{
-	Use:   "remove <id or json.file>",
+	Use:   "remove id | json-file",
 	Short: "Removes a document from Vespa",
 	Long: `Removes the document specified either as a document id or given in the json file.
 If the document id is specified both as an argument and in the file the argument takes precedence.`,
@@ -98,7 +98,7 @@ $ vespa document remove id:mynamespace:music::a-head-full-of-dreams`,
 }
 
 var documentGetCmd = &cobra.Command{
-	Use:               "get <id>",
+	Use:               "get id",
 	Short:             "Gets a document",
 	Args:              cobra.ExactArgs(1),
 	DisableAutoGenTag: true,

--- a/client/go/cmd/man.go
+++ b/client/go/cmd/man.go
@@ -10,7 +10,7 @@ func init() {
 }
 
 var manCmd = &cobra.Command{
-	Use:               "man <directory>",
+	Use:               "man directory",
 	Short:             "Generate man pages and write them to given directory",
 	Args:              cobra.ExactArgs(1),
 	Hidden:            true, // Not intended to be called by users

--- a/client/go/cmd/query.go
+++ b/client/go/cmd/query.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 var queryCmd = &cobra.Command{
-	Use:     "query <query-parameters>",
+	Use:     "query query-parameters",
 	Short:   "Issue a query to Vespa",
 	Example: `$ vespa query "yql=select * from sources * where title contains 'foo';" hits=5`,
 	Long: `Issue a query to Vespa.

--- a/client/go/cmd/query_test.go
+++ b/client/go/cmd/query_test.go
@@ -54,17 +54,6 @@ func assertQuery(t *testing.T, expectedQuery string, query ...string) {
 	assert.Equal(t, queryURL+"/search/"+expectedQuery, client.lastRequest.URL.String())
 }
 
-func assertQueryNonJsonResult(t *testing.T, expectedQuery string, query ...string) {
-	client := &mockHttpClient{}
-	queryURL := queryServiceURL(client)
-	client.NextResponse(200, "query result")
-	assert.Equal(t,
-		"query result\n",
-		executeCommand(t, client, []string{"query"}, query),
-		"query output")
-	assert.Equal(t, queryURL+"/search/"+expectedQuery, client.lastRequest.URL.String())
-}
-
 func assertQueryError(t *testing.T, status int, errorMessage string) {
 	client := &mockHttpClient{}
 	convergeServices(client)

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -18,7 +18,7 @@ var (
 	// TODO: add timeout flag
 	// TODO: add flag to show http request made
 	rootCmd = &cobra.Command{
-		Use:   "vespa <command>",
+		Use:   "vespa command-name",
 		Short: "The command-line tool for Vespa.ai",
 		Long: `The command-line tool for Vespa.ai.
 

--- a/client/go/vespa/target.go
+++ b/client/go/vespa/target.go
@@ -30,7 +30,6 @@ const (
 type Service struct {
 	BaseURL     string
 	Name        string
-	description string
 	certificate tls.Certificate
 }
 


### PR DESCRIPTION
Noticed that usage was messed up in the generated man pages. Example from `man vespa-document-put`:

```
SYNOPSIS
       vespa document put []  [flags]
```

https://github.com/spf13/cobra/issues/1137 /
https://www.ibm.com/docs/en/iis/8.5?topic=home-reading-command-line-syntax
recommend writing out required arguments as simply `arg-name` and optional arguments
as `[arg-name]`.

@bratseth