### PR TITLE
Encode tensors passed as encode(text)

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
@@ -17,6 +17,7 @@ import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.handler.RequestHandler;
 import com.yahoo.jdisc.test.MockMetric;
 import com.yahoo.language.Linguistics;
+import com.yahoo.language.process.Encoder;
 import com.yahoo.language.simple.SimpleLinguistics;
 
 import java.io.File;
@@ -140,6 +141,7 @@ public class HandlersConfigurerTestWrapper {
             protected void configure() {
                 // Needed by e.g. SearchHandler
                 bind(Linguistics.class).to(SimpleLinguistics.class).in(Scopes.SINGLETON);
+                bind(Encoder.class).to(Encoder.FailingEncoder.class).in(Scopes.SINGLETON);
                 bind(ContainerThreadPool.class).to(SimpleContainerThreadpool.class);
                 bind(Metric.class).to(MockMetric.class);
             }

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -1786,6 +1786,27 @@
     ],
     "fields": []
   },
+  "com.yahoo.search.Query$Builder": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>()",
+      "public com.yahoo.search.Query$Builder setRequest(java.lang.String)",
+      "public com.yahoo.search.Query$Builder setRequest(com.yahoo.container.jdisc.HttpRequest)",
+      "public com.yahoo.container.jdisc.HttpRequest getRequest()",
+      "public com.yahoo.search.Query$Builder setRequestMap(java.util.Map)",
+      "public java.util.Map getRequestMap()",
+      "public com.yahoo.search.Query$Builder setQueryProfile(com.yahoo.search.query.profile.compiled.CompiledQueryProfile)",
+      "public com.yahoo.search.query.profile.compiled.CompiledQueryProfile getQueryProfile()",
+      "public com.yahoo.search.Query$Builder setEncoder(com.yahoo.language.process.Encoder)",
+      "public com.yahoo.language.process.Encoder getEncoder()",
+      "public com.yahoo.search.Query build()"
+    ],
+    "fields": []
+  },
   "com.yahoo.search.Query$Type": {
     "superClass": "java.lang.Enum",
     "interfaces": [],
@@ -4237,6 +4258,7 @@
       "public"
     ],
     "methods": [
+      "public void <init>(com.yahoo.statistics.Statistics, com.yahoo.jdisc.Metric, com.yahoo.container.handler.threadpool.ContainerThreadPool, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry, com.yahoo.container.core.ContainerHttpConfig, com.yahoo.language.process.Encoder, com.yahoo.search.searchchain.ExecutionFactory)",
       "public void <init>(com.yahoo.statistics.Statistics, com.yahoo.jdisc.Metric, com.yahoo.container.handler.threadpool.ContainerThreadPool, com.yahoo.container.logging.AccessLog, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry, com.yahoo.container.core.ContainerHttpConfig, com.yahoo.search.searchchain.ExecutionFactory)",
       "public void <init>(com.yahoo.statistics.Statistics, com.yahoo.jdisc.Metric, java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry, com.yahoo.container.core.ContainerHttpConfig, com.yahoo.search.searchchain.ExecutionFactory)",
       "public void <init>(com.yahoo.statistics.Statistics, com.yahoo.jdisc.Metric, java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.search.query.profile.config.QueryProfilesConfig, com.yahoo.container.core.ContainerHttpConfig, com.yahoo.search.searchchain.ExecutionFactory)",
@@ -5863,6 +5885,7 @@
     ],
     "methods": [
       "public void <init>(com.yahoo.search.query.profile.compiled.CompiledQueryProfile)",
+      "public void <init>(com.yahoo.search.query.profile.compiled.CompiledQueryProfile, com.yahoo.language.process.Encoder)",
       "public com.yahoo.search.query.profile.compiled.CompiledQueryProfile getQueryProfile()",
       "public java.lang.Object get(com.yahoo.processing.request.CompoundName, java.util.Map, com.yahoo.processing.request.Properties)",
       "public void set(com.yahoo.processing.request.CompoundName, java.lang.Object, java.util.Map)",
@@ -6229,6 +6252,18 @@
     ],
     "fields": []
   },
