### PR TITLE
Create persistence engine before creating document db in BmNode.

### DIFF
--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -501,8 +501,8 @@ MyBmNode::MyBmNode(const vespalib::string& base_dir, int base_port, uint32_t nod
       _distributor_chain_context(),
       _distributor()
 {
-    create_document_db(params);
     _persistence_engine = std::make_unique<proton::PersistenceEngine>(_persistence_owner, _write_filter, _disk_mem_usage_notifier, -1, false);
+    create_document_db(params);
     auto proxy = std::make_shared<proton::PersistenceHandlerProxy>(_document_db);
     _persistence_engine->putHandler(_persistence_engine->getWLock(), _bucket_space, _doc_type_name, proxy);
     _service_layer_config.add_builders(_config_set);


### PR DESCRIPTION
This order is needed to pass a proper bucket executor to the document db.

@geirst : please review
@baldersheim : FYI
