### PR TITLE
Change loading of nearest neighbor index to use direct I/O instead of…

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/load_utils.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/load_utils.cpp
@@ -24,8 +24,6 @@ LoadUtils::openFile(const AttributeVector& attr, const vespalib::string& suffix)
     return FileUtil::openFile(attr.getBaseFileName() + "." + suffix);
 }
 
-
-
 FileInterfaceUP
 LoadUtils::openDAT(const AttributeVector& attr)
 {

--- a/searchlib/src/vespa/searchlib/attribute/load_utils.h
+++ b/searchlib/src/vespa/searchlib/attribute/load_utils.h
@@ -16,10 +16,7 @@ public:
     using FileInterfaceUP = std::unique_ptr<FastOS_FileInterface>;
     using LoadedBufferUP = std::unique_ptr<fileutil::LoadedBuffer>;
 
-private:
     static FileInterfaceUP openFile(const AttributeVector& attr, const vespalib::string& suffix);
-
-public:
     static FileInterfaceUP openDAT(const AttributeVector& attr);
     static FileInterfaceUP openIDX(const AttributeVector& attr);
     static FileInterfaceUP openWeight(const AttributeVector& attr);

--- a/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/tensor/CMakeLists.txt
@@ -17,7 +17,6 @@ vespa_add_library(searchlib_tensor OBJECT
     hash_set_visited_tracker.cpp
     hnsw_graph.cpp
     hnsw_index.cpp
-    hnsw_index_loader.cpp
     hnsw_index_saver.cpp
     imported_tensor_attribute_vector.cpp
     imported_tensor_attribute_vector_read_guard.cpp

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.cpp
@@ -4,7 +4,7 @@
 #include "distance_function.h"
 #include "hash_set_visited_tracker.h"
 #include "hnsw_index.h"
-#include "hnsw_index_loader.h"
+#include "hnsw_index_loader.hpp"
 #include "hnsw_index_saver.h"
 #include "random_level_generator.h"
 #include "reusable_set_visited_tracker.h"
@@ -696,10 +696,12 @@ HnswIndex::make_saver() const
 }
 
 std::unique_ptr<NearestNeighborIndexLoader>
-HnswIndex::make_loader(std::unique_ptr<fileutil::LoadedBuffer> buf)
+HnswIndex::make_loader(FastOS_FileInterface& file)
 {
     assert(get_entry_docid() == 0); // cannot load after index has data
-    return std::make_unique<HnswIndexLoader>(_graph, std::move(buf));
+    using ReaderType = FileReader<uint32_t>;
+    using LoaderType = HnswIndexLoader<ReaderType>;
+    return std::make_unique<LoaderType>(_graph, std::make_unique<ReaderType>(file));
 }
 
 struct NeighborsByDocId {

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
@@ -183,7 +183,7 @@ public:
     void shrink_lid_space(uint32_t doc_id_limit) override;
 
     std::unique_ptr<NearestNeighborIndexSaver> make_saver() const override;
-    std::unique_ptr<NearestNeighborIndexLoader> make_loader(std::unique_ptr<fileutil::LoadedBuffer> buf) override;
+    std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file) override;
 
     std::vector<Neighbor> find_top_k(uint32_t k, TypedCells vector, uint32_t explore_k,
                                      double distance_threshold) const override;

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index_loader.hpp
@@ -1,30 +1,29 @@
 // Copyright Verizon Media. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#pragma once
+
 #include "hnsw_index_loader.h"
 #include "hnsw_graph.h"
 #include <vespa/searchlib/util/fileutil.h>
 
 namespace search::tensor {
 
+template <typename ReaderType>
 void
-HnswIndexLoader::init()
+HnswIndexLoader<ReaderType>::init()
 {
-    size_t num_readable = _buf->size(sizeof(uint32_t));
-    _ptr = static_cast<const uint32_t *>(_buf->buffer());
-    _end = _ptr + num_readable;
     _entry_docid = next_int();
     _entry_level = next_int();
     _num_nodes = next_int();
 }
 
-HnswIndexLoader::~HnswIndexLoader() {}
+template <typename ReaderType>
+HnswIndexLoader<ReaderType>::~HnswIndexLoader() {}
 
-
-HnswIndexLoader::HnswIndexLoader(HnswGraph& graph, std::unique_ptr<fileutil::LoadedBuffer> buf)
+template <typename ReaderType>
+HnswIndexLoader<ReaderType>::HnswIndexLoader(HnswGraph& graph, std::unique_ptr<ReaderType> reader)
     : _graph(graph),
-      _buf(std::move(buf)),
-      _ptr(nullptr),
-      _end(nullptr),
+      _reader(std::move(reader)),
       _entry_docid(0),
       _entry_level(0),
       _num_nodes(0),
@@ -35,8 +34,9 @@ HnswIndexLoader::HnswIndexLoader(HnswGraph& graph, std::unique_ptr<fileutil::Loa
     init();
 }
 
+template <typename ReaderType>
 bool
-HnswIndexLoader::load_next()
+HnswIndexLoader<ReaderType>::load_next()
 {
     assert(!_complete);
     if (_docid < _num_nodes) {

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
@@ -10,6 +10,8 @@
 #include <memory>
 #include <vector>
 
+class FastOS_FileInterface;
+
 namespace vespalib::slime { struct Inserter; }
 
 namespace search::fileutil { class LoadedBuffer; }
@@ -80,11 +82,11 @@ public:
     virtual std::unique_ptr<NearestNeighborIndexSaver> make_saver() const = 0;
 
     /**
-     * Creates a loader that is used to load the index from the given buffer.
+     * Creates a loader that is used to load the index from the given file.
      *
-     * This might throw vespalib::IoException.
+     * This might throw std::runtime_error.
      */
-    virtual std::unique_ptr<NearestNeighborIndexLoader> make_loader(std::unique_ptr<fileutil::LoadedBuffer> buf) = 0;
+    virtual std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file) = 0;
 
     virtual std::vector<Neighbor> find_top_k(uint32_t k,
                                              vespalib::eval::TypedCells vector,

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_loader.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index_loader.h
@@ -15,7 +15,7 @@ public:
      * Loads the next part of the index (e.g. the node corresponding to a given document)
      * and returns whether there is more data to load.
      *
-     * This might throw vespalib::IoException.
+     * This might throw std::runtime_error.
      */
     virtual bool load_next() = 0;
 };


### PR DESCRIPTION
… mmapping.

This should further reduce memory spike during loading.

@toregge please review
@baldersheim @jobergum FYI