### PR TITLE
Don't let a blocked maintenance operation inhibit remaining maintenance queue [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -179,6 +179,16 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         configure_stripe(builder);
     }
 
+    void configure_implicitly_clear_priority_on_schedule(bool implicitly_clear) {
+        ConfigBuilder builder;
+        builder.implicitlyClearBucketPriorityOnSchedule = implicitly_clear;
+        configure_stripe(builder);
+    }
+
+    bool scheduler_has_implicitly_clear_priority_on_schedule_set() const noexcept {
+        return _stripe->_scheduler->implicitly_clear_priority_on_schedule();
+    }
+
     void configureMaxClusterClockSkew(int seconds);
     void configure_mutation_sequencing(bool enabled);
     void configure_merge_busy_inhibit_duration(int seconds);
@@ -886,6 +896,17 @@ TEST_F(DistributorStripeTest, max_activation_inhibited_out_of_sync_groups_config
 
     configure_max_activation_inhibited_out_of_sync_groups(0);
     EXPECT_EQ(getConfig().max_activation_inhibited_out_of_sync_groups(), 0);
+}
+
+TEST_F(DistributorStripeTest, implicitly_clear_priority_on_schedule_config_is_propagated_to_scheduler)
+{
+    setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    configure_implicitly_clear_priority_on_schedule(true);
+    EXPECT_TRUE(scheduler_has_implicitly_clear_priority_on_schedule_set());
+
+    configure_implicitly_clear_priority_on_schedule(false);
+    EXPECT_FALSE(scheduler_has_implicitly_clear_priority_on_schedule_set());
 }
 
 TEST_F(DistributorStripeTest, wanted_split_bit_count_is_lower_bounded)

--- a/storage/src/tests/distributor/maintenancemocks.h
+++ b/storage/src/tests/distributor/maintenancemocks.h
@@ -4,6 +4,7 @@
 #include <vespa/document/test/make_bucket_space.h>
 #include <vespa/storage/distributor/maintenance/maintenanceprioritygenerator.h>
 #include <vespa/storage/distributor/maintenance/maintenanceoperationgenerator.h>
+#include <vespa/storage/distributor/maintenance/pending_window_checker.h>
 #include <vespa/storage/distributor/operationstarter.h>
 #include <vespa/storage/distributor/operations/operation.h>
 #include <vespa/storageframework/defaultimplementation/clock/fakeclock.h>
@@ -119,6 +120,18 @@ public:
 
     std::string toString() const {
         return _started.str();
+    }
+};
+
+class MockPendingWindowChecker : public PendingWindowChecker {
+    bool _allow = true;
+public:
+    void allow_operations(bool allow) noexcept {
+        _allow = allow;
+    }
+
+    bool may_allow_operation_with_priority(OperationStarter::Priority) const noexcept override {
+        return _allow;
     }
 };
 

--- a/storage/src/tests/distributor/maintenanceschedulertest.cpp
+++ b/storage/src/tests/distributor/maintenanceschedulertest.cpp
@@ -18,60 +18,77 @@ using Priority = MaintenancePriority;
 using WaitTimeMs = MaintenanceScheduler::WaitTimeMs;
 
 struct MaintenanceSchedulerTest : Test {
-    std::unique_ptr<SimpleBucketPriorityDatabase> _priorityDb;
-    std::unique_ptr<MockMaintenanceOperationGenerator> _operationGenerator;
-    std::unique_ptr<MockOperationStarter> _operationStarter;
-    std::unique_ptr<MaintenanceScheduler> _scheduler;
+    SimpleBucketPriorityDatabase      _priority_db;
+    MockMaintenanceOperationGenerator _operation_generator;
+    MockOperationStarter              _operation_starter;
+    MockPendingWindowChecker          _pending_window_checker;
+    MaintenanceScheduler              _scheduler;
 
-    void SetUp() override;
+    MaintenanceSchedulerTest()
+        : _priority_db(),
+          _operation_generator(),
+          _operation_starter(),
+          _pending_window_checker(),
+          _scheduler(_operation_generator, _priority_db, _pending_window_checker, _operation_starter)
+    {}
 };
 
