### PR TITLE
Tolerate missing file references

### DIFF
--- a/standalone-container/src/main/java/com/yahoo/container/standalone/LocalFileDb.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/LocalFileDb.java
@@ -37,7 +37,7 @@ public class LocalFileDb implements FileAcquirer, FileRegistry {
         synchronized (this) {
             File file = fileReferenceToFile.get(reference);
             if (file == null) {
-                throw new RuntimeException("Invalid file reference " + reference);
+                return new File(reference.value()); // Downloaded file reference: Will (hopefully) be resolved client side
             }
             return file;
         }


### PR DESCRIPTION
If Vespa contains a config definition with a path, and this is
set by the application, this will cause a hash file reference,
which we should not attemt to resolve server side.
