### PR TITLE
GC unused flag and methods

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.api;
 
 import com.yahoo.component.Version;
@@ -84,8 +84,8 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"baldersheim"}) default int metricsproxyNumThreads() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default boolean enforceRankProfileInheritance() { return false; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int largeRankExpressionLimit() { return 8192; }
-        @ModelFeatureFlag(owners = {"baldersheim"}) default boolean useExternalRankExpressions() { return true; }
-        @ModelFeatureFlag(owners = {"baldersheim"}) default boolean distributeExternalRankExpressions() { return true; }
+        @ModelFeatureFlag(owners = {"baldersheim"}, removeAfter = "7.468") default boolean useExternalRankExpressions() { return true; }
+        @ModelFeatureFlag(owners = {"baldersheim"}, removeAfter = "7.468") default boolean distributeExternalRankExpressions() { return true; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxConcurrentMergesPerNode() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxMergeQueueSize() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default boolean dryRunOnnxOnSetup() { return true; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.deploy;
 
 import com.google.common.collect.ImmutableList;
@@ -50,7 +50,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean useAsyncMessageHandlingOnSchedule = false;
     private double feedConcurrency = 0.5;
     private boolean enableFeedBlockInDistributor = true;
-    private boolean useExternalRankExpression = true;
     private boolean enforceRankProfileInheritance = true;
     private int maxActivationInhibitedOutOfSyncGroups = 0;
     private List<TenantSecretStore> tenantSecretStores = Collections.emptyList();
@@ -99,8 +98,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public int numDistributorStripes() { return numDistributorStripes; }
     @Override public boolean allowDisableMtls() { return allowDisableMtls; }
     @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
-    @Override public boolean useExternalRankExpressions() { return useExternalRankExpression; }
-    @Override public boolean distributeExternalRankExpressions() { return useExternalRankExpression; }
     @Override public int largeRankExpressionLimit() { return largeRankExpressionLimit; }
     @Override public int maxConcurrentMergesPerNode() { return maxConcurrentMergesPerNode; }
     @Override public int maxMergeQueueSize() { return maxMergeQueueSize; }
@@ -112,10 +109,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties enforceRankProfileInheritance(boolean value) {
         enforceRankProfileInheritance = value;
-        return this;
-    }
-    public TestProperties useExternalRankExpression(boolean value) {
-        useExternalRankExpression = value;
         return this;
     }
     public TestProperties largeRankExpressionLimit(int value) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/RawRankProfile.java
@@ -1,4 +1,4 @@
-// Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchdefinition.derived;
 
 import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
@@ -139,8 +139,6 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
         private final double termwiseLimit;
         private final double rankScoreDropLimit;
         private final int largeRankExpressionLimit;
-        private final boolean distributeLargeRankExpressions;
-        private final boolean useDistributedRankExpressions;
 
         /**
          * The rank type definitions used to derive settings for the native rank features
@@ -176,8 +174,6 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
             rankScoreDropLimit = compiled.getRankScoreDropLimit();
             ignoreDefaultRankFeatures = compiled.getIgnoreDefaultRankFeatures();
             largeRankExpressionLimit = deployProperties.featureFlags().largeRankExpressionLimit();
-            distributeLargeRankExpressions = deployProperties.featureFlags().distributeExternalRankExpressions();
-            useDistributedRankExpressions = deployProperties.featureFlags().useExternalRankExpressions();
             rankProperties = new ArrayList<>(compiled.getRankProperties());
 
             Map<String, RankProfile.RankingExpressionFunction> functions = compiled.getFunctions();
@@ -413,7 +409,6 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
         }
 
         private void distributeLargeExpressionsAsFiles(List<Pair<String, String>> properties, LargeRankExpressions largeRankExpressions) {
-            if (!distributeLargeRankExpressions) return;
             for (ListIterator<Pair<String, String>> iter = properties.listIterator(); iter.hasNext();) {
                 Pair<String, String> property = iter.next();
                 String expression = property.getSecond();
@@ -423,9 +418,7 @@ public class RawRankProfile implements RankProfilesConfig.Producer {
                     if (functionName != null) {
                         String mangledName = rankprofileName + "." + functionName;
                         largeRankExpressions.add(new RankExpressionBody(mangledName, ByteBuffer.wrap(expression.getBytes(StandardCharsets.UTF_8))));
-                        if (useDistributedRankExpressions) {
-                            iter.set(new Pair<>(RankingExpression.propertyExpressionName(functionName), mangledName));
-                        }
+                        iter.set(new Pair<>(RankingExpression.propertyExpressionName(functionName), mangledName));
                     }
                 }
             }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.deploy;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
@@ -178,8 +178,6 @@ public class ModelContextImpl implements ModelContext {
         private final List<String> allowedAthenzProxyIdentities;
         private final int maxActivationInhibitedOutOfSyncGroups;
         private final ToIntFunction<ClusterSpec.Type> jvmOmitStackTraceInFastThrow;
-        private final boolean useExternalRankExpression;
-        private final boolean distributeExternalRankExpressions;
         private final int numDistributorStripes;
         private final boolean requireConnectivityCheck;
         private final int maxConcurrentMergesPerContentNode;
@@ -209,8 +207,6 @@ public class ModelContextImpl implements ModelContext {
             this.maxActivationInhibitedOutOfSyncGroups = flagValue(source, appId, Flags.MAX_ACTIVATION_INHIBITED_OUT_OF_SYNC_GROUPS);
             this.jvmOmitStackTraceInFastThrow = type -> flagValueAsInt(source, appId, type, PermanentFlags.JVM_OMIT_STACK_TRACE_IN_FAST_THROW);
             this.numDistributorStripes = flagValue(source, appId, Flags.NUM_DISTRIBUTOR_STRIPES);
-            this.useExternalRankExpression = flagValue(source, appId, Flags.USE_EXTERNAL_RANK_EXPRESSION);
-            this.distributeExternalRankExpressions = flagValue(source, appId, Flags.DISTRIBUTE_EXTERNAL_RANK_EXPRESSION);
             this.largeRankExpressionLimit = flagValue(source, appId, Flags.LARGE_RANK_EXPRESSION_LIMIT);
             this.requireConnectivityCheck = flagValue(source, appId, Flags.REQUIRE_CONNECTIVITY_CHECK);
             this.maxConcurrentMergesPerContentNode = flagValue(source, appId, Flags.MAX_CONCURRENT_MERGES_PER_NODE);
@@ -241,8 +237,6 @@ public class ModelContextImpl implements ModelContext {
             return translateJvmOmitStackTraceInFastThrowIntToString(jvmOmitStackTraceInFastThrow, type);
         }
         @Override public int numDistributorStripes() { return numDistributorStripes; }
-        @Override public boolean useExternalRankExpressions() { return useExternalRankExpression; }
-        @Override public boolean distributeExternalRankExpressions() { return distributeExternalRankExpressions; }
         @Override public int largeRankExpressionLimit() { return largeRankExpressionLimit; }
         @Override public boolean requireConnectivityCheck() { return requireConnectivityCheck; }
         @Override public int maxConcurrentMergesPerNode() { return maxConcurrentMergesPerContentNode; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -210,7 +210,7 @@ public class Flags {
 
     public static final UnboundIntFlag LARGE_RANK_EXPRESSION_LIMIT = defineIntFlag(
             "large-rank-expression-limit", 8192,
-            List.of("baldersheim"), "2021-06-09", "2021-09-15",
+            List.of("baldersheim"), "2021-06-09", "2021-10-15",
             "Limit for size of rank expressions distributed by filedistribution",
             "Takes effect on next internal redeployment",
             APPLICATION_ID);

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -1,4 +1,4 @@
-// Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags;
 
 import com.yahoo.component.Vtag;
@@ -207,20 +207,6 @@ public class Flags {
             "Specifies max size of merge queue.",
             "Takes effect at redeploy",
             ZONE_ID, APPLICATION_ID);
-
-    public static final UnboundBooleanFlag USE_EXTERNAL_RANK_EXPRESSION = defineFeatureFlag(
-            "use-external-rank-expression", true,
-            List.of("baldersheim"), "2021-05-24", "2021-09-15",
-            "Whether to use distributed external rank expression or inline in rankproperties",
-            "Takes effect on next internal redeployment",
-            APPLICATION_ID);
-
-    public static final UnboundBooleanFlag DISTRIBUTE_EXTERNAL_RANK_EXPRESSION = defineFeatureFlag(
-            "distribute-external-rank-expression", true,
-            List.of("baldersheim"), "2021-05-27", "2021-09-15",
-            "Whether to use distributed external rank expression files by filedistribution",
-            "Takes effect on next internal redeployment",
-            APPLICATION_ID);
 
     public static final UnboundIntFlag LARGE_RANK_EXPRESSION_LIMIT = defineIntFlag(
             "large-rank-expression-limit", 8192,


### PR DESCRIPTION
largeRankExpressionLimit() can be used to control use of external rank
expressions if needed.