-void
-MaintenanceSchedulerTest::SetUp()
-{
-    _priorityDb = std::make_unique<SimpleBucketPriorityDatabase>();
-    _operationGenerator = std::make_unique<MockMaintenanceOperationGenerator>();
-    _operationStarter = std::make_unique<MockOperationStarter>();
-    _scheduler = std::make_unique<MaintenanceScheduler>(*_operationGenerator, *_priorityDb, *_operationStarter);
-}
-
 TEST_F(MaintenanceSchedulerTest, priority_cleared_after_scheduled) {
-    _priorityDb->setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGHEST));
-    _scheduler->tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
-    EXPECT_EQ("", _priorityDb->toString());
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGHEST));
+    _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
+    EXPECT_EQ("", _priority_db.toString());
 }
 
 TEST_F(MaintenanceSchedulerTest, operation_is_scheduled) {
-    _priorityDb->setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::MEDIUM));
-    _scheduler->tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::MEDIUM));
+    _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
     EXPECT_EQ("Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri 100\n",
-              _operationStarter->toString());
+              _operation_starter.toString());
+}
+
+TEST_F(MaintenanceSchedulerTest, operation_is_not_scheduled_if_pending_ops_not_accepted) {
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::MEDIUM));
+    _pending_window_checker.allow_operations(false);
+    _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
+    EXPECT_EQ("", _operation_starter.toString());
+    // Priority DB entry is not cleared
+    EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri MEDIUM)\n",
+              _priority_db.toString());
 }
 
 TEST_F(MaintenanceSchedulerTest, no_operations_to_schedule) {
-    WaitTimeMs waitMs(_scheduler->tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
+    WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
     EXPECT_EQ(WaitTimeMs(1), waitMs);
-    EXPECT_EQ("", _operationStarter->toString());
+    EXPECT_EQ("", _operation_starter.toString());
 }
 
 TEST_F(MaintenanceSchedulerTest, suppress_low_priorities_in_emergency_mode) {
-    _priorityDb->setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::VERY_HIGH));
-    _priorityDb->setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 2)), Priority::HIGHEST));
-    EXPECT_EQ(WaitTimeMs(0), _scheduler->tick(MaintenanceScheduler::RECOVERY_SCHEDULING_MODE));
-    EXPECT_EQ(WaitTimeMs(1), _scheduler->tick(MaintenanceScheduler::RECOVERY_SCHEDULING_MODE));
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::VERY_HIGH));
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 2)), Priority::HIGHEST));
+    EXPECT_EQ(WaitTimeMs(0), _scheduler.tick(MaintenanceScheduler::RECOVERY_SCHEDULING_MODE));
+    EXPECT_EQ(WaitTimeMs(1), _scheduler.tick(MaintenanceScheduler::RECOVERY_SCHEDULING_MODE));
     EXPECT_EQ("Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000002)), pri 0\n",
-              _operationStarter->toString());
+              _operation_starter.toString());
     EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri VERY_HIGH)\n",
-              _priorityDb->toString());
+              _priority_db.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started) {
-    _priorityDb->setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
-    _operationStarter->setShouldStartOperations(false);
-    WaitTimeMs waitMs(_scheduler->tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
+TEST_F(MaintenanceSchedulerTest, priority_cleared_if_operation_not_started_inside_pending_window) {
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
+    _operation_starter.setShouldStartOperations(false);
+    WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
+    EXPECT_EQ(WaitTimeMs(1), waitMs);
+    EXPECT_EQ("", _priority_db.toString());
+}
+
+TEST_F(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_outside_pending_window) {
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
+    _operation_starter.setShouldStartOperations(false);
+    _pending_window_checker.allow_operations(false);
+    WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
     EXPECT_EQ(WaitTimeMs(1), waitMs);
     EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri HIGH)\n",
-              _priorityDb->toString());
+              _priority_db.toString());
 }
 
 }

--- a/storage/src/tests/distributor/maintenanceschedulertest.cpp
+++ b/storage/src/tests/distributor/maintenanceschedulertest.cpp
@@ -103,6 +103,15 @@ TEST_P(MaintenanceSchedulerTest, priority_cleared_if_operation_not_started_insid
     EXPECT_EQ("", _priority_db.toString());
 }
 
