### PR TITLE
Validates the 'paged' attribute setting and throws if specified on un…

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/PagedAttributeValidator.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/PagedAttributeValidator.java
@@ -1,0 +1,52 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchdefinition.processing;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.document.Field;
+import com.yahoo.searchdefinition.RankProfileRegistry;
+import com.yahoo.searchdefinition.Search;
+import com.yahoo.searchdefinition.document.Attribute;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.vespa.model.container.search.QueryProfiles;
+
+/**
+ * Validates the 'paged' attribute setting and throws if specified on unsupported types.
+ *
+ * @author geirst
+ */
+public class PagedAttributeValidator extends Processor {
+
+
+    public PagedAttributeValidator(Search search,
+                                   DeployLogger deployLogger,
+                                   RankProfileRegistry rankProfileRegistry,
+                                   QueryProfiles queryProfiles) {
+        super(search, deployLogger, rankProfileRegistry, queryProfiles);
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly) {
+        if (!validate) {
+            return;
+        }
+        for (var field : search.allConcreteFields()) {
+            for (var attribute : field.getAttributes().values()) {
+                if (attribute.isPaged()) {
+                    validatePagedSetting(field, attribute);
+                }
+            }
+        }
+    }
+
+    private void validatePagedSetting(Field field, Attribute attribute) {
+        var tensorType = attribute.tensorType();
+        if (!tensorType.isPresent() ||
+                !isDenseTensorType(tensorType.get())) {
+            fail(search, field, "The 'paged' attribute setting is only supported for dense tensor types");
+        }
+    }
+
+    private boolean isDenseTensorType(TensorType type) {
+        return type.dimensions().stream().allMatch(d -> d.isIndexed());
+    }
+}

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/Processing.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/Processing.java
@@ -79,6 +79,7 @@ public class Processing {
                 OnnxModelTypeResolver::new,
                 RankingExpressionTypeResolver::new,
                 BoolAttributeValidator::new,
+                PagedAttributeValidator::new,
                 // These should be last:
                 IndexingValidation::new,
                 IndexingValues::new);

--- a/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/AttributeSettingsTestCase.java
@@ -114,11 +114,11 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
     }
 
     @Test
-    public void requireThatSwappableIsDefaultOff() throws ParseException {
+    public void requireThatPagedIsDefaultOff() throws ParseException {
         Attribute attr = getAttributeF(
                 "search test {\n" +
                         "  document test { \n" +
-                        "    field f type int { \n" +
+                        "    field f type tensor(x[2]) { \n" +
                         "      indexing: attribute \n" +
                         "    }\n" +
                         "  }\n" +
@@ -126,11 +126,11 @@ public class AttributeSettingsTestCase extends SchemaTestCase {
         assertFalse(attr.isPaged());
     }
     @Test
-    public void requireThatSwappableCanBeSet() throws ParseException {
+    public void requireThatPagedCanBeSet() throws ParseException {
         Attribute attr = getAttributeF(
                 "search test {\n" +
                         "  document test { \n" +
-                        "    field f type int { \n" +
+                        "    field f type tensor(x[2]) { \n" +
                         "      indexing: attribute \n" +
                         "      attribute: paged \n" +
                         "    }\n" +

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/PagedAttributeValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/PagedAttributeValidatorTestCase.java
@@ -1,0 +1,50 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.searchdefinition.processing;
+
+import com.yahoo.searchdefinition.parser.ParseException;
+import org.junit.Test;
+
+import static com.yahoo.config.model.test.TestUtil.joinLines;
+import static com.yahoo.searchdefinition.SearchBuilder.createFromString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class PagedAttributeValidatorTestCase {
+
+    @Test
+    public void dense_tensor_attribute_does_support_paged_setting() throws ParseException {
+        createFromString(getSd("tensor(x[2],y[2])"));
+    }
+
+    @Test
+    public void non_dense_tensor_attribute_does_not_support_paged_setting() throws ParseException {
+        assertPagedSettingNotSupported("tensor(x{},y[2])");
+    }
+
+    @Test
+    public void non_tensor_attribute_does_not_support_paged_setting() throws ParseException {
+        assertPagedSettingNotSupported("string");
+    }
+
+    private void assertPagedSettingNotSupported(String fieldType) throws ParseException {
+        try {
+            createFromString(getSd(fieldType));
+            fail("Expected exception");
+        }  catch (IllegalArgumentException e) {
+            assertEquals("For search 'test', field 'foo': The 'paged' attribute setting is only supported for dense tensor types",
+                    e.getMessage());
+        }
+    }
+
+    private String getSd(String type) {
+        return joinLines("search test {",
+                "  document test {",
+                "    field foo type " + type + "{",
+                "      indexing: attribute",
+                "      attribute: paged",
+                "    }",
+                "  }",
+                "}");
+    }
+
+}


### PR DESCRIPTION
…supported types.

It is only supported for dense tensor types.

@baldersheim please review
@jobergum FYI
