### PR TITLE
In order to avoid possible deadlock when calling yourself for metrics…

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandler.java
@@ -50,6 +50,7 @@ public class ApplicationMetricsHandler extends HttpHandlerBase {
         super(executor);
         this.metricsRetriever = metricsRetriever;
         this.metricsConsumers = metricsConsumers;
+        metricsRetriever.startPollAnwWait();
     }
 
     @Override

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/application/Node.java
@@ -55,4 +55,10 @@ public class Node {
     public int hashCode() {
         return Objects.hash(role, hostname, port, path);
     }
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(role).append(":").append(metricsUriBase);
+        return sb.toString();
+    }
 }

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/application/ApplicationMetricsHandlerTest.java
@@ -4,6 +4,7 @@ package ai.vespa.metricsproxy.http.application;
 import ai.vespa.metricsproxy.core.ConsumersConfig;
 import ai.vespa.metricsproxy.core.MetricsConsumers;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
+import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.json.GenericApplicationModel;
 import ai.vespa.metricsproxy.metric.model.json.GenericJsonModel;
 import ai.vespa.metricsproxy.metric.model.json.GenericMetrics;
@@ -84,6 +85,8 @@ public class ApplicationMetricsHandlerTest {
         ApplicationMetricsHandler handler = new ApplicationMetricsHandler(Executors.newSingleThreadExecutor(),
                                                                           applicationMetricsRetriever,
                                                                           getMetricsConsumers());
+        applicationMetricsRetriever.getMetrics(ConsumerId.toConsumerId(CUSTOM_CONSUMER));
+        applicationMetricsRetriever.startPollAnwWait();
         testDriver = new RequestHandlerTestDriver(handler);
     }
 


### PR DESCRIPTION
… when TTL expires, we only fetch metrics in the background.

If it is present use it, if not it will be there next time.

@bjorncs @gjoranv PR