### PR TITLE
Remove explicit tracking of enum store and multi-value address space …

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_usage_filter/attribute_usage_filter_test.cpp
@@ -12,6 +12,7 @@ LOG_SETUP("attribute_usage_filter_test");
 using proton::AttributeUsageFilter;
 using proton::AttributeUsageStats;
 using proton::IAttributeUsageListener;
+using search::AddressSpaceComponents;
 using search::AddressSpaceUsage;
 using vespalib::AddressSpace;
 
@@ -27,17 +28,15 @@ class MyAttributeStats : public AttributeUsageStats
 {
 public:
     void triggerEnumStoreLimit() {
-        merge({ enumStoreOverLoad,
-                search::AddressSpaceComponents::default_multi_value_usage() },
-              "enumeratedName",
-              "ready");
+        AddressSpaceUsage usage;
+        usage.set(AddressSpaceComponents::enum_store, enumStoreOverLoad);
+        merge(usage, "enumeratedName", "ready");
     }
 
     void triggerMultiValueLimit() {
-        merge({ search::AddressSpaceComponents::default_enum_store_usage(),
-                multiValueOverLoad },
-              "multiValueName",
-              "ready");
+        AddressSpaceUsage usage;
+        usage.set(AddressSpaceComponents::multi_value, multiValueOverLoad);
+        merge(usage, "multiValueName", "ready");
     }
 };
 