+  "com.yahoo.search.query.profile.types.ConversionContext": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry, com.yahoo.language.process.Encoder, java.util.Map)",
+      "public static com.yahoo.search.query.profile.types.ConversionContext empty()"
+    ],
+    "fields": []
+  },
   "com.yahoo.search.query.profile.types.FieldDescription": {
     "superClass": "java.lang.Object",
     "interfaces": [
@@ -6276,7 +6311,7 @@
       "public abstract java.lang.String toString()",
       "public abstract java.lang.String toInstanceDescription()",
       "public abstract java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)",
-      "public abstract java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public abstract java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)",
       "public com.yahoo.tensor.TensorType asTensorType()",
       "public static com.yahoo.search.query.profile.types.FieldType fromString(java.lang.String, com.yahoo.search.query.profile.types.QueryProfileTypeRegistry)",
       "public static boolean isLegalFieldValue(java.lang.Object)"
@@ -6303,7 +6338,7 @@
       "public java.lang.String stringValue()",
       "public java.lang.String toString()",
       "public java.lang.String toInstanceDescription()",
-      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)",
       "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)",
       "public int hashCode()",
       "public boolean equals(java.lang.Object)"
@@ -6323,7 +6358,7 @@
       "public java.lang.String toString()",
       "public java.lang.String toInstanceDescription()",
       "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)",
-      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)"
+      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)"
     ],
     "fields": []
   },
@@ -6342,11 +6377,11 @@
       "public java.lang.String stringValue()",
       "public java.lang.String toString()",
       "public java.lang.String toInstanceDescription()",
-      "public com.yahoo.search.query.profile.compiled.CompiledQueryProfile convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public com.yahoo.search.query.profile.compiled.CompiledQueryProfile convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)",
       "public com.yahoo.search.query.profile.QueryProfile convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)",
       "public int hashCode()",
       "public boolean equals(java.lang.Object)",
-      "public bridge synthetic java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public bridge synthetic java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)",
       "public bridge synthetic java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)"
     ],
     "fields": []
@@ -6419,7 +6454,7 @@
       "public java.lang.String toString()",
       "public java.lang.String toInstanceDescription()",
       "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.QueryProfileRegistry)",
-      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public java.lang.Object convertFrom(java.lang.Object, com.yahoo.search.query.profile.types.ConversionContext)",
       "public static com.yahoo.search.query.profile.types.TensorFieldType fromTypeString(java.lang.String)"
     ],
     "fields": []
