### PR TITLE
Remove version management for jakarta artifacts.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -543,18 +543,6 @@
                 <version>${prometheus.client.version}</version>
             </dependency>
             <dependency>
-                <!-- TODO: Try to remove, as this overlaps with javax.activation. -->
-                <groupId>jakarta.activation</groupId>
-                <artifactId>jakarta.activation-api</artifactId>
-                <version>1.2.1</version>
-            </dependency>
-            <dependency>
-                <!-- TODO: Try to remove, as this conflicts with javax.xml.bind:jaxb-api -->
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>2.3.2</version>
-            </dependency>
-            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>


### PR DESCRIPTION
- They should be excluded everywhere in Vespa, because
  1. jakarta.activation overlaps with javax.activation
  2. jakarta.xml.bind conflicts with javax.xml.bind:jaxb-api

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
