### PR TITLE
Continue grouping even when there is an error

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/GroupingExecutorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/GroupingExecutorTestCase.java
@@ -363,7 +363,7 @@ public class GroupingExecutorTestCase {
         res = exec.search(query);
         assertTrue(res.hits().getError() != null);
         assertEquals(Error.TIMEOUT.code, res.hits().getError().getCode());
-        assertFalse(err.continuedOnFail);
+        assertTrue(err.continuedOnFail);
     }
 
     @Test


### PR DESCRIPTION
* If a grouping pass result includes an error, that
  does not necessarily mean we should give up entirely
  and throw away all grouping results.
* Instead, just merge errors into the main results just
  like all the other errors.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
@baldersheim @havardpe FYI