@@ -6496,7 +6531,7 @@
       "public"
     ],
     "methods": [
-      "public void <init>(com.yahoo.search.Query, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry)",
+      "public void <init>(com.yahoo.search.Query, com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry, com.yahoo.language.process.Encoder)",
       "public void setParentQuery(com.yahoo.search.Query)",
       "public java.lang.Object get(com.yahoo.processing.request.CompoundName, java.util.Map, com.yahoo.processing.request.Properties)",
       "public void set(com.yahoo.processing.request.CompoundName, java.lang.Object, java.util.Map)",

--- a/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/QueryProfileProperties.java
@@ -2,14 +2,15 @@
 package com.yahoo.search.query.profile;
 
 import com.yahoo.collections.Pair;
+import com.yahoo.language.process.Encoder;
 import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.processing.request.properties.PropertyMap;
 import com.yahoo.protect.Validator;
-import com.yahoo.search.Query;
 import com.yahoo.search.query.Properties;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfile;
 import com.yahoo.search.query.profile.compiled.DimensionalValue;
+import com.yahoo.search.query.profile.types.ConversionContext;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileFieldType;
 import com.yahoo.search.query.profile.types.QueryProfileType;
@@ -29,6 +30,7 @@ import java.util.Map;
 public class QueryProfileProperties extends Properties {
 
     private final CompiledQueryProfile profile;
+    private final Encoder encoder;
 
     // Note: The priority order is: values has precedence over references
 
@@ -42,10 +44,15 @@ public class QueryProfileProperties extends Properties {
      */
     private List<Pair<CompoundName, CompiledQueryProfile>> references = null;
 
-    /** Creates an instance from a profile, throws an exception if the given profile is null */
     public QueryProfileProperties(CompiledQueryProfile profile) {
+        this(profile, Encoder.throwsOnUse);
+    }
+
+    /** Creates an instance from a profile, throws an exception if the given profile is null */
+    public QueryProfileProperties(CompiledQueryProfile profile, Encoder encoder) {
         Validator.ensureNotNull("The profile wrapped by this cannot be null", profile);
         this.profile = profile;
+        this.encoder = encoder;
     }
 
     /** Returns the query profile backing this, or null if none */
@@ -114,7 +121,9 @@ public class QueryProfileProperties extends Properties {
 
                     if (fieldDescription != null) {
                         if (i == name.size() - 1) { // at the end of the path, check the assignment type
-                            value = fieldDescription.getType().convertFrom(value, profile.getRegistry());
+                            value = fieldDescription.getType().convertFrom(value, new ConversionContext(profile.getRegistry(),
+                                                                                                        encoder,
+                                                                                                        context));
                             if (value == null)
                                 throw new IllegalInputException("'" + value + "' is not a " +
                                                                 fieldDescription.getType().toInstanceDescription());

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/ConversionContext.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/ConversionContext.java
@@ -1,0 +1,40 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.query.profile.types;
+
+import com.yahoo.language.Language;
+import com.yahoo.language.process.Encoder;
+import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
+
+import java.util.Map;
+
+/**
+ * @author bratseth
+ */
+public class ConversionContext {
+
+    private final CompiledQueryProfileRegistry registry;
+    private final Encoder encoder;
+    private final Language language;
+
+    public ConversionContext(CompiledQueryProfileRegistry registry, Encoder encoder, Map<String, String> context) {
+        this.registry = registry;
+        this.encoder = encoder;
+        this.language = context.containsKey("language") ? Language.fromLanguageTag(context.get("language"))
+                                                        : Language.UNKNOWN;
+    }
+
+    /** Returns the profile registry, or null if none */
+    CompiledQueryProfileRegistry getRegistry() {return registry;}
+
+    /** Returns the configured encoder, never null */
+    Encoder getEncoder() { return encoder; }
+
+    /** Returns the language, which is never null but may be UNKNOWN */
+    Language getLanguage() { return language; }
+
+    /** Returns an empty context */
+    public static ConversionContext empty() {
+        return new ConversionContext(null, Encoder.throwsOnUse, Map.of());
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldDescription.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldDescription.java
@@ -33,7 +33,7 @@ public class FieldDescription implements Comparable<FieldDescription> {
     }
 
     public FieldDescription(String name, String type) {
-        this(name,FieldType.fromString(type,null));
+        this(name,FieldType.fromString(type, null));
     }
 
     public FieldDescription(String name, FieldType type, boolean mandatory) {
@@ -60,7 +60,7 @@ public class FieldDescription implements Comparable<FieldDescription> {
      * @param overridable whether this can be overridden when first set in a profile. Default: true
      */
     public FieldDescription(String name, String typeString, String aliases, boolean mandatory, boolean overridable) {
-        this(name,FieldType.fromString(typeString,null),aliases,mandatory,overridable);
+        this(name,FieldType.fromString(typeString, null), aliases, mandatory, overridable);
     }
 
     public FieldDescription(String name, FieldType type, boolean mandatory, boolean overridable) {

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/FieldType.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.profile.types;
 
+import com.yahoo.language.process.Encoder;
 import com.yahoo.search.query.profile.QueryProfile;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
@@ -41,7 +42,7 @@ public abstract class FieldType {
     public abstract Object convertFrom(Object o, QueryProfileRegistry registry);
 
     /** Converts the given type to an instance of this type, if possible. Returns null if not possible. */
-    public abstract Object convertFrom(Object o, CompiledQueryProfileRegistry registry);
+    public abstract Object convertFrom(Object o, ConversionContext context);
 
     /**
      * Returns this type as a tensor type: The true tensor type is this is a tensor field an an empty type -
@@ -77,7 +78,7 @@ public abstract class FieldType {
         if ("query-profile".equals(typeString))
             return genericQueryProfileType;
         if (typeString.startsWith("query-profile:"))
-            return QueryProfileFieldType.fromString(typeString.substring("query-profile:".length()),registry);
+            return QueryProfileFieldType.fromString(typeString.substring("query-profile:".length()), registry);
         throw new IllegalArgumentException("Unknown type '" + typeString + "'");
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/PrimitiveFieldType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/PrimitiveFieldType.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.profile.types;
 
+import com.yahoo.language.process.Encoder;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
 
@@ -37,7 +38,7 @@ public class PrimitiveFieldType extends FieldType {
     }
 
     @Override
-    public Object convertFrom(Object object, CompiledQueryProfileRegistry registry) {
+    public Object convertFrom(Object object, ConversionContext context) {
         return convertFrom(object, (QueryProfileRegistry)null);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/QueryFieldType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/QueryFieldType.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.profile.types;
 
+import com.yahoo.language.process.Encoder;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
 import com.yahoo.search.yql.YqlQuery;
@@ -32,7 +33,7 @@ public class QueryFieldType extends FieldType {
     }
 
     @Override
-    public Object convertFrom(Object o, CompiledQueryProfileRegistry registry) {
+    public Object convertFrom(Object o, ConversionContext context) {
         return convertFrom(o, (QueryProfileRegistry)null);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/query/profile/types/QueryProfileFieldType.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/types/QueryProfileFieldType.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.profile.types;
 
+import com.yahoo.language.process.Encoder;
 import com.yahoo.search.query.profile.QueryProfile;
 import com.yahoo.search.query.profile.QueryProfileRegistry;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfile;
@@ -57,11 +58,11 @@ public class QueryProfileFieldType extends FieldType {
     }
 
     @Override
-    public CompiledQueryProfile convertFrom(Object object, CompiledQueryProfileRegistry registry) {
+    public CompiledQueryProfile convertFrom(Object object, ConversionContext context) {
         String profileId = object.toString();
         if (profileId.startsWith("ref:"))
             profileId = profileId.substring("ref:".length());
-        CompiledQueryProfile profile = registry.getComponent(profileId);
+        CompiledQueryProfile profile = context.getRegistry().getComponent(profileId);
         if (profile == null) return null;
         if (type != null && ! type.equals(profile.getType())) return null;
         return profile;

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.query.properties;
 
+import com.yahoo.language.process.Encoder;
 import com.yahoo.processing.IllegalInputException;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
@@ -11,6 +12,7 @@ import com.yahoo.search.query.Properties;
 import com.yahoo.search.query.Ranking;
 import com.yahoo.search.query.Select;
 import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
+import com.yahoo.search.query.profile.types.ConversionContext;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
 import com.yahoo.search.query.ranking.Diversity;
@@ -32,10 +34,12 @@ public class QueryProperties extends Properties {
 
     private Query query;
     private final CompiledQueryProfileRegistry profileRegistry;
+    private final Encoder encoder;
 
-    public QueryProperties(Query query, CompiledQueryProfileRegistry profileRegistry) {
+    public QueryProperties(Query query, CompiledQueryProfileRegistry profileRegistry, Encoder encoder) {
         this.query = query;
         this.profileRegistry = profileRegistry;
+        this.encoder = encoder;
     }
 
     public void setParentQuery(Query query) {
@@ -256,9 +260,15 @@ public class QueryProperties extends Properties {
                 else if (key.size() > 2) {
                     String restKey = key.rest().rest().toString();
                     if (key.get(1).equals(Ranking.FEATURES))
-                        setRankingFeature(query, restKey, toSpecifiedType(restKey, value, profileRegistry.getTypeRegistry().getComponent("features")));
+                        setRankingFeature(query, restKey, toSpecifiedType(restKey,
+                                                                          value,
+                                                                          profileRegistry.getTypeRegistry().getComponent("features"),
+                                                                          context));
                     else if (key.get(1).equals(Ranking.PROPERTIES))
-                        ranking.getProperties().put(restKey, toSpecifiedType(restKey, value, profileRegistry.getTypeRegistry().getComponent("properties")));
+                        ranking.getProperties().put(restKey, toSpecifiedType(restKey,
+                                                                             value,
+                                                                             profileRegistry.getTypeRegistry().getComponent("properties"),
+                                                                             context));
                     else
                         throwIllegalParameter(key.rest().toString(), Ranking.RANKING);
                 }
@@ -294,9 +304,15 @@ public class QueryProperties extends Properties {
                 }
             }
             else if (key.first().equals("rankfeature") || key.first().equals("featureoverride") ) { // featureoverride is deprecated
-                setRankingFeature(query, key.rest().toString(), toSpecifiedType(key.rest().toString(), value, profileRegistry.getTypeRegistry().getComponent("features")));
+                setRankingFeature(query, key.rest().toString(), toSpecifiedType(key.rest().toString(),
+                                                                                value,
+                                                                                profileRegistry.getTypeRegistry().getComponent("features"),
+                                                                                context));
             } else if (key.first().equals("rankproperty")) {
-                query.getRanking().getProperties().put(key.rest().toString(), toSpecifiedType(key.rest().toString(), value, profileRegistry.getTypeRegistry().getComponent("properties")));
+                query.getRanking().getProperties().put(key.rest().toString(), toSpecifiedType(key.rest().toString(),
+                                                                                              value,
+                                                                                              profileRegistry.getTypeRegistry().getComponent("properties"),
+                                                                                              context));
             } else if (key.size()==1) {
                 if (key.equals(Query.HITS))
                     query.setHits(asInteger(value,10));
@@ -359,12 +375,12 @@ public class QueryProperties extends Properties {
         }
     }
 
-    private Object toSpecifiedType(String key, Object value, QueryProfileType type) {
+    private Object toSpecifiedType(String key, Object value, QueryProfileType type, Map<String,String> context) {
         if ( ! ( value instanceof String)) return value; // already typed
         if (type == null) return value; // no type info -> keep as string
         FieldDescription field = type.getField(key);
         if (field == null) return value; // ditto
-        return field.getType().convertFrom(value, profileRegistry);
+        return field.getType().convertFrom(value, new ConversionContext(profileRegistry, encoder, context));
     }
 
     private void throwIllegalParameter(String key,String namespace) {


### PR DESCRIPTION
This lets you pass tensors in queries as "encode(some text)" instead of a tensor value, to create a tensor of the type required by this variable created by passing the text enclosed in "encode()" through the configured encoder.

https://github.com/vespa-engine/vespa/pull/19198 lets you write tensor fields in documents by passing a text through the "encode" il function, which will again derive the target type from the target field.

Do you think this makes sense as a possible way to use encoders for simple use cases without requiring Java code?