@@ -130,7 +129,8 @@ TEST_F("Check that multivalue limit can be reached", Fixture)
 TEST_F("listener is updated when attribute stats change", Fixture)
 {
    AttributeUsageStats stats;
-   AddressSpaceUsage usage(AddressSpace(12, 10, 15), AddressSpace(22, 20, 25));
+   AddressSpaceUsage usage;
+   usage.set("my_comp", AddressSpace(12, 10, 15));
    stats.merge(usage, "my_attr", "my_subdb");
    f.setAttributeStats(stats);
    EXPECT_EQUAL(stats, f.listener->stats);

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -435,18 +435,6 @@ initialize.threads int default = 0
 ## before put and update operations in feed is blocked.
 writefilter.attribute.address_space_limit double default = 0.9
 
-## Portion of enumstore address space that can be used before put and update
-## portion of feed is blocked.
-## Deprecated -> Use address_space_limit
-## TODO: remove this when enum store is removed from AttributeUsageStats
-writefilter.attribute.enumstorelimit double default = 0.9
-
-## Portion of attribute multivalue mapping address space that can be used
-## before put and update portion of feed is blocked.
-## Deprecated -> Use address_space_limit
-## TODO: remove this when multi value is removed from AttributeUsageStats
-writefilter.attribute.multivaluelimit double default = 0.9
-
 ## Portion of physical memory that can be resident memory in anonymous mapping
 ## by the proton process before put and update portion of feed is blocked.
 writefilter.memorylimit double default = 0.8

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.cpp
@@ -9,9 +9,7 @@ using search::AddressSpaceComponents;
 namespace proton {
 
 AttributeUsageStats::AttributeUsageStats()
-    : _enumStoreUsage(AddressSpaceComponents::default_enum_store_usage()),
-      _multiValueUsage(AddressSpaceComponents::default_multi_value_usage()),
-      _max_usage(vespalib::AddressSpace())
+    : _max_usage(vespalib::AddressSpace())
 {
 }
 
@@ -22,8 +20,6 @@ AttributeUsageStats::merge(const search::AddressSpaceUsage &usage,
                            const vespalib::string &attributeName,
                            const vespalib::string &subDbName)
 {
-    _enumStoreUsage.merge(usage.enum_store_usage(), attributeName, AddressSpaceComponents::enum_store, subDbName);
-    _multiValueUsage.merge(usage.multi_value_usage(), attributeName, AddressSpaceComponents::multi_value, subDbName);
     for (const auto& entry : usage.get_all()) {
         _max_usage.merge(entry.second, attributeName, entry.first, subDbName);
     }
@@ -32,9 +28,7 @@ AttributeUsageStats::merge(const search::AddressSpaceUsage &usage,
 std::ostream&
 operator<<(std::ostream& out, const AttributeUsageStats& rhs)
 {
-    out << "{enum_store=" << rhs.enumStoreUsage() <<
-            ", multi_value=" << rhs.multiValueUsage() <<
-            ", max_address_space_usage=" << rhs.max_address_space_usage() << "}";
+    out << "{max_address_space_usage=" << rhs.max_address_space_usage() << "}";
     return out;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_usage_stats.h
@@ -8,14 +8,11 @@
 namespace proton {
 
 /**
- * Class representing aggregated attribute usage, with info about
- * the most bloated attributes with regards to enum store and
- * multivalue mapping.
+ * Class representing aggregated max address space usage
+ * among components in attributes vectors in all sub databases.
  */
 class AttributeUsageStats
 {
-    AddressSpaceUsageStats _enumStoreUsage;
-    AddressSpaceUsageStats _multiValueUsage;
     AddressSpaceUsageStats _max_usage;
 
 public:
@@ -25,14 +22,10 @@ public:
                const vespalib::string &attributeName,
                const vespalib::string &subDbName);
 
-    const AddressSpaceUsageStats& enumStoreUsage() const { return _enumStoreUsage; }
-    const AddressSpaceUsageStats& multiValueUsage() const { return _multiValueUsage; }
     const AddressSpaceUsageStats& max_address_space_usage() const { return _max_usage; }
 
     bool operator==(const AttributeUsageStats& rhs) const {
-        return (_enumStoreUsage == rhs._enumStoreUsage) &&
-                (_multiValueUsage == rhs._multiValueUsage) &&
-                (_max_usage == rhs._max_usage);
+        return (_max_usage == rhs._max_usage);
     }
 };
 

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.cpp
@@ -92,10 +92,6 @@ DocumentDBTaggedMetrics::AttributeMetrics::~AttributeMetrics() = default;
 
 DocumentDBTaggedMetrics::AttributeMetrics::ResourceUsageMetrics::ResourceUsageMetrics(MetricSet *parent)
     : MetricSet("resource_usage", {}, "Metrics for various attribute vector resources usage", parent),
-      enumStore("enum_store", {}, "The highest relative amount of enum store address space used among "
-              "all enumerated attribute vectors in this document db (value in the range [0, 1])", this),
-      multiValue("multi_value", {}, "The highest relative amount of multi-value address space used among "
-              "all multi-value attribute vectors in this document db (value in the range [0, 1])", this),
       address_space("address_space", {}, "The max relative address space used among "
               "components in all attribute vectors in this document db (value in the range [0, 1])", this),
       feedingBlocked("feeding_blocked", {}, "Whether feeding is blocked due to attribute resource limits being reached (value is either 0 or 1)", this)

--- a/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/documentdb_tagged_metrics.h
@@ -86,8 +86,6 @@ struct DocumentDBTaggedMetrics : metrics::MetricSet
     {
         struct ResourceUsageMetrics : metrics::MetricSet
         {
-            metrics::DoubleValueMetric enumStore;
-            metrics::DoubleValueMetric multiValue;
             metrics::DoubleValueMetric address_space;
             metrics::LongValueMetric   feedingBlocked;
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb_metrics_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb_metrics_updater.cpp
@@ -304,11 +304,7 @@ DocumentDBMetricsUpdater::updateAttributeResourceUsageMetrics(DocumentDBTaggedMe
 {
     AttributeUsageStats stats = _writeFilter.getAttributeUsageStats();
     bool feedBlocked = !_writeFilter.acceptWriteOperation();
-    double enumStoreUsed = stats.enumStoreUsage().getUsage().usage();
-    double multiValueUsed = stats.multiValueUsage().getUsage().usage();
     double address_space_used = stats.max_address_space_usage().getUsage().usage();
-    metrics.resourceUsage.enumStore.set(enumStoreUsed);
-    metrics.resourceUsage.multiValue.set(multiValueUsed);
     metrics.resourceUsage.address_space.set(address_space_used);
     metrics.resourceUsage.feedingBlocked.set(feedBlocked ? 1 : 0);
 }

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.cpp
@@ -12,15 +12,6 @@ AddressSpaceUsage::AddressSpaceUsage()
 {
 }
 
-AddressSpaceUsage::AddressSpaceUsage(const AddressSpace& enum_store_usage,
-                                     const AddressSpace& multi_value_usage)
-    : _map()
-{
-    // TODO: Remove this constructor and instead add usage for each relevant component explicit.
-    set(AddressSpaceComponents::enum_store, enum_store_usage);
-    set(AddressSpaceComponents::multi_value, multi_value_usage);
-}
-
 void
 AddressSpaceUsage::set(const vespalib::string& component, const vespalib::AddressSpace& usage)
 {

--- a/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
+++ b/searchlib/src/vespa/searchlib/attribute/address_space_usage.h
@@ -20,8 +20,6 @@ private:
 
 public:
     AddressSpaceUsage();
-    AddressSpaceUsage(const vespalib::AddressSpace& enum_store_usage,
-                      const vespalib::AddressSpace& multi_value_usage);
     void set(const vespalib::string& component, const vespalib::AddressSpace& usage);
     vespalib::AddressSpace get(const vespalib::string& component) const;
     const AddressSpaceMap& get_all() const { return _map; }


### PR DESCRIPTION
…usage.

This has been replaced by generic tracking of address space usage
among components in attributes vectors in all sub databases.

@toregge please review