### PR TITLE
Dirty all nodes on application removal

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -196,13 +196,11 @@ public class NodeRepository extends AbstractComponent {
                              .collect(Collectors.toUnmodifiableList());
     }
 
-    /** Removes this application: Active nodes are deactivated while all non-active nodes are set dirty. */
+    /** Removes this application: all nodes are set dirty. */
     public void remove(ApplicationTransaction transaction) {
         NodeList applicationNodes = nodes().list().owner(transaction.application());
-        NodeList activeNodes = applicationNodes.state(State.active);
-        nodes().deactivate(activeNodes.asList(), transaction);
         db.writeTo(State.dirty,
-                   applicationNodes.except(activeNodes.asSet()).asList(),
+                   applicationNodes.asList(),
                    Agent.system,
                    Optional.of("Application is removed"),
                    transaction.nested());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -63,7 +63,7 @@ public class InactiveAndFailedExpirerTest {
         List<HostSpec> preparedNodes = tester.prepare(applicationId, cluster, Capacity.from(new ClusterResources(2, 1, nodeResources)));
         tester.activate(applicationId, new HashSet<>(preparedNodes));
         assertEquals(2, tester.getNodes(applicationId, Node.State.active).size());
-        tester.deactivate(applicationId);
+        tester.activate(applicationId, List.of());
         List<Node> inactiveNodes = tester.getNodes(applicationId, Node.State.inactive).asList();
         assertEquals(2, inactiveNodes.size());
 
@@ -149,7 +149,7 @@ public class InactiveAndFailedExpirerTest {
         List<HostSpec> preparedNodes = tester.prepare(testerId, cluster, Capacity.from(new ClusterResources(2, 1, nodeResources)));
         tester.activate(testerId, new HashSet<>(preparedNodes));
         assertEquals(1, tester.getNodes(testerId, Node.State.active).size());
-        tester.deactivate(testerId);
+        tester.activate(testerId, List.of());
         List<Node> inactiveNodes = tester.getNodes(testerId, Node.State.inactive).asList();
         assertEquals(1, inactiveNodes.size());
 
@@ -171,7 +171,7 @@ public class InactiveAndFailedExpirerTest {
         List<HostSpec> preparedNodes = tester.prepare(applicationId, cluster, Capacity.fromRequiredNodeType(NodeType.host));
         tester.activate(applicationId, new HashSet<>(preparedNodes));
         assertEquals(2, tester.getNodes(applicationId, Node.State.active).size());
-        tester.deactivate(applicationId);
+        tester.activate(applicationId, List.of());
         List<Node> inactiveNodes = tester.getNodes(applicationId, Node.State.inactive).asList();
         assertEquals(2, inactiveNodes.size());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -104,12 +104,10 @@ public class ProvisioningTest {
         assertEquals(3, tester.getNodes(application1, Node.State.inactive).size());
 
         // delete app
-        NodeList previouslyActive = tester.getNodes(application1, Node.State.active);
-        NodeList previouslyInactive = tester.getNodes(application1, Node.State.inactive);
+        NodeList previousNodes = tester.getNodes(application1);
         tester.remove(application1);
-        assertEquals(previouslyActive.not().container().hostnames(),
-                     tester.nodeRepository().nodes().list(Node.State.inactive).owner(application1).hostnames());
-        assertTrue(tester.nodeRepository().nodes().list(Node.State.dirty).asList().containsAll(previouslyActive.container().asList()));
+        assertEquals(previousNodes.hostnames(),
+                     tester.nodeRepository().nodes().list(Node.State.dirty).owner(application1).hostnames());
         assertEquals(0, tester.getNodes(application1, Node.State.active).size());
         assertTrue(tester.nodeRepository().applications().get(application1).isEmpty());
 
@@ -978,7 +976,7 @@ public class ProvisioningTest {
             ProvisioningTester tester = new ProvisioningTester.Builder().zone(zone).build();
             tester.makeReadyHosts(2, defaultResources).activateTenantHosts();
             tester.activate(application, tester.prepare(application, cluster, capacity));
-            tester.deactivate(application);
+            tester.activate(application, List.of());
             assertEquals(2, tester.getNodes(application, state).size());
         };
 


### PR DESCRIPTION
Fixes VESPA-21576. With this, we will only get `inactive` nodes when new application deployment is unable to reuse some of the previous stateful nodes, e.g. due to flavor change or cluster size reduction. 

Application removal will move nodes directly to `dirty`. This is OK because application removal already requires `deployment-removal` validation override, or going through a confirmation menu in the console.