+TEST_P(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_inside_pending_window_for_highest_pri) {
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGHEST));
+    _operation_starter.setShouldStartOperations(false);
+    WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
+    EXPECT_EQ(WaitTimeMs(1), waitMs);
+    EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri HIGHEST)\n",
+              _priority_db.toString());
+}
+
 TEST_P(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_outside_pending_window) {
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
     _operation_starter.setShouldStartOperations(false);

--- a/storage/src/tests/distributor/maintenanceschedulertest.cpp
+++ b/storage/src/tests/distributor/maintenanceschedulertest.cpp
@@ -17,7 +17,7 @@ using document::BucketId;
 using Priority = MaintenancePriority;
 using WaitTimeMs = MaintenanceScheduler::WaitTimeMs;
 
-struct MaintenanceSchedulerTest : Test {
+struct MaintenanceSchedulerTest : TestWithParam<bool> {
     SimpleBucketPriorityDatabase      _priority_db;
     MockMaintenanceOperationGenerator _operation_generator;
     MockOperationStarter              _operation_starter;
@@ -31,22 +31,29 @@ struct MaintenanceSchedulerTest : Test {
           _pending_window_checker(),
           _scheduler(_operation_generator, _priority_db, _pending_window_checker, _operation_starter)
     {}
+
+    void SetUp() override {
+        _scheduler.set_implicitly_clear_priority_on_schedule(GetParam());
+    }
 };
 
-TEST_F(MaintenanceSchedulerTest, priority_cleared_after_scheduled) {
+TEST_P(MaintenanceSchedulerTest, priority_cleared_after_scheduled) {
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGHEST));
     _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
     EXPECT_EQ("", _priority_db.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, operation_is_scheduled) {
+TEST_P(MaintenanceSchedulerTest, operation_is_scheduled) {
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::MEDIUM));
     _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
     EXPECT_EQ("Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri 100\n",
               _operation_starter.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, operation_is_not_scheduled_if_pending_ops_not_accepted) {
+TEST_P(MaintenanceSchedulerTest, operation_is_not_scheduled_if_pending_ops_not_accepted) {
+    if (!GetParam()) {
+        return; // Only works when implicit clearing is enabled
+    }
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::MEDIUM));
     _pending_window_checker.allow_operations(false);
     _scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE);
@@ -56,13 +63,13 @@ TEST_F(MaintenanceSchedulerTest, operation_is_not_scheduled_if_pending_ops_not_a
               _priority_db.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, no_operations_to_schedule) {
+TEST_P(MaintenanceSchedulerTest, no_operations_to_schedule) {
     WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
     EXPECT_EQ(WaitTimeMs(1), waitMs);
     EXPECT_EQ("", _operation_starter.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, suppress_low_priorities_in_emergency_mode) {
+TEST_P(MaintenanceSchedulerTest, suppress_low_priorities_in_emergency_mode) {
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::VERY_HIGH));
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 2)), Priority::HIGHEST));
     EXPECT_EQ(WaitTimeMs(0), _scheduler.tick(MaintenanceScheduler::RECOVERY_SCHEDULING_MODE));
