### PR TITLE
Move initializing handling to top-level distributor

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test_util.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.cpp
@@ -25,6 +25,7 @@ DistributorStripeTestUtil::DistributorStripeTestUtil()
       _sender(),
       _senderDown(),
       _hostInfo(),
+      _done_initializing(true),
       _messageSender(_sender, _senderDown)
 {
     _config = getStandardConfig(false);
@@ -47,7 +48,8 @@ DistributorStripeTestUtil::createLinks()
                                                   *this,
                                                   _messageSender,
                                                   *this,
-                                                  false);
+                                                  false,
+                                                  _done_initializing);
 }
 
 void

--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -219,6 +219,7 @@ protected:
     DistributorMessageSenderStub _sender;
     DistributorMessageSenderStub _senderDown;
     HostInfo _hostInfo;
+    bool _done_initializing;
 
     struct MessageSenderImpl : public ChainedMessageSender {
         DistributorMessageSenderStub& _sender;

--- a/storage/src/tests/distributor/legacy_distributor_test.cpp
+++ b/storage/src/tests/distributor/legacy_distributor_test.cpp
@@ -301,6 +301,15 @@ TEST_F(LegacyDistributorTest, recovery_mode_on_cluster_state_change) {
     EXPECT_TRUE(distributor_is_in_recovery_mode());
 }
 
+TEST_F(LegacyDistributorTest, distributor_considered_initialized_once_self_observed_up) {
+    setupDistributor(Redundancy(1), NodeCount(2), "distributor:1 .0.s:d storage:1"); // We're down D:
+    EXPECT_FALSE(_distributor->done_initializing());
+    enableDistributorClusterState("distributor:1 storage:1"); // We're up :D
+    EXPECT_TRUE(_distributor->done_initializing());
+    enableDistributorClusterState("distributor:1 .0.s:d storage:1"); // And down again :I but that does not change init state
+    EXPECT_TRUE(_distributor->done_initializing());
+}
+
 // Migrated to DistributorStripeTest
 TEST_F(LegacyDistributorTest, operations_are_throttled) {
     setupDistributor(Redundancy(1), NodeCount(1), "storage:1 distributor:1");

--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -162,6 +162,15 @@ TEST_F(TopLevelDistributorTest, recovery_mode_on_cluster_state_change_is_trigger
     EXPECT_TRUE(all_distributor_stripes_are_in_recovery_mode());
 }
 
+TEST_F(TopLevelDistributorTest, distributor_considered_initialized_once_self_observed_up) {
+    setup_distributor(Redundancy(1), NodeCount(2), "distributor:1 .0.s:d storage:1"); // We're down D:
+    EXPECT_FALSE(_distributor->done_initializing());
+    enable_distributor_cluster_state("distributor:1 storage:1"); // We're up :D
+    EXPECT_TRUE(_distributor->done_initializing());
+    enable_distributor_cluster_state("distributor:1 .0.s:d storage:1"); // And down again :I but that does not change init state
+    EXPECT_TRUE(_distributor->done_initializing());
+}
+
 // TODO STRIPE consider moving to generic test, not specific to top-level distributor or stripe
 TEST_F(TopLevelDistributorTest, contains_time_statement) {
     setup_distributor(Redundancy(1), NodeCount(1), "storage:1 distributor:1");

--- a/storage/src/vespa/storage/distributor/cluster_state_bundle_activation_listener.h
+++ b/storage/src/vespa/storage/distributor/cluster_state_bundle_activation_listener.h
@@ -1,0 +1,23 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+namespace storage::lib { class ClusterStateBundle; }
+
+namespace storage::distributor {
+
+/**
+ * Listener where on_cluster_state_bundle_activated() is invoked by the top-level
+ * bucket DB updater component upon a cluster state activation edge.
+ *
+ * Thread/concurrency note: this listener is always invoked from the top-level
+ * distributor thread and in a context where all stripe threads are paused.
+ * This means the callee must not directly or indirectly try to pause stripe
+ * threads itself, but it may safely modify shared state since no stripe threads
+ * are active.
+ */
+class ClusterStateBundleActivationListener {
+public:
+    virtual ~ClusterStateBundleActivationListener() = default;
+    virtual void on_cluster_state_bundle_activated(const lib::ClusterStateBundle&) = 0;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -66,6 +66,7 @@ public:
                       ChainedMessageSender& messageSender,
                       StripeHostInfoNotifier& stripe_host_info_notifier,
                       bool use_legacy_mode,
+                      bool& done_initializing_ref, // TODO STRIPE const ref once legacy is gone and stripe can't mutate init state
                       uint32_t stripe_index = 0);
 
     ~DistributorStripe() override;
@@ -147,7 +148,7 @@ public:
     void handleCompletedMerge(const std::shared_ptr<api::MergeBucketReply>& reply) override;
 
     bool initializing() const override {
-        return !_doneInitializing;
+        return !_done_initializing_ref;
     }
 
     const DistributorConfiguration& getConfig() const override {
@@ -342,8 +343,8 @@ private:
     mutable std::vector<std::shared_ptr<DistributorStatus>> _statusToDo;
     mutable std::vector<std::shared_ptr<DistributorStatus>> _fetchedStatusRequests;
 
-    DoneInitializeHandler& _doneInitializeHandler;
-    bool _doneInitializing;
+    DoneInitializeHandler& _doneInitializeHandler; // TODO STRIPE remove when legacy is gone
+    bool& _done_initializing_ref;
 
     std::unique_ptr<BucketPriorityDatabase> _bucketPriorityDb;
     std::unique_ptr<SimpleMaintenanceScanner> _scanner;

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
@@ -28,6 +28,7 @@ namespace storage::distributor {
 
 struct BucketSpaceDistributionConfigs;
 class BucketSpaceDistributionContext;
+class ClusterStateBundleActivationListener;
 class DistributorInterface;
 class StripeAccessor;
 class StripeAccessGuard;
@@ -42,7 +43,8 @@ public:
                             DistributorInterface& distributor_interface,
                             ChainedMessageSender& chained_sender,
                             std::shared_ptr<const lib::Distribution> bootstrap_distribution,
-                            StripeAccessor& stripe_accessor);
+                            StripeAccessor& stripe_accessor,
+                            ClusterStateBundleActivationListener* state_activation_listener);
     ~TopLevelBucketDBUpdater() override;
 
     void flush();
@@ -109,6 +111,7 @@ private:
 
     // TODO STRIPE remove once distributor component dependencies have been pruned
     StripeAccessor& _stripe_accessor;
+    ClusterStateBundleActivationListener* _state_activation_listener;
     lib::ClusterStateBundle _active_state_bundle;
 
     const DistributorNodeContext& _node_ctx;


### PR DESCRIPTION
@geirst and @toregge please review

Add a listener interface that lets the top-level distributor intercept
cluster state activations and use this for triggering the node init edge.
This happens when all stripes are paused so this is safe from data races.
Legacy code in the `DistributorStripe` remains for now.

Note: the `TopLevelBucketDBUpdater` component only exists when legacy
mode is _not_ active, so the new code path cannot be invoked in this case.

