### PR TITLE
Add grace period inhibiting maintenance after state transitions with bucket ownership transfer [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -122,6 +122,12 @@ struct TopLevelDistributorTest : Test, TopLevelDistributorTestUtil {
     void assert_single_ok_remove_reply_present() {
         assert_single_reply_present_with_return_code(api::ReturnCode::OK);
     }
+
+    void assert_all_stripes_are_maintenance_inhibited(bool inhibited) const {
+        for (auto* stripe : distributor_stripes()) {
+            EXPECT_EQ(stripe->non_activation_maintenance_is_inhibited(), inhibited);
+        }
+    }
 };
 
 TopLevelDistributorTest::TopLevelDistributorTest()
@@ -533,7 +539,7 @@ TEST_F(TopLevelDistributorTest, leaving_recovery_mode_immediately_sends_getnodes
 // TODO refactor this to set proper highest timestamp as part of bucket info
 // reply once we have the "highest timestamp across all owned buckets" feature
 // in place.
-TEST_F(TopLevelDistributorTest, configured_safe_time_point_rejection_works_end_to_end) {
+TEST_F(TopLevelDistributorTest, configured_feed_safe_time_point_rejection_works_end_to_end) {
     setup_distributor(Redundancy(2), NodeCount(2), "storage:1 distributor:2");
     fake_clock().setAbsoluteTimeInSeconds(1000);
 
@@ -556,6 +562,44 @@ TEST_F(TopLevelDistributorTest, configured_safe_time_point_rejection_works_end_t
     tick_distributor_and_stripes_n_times(1); // Process queued message
     // We don't have any buckets in our DB so we'll get an OK remove reply back (nothing to remove!)
     ASSERT_NO_FATAL_FAILURE(assert_single_ok_remove_reply_present());
+}
+
+TEST_F(TopLevelDistributorTest, configured_maintenance_safe_time_point_inhibition_works_end_to_end) {
+    setup_distributor(Redundancy(2), NodeCount(2), "storage:1 distributor:2");
+    fake_clock().setAbsoluteTimeInSeconds(1000);
+
+    auto cfg = current_distributor_config();
+    cfg.maxClusterClockSkewSec = 10;
+    reconfigure(cfg);
+
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(false));
+
+    enable_distributor_cluster_state("storage:1 distributor:1", true);
+    tick_distributor_and_stripes_n_times(1);
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(true));
+
+    fake_clock().setAbsoluteTimeInSeconds(1010); // Safe period still not expired
+    tick_distributor_and_stripes_n_times(1);
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(true));
+
+    fake_clock().setAbsoluteTimeInSeconds(1011); // Safe period now expired
+    tick_distributor_and_stripes_n_times(1);
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(false));
+}
+
+TEST_F(TopLevelDistributorTest, maintenance_safe_time_not_triggered_if_state_transition_does_not_have_ownership_transfer) {
+    setup_distributor(Redundancy(2), NodeCount(2), "storage:1 distributor:2");
+    fake_clock().setAbsoluteTimeInSeconds(1000);
+
+    auto cfg = current_distributor_config();
+    cfg.maxClusterClockSkewSec = 10;
+    reconfigure(cfg);
+
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(false));
+
+    enable_distributor_cluster_state("storage:1 distributor:1", false);
+    tick_distributor_and_stripes_n_times(1);
+    ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(false));
 }
 
 }

