### PR TITLE
Add node to system info take2

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -310,11 +310,12 @@ public abstract class Container extends AbstractService implements
     @Override
     public void getConfig(QrConfig.Builder builder) {
         builder.rpc(new Rpc.Builder()
-                        .enabled(rpcServerEnabled())
-                        .port(getRpcPort())
-                        .slobrokId(serviceSlobrokId()))
+                            .enabled(rpcServerEnabled())
+                            .port(getRpcPort())
+                            .slobrokId(serviceSlobrokId()))
                 .filedistributor(filedistributorConfig())
-                .discriminator((clusterName != null ? clusterName + "." : "" ) + name);
+                .discriminator((clusterName != null ? clusterName + "." : "" ) + name)
+                .nodeIndex(index);
     }
 
     /** Returns the jvm args set explicitly for this node */

--- a/container-core/src/main/resources/configdefinitions/container.qr.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr.def
@@ -23,5 +23,10 @@ rpc.slobrokId string default="" restart
 ## this string will be unique for every QRS in a Vespa application.
 discriminator string default="qrserver.0" restart
 
+## Index of this container inside the cluster. Guaranteed to be non-negative
+## and unique for every container in a cluster, but not necessarily contiguous
+## or starting from zero.
+nodeIndex int default=0
+
 ## Force restart of container on deploy, and defer any changes until restart
 restartOnDeploy bool default=false restart

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
@@ -1,11 +1,13 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.jdisc;
 
+import ai.vespa.cloud.Cluster;
 import ai.vespa.cloud.Environment;
 import ai.vespa.cloud.Node;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
 import com.google.inject.Inject;
+import com.yahoo.cloud.config.ClusterInfoConfig;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.container.QrConfig;
@@ -22,8 +24,9 @@ public class SystemInfoProvider extends AbstractComponent implements Provider<Sy
     private final SystemInfo instance;
 
     @Inject