@@ -73,7 +80,22 @@ TEST_F(MaintenanceSchedulerTest, suppress_low_priorities_in_emergency_mode) {
               _priority_db.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, priority_cleared_if_operation_not_started_inside_pending_window) {
+TEST_P(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started) {
+    if (GetParam()) {
+        return; // Only works when implicit clearing is NOT enabled
+    }
+    _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
+    _operation_starter.setShouldStartOperations(false);
+    WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
+    EXPECT_EQ(WaitTimeMs(1), waitMs);
+    EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri HIGH)\n",
+              _priority_db.toString());
+}
+
+TEST_P(MaintenanceSchedulerTest, priority_cleared_if_operation_not_started_inside_pending_window) {
+    if (!GetParam()) {
+        return; // Only works when implicit clearing is enabled
+    }
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
     _operation_starter.setShouldStartOperations(false);
     WaitTimeMs waitMs(_scheduler.tick(MaintenanceScheduler::NORMAL_SCHEDULING_MODE));
@@ -81,7 +103,7 @@ TEST_F(MaintenanceSchedulerTest, priority_cleared_if_operation_not_started_insid
     EXPECT_EQ("", _priority_db.toString());
 }
 
-TEST_F(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_outside_pending_window) {
+TEST_P(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_outside_pending_window) {
     _priority_db.setPriority(PrioritizedBucket(makeDocumentBucket(BucketId(16, 1)), Priority::HIGH));
     _operation_starter.setShouldStartOperations(false);
     _pending_window_checker.allow_operations(false);
@@ -90,5 +112,7 @@ TEST_F(MaintenanceSchedulerTest, priority_not_cleared_if_operation_not_started_o
     EXPECT_EQ("PrioritizedBucket(Bucket(BucketSpace(0x0000000000000001), BucketId(0x4000000000000001)), pri HIGH)\n",
               _priority_db.toString());
 }
+
+VESPA_GTEST_INSTANTIATE_TEST_SUITE_P(ImplicitClearOfDbPri, MaintenanceSchedulerTest, ::testing::Values(false, true));
 
 }

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -49,6 +49,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _enable_metadata_only_fetch_phase_for_inconsistent_updates(false),
       _prioritize_global_bucket_merges(true),
       _enable_revert(true),
+      _implicitly_clear_priority_on_schedule(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
 }
@@ -169,6 +170,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _prioritize_global_bucket_merges = config.prioritizeGlobalBucketMerges;
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_revert = config.enableRevert;
+    _implicitly_clear_priority_on_schedule = config.implicitlyClearBucketPriorityOnSchedule;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -264,6 +264,9 @@ public:
     bool enable_revert() const noexcept {
         return _enable_revert;
     }
+    [[nodiscard]] bool implicitly_clear_priority_on_schedule() const noexcept {
+        return _implicitly_clear_priority_on_schedule;
+    }
 
     uint32_t num_distributor_stripes() const noexcept { return _num_distributor_stripes; }
 
@@ -320,6 +323,7 @@ private:
     bool _enable_metadata_only_fetch_phase_for_inconsistent_updates;
     bool _prioritize_global_bucket_merges;
     bool _enable_revert;
+    bool _implicitly_clear_priority_on_schedule;
 
     DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -280,3 +280,9 @@ max_activation_inhibited_out_of_sync_groups int default=0
 ## CPU cores available. If > 0, the number of stripes is explicitly overridden.
 ## Stripe counts must be a power of two.
 num_distributor_stripes int default=0 restart
+
+## If set, the maintenance scheduler will implicitly clear entries from its internal
+## bucket maintenance priority database even when no operation can be started for the
+## bucket due to being blocked by concurrent operations. This avoids potential head-of-line
+## blocking of later buckets in the priority database.
+implicitly_clear_bucket_priority_on_schedule bool default=false

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -760,6 +760,7 @@ DistributorStripe::propagate_config_snapshot_to_internal_components()
             getConfig().allowStaleReadsDuringClusterStateTransitions());
     _externalOperationHandler.set_use_weak_internal_read_consistency_for_gets(
             getConfig().use_weak_internal_read_consistency_for_client_gets());
+    _scheduler->set_implicitly_clear_priority_on_schedule(getConfig().implicitly_clear_priority_on_schedule());
 }
 
 void

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -62,7 +62,8 @@ DistributorStripe::DistributorStripe(DistributorComponentRegister& compReg,
       _throttlingStarter(std::make_unique<ThrottlingOperationStarter>(_maintenanceOperationOwner)),
       _blockingStarter(std::make_unique<BlockingOperationStarter>(_component, *_operation_sequencer,
                                                                   *_throttlingStarter)),
-      _scheduler(std::make_unique<MaintenanceScheduler>(_idealStateManager, *_bucketPriorityDb, *_blockingStarter)),
+      _scheduler(std::make_unique<MaintenanceScheduler>(_idealStateManager, *_bucketPriorityDb,
+                                                        *_throttlingStarter, *_blockingStarter)),
       _schedulingMode(MaintenanceScheduler::NORMAL_SCHEDULING_MODE),
       _recoveryTimeStarted(_component.getClock()),
       _tickResult(framework::ThreadWaitInfo::NO_MORE_CRITICAL_WORK_KNOWN),
@@ -709,7 +710,9 @@ DistributorStripe::doNonCriticalTick(framework::ThreadIndex)
     // did any useful work with incoming data, this check must be performed _after_ the call.
     if (!should_inhibit_current_maintenance_scan_tick()) {
         scanNextBucket();
-        startNextMaintenanceOperation();
+        if (!_bucketDBUpdater.hasPendingClusterState()) {
+            startNextMaintenanceOperation();
+        }
         if (isInRecoveryMode()) {
             signalWorkWasDone();
         }

--- a/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
+++ b/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
@@ -9,6 +9,7 @@ namespace storage::distributor {
 
 class MaintenanceOperationGenerator;
 class BucketPriorityDatabase;
+class PendingWindowChecker;
 
 class MaintenanceScheduler
 {
@@ -22,6 +23,7 @@ public:
 
     MaintenanceScheduler(MaintenanceOperationGenerator& operationGenerator,
                          BucketPriorityDatabase& priorityDb,
+                         const PendingWindowChecker& pending_window_checker,
                          OperationStarter& operationStarter);
 
     WaitTimeMs tick(SchedulingMode currentMode);
@@ -40,6 +42,7 @@ private:
 
     MaintenanceOperationGenerator& _operationGenerator;
     BucketPriorityDatabase& _priorityDb;
+    const PendingWindowChecker& _pending_window_checker;
     OperationStarter& _operationStarter;
 };
 

--- a/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
+++ b/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
@@ -28,6 +28,13 @@ public:
 
     WaitTimeMs tick(SchedulingMode currentMode);
 
+    void set_implicitly_clear_priority_on_schedule(bool implicitly_clear) noexcept {
+        _implicitly_clear_priority_on_schedule = implicitly_clear;
+    }
+    [[nodiscard]] bool implicitly_clear_priority_on_schedule() const noexcept {
+        return _implicitly_clear_priority_on_schedule;
+    }
+
 private:
     MaintenanceScheduler(const MaintenanceScheduler&);
     MaintenanceScheduler& operator=(const MaintenanceScheduler&);
@@ -41,9 +48,10 @@ private:
             MaintenancePriority::Priority priority) const;
 
     MaintenanceOperationGenerator& _operationGenerator;
-    BucketPriorityDatabase& _priorityDb;
-    const PendingWindowChecker& _pending_window_checker;
-    OperationStarter& _operationStarter;
+    BucketPriorityDatabase&        _priorityDb;
+    const PendingWindowChecker&    _pending_window_checker;
+    OperationStarter&              _operationStarter;
+    bool                           _implicitly_clear_priority_on_schedule;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
+++ b/storage/src/vespa/storage/distributor/maintenance/maintenancescheduler.h
@@ -44,8 +44,8 @@ private:
     bool possibleToScheduleInEmergency(const PrioritizedBucket& bucket) const;
     void clearPriority(const PrioritizedBucket& bucket);
     bool startOperation(const PrioritizedBucket& bucket);
-    OperationStarter::Priority convertToOperationPriority(
-            MaintenancePriority::Priority priority) const;
+    OperationStarter::Priority convertToOperationPriority(MaintenancePriority::Priority priority) const;
+    bool has_bucket_activation_priority(const PrioritizedBucket&) const noexcept;
 
     MaintenanceOperationGenerator& _operationGenerator;
     BucketPriorityDatabase&        _priorityDb;

--- a/storage/src/vespa/storage/distributor/maintenance/pending_window_checker.h
+++ b/storage/src/vespa/storage/distributor/maintenance/pending_window_checker.h
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/storage/distributor/operationstarter.h>
+
+namespace storage::distributor {
+
+/**
+ * Allows for easily and cheaply checking if an operation with a given internal maintenance
+ * priority could possibly be started "downstream" due to there being available capacity
+ * in the maintenance pending window.
+ */
+class PendingWindowChecker {
+public:
+    virtual ~PendingWindowChecker() = default;
+    [[nodiscard]] virtual bool may_allow_operation_with_priority(OperationStarter::Priority) const noexcept = 0;
+};
+
+}


### PR DESCRIPTION
@geirst please review
@toregge FYI

The old maintenance scheduler behavior is to only remove a bucket from the
priority DB if its maintenance operation was successfully started. Failing
to start an operation could happen from both max pending throttling as well
as operation/bucket-specific blocking behavior. Since the scheduler would
encounter the same bucket as the one previously blocked upon its next tick
invocation, a single blocked bucket would run the risk of head-of-line
stalling the rest of the remaining maintenance queue (assuming the ongoing
DB scan did not encounter any higher priority buckets).

This commit changes the following aspects of maintenance scheduling:
 * Always clear entries from the priority DB before trying to start an
   operation. A blocked operation will be retried the next time the
   regular bucket DB scan encounters the bucket.
 * Avoid trying to start (and clear) inherently doomed operations by
   _not_ trying to schedule any operations if it would be blocked due
   to too many pending maintenance operations anyway. Introduces a
   new `PendingWindowChecker` interface for this purpose.
 * Explicitly inhibit all maintenance scheduling if a pending cluster
   state is present. Operations are already _implicitly_ blocked from
   starting if there's a pending cluster state, but this would cause
   the priority DB from being pointlessly cleared.

