### PR TITLE
Update metrics when we don't have source-only bucket copies.

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -248,9 +248,9 @@ MergeOperation::deleteSourceOnlyNodes(
             _ok = _removeOperation->ok();
             done();
         }
+    } else {
+        done();
     }
-    // FIXME what about the else-case here...? done() is not invoked by caller in this branch.
-    // Not calling done() doesn't leak anything, but causes metric updates to be missed.
 }
 
 void


### PR DESCRIPTION
@vekterli : please review
