### PR TITLE
extend element size to at least contain all matches

### DIFF
--- a/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/element_similarity_feature.cpp
@@ -181,7 +181,8 @@ struct State {
     }
 
     void calculate_scores(size_t num_query_terms, int total_term_weight) {
-        double matches = std::min(element_length, matched_terms);
+        element_length = std::max(element_length, matched_terms);
+        double matches = matched_terms;
         if (matches < 2) {
             proximity = proximity_score(element_length);
             order = (num_query_terms == 1) ? 1.0 : 0.0;


### PR DESCRIPTION
Increase element size rather than reduce the number of matches. This
is to avoid getting scores over 1 for cases where we have matches
outside the element. We do not know if or when this might happen, but
reversing the guard makes it more robust.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 please review
@bratseth FYI