### PR TITLE
Use max instead of min from current and pending cluster states' distribution bit counts [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor_bucket_space.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_bucket_space.cpp
@@ -50,7 +50,7 @@ DistributorBucketSpace::enumerate_available_nodes()
     _distribution_bits = _clusterState->getDistributionBitCount();
     auto node_count = _clusterState->getNodeCount(lib::NodeType::STORAGE);
     if (_pending_cluster_state) {
-        _distribution_bits = std::min(_distribution_bits, _pending_cluster_state->getDistributionBitCount());
+        _distribution_bits = std::max(_distribution_bits, _pending_cluster_state->getDistributionBitCount());
         node_count = std::min(node_count, _pending_cluster_state->getNodeCount(lib::NodeType::STORAGE));
     }
     std::vector<bool> nodes(node_count);


### PR DESCRIPTION
@toregge please review
@geirst FYI

Using min() has an unfortunate (very rare) edge case if a cluster goes _down_
in distribution bit counts (whether we really want to support this at all is
a different discussion, since it has some other unfortunate implications).
If the current state has e.g. 14 bits and the pending state has 8 bits, using 8
bits for `_distribution_bits` will trigger a `TooFewBucketBitsInUse` exception when
computing a cached ideal state for a bucket in the bucket DB. This is because the
ideal state algorithm is not defined for buckets using fewer bits than the state's
distribution bit count.

The cluster controller shall never push a cluster state with a distribution bit
count higher than the least split bucket across all nodes in the cluster, so
the cache lookup code should theoretically(tm) never be invoked with a bucket that
has fewer used bits than what's present in the pending state.
