### PR TITLE
Do not busy-bounce merges forwarded from other nodes

### DIFF
--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -45,6 +45,14 @@ max_merge_queue_size int default=1024
 ## "source only", as merges do not cause mutations on such nodes.
 resource_exhaustion_merge_back_pressure_duration_secs double default=30.0
 
+## If true, received merges that have already been accepted into the pending
+## merge window on at least one node will not be restricted by the configured
+## max_merge_queue_size limit. They will be allowed to enqueue regardless of
+## the current queue size. This avoids wasting the time spent being accepted
+## into merge windows, which would happen if the merge were to be bounced with
+## a busy-reply that would subsequently be unwound throuh the entire merge chain.
+disable_queue_limits_for_chained_merges bool default=false
+
 ## Whether the deadlock detector should be enabled or not. If disabled, it will
 ## still run, but it will never actually abort the process it is running in.
 enable_dead_lock_detector bool default=false restart

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -50,7 +50,7 @@ resource_exhaustion_merge_back_pressure_duration_secs double default=30.0
 ## max_merge_queue_size limit. They will be allowed to enqueue regardless of
 ## the current queue size. This avoids wasting the time spent being accepted
 ## into merge windows, which would happen if the merge were to be bounced with
-## a busy-reply that would subsequently be unwound throuh the entire merge chain.
+## a busy-reply that would subsequently be unwound through the entire merge chain.
 disable_queue_limits_for_chained_merges bool default=false
 
 ## Whether the deadlock detector should be enabled or not. If disabled, it will

--- a/storage/src/vespa/storage/storageserver/mergethrottler.cpp
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.cpp
@@ -732,7 +732,10 @@ MergeThrottler::handleMessageDown(
             processCycledMergeCommand(msg, msgGuard);
         } else if (canProcessNewMerge()) {
             processNewMergeCommand(msg, msgGuard);
-        } else if (_queue.size() < _maxQueueSize) {
+        } else if ((_queue.size() < _maxQueueSize) || !mergeCmd.getChain().empty()) {
+            // We let any merge through that has already passed through at least one other node's merge
+            // window, as that has already taken up a logical resource slot on all those nodes. Busy-bouncing
+            // a merge at that point would undo a great amount of thumb-twiddling and waiting.
             enqueueMerge(msg, msgGuard); // Queue for later processing
         } else {
             // No more room at the inn. Return BUSY so that the

--- a/storage/src/vespa/storage/storageserver/mergethrottler.h
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.h
@@ -172,6 +172,7 @@ private:
     RendezvousState _rendezvous;
     mutable std::chrono::steady_clock::time_point _throttle_until_time;
     std::chrono::steady_clock::duration _backpressure_duration;
+    bool _disable_queue_limits_for_chained_merges;
     bool _closing;
 public:
     /**
@@ -209,6 +210,7 @@ public:
     // For unit testing only
     const mbus::StaticThrottlePolicy& getThrottlePolicy() const { return *_throttlePolicy; }
     mbus::StaticThrottlePolicy& getThrottlePolicy() { return *_throttlePolicy; }
+    void set_disable_queue_limits_for_chained_merges(bool disable_limits) noexcept;
     // For unit testing only
     std::mutex & getMonitor() { return _messageLock; }
     std::mutex & getStateLock() { return _stateLock; }
@@ -347,6 +349,7 @@ private:
     bool merge_has_this_node_as_source_only_node(const api::MergeBucketCommand& cmd) const;
     bool backpressure_mode_active_no_lock() const;
     void backpressure_bounce_all_queued_merges(MessageGuard& guard);
+    bool allow_merge_with_queue_full(const api::MergeBucketCommand& cmd) const noexcept;
 
     void sendReply(const api::MergeBucketCommand& cmd,
                    const api::ReturnCode& result,


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Let any merge through that has already passed through at least one
other node's merge window, as that has already taken up a logical
resource slot on all those nodes. Busy-bouncing a merge at that point
would undo a great amount of time already expended.

The max number of enqueued merges is bounded by the number of nodes
in the system, as each node can still only accept a configurable number
of merges from distributors, and each distributor throttles their
maintenance operations based on priority-relative max pending limits.

This feature can be toggled with a live reconfig. Currently defaults to false,
i.e. queue limits are still enforced.
