### PR TITLE
use same timing for initial health check

### DIFF
--- a/slobrok/src/vespa/slobrok/server/managed_rpc_server.cpp
+++ b/slobrok/src/vespa/slobrok/server/managed_rpc_server.cpp
@@ -23,7 +23,7 @@ ManagedRpcServer::ManagedRpcServer(const std::string & name,
       _monitoredServer(nullptr),
       _checkServerReq(nullptr)
 {
-    double seconds = randomIn(0.2, 0.8);
+    double seconds = randomIn(2.5, 2.9);
     LOG(debug, "first healthcheck for %s in %g seconds", name.c_str(), seconds);
     Schedule(seconds);
 }
@@ -35,7 +35,7 @@ void ManagedRpcServer::PerformTask() {
     if (_checkServerReq == nullptr) {
         _checkServerReq = _mmanager.getSupervisor()->AllocRPCRequest();
         _checkServerReq->SetMethodName("slobrok.callback.listNamesServed");
-        _monitoredServer->InvokeAsync(_checkServerReq, 25.0, this);
+        _monitoredServer->InvokeAsync(_checkServerReq, 5.0, this);
     }
     double seconds = randomIn(2.5, 2.9);
     LOG(debug, "next healthcheck for %s in %g seconds", getName().c_str(), seconds);


### PR DESCRIPTION
* use the 2.7s +- 0.2s timing for first health check,
  that is also used for subsequent health checks
* also, set timeout for ping to the usual 5 seconds value

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review and merge
