### PR TITLE
Update use of md5 and xxhash64 in more places [run-systemtest]

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/PayloadChecksums.java
+++ b/config/src/main/java/com/yahoo/vespa/config/PayloadChecksums.java
@@ -24,14 +24,20 @@ public class PayloadChecksums {
     private final Map<PayloadChecksum.Type, PayloadChecksum> checksums = new LinkedHashMap<>();
 
     private PayloadChecksums() {
-        Arrays.stream(PayloadChecksum.Type.values()).forEach(type -> checksums.put(type, PayloadChecksum.empty(type)));
+        this(false);
     }
 
-    public static PayloadChecksums empty() { return new PayloadChecksums(); }
+    private PayloadChecksums(boolean addEmptyChecksumForAllTypes) {
+        if (addEmptyChecksumForAllTypes)
+            Arrays.stream(PayloadChecksum.Type.values())
+                  .forEach(type -> checksums.put(type, PayloadChecksum.empty(type)));
+    }
+
+    public static PayloadChecksums empty() { return new PayloadChecksums(true); }
 
     public static PayloadChecksums from(PayloadChecksum... checksums) {
         PayloadChecksums payloadChecksums = new PayloadChecksums();
-        Arrays.stream(checksums).forEach(payloadChecksums::add);
+        Arrays.stream(checksums).filter(Objects::nonNull).forEach(payloadChecksums::add);
         return payloadChecksums;
     }
 

--- a/config/src/main/java/com/yahoo/vespa/config/RawConfig.java
+++ b/config/src/main/java/com/yahoo/vespa/config/RawConfig.java
@@ -141,7 +141,15 @@ public class RawConfig extends ConfigInstance {
      * @return  true if this config is equal to the config in the given request.
      */
     public boolean hasEqualConfig(JRTServerConfigRequest req) {
-        return getConfigMd5().equals(req.getRequestConfigMd5());
+        PayloadChecksums payloadChecksums = getPayloadChecksums();
+        PayloadChecksum xxhash64 = payloadChecksums.getForType(PayloadChecksum.Type.XXHASH64);
+        PayloadChecksum md5 = payloadChecksums.getForType(PayloadChecksum.Type.MD5);
+        if (xxhash64 != null)
+            return xxhash64.equals(req.getRequestConfigChecksums().getForType(PayloadChecksum.Type.XXHASH64));
+        if (md5 != null)
+            return md5.equals(req.getRequestConfigChecksums().getForType(PayloadChecksum.Type.MD5));
+
+        return true;
     }
 
     /**

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/ConfigResponse.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/ConfigResponse.java
@@ -1,6 +1,7 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.protocol;
 
+import com.yahoo.vespa.config.PayloadChecksum;
 import com.yahoo.vespa.config.PayloadChecksums;
 import com.yahoo.text.AbstractUtf8Array;
 
@@ -28,7 +29,15 @@ public interface ConfigResponse {
     void serialize(OutputStream os, CompressionType uncompressed) throws IOException;
 
     default boolean hasEqualConfig(JRTServerConfigRequest request) {
-        return (getConfigMd5().equals(request.getRequestConfigMd5()));
+        PayloadChecksums payloadChecksums = getPayloadChecksums();
+        PayloadChecksum xxhash64 = payloadChecksums.getForType(PayloadChecksum.Type.XXHASH64);
+        PayloadChecksum md5 = payloadChecksums.getForType(PayloadChecksum.Type.MD5);
+        if (xxhash64 != null)
+            return xxhash64.equals(request.getRequestConfigChecksums().getForType(PayloadChecksum.Type.XXHASH64));
+        if (md5 != null)
+            return md5.equals(request.getRequestConfigChecksums().getForType(PayloadChecksum.Type.MD5));
+
+        return true;
     }
 
     default boolean hasNewerGeneration(JRTServerConfigRequest request) {

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
@@ -82,8 +82,10 @@ public class JRTServerConfigRequestV3 implements JRTServerConfigRequest {
             JsonGenerator jsonGenerator = createJsonGenerator(byteArrayOutputStream);
             jsonGenerator.writeStartObject();
             addCommonReturnValues(jsonGenerator);
-            setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_MD5, payloadChecksums.getForType(MD5).asString());
-            setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_XXHASH64, payloadChecksums.getForType(XXHASH64).asString());
+            if (payloadChecksums.getForType(MD5) != null)
+                setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_MD5, payloadChecksums.getForType(MD5).asString());
+            if (payloadChecksums.getForType(XXHASH64) != null)
+                setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_XXHASH64, payloadChecksums.getForType(XXHASH64).asString());
             setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_GENERATION, generation);
             setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_APPLY_ON_RESTART, applyOnRestart);
             jsonGenerator.writeObjectFieldStart(SlimeResponseData.RESPONSE_COMPRESSION_INFO);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactoryTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.MD5;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.XXHASH64;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author Ulf Lilleengen
@@ -39,30 +40,30 @@ public class ConfigResponseFactoryTest {
 
     @Test
     public void testLZ4CompressedFactory() {
-        // Both checksums in request
+        // md5 and xxhash64 checksums in request, both md5 and xxhash64 checksums should be in response
         {
             ConfigResponse response = createResponse(payloadChecksums);
             assertEquals(payloadChecksums, response.getPayloadChecksums());
         }
 
-        // No checksums in request (empty checksums), both checksums should be in response
+        // Empty md5 and xxhash64 checksums in request, both md5 and xxhash64 checksum should be in response
         {
             ConfigResponse response = createResponse(payloadChecksumsEmpty);
             assertEquals(payloadChecksums.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
             assertEquals(payloadChecksums.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
 
-        // Only md5 checksums in request
+        // md5 checksum and no xxhash64 checksum in request, md5 and xxhash6 checksum in response
         {
             ConfigResponse response = createResponse(payloadChecksumsOnlyMd5);
             assertEquals(payloadChecksumsOnlyMd5.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
-            assertEquals(payloadChecksumsOnlyMd5.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
+            assertEquals(payloadChecksums.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
 
-        // Only xxhash64 checksums in request
+        // Only xxhash64 checksum in request, only xxhash64 checksums in response
         {
             ConfigResponse response = createResponse(payloadChecksumsOnlyXxhash64);
-            assertEquals(payloadChecksumsOnlyXxhash64.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
+            assertNull(response.getPayloadChecksums().getForType(MD5));
             assertEquals(payloadChecksumsOnlyXxhash64.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
     }


### PR DESCRIPTION
Set md5 and xxhash64 only when non-null in request and response.
Update hasEqualConfig methods.
Always return xxhash64 in response.