--- a/storage/src/vespa/storage/distributor/cluster_state_bundle_activation_listener.h
+++ b/storage/src/vespa/storage/distributor/cluster_state_bundle_activation_listener.h
@@ -17,7 +17,8 @@ namespace storage::distributor {
 class ClusterStateBundleActivationListener {
 public:
     virtual ~ClusterStateBundleActivationListener() = default;
-    virtual void on_cluster_state_bundle_activated(const lib::ClusterStateBundle&) = 0;
+    virtual void on_cluster_state_bundle_activated(const lib::ClusterStateBundle&,
+                                                   bool has_bucket_ownership_transfer) = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -22,6 +22,7 @@
 #include <vespa/storageapi/message/state.h>
 #include <vespa/storageframework/generic/metric/metricupdatehook.h>
 #include <vespa/storageframework/generic/thread/tickingthread.h>
+#include <atomic>
 #include <mutex>
 #include <queue>
 #include <unordered_map>
@@ -180,6 +181,14 @@ public:
 
     std::chrono::steady_clock::duration db_memory_sample_interval() const noexcept {
         return _db_memory_sample_interval;
+    }
+
+    void inhibit_non_activation_maintenance_operations(bool inhibit) noexcept {
+        _non_activation_maintenance_is_inhibited.store(inhibit, std::memory_order_relaxed);
+    }
+
+    bool non_activation_maintenance_is_inhibited() const noexcept {
+        return _non_activation_maintenance_is_inhibited.load(std::memory_order_relaxed);
     }
 
     bool tick() override;
@@ -342,8 +351,9 @@ private:
     std::chrono::steady_clock::duration _db_memory_sample_interval;
     std::chrono::steady_clock::time_point _last_db_memory_sample_time_point;
     size_t _inhibited_maintenance_tick_count;
-    bool _must_send_updated_host_info;
     uint32_t _stripe_index;
+    std::atomic<bool> _non_activation_maintenance_is_inhibited;
+    bool _must_send_updated_host_info;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/ownership_transfer_safe_time_point_calculator.cpp
+++ b/storage/src/vespa/storage/distributor/ownership_transfer_safe_time_point_calculator.cpp
@@ -7,8 +7,7 @@ namespace storage {
 namespace distributor {
 
 OwnershipTransferSafeTimePointCalculator::TimePoint
-OwnershipTransferSafeTimePointCalculator::safeTimePoint(
-        TimePoint now) const
+OwnershipTransferSafeTimePointCalculator::safeTimePoint(TimePoint now) const
 {
     if (_max_cluster_clock_skew.count() == 0) {
         return TimePoint{};
@@ -27,8 +26,7 @@ OwnershipTransferSafeTimePointCalculator::safeTimePoint(
     // adding the max skew. This prevents generating time stamps within
     // the same whole second as another distributor already has done for
     // any of the buckets a node now owns.
-    auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(
-            now.time_since_epoch());
+    auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
     return TimePoint(now_sec + std::chrono::seconds(1) + _max_cluster_clock_skew);
 }
 

--- a/storage/src/vespa/storage/distributor/ownership_transfer_safe_time_point_calculator.h
+++ b/storage/src/vespa/storage/distributor/ownership_transfer_safe_time_point_calculator.h
@@ -4,8 +4,7 @@
 
 #include <chrono>
 
-namespace storage {
-namespace distributor {
+namespace storage::distributor {
 
 /**
  * When bucket ownership changes in a cluster, there exists a time period
@@ -25,7 +24,6 @@ namespace distributor {
  * equal to or lower than this. The stop-gap also breaks down if, in fact,
  * the clock skew is higher than the expected one.
  *
- * This is an interface to avoid having to do real wall-clocks in unit tests.
  */
 class OwnershipTransferSafeTimePointCalculator {
     std::chrono::seconds _max_cluster_clock_skew;
@@ -46,5 +44,4 @@ public:
     TimePoint safeTimePoint(TimePoint now) const;
 };
 
-}
 }

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
@@ -50,19 +50,19 @@ TopLevelBucketDBUpdater::TopLevelBucketDBUpdater(const DistributorNodeContext& n
       _stale_reads_enabled(false)
 {
     // FIXME STRIPE top-level Distributor needs a proper way to track the current cluster state bundle!
-    propagate_active_state_bundle_internally();
+    propagate_active_state_bundle_internally(true); // We're just starting up so assume ownership transfer.
     bootstrap_distribution_config(bootstrap_distribution);
 }
 
 TopLevelBucketDBUpdater::~TopLevelBucketDBUpdater() = default;
 
 void
-TopLevelBucketDBUpdater::propagate_active_state_bundle_internally() {
+TopLevelBucketDBUpdater::propagate_active_state_bundle_internally(bool has_bucket_ownership_transfer) {
     for (auto& elem : _op_ctx.bucket_space_states()) {
         elem.second->set_cluster_state(_active_state_bundle.getDerivedClusterState(elem.first));
     }
     if (_state_activation_listener) {
-        _state_activation_listener->on_cluster_state_bundle_activated(_active_state_bundle);
+        _state_activation_listener->on_cluster_state_bundle_activated(_active_state_bundle, has_bucket_ownership_transfer);
     }
 }
 
@@ -412,7 +412,7 @@ TopLevelBucketDBUpdater::enable_current_cluster_state_bundle_in_distributor_and_
     _active_state_bundle = _pending_cluster_state->getNewClusterStateBundle();
 
     guard.enable_cluster_state_bundle(state, _pending_cluster_state->hasBucketOwnershipTransfer());
-    propagate_active_state_bundle_internally();
+    propagate_active_state_bundle_internally(_pending_cluster_state->hasBucketOwnershipTransfer());
 
     LOG(debug, "TopLevelBucketDBUpdater finished processing state %s",
         state.getBaselineClusterState()->toString().c_str());
@@ -425,7 +425,7 @@ void TopLevelBucketDBUpdater::simulate_cluster_state_bundle_activation(const lib
     guard->enable_cluster_state_bundle(activated_state, has_bucket_ownership_transfer);
 
     _active_state_bundle = activated_state;
-    propagate_active_state_bundle_internally();
+    propagate_active_state_bundle_internally(has_bucket_ownership_transfer);
 }
 
 void

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
@@ -75,7 +75,6 @@ public:
 private:
 
     friend class DistributorStripeTestUtil;
-    friend class DistributorTestUtil;
     friend class TopLevelDistributorTestUtil;
     // Only to be used by tests that want to ensure both the TopLevelBucketDBUpdater _and_ the Distributor
     // components agree on the currently active cluster state bundle.
@@ -104,7 +103,7 @@ private:
     void enable_current_cluster_state_bundle_in_distributor_and_stripes(StripeAccessGuard& guard);
     void add_current_state_to_cluster_state_history();
 
-    void propagate_active_state_bundle_internally();
+    void propagate_active_state_bundle_internally(bool has_bucket_ownership_transfer);
 
     void maybe_inject_simulated_db_pruning_delay();
     void maybe_inject_simulated_db_merging_delay();

--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -131,7 +131,7 @@ DistributorNode::generate_unique_timestamp()
                 _intra_second_pseudo_usec_counter);
             std::_Exit(65);
         }
-        assert(_intra_second_pseudo_usec_counter < 1'000'000);
+        assert(_intra_second_pseudo_usec_counter < 999'999);
         ++_intra_second_pseudo_usec_counter;
     } else {
         _timestamp_second_counter = now_seconds;


### PR DESCRIPTION
@geirst @toregge please review.

Avoids the case where different distributors can start merges with a max timestamp
that is lower than timestamps generated intra-second by other distributors used for
feed bound to the same bucket.

This is analogous to the existing "safe time period" functionality used for
handling external feed, and uses the same max clock skew config as this.
Correctness of this grace period is therefore inherently dependent on actual
cluster clock skew being less than this configured number.

Bucket activations are still allowed to take place during the grace period time
window, as these do not mutate the bucket contents and are therefore safe.
