### PR TITLE
Use ideal state cache when populating StateChecker context

### DIFF
--- a/storage/src/vespa/storage/distributor/statechecker.cpp
+++ b/storage/src/vespa/storage/distributor/statechecker.cpp
@@ -58,7 +58,7 @@ StateChecker::Result::createStoredResult(
         IdealStateOperation::UP operation,
         MaintenancePriority::Priority priority)
 {
-    return Result(std::unique_ptr<ResultImpl>(new StoredResultImpl(std::move(operation), MaintenancePriority(priority))));
+    return Result(std::make_unique<StoredResultImpl>(std::move(operation), MaintenancePriority(priority)));
 }
 
 StateChecker::Context::Context(const DistributorNodeContext& node_ctx_in,
@@ -79,8 +79,7 @@ StateChecker::Context::Context(const DistributorNodeContext& node_ctx_in,
       db(distributorBucketSpace.getBucketDatabase()),
       stats(statsTracker)
 {
-    // TODO STRIPE use existing cache for computing ideal storage nodes for bucket
-    idealState = distribution.getIdealStorageNodes(systemState, bucket.getBucketId());
+    idealState = distributorBucketSpace.get_ideal_service_layer_nodes_bundle(bucket.getBucketId()).get_available_nonretired_or_maintenance_nodes();
     unorderedIdealState.insert(idealState.begin(), idealState.end());
 }
 


### PR DESCRIPTION
@geirst and @toregge please review