-    public SystemInfoProvider(ConfigserverConfig csConfig, QrConfig qrConfig) {
+    public SystemInfoProvider(ConfigserverConfig csConfig, QrConfig qrConfig, ClusterInfoConfig ciConfig) {
         this.instance = new SystemInfo(new Zone(Environment.valueOf(csConfig.environment()), csConfig.region()),
+                                       new Cluster(ciConfig.nodeCount()),
                                        new Node(qrConfig.nodeIndex()));
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
@@ -2,11 +2,13 @@
 package com.yahoo.container.jdisc;
 
 import ai.vespa.cloud.Environment;
+import ai.vespa.cloud.Node;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
+import com.yahoo.container.QrConfig;
 import com.yahoo.container.di.componentgraph.Provider;
 
 /**
@@ -20,8 +22,9 @@ public class SystemInfoProvider extends AbstractComponent implements Provider<Sy
     private final SystemInfo instance;
 
     @Inject
-    public SystemInfoProvider(ConfigserverConfig config) {
-        this.instance = new SystemInfo(new Zone(Environment.valueOf(config.environment()), config.region()));
+    public SystemInfoProvider(ConfigserverConfig csConfig, QrConfig qrConfig) {
+        this.instance = new SystemInfo(new Zone(Environment.valueOf(csConfig.environment()), csConfig.region()),
+                                       new Node(qrConfig.nodeIndex()));
     }
 
     @Override

--- a/hosted-zone-api/abi-spec.json
+++ b/hosted-zone-api/abi-spec.json
@@ -19,6 +19,20 @@
       "public static final enum ai.vespa.cloud.Environment prod"
     ]
   },
+  "ai.vespa.cloud.Node": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(int)",
+      "public int index()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()"
+    ],
+    "fields": []
+  },
   "ai.vespa.cloud.SystemInfo": {
     "superClass": "java.lang.Object",
     "interfaces": [],
@@ -26,8 +40,9 @@
       "public"
     ],
     "methods": [
-      "public void <init>(ai.vespa.cloud.Zone)",
-      "public ai.vespa.cloud.Zone zone()"
+      "public void <init>(ai.vespa.cloud.Zone, ai.vespa.cloud.Node)",
+      "public ai.vespa.cloud.Zone zone()",
+      "public ai.vespa.cloud.Node node()"
     ],
     "fields": []
   },

--- a/hosted-zone-api/abi-spec.json
+++ b/hosted-zone-api/abi-spec.json
@@ -1,4 +1,16 @@
 {
+  "ai.vespa.cloud.Cluster": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(int)",
+      "public int size()"
+    ],
+    "fields": []
+  },
   "ai.vespa.cloud.Environment": {
     "superClass": "java.lang.Enum",
     "interfaces": [],
@@ -40,8 +52,9 @@
       "public"
     ],
     "methods": [
-      "public void <init>(ai.vespa.cloud.Zone, ai.vespa.cloud.Node)",
+      "public void <init>(ai.vespa.cloud.Zone, ai.vespa.cloud.Cluster, ai.vespa.cloud.Node)",
       "public ai.vespa.cloud.Zone zone()",
+      "public ai.vespa.cloud.Cluster cluster()",
       "public ai.vespa.cloud.Node node()"
     ],
     "fields": []

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/Cluster.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/Cluster.java
@@ -1,0 +1,7 @@
+package ai.vespa.cloud;
+
+/**
+ * @author gjoranv
+ */
+public class Cluster {
+}

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/Cluster.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/Cluster.java
@@ -1,7 +1,19 @@
 package ai.vespa.cloud;
 
 /**
+ * The properties of a cluster of nodes.
+ *
  * @author gjoranv
  */
 public class Cluster {
+
+    private final int size;
+
+    public Cluster(int size) {
+        this.size = size;
+    }
+
+    /** Returns the number of nodes in this cluster. */
+    public int size() { return size; }
+
 }

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/Node.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/Node.java
@@ -1,0 +1,34 @@
+package ai.vespa.cloud;
+
+import java.util.Objects;
+
+/**
+ * A node that is part of a cluster of e.g. Jdisc containers.
+ *
+ * @author gjoranv
+ */
+public class Node {
+
+    private final int index;
+
+    public Node(int index) {
+        this.index = index;
+    }
+
+    /** Returns the unique index for this node in the cluster.
+     * Indices are non-negative, but not necessarily contiguous or starting from zero. */
+    public int index() { return index; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node node = (Node) o;
+        return index == node.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index);
+    }
+}

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
@@ -10,16 +10,20 @@ package ai.vespa.cloud;
 public class SystemInfo {
 
     private final Zone zone;
+    private final Cluster cluster;
     private final Node node;
 
-    public SystemInfo(Zone zone, Node node) {
+    public SystemInfo(Zone zone, Cluster cluster, Node node) {
         this.zone = zone;
+        this.cluster = cluster;
         this.node = node;
     }
 
     /** Returns the zone this is running in */
     public Zone zone() { return zone; }
 
+    /** Returns the cluster this is part of */
+    public Cluster cluster() { return cluster; }
 
     /** Returns the node this is running on */
     public Node node() { return node; }

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
@@ -10,12 +10,18 @@ package ai.vespa.cloud;
 public class SystemInfo {
 
     private final Zone zone;
+    private final Node node;
 
-    public SystemInfo(Zone zone) {
+    public SystemInfo(Zone zone, Node node) {
         this.zone = zone;
+        this.node = node;
     }
 
     /** Returns the zone this is running in */
     public Zone zone() { return zone; }
+
+
+    /** Returns the node this is running on */
+    public Node node() { return node; }
 
 }

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
@@ -1,6 +1,8 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.cloud;
 
+import java.util.Objects;
+
 /**
  * Provides information about the system in which this container is running.
  * This is available and can be injected when running in a cloud environment.
@@ -14,6 +16,9 @@ public class SystemInfo {
     private final Node node;
 
     public SystemInfo(Zone zone, Cluster cluster, Node node) {
+        Objects.requireNonNull(zone, "Zone cannot be null!");
+        Objects.requireNonNull(cluster, "Cluster cannot be null!");
+        Objects.requireNonNull(node, "Node cannot be null!");
         this.zone = zone;
         this.cluster = cluster;
         this.node = node;

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/Zone.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/Zone.java
@@ -16,6 +16,8 @@ public class Zone {
     private final String region;
 
     public Zone(Environment environment, String region) {
+        Objects.requireNonNull(environment, "Environment cannot be null!");
+        Objects.requireNonNull(region, "Region cannot be null!");
         this.environment = environment;
         this.region = region;
     }

--- a/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
+++ b/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
@@ -14,9 +14,12 @@ public class SystemInfoTest {
     @Test
     public void testSystemInfo() {
         Zone zone = new Zone(Environment.dev, "us-west-1");
+        Cluster cluster = new Cluster(1);
         Node node = new Node(0);
-        SystemInfo info = new SystemInfo(zone, node);
+
+        SystemInfo info = new SystemInfo(zone, cluster, node);
         assertEquals(zone, info.zone());
+        assertEquals(cluster, info.cluster());
         assertEquals(node, info.node());
     }
 
@@ -46,6 +49,13 @@ public class SystemInfoTest {
         catch (IllegalArgumentException e) {
             assertEquals("Invalid zone 'invalid.us-west-1': No environment named 'invalid'", e.getMessage());
         }
+    }
+
+    @Test
+    public void testCluster() {
+        int size = 1;
+        Cluster cluster = new Cluster(size);
+        assertEquals(size, cluster.size());
     }
 
     @Test

--- a/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
+++ b/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
@@ -14,8 +14,10 @@ public class SystemInfoTest {
     @Test
     public void testSystemInfo() {
         Zone zone = new Zone(Environment.dev, "us-west-1");
-        SystemInfo info = new SystemInfo(zone);
+        Node node = new Node(0);
+        SystemInfo info = new SystemInfo(zone, node);
         assertEquals(zone, info.zone());
+        assertEquals(node, info.node());
     }
 
     @Test
@@ -44,6 +46,13 @@ public class SystemInfoTest {
         catch (IllegalArgumentException e) {
             assertEquals("Invalid zone 'invalid.us-west-1': No environment named 'invalid'", e.getMessage());
         }
+    }
+
+    @Test
+    public void testNode() {
+        int index = 0;
+        Node node = new Node(index);
+        assertEquals(index, node.index());
     }
 
 }


### PR DESCRIPTION
New apis:
`systemInfo.node().index()`
`systemInfo.cluster().size()`

I thought about putting the Node inside Cluster, but the actual node for the runtime seems more natural to keep in SystemInfo. However, the cluster could be extended to contain  e.g. a list of node indices, cluster id etc.