### PR TITLE
Build security utils with maven bundle plugin

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -823,7 +823,7 @@ fi
 %{_prefix}/lib/jars/model-integration-jar-with-dependencies.jar
 %{_prefix}/lib/jars/org.apache.aries.spifly.dynamic.bundle-*.jar
 %{_prefix}/lib/jars/osgi-resource-locator-*.jar
-%{_prefix}/lib/jars/security-utils-jar-with-dependencies.jar
+%{_prefix}/lib/jars/security-utils.jar
 %{_prefix}/lib/jars/standalone-container-jar-with-dependencies.jar
 %{_prefix}/lib/jars/validation-api-*.jar
 %{_prefix}/lib/jars/vespa-athenz-jar-with-dependencies.jar

--- a/security-utils/CMakeLists.txt
+++ b/security-utils/CMakeLists.txt
@@ -1,2 +1,2 @@
 # Copyright 2018 Yahoo Holdings. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-install_fat_java_artifact(security-utils)
+install_java_artifact(security-utils)

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -108,7 +108,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
             <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
-            <_nouses>true</_nouses>
+            <_nouses>true</_nouses> <!-- Don't include 'uses' directives for package exports -->
             <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages> <!-- Hide warnings for bouncycastle multi-release jars -->
           </instructions>
         </configuration>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -111,6 +111,7 @@
             <Embed-Transitive>true</Embed-Transitive>
             <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
             <_nouses>true</_nouses>
+            <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages> <!-- Hide warnings for bouncycastle multi-release jars -->
           </instructions>
         </configuration>
       </plugin>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>security-utils</artifactId>
-  <packaging>container-plugin</packaging>
+  <packaging>bundle</packaging>
   <version>7-SNAPSHOT</version>
 
   <properties>
@@ -77,11 +77,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.yahoo.vespa</groupId>
-        <artifactId>bundle-plugin</artifactId>
-        <extensions>true</extensions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
@@ -96,6 +91,34 @@
             <arg>-Xlint:-serial</arg>
             <arg>-Werror</arg>
           </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Build with maven-bundle-plugin to avoid depending on jdisc_core to get the correct Import-Packages -->
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
+            <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
+            <_nouses>true</_nouses>
+          </instructions>
         </configuration>
       </plugin>
     </plugins>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -107,8 +107,6 @@
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
-            <Embed-Dependency>*;scope=compile|runtime</Embed-Dependency>
-            <Embed-Transitive>true</Embed-Transitive>
             <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
             <_nouses>true</_nouses>
             <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages> <!-- Hide warnings for bouncycastle multi-release jars -->

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -26,13 +26,6 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <!-- required for bundle-plugin to generate import-package statements for Java's standard library -->
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>jdisc_core</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- compile scope -->
     <dependency>


### PR DESCRIPTION
This reduces the size of the bundle by >98%, and allows dropping the dependency to jdisc_core.