### PR TITLE
Flip to always use the new distributor stripe code path.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
@@ -52,6 +52,8 @@ public class Distributor extends ContentNode implements StorDistributormanagerCo
         if (numDistributorStripesFlag == -1) {
             if (getHostResource() != null) {
                 int cores = (int)getHostResource().realResources().vcpu();
+                // This should match the calculation used when node flavor is not available:
+                // storage/src/vespa/storage/common/bucket_stripe_utils.cpp
                 if (cores <= 16) {
                     return 1;
                 } else if (cores <= 64) {

--- a/storage/src/tests/common/bucket_stripe_utils_test.cpp
+++ b/storage/src/tests/common/bucket_stripe_utils_test.cpp
@@ -5,9 +5,10 @@
 #include <vespa/vespalib/gtest/gtest.h>
 
 using document::BucketId;
+using storage::adjusted_num_stripes;
 using storage::calc_num_stripe_bits;
 using storage::stripe_of_bucket_key;
-using storage::adjusted_num_stripes;
+using storage::tune_num_stripes_based_on_cpu_cores;
 constexpr uint8_t MUB = storage::spi::BucketLimits::MinUsedBits;
 
 TEST(BucketStripeUtilsTest, stripe_of_bucket_key)
@@ -45,5 +46,15 @@ TEST(BucketStripeUtilsTest, max_stripe_values)
 {
     EXPECT_EQ(8, storage::MaxStripeBits);
     EXPECT_EQ(256, storage::MaxStripes);
+}
+
+TEST(BucketStripeUtilsTest, num_stripes_tuned_based_on_cpu_cores)
+{
+    EXPECT_EQ(1, tune_num_stripes_based_on_cpu_cores(0));
+    EXPECT_EQ(1, tune_num_stripes_based_on_cpu_cores(1));
+    EXPECT_EQ(1, tune_num_stripes_based_on_cpu_cores(16));
+    EXPECT_EQ(2, tune_num_stripes_based_on_cpu_cores(17));
+    EXPECT_EQ(2, tune_num_stripes_based_on_cpu_cores(64));
+    EXPECT_EQ(4, tune_num_stripes_based_on_cpu_cores(65));
 }
 

--- a/storage/src/vespa/storage/common/bucket_stripe_utils.cpp
+++ b/storage/src/vespa/storage/common/bucket_stripe_utils.cpp
@@ -39,7 +39,8 @@ calc_num_stripe_bits(uint32_t n_stripes) noexcept
     return result;
 }
 
-uint32_t adjusted_num_stripes(uint32_t n_stripes) noexcept
+uint32_t
+adjusted_num_stripes(uint32_t n_stripes) noexcept
 {
     if (n_stripes > 1) {
         if (n_stripes > MaxStripes) {
@@ -48,6 +49,20 @@ uint32_t adjusted_num_stripes(uint32_t n_stripes) noexcept
         return vespalib::roundUp2inN(n_stripes);
     }
     return n_stripes;
+}
+
+uint32_t
+tune_num_stripes_based_on_cpu_cores(uint32_t cpu_cores) noexcept
+{
+    // This should match the calculation used when node flavor is available:
+    // config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
+    if (cpu_cores <= 16) {
+        return 1;
+    } else if (cpu_cores <= 64) {
+        return 2;
+    } else {
+        return 4;
+    }
 }
 
 }

--- a/storage/src/vespa/storage/common/bucket_stripe_utils.h
+++ b/storage/src/vespa/storage/common/bucket_stripe_utils.h
@@ -31,5 +31,10 @@ uint8_t calc_num_stripe_bits(uint32_t n_stripes) noexcept;
  */
 [[nodiscard]] uint32_t adjusted_num_stripes(uint32_t n_stripes) noexcept;
 
+/**
+ * Tune the number of stripes based on the number of CPU cores.
+ */
+uint32_t tune_num_stripes_based_on_cpu_cores(uint32_t cpu_cores) noexcept;
+
 }
 


### PR DESCRIPTION
If the number of stripes is not configured, we tune it based on the sampled number of CPU cores.

@vekterli please review
@baldersheim @toregge FYI