### PR TITLE
Tenant removal refinements

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedTenant.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/LockedTenant.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 import com.yahoo.vespa.hosted.controller.api.integration.secrets.TenantSecretStore;
 import com.yahoo.vespa.hosted.controller.tenant.AthenzTenant;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
+import com.yahoo.vespa.hosted.controller.tenant.DeletedTenant;
 import com.yahoo.vespa.hosted.controller.tenant.LastLoginInfo;
 import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 import com.yahoo.vespa.hosted.controller.tenant.TenantInfo;
@@ -47,9 +48,10 @@ public abstract class LockedTenant {
 
     static LockedTenant of(Tenant tenant, Lock lock) {
         switch (tenant.type()) {
-            case athenz: return new Athenz((AthenzTenant) tenant);
-            case cloud:  return new Cloud((CloudTenant) tenant);
-            default:     throw new IllegalArgumentException("Unexpected tenant type '" + tenant.getClass().getName() + "'.");
+            case athenz:  return new Athenz((AthenzTenant) tenant);
+            case cloud:   return new Cloud((CloudTenant) tenant);
+            case deleted: return new Deleted((DeletedTenant) tenant);
+            default:      throw new IllegalArgumentException("Unexpected tenant type '" + tenant.getClass().getName() + "'.");
         }
     }
 
@@ -57,6 +59,10 @@ public abstract class LockedTenant {
     public abstract Tenant get();
 
     public abstract LockedTenant with(LastLoginInfo lastLoginInfo);
+
+    public Deleted deleted(Instant deletedAt) {
+        return new Deleted(new DeletedTenant(name, createdAt, deletedAt));
+    }
 
     @Override
     public String toString() {
@@ -180,6 +186,28 @@ public abstract class LockedTenant {
 
         public Cloud withArchiveAccessRole(Optional<String> role) {
             return new Cloud(name, createdAt, lastLoginInfo, creator, developerKeys, info, tenantSecretStores, role);
+        }
+    }
+
+
+    /** A locked DeletedTenant. */
+    public static class Deleted extends LockedTenant {
+
+        private final Instant deletedAt;
+
+        private Deleted(DeletedTenant tenant) {
+            super(tenant.name(), tenant.createdAt(), tenant.lastLoginInfo());
+            this.deletedAt = tenant.deletedAt();
+        }
+
+        @Override
+        public DeletedTenant get() {
+            return new DeletedTenant(name, createdAt, deletedAt);
+        }
+
+        @Override
+        public LockedTenant with(LastLoginInfo lastLoginInfo) {
+            return this;
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializer.java
@@ -19,6 +19,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.BillingInfo;
 import com.yahoo.vespa.hosted.controller.tenant.AthenzTenant;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
+import com.yahoo.vespa.hosted.controller.tenant.DeletedTenant;
 import com.yahoo.vespa.hosted.controller.tenant.LastLoginInfo;
 import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 import com.yahoo.vespa.hosted.controller.tenant.TenantInfo;
@@ -56,6 +57,7 @@ public class TenantSerializer {
     private static final String propertyIdField = "propertyId";
     private static final String creatorField = "creator";
     private static final String createdAtField = "createdAt";
+    private static final String deletedAtField = "deletedAt";
     private static final String contactField = "contact";
     private static final String contactUrlField = "contactUrl";
     private static final String propertyUrlField = "propertyUrl";
@@ -84,9 +86,10 @@ public class TenantSerializer {
         toSlime(tenant.lastLoginInfo(), tenantObject.setObject(lastLoginInfoField));
 
         switch (tenant.type()) {
-            case athenz: toSlime((AthenzTenant) tenant, tenantObject); break;
-            case cloud:  toSlime((CloudTenant) tenant, tenantObject);  break;
-            default:     throw new IllegalArgumentException("Unexpected tenant type '" + tenant.type() + "'.");
+            case athenz:  toSlime((AthenzTenant) tenant, tenantObject); break;
+            case cloud:   toSlime((CloudTenant) tenant, tenantObject);  break;
+            case deleted: toSlime((DeletedTenant) tenant, tenantObject);  break;
+            default:      throw new IllegalArgumentException("Unexpected tenant type '" + tenant.type() + "'.");
         }
         return slime;
     }
@@ -114,6 +117,10 @@ public class TenantSerializer {
         tenant.archiveAccessRole().ifPresent(role -> root.setString(archiveAccessRoleField, role));
     }
 
+    private void toSlime(DeletedTenant tenant, Cursor root) {
+        root.setLong(deletedAtField, tenant.deletedAt().toEpochMilli());
+    }
+
     private void developerKeysToSlime(BiMap<PublicKey, Principal> keys, Cursor array) {
         keys.forEach((key, user) -> {
             Cursor object = array.addObject();
@@ -139,9 +146,10 @@ public class TenantSerializer {
         Tenant.Type type = typeOf(tenantObject.field(typeField).asString());
 
         switch (type) {
-            case athenz: return athenzTenantFrom(tenantObject);
-            case cloud:  return cloudTenantFrom(tenantObject);
-            default:     throw new IllegalArgumentException("Unexpected tenant type '" + type + "'.");
+            case athenz:  return athenzTenantFrom(tenantObject);
+            case cloud:   return cloudTenantFrom(tenantObject);
+            case deleted: return deletedTenantFrom(tenantObject);
+            default:      throw new IllegalArgumentException("Unexpected tenant type '" + type + "'.");
         }
     }
 
@@ -166,6 +174,13 @@ public class TenantSerializer {
         List<TenantSecretStore> tenantSecretStores = secretStoresFromSlime(tenantObject.field(secretStoresField));
         Optional<String> archiveAccessRole = SlimeUtils.optionalString(tenantObject.field(archiveAccessRoleField));
         return new CloudTenant(name, createdAt, lastLoginInfo, creator, developerKeys, info, tenantSecretStores, archiveAccessRole);
+    }
+
+    private DeletedTenant deletedTenantFrom(Inspector tenantObject) {
+        TenantName name = TenantName.from(tenantObject.field(nameField).asString());
+        Instant createdAt = SlimeUtils.instant(tenantObject.field(createdAtField));
+        Instant deletedAt = SlimeUtils.instant(tenantObject.field(deletedAtField));
+        return new DeletedTenant(name, createdAt, deletedAt);
     }
 
     private BiMap<PublicKey, Principal> developerKeysFromSlime(Inspector array) {
@@ -321,23 +336,20 @@ public class TenantSerializer {
         return personLists;
     }
 
-    private BillingInfo billingInfoFrom(Inspector billingInfoObject) {
-        return new BillingInfo(billingInfoObject.field(customerIdField).asString(),
-                               billingInfoObject.field(productCodeField).asString());
-    }
-
     private static Tenant.Type typeOf(String value) {
         switch (value) {
-            case "athenz": return Tenant.Type.athenz;
-            case "cloud":  return Tenant.Type.cloud;
+            case "athenz":  return Tenant.Type.athenz;
+            case "cloud":   return Tenant.Type.cloud;
+            case "deleted": return Tenant.Type.deleted;
             default: throw new IllegalArgumentException("Unknown tenant type '" + value + "'.");
         }
     }
 
     private static String valueOf(Tenant.Type type) {
         switch (type) {
-            case athenz: return "athenz";
-            case cloud:  return "cloud";
+            case athenz:  return "athenz";
+            case cloud:   return "cloud";
+            case deleted: return "deleted";
             default: throw new IllegalArgumentException("Unexpected tenant type '" + type + "'.");
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
@@ -42,7 +42,6 @@ import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 import com.yahoo.yolean.Exceptions;
 
 import java.security.PublicKey;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/security/CloudAccessControl.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/security/CloudAccessControl.java
@@ -72,7 +72,7 @@ public class CloudAccessControl implements AccessControl {
 
     private void requireTenantTrialLimitNotReached(List<Tenant> existing) {
         var trialPlanId = PlanId.from("trial");
-        var tenantNames = existing.stream().map(Tenant::name).collect(Collectors.toList());
+        var tenantNames = existing.stream().filter(tenant -> tenant.type() == Tenant.Type.cloud).map(Tenant::name).collect(Collectors.toList());
         var trialTenants = billingController.tenantsWithPlan(tenantNames, trialPlanId).size();
 
         if (maxTrialTenants.value() >= 0 && maxTrialTenants.value() <= trialTenants) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tenant/DeletedTenant.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tenant/DeletedTenant.java
@@ -1,0 +1,39 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.tenant;
+
+import com.yahoo.config.provision.TenantName;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Represents a tenant that has been deleted. Exists to prevent creation of a new tenant with the same name.
+ *
+ * @author freva
+ */
+public class DeletedTenant extends Tenant {
+
+    private final Instant deletedAt;
+
+    public DeletedTenant(TenantName name, Instant createdAt, Instant deletedAt) {
+        super(name, createdAt, LastLoginInfo.EMPTY, Optional.empty());
+        this.deletedAt = Objects.requireNonNull(deletedAt, "deletedAt must be non-null");
+    }
+
+    /** Instant when the tenant was deleted */
+    public Instant deletedAt() {
+        return deletedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "deleted tenant '" + name() + "'";
+    }
+
+    @Override
+    public Type type() {
+        return Type.deleted;
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tenant/Tenant.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/tenant/Tenant.java
@@ -78,7 +78,10 @@ public abstract class Tenant {
         athenz,
 
         /** Tenant authenticated through some cloud identity provider. */
-        cloud
+        cloud,
+
+        /** Tenant has been deleted. */
+        deleted,
 
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializerTest.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.controller.api.integration.secrets.TenantSecretSto
 import com.yahoo.vespa.hosted.controller.api.role.SimplePrincipal;
 import com.yahoo.vespa.hosted.controller.tenant.AthenzTenant;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
+import com.yahoo.vespa.hosted.controller.tenant.DeletedTenant;
 import com.yahoo.vespa.hosted.controller.tenant.LastLoginInfo;
 import com.yahoo.vespa.hosted.controller.tenant.TenantInfo;
 import com.yahoo.vespa.hosted.controller.tenant.TenantInfoAddress;
@@ -170,6 +171,16 @@ public class TenantSerializerTest {
         TenantInfo roundTripInfo = serializer.tenantInfoFromSlime(parentCursor.field("info"));
 
         assertEquals(fullInfo, roundTripInfo);
+    }
+
+    @Test
+    public void deleted_tenant() {
+        DeletedTenant tenant = new DeletedTenant(
+                TenantName.from("tenant1"), Instant.ofEpochMilli(1234L), Instant.ofEpochMilli(2345L));
+        DeletedTenant serialized = (DeletedTenant) serializer.tenantFrom(serializer.toSlime(tenant));
+        assertEquals(tenant.name(), serialized.name());
+        assertEquals(tenant.createdAt(), serialized.createdAt());
+        assertEquals(tenant.deletedAt(), serialized.deletedAt());
     }
 
     private static Contact contact() {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/tenant1-deleted.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/tenant1-deleted.json
@@ -1,0 +1,9 @@
+{
+  "tenant": "tenant1",
+  "type": "DELETED",
+  "applications": [],
+  "metaData": {
+    "createdAtMillis": "(ignore)",
+    "deletedAtMillis": "(ignore)"
+  }
+}


### PR DESCRIPTION
Fixes VESPA-21368 by creating a new type of tenant: `deleted`. This type tenant is by default ignored except in a few places: Tenant creation, tenant deletion, and in REST API if `includeDeleted` query property is set to `true`.

Regular users can only mark a tenant as deleted, operators have the option to forget the tenant completely by doing the same REST DELETE, but with query property `forget` set to `true`.