### PR TITLE
Support tf2onnx versions >= 1.9.1

### DIFF
--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/tensorflow/TensorFlowImporter.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/tensorflow/TensorFlowImporter.java
@@ -102,7 +102,8 @@ public class TensorFlowImporter extends ModelImporter {
 
     private Pair<Integer, String> convertToOnnx(String savedModel, String output, int opset) throws IOException {
         ProcessExecuter executer = new ProcessExecuter();
-        String job = "vespa-convert-tf2onnx --saved-model " + savedModel + " --output " + output + " --opset " + opset;
+        String job = "vespa-convert-tf2onnx --saved-model " + savedModel + " --output " + output + " --opset " + opset
+                + " --use-graph-names";  // for backward compatibility with tf2onnx versions < 1.9.1
         return executer.exec(job);
     }
 


### PR DESCRIPTION
Tf2onnx introduced a change to use structured inputs by default from version 1.9.1. Vespa import assumes the actual graph name. The tf2onnx option "--use-graph-names" enables old behavior.

@aressem Please review.

Tested that with this tf2onnx can be updated to 1.9.2. 
