### PR TITLE
Set source platform and application on dev deployment upgrades

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -520,8 +520,8 @@ public class JobController {
                                                                  .flatMap(controller.applications()::lastCompatibleVersion)
                                                                  .orElseGet(controller::readSystemVersion)),
                                version,
-                               Optional.empty(),
-                               Optional.empty()),
+                               lastRun.map(run -> run.versions().targetPlatform()),
+                               lastRun.map(run -> run.versions().targetApplication())),
                   false,
                   JobProfile.development);
         });

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentUpgrader.java
@@ -44,7 +44,7 @@ public class DeploymentUpgrader extends ControllerMaintainer {
                         if ( ! deployment.zone().environment().isManuallyDeployed()) continue;
 
                         Run last = controller().jobController().last(job).get();
-                        Versions target = new Versions(systemVersion, last.versions().targetApplication(), Optional.empty(), Optional.empty());
+                        Versions target = new Versions(systemVersion, last.versions().targetApplication(), Optional.of(last.versions().targetPlatform()), Optional.of(last.versions().targetApplication()));
                         if ( ! deployment.version().isBefore(target.targetPlatform())) continue;
                         if (   controller().clock().instant().isBefore(last.start().plus(Duration.ofDays(1)))) continue;
                         if ( ! isLikelyNightFor(job)) continue;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelperTest.java
@@ -157,9 +157,10 @@ public class JobControllerApiHandlerHelperTest {
         tester.configServer().setLogStream(() -> "Nope, this won't be logged");
         tester.configServer().convergeServices(app.instanceId(), zone);
         tester.runner().run();
-
-        assertResponse(JobControllerApiHandlerHelper.jobTypeResponse(tester.controller(), app.instanceId(), URI.create("https://some.url:43/root")), "dev-overview.json");
         assertResponse(JobControllerApiHandlerHelper.runDetailsResponse(tester.jobs(), tester.jobs().last(app.instanceId(), devUsEast1).get().id(), "8"), "dev-us-east-1-log-second-part.json");
+
+        tester.jobs().deploy(app.instanceId(), JobType.devUsEast1, Optional.empty(), applicationPackage());
+        assertResponse(JobControllerApiHandlerHelper.jobTypeResponse(tester.controller(), app.instanceId(), URI.create("https://some.url:43/root")), "dev-overview.json");
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/dev-overview.json
@@ -6,6 +6,36 @@
         {
           "versions": {
             "targetApplication": {
+              "build": 2
+            },
+            "targetPlatform": "6.1.0",
+            "sourceApplication": {
+              "build": 1
+            },
+            "sourcePlatform": "6.1.0"
+          },
+          "start": 0,
+          "id": 2,
+          "steps": [
+            {
+              "name": "deployReal",
+              "status": "succeeded"
+            },
+            {
+              "name": "installReal",
+              "status": "unfinished"
+            },
+            {
+              "name": "copyVespaLogs",
+              "status": "unfinished"
+            }
+          ],
+          "url": "https://some.url:43/root/run/2",
+          "status": "running"
+        },
+        {
+          "versions": {
+            "targetApplication": {
               "build": 1
             },
             "targetPlatform": "6.1.0"


### PR DESCRIPTION
This is to get console to shows diff link (only shown for runs that upgrade application (both source and target application set))