### PR TITLE
Avoid unknown service status on suspended host

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -43,7 +43,6 @@ import com.yahoo.vespa.hosted.provision.node.filter.NodeHostFilter;
 import com.yahoo.vespa.hosted.provision.persistence.NameResolver;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 import com.yahoo.vespa.hosted.provision.testutils.MockProvisionServiceProvider;
-import com.yahoo.vespa.orchestrator.OrchestrationException;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.vespa.service.duper.ConfigServerApplication;
 
@@ -687,11 +686,7 @@ public class ProvisioningTester {
             Orchestrator orchestrator = Optional.ofNullable(this.orchestrator)
                     .orElseGet(() -> {
                         Orchestrator orch = mock(Orchestrator.class);
-                        try {
-                            doThrow(new RuntimeException()).when(orch).acquirePermissionToRemove(any());
-                        } catch (OrchestrationException e) {
-                            throw new RuntimeException(e);
-                        }
+                        doThrow(new RuntimeException()).when(orch).acquirePermissionToRemove(any());
                         return orch;
                     });
 

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestrationException.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/OrchestrationException.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.orchestrator;
 
 import java.util.Arrays;
 
-public class OrchestrationException extends Exception {
+public class OrchestrationException extends RuntimeException {
 
     public OrchestrationException(Throwable cause) {
         super(cause);

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/policy/HostedVespaClusterPolicy.java
@@ -58,8 +58,7 @@ public class HostedVespaClusterPolicy implements ClusterPolicy {
             return;
         }
 
-        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi)
-                .asPercentage();
+        int percentageOfServicesAllowedToBeDown = getConcurrentSuspensionLimit(clusterApi).asPercentage();
         if (clusterApi.percentageOfServicesDownIfGroupIsAllowedToBeDown() <= percentageOfServicesAllowedToBeDown) {
             return;
         }


### PR DESCRIPTION
Avoid throwing unknown-service-status suspension denial, if the service is on a
host which is suspended: In that case the status is effectively down.