### PR TITLE
Remove double mapping in cache [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/Application.java
@@ -114,7 +114,6 @@ public class Application implements ModelResult {
             config = cache.computeIfAbsent(cacheKey, (ConfigCacheKey key) -> {
                 var response = createConfigResponse(configKey, req, responseFactory);
                 metricUpdater.setCacheConfigElems(cache.configElems());
-                metricUpdater.setCacheChecksumElems(cache.checkSumElems());
                 return response;
             });
         } else {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/MetricUpdater.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/monitoring/MetricUpdater.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.monitoring;
 
 import com.yahoo.jdisc.Metric;
@@ -30,7 +30,6 @@ public class MetricUpdater {
     private static final String METRIC_HOSTS = getMetricName("hosts");
     private static final String METRIC_APPLICATIONS = getMetricName("applications");
     private static final String METRIC_CACHE_CONFIG_ELEMENTS = getMetricName("cacheConfigElems");
-    private static final String METRIC_CACHE_CONFIG_CHECKSUMS = getMetricName("cacheChecksumElems");
     private static final String METRIC_DELAYED_RESPONSES = getMetricName("delayedResponses");
     private static final String METRIC_RPCSERVER_WORK_QUEUE_SIZE = getMetricName("rpcServerWorkQueueSize");
 
@@ -65,15 +64,6 @@ public class MetricUpdater {
      */
     public void setCacheConfigElems(long elems) {
         staticMetrics.put(METRIC_CACHE_CONFIG_ELEMENTS, elems);
-    }
-
-    /**
-     * Sets the count for number of checksum elements in the {@link ServerCache}
-     *
-     * @param elems number of elements
-     */
-    public void setCacheChecksumElems(long elems) {
-        staticMetrics.put(METRIC_CACHE_CONFIG_CHECKSUMS, elems);
     }
 
     /**

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
@@ -73,8 +73,6 @@ public class ServerCacheTest {
 
     @Test
     public void testThatCacheWorksWithDifferentKeySameMd5() {
-        System.out.println(cache.get(fooBarCacheKey));
-        System.out.println(cache.get(bazQuuxCacheKey));
         assertEquals(cache.get(fooBarCacheKey).getPayload(), cache.get(bazQuuxCacheKey).getPayload());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ServerCacheTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server;
 
 import com.yahoo.vespa.config.ConfigCacheKey;
@@ -12,9 +12,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author Ulf Lilleengen
@@ -73,6 +73,9 @@ public class ServerCacheTest {
 
     @Test
     public void testThatCacheWorksWithDifferentKeySameMd5() {
-        assertTrue(cache.get(fooBarCacheKey) == cache.get(bazQuuxCacheKey));
+        System.out.println(cache.get(fooBarCacheKey));
+        System.out.println(cache.get(bazQuuxCacheKey));
+        assertEquals(cache.get(fooBarCacheKey).getPayload(), cache.get(bazQuuxCacheKey).getPayload());
     }
+
 }


### PR DESCRIPTION
If configs have the same checksum, they are the same, no need for
double mapping.