### PR TITLE
Remove getSupervisor() from ConnectionPool interface [run-systemtest]

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
@@ -28,7 +28,7 @@ public class FileDistributionAndUrlDownload {
     public FileDistributionAndUrlDownload(Supervisor supervisor, ConfigSourceSet source) {
         fileDistributionRpcServer =
                 new FileDistributionRpcServer(supervisor,
-                                              new FileDownloader(new JRTConnectionPool(source, supervisor)));
+                                              new FileDownloader(new JRTConnectionPool(source, supervisor), supervisor));
         urlDownloadRpcServer = new UrlDownloadRpcServer(supervisor);
         cleanupExecutor.scheduleAtFixedRate(new CachedFilesMaintainer(), delay.toSeconds(), delay.toSeconds(), TimeUnit.SECONDS);
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
@@ -3,7 +3,6 @@ package com.yahoo.config.subscription.impl;
 
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.RequestWaiter;
-import com.yahoo.jrt.Supervisor;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
@@ -72,11 +71,6 @@ public class MockConnection implements ConnectionPool, Connection {
     @Override
     public int getSize() {
         return numSpecs;
-    }
-
-    @Override
-    public Supervisor getSupervisor() {
-        return null;
     }
 
     public int getNumberOfRequests() {

--- a/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConnectionPool.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config;
 
-import com.yahoo.jrt.Supervisor;
-
 /**
  * @author hmusum
  */
@@ -21,8 +19,5 @@ public interface ConnectionPool extends AutoCloseable {
     Connection switchConnection(Connection failingConnection);
 
     int getSize();
-
-    // TODO: Exposes implementation, try to remove
-    Supervisor getSupervisor();
 
 }

--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -148,9 +148,4 @@ public class JRTConnectionPool implements ConnectionPool {
         }
     }
 
-    @Override
-    public Supervisor getSupervisor() {
-        return supervisor;
-    }
-
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionUtil.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionUtil.java
@@ -3,13 +3,7 @@ package com.yahoo.vespa.config.server.filedistribution;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.FileReference;
-import com.yahoo.config.subscription.ConfigSourceSet;
-import com.yahoo.jrt.Supervisor;
-import com.yahoo.jrt.Transport;
 import com.yahoo.net.HostName;
-import com.yahoo.vespa.config.Connection;
-import com.yahoo.vespa.config.ConnectionPool;
-import com.yahoo.vespa.config.JRTConnectionPool;
 import com.yahoo.vespa.config.server.ConfigServerSpec;
 
 import java.io.File;
@@ -38,62 +32,16 @@ public class FileDistributionUtil {
         return fileReferencesOnDisk;
     }
 
-    /**
-     * Returns a connection pool with all config servers except this one, or an empty pool if there
-     * is only one config server (no point in trying to download from yourself).
-     */
-    public static ConnectionPool createConnectionPool(ConfigserverConfig configserverConfig) {
-        List<String> configServers = ConfigServerSpec.fromConfig(configserverConfig)
-                .stream()
-                .filter(spec -> !spec.getHostName().equals(HostName.getLocalhost()))
-                .map(spec -> "tcp/" + spec.getHostName() + ":" + spec.getConfigServerPort())
-                .collect(Collectors.toList());
-
-        return configServers.size() > 0
-                ? new JRTConnectionPool(new ConfigSourceSet(configServers),
-                                        new Supervisor(new Transport("filedistribution-pool"))
-                                                .setDropEmptyBuffers(true))
-                : emptyConnectionPool();
+    public static List<String> getOtherConfigServersInCluster(ConfigserverConfig configserverConfig) {
+        return ConfigServerSpec.fromConfig(configserverConfig)
+                               .stream()
+                               .filter(spec -> !spec.getHostName().equals(HostName.getLocalhost()))
+                               .map(spec -> "tcp/" + spec.getHostName() + ":" + spec.getConfigServerPort())
+                               .collect(Collectors.toList());
     }
 
     public static boolean fileReferenceExistsOnDisk(File downloadDirectory, FileReference applicationPackageReference) {
         return getFileReferencesOnDisk(downloadDirectory).contains(applicationPackageReference.value());
-    }
-
-    static ConnectionPool emptyConnectionPool() {
-        return new EmptyConnectionPool();
-    }
-
-    private static class EmptyConnectionPool implements ConnectionPool {
-        private Supervisor supervisor;
-
-        @Override
-        public void close() {
-            synchronized (this) {
-                if (supervisor != null) {
-                    supervisor.transport().shutdown().join();
-                }
-            }
-        }
-
-        @Override
-        public Connection getCurrent() { return null; }
-
-        @Override
-        public Connection switchConnection(Connection connection) { return null; }
-
-        @Override
-        public int getSize() { return 0; }
-
-        @Override
-        public Supervisor getSupervisor() {
-            synchronized (this) {
-                if (supervisor == null) {
-                    supervisor = new Supervisor(new Transport("empty-connection-pool")).setDropEmptyBuffers(true);
-                }
-            }
-            return supervisor;
-        }
     }
 
 }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.config.server.filedistribution;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.config.FileReference;
 import com.yahoo.io.IOUtils;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Transport;
 import com.yahoo.net.HostName;
 import com.yahoo.vespa.filedistribution.Downloads;
 import com.yahoo.vespa.filedistribution.FileDownloader;
@@ -22,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import static com.yahoo.vespa.config.server.filedistribution.FileDistributionUtil.emptyConnectionPool;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -138,7 +139,12 @@ public class FileServerTest {
     private static class MockFileDownloader extends FileDownloader {
 
         public MockFileDownloader(File downloadDirectory) {
-            super(emptyConnectionPool(), downloadDirectory, new Downloads(), Duration.ofMillis(100), Duration.ofMillis(100));
+            super(FileDownloader.emptyConnectionPool(),
+                  new Supervisor(new Transport("mock")).setDropEmptyBuffers(true),
+                  downloadDirectory,
+                  new Downloads(),
+                  Duration.ofMillis(100),
+                  Duration.ofMillis(100));
         }
 
     }


### PR DESCRIPTION
Cleanup use of supervisor in connection pool and some file download
classes.