### PR TITLE
Revert "Update use of md5 and xxhash64 in more places [run-systemtest]"

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/PayloadChecksums.java
+++ b/config/src/main/java/com/yahoo/vespa/config/PayloadChecksums.java
@@ -24,20 +24,14 @@ public class PayloadChecksums {
     private final Map<PayloadChecksum.Type, PayloadChecksum> checksums = new LinkedHashMap<>();
 
     private PayloadChecksums() {
-        this(false);
+        Arrays.stream(PayloadChecksum.Type.values()).forEach(type -> checksums.put(type, PayloadChecksum.empty(type)));
     }
 
-    private PayloadChecksums(boolean addEmptyChecksumForAllTypes) {
-        if (addEmptyChecksumForAllTypes)
-            Arrays.stream(PayloadChecksum.Type.values())
-                  .forEach(type -> checksums.put(type, PayloadChecksum.empty(type)));
-    }
-
-    public static PayloadChecksums empty() { return new PayloadChecksums(true); }
+    public static PayloadChecksums empty() { return new PayloadChecksums(); }
 
     public static PayloadChecksums from(PayloadChecksum... checksums) {
         PayloadChecksums payloadChecksums = new PayloadChecksums();
-        Arrays.stream(checksums).filter(Objects::nonNull).forEach(payloadChecksums::add);
+        Arrays.stream(checksums).forEach(payloadChecksums::add);
         return payloadChecksums;
     }
 

--- a/config/src/main/java/com/yahoo/vespa/config/RawConfig.java
+++ b/config/src/main/java/com/yahoo/vespa/config/RawConfig.java
@@ -141,15 +141,7 @@ public class RawConfig extends ConfigInstance {
      * @return  true if this config is equal to the config in the given request.
      */
     public boolean hasEqualConfig(JRTServerConfigRequest req) {
-        PayloadChecksums payloadChecksums = getPayloadChecksums();
-        PayloadChecksum xxhash64 = payloadChecksums.getForType(PayloadChecksum.Type.XXHASH64);
-        PayloadChecksum md5 = payloadChecksums.getForType(PayloadChecksum.Type.MD5);
-        if (xxhash64 != null)
-            return xxhash64.equals(req.getRequestConfigChecksums().getForType(PayloadChecksum.Type.XXHASH64));
-        if (md5 != null)
-            return md5.equals(req.getRequestConfigChecksums().getForType(PayloadChecksum.Type.MD5));
-
-        return true;
+        return getConfigMd5().equals(req.getRequestConfigMd5());
     }
 
     /**

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/ConfigResponse.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/ConfigResponse.java
@@ -1,7 +1,6 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.protocol;
 
-import com.yahoo.vespa.config.PayloadChecksum;
 import com.yahoo.vespa.config.PayloadChecksums;
 import com.yahoo.text.AbstractUtf8Array;
 
@@ -29,15 +28,7 @@ public interface ConfigResponse {
     void serialize(OutputStream os, CompressionType uncompressed) throws IOException;
 
     default boolean hasEqualConfig(JRTServerConfigRequest request) {
-        PayloadChecksums payloadChecksums = getPayloadChecksums();
-        PayloadChecksum xxhash64 = payloadChecksums.getForType(PayloadChecksum.Type.XXHASH64);
-        PayloadChecksum md5 = payloadChecksums.getForType(PayloadChecksum.Type.MD5);
-        if (xxhash64 != null)
-            return xxhash64.equals(request.getRequestConfigChecksums().getForType(PayloadChecksum.Type.XXHASH64));
-        if (md5 != null)
-            return md5.equals(request.getRequestConfigChecksums().getForType(PayloadChecksum.Type.MD5));
-
-        return true;
+        return (getConfigMd5().equals(request.getRequestConfigMd5()));
     }
 
     default boolean hasNewerGeneration(JRTServerConfigRequest request) {

--- a/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
+++ b/config/src/main/java/com/yahoo/vespa/config/protocol/JRTServerConfigRequestV3.java
@@ -82,10 +82,8 @@ public class JRTServerConfigRequestV3 implements JRTServerConfigRequest {
             JsonGenerator jsonGenerator = createJsonGenerator(byteArrayOutputStream);
             jsonGenerator.writeStartObject();
             addCommonReturnValues(jsonGenerator);
-            if (payloadChecksums.getForType(MD5) != null)
-                setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_MD5, payloadChecksums.getForType(MD5).asString());
-            if (payloadChecksums.getForType(XXHASH64) != null)
-                setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_XXHASH64, payloadChecksums.getForType(XXHASH64).asString());
+            setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_MD5, payloadChecksums.getForType(MD5).asString());
+            setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_XXHASH64, payloadChecksums.getForType(XXHASH64).asString());
             setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_CONFIG_GENERATION, generation);
             setResponseField(jsonGenerator, SlimeResponseData.RESPONSE_APPLY_ON_RESTART, applyOnRestart);
             jsonGenerator.writeObjectFieldStart(SlimeResponseData.RESPONSE_COMPRESSION_INFO);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactory.java
@@ -50,23 +50,22 @@ public interface ConfigResponseFactory {
     default PayloadChecksums generatePayloadChecksums(AbstractUtf8Array rawPayload, PayloadChecksums requestsPayloadChecksums) {
         PayloadChecksum requestChecksumMd5 = requestsPayloadChecksums.getForType(MD5);
         PayloadChecksum requestChecksumXxhash64 = requestsPayloadChecksums.getForType(XXHASH64);
-        PayloadChecksum xxhash64 = new PayloadChecksum(ConfigUtils.getXxhash64(rawPayload), XXHASH64);
 
-        if (requestChecksumMd5 == null)
-            return PayloadChecksums.from(xxhash64);
-
-        // Return xxhash64 checksum, even if none in request
-        if (requestChecksumXxhash64 == null)
-            return PayloadChecksums.from(new PayloadChecksum(ConfigUtils.getMd5(rawPayload), MD5), xxhash64);
-
-        // Response always contains xxhash64 checksum, md5 checksum is included
-        // when both are present, both are absent or only md5 is present in request
-        PayloadChecksum md5 = null;
-        if (( ! requestChecksumMd5.isEmpty() && ! requestChecksumXxhash64.isEmpty())
-                || (requestChecksumMd5.isEmpty() && requestChecksumXxhash64.isEmpty())) {
+        PayloadChecksum md5 = PayloadChecksum.empty(MD5);
+        PayloadChecksum xxhash64 = PayloadChecksum.empty(XXHASH64);
+        // Response contains same checksum type as in request, except when both are empty,
+        // then use both checksum types in response
+        if (requestChecksumMd5.isEmpty() && requestChecksumXxhash64.isEmpty()
+                || ( ! requestChecksumMd5.isEmpty() && ! requestChecksumXxhash64.isEmpty())) {
             md5 = new PayloadChecksum(ConfigUtils.getMd5(rawPayload), MD5);
-        } else if (! requestChecksumMd5.isEmpty() && requestChecksumXxhash64.isEmpty()) {
+            xxhash64 = new PayloadChecksum(ConfigUtils.getXxhash64(rawPayload), XXHASH64);
+        } else if ( ! requestChecksumMd5.isEmpty()) {
             md5 = new PayloadChecksum(ConfigUtils.getMd5(rawPayload), MD5);
+        } else if (requestChecksumMd5.isEmpty() && !requestChecksumXxhash64.isEmpty()) {
+            xxhash64 = new PayloadChecksum(ConfigUtils.getXxhash64(rawPayload), XXHASH64);
+        } else {
+            md5 = new PayloadChecksum(ConfigUtils.getMd5(rawPayload), MD5);
+            xxhash64 = new PayloadChecksum(ConfigUtils.getXxhash64(rawPayload), XXHASH64);
         }
 
         return PayloadChecksums.from(md5, xxhash64);

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/rpc/ConfigResponseFactoryTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.MD5;
 import static com.yahoo.vespa.config.PayloadChecksum.Type.XXHASH64;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * @author Ulf Lilleengen
@@ -40,30 +39,30 @@ public class ConfigResponseFactoryTest {
 
     @Test
     public void testLZ4CompressedFactory() {
-        // md5 and xxhash64 checksums in request, both md5 and xxhash64 checksums should be in response
+        // Both checksums in request
         {
             ConfigResponse response = createResponse(payloadChecksums);
             assertEquals(payloadChecksums, response.getPayloadChecksums());
         }
 
-        // Empty md5 and xxhash64 checksums in request, both md5 and xxhash64 checksum should be in response
+        // No checksums in request (empty checksums), both checksums should be in response
         {
             ConfigResponse response = createResponse(payloadChecksumsEmpty);
             assertEquals(payloadChecksums.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
             assertEquals(payloadChecksums.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
 
-        // md5 checksum and no xxhash64 checksum in request, md5 and xxhash6 checksum in response
+        // Only md5 checksums in request
         {
             ConfigResponse response = createResponse(payloadChecksumsOnlyMd5);
             assertEquals(payloadChecksumsOnlyMd5.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
-            assertEquals(payloadChecksums.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
+            assertEquals(payloadChecksumsOnlyMd5.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
 
-        // Only xxhash64 checksum in request, only xxhash64 checksums in response
+        // Only xxhash64 checksums in request
         {
             ConfigResponse response = createResponse(payloadChecksumsOnlyXxhash64);
-            assertNull(response.getPayloadChecksums().getForType(MD5));
+            assertEquals(payloadChecksumsOnlyXxhash64.getForType(MD5), response.getPayloadChecksums().getForType(MD5));
             assertEquals(payloadChecksumsOnlyXxhash64.getForType(XXHASH64), response.getPayloadChecksums().getForType(XXHASH64));
         }
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#19128

A few system tests failed (looks like reconfiguration of C++ services did not work, need to investigate).