### PR TITLE
contributing vespaclient in go by <Get.It>

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -12,7 +12,7 @@ BIN ?= $(CURDIR)/bin
 SHARE ?= $(CURDIR)/share
 DIST ?= $(CURDIR)/dist
 
-GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/build.Version=$(VERSION)"
+GO_FLAGS := -ldflags "-X github.com/vespa-engine/client/go/api/build.Version=$(VERSION)"
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 DIST_TARGETS := dist-mac dist-mac-arm64 dist-linux dist-win32 dist-win64
 

--- a/client/go/api/.gitignore
+++ b/client/go/api/.gitignore
@@ -1,0 +1,2 @@
+client.crt
+client.key

--- a/client/go/api/.golangci.yml
+++ b/client/go/api/.golangci.yml
@@ -1,0 +1,43 @@
+linters-settings:
+  govet:
+    check-shadowing: false
+  gocyclo:
+    min-complexity: 20
+  maligned:
+    suggest-new: true
+  gocritic:
+    color: true
+    shorterErrLocation: true
+
+    enabled-tags:
+    - performance
+    - style
+    - experimental
+
+    disabled-checks:
+    - hugeParam
+    - rangeValCopy
+
+linters:
+  enable:
+  - golint
+  - maligned
+  - megacheck
+  - interfacer
+  - unconvert
+  - goconst
+  - misspell
+  - unparam
+  - gofmt
+  - goimports
+  - gocyclo
+  - gocritic
+  - govet
+  - unused
+  - depguard
+  disable:
+  - gas
+
+issues:
+  exclude-use-default: false
+max-same-issues: 10

--- a/client/go/api/Makefile
+++ b/client/go/api/Makefile
@@ -1,0 +1,16 @@
+##@ Test
+test: ## Run unit-tests with coverage.
+	@echo "\033[2m→ Running unit tests...\033[0m"
+	go test -timeout 30s --cover `go list ./...`
+
+lint: ## Run linters only.
+	@echo "\033[2m→ Running linters...\033[0m"
+	golangci-lint run --config .golangci.yml
+
+help:  ## Display help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+#------------- <https://suva.sh/posts/well-documented-makefiles> --------------
+
+
+.DEFAULT_GOAL := help
+.PHONY: build test integration help

--- a/client/go/api/README.md
+++ b/client/go/api/README.md
@@ -1,0 +1,155 @@
+# Vespa-Go
+
+Vespa-Go is a Client for [Vespa](https://vespa.ai/) heavily inspired by [olivere/elastic](https://github.com/olivere/elastic).
+
+## Motivation
+
+# Business
+
+## Features
+
+## Technology Stack
+
+# Technical
+
+## Getting Started
+
+To install the Vespa-Go package, you can run the following:
+
+1. Install:
+```
+$ go get -u github.com/vespa-engine/vespa/vespaclient-go
+```
+
+2. Import in your code:
+
+```
+import github.com/vespa-engine/vespa/vespaclient-go
+```
+
+The minimun go version we have tried is GO 1.14
+
+---
+
+### Quick Start
+
+```
+$ cat quickstart.go
+```
+
+```Go
+// vespa.go
+
+package main
+
+import github.com/vespa-engine/vespa/vespaclient-go
+
+func main() {
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new Vespa client
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the Get Service
+	svc := vespa.NewGetService(client)
+
+	// Get the document by ID
+	res, err := svc.Scheme("job").
+		ID("abc1234").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Note that we leave as you the user the step
+	// to decode the paylod of *res.Fields* to which ever structure
+	// you need.
+}
+
+```
+
+More examples can be found over the [example](./examples/) folder
+
+## Development
+
+## Testing
+
+### **Unit tests**
+
+### **Integration tests**
+
+### **Code analysis**
+
+## Deployment
+
+## Structure of the repository
+
+## Code style
+
+## APIs
+
+The library aims to implement all the operations exposed as API by Vespa.
+
+Logically, the operations are divided by services, where service represents a identificable operation:
+
+- **CreateService**: Used to create or update documents
+- **UpdateService**: Used to *partially* update documents
+- **DeleteService**: Used to delete documents
+- **GetService**: Used to retrieve documents by ID
+- **BatchService**: Used to execute operation such as the ones above, but making multiple requests at the same time using goroutines.
+- **SearchService**: Used to search for documents using YQL
+- **VisitService**: Used to iterate over and get all documents, or a selection of documents, in chunks, using continuation tokens to track progress.
+
+In the future, the batch request will make use of the Async API in order to make a single Request.
+
+For example, in order to BatchDelete documents you could:
+
+```Go
+// delete.go
+
+package main
+
+import github.com/vespa-engine/vespa/vespaclient-go
+
+func main() {
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new Vespa client
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the Get Service
+	svc := vespa.NewDeleteService(client)
+
+	resDelete, err := dSvc.Scheme("job").
+		Selection("job.external_id = ?", "zyx2345").
+		Cluster("job").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Delete response: %+v\n", resDelete)
+}
+```
+> **Warning**:
+> The current API is not considered stable and it is subject to change. However, we hope to stick to semantic versioning in order to keep changes as stable as possible.
+
+## Logging and error handling
+
+### **Logging**
+
+### **Error handling**
+
+## Diagrams/Visuals
+
+## Packages
+
+# External Resources

--- a/client/go/api/Vespa.md
+++ b/client/go/api/Vespa.md
@@ -1,0 +1,81 @@
+# Vespa development environment
+
+Vespa is an engine for low-latency computation over large data sets. 
+It stores and indexes your data so that queries, selection and processing over 
+the data can be performed at serving time. Functionality can be customized and 
+extended with application components hosted within Vespa.
+
+Vespa allows application developers to create backend and middleware systems 
+which scale to accommodate large amounts of data and high loads without 
+sacrificing latency or reliability. A Vespa instance consists of a number of 
+stateless Java container clusters and zero or more content clusters storing data.
+
+Vespa accepts the following operations:
+
+- Writes: Put (add and replace) and remove documents, and update fields in these.
+- Lookup of a document (or some subset of it) by id.
+- Queries: Select documents whose fields match a boolean combination of conditions; 
+matches are either sorted, ranked or grouped. Ranking is done according to a 
+ranking expression, which can be simple mathematical function, express complex 
+business logic, or evaluate a machine learned search ranking model. Grouping is 
+done by field values, in a set of hierarchical groups, where each group can 
+contain aggregated values over the data in the group. Grouping can be combined 
+with aggregation to calculate values for, e.g., navigation aids, tag clouds, 
+graphs or for clustering — all in a distributed fashion, without having to ship 
+all the data back up to a container cluster, which is prohibitively expensive 
+with large data sets.
+- Data dumps: Content matching some criterion can be streamed out for background 
+reprocessing, backup, etc., by using the visit operation.
+- Any other custom network request which can be handled by application components 
+deployed on a container cluster.
+
+These operations allow developers to build feature rich applications expressed 
+as Java middleware logic working on stored content, where selection, keyword 
+searches and organization and processing of the content can be expressed as 
+declarative queries by the middleware logic.
+
+---
+
+## Installation
+
+### List of tools
+
+This is the list of tools a developer needs to install locally to work with Vespa:
+
+- Docker desktop
+- Git
+- Minimum 6GB memory dedicated to Docker (the default is 2GB on Macs) & 10G for monitoring section
+
+
+### Setup Vespa locally
+
+Follow the next steps to setup Vespa locally:
+
+- Insert a new container that defines Vespa details inside the `docker-compose.yaml` file
+- Add the new package called **vespa** in your Golang project
+- Create the `/application` folder
+- Define the configuration files `hosts.xml` & `services.xml`
+- Include the `/schema` folder and create the definition of the document `<document name>.sd`
+- Run the next command to initialize the Vespa container:
+```
+$ docker-compose up -d <vespa container name>
+```
+
+
+### Connect to Vespa Cloud
+
+- Create an application in the Vespa Cloud
+
+- Create a self-signed certificate for the local application source 
+(If you didn't add it when you create the local application)
+- Deploy the application
+- Verify that you can reach the application endpoint
+- Store data and run queries using the **/document/v1 api** 
+
+For more details: 
+- [Getting Started with the Vespa Cloud](https://cloud.vespa.ai/en/getting-started)
+- [/document/v1 API](https://docs.vespa.ai/en/reference/document-v1-api-reference.html)
+- [Query API](https://docs.vespa.ai/en/reference/query-api-reference.html)
+
+---
+

--- a/client/go/api/batch.go
+++ b/client/go/api/batch.go
@@ -1,0 +1,169 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+)
+
+// BatchService allows for batching batch requests to Vespa. It currently
+// makes use of the sync api. In the future we expect this to work with the
+// async api.
+type BatchService struct {
+	client HTTPClient
+
+	namespace string
+	scheme    string
+	timeout   string
+	headers   http.Header
+
+	requests []BatchableRequest
+}
+
+// NewBatchService will create and instance of BatchService.
+func NewBatchService(client HTTPClient) *BatchService {
+	return &BatchService{
+		client: client,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *BatchService) Namespace(name string) *BatchService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *BatchService) Scheme(scheme string) *BatchService {
+	s.scheme = scheme
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional
+// ks, s, ms or µs unit.
+func (s *BatchService) Timeout(timeout string) *BatchService {
+	s.timeout = timeout
+	return s
+}
+
+// Add adds batchable requests, such as CreateBatchRequest
+func (s *BatchService) Add(requests ...BatchableRequest) *BatchService {
+	s.requests = append(s.requests, requests...)
+	return s
+}
+
+// Len return the number of requests to send
+func (s *BatchService) Len() int {
+	return len(s.requests)
+}
+
+// Do will send a number of current goroutines to Vespa. It will reuse the connection
+// pool of the HttpClient
+func (s *BatchService) Do(ctx context.Context) *BatchResponse {
+	now := time.Now()
+	resCh := make(chan HTTPResponse)
+	for _, item := range s.requests {
+		go s.makeRequest(ctx, item, resCh)
+	}
+
+	var batchResponse BatchResponse
+
+	for i := 0; i < s.Len(); i++ {
+		res := <-resCh
+		item, err := s.processResponse(res)
+		if err {
+			batchResponse.Errors = true
+		}
+		batchResponse.Items = append(batchResponse.Items, item)
+	}
+
+	batchResponse.Took = time.Since(now)
+
+	return &batchResponse
+
+}
+
+func (s *BatchService) makeRequest(ctx context.Context, request BatchableRequest, out chan<- HTTPResponse) {
+	if err := request.Validate(); err != nil {
+		out <- HTTPResponse{
+			res: nil,
+			err: err,
+		}
+		return
+	}
+
+	// Get URL for request
+	method, path, params := request.BuildURL()
+	data := request.Source()
+
+	// Get HTTP response
+	response, err := s.client.PerformRequest(ctx, PerformRequest{
+		Method:  method,
+		Path:    path,
+		Params:  params,
+		Body:    data,
+		Headers: s.headers,
+	})
+	if err != nil {
+		out <- HTTPResponse{
+			res: nil,
+			err: err,
+		}
+		return
+	}
+
+	out <- HTTPResponse{
+		res: response,
+		err: err,
+	}
+
+}
+
+func (s *BatchService) processResponse(res HTTPResponse) (BatchResponseItem, bool) {
+	var item BatchResponseItem
+
+	if res.err != nil {
+		item.Message = res.err.Error()
+		return item, true
+	}
+
+	defer func() {
+		err := res.res.Body.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	item.Status = res.res.StatusCode
+
+	err := json.NewDecoder(res.res.Body).Decode(&item)
+	if err != nil {
+		item.Message = err.Error()
+	}
+
+	return item, false
+}
+
+// BatchResponse is the return of a batch Response.
+type BatchResponse struct {
+	Took   time.Duration
+	Errors bool
+	Items  []BatchResponseItem
+}
+
+// BatchResponseItem is one of the items under a batch response.
+type BatchResponseItem struct {
+	Status  int    `json:"status"`
+	ID      string `json:"id,omitempty"`
+	PathID  string `json:"pathId,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// HTTPResponse groups a *httpResponse and an error to send through a channel
+type HTTPResponse struct {
+	res *http.Response
+	err error
+}

--- a/client/go/api/batch_request.go
+++ b/client/go/api/batch_request.go
@@ -1,0 +1,11 @@
+package vespa
+
+import "net/url"
+
+// BatchableRequest defines a struc that is able to
+// be used by the BatchService. Wraps the method Source()
+type BatchableRequest interface {
+	Source() interface{}
+	Validate() error
+	BuildURL() (method, path string, parameters url.Values)
+}

--- a/client/go/api/batch_test.go
+++ b/client/go/api/batch_test.go
@@ -1,0 +1,473 @@
+package vespa
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestNewBatchService(t *testing.T) {
+	client := &Client{}
+
+	want := &BatchService{
+		client: client,
+	}
+	got := NewBatchService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewCreateService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestBatchService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *BatchService
+	}{
+		{
+			name: " with default value",
+			args: args{
+				name: "default",
+			},
+			want: &BatchService{
+				namespace: "default",
+			},
+		},
+		{
+			name: " with specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &BatchService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{}
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+func TestBatchService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *BatchService
+	}{
+		{
+			name: " with cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &BatchService{
+				scheme: "cars",
+			},
+		},
+		{
+			name: " with places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &BatchService{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{}
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BatchService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchService_Timeout(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *BatchService
+	}{
+		{
+			name: "with a second value",
+			args: args{
+				timeout: "12s",
+			},
+			want: &BatchService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "with a minute value",
+			args: args{
+				timeout: "1m",
+			},
+			want: &BatchService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchService_Add(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		timeout   string
+		headers   http.Header
+		requests  []BatchableRequest
+	}
+	type args struct {
+		requests []BatchableRequest
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *BatchService
+	}{
+		{
+			name: "with valid data it should be set on requests field",
+			args: args{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "job",
+						id:        "21",
+						data:      "data",
+					},
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "job",
+						id:        "22",
+						data:      "data2",
+					},
+				},
+			},
+			want: &BatchService{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "job",
+						id:        "21",
+						data:      "data",
+					},
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "job",
+						id:        "22",
+						data:      "data2",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+				requests:  tt.fields.requests,
+			}
+			if got := s.Add(tt.args.requests...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BatchService.Add() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchService_Len(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		timeout   string
+		headers   http.Header
+		requests  []BatchableRequest
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		{
+			name: "with 2 requests expect len of 2",
+			fields: fields{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						id:   "21",
+						data: "data",
+					},
+					&CreateBatchRequest{
+						id:   "22",
+						data: "data2",
+					},
+				},
+			},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+				requests:  tt.fields.requests,
+			}
+			if got := s.Len(); got != tt.want {
+				t.Errorf("BatchService.Len() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBatchService_Do(t *testing.T) {
+	ctx := context.Background()
+
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		timeout   string
+		headers   http.Header
+		requests  []BatchableRequest
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *BatchResponse
+	}{
+		{
+			name: "when the process completes the operation, we should get the expected response",
+			args: args{
+				ctx: ctx,
+			},
+			fields: fields{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "post",
+						id:        "21",
+						data:      "data",
+					},
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "post",
+						id:        "22",
+						data:      "data2",
+					},
+				},
+				client: &httpClientBatchMock{
+					responses: map[string]BatchMockResponse{
+						"/document/v1/default/post/docid/21": {
+							code: 200,
+							data: ioutil.NopCloser(strings.NewReader(`
+								{
+									"id":      "21",
+									"pathId":  "/document/v1/default/post/docid/21"
+								}
+							`)),
+							err: nil,
+						},
+						"/document/v1/default/post/docid/22": {
+							code: 200,
+							data: ioutil.NopCloser(strings.NewReader(`
+								{
+									"id":      "22",
+									"pathId":  "/document/v1/default/post/docid/22"						
+								}
+							`)),
+							err: nil,
+						},
+					},
+				},
+			},
+			want: &BatchResponse{
+				Errors: false,
+				Items: []BatchResponseItem{
+					{
+						Status:  200,
+						ID:      "21",
+						PathID:  "/document/v1/default/post/docid/21",
+						Message: "",
+					},
+					{
+						Status:  200,
+						ID:      "22",
+						PathID:  "/document/v1/default/post/docid/22",
+						Message: "",
+					},
+				},
+			},
+		},
+		{
+			name: "when the request is invalid we should get an error",
+			args: args{
+				ctx: ctx,
+			},
+			fields: fields{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "post",
+						data:      "data",
+					},
+				},
+				client: &httpClientBatchMock{
+					responses: map[string]BatchMockResponse{},
+				},
+			},
+			want: &BatchResponse{
+				Errors: true,
+				Items: []BatchResponseItem{
+					{
+						Status:  0,
+						Message: "missing required fields for operation: [id]",
+					},
+				},
+			},
+		},
+		{
+			name: "when performing a requests returns an error we should get an error",
+			args: args{
+				ctx: ctx,
+			},
+			fields: fields{
+				requests: []BatchableRequest{
+					&CreateBatchRequest{
+						namespace: "default",
+						scheme:    "post",
+						id:        "21",
+						data:      "data",
+					},
+				},
+				client: &httpClientBatchMock{
+					err:       errors.New("http client error"),
+					responses: map[string]BatchMockResponse{},
+				},
+			},
+			want: &BatchResponse{
+				Errors: true,
+				Items: []BatchResponseItem{
+					{
+						Status:  0,
+						Message: "http client error",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &BatchService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+				requests:  tt.fields.requests,
+			}
+			got := s.Do(tt.args.ctx)
+			// We sort the output by id so we don't care about the order of
+			// the routines
+			sort.Slice(got.Items, func(i, j int) bool {
+				return got.Items[i].ID < got.Items[j].ID
+			})
+
+			if !reflect.DeepEqual(got.Items, tt.want.Items) {
+				t.Errorf("BatchService.Do() = %v, want %v", got.Items, tt.want.Items)
+			}
+
+		})
+	}
+}
+
+type httpClientBatchMock struct {
+	err error
+
+	responses map[string]BatchMockResponse
+}
+
+type BatchMockResponse struct {
+	code int
+	err  error
+	data io.ReadCloser
+}
+
+func (m *httpClientBatchMock) PerformRequest(ctx context.Context, opt PerformRequest) (*http.Response, error) {
+	res := &http.Response{}
+
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	item, ok := m.responses[opt.Path]
+	if !ok {
+		return nil, errors.New("no response set on test")
+	}
+
+	if item.code == 0 {
+		return nil, item.err
+	}
+
+	res.StatusCode = item.code
+
+	res.Body = item.data
+
+	return res, nil
+}

--- a/client/go/api/bitbucket-pipelines.yml
+++ b/client/go/api/bitbucket-pipelines.yml
@@ -1,0 +1,33 @@
+# This is a sample build configuration for Go.
+# Check our guides at https://confluence.atlassian.com/x/5Q4SMw for more examples.
+# Only use spaces to indent your .yml configuration.
+# -----
+# You can specify a custom docker image from Docker Hub as your build environment.
+image: golang:1.16-alpine
+
+options:
+  docker: true
+
+definitions:
+  steps:
+    - step: &test
+        script:
+          - CGO_ENABLED=0 go test -covermode=count -timeout=30s ./...
+    - step: &lint
+        script:
+          - apk add --update git
+          - wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
+          - GO111MODULE=on CGO_ENABLED=0 golangci-lint run --config .golangci.yml
+
+pipelines:
+  default:
+    - step: *test
+    - step: *lint
+  tags:
+    "v*.*.*":
+      - step: *test
+      # - step: *lint
+  branches:
+    master:
+      - step: *test
+      - step: *lint

--- a/client/go/api/client.go
+++ b/client/go/api/client.go
@@ -1,0 +1,230 @@
+package vespa
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+const (
+	// DefaultHost is the default host where Vespa would be running. All endpoints should be relative to this url
+	DefaultHost = "127.0.0.1:6800"
+	// DefaultScheme is the default schema used to communicate with Vespa.
+	DefaultScheme = "http"
+	// DefaultContentType is the default time we expect
+	DefaultContentType = "application/json"
+)
+
+// Doer is the interface that wraps the Do methos which performs an http Request.
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// ClientOptionFunc is a function that handles a single configure option for
+// a Client. It is used when calling NewClient
+type ClientOptionFunc func(*Client) error
+
+// Client is the Vespa Client. Usually created by calling NewClient
+type Client struct {
+	c           Doer
+	baseURL     *url.URL
+	UserAgent   string
+	GzipRequest bool
+}
+
+// NewClient creates a new client to work with vespa. If no options provided, it
+// will create the options with default values
+func NewClient(ctx context.Context, options ...ClientOptionFunc) (*Client, error) {
+
+	c := &Client{
+		c: http.DefaultClient,
+	}
+
+	c.baseURL = &url.URL{Host: DefaultHost, Scheme: DefaultScheme}
+
+	// Run the options on it
+	for _, option := range options {
+		if err := option(c); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+// SetHTTPClient can be used to specify the http.Client to use when making
+// HTTP requests to Elasticsearch.
+func SetHTTPClient(httpClient Doer) ClientOptionFunc {
+	return func(c *Client) error {
+		if httpClient != nil {
+			c.c = httpClient
+		} else {
+			c.c = http.DefaultClient
+		}
+		return nil
+	}
+}
+
+// SetURL defines the URL where Vespa can be reached.
+func SetURL(urlStr string) ClientOptionFunc {
+	return func(c *Client) error {
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			return err
+		}
+
+		c.baseURL = u
+		return nil
+	}
+}
+
+// GzipRequests will make all requests' body be gzipped before sending
+func GzipRequests(v bool) ClientOptionFunc {
+	return func(c *Client) error {
+		c.GzipRequest = v
+		return nil
+	}
+}
+
+// PerformRequest contains all the necessary parameters in order to
+// performn a Request to Vespa.
+type PerformRequest struct {
+	Method      string
+	Path        string
+	Params      url.Values
+	Body        interface{}
+	ContentType string
+	// IgnoreErrors     []int
+	// // Retrier          Retrier
+	// RetryStatusCodes []int
+	Headers         http.Header
+	MaxResponseSize int64
+}
+
+// PerformRequest will send the request to Vespa and will return a http.Response object. In
+// the case of an error, it will return
+func (c *Client) PerformRequest(ctx context.Context, opt PerformRequest) (*http.Response, error) {
+	pathWithParams := opt.Path
+	if len(opt.Params) > 0 {
+		pathWithParams = fmt.Sprintf("%s?%s", pathWithParams, opt.Params.Encode())
+	}
+
+	req, err := c.newRequest(opt.Method, pathWithParams, opt.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if opt.ContentType != "" {
+		req.Header.Set("Content-Type", opt.ContentType)
+	} else {
+		req.Header.Set("Content-Type", DefaultContentType)
+	}
+
+	if len(opt.Headers) > 0 {
+		for key, value := range opt.Headers {
+			for _, v := range value {
+				req.Header.Add(key, v)
+			}
+		}
+	}
+
+	res, err := c.c.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+
+}
+
+func (c *Client) newRequest(method, path string, body interface{}) (*http.Request, error) {
+	var req *http.Request
+
+	rel, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+
+	u := c.baseURL.ResolveReference(rel)
+
+	var buf io.ReadWriter
+	if body != nil {
+		if c.GzipRequest {
+			r, w := io.Pipe()
+
+			go func() {
+				gz := GetGzipWriter()
+				gz.Reset(w)
+				defer gzPool.Put(gz)
+
+				if err := json.NewEncoder(gz).Encode(body); err != nil {
+					log.Println(err)
+				}
+
+				err = gz.Close()
+				if err != nil {
+					log.Println(err)
+				}
+
+				err = w.CloseWithError(err)
+				if err != nil {
+					log.Println(err)
+				}
+			}()
+
+			req, err = http.NewRequest(method, u.String(), r)
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Encoding", "gzip")
+		} else {
+			buf = new(bytes.Buffer)
+			err := json.NewEncoder(buf).Encode(body)
+			if err != nil {
+				return nil, err
+			}
+			req, err = http.NewRequest(method, u.String(), buf)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		req, err = http.NewRequest(method, u.String(), nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.UserAgent)
+
+	return req, nil
+}
+
+var gzPool = sync.Pool{
+	New: func() interface{} {
+		return gzip.NewWriter(ioutil.Discard)
+	},
+}
+
+// GetGzipWriter grabs a gzipper from the sync pool
+func GetGzipWriter() *gzip.Writer {
+	return gzPool.Get().(*gzip.Writer)
+}
+
+// PutGzipWriter returns the gzipper to the sync pool
+func PutGzipWriter(buf *gzip.Writer) {
+	err := buf.Flush()
+	if err != nil {
+		log.Printf("Could not flush writer: %v", err)
+	}
+	gzPool.Put(buf)
+}

--- a/client/go/api/client_test.go
+++ b/client/go/api/client_test.go
@@ -1,0 +1,361 @@
+package vespa
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestClientDefaults(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := NewClient(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	durl := &url.URL{Scheme: "http", Host: "127.0.0.1:6800"}
+
+	if client.baseURL.String() != durl.String() {
+		t.Errorf("expected default url to be %v, got: %v", durl, client.baseURL)
+	}
+
+	if client.c != http.DefaultClient {
+		t.Errorf("expected c to be %v, got: %v", http.DefaultClient, client.c)
+
+	}
+}
+
+func TestClientWithErrorOption(t *testing.T) {
+	ctx := context.Background()
+
+	errFn := func(*Client) error {
+		return errors.New("error")
+	}
+
+	_, err := NewClient(ctx, errFn)
+	if err == nil {
+		t.Errorf("expected New client to return error, got: %v", err)
+	}
+}
+
+func TestClientWithHTTPClient(t *testing.T) {
+	ctx := context.Background()
+
+	c := &http.Client{}
+	client, err := NewClient(ctx, SetHTTPClient(c))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.c != c {
+		t.Errorf("expected client.c(doer) to be %v, got: %v ", c, client.c)
+	}
+}
+
+func TestClientWithNikHTTPClient(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, SetHTTPClient(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if client.c != http.DefaultClient {
+		t.Errorf("expected client.c(doer) to be %v, got: %v ", http.DefaultClient, client.c)
+	}
+}
+
+func TestClientWithSetURL(t *testing.T) {
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, SetURL("https://localhost:8080"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &url.URL{Host: "localhost:8080", Scheme: "https"}
+
+	if client.baseURL.String() != expected.String() {
+		t.Errorf("expected baseURL to be %v, got: %v", expected.String(), client.baseURL)
+	}
+}
+
+func TestClientWithInvalidSetURL(t *testing.T) {
+	ctx := context.Background()
+
+	_, err := NewClient(ctx, SetURL("http://foo.com/?foo\nbar"))
+	if err == nil {
+		t.Errorf("expected NewClient() to return error, got: %v", err)
+	}
+
+}
+
+func TestPerformRequest(t *testing.T) {
+
+	data := `{"data": "json"})`
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.PerformRequest(ctx, PerformRequest{
+		Method: "Get",
+		Path:   "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != data {
+		t.Errorf(" expected response body to return %s, got: %s", data, body)
+	}
+
+}
+
+func TestPerformGzippedRequest(t *testing.T) {
+
+	expect := "\"{\\\"type\\\": \\\"gzip\\\"}\"\n"
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			res, _ := ioutil.ReadAll(req.Body)
+			b := bytes.NewBuffer(res)
+
+			var r io.Reader
+			r, err := gzip.NewReader(b)
+			if err != nil {
+				return
+			}
+
+			var resB bytes.Buffer
+			_, err = resB.ReadFrom(r)
+			if err != nil {
+				return
+			}
+
+			resData := resB.String()
+
+			fmt.Fprint(w, resData)
+		},
+	))
+
+	ctx := context.Background()
+
+	client, err := NewClient(ctx, SetURL(ts.URL), GzipRequests(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.PerformRequest(ctx, PerformRequest{
+		Method: "POST",
+		Path:   "",
+		Body:   "{\"type\": \"gzip\"}",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(string(body))
+
+	if string(body) != expect {
+		t.Errorf(" expected response body to return %s, got: %s", expect, body)
+	}
+
+}
+
+func TestPerformRequestWithParam(t *testing.T) {
+	expect := `/document/v1?page=1`
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			data := fmt.Sprintf("%s?%s", r.URL.Path, r.URL.RawQuery)
+
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	u := url.URL{}
+	params := u.Query()
+	params.Add("page", "1")
+
+	res, err := client.PerformRequest(ctx, PerformRequest{
+		Method: "Get",
+		Path:   "document/v1",
+		Params: params,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != expect {
+		t.Errorf(" expected response body to return %s, got: %s", expect, body)
+	}
+
+}
+
+func TestPerformRequestWithContentHeader(t *testing.T) {
+	expect := `Content-Type: application/json`
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			ct := r.Header.Get("Content-Type")
+			data := fmt.Sprintf("Content-Type: %s", ct)
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.PerformRequest(ctx, PerformRequest{
+		Method:      "Get",
+		Path:        "document/v1",
+		ContentType: "application/json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != expect {
+		t.Errorf(" expected response body to return %s, got: %s", expect, body)
+	}
+}
+
+func TestPerformRequestWithHeader(t *testing.T) {
+	expect := `header: value`
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			value := r.Header.Get("header")
+			data := fmt.Sprintf("header: %s", value)
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headers := http.Header{}
+	headers.Add("header", "value")
+
+	res, err := client.PerformRequest(ctx, PerformRequest{
+		Method:  "Get",
+		Path:    "document/v1",
+		Headers: headers,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(body) != expect {
+		t.Errorf(" expected response body to return %s, got: %s", expect, body)
+	}
+}
+
+func TestPerformRequestWithInvalidBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			value := r.Header.Get("header")
+			data := fmt.Sprintf("header: %s", value)
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headers := http.Header{}
+	headers.Add("header", "value")
+
+	_, err = client.PerformRequest(ctx, PerformRequest{
+		Method:  "Get",
+		Path:    "document/v1",
+		Headers: headers,
+		Body:    make(chan int),
+	})
+	if err == nil {
+		t.Errorf(" expected PerformRequest() to return error on invalid body value")
+	}
+}
+
+func TestPerformRequestWithValidBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			value := r.Header.Get("header")
+			data := fmt.Sprintf("header: %s", value)
+			fmt.Fprint(w, data)
+		},
+	))
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, SetURL(ts.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	headers := http.Header{}
+	headers.Add("header", "value")
+
+	_, err = client.PerformRequest(ctx, PerformRequest{
+		Method:  "Post",
+		Path:    "document/v1",
+		Headers: headers,
+		Body:    `{"name": "valid"}`,
+	})
+	if err != nil {
+		t.Errorf(" expected PerformRequest() to not return err")
+	}
+}

--- a/client/go/api/create.go
+++ b/client/go/api/create.go
@@ -1,0 +1,171 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+const (
+	// DefaultNamespace defines the default namespace documents live in when we the
+	// user does not specifies one namespace
+	DefaultNamespace = "default"
+)
+
+// CreateService adds or updates a typed JSON document in a specified schema,
+// making it searchable.
+//
+// See https://docs.vespa.ai/en/document-v1-api-guide.html
+// for details.
+type CreateService struct {
+	client HTTPClient
+
+	namespace string
+	scheme    string
+	id        string
+	data      interface{}
+	timeout   string
+	headers   http.Header
+}
+
+// HTTPClient is the interface that wraps the PerformRequest operation
+// which makes requests to Vespa through http.
+type HTTPClient interface {
+	PerformRequest(ctx context.Context, opt PerformRequest) (*http.Response, error)
+}
+
+// NewCreateService will create and instance of CreateService.
+func NewCreateService(client HTTPClient) *CreateService {
+	return &CreateService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *CreateService) Namespace(name string) *CreateService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *CreateService) Scheme(scheme string) *CreateService {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *CreateService) ID(id string) *CreateService {
+	s.id = id
+	return s
+}
+
+// Body sets the documents to insert. It needs to be a JSON serializable object.
+func (s *CreateService) Body(body interface{}) *CreateService {
+	s.data = body
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional
+// ks, s, ms or µs unit.
+func (s *CreateService) Timeout(timeout string) *CreateService {
+	s.timeout = timeout
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *CreateService) Validate() error {
+	var invalid []string
+	if s.id == "" {
+		invalid = append(invalid, "id")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+	if s.data == nil {
+		invalid = append(invalid, "data")
+	}
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+func (s *CreateService) buildURL() (method, path string, params url.Values) {
+
+	method = http.MethodPost
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params = url.Values{}
+	if s.timeout != "" {
+		params.Set("timeout", s.timeout)
+	}
+
+	return method, path, params
+
+}
+
+// Source returns the body of the request we will make to create job
+// endpoint
+func (s *CreateService) Source() interface{} {
+	payload := make(map[string]interface{})
+
+	payload["fields"] = s.data
+
+	return payload
+}
+
+// Do executes the create operation. Returns a CreateResponse or an error.
+func (s *CreateService) Do(ctx context.Context) (*CreateResponse, error) {
+
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	method, path, params := s.buildURL()
+	data := s.Source()
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequest{
+		Method:  method,
+		Path:    path,
+		Params:  params,
+		Body:    data,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	var cr CreateResponse
+	cr.Status = res.StatusCode
+
+	err = json.NewDecoder(res.Body).Decode(&cr)
+
+	return &cr, err
+
+}
+
+// CreateResponse is the result of creating a document in Vespa.
+type CreateResponse struct {
+	Status  int    `json:"status"`
+	ID      string `json:"id,omitempty"`
+	PathID  string `json:"pathId,omitempty"`
+	Message string `json:"message,omitempty"`
+}

--- a/client/go/api/create_batch_request.go
+++ b/client/go/api/create_batch_request.go
@@ -1,0 +1,95 @@
+package vespa
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// CreateBatchRequest is a request to insert document into vespa.
+// Implements the Batcheable interface so it can be used with
+// the Batch Service.
+type CreateBatchRequest struct {
+	BatchableRequest
+	namespace string
+	scheme    string
+	id        string
+	data      interface{}
+	headers   http.Header
+}
+
+// NewCreateBatchRequest returns a new CreateBatchRequest object.
+func NewCreateBatchRequest() *CreateBatchRequest {
+	return &CreateBatchRequest{}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *CreateBatchRequest) Namespace(name string) *CreateBatchRequest {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *CreateBatchRequest) Scheme(scheme string) *CreateBatchRequest {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *CreateBatchRequest) ID(id string) *CreateBatchRequest {
+	s.id = id
+	return s
+}
+
+// Body sets the documents to insert. It needs to be a JSON serializable object.
+func (s *CreateBatchRequest) Body(body interface{}) *CreateBatchRequest {
+	s.data = body
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *CreateBatchRequest) Validate() error {
+	var invalid []string
+	if s.id == "" {
+		invalid = append(invalid, "id")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+	if s.data == nil {
+		invalid = append(invalid, "data")
+	}
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+// BuildURL returns the values that combined can be used to build the target
+// url for the batch operation.
+func (s *CreateBatchRequest) BuildURL() (method, path string, params url.Values) {
+
+	method = http.MethodPost
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params = url.Values{}
+
+	return method, path, params
+
+}
+
+// Source returns the body of the request we will make to create job
+// endpoint
+func (s *CreateBatchRequest) Source() interface{} {
+	payload := make(map[string]interface{})
+
+	payload["fields"] = s.data
+
+	return payload
+}

--- a/client/go/api/create_batch_request_test.go
+++ b/client/go/api/create_batch_request_test.go
@@ -1,0 +1,242 @@
+package vespa
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestNewCreateBatchRequest(t *testing.T) {
+
+	want := &CreateBatchRequest{}
+	got := NewCreateBatchRequest()
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewCreateBatchRequest() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestNewCreateBatchRequest_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateBatchRequest
+	}{
+		{
+			name: " with default value",
+			args: args{
+				name: "default",
+			},
+			want: &CreateBatchRequest{
+				namespace: "default",
+			},
+		},
+		{
+			name: " with specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &CreateBatchRequest{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateBatchRequest{}
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewCreateBatchRequest.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateBatchRequest_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateBatchRequest
+	}{
+		{
+			name: " with cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &CreateBatchRequest{
+				scheme: "cars",
+			},
+		},
+		{
+			name: " with places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &CreateBatchRequest{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateBatchRequest{}
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateBatchRequest.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateBatchRequest_ID(t *testing.T) {
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateBatchRequest
+	}{
+		{
+			name: " with an id value value",
+			args: args{
+				id: "aaaa",
+			},
+			want: &CreateBatchRequest{
+				id: "aaaa",
+			},
+		},
+		{
+			name: " with another id value",
+			args: args{
+				id: "bbbb",
+			},
+			want: &CreateBatchRequest{
+				id: "bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateBatchRequest{}
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateBatchRequest.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateBatchRequest_Body(t *testing.T) {
+
+	type args struct {
+		body interface{}
+	}
+
+	object := struct {
+		field string
+	}{
+		field: "value",
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *CreateBatchRequest
+	}{
+		{
+			name: " with an string value",
+			args: args{
+				body: "string",
+			},
+			want: &CreateBatchRequest{
+				data: "string",
+			},
+		},
+		{
+			name: " with int value",
+			args: args{
+				body: 23,
+			},
+			want: &CreateBatchRequest{
+				data: 23,
+			},
+		},
+		{
+			name: " with struct value",
+			args: args{
+				body: object,
+			},
+			want: &CreateBatchRequest{
+				data: object,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateBatchRequest{}
+			if got := s.Body(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateBatchRequest.Body() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateBatchRequest_Validate(t *testing.T) {
+	type fields struct {
+		namespace string
+		scheme    string
+		id        string
+		data      interface{}
+
+		headers http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "missing one required field should return error",
+			fields: fields{
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all fields set should return error nil",
+			fields: fields{
+				id:        "1",
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateBatchRequest{
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				headers:   tt.fields.headers,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("CreateBatchRequest.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/client/go/api/create_test.go
+++ b/client/go/api/create_test.go
@@ -1,0 +1,596 @@
+package vespa
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewCreateService(t *testing.T) {
+	client := &Client{}
+
+	want := &CreateService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+	got := NewCreateService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewCreateService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestCreateService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateService
+	}{
+		{
+			name: " with default value",
+			args: args{
+				name: "default",
+			},
+			want: &CreateService{
+				namespace: "default",
+			},
+		},
+		{
+			name: " with specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &CreateService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{}
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateService
+	}{
+		{
+			name: " with cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &CreateService{
+				scheme: "cars",
+			},
+		},
+		{
+			name: " with places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &CreateService{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{}
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateService_ID(t *testing.T) {
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CreateService
+	}{
+		{
+			name: " with an id value value",
+			args: args{
+				id: "aaaa",
+			},
+			want: &CreateService{
+				id: "aaaa",
+			},
+		},
+		{
+			name: " with another id value",
+			args: args{
+				id: "bbbb",
+			},
+			want: &CreateService{
+				id: "bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{}
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateService_Body(t *testing.T) {
+
+	type args struct {
+		body interface{}
+	}
+
+	object := struct {
+		field string
+	}{
+		field: "value",
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want *CreateService
+	}{
+		{
+			name: " with an string value",
+			args: args{
+				body: "string",
+			},
+			want: &CreateService{
+				data: "string",
+			},
+		},
+		{
+			name: " with int value",
+			args: args{
+				body: 23,
+			},
+			want: &CreateService{
+				data: 23,
+			},
+		},
+		{
+			name: " with struct value",
+			args: args{
+				body: object,
+			},
+			want: &CreateService{
+				data: object,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{}
+			if got := s.Body(tt.args.body); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Body() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateService_Timeout(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      interface{}
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *CreateService
+	}{
+		{
+			name: "with a second value",
+			args: args{
+				timeout: "12s",
+			},
+			want: &CreateService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "with a minute value",
+			args: args{
+				timeout: "1m",
+			},
+			want: &CreateService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateService_Validate(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      interface{}
+		timeout   string
+		headers   http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "missing one required field should return error",
+			fields: fields{
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all fields set should return error nil",
+			fields: fields{
+				id:        "1",
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("CreateService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCreateService_buildURL(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      interface{}
+		timeout   string
+		headers   http.Header
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "when called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+			},
+			want:  "POST",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{},
+		},
+		{
+			name: "when called with timeout, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+				timeout:   "12s",
+			},
+			want:  "POST",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{
+				"timeout": []string{"12s"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, got1, got2 := s.buildURL()
+
+			if got != tt.want {
+				t.Errorf("CreateService.buildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("CreateService.buildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("CreateService.buildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestCreateService_Source(t *testing.T) {
+	data := struct {
+		ID string `json:"id,omitempty"`
+	}{
+		ID: "aaa",
+	}
+
+	data2 := map[string]string{
+		"key": "value",
+	}
+
+	type fields struct {
+		data interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   interface{}
+	}{
+		{
+			name: "when called, the fields should be under a fields key",
+			fields: fields{
+				data: data,
+			},
+			want: map[string]interface{}{
+				"fields": data,
+			},
+		},
+		{
+			name: "when called and data is a map, map should be under a fields key",
+			fields: fields{
+				data: data2,
+			},
+			want: map[string]interface{}{
+				"fields": data2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{
+				data: tt.fields.data,
+			}
+			got := s.Source()
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Source() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type httpClientMock struct {
+	code      int
+	err       error
+	body      io.ReadCloser
+	responses []mockResponse // used to simulate multiple requests
+	current   int
+}
+
+type mockResponse struct {
+	status int
+	body   io.ReadCloser
+}
+
+func (m *httpClientMock) PerformRequest(ctx context.Context, opt PerformRequest) (*http.Response, error) {
+	res := &http.Response{}
+
+	if m.code == 0 {
+		return nil, m.err
+	}
+
+	res.StatusCode = m.code
+	res.Body = m.body
+
+	if len(m.responses) > 0 {
+		res.Body = m.responses[m.current].body
+		res.StatusCode = m.responses[m.current].status
+
+		m.current++
+	}
+
+	return res, nil
+}
+
+func TestCreateService_Do(t *testing.T) {
+
+	ctx := context.Background()
+
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      interface{}
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *CreateResponse
+		wantErr bool
+	}{
+		{
+			name:   "when validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				id:        "1",
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request succeeds, it should return a CreateResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:post:001",
+						"pathId":  "/document/v1/default/job/docid/001"						
+					}
+					`)),
+				},
+				id:        "1",
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &CreateResponse{
+				Status:  200,
+				ID:      "id:default:post:001",
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request returns with an http error, we should return a message",
+			fields: fields{
+				client: &httpClientMock{
+					code: 400,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"pathId":  "/document/v1/default/job/docid/001",
+						"message":	"No field 'beat_that' in the structure of type 'work'"
+					}
+					`)),
+				},
+				id:        "1",
+				scheme:    "posts",
+				data:      "data",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &CreateResponse{
+				Status:  400,
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "No field 'beat_that' in the structure of type 'work'",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &CreateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, err := s.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CreateService.Do() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/delete.go
+++ b/client/go/api/delete.go
@@ -1,0 +1,224 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// DeleteService removes documents from a given schema
+//
+// See https://docs.vespa.ai/en/document-v1-api-guide.html
+// for details.
+type DeleteService struct {
+	client HTTPClient
+
+	namespace       string
+	scheme          string
+	id              string
+	selection       string
+	selectionClause whereParams
+	timeout         string
+	continuation    string
+	cluster         string
+
+	headers http.Header
+}
+
+// NewDeleteService will create and instance of DeleteService.
+func NewDeleteService(client HTTPClient) *DeleteService {
+	return &DeleteService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *DeleteService) Namespace(name string) *DeleteService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *DeleteService) Scheme(scheme string) *DeleteService {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *DeleteService) ID(id string) *DeleteService {
+	s.id = id
+	return s
+}
+
+// Continuation sets the continuation values to make a new request
+func (s *DeleteService) Continuation(continuation string) *DeleteService {
+	s.continuation = continuation
+	return s
+}
+
+// Cluster sets the cluster value to make a new request
+func (s *DeleteService) Cluster(cluster string) *DeleteService {
+	s.cluster = cluster
+	return s
+}
+
+// Selection sets the selection string for the update. Check
+// https://docs.vespa.ai/en/reference/document-select-language.html for
+// supported sintax.
+func (s *DeleteService) Selection(where string, params ...interface{}) *DeleteService {
+	s.selectionClause = whereParams{
+		where:  where,
+		params: params,
+	}
+	s.buildSelect()
+
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional
+// ks, s, ms or µs unit.
+func (s *DeleteService) Timeout(timeout string) *DeleteService {
+	s.timeout = timeout
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *DeleteService) Validate() error {
+	var invalid []string
+	if s.id == "" && s.selection == "" {
+		invalid = append(invalid, "id/selection")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+func (s *DeleteService) buildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodDelete
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params := url.Values{}
+	if s.timeout != "" {
+		params.Set("timeout", s.timeout)
+	}
+	if s.selection != "" {
+		params.Set("selection", s.selection)
+	}
+
+	if s.continuation != "" {
+		params.Set("continuation", s.continuation)
+	}
+
+	if s.cluster != "" {
+		params.Set("cluster", s.cluster)
+	}
+
+	return method, path, params
+
+}
+
+// Generate the YQL query
+func (s *DeleteService) buildSelect() {
+	var selection string
+	var idx int
+
+	if s.selectionClause.where != "" {
+		selection = s.selectionClause.where
+
+		for _, v := range []byte(selection) {
+			if v == '?' && len(s.selectionClause.params) > idx {
+				selection = VisitReplace(selection, s.selectionClause.params[idx])
+				idx++
+			}
+		}
+	}
+
+	s.selection = selection
+}
+
+// Do executes the create operation. Returns a DeleteResponse or an error.
+func (s *DeleteService) Do(ctx context.Context) (*DeleteResponse, error) {
+
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	var endResponse DeleteResponse
+	var lastErr error
+
+	for {
+		// Get URL for request
+		method, path, params := s.buildURL()
+
+		// Get HTTP response
+		res, err := s.client.PerformRequest(ctx, PerformRequest{
+			Method:  method,
+			Path:    path,
+			Params:  params,
+			Headers: s.headers,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		defer func() {
+			err := res.Body.Close()
+			if err != nil {
+				log.Print(err)
+			}
+		}()
+
+		var dr DeleteResponse
+		endResponse.Status = res.StatusCode
+
+		err = json.NewDecoder(res.Body).Decode(&dr)
+		if err != nil {
+			lastErr = err
+			break
+		}
+
+		endResponse.DocumentCount += dr.DocumentCount // this could be 0.
+		endResponse.ID = dr.ID
+		endResponse.PathID = dr.PathID
+		endResponse.Message = dr.Message
+
+		if endResponse.Message != "" {
+			lastErr = fmt.Errorf(endResponse.Message)
+		}
+
+		if dr.Continuation == "" {
+			// when there is no continuation, the request is complete
+			break
+		}
+		s.Continuation(dr.Continuation) // set continuation for the next loop
+
+	}
+	return &endResponse, lastErr
+
+}
+
+// DeleteResponse is the result of updating a document in Vespa.
+type DeleteResponse struct {
+	Status        int    `json:"status"`
+	ID            string `json:"id,omitempty"`
+	PathID        string `json:"pathId,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Continuation  string `json:"continuation,omitempty"`
+	DocumentCount int    `json:"documentCount,omitempty"`
+}

--- a/client/go/api/delete_test.go
+++ b/client/go/api/delete_test.go
@@ -1,0 +1,637 @@
+package vespa
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewDeleteService(t *testing.T) {
+	client := &Client{}
+
+	want := &DeleteService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+	got := NewDeleteService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewDeleteService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestDeleteService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DeleteService
+	}{
+		{
+			name: " with default value",
+			args: args{
+				name: "default",
+			},
+			want: &DeleteService{
+				namespace: "default",
+			},
+		},
+		{
+			name: " with specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &DeleteService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{}
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DeleteService
+	}{
+		{
+			name: " with cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &DeleteService{
+				scheme: "cars",
+			},
+		},
+		{
+			name: " with places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &DeleteService{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{}
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Cluster(t *testing.T) {
+	type args struct {
+		cluster string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DeleteService
+	}{
+		{
+			name: " with value",
+			args: args{
+				cluster: "cluster-name",
+			},
+			want: &DeleteService{
+				cluster: "cluster-name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{}
+			if got := s.Cluster(tt.args.cluster); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Cluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_ID(t *testing.T) {
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DeleteService
+	}{
+		{
+			name: " with an id value value",
+			args: args{
+				id: "aaaa",
+			},
+			want: &DeleteService{
+				id: "aaaa",
+			},
+		},
+		{
+			name: " with another id value",
+			args: args{
+				id: "bbbb",
+			},
+			want: &DeleteService{
+				id: "bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{}
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Selection(t *testing.T) {
+	type args struct {
+		query  string
+		params []interface{}
+	}
+	tests := []struct {
+		selection string
+		args      args
+		want      *DeleteService
+	}{
+		{
+			selection: "with value",
+			args: args{
+				query: "music.author = ? and music.length <= ?",
+				params: []interface{}{
+					"Bon Jovi", 1000,
+				},
+			},
+			want: &DeleteService{
+				selection: `music.author = "Bon Jovi" and music.length <= 1000`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.selection, func(t *testing.T) {
+			s := &DeleteService{}
+			got := s.Selection(tt.args.query, tt.args.params...)
+			if got.selection != tt.want.selection {
+				t.Errorf("DeleteService.Selection() = %v, want %v", got.selection, tt.want.selection)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Timeout(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *DeleteService
+	}{
+		{
+			name: "with a second value",
+			args: args{
+				timeout: "12s",
+			},
+			want: &DeleteService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "with a minute value",
+			args: args{
+				timeout: "1m",
+			},
+			want: &DeleteService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Validate(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		selection string
+		headers   http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "missing one required field should return error",
+			fields: fields{
+				scheme:    "posts",
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all fields set should return error nil",
+			fields: fields{
+				id:        "1",
+				scheme:    "posts",
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "sequence but no id should be valid",
+			fields: fields{
+				selection: "count >= 10",
+				scheme:    "posts",
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				selection: tt.fields.selection,
+				headers:   tt.fields.headers,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("DeleteService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeleteService_buildURL(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		selection string
+		headers   http.Header
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "when called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+			},
+			want:  "DELETE",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{},
+		},
+		{
+			name: "when called with timeout, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+				timeout:   "12s",
+			},
+			want:  "DELETE",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{
+				"timeout": []string{"12s"},
+			},
+		},
+		{
+			name: "when called with selection, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+				selection: "music.author and music.length <= 1000",
+			},
+			want:  "DELETE",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{
+				"selection": []string{"music.author and music.length <= 1000"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				selection: tt.fields.selection,
+				headers:   tt.fields.headers,
+			}
+			got, got1, got2 := s.buildURL()
+
+			if got != tt.want {
+				t.Errorf("DeleteService.buildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("DeleteService.buildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("DeleteService.buildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestDeleteService_Do(t *testing.T) {
+
+	ctx := context.Background()
+
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      map[string]PartialUpdateItem
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *DeleteResponse
+		wantErr bool
+	}{
+		{
+			name:   "when validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request succeeds, it should return a UpdateResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:post:001",
+						"pathId":  "/document/v1/default/job/docid/001"						
+					}
+					`)),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &DeleteResponse{
+				Status:  200,
+				ID:      "id:default:post:001",
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request returns with an http error, we should return a message",
+			fields: fields{
+				client: &httpClientMock{
+					code: 400,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"pathId":  "/document/v1/default/job/docid/001",
+						"message":	"No field 'beat_that' in the structure of type 'work'"
+					}
+					`)),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &DeleteResponse{
+				Status:  400,
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "No field 'beat_that' in the structure of type 'work'",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, err := s.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("DeleteService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Do() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeleteService_DoWithContinuation(t *testing.T) {
+
+	client := &httpClientMock{
+		code: 200,
+		err:  nil,
+		responses: []mockResponse{
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"continuation": "AaaaahhZh",
+					"documentCount": 10
+				}
+				`)),
+			},
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"continuation": "AaaaahhZh",
+					"documentCount": 10
+				}
+				`)),
+			},
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"documentCount": 2
+				}
+				`)),
+			},
+		},
+	}
+
+	s := &DeleteService{
+		client:    client,
+		namespace: "default",
+		scheme:    "job",
+
+		selection: "feed_id = 22",
+		cluster:   "cluster-name",
+	}
+
+	ctx := context.Background()
+
+	wantErr := false
+	want := &DeleteResponse{
+		Status:        200,
+		PathID:        "/document/v1/default/job/docid/",
+		DocumentCount: 22,
+	}
+
+	got, err := s.Do(ctx)
+	if (err != nil) != wantErr {
+		t.Errorf("DeleteService.Do() error = %v, wantErr %v", err, wantErr)
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("DeleteService.Do() = %+v, want %+v", got, want)
+	}
+}
+
+func TestDeleteService_Continuation(t *testing.T) {
+	type args struct {
+		continuation string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *DeleteService
+	}{
+		{
+			name: "with value",
+			args: args{
+				continuation: "aaahhhzzzAa",
+			},
+			want: &DeleteService{
+				continuation: "aaahhhzzzAa",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &DeleteService{}
+			if got := s.Continuation(tt.args.continuation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DeleteService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/examples/batch-insert/batch_insert.go
+++ b/client/go/api/examples/batch-insert/batch_insert.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+
+	ctx := context.Background()
+
+	hClient := http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns: 20,
+		},
+	}
+
+	client, err := vespa.NewClient(ctx, vespa.SetHTTPClient(&hClient))
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewBatchService(client)
+
+	for _, job := range ManyJobs(1000) {
+		item := vespa.NewCreateBatchRequest().
+			Namespace("default").
+			Scheme("job").
+			ID(job.ID).
+			Body(job)
+
+		svc.Add(item)
+	}
+
+	res := svc.Do(ctx)
+
+	fmt.Printf("%+v\n", res)
+
+}
+
+func Jobs() []job {
+	data := []job{
+		{
+			ID:    "11223344",
+			Title: "Sr Software Engineer",
+		},
+		{
+			ID:    "11223345",
+			Title: "Doctor",
+		},
+		{
+			ID:    "11223346",
+			Title: "Web Developer",
+		},
+		{
+			ID:    "11223347",
+			Title: "Mobile Developer",
+		},
+		{
+			ID:    "11223348",
+			Title: "Backend Engineer",
+		},
+	}
+
+	return data
+}
+
+func ManyJobs(max int) []job {
+	var data []job
+
+	for i := 0; i < max; i++ {
+		item := job{
+			ID: fmt.Sprintf("sample-%d", i+1),
+
+			Title: "Sr Software Engineer",
+		}
+		data = append(data, item)
+	}
+
+	return data
+}
+
+type job struct {
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+}

--- a/client/go/api/examples/batch-update/batch-update.go
+++ b/client/go/api/examples/batch-update/batch-update.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	hClient := http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns: 20,
+		},
+	}
+
+	client, err := vespa.NewClient(ctx, vespa.SetHTTPClient(&hClient))
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewBatchService(client)
+
+	for _, job := range ManyJobs(20) {
+		item := vespa.NewCreateBatchRequest().
+			Namespace("default").
+			Scheme("job").
+			ID(job.ID).
+			Body(job)
+
+		svc.Add(item)
+	}
+
+	insertRes := svc.Do(ctx)
+
+	fmt.Printf("Inserted documents: %d\n", len(insertRes.Items))
+
+	svc = vespa.NewBatchService(client)
+
+	for _, job := range insertRes.Items {
+		item := vespa.NewUpdateBatchRequest().
+			Namespace("default").
+			Scheme("job").
+			ID(job.ID).
+			Field("hidden", true)
+
+		svc.Add(item)
+	}
+
+	updateRes := svc.Do(ctx)
+
+	fmt.Printf("Updated documents: %d\n", len(insertRes.Items))
+	fmt.Printf("%+v\n", updateRes)
+
+}
+
+// ManyJobs creates a jobs array and it includes
+// so many items as we defined in the "max" parameter.
+func ManyJobs(max int) []job {
+	var data []job
+
+	for i := 0; i < max; i++ {
+		item := job{
+			ID:    fmt.Sprintf("sample-%d", i+1),
+			Title: "Sr Software Engineer",
+		}
+		data = append(data, item)
+	}
+
+	return data
+}
+
+type job struct {
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+}

--- a/client/go/api/examples/delete/delete.go
+++ b/client/go/api/examples/delete/delete.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+
+	ctx := context.Background()
+
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewCreateService(client)
+
+	data := job{
+		ID:    "abc1234",
+		Title: "Book Keeper",
+	}
+
+	resCreate, err := svc.Scheme("job").
+		ID("abc1234").
+		Body(data).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Insert response: %+v\n", resCreate)
+
+	dSvc := vespa.NewDeleteService(client)
+	resDelete, err := dSvc.Scheme("job").
+		Selection("job.id = ?", "zyx2345").
+		Cluster("job").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Delete response: %+v\n", resDelete)
+}
+
+type job struct {
+	ID    string `json:"id,omitempty"`
+	Title string `json:"title,omitempty"`
+}

--- a/client/go/api/examples/export/export.go
+++ b/client/go/api/examples/export/export.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+// The following is an example on how to achieve data export based on Search
+// when high performance is needed.
+// The main things to set when doing so are:
+// - Disable ranking softtimeout
+// - Disable sorting degrating
+// - Set enough timeout
+
+func main() {
+	ctx := context.Background()
+
+	httpTransport := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 10,
+	}
+
+	httpClient := &http.Client{
+		Transport: httpTransport,
+		Timeout:   25 * time.Second,
+	}
+
+	var opts []vespa.ClientOptionFunc
+
+	connStr := "http://localhost"
+
+	opts = append(opts,
+		vespa.SetHTTPClient(httpClient),
+		vespa.SetURL(connStr),
+	)
+
+	client, err := vespa.NewClient(ctx, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewSearchService(client)
+
+	degrating := false
+
+	res, err := svc.Scheme("job").
+		Where("weightedSet(?, ?)", "feed_id", []vespa.WeightedElement{
+			{Index: "16449", Value: 1}, {Index: "34558", Value: 1},
+		}).
+		Ranking(vespa.Ranking{
+			SoftTimeout: &vespa.SoftTimeout{
+				Enabled: false,
+			},
+		}).
+		Sorting(
+			vespa.Sorting{
+				Degrading: &degrating,
+			},
+		).
+		Timeout("10s").
+		Limit(400).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+
+}

--- a/client/go/api/examples/get/get.go
+++ b/client/go/api/examples/get/get.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new Vespa client
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the Get Service
+	svc := vespa.NewGetService(client)
+
+	// Get the document by ID
+	res, err := svc.Scheme("job").
+		ID("abc1234").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify if there's a retrieved document
+	if res.Fields != nil {
+		// Declare struct map
+		doc := &job{}
+
+		// Decode the json.RawMessage
+		err = json.Unmarshal(res.Fields, doc)
+		if err != nil {
+			panic(err)
+		}
+
+		// Print the document
+		fmt.Printf("%+v\n", doc)
+	}
+
+	// Verify if there's a failed message
+	if res.Message != "" {
+		// Print result
+		fmt.Printf("%+v\n", res)
+	}
+}
+
+// job attribute contains the fields of the documents
+type job struct {
+	ID          string   `json:"id,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Location    Location `json:"location,omitempty"`
+}
+
+// Location attribute contains the detailed position of a physical location
+type Location struct {
+	Lat float64 `json:"y,omitempty"`
+	Lon float64 `json:"x,omitempty"`
+}

--- a/client/go/api/examples/insert/insert.go
+++ b/client/go/api/examples/insert/insert.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewCreateService(client)
+
+	data := job{
+		ID:          "abc1234",
+		Title:       "Sr Software Engineer",
+		Description: "Senior Software Engineer provides innovative, simple solutions that allows the stores and other business partners to operate more efficiently while driving profitability and sustainability through the Vendor-DC-Store supply chain network. Supports the store allocation of associate labor through accurate engineered labor standards. Responsible for new and remodel store layout/design and new equipment and processes to support operational efficiency and damage reduction .",
+	}
+
+	res, err := svc.Scheme("job").
+		ID("abc1234").
+		Body(data).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%+v\n", res)
+}
+
+type job struct {
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/client/go/api/examples/mtls/mtls.go
+++ b/client/go/api/examples/mtls/mtls.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	httpTransport := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 10,
+	}
+
+	// Setup mTLS
+	cert, err := tls.LoadX509KeyPair("client.crt", "client.key")
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a CA certificate pool and add cert.pem to it
+	caCert, err := ioutil.ReadFile("client.crt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	httpTransport.TLSClientConfig = &tls.Config{
+		RootCAs:      caCertPool,
+		Certificates: []tls.Certificate{cert},
+		// TODO: this should be false in production. Need to find a way to make it work
+		InsecureSkipVerify: true,
+	}
+
+	httpClient := &http.Client{
+		Transport: httpTransport,
+		Timeout:   25 * time.Second,
+	}
+
+	var opts []vespa.ClientOptionFunc
+
+	connStr := "http://localhost:8080"
+
+	opts = append(opts,
+		vespa.SetHTTPClient(httpClient),
+		vespa.SetURL(connStr),
+	)
+
+	client, err := vespa.NewClient(ctx, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	client.GzipRequest = true
+
+	svc := vespa.NewSearchService(client)
+
+	res, err := svc.Scheme("job").
+		Query("Software Engineer").
+		Where("userQuery() AND status contains \"active\" AND geoLocation(location, 33.64, -84.33, \"100mi\") AND hidden = false").
+		Timeout("5s").
+		Ranking(vespa.Ranking{Profile: "bm25"}).
+		Hits(10).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Number of matches: %d \n", res.Root.Fields.TotalCount)
+
+}
+
+type JobRes struct {
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// LocationPosition is the representation Vespa returns
+// when a record has a location field set.
+type LocationPosition struct {
+	X      float64 `json:"x,omitempty"`
+	Y      float64 `json:"y,omitempty"`
+	LatLon string  `json:"latlon,omitempty"`
+}

--- a/client/go/api/examples/search/search.go
+++ b/client/go/api/examples/search/search.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	ctx := context.Background()
+
+	httpTransport := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConnsPerHost: 10,
+	}
+
+	// Setup mTLS
+	cert, err := tls.LoadX509KeyPair("client.crt", "client.key")
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a CA certificate pool and add cert.pem to it
+	caCert, err := ioutil.ReadFile("client.crt")
+	if err != nil {
+		log.Fatal(err)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	httpTransport.TLSClientConfig = &tls.Config{
+		RootCAs:            caCertPool,
+		Certificates:       []tls.Certificate{cert},
+		InsecureSkipVerify: true, // for development only
+	}
+
+	httpClient := &http.Client{
+		Transport: httpTransport,
+		Timeout:   25 * time.Second,
+	}
+
+	var opts []vespa.ClientOptionFunc
+
+	connStr := "http://localhost:8080"
+
+	opts = append(opts,
+		vespa.SetHTTPClient(httpClient),
+		vespa.SetURL(connStr),
+	)
+
+	client, err := vespa.NewClient(ctx, opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	client.GzipRequest = true
+
+	svc := vespa.NewSearchService(client)
+	weak := vespa.NewWeakAnd(10)
+	weak.AddEntry("default", "Trucking")
+	weak.AddEntry("default", "Class")
+	weak.AddEntry("default", "B")
+	weak.AddEntry("default", "Truck")
+	weak.AddEntry("default", "Driving")
+
+	res, err := svc.Scheme("job").
+		Where("? AND status contains \"active\" AND geoLocation(location, 33.64, -84.33, \"25mi\") AND hidden = false", *weak).
+		Timeout("5s").
+		Ranking(vespa.Ranking{Profile: "bm25"}).
+		// RankingFeatureQuery(vespa.RankingFeaturesQuery{
+		// 	Values: map[string]interface{}{
+		// 		"cpcfactor":       1,
+		// 		"closenessfactor": 20,
+		// 	},
+		// }).
+		Hits(10).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Number of matches: %d \n", res.Root.Fields.TotalCount)
+
+	for i, item := range res.Root.Children {
+		vespaJob := JobRes{}
+		// Decoder the result into the new job object
+		err = json.Unmarshal(res.Root.Children[i].Fields, &vespaJob)
+		// Check if the unmarshal operation has an error
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Title: %s, Relevance: %f\n", vespaJob.Title, item.Relevance)
+	}
+
+	fmt.Println("---------------")
+	fmt.Println("USING ALL MODE!")
+
+	svc2 := vespa.NewSearchService(client)
+	res, err = svc2.Scheme("job").
+		Query("Trucking Class B Truck Driving").
+		Where("userQuery() AND status contains \"active\" AND geoLocation(location, 33.64, -84.33, \"25mi\") AND hidden = false").
+		Timeout("5s").
+		Ranking(vespa.Ranking{Profile: "bm25"}).
+		// RankingFeatureQuery(vespa.RankingFeaturesQuery{
+		// 	Values: map[string]interface{}{
+		// 		"cpcfactor":       1,
+		// 		"closenessfactor": 20,
+		// 	},
+		// }).
+		// UseWeakAndQuery(*weak).
+		Hits(10).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Number of matches: %d \n", res.Root.Fields.TotalCount)
+
+	for i, item := range res.Root.Children {
+		vespaJob := JobRes{}
+		// Decoder the result into the new job object
+		err = json.Unmarshal(res.Root.Children[i].Fields, &vespaJob)
+		// Check if the unmarshal operation has an error
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Title: %s Relevance: %f\n", vespaJob.Title, item.Relevance)
+	}
+
+}
+
+type JobRes struct {
+	ID               string           `json:"id,omitempty"`
+	Title            string           `json:"title,omitempty"`
+	Description      string           `json:"description,omitempty"`
+	DescriptionFull  string           `json:"descriptionfull,omitempty"`
+	Location         LocationPosition `json:"location,omitempty"`
+	LocationPosition LocationPosition `json:"location.position,omitempty"`
+}
+
+// LocationPosition is the representation Vespa returns
+// when a record has a location field set.
+type LocationPosition struct {
+	X      float64 `json:"x,omitempty"`
+	Y      float64 `json:"y,omitempty"`
+	LatLon string  `json:"latlon,omitempty"`
+}

--- a/client/go/api/examples/update/update.go
+++ b/client/go/api/examples/update/update.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+
+	ctx := context.Background()
+
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	svc := vespa.NewCreateService(client)
+
+	data := job{
+		ID:          "abc1234",
+		Title:       "Book Keeper",
+		Description: "Culpa dolor Lorem magna laboris exercitation cillum adipisicing. Ea veniam excepteur et ex velit non commodo id incididunt mollit cupidatat quis. Laborum pariatur aliqua occaecat nulla reprehenderit irure ut pariatur consequat cillum. Elit excepteur cupidatat labore eiusmod cillum reprehenderit labore. Aliquip exercitation irure ut consequat. Et dolore esse nostrud do anim dolore voluptate laboris magna incididunt pariatur.",
+	}
+
+	resCreate, err := svc.Scheme("job").
+		ID("abc1234").
+		Body(data).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Insert response: %+v", resCreate)
+
+	uSvc := vespa.NewUpdateService(client)
+
+	resUpdate, err := uSvc.Scheme("job").
+		ID("abc1234").
+		Field("title", "Chief officer").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Update response: %+v", resUpdate)
+
+	// You can also use selection to update multiple documents.
+	// For the request to work, you need to fill the cluster name
+
+	uSvc = vespa.NewUpdateService(client)
+	_, err = uSvc.Scheme("job").
+		Field("title", "Chief officer").
+		Selection("external_id = ?", "zyx2345").
+		Cluster("cluster-names").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+}
+
+type job struct {
+	ID          string `json:"id,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/client/go/api/examples/visit/visit.go
+++ b/client/go/api/examples/visit/visit.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	vespa "github.com/vespa-engine/vespa/vespaclient-go"
+)
+
+func main() {
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new Vespa client
+	client, err := vespa.NewClient(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create the Visit Service
+	svc := vespa.NewVisitService(client)
+
+	// Define a selection
+	res, err := svc.Scheme("job").
+		Selection("job.status == ?", "active").
+		WantedDocumentCount(1000).
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify if there's a failed message
+	if res.Message != "" {
+		// Print result
+		fmt.Printf("Error Message: %+v\n", res)
+	}
+
+	fmt.Printf("Result: %+v", res)
+
+	// Create a new Visit Service
+	svc = vespa.NewVisitService(client)
+
+	// Define a continuation
+	res, err = svc.Scheme("job").
+		Continuation("AAAAEAAAAAAAAAM3AAAAAAAAAzYAAAAAAAEAAAAAAAFAAAAAAABswAAAAAAAAAAA").
+		Do(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	// Verify if there's a failed message
+	if res.Message != "" {
+		// Print result
+		fmt.Printf("Error Message: %+v\n", res)
+	}
+
+	fmt.Printf("Result using the continuation token: %+v", res)
+}

--- a/client/go/api/get.go
+++ b/client/go/api/get.go
@@ -1,0 +1,134 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// GetService retrieves the document by ID
+type GetService struct {
+	client HTTPClient
+
+	namespace string
+	scheme    string
+	id        string
+	timeout   string
+	headers   http.Header
+}
+
+// NewGetService will create an instance of GetService
+func NewGetService(client HTTPClient) *GetService {
+	return &GetService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *GetService) Namespace(name string) *GetService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *GetService) Scheme(scheme string) *GetService {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *GetService) ID(id string) *GetService {
+	s.id = id
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional ks, s, ms or µs unit.
+func (s *GetService) Timeout(timeout string) *GetService {
+	s.timeout = timeout
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *GetService) Validate() error {
+	var invalid []string
+	if s.id == "" {
+		invalid = append(invalid, "id")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+func (s *GetService) buildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodGet
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params := url.Values{}
+	if s.timeout != "" {
+		params.Set("timeout", s.timeout)
+	}
+
+	return method, path, params
+
+}
+
+// Do executes the get operation. Returns a GetResponse or an error.
+func (s *GetService) Do(ctx context.Context) (*GetResponse, error) {
+
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	method, path, params := s.buildURL()
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, PerformRequest{
+		Method:  method,
+		Path:    path,
+		Params:  params,
+		Headers: s.headers,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	var gr GetResponse
+	gr.Status = res.StatusCode
+
+	err = json.NewDecoder(res.Body).Decode(&gr)
+
+	return &gr, err
+
+}
+
+// GetResponse is the result of retrieve a specific document in Vespa.
+type GetResponse struct {
+	Status  int             `json:"status"`
+	ID      string          `json:"id,omitempty"`
+	PathID  string          `json:"pathId,omitempty"`
+	Message string          `json:"message,omitempty"`
+	Fields  json.RawMessage `json:"fields,omitempty"`
+}

--- a/client/go/api/get_test.go
+++ b/client/go/api/get_test.go
@@ -1,0 +1,440 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewGetService(t *testing.T) {
+	client := &Client{}
+
+	want := &GetService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+
+	got := NewGetService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewGetService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestGetService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *GetService
+	}{
+		{
+			name: "Set the default value to namespace",
+			args: args{
+				name: "default",
+			},
+			want: &GetService{
+				namespace: "default",
+			},
+		},
+		{
+			name: "Set a specific value to namespace",
+			args: args{
+				name: "specific",
+			},
+			want: &GetService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{}
+
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *GetService
+	}{
+		{
+			name: "Set the job to scheme",
+			args: args{
+				scheme: "job",
+			},
+			want: &GetService{
+				scheme: "job",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{}
+
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetService_ID(t *testing.T) {
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *GetService
+	}{
+		{
+			name: "Set the job to scheme",
+			args: args{
+				id: "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+			want: &GetService{
+				id: "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{}
+
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetService_Timeout(t *testing.T) {
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *GetService
+	}{
+		{
+			name: "Set a second value to timeout",
+			args: args{
+				timeout: "12s",
+			},
+			want: &GetService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "Set a minute value to timeout",
+			args: args{
+				timeout: "1m",
+			},
+			want: &GetService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetService_Validate(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		headers   http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "Missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "Missing one required field should return an error",
+			fields: fields{
+				namespace: "default",
+				id:        "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+			wantErr: true,
+		},
+		{
+			name: "All fields set should return error nil",
+			fields: fields{
+				namespace: "default",
+				scheme:    "job",
+				id:        "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("GetService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetService_buildURL(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		headers   http.Header
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "When called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "job",
+				id:        "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+			want:  "GET",
+			want1: "/document/v1/default/job/docid/54af81d8-6b35-11eb-9439-0242ac130002",
+			want2: url.Values{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, got1, got2 := s.buildURL()
+			if got != tt.want {
+				t.Errorf("GetService.buildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetService.buildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("GetService.buildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestGetService_Do(t *testing.T) {
+	ctx := context.Background()
+
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *GetResponse
+		wantErr bool
+	}{
+		{
+			name:   "when validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "When perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				scheme:    "job",
+				namespace: "default",
+				id:        "54af81d8-6b35-11eb-9439-0242ac130002",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request succeeds, it should return a CreateResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:job:aaa",
+						"pathId":  "/document/v1/default/job/docid/aaa",
+						"fields": {
+							"sddocname": "job",
+							"documentid": "id:default:job::abc1234",
+							"id": "abc1234",
+							"external_id": "zyx2345",
+							"title": "Sr Software Engineer",
+							"description": "Senior <hi>Software</hi> Engineer provides innovative, simple solutions that<sep/>",
+							"hash": [
+								104,
+								97,
+								115,
+								104,
+								50,
+								53,
+								54
+
+							],
+							"feed_id": 46007,
+							"hiring_organization": "Guegue Comunicaciones",
+							"url": "https://jobs.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+							"url_mobile": "https://jobs.mobile.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+							"street_address1": "4846 University Street",
+							"street_address2": "",
+							"city": "Seattle",
+							"state": "WA",
+							"country": "",
+							"country_name": "",
+							"region": "",
+							"postal_code": 98106,
+							"location": {
+								"y": 3.7401e+07,
+								"x": -1.21996e+08
+							},
+							"bid_cpc": 0.5,
+							"creation_date": 1612310992,
+							"posting_creation_date": 1612310992,
+							"posting_update_date": 1612310992,
+							"posting_last_seen": 1612310992,
+							"hidden": false,
+							"sequence": 1
+						}					
+					}
+					`)),
+				},
+				id:        "aaa",
+				scheme:    "job",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &GetResponse{
+				Status:  200,
+				ID:      "id:default:job:aaa",
+				PathID:  "/document/v1/default/job/docid/aaa",
+				Message: "",
+				Fields: json.RawMessage{
+					123, 10, 9, 9, 9, 9, 9, 9, 9, 34, 115, 100, 100, 111, 99, 110, 97, 109, 101, 34, 58, 32, 34, 106, 111, 98, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 100, 111, 99, 117, 109, 101, 110, 116, 105, 100, 34, 58, 32, 34, 105, 100, 58, 100, 101, 102, 97, 117, 108, 116, 58, 106, 111, 98, 58, 58, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 105, 100, 34, 58, 32, 34, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 101, 120, 116, 101, 114, 110, 97, 108, 95, 105, 100, 34, 58, 32, 34, 122, 121, 120, 50, 51, 52, 53, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 116, 105, 116, 108, 101, 34, 58, 32, 34, 83, 114, 32, 83, 111, 102, 116, 119, 97, 114, 101, 32, 69, 110, 103, 105, 110, 101, 101, 114, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 34, 58, 32, 34, 83, 101, 110, 105, 111, 114, 32, 60, 104, 105, 62, 83, 111, 102, 116, 119, 97, 114, 101, 60, 47, 104, 105, 62, 32, 69, 110, 103, 105, 110, 101, 101, 114, 32, 112, 114, 111, 118, 105, 100, 101, 115, 32, 105, 110, 110, 111, 118, 97, 116, 105, 118, 101, 44, 32, 115, 105, 109, 112, 108, 101, 32, 115, 111, 108, 117, 116, 105, 111, 110, 115, 32, 116, 104, 97, 116, 60, 115, 101, 112, 47, 62, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 104, 97, 115, 104, 34, 58, 32, 91, 10, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 57, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 49, 49, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 53, 48, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 53, 51, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 53, 52, 10, 10, 9, 9, 9, 9, 9, 9, 9, 93, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 102, 101, 101, 100, 95, 105, 100, 34, 58, 32, 52, 54, 48, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 114, 105, 110, 103, 95, 111, 114, 103, 97, 110, 105, 122, 97, 116, 105, 111, 110, 34, 58, 32, 34, 71, 117, 101, 103, 117, 101, 32, 67, 111, 109, 117, 110, 105, 99, 97, 99, 105, 111, 110, 101, 115, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 95, 109, 111, 98, 105, 108, 101, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 109, 111, 98, 105, 108, 101, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 49, 34, 58, 32, 34, 52, 56, 52, 54, 32, 85, 110, 105, 118, 101, 114, 115, 105, 116, 121, 32, 83, 116, 114, 101, 101, 116, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 50, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 99, 105, 116, 121, 34, 58, 32, 34, 83, 101, 97, 116, 116, 108, 101, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 97, 116, 101, 34, 58, 32, 34, 87, 65, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 95, 110, 97, 109, 101, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 114, 101, 103, 105, 111, 110, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 97, 108, 95, 99, 111, 100, 101, 34, 58, 32, 57, 56, 49, 48, 54, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 108, 111, 99, 97, 116, 105, 111, 110, 34, 58, 32, 123, 10, 9, 9, 9, 9, 9, 9, 9, 9, 34, 121, 34, 58, 32, 51, 46, 55, 52, 48, 49, 101, 43, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 34, 120, 34, 58, 32, 45, 49, 46, 50, 49, 57, 57, 54, 101, 43, 48, 56, 10, 9, 9, 9, 9, 9, 9, 9, 125, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 98, 105, 100, 95, 99, 112, 99, 34, 58, 32, 48, 46, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 117, 112, 100, 97, 116, 101, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 108, 97, 115, 116, 95, 115, 101, 101, 110, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 100, 100, 101, 110, 34, 58, 32, 102, 97, 108, 115, 101, 44, 10, 9, 9, 9, 9, 9, 9, 9, 34, 115, 101, 113, 117, 101, 110, 99, 101, 34, 58, 32, 49, 10, 9, 9, 9, 9, 9, 9, 125,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request returns with an http error, we should return a message",
+			fields: fields{
+				client: &httpClientMock{
+					code: 500,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"pathId":  "/document/v1/default/jobs/docid/001",
+						"message":	"Unknown bucket space mapping for document type 'jobs' in id: 'id:default:jobs::001"
+					}
+					`)),
+				},
+				id:        "001",
+				scheme:    "jobs",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &GetResponse{
+				Status:  500,
+				PathID:  "/document/v1/default/jobs/docid/001",
+				Message: "Unknown bucket space mapping for document type 'jobs' in id: 'id:default:jobs::001",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &GetService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, err := s.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetService.Do() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/go.mod
+++ b/client/go/api/go.mod
@@ -1,0 +1,3 @@
+module github.com/vespa-engine/vespa/vespaclient-go
+
+go 1.14

--- a/client/go/api/partial_update.go
+++ b/client/go/api/partial_update.go
@@ -1,0 +1,18 @@
+package vespa
+
+// PartialUpdateField allow us to use the function Fields() with multiple
+// parameters
+type PartialUpdateField struct {
+	Key   string
+	Value interface{}
+}
+
+// PartialUpdateItem is the representation Vespa uses to declare a field update
+type PartialUpdateItem struct {
+	Assign interface{} `json:"assign"`
+}
+
+// NewPartialUpdateField returns a new *NewPartialUpdateField
+func NewPartialUpdateField(key string, value interface{}) *PartialUpdateField {
+	return &PartialUpdateField{Key: key, Value: value}
+}

--- a/client/go/api/partial_update_test.go
+++ b/client/go/api/partial_update_test.go
@@ -1,0 +1,37 @@
+package vespa
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewPartialUpdateField(t *testing.T) {
+	type args struct {
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *PartialUpdateField
+	}{
+		{
+			name: "when called I should get the expected result",
+			args: args{
+				key:   "key",
+				value: "value",
+			},
+			want: &PartialUpdateField{
+				Key:   "key",
+				Value: "value",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewPartialUpdateField(tt.args.key, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewPartialUpdateField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/ranking_feature_query.go
+++ b/client/go/api/ranking_feature_query.go
@@ -1,0 +1,17 @@
+package vespa
+
+// RankingFeaturesQuery represents a Vespa's Ranking Feature Query
+type RankingFeaturesQuery struct {
+	Values map[string]interface{}
+}
+
+// NewRankingFeaturesQuery creates a new *RankingFeaturesQuery
+func NewRankingFeaturesQuery() *RankingFeaturesQuery {
+	values := make(map[string]interface{})
+	return &RankingFeaturesQuery{Values: values}
+}
+
+// Set adds a new RankingFeatures entry
+func (rfq *RankingFeaturesQuery) Set(name string, value interface{}) {
+	rfq.Values[name] = value
+}

--- a/client/go/api/ranking_feature_query_test.go
+++ b/client/go/api/ranking_feature_query_test.go
@@ -1,0 +1,69 @@
+package vespa
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewRankingFeaturesQuery(t *testing.T) {
+	got := NewRankingFeaturesQuery()
+
+	if got.Values == nil {
+		t.Errorf("NewRankingFeaturesQuery = nil, want not nil")
+	}
+}
+
+func TestRankingFeaturesQuery_Set(t *testing.T) {
+	type fields struct {
+		Values map[string]interface{}
+	}
+	type args struct {
+		name  string
+		value interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]interface{}
+	}{
+		{
+			name: "when setting a string we should get the value",
+			fields: fields{
+				Values: map[string]interface{}{},
+			},
+			args: args{
+				name:  "test",
+				value: "value",
+			},
+			want: map[string]interface{}{
+				"test": "value",
+			},
+		},
+		{
+			name: "when setting a int we should get the value",
+			fields: fields{
+				Values: map[string]interface{}{},
+			},
+			args: args{
+				name:  "test",
+				value: 22,
+			},
+			want: map[string]interface{}{
+				"test": 22,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rfq := &RankingFeaturesQuery{
+				Values: tt.fields.Values,
+			}
+			rfq.Set(tt.args.name, tt.args.value)
+
+			if !reflect.DeepEqual(tt.want, rfq.Values) {
+				t.Errorf("RankingFeaturesQuery.Set() = %+v, want %+v", tt.want, rfq.Values)
+			}
+		})
+	}
+}

--- a/client/go/api/relevance.go
+++ b/client/go/api/relevance.go
@@ -1,0 +1,27 @@
+package vespa
+
+import (
+	"encoding/json"
+)
+
+// Relevance is the type to hold relevance data, incluiding handling NaN cases.
+type Relevance float64
+
+// UnmarshalJSON decodes a json entry into thje right Relevance Implementation
+func (r *Relevance) UnmarshalJSON(b []byte) error {
+	var data interface{}
+
+	err := json.Unmarshal(b, &data)
+	if err != nil {
+		return err
+	}
+
+	switch v := data.(type) {
+	case float64:
+		*r = Relevance(v)
+	case string:
+		*r = 0
+	}
+
+	return nil
+}

--- a/client/go/api/search.go
+++ b/client/go/api/search.go
@@ -1,0 +1,483 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+// SearchService retrieves the documents depending on a query that is
+// generated according to the parameters that the user provides
+type SearchService struct {
+	client HTTPClient
+
+	namespace      string
+	scheme         string
+	selectedFields string
+	whereClause    whereParams
+	ranking        Ranking
+	sorting        Sorting
+	limit          int
+	offset         int
+	orderBy        string
+	isDesc         bool
+	timeout        string
+	presentation   []Presentation
+	headers        http.Header
+
+	searchRequest        SearchRequest
+	query                string
+	searchType           string
+	hits                 int
+	rankingFeaturesQuery RankingFeaturesQuery
+}
+
+// SearchRequest is the data we send inside a search request body.
+type SearchRequest struct {
+	YQL     string `json:"yql,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Query   string `json:"query,omitempty"`
+	Hits    int    `json:"hits,omitempty"`
+	Ranking string `json:"ranking,omitempty"`
+}
+
+// WeightedElement represents a single item inside a Vespa's WeightedSet
+type WeightedElement struct {
+	Index string
+	Value int
+}
+
+// Ranking reflects the ranking configuration for a search request
+type Ranking struct {
+	Profile     string
+	SoftTimeout *SoftTimeout
+}
+
+// SoftTimeout reflects the ranking.Softimeout request configuration
+type SoftTimeout struct {
+	Enabled bool
+	Factor  float32
+}
+
+// Sorting enables certain sorting options
+type Sorting struct {
+	Degrading *bool
+}
+
+// Presentation holds presentation parameters that can be used on queries
+type Presentation struct {
+	key   string
+	value interface{}
+}
+
+type whereParams struct {
+	where  string
+	params []interface{}
+}
+
+// NewSearchService will create an instance of SearchService.
+func NewSearchService(client HTTPClient) *SearchService {
+	return &SearchService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *SearchService) Namespace(name string) *SearchService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *SearchService) Scheme(scheme string) *SearchService {
+	s.scheme = scheme
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional ks, s, ms or µs unit.
+func (s *SearchService) Timeout(timeout string) *SearchService {
+	s.timeout = timeout
+	return s
+}
+
+// Type sets the type of search we want to run. Options are: all(default), where, any, phrase
+func (s *SearchService) Type(t string) *SearchService {
+	s.searchType = t
+	return s
+}
+
+// Hits sets the numer of records we want to return in a search
+func (s *SearchService) Hits(n int) *SearchService {
+	s.hits = n
+	return s
+}
+
+// Query sets the main query input for a search
+func (s *SearchService) Query(query string) *SearchService {
+	s.query = query
+	return s
+}
+
+// Fields selects the required fields to display in the final result
+func (s *SearchService) Fields(fields ...string) *SearchService {
+	s.selectedFields = strings.Join(fields, ", ")
+	return s
+}
+
+// Where sets the condition part and the parameters inside the YQL query
+func (s *SearchService) Where(where string, params ...interface{}) *SearchService {
+	s.whereClause = whereParams{
+		where:  where,
+		params: params,
+	}
+	return s
+}
+
+// Ranking sets the name of the ranking to use.
+func (s *SearchService) Ranking(ranking Ranking) *SearchService {
+	s.ranking = ranking
+	return s
+}
+
+// Sorting sets sorting options
+func (s *SearchService) Sorting(sorting Sorting) *SearchService {
+	s.sorting = sorting
+	return s
+}
+
+// Limit sets the number of the hits to return from the result set
+func (s *SearchService) Limit(limit int) *SearchService {
+	s.limit = limit
+	return s
+}
+
+// Offset sets the index of the first hit to return from the result set
+func (s *SearchService) Offset(offset int) *SearchService {
+	s.offset = offset
+	return s
+}
+
+// OrderBy sets the field to order by. isDesc is a flag to determine the
+// orientation of the order. ASC is the default value
+func (s *SearchService) OrderBy(field string, isDesc bool) *SearchService {
+	s.orderBy = field
+	s.isDesc = isDesc
+	return s
+}
+
+// RankingFeatureQuery adds features to the search query.
+func (s *SearchService) RankingFeatureQuery(features RankingFeaturesQuery) *SearchService {
+	s.rankingFeaturesQuery = features
+	return s
+}
+
+// Presentation sets the presentation which can be any of the following keys:
+// presentation.bolding. presentation.format, presentation.summary, presentation.template,
+// presentation.timing. See https://docs.vespa.ai/en/reference/query-api-reference.html#presentation
+// for options
+func (s *SearchService) Presentation(key string, value interface{}) *SearchService {
+	item := Presentation{
+		key:   key,
+		value: value,
+	}
+	s.presentation = append(s.presentation, item)
+	return s
+}
+
+// Generate the YQL query
+func (s *SearchService) buildQuery() {
+	var setFields, setWhere, setLimit, setOffset, setOrderBy string
+	// var idx int
+
+	if s.selectedFields != "" {
+		setFields = s.selectedFields
+	} else {
+		setFields = "*"
+	}
+
+	setWhere = s.prepareWhere()
+
+	if s.offset > 0 {
+		setOffset = fmt.Sprintf(" offset %d", s.offset)
+	}
+
+	if s.limit > 0 {
+		setLimit = fmt.Sprintf(" limit %d", s.offset+s.limit)
+	}
+
+	if s.orderBy != "" {
+		setOrderBy = fmt.Sprintf(" order by %s", s.orderBy)
+
+		if s.isDesc {
+			setOrderBy = fmt.Sprintf(" order by %s desc", s.orderBy)
+		}
+	}
+
+	if s.searchType == "" { // use default when empty.
+		s.searchType = "all"
+	}
+
+	// Concatenate all the components to create the YQL query
+	yql := fmt.Sprintf("select %s from %s%s%s%s%s;", setFields, s.scheme, setWhere, setOrderBy, setLimit, setOffset)
+
+	s.searchRequest = SearchRequest{
+		Query:   s.query,
+		YQL:     yql,
+		Type:    s.searchType,
+		Hits:    s.hits,
+		Ranking: s.ranking.Profile,
+	}
+}
+
+func (s *SearchService) prepareWhere() string {
+
+	var setWhere string
+	var idx int
+	if s.whereClause.where != "" || s.query != "" {
+		setWhere = s.whereClause.where
+
+		for _, v := range []byte(setWhere) {
+			if v == '?' && len(s.whereClause.params) > idx {
+				setWhere = SearchReplace(setWhere, s.whereClause.params[idx])
+				idx++
+			}
+		}
+
+		switch {
+		case s.query != "" && s.whereClause.where != "":
+			setWhere = fmt.Sprintf(" where %s AND %s", "userQuery()", setWhere)
+		case s.query != "":
+			setWhere = fmt.Sprintf(" where %s", "userQuery()")
+		default:
+			setWhere = fmt.Sprintf(" where %s", setWhere)
+		}
+
+	}
+
+	return setWhere
+}
+
+// SearchReplace replaces ? sign with the correct format depending on the input type
+func SearchReplace(where string, in interface{}) string {
+	switch t := in.(type) {
+	case int, int32:
+		where = strings.Replace(where, "?", fmt.Sprintf("%d", in), 1)
+	case int64:
+		where = strings.Replace(where, "?", fmt.Sprintf("'%d'", in), 1)
+	case float32, float64:
+		where = strings.Replace(where, "?", fmt.Sprintf("%.2f", in), 1)
+	case string:
+		where = strings.Replace(where, "?", fmt.Sprintf("%q", in), 1)
+	case bool:
+		where = strings.Replace(where, "?", fmt.Sprintf("%t", in), 1)
+	case []int, []int32, []int64, []float32, []float64, []string, []bool:
+		params := anythingToSlice(in)
+		values := SearchReplaceArray(params)
+		where = strings.Replace(where, "?", values, 1)
+	case []WeightedElement:
+		var values []string
+		for _, item := range t {
+			values = append(values, fmt.Sprintf(`"%s":%d`, item.Index, item.Value))
+		}
+		strValues := strings.Join(values, ",")
+
+		where = strings.Replace(where, "?", fmt.Sprintf(`{%s}`, strValues), 1)
+	case WeakAnd:
+		where = strings.Replace(where, "?", t.Source(), 1)
+	default:
+		fmt.Print("Different type", t)
+		where = strings.Replace(where, "?", fmt.Sprintf("%v", in), 1)
+	}
+
+	return where
+}
+
+// SearchReplaceArray handles cases where the params is an array object.
+func SearchReplaceArray(params []interface{}) string {
+	arr := make([]string, 0, len(params))
+	for _, param := range params {
+		arr = append(arr, SearchReplace("?", param))
+	}
+
+	return strings.Join(arr, ",")
+}
+
+func anythingToSlice(a interface{}) []interface{} {
+	v := reflect.ValueOf(a)
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		result := make([]interface{}, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			result[i] = v.Index(i).Interface()
+		}
+		return result
+	default:
+		panic("not supported")
+	}
+}
+
+// Validate checks if the operation is valid.
+func (s *SearchService) Validate() error {
+	var invalid []string
+
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+func (s *SearchService) buildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodPost
+	path = "/search/"
+
+	params := url.Values{}
+	if s.timeout != "" {
+		params.Set("timeout", s.timeout)
+	}
+
+	if s.ranking.Profile != "" {
+		params.Set("ranking", s.ranking.Profile)
+	}
+
+	if s.ranking.SoftTimeout != nil {
+
+		if !s.ranking.SoftTimeout.Enabled {
+			params.Set("ranking.softtimeout.enable", "false")
+		}
+	}
+
+	if s.sorting.Degrading != nil {
+		if !*s.sorting.Degrading {
+			params.Set("sorting.degrading", "false")
+		}
+	}
+
+	for _, p := range s.presentation {
+		params.Set(p.key, fmt.Sprintf("%v", p.value))
+	}
+
+	if len(s.rankingFeaturesQuery.Values) > 0 {
+		for index, value := range s.rankingFeaturesQuery.Values {
+			params.Set(fmt.Sprintf("ranking.features.query(%s)", index), fmt.Sprintf("%v", value))
+		}
+	}
+
+	return method, path, params
+
+}
+
+// Source returns the body of the request we will make to create job
+// endpoint
+func (s *SearchService) Source() interface{} {
+	s.buildQuery()
+
+	return s.searchRequest
+}
+
+// Do executes the search operation. Returns a SearchResponse or an error.
+func (s *SearchService) Do(ctx context.Context) (*SearchResponse, error) {
+
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	method, path, params := s.buildURL()
+
+	data := s.Source()
+
+	pr := PerformRequest{
+		Method:  method,
+		Path:    path,
+		Params:  params,
+		Body:    data,
+		Headers: s.headers,
+	}
+
+	// Get HTTP response
+	res, err := s.client.PerformRequest(ctx, pr)
+
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	var sr SearchResponse
+	sr.Status = res.StatusCode
+
+	err = json.NewDecoder(res.Body).Decode(&sr)
+
+	return &sr, err
+
+}
+
+// SearchResponse is the result of executing a YQL query in Vespa.
+type SearchResponse struct {
+	Status int  `json:"status"`
+	Root   Root `json:"root,omitempty"`
+}
+
+// Root is the tree of returned data
+type Root struct {
+	ID        string    `json:"id"`
+	Relevance Relevance `json:"relevance,omitempty"`
+	Fields    Fields    `json:"fields,omitempty"`
+	Coverage  Coverage  `json:"coverage,omitempty"`
+	Errors    []Error   `json:"errors,omitempty"`
+	Children  []Child   `json:"children,omitempty"`
+}
+
+// Fields attribute contains the number of hits
+type Fields struct {
+	TotalCount int `json:"totalCount,omitempty"`
+}
+
+// Coverage attribute is the metadata about how much of the total corpus has been scanned to return the given documents.
+type Coverage struct {
+	Coverage    int  `json:"coverage,omitempty"`
+	Documents   int  `json:"documents,omitempty"`
+	Full        bool `json:"full,omitempty"`
+	Nodes       int  `json:"nodes,omitempty"`
+	Results     int  `json:"results,omitempty"`
+	ResultsFull int  `json:"resultsFull,omitempty"`
+}
+
+// Child attribute is the array of JSON objects with exactly the same structure as root.
+type Child struct {
+	ID        string          `json:"id,omitempty"`
+	Relevance Relevance       `json:"relevance,omitempty"`
+	Source    string          `json:"source,omitempty"`
+	Fields    json.RawMessage `json:"fields,omitempty"`
+}
+
+// Error represents an error returned by Vespa.
+type Error struct {
+	Code       int    `json:"code,omitempty"`
+	Message    string `json:"message,omitempty"`
+	Source     string `json:"source,omitempty"`
+	StackTrace string `json:"stackTrace,omitempty"`
+	Summary    string `json:"summary,omitempty"`
+	Transient  string `json:"transient,omitempty"`
+}

--- a/client/go/api/search_test.go
+++ b/client/go/api/search_test.go
@@ -1,0 +1,1703 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewSearchService(t *testing.T) {
+	client := &Client{}
+
+	want := &SearchService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+
+	got := NewSearchService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewSearchService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestSearchService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set the default value to namespace",
+			args: args{
+				name: "default",
+			},
+			want: &SearchService{
+				namespace: "default",
+			},
+		},
+		{
+			name: "Set a specific value to namespace",
+			args: args{
+				name: "specific",
+			},
+			want: &SearchService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set the job to scheme",
+			args: args{
+				scheme: "job",
+			},
+			want: &SearchService{
+				scheme: "job",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Ranking(t *testing.T) {
+	type args struct {
+		ranking Ranking
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set ranking",
+			args: args{
+				ranking: Ranking{
+					Profile: "custom",
+				},
+			},
+			want: &SearchService{
+				ranking: Ranking{
+					Profile: "custom",
+				},
+			},
+		},
+		{
+			name: "Set ranking with softtimeout",
+			args: args{
+				ranking: Ranking{
+					Profile: "custom",
+					SoftTimeout: &SoftTimeout{
+						Enabled: true,
+					},
+				},
+			},
+			want: &SearchService{
+				ranking: Ranking{
+					Profile: "custom",
+					SoftTimeout: &SoftTimeout{
+						Enabled: true,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Ranking(tt.args.ranking); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.ranking() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Timeout(t *testing.T) {
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set a second value to timeout",
+			args: args{
+				timeout: "12s",
+			},
+			want: &SearchService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "Set a minute value to timeout",
+			args: args{
+				timeout: "1m",
+			},
+			want: &SearchService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Query(t *testing.T) {
+	type args struct {
+		query string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set a second value to timeout",
+			args: args{
+				query: "nurse",
+			},
+			want: &SearchService{
+				query: "nurse",
+			},
+		},
+		{
+			name: "Set a minute value to timeout",
+			args: args{
+				query: "engineer",
+			},
+			want: &SearchService{
+				query: "engineer",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Query(tt.args.query); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Type(t *testing.T) {
+	type args struct {
+		searchType string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set a second value to timeout",
+			args: args{
+				searchType: "all",
+			},
+			want: &SearchService{
+				searchType: "all",
+			},
+		},
+		{
+			name: "Set a minute value to timeout",
+			args: args{
+				searchType: "any",
+			},
+			want: &SearchService{
+				searchType: "any",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Type(tt.args.searchType); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Hits(t *testing.T) {
+	type args struct {
+		hits int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set a second value to timeout",
+			args: args{
+				hits: 10,
+			},
+			want: &SearchService{
+				hits: 10,
+			},
+		},
+		{
+			name: "Set a minute value to timeout",
+			args: args{
+				hits: 25,
+			},
+			want: &SearchService{
+				hits: 25,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Hits(tt.args.hits); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Fields(t *testing.T) {
+	type args struct {
+		fields []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set the required fields to display in the final result",
+			args: args{
+				fields: []string{"title", "description"},
+			},
+			want: &SearchService{
+				selectedFields: "title, description",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+			if got := s.Fields(tt.args.fields...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Fields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Where(t *testing.T) {
+	type args struct {
+		query  string
+		params []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set a where clause with a contain condition",
+			args: args{
+				query: `title contains ?`,
+				params: []interface{}{
+					"software",
+				},
+			},
+			want: &SearchService{
+				whereClause: whereParams{
+					where: `title contains ?`,
+					params: []interface{}{
+						"software",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Where(tt.args.query, tt.args.params...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Where() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Limit(t *testing.T) {
+	type args struct {
+		limit int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set limit in the query",
+			args: args{
+				limit: 25,
+			},
+			want: &SearchService{
+				limit: 25,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Limit(tt.args.limit); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Limit() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Offset(t *testing.T) {
+
+	type args struct {
+		offset int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set offset in the query",
+			args: args{
+				offset: 10,
+			},
+			want: &SearchService{
+				offset: 10,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.Offset(tt.args.offset); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Offset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_OrderBy(t *testing.T) {
+
+	type args struct {
+		field  string
+		isDesc bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "Set order by title ASC",
+			args: args{
+				field: "title",
+			},
+			want: &SearchService{
+				orderBy: "title",
+			},
+		},
+		{
+			name: "Set order by title DESC",
+			args: args{
+				field:  "title",
+				isDesc: true,
+			},
+			want: &SearchService{
+				orderBy: "title",
+				isDesc:  true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+
+			if got := s.OrderBy(tt.args.field, tt.args.isDesc); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.OrderBy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_buildQuery(t *testing.T) {
+	type fields struct {
+		scheme         string
+		selectedFields string
+		whereClause    whereParams
+		limit          int
+		offset         int
+		orderBy        string
+		isDesc         bool
+		query          string
+		searchType     string
+		hits           int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   SearchRequest
+	}{
+		{
+			name: "Set a contain condition to the final YQL query",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where title contains "developer";`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using a query we should get the desired Search Request",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "status contains ?",
+					params: []interface{}{
+						"active",
+					},
+				},
+				query: "amazing job",
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where userQuery() AND status contains "active";`,
+				Type:    "all",
+				Query:   "amazing job",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using query but not where, we should get the desired Search Request",
+			fields: fields{
+				scheme: "job",
+				query:  "amazing job",
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where userQuery();`,
+				Type:    "all",
+				Query:   "amazing job",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set fields and a contain condition to the final YQL query",
+			fields: fields{
+				scheme:         "job",
+				selectedFields: "title, description",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select title, description from job where title contains "developer";`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set fields and all inactive jobs condition to the final YQL query",
+			fields: fields{
+				scheme:         "job",
+				selectedFields: "title, description",
+				whereClause: whereParams{
+					where: "hidden = ?",
+					params: []interface{}{
+						true,
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select title, description from job where hidden = true;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set fields and get the jobs with CPC greater than 0.20 to the final YQL query",
+			fields: fields{
+				scheme:         "job",
+				selectedFields: "title, description, bid_cpc",
+				whereClause: whereParams{
+					where: "bid_cpc > ?",
+					params: []interface{}{
+						0.20,
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select title, description, bid_cpc from job where bid_cpc > 0.20;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set a phrase condition to the final YQL query",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title contains phrase(?)",
+					params: []interface{}{
+						"software developer",
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where title contains phrase("software developer");`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set a match condition with a limit and offset",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title matches ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				limit:  25,
+				offset: 50,
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where title matches "developer" limit 75 offset 50;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set an order by title ASC",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "range(sequence, ?, ?)",
+					params: []interface{}{
+						0, 5,
+					},
+				},
+				orderBy: "sequence",
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where range(sequence, 0, 5) order by sequence;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "Set an order by title DESC",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "range(sequence, ?, ?)",
+					params: []interface{}{
+						0, 5,
+					},
+				},
+				orderBy: "sequence",
+				isDesc:  true,
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where range(sequence, 0, 5) order by sequence desc;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+
+		{
+			name: "Set pagination without condition",
+			fields: fields{
+				scheme:  "job",
+				limit:   10,
+				offset:  50,
+				orderBy: "title",
+			},
+			want: SearchRequest{
+				YQL:     `select * from job order by title limit 60 offset 50;`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using IN with numbers, we should get the expected result",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "id IN(?)",
+					params: []interface{}{
+						[]int{1, 2, 3},
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where id IN(1,2,3);`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using IN with string, we should get the expected result",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "name IN(?)",
+					params: []interface{}{
+						[]string{"Tom", "Joe", "Aaron"},
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where name IN("Tom","Joe","Aaron");`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using IN with int64, we should get the value between single quotes",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "value > ?",
+					params: []interface{}{
+						int64(355425505594573937),
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where value > '355425505594573937';`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "when type is set, we should see it on Search Request",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				searchType: "any",
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where title contains "developer";`,
+				Type:    "any",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "when hitss is set, we should see it on Search Request",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				hits: 25,
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where title contains "developer";`,
+				Type:    "all",
+				Query:   "",
+				Hits:    25,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using []WeightedElement, we should get the desired output",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "weightedSet(?, ?)",
+					params: []interface{}{
+						"feed_id",
+						[]WeightedElement{
+							{
+								Index: "32234",
+								Value: 1,
+							},
+							{
+								Index: "50123",
+								Value: 2,
+							},
+						},
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where weightedSet("feed_id", {"32234":1,"50123":2});`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+		{
+			name: "When using WeakAnd, we should get the desired output",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "?",
+					params: []interface{}{
+						WeakAnd{
+							Hits: 10,
+							Entries: []WeakAndEntry{
+								{Field: "default", Value: "software"},
+								{Field: "default", Value: "engineer"},
+							},
+						},
+					},
+				},
+			},
+			want: SearchRequest{
+				YQL:     `select * from job where ([{"targetHits":10}] weakAnd(default contains "software", default contains "engineer"));`,
+				Type:    "all",
+				Query:   "",
+				Hits:    0,
+				Ranking: "",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				scheme:         tt.fields.scheme,
+				selectedFields: tt.fields.selectedFields,
+				whereClause:    tt.fields.whereClause,
+				limit:          tt.fields.limit,
+				offset:         tt.fields.offset,
+				orderBy:        tt.fields.orderBy,
+				isDesc:         tt.fields.isDesc,
+				query:          tt.fields.query,
+				searchType:     tt.fields.searchType,
+				hits:           tt.fields.hits,
+			}
+			s.buildQuery()
+
+			if !reflect.DeepEqual(tt.want, s.searchRequest) {
+				t.Errorf(" expected buildQuery() to return %+v, got %+v", tt.want, s.searchRequest)
+			}
+		})
+	}
+}
+
+func TestSearchService_Validate(t *testing.T) {
+	type fields struct {
+		client      HTTPClient
+		namespace   string
+		scheme      string
+		whereClause whereParams
+		query       string
+		timeout     string
+		headers     http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "Missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "Missing one required field should return an error",
+			fields: fields{
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "All fields set should return error nil",
+			fields: fields{
+				scheme: "job",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				client:      tt.fields.client,
+				namespace:   tt.fields.namespace,
+				scheme:      tt.fields.scheme,
+				whereClause: tt.fields.whereClause,
+				query:       tt.fields.query,
+				timeout:     tt.fields.timeout,
+				headers:     tt.fields.headers,
+			}
+
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("SearchService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSearchService_buildURL(t *testing.T) {
+	type fields struct {
+		client               HTTPClient
+		namespace            string
+		scheme               string
+		whereClause          whereParams
+		query                string
+		timeout              string
+		headers              http.Header
+		presentation         []Presentation
+		ranking              Ranking
+		rankingFeaturesQuery RankingFeaturesQuery
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "When called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				scheme: "job",
+			},
+			want:  "POST",
+			want1: "/search/",
+			want2: url.Values{},
+		},
+		{
+			name: "When called with presentation, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				scheme: "job",
+				presentation: []Presentation{
+					{
+						key:   "presentation.bolding",
+						value: true,
+					},
+				},
+			},
+			want:  "POST",
+			want1: "/search/",
+			want2: url.Values{
+				"presentation.bolding": []string{"true"},
+			},
+		},
+		{
+			name: "When called with ranking, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				scheme: "job",
+				ranking: Ranking{
+					Profile: "custom_rank",
+				},
+			},
+			want:  "POST",
+			want1: "/search/",
+			want2: url.Values{
+				"ranking": []string{"custom_rank"},
+			},
+		},
+		{
+			name: "When called with ranking softimeout, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				scheme: "job",
+				ranking: Ranking{
+					Profile: "custom_rank",
+					SoftTimeout: &SoftTimeout{
+						Enabled: false,
+					},
+				},
+			},
+			want:  "POST",
+			want1: "/search/",
+			want2: url.Values{
+				"ranking":                    []string{"custom_rank"},
+				"ranking.softtimeout.enable": []string{"false"},
+			},
+		},
+		{
+			name: "When called with ranking features query, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				scheme: "job",
+				rankingFeaturesQuery: RankingFeaturesQuery{
+					Values: map[string]interface{}{
+						"param1": 1,
+						"param2": 1.2,
+					},
+				},
+			},
+			want:  "POST",
+			want1: "/search/",
+			want2: url.Values{
+				"ranking.features.query(param1)": []string{"1"},
+				"ranking.features.query(param2)": []string{"1.2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				client:               tt.fields.client,
+				namespace:            tt.fields.namespace,
+				scheme:               tt.fields.scheme,
+				whereClause:          tt.fields.whereClause,
+				query:                tt.fields.query,
+				timeout:              tt.fields.timeout,
+				headers:              tt.fields.headers,
+				presentation:         tt.fields.presentation,
+				ranking:              tt.fields.ranking,
+				rankingFeaturesQuery: tt.fields.rankingFeaturesQuery,
+			}
+			got, got1, got2 := s.buildURL()
+			if got != tt.want {
+				t.Errorf("SearchService.buildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("SearchService.buildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("SearchService.buildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestSearchService_Source(t *testing.T) {
+	type fields struct {
+		scheme string
+		where  string
+		offset int
+		limit  int
+		params []interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   SearchRequest
+	}{
+		{
+			name: "",
+			fields: fields{
+				scheme: "job",
+				where:  `title contains ?`,
+				params: []interface{}{
+					"developer",
+				},
+			},
+			want: SearchRequest{
+				YQL:  `select * from job where title contains "developer";`,
+				Type: "all",
+			},
+		},
+		{
+			name: "with pagination",
+			fields: fields{
+				scheme: "job",
+				where:  `title contains ?`,
+				params: []interface{}{
+					"developer",
+				},
+				offset: 0,
+				limit:  10,
+			},
+			want: SearchRequest{
+				YQL:  `select * from job where title contains "developer" limit 10;`,
+				Type: "all",
+			},
+		},
+		{
+			name: "with offset 10",
+			fields: fields{
+				scheme: "job",
+				where:  `title contains ?`,
+				params: []interface{}{
+					"developer",
+				},
+				offset: 10,
+				limit:  10,
+			},
+			want: SearchRequest{
+				YQL:  `select * from job where title contains "developer" limit 20 offset 10;`,
+				Type: "all",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				client:         nil,
+				namespace:      "",
+				scheme:         tt.fields.scheme,
+				selectedFields: "",
+				whereClause:    whereParams{where: tt.fields.where, params: tt.fields.params},
+				limit:          tt.fields.limit,
+				offset:         tt.fields.offset,
+				orderBy:        "",
+				isDesc:         false,
+				timeout:        "",
+				presentation:   []Presentation{},
+				headers:        map[string][]string{},
+			}
+
+			got := s.Source()
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Source() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_Do(t *testing.T) {
+	ctx := context.Background()
+
+	type fields struct {
+		client      HTTPClient
+		namespace   string
+		scheme      string
+		whereClause whereParams
+		query       string
+		timeout     string
+		headers     http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *SearchResponse
+		wantErr bool
+	}{
+		{
+			name:   "When validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "When perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				scheme:    "job",
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				query: `select * from job where title contains "developer";`,
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "When perform request succeed, it should return a SearchResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"root": {
+							"id": "toplevel",
+							"relevance": 1,
+							"fields": {
+								"totalCount": 1
+							},
+							"coverage": {
+								"coverage": 100,
+								"documents": 1,
+								"full": true,
+								"nodes": 1,
+								"results": 1,
+								"resultsFull": 1
+							},
+							"children": [{
+								"id": "id:default:job::abc1234",
+								"relevance": 1,
+								"source": "job",
+								"fields": {
+									"sddocname": "job",
+									"documentid": "id:default:job::abc1234",
+									"id": "abc1234",
+									"external_id": "zyx2345",
+									"title": "Sr Software Engineer",
+									"description": "Senior <hi>Software</hi> Engineer provides innovative, simple solutions that<sep/>",
+									"hash": [
+										104,
+										97,
+										115,
+										104,
+										50,
+										53,
+										54
+
+									],
+									"feed_id": 46007,
+									"hiring_organization": "Guegue Comunicaciones",
+									"url": "https://jobs.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+									"url_mobile": "https://jobs.mobile.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+									"street_address1": "4846 University Street",
+									"street_address2": "",
+									"city": "Seattle",
+									"state": "WA",
+									"country": "",
+									"country_name": "",
+									"region": "",
+									"postal_code": 98106,
+									"location": {
+										"y": 3.7401e+07,
+										"x": -1.21996e+08
+									},
+									"bid_cpc": 0.5,
+									"creation_date": 1612310992,
+									"posting_creation_date": 1612310992,
+									"posting_update_date": 1612310992,
+									"posting_last_seen": 1612310992,
+									"hidden": false,
+									"sequence": 1
+								}
+							}]
+						}
+					}
+					`)),
+				},
+				scheme:    "job",
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				query: `select * from job where title contains "developer";`,
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &SearchResponse{
+				Status: 200,
+				Root: Root{
+					ID:        "toplevel",
+					Relevance: 1,
+					Fields: Fields{
+						TotalCount: 1,
+					},
+					Coverage: Coverage{
+						Coverage:    100,
+						Documents:   1,
+						Full:        true,
+						Nodes:       1,
+						Results:     1,
+						ResultsFull: 1,
+					},
+					Children: []Child{
+						{
+							ID:        "id:default:job::abc1234",
+							Relevance: 1,
+							Source:    "job",
+							Fields: json.RawMessage{
+								123, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 100, 100, 111, 99, 110, 97, 109, 101, 34, 58, 32, 34, 106, 111, 98, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 100, 111, 99, 117, 109, 101, 110, 116, 105, 100, 34, 58, 32, 34, 105, 100, 58, 100, 101, 102, 97, 117, 108, 116, 58, 106, 111, 98, 58, 58, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 105, 100, 34, 58, 32, 34, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 101, 120, 116, 101, 114, 110, 97, 108, 95, 105, 100, 34, 58, 32, 34, 122, 121, 120, 50, 51, 52, 53, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 116, 105, 116, 108, 101, 34, 58, 32, 34, 83, 114, 32, 83, 111, 102, 116, 119, 97, 114, 101, 32, 69, 110, 103, 105, 110, 101, 101, 114, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 34, 58, 32, 34, 83, 101, 110, 105, 111, 114, 32, 60, 104, 105, 62, 83, 111, 102, 116, 119, 97, 114, 101, 60, 47, 104, 105, 62, 32, 69, 110, 103, 105, 110, 101, 101, 114, 32, 112, 114, 111, 118, 105, 100, 101, 115, 32, 105, 110, 110, 111, 118, 97, 116, 105, 118, 101, 44, 32, 115, 105, 109, 112, 108, 101, 32, 115, 111, 108, 117, 116, 105, 111, 110, 115, 32, 116, 104, 97, 116, 60, 115, 101, 112, 47, 62, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 97, 115, 104, 34, 58, 32, 91, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 57, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 49, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 48, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 51, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 52, 10, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 93, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 102, 101, 101, 100, 95, 105, 100, 34, 58, 32, 52, 54, 48, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 114, 105, 110, 103, 95, 111, 114, 103, 97, 110, 105, 122, 97, 116, 105, 111, 110, 34, 58, 32, 34, 71, 117, 101, 103, 117, 101, 32, 67, 111, 109, 117, 110, 105, 99, 97, 99, 105, 111, 110, 101, 115, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 95, 109, 111, 98, 105, 108, 101, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 109, 111, 98, 105, 108, 101, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 49, 34, 58, 32, 34, 52, 56, 52, 54, 32, 85, 110, 105, 118, 101, 114, 115, 105, 116, 121, 32, 83, 116, 114, 101, 101, 116, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 50, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 105, 116, 121, 34, 58, 32, 34, 83, 101, 97, 116, 116, 108, 101, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 97, 116, 101, 34, 58, 32, 34, 87, 65, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 95, 110, 97, 109, 101, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 114, 101, 103, 105, 111, 110, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 97, 108, 95, 99, 111, 100, 101, 34, 58, 32, 57, 56, 49, 48, 54, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 108, 111, 99, 97, 116, 105, 111, 110, 34, 58, 32, 123, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 121, 34, 58, 32, 51, 46, 55, 52, 48, 49, 101, 43, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 120, 34, 58, 32, 45, 49, 46, 50, 49, 57, 57, 54, 101, 43, 48, 56, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 125, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 98, 105, 100, 95, 99, 112, 99, 34, 58, 32, 48, 46, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 117, 112, 100, 97, 116, 101, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 108, 97, 115, 116, 95, 115, 101, 101, 110, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 100, 100, 101, 110, 34, 58, 32, 102, 97, 108, 115, 101, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 101, 113, 117, 101, 110, 99, 101, 34, 58, 32, 49, 10, 9, 9, 9, 9, 9, 9, 9, 9, 125,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "When there's not any result",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"root": {
+							"id": "toplevel",
+							"relevance": 1,
+							"fields": {
+								"totalCount": 0
+							},
+							"coverage": {
+								"coverage": 100,
+								"documents": 1,
+								"full": true,
+								"nodes": 1,
+								"results": 1,
+								"resultsFull": 1
+							},
+							"children": []
+						}
+					}
+					`)),
+				},
+				scheme:    "job",
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"pilot",
+					},
+				},
+				query: `select * from job where title contains "pilot";`,
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &SearchResponse{
+				Status: 200,
+				Root: Root{
+					ID:        "toplevel",
+					Relevance: 1,
+					Fields: Fields{
+						TotalCount: 0,
+					},
+					Coverage: Coverage{
+						Coverage:    100,
+						Documents:   1,
+						Full:        true,
+						Nodes:       1,
+						Results:     1,
+						ResultsFull: 1,
+					},
+					Children: []Child{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "When the relevance is a string(NAN) we should treat it as 0",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"root": {
+							"id": "toplevel",
+							"relevance": 1,
+							"fields": {
+								"totalCount": 1
+							},
+							"coverage": {
+								"coverage": 100,
+								"documents": 1,
+								"full": true,
+								"nodes": 1,
+								"results": 1,
+								"resultsFull": 1
+							},
+							"children": [{
+								"id": "id:default:job::abc1234",
+								"relevance": "NaN",
+								"source": "job",
+								"fields": {
+									"sddocname": "job",
+									"documentid": "id:default:job::abc1234",
+									"id": "abc1234",
+									"external_id": "zyx2345",
+									"title": "Sr Software Engineer",
+									"description": "Senior <hi>Software</hi> Engineer provides innovative, simple solutions that<sep/>",
+									"hash": [
+										104,
+										97,
+										115,
+										104,
+										50,
+										53,
+										54
+
+									],
+									"feed_id": 46007,
+									"hiring_organization": "Guegue Comunicaciones",
+									"url": "https://jobs.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+									"url_mobile": "https://jobs.mobile.foo.bar/job/Sr-Software-Engineer-MA-01752/707809600/?feedId=289100&utm_source=Indeed&utm_campaign=TJX_Indeed&utm_source=Indeed&mediaGuid=2f0f3f22-5295-44fb-a9f0-4ce776277ecc&bidCode=6dc807ce-a039-400c-b6d5-dd7ceea39c85&sponsored=ppc",
+									"street_address1": "4846 University Street",
+									"street_address2": "",
+									"city": "Seattle",
+									"state": "WA",
+									"country": "",
+									"country_name": "",
+									"region": "",
+									"postal_code": 98106,
+									"location": {
+										"y": 3.7401e+07,
+										"x": -1.21996e+08
+									},
+									"bid_cpc": 0.5,
+									"creation_date": 1612310992,
+									"posting_creation_date": 1612310992,
+									"posting_update_date": 1612310992,
+									"posting_last_seen": 1612310992,
+									"hidden": false,
+									"sequence": 1
+								}
+							}]
+						}
+					}
+					`)),
+				},
+				scheme:    "job",
+				namespace: "default",
+				whereClause: whereParams{
+					where: "title contains ?",
+					params: []interface{}{
+						"developer",
+					},
+				},
+				query: `select * from job where title contains "developer";`,
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &SearchResponse{
+				Status: 200,
+				Root: Root{
+					ID:        "toplevel",
+					Relevance: 1,
+					Fields: Fields{
+						TotalCount: 1,
+					},
+					Coverage: Coverage{
+						Coverage:    100,
+						Documents:   1,
+						Full:        true,
+						Nodes:       1,
+						Results:     1,
+						ResultsFull: 1,
+					},
+					Children: []Child{
+						{
+							ID:        "id:default:job::abc1234",
+							Relevance: 0,
+							Source:    "job",
+							Fields: json.RawMessage{
+								123, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 100, 100, 111, 99, 110, 97, 109, 101, 34, 58, 32, 34, 106, 111, 98, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 100, 111, 99, 117, 109, 101, 110, 116, 105, 100, 34, 58, 32, 34, 105, 100, 58, 100, 101, 102, 97, 117, 108, 116, 58, 106, 111, 98, 58, 58, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 105, 100, 34, 58, 32, 34, 97, 98, 99, 49, 50, 51, 52, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 101, 120, 116, 101, 114, 110, 97, 108, 95, 105, 100, 34, 58, 32, 34, 122, 121, 120, 50, 51, 52, 53, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 116, 105, 116, 108, 101, 34, 58, 32, 34, 83, 114, 32, 83, 111, 102, 116, 119, 97, 114, 101, 32, 69, 110, 103, 105, 110, 101, 101, 114, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 100, 101, 115, 99, 114, 105, 112, 116, 105, 111, 110, 34, 58, 32, 34, 83, 101, 110, 105, 111, 114, 32, 60, 104, 105, 62, 83, 111, 102, 116, 119, 97, 114, 101, 60, 47, 104, 105, 62, 32, 69, 110, 103, 105, 110, 101, 101, 114, 32, 112, 114, 111, 118, 105, 100, 101, 115, 32, 105, 110, 110, 111, 118, 97, 116, 105, 118, 101, 44, 32, 115, 105, 109, 112, 108, 101, 32, 115, 111, 108, 117, 116, 105, 111, 110, 115, 32, 116, 104, 97, 116, 60, 115, 101, 112, 47, 62, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 97, 115, 104, 34, 58, 32, 91, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 57, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 49, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 49, 48, 52, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 48, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 51, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 53, 52, 10, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 93, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 102, 101, 101, 100, 95, 105, 100, 34, 58, 32, 52, 54, 48, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 114, 105, 110, 103, 95, 111, 114, 103, 97, 110, 105, 122, 97, 116, 105, 111, 110, 34, 58, 32, 34, 71, 117, 101, 103, 117, 101, 32, 67, 111, 109, 117, 110, 105, 99, 97, 99, 105, 111, 110, 101, 115, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 117, 114, 108, 95, 109, 111, 98, 105, 108, 101, 34, 58, 32, 34, 104, 116, 116, 112, 115, 58, 47, 47, 106, 111, 98, 115, 46, 109, 111, 98, 105, 108, 101, 46, 102, 111, 111, 46, 98, 97, 114, 47, 106, 111, 98, 47, 83, 114, 45, 83, 111, 102, 116, 119, 97, 114, 101, 45, 69, 110, 103, 105, 110, 101, 101, 114, 45, 77, 65, 45, 48, 49, 55, 53, 50, 47, 55, 48, 55, 56, 48, 57, 54, 48, 48, 47, 63, 102, 101, 101, 100, 73, 100, 61, 50, 56, 57, 49, 48, 48, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 99, 97, 109, 112, 97, 105, 103, 110, 61, 84, 74, 88, 95, 73, 110, 100, 101, 101, 100, 38, 117, 116, 109, 95, 115, 111, 117, 114, 99, 101, 61, 73, 110, 100, 101, 101, 100, 38, 109, 101, 100, 105, 97, 71, 117, 105, 100, 61, 50, 102, 48, 102, 51, 102, 50, 50, 45, 53, 50, 57, 53, 45, 52, 52, 102, 98, 45, 97, 57, 102, 48, 45, 52, 99, 101, 55, 55, 54, 50, 55, 55, 101, 99, 99, 38, 98, 105, 100, 67, 111, 100, 101, 61, 54, 100, 99, 56, 48, 55, 99, 101, 45, 97, 48, 51, 57, 45, 52, 48, 48, 99, 45, 98, 54, 100, 53, 45, 100, 100, 55, 99, 101, 101, 97, 51, 57, 99, 56, 53, 38, 115, 112, 111, 110, 115, 111, 114, 101, 100, 61, 112, 112, 99, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 49, 34, 58, 32, 34, 52, 56, 52, 54, 32, 85, 110, 105, 118, 101, 114, 115, 105, 116, 121, 32, 83, 116, 114, 101, 101, 116, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 114, 101, 101, 116, 95, 97, 100, 100, 114, 101, 115, 115, 50, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 105, 116, 121, 34, 58, 32, 34, 83, 101, 97, 116, 116, 108, 101, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 116, 97, 116, 101, 34, 58, 32, 34, 87, 65, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 111, 117, 110, 116, 114, 121, 95, 110, 97, 109, 101, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 114, 101, 103, 105, 111, 110, 34, 58, 32, 34, 34, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 97, 108, 95, 99, 111, 100, 101, 34, 58, 32, 57, 56, 49, 48, 54, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 108, 111, 99, 97, 116, 105, 111, 110, 34, 58, 32, 123, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 121, 34, 58, 32, 51, 46, 55, 52, 48, 49, 101, 43, 48, 55, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 120, 34, 58, 32, 45, 49, 46, 50, 49, 57, 57, 54, 101, 43, 48, 56, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 125, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 98, 105, 100, 95, 99, 112, 99, 34, 58, 32, 48, 46, 53, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 99, 114, 101, 97, 116, 105, 111, 110, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 117, 112, 100, 97, 116, 101, 95, 100, 97, 116, 101, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 112, 111, 115, 116, 105, 110, 103, 95, 108, 97, 115, 116, 95, 115, 101, 101, 110, 34, 58, 32, 49, 54, 49, 50, 51, 49, 48, 57, 57, 50, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 104, 105, 100, 100, 101, 110, 34, 58, 32, 102, 97, 108, 115, 101, 44, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 34, 115, 101, 113, 117, 101, 110, 99, 101, 34, 58, 32, 49, 10, 9, 9, 9, 9, 9, 9, 9, 9, 125,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				client:      tt.fields.client,
+				namespace:   tt.fields.namespace,
+				scheme:      tt.fields.scheme,
+				whereClause: tt.fields.whereClause,
+				query:       tt.fields.query,
+				timeout:     tt.fields.timeout,
+				headers:     tt.fields.headers,
+			}
+			got, err := s.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SearchService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Do() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWhereWithSliceParam(t *testing.T) {
+
+	svc := SearchService{}
+	param := []int{1, 2, 3}
+
+	want := SearchService{
+		whereClause: whereParams{
+			params: []interface{}{
+				[]int{1, 2, 3},
+				"01",
+			},
+		},
+	}
+
+	svc.Where("", param, "01")
+
+	if !reflect.DeepEqual(svc, want) {
+		t.Errorf("SearchService.Where() = %v, want %v", svc, want)
+	}
+
+}
+
+func TestSearchService_Presentation(t *testing.T) {
+	type fields struct {
+		client         HTTPClient
+		namespace      string
+		scheme         string
+		selectedFields string
+		whereClause    whereParams
+		limit          int
+		offset         int
+		orderBy        string
+		isDesc         bool
+		query          string
+		timeout        string
+		presentation   []Presentation
+		headers        http.Header
+	}
+	type args struct {
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *SearchService
+	}{
+		{
+			name: "when used we should expect the value in the presentation array",
+			args: args{
+				key:   "presentation.summary",
+				value: "record",
+			},
+			want: &SearchService{
+				presentation: []Presentation{
+					{
+						key:   "presentation.summary",
+						value: "record",
+					},
+				},
+			},
+		},
+		{
+			name: "when used with a bool value should expect the value in the presentation array",
+			args: args{
+				key:   "presentation.summary",
+				value: true,
+			},
+			want: &SearchService{
+				presentation: []Presentation{
+					{
+						key:   "presentation.summary",
+						value: true,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{
+				client:         tt.fields.client,
+				namespace:      tt.fields.namespace,
+				scheme:         tt.fields.scheme,
+				selectedFields: tt.fields.selectedFields,
+				whereClause:    tt.fields.whereClause,
+				limit:          tt.fields.limit,
+				offset:         tt.fields.offset,
+				orderBy:        tt.fields.orderBy,
+				isDesc:         tt.fields.isDesc,
+				query:          tt.fields.query,
+				timeout:        tt.fields.timeout,
+				presentation:   tt.fields.presentation,
+				headers:        tt.fields.headers,
+			}
+			if got := s.Presentation(tt.args.key, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.Presentation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchService_RankingFeatureQuery(t *testing.T) {
+	type args struct {
+		features RankingFeaturesQuery
+	}
+	tests := []struct {
+		name string
+		args args
+		want *SearchService
+	}{
+		{
+			name: "when calling rankingfeaturequery we should have the value set",
+			args: args{
+				features: RankingFeaturesQuery{
+					Values: map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+			want: &SearchService{
+				rankingFeaturesQuery: RankingFeaturesQuery{
+					Values: map[string]interface{}{
+						"key": "value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SearchService{}
+			if got := s.RankingFeatureQuery(tt.args.features); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SearchService.RankingFeatureQuery() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/update.go
+++ b/client/go/api/update.go
@@ -1,0 +1,270 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+)
+
+// UpdateService adds or updates a typed JSON document in a specified schema,
+// making it searchable.
+//
+// See https://docs.vespa.ai/en/document-v1-api-guide.html
+// for details.
+type UpdateService struct {
+	client HTTPClient
+
+	namespace       string
+	scheme          string
+	id              string
+	selection       string
+	selectionClause whereParams
+	data            map[string]PartialUpdateItem
+	timeout         string
+	continuation    string
+	cluster         string
+
+	headers http.Header
+}
+
+// NewUpdateService will create and instance of UpdateService.
+func NewUpdateService(client HTTPClient) *UpdateService {
+	return &UpdateService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *UpdateService) Namespace(name string) *UpdateService {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *UpdateService) Scheme(scheme string) *UpdateService {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *UpdateService) ID(id string) *UpdateService {
+	s.id = id
+	return s
+}
+
+// Continuation sets the continuation value to make a new request
+func (s *UpdateService) Continuation(continuation string) *UpdateService {
+	s.continuation = continuation
+	return s
+}
+
+// Cluster sets the cluster value to make a new request
+func (s *UpdateService) Cluster(cluster string) *UpdateService {
+	s.cluster = cluster
+	return s
+}
+
+// Selection sets the selection string for the update. Check
+// https://docs.vespa.ai/en/reference/document-select-language.html for
+// supported sintax.
+func (s *UpdateService) Selection(where string, params ...interface{}) *UpdateService {
+	s.selectionClause = whereParams{
+		where:  where,
+		params: params,
+	}
+	s.buildSelect()
+
+	return s
+}
+
+// Field sets a single field to be updated. Can be called multiple times.
+func (s *UpdateService) Field(key string, value interface{}) *UpdateService {
+	if s.data == nil {
+		s.data = make(map[string]PartialUpdateItem)
+	}
+
+	s.data[key] = PartialUpdateItem{
+		Assign: value,
+	}
+
+	return s
+}
+
+// Fields sets the fields to update
+func (s *UpdateService) Fields(items ...PartialUpdateField) *UpdateService {
+	if s.data == nil {
+		s.data = make(map[string]PartialUpdateItem)
+	}
+
+	for _, item := range items {
+		s.data[item.Key] = PartialUpdateItem{
+			Assign: item.Value,
+		}
+	}
+
+	return s
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional
+// ks, s, ms or µs unit.
+func (s *UpdateService) Timeout(timeout string) *UpdateService {
+	s.timeout = timeout
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *UpdateService) Validate() error {
+	var invalid []string
+	if s.id == "" && s.selection == "" {
+		invalid = append(invalid, "id/selection")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+	if s.data == nil || len(s.data) == 0 {
+		invalid = append(invalid, "data")
+	}
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+func (s *UpdateService) buildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodPut
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params := url.Values{}
+	if s.timeout != "" {
+		params.Set("timeout", s.timeout)
+	}
+
+	if s.selection != "" {
+		params.Set("selection", s.selection)
+	}
+
+	if s.continuation != "" {
+		params.Set("continuation", s.continuation)
+	}
+
+	if s.cluster != "" {
+		params.Set("cluster", s.cluster)
+	}
+
+	return method, path, params
+
+}
+
+// Generate the YQL query
+func (s *UpdateService) buildSelect() {
+	var selection string
+	var idx int
+
+	if s.selectionClause.where != "" {
+		selection = s.selectionClause.where
+
+		for _, v := range []byte(selection) {
+			if v == '?' && len(s.selectionClause.params) > idx {
+				selection = VisitReplace(selection, s.selectionClause.params[idx])
+				idx++
+			}
+		}
+	}
+
+	s.selection = selection
+}
+
+// Source returns the body of the request we will make to create job
+// endpoint
+func (s *UpdateService) Source() interface{} {
+	payload := make(map[string]interface{})
+
+	payload["fields"] = s.data
+
+	return payload
+}
+
+// Do executes the create operation. Returns a UpdateResponse or an error.
+func (s *UpdateService) Do(ctx context.Context) (*UpdateResponse, error) {
+
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
+
+	var endResponse UpdateResponse
+	var lastErr error
+
+	for {
+		// Get URL for request
+		method, path, params := s.buildURL()
+		data := s.Source()
+
+		// Get HTTP response
+		res, err := s.client.PerformRequest(ctx, PerformRequest{
+			Method:  method,
+			Path:    path,
+			Params:  params,
+			Body:    data,
+			Headers: s.headers,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		defer func() {
+			err := res.Body.Close()
+			if err != nil {
+				log.Print(err)
+			}
+		}()
+
+		var ur UpdateResponse
+		endResponse.Status = res.StatusCode
+
+		err = json.NewDecoder(res.Body).Decode(&ur)
+		if err != nil {
+			lastErr = err
+			break
+		}
+
+		endResponse.DocumentCount += ur.DocumentCount // this could be 0.
+		endResponse.ID = ur.ID
+		endResponse.PathID = ur.PathID
+		endResponse.Message = ur.Message
+
+		if endResponse.Message != "" {
+			lastErr = fmt.Errorf(endResponse.Message)
+		}
+
+		if ur.Continuation == "" {
+			// when there is no continuation, the request is complete
+			break
+		}
+		s.Continuation(ur.Continuation) // set continuation for the next loop
+
+	}
+
+	return &endResponse, lastErr
+
+}
+
+// UpdateResponse is the result of updating a document in Vespa.
+type UpdateResponse struct {
+	Status        int    `json:"status"`
+	ID            string `json:"id,omitempty"`
+	PathID        string `json:"pathId,omitempty"`
+	Message       string `json:"message,omitempty"`
+	Continuation  string `json:"continuation,omitempty"`
+	DocumentCount int    `json:"documentCount,omitempty"`
+}

--- a/client/go/api/update_batch_request.go
+++ b/client/go/api/update_batch_request.go
@@ -1,0 +1,117 @@
+package vespa
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// UpdateBatchRequest is a request to update document in Vespa.
+// Implements the Batcheable interface so it can be used with
+// the Batch Service.
+type UpdateBatchRequest struct {
+	BatchableRequest
+	namespace string
+	scheme    string
+	id        string
+	data      map[string]PartialUpdateItem
+	headers   http.Header
+}
+
+// NewUpdateBatchRequest creates a new instance of UpdateBatchRequest
+func NewUpdateBatchRequest() *UpdateBatchRequest {
+	return &UpdateBatchRequest{}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (s *UpdateBatchRequest) Namespace(name string) *UpdateBatchRequest {
+	s.namespace = name
+	return s
+}
+
+// Scheme sets the name of the scheme.
+func (s *UpdateBatchRequest) Scheme(scheme string) *UpdateBatchRequest {
+	s.scheme = scheme
+	return s
+}
+
+// ID sets the id of the document
+func (s *UpdateBatchRequest) ID(id string) *UpdateBatchRequest {
+	s.id = id
+	return s
+}
+
+// Field sets a single field to be updated. Can be called multiple times.
+func (s *UpdateBatchRequest) Field(key string, value interface{}) *UpdateBatchRequest {
+	if s.data == nil {
+		s.data = make(map[string]PartialUpdateItem)
+	}
+
+	s.data[key] = PartialUpdateItem{
+		Assign: value,
+	}
+
+	return s
+}
+
+// Fields sets the fields to update
+func (s *UpdateBatchRequest) Fields(items ...PartialUpdateField) *UpdateBatchRequest {
+	if s.data == nil {
+		s.data = make(map[string]PartialUpdateItem)
+	}
+
+	for _, item := range items {
+		s.data[item.Key] = PartialUpdateItem{
+			Assign: item.Value,
+		}
+	}
+
+	return s
+}
+
+// Validate checks if the operation is valid.
+func (s *UpdateBatchRequest) Validate() error {
+	var invalid []string
+	if s.id == "" {
+		invalid = append(invalid, "id")
+	}
+	if s.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+	if s.data == nil {
+		invalid = append(invalid, "data")
+	}
+	if s.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+// BuildURL returns the values that combined can be used to build the target
+// url for the batch operation.
+func (s *UpdateBatchRequest) BuildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodPut
+	path = fmt.Sprintf("/document/v1/%s/%s/docid/%s", s.namespace, s.scheme, s.id)
+
+	params := url.Values{}
+
+	return method, path, params
+
+}
+
+// Source returns the body of the request we will make to create job
+// endpoint
+func (s *UpdateBatchRequest) Source() interface{} {
+	payload := make(map[string]interface{})
+
+	payload["fields"] = s.data
+
+	return payload
+}

--- a/client/go/api/update_batch_request_test.go
+++ b/client/go/api/update_batch_request_test.go
@@ -1,0 +1,365 @@
+package vespa
+
+import (
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+func TestNewUpdateBatchRequest(t *testing.T) {
+	want := &UpdateBatchRequest{}
+	got := NewUpdateBatchRequest()
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("NewUpdateBatchRequest() = %v, want %v", got, want)
+	}
+}
+
+func TestUpdateBatchRequest_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateBatchRequest
+	}{
+		{
+			name: "Set a default value",
+			args: args{
+				name: "default",
+			},
+			want: &UpdateBatchRequest{
+				namespace: "default",
+			},
+		},
+		{
+			name: "Set a specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &UpdateBatchRequest{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{}
+
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateBatchRequest
+	}{
+		{
+			name: "Set cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &UpdateBatchRequest{
+				scheme: "cars",
+			},
+		},
+		{
+			name: "Set places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &UpdateBatchRequest{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{}
+
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_ID(t *testing.T) {
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateBatchRequest
+	}{
+		{
+			name: "Set an id value",
+			args: args{
+				id: "aaaa",
+			},
+			want: &UpdateBatchRequest{
+				id: "aaaa",
+			},
+		},
+		{
+			name: "Set a different id value",
+			args: args{
+				id: "bbb55",
+			},
+			want: &UpdateBatchRequest{
+				id: "bbb55",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{}
+
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_Field(t *testing.T) {
+	type args struct {
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateBatchRequest
+	}{
+		{
+			name: "when assigning a field, we should have data in the data field",
+			args: args{
+				key:   "key",
+				value: "value",
+			},
+			want: &UpdateBatchRequest{
+				data: map[string]PartialUpdateItem{
+					"key": {
+						Assign: "value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{}
+
+			if got := s.Field(tt.args.key, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.Field() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_Fields(t *testing.T) {
+	type args struct {
+		items []PartialUpdateField
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateBatchRequest
+	}{
+		{
+			name: "when assigning a field, we should have data in the data field",
+			args: args{
+				items: []PartialUpdateField{
+					{Key: "key", Value: "value"},
+				},
+			},
+			want: &UpdateBatchRequest{
+				data: map[string]PartialUpdateItem{
+					"key": {
+						Assign: "value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{}
+
+			if got := s.Fields(tt.args.items...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.Fields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_Validate(t *testing.T) {
+	type fields struct {
+		BatchableRequest BatchableRequest
+		namespace        string
+		scheme           string
+		id               string
+		data             map[string]PartialUpdateItem
+		headers          http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "Missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "Missing one required field should return error",
+			fields: fields{
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"key": {Assign: "value"},
+				},
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all fields set should return error nil",
+			fields: fields{
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"key": {Assign: "value"},
+				},
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{
+				BatchableRequest: tt.fields.BatchableRequest,
+				namespace:        tt.fields.namespace,
+				scheme:           tt.fields.scheme,
+				id:               tt.fields.id,
+				data:             tt.fields.data,
+				headers:          tt.fields.headers,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateBatchRequest.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_BuildURL(t *testing.T) {
+	type fields struct {
+		BatchableRequest BatchableRequest
+		namespace        string
+		scheme           string
+		id               string
+		data             map[string]PartialUpdateItem
+		headers          http.Header
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "when called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+			},
+			want:  "PUT",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{},
+		},
+		{
+			name: "when called with timeout, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+			},
+			want:  "PUT",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{
+				BatchableRequest: tt.fields.BatchableRequest,
+				namespace:        tt.fields.namespace,
+				scheme:           tt.fields.scheme,
+				id:               tt.fields.id,
+				data:             tt.fields.data,
+				headers:          tt.fields.headers,
+			}
+			got, got1, got2 := s.BuildURL()
+			if got != tt.want {
+				t.Errorf("UpdateBatchRequest.BuildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("UpdateBatchRequest.BuildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("UpdateBatchRequest.BuildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestUpdateBatchRequest_Source(t *testing.T) {
+	data := map[string]PartialUpdateItem{
+		"id": {Assign: "aaa"},
+	}
+
+	type fields struct {
+		data map[string]PartialUpdateItem
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   interface{}
+	}{
+		{
+			name: "when called, the fields should be under a fields key",
+			fields: fields{
+				data: data,
+			},
+			want: map[string]interface{}{
+				"fields": data,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateBatchRequest{
+				data: tt.fields.data,
+			}
+
+			if got := s.Source(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateBatchRequest.Source() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/update_test.go
+++ b/client/go/api/update_test.go
@@ -1,0 +1,808 @@
+package vespa
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewUpdateService(t *testing.T) {
+	client := &Client{}
+
+	want := &UpdateService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+	got := NewUpdateService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewUpdateService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestUpdateService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateService
+	}{
+		{
+			name: " with default value",
+			args: args{
+				name: "default",
+			},
+			want: &UpdateService{
+				namespace: "default",
+			},
+		},
+		{
+			name: " with specific value",
+			args: args{
+				name: "specific",
+			},
+			want: &UpdateService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{}
+			if got := s.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateService
+	}{
+		{
+			name: " with cars value",
+			args: args{
+				scheme: "cars",
+			},
+			want: &UpdateService{
+				scheme: "cars",
+			},
+		},
+		{
+			name: " with places value",
+			args: args{
+				scheme: "places",
+			},
+			want: &UpdateService{
+				scheme: "places",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{}
+			if got := s.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Cluster(t *testing.T) {
+	type args struct {
+		cluster string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateService
+	}{
+		{
+			name: " with value",
+			args: args{
+				cluster: "cluster-name",
+			},
+			want: &UpdateService{
+				cluster: "cluster-name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{}
+			if got := s.Cluster(tt.args.cluster); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Cluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_ID(t *testing.T) {
+
+	type args struct {
+		id string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateService
+	}{
+		{
+			name: " with an id value value",
+			args: args{
+				id: "aaaa",
+			},
+			want: &UpdateService{
+				id: "aaaa",
+			},
+		},
+		{
+			name: " with another id value",
+			args: args{
+				id: "bbbb",
+			},
+			want: &UpdateService{
+				id: "bbbb",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{}
+			if got := s.ID(tt.args.id); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.ID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Selection(t *testing.T) {
+	type args struct {
+		query  string
+		params []interface{}
+	}
+	tests := []struct {
+		selection string
+		args      args
+		want      *UpdateService
+	}{
+		{
+			selection: "with value",
+			args: args{
+				query: "music.author = ? and music.length <= ?",
+				params: []interface{}{
+					"Bon Jovi", 1000,
+				},
+			},
+			want: &UpdateService{
+				selection: `music.author = "Bon Jovi" and music.length <= 1000`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.selection, func(t *testing.T) {
+			s := &UpdateService{}
+			got := s.Selection(tt.args.query, tt.args.params...)
+			if got.selection != tt.want.selection {
+				t.Errorf("UpdateService.Selection() = %v, want %v", got.selection, tt.want.selection)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Timeout(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *UpdateService
+	}{
+		{
+			name: "with a second value",
+			args: args{
+				timeout: "12s",
+			},
+			want: &UpdateService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "with a minute value",
+			args: args{
+				timeout: "1m",
+			},
+			want: &UpdateService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+
+			if got := s.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Validate(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      map[string]PartialUpdateItem
+		timeout   string
+		selection string
+		headers   http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "missing one required field should return error",
+			fields: fields{
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"key": {Assign: "value"},
+				},
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "all fields set should return error nil",
+			fields: fields{
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"key": {Assign: "value"},
+				},
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "sequence but no id should be valid",
+			fields: fields{
+				selection: "count >= 10",
+				scheme:    "posts",
+				data: map[string]PartialUpdateItem{
+					"key": {Assign: "value"},
+				},
+				namespace: "default",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				selection: tt.fields.selection,
+				headers:   tt.fields.headers,
+				data:      tt.fields.data,
+			}
+			if err := s.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("UpdateService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUpdateService_buildURL(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		timeout   string
+		selection string
+		headers   http.Header
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+		want1  string
+		want2  url.Values
+	}{
+		{
+			name: "when called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+			},
+			want:  "PUT",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{},
+		},
+		{
+			name: "when called with timeout, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+				timeout:   "12s",
+			},
+			want:  "PUT",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{
+				"timeout": []string{"12s"},
+			},
+		},
+		{
+			name: "when called with selection, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				id:        "aaa",
+				selection: "music.author and music.length <= 1000",
+			},
+			want:  "PUT",
+			want1: "/document/v1/default/posts/docid/aaa",
+			want2: url.Values{
+				"selection": []string{"music.author and music.length <= 1000"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				timeout:   tt.fields.timeout,
+				selection: tt.fields.selection,
+				headers:   tt.fields.headers,
+			}
+			got, got1, got2 := s.buildURL()
+
+			if got != tt.want {
+				t.Errorf("UpdateService.buildURL() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("UpdateService.buildURL() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("UpdateService.buildURL() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Source(t *testing.T) {
+
+	data := map[string]PartialUpdateItem{
+		"id": {Assign: "aaa"},
+	}
+
+	data2 := map[string]PartialUpdateItem{
+		"key": {Assign: "value"},
+	}
+
+	type fields struct {
+		data map[string]PartialUpdateItem
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   interface{}
+	}{
+		{
+			name: "when called, the fields should be under a fields key",
+			fields: fields{
+				data: data,
+			},
+			want: map[string]interface{}{
+				"fields": data,
+			},
+		},
+		{
+			name: "when called and data is a map, map should be under a fields key",
+			fields: fields{
+				data: data2,
+			},
+			want: map[string]interface{}{
+				"fields": data2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				data: tt.fields.data,
+			}
+			got := s.Source()
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Source() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Do(t *testing.T) {
+
+	ctx := context.Background()
+
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      map[string]PartialUpdateItem
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *UpdateResponse
+		wantErr bool
+	}{
+		{
+			name:   "when validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request succeeds, it should return a UpdateResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:post:001",
+						"pathId":  "/document/v1/default/job/docid/001"						
+					}
+					`)),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &UpdateResponse{
+				Status:  200,
+				ID:      "id:default:post:001",
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request returns with an http error, we should return a message",
+			fields: fields{
+				client: &httpClientMock{
+					code: 400,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"pathId":  "/document/v1/default/job/docid/001",
+						"message":	"No field 'beat_that' in the structure of type 'work'"
+					}
+					`)),
+				},
+				id:     "1",
+				scheme: "posts",
+				data: map[string]PartialUpdateItem{
+					"data": {Assign: "data"},
+				},
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &UpdateResponse{
+				Status:  400,
+				PathID:  "/document/v1/default/job/docid/001",
+				Message: "No field 'beat_that' in the structure of type 'work'",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			got, err := s.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UpdateService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Do() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_DoWithContinuation(t *testing.T) {
+
+	client := &httpClientMock{
+		code: 200,
+		err:  nil,
+		responses: []mockResponse{
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"continuation": "AaaaahhZh",
+					"documentCount": 10
+				}
+				`)),
+			},
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"continuation": "AaaaahhZh",
+					"documentCount": 10
+				}
+				`)),
+			},
+			{
+				status: 200,
+				body: ioutil.NopCloser(strings.NewReader(`
+				{
+					"pathId":  "/document/v1/default/job/docid/",
+					"documentCount": 2
+				}
+				`)),
+			},
+		},
+	}
+
+	s := &UpdateService{
+		client:    client,
+		namespace: "default",
+		scheme:    "job",
+		data: map[string]PartialUpdateItem{
+			"data": {Assign: "data"},
+		},
+		selection: "feed_id = 22",
+		cluster:   "cluster-name",
+	}
+
+	ctx := context.Background()
+
+	wantErr := false
+	want := &UpdateResponse{
+		Status:        200,
+		PathID:        "/document/v1/default/job/docid/",
+		DocumentCount: 22,
+	}
+
+	got, err := s.Do(ctx)
+	if (err != nil) != wantErr {
+		t.Errorf("UpdateService.Do() error = %v, wantErr %v", err, wantErr)
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UpdateService.Do() = %+v, want %+v", got, want)
+	}
+}
+
+func TestUpdateService_Field(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      map[string]PartialUpdateItem
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *UpdateService
+	}{
+		{
+			name: "when assigning a field, we should have data in the data field",
+			args: args{
+				key:   "key",
+				value: "value",
+			},
+			want: &UpdateService{
+				data: map[string]PartialUpdateItem{
+					"key": {
+						Assign: "value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			if got := s.Field(tt.args.key, tt.args.value); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Field() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Fields(t *testing.T) {
+	type fields struct {
+		client    HTTPClient
+		namespace string
+		scheme    string
+		id        string
+		data      map[string]PartialUpdateItem
+		timeout   string
+		headers   http.Header
+	}
+	type args struct {
+		items []PartialUpdateField
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *UpdateService
+	}{
+		{
+			name: "when assigning a field, we should have data in the data field",
+			args: args{
+				items: []PartialUpdateField{
+					{Key: "key", Value: "value"},
+				},
+			},
+			want: &UpdateService{
+				data: map[string]PartialUpdateItem{
+					"key": {
+						Assign: "value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				scheme:    tt.fields.scheme,
+				id:        tt.fields.id,
+				data:      tt.fields.data,
+				timeout:   tt.fields.timeout,
+				headers:   tt.fields.headers,
+			}
+			if got := s.Fields(tt.args.items...); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Fields() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateService_Continuation(t *testing.T) {
+	type args struct {
+		continuation string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *UpdateService
+	}{
+		{
+			name: "with value",
+			args: args{
+				continuation: "aaahhhzzzAa",
+			},
+			want: &UpdateService{
+				continuation: "aaahhhzzzAa",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &UpdateService{}
+			if got := s.Continuation(tt.args.continuation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("UpdateService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/visit.go
+++ b/client/go/api/visit.go
@@ -1,0 +1,255 @@
+package vespa
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// VisitService iterates over and gets all documents, or a selection of
+// documents, in chunks, using continuation tokens to track progress.
+//
+// See https://docs.vespa.ai/en/document-v1-api-guide.html
+// for details.
+type VisitService struct {
+	client HTTPClient
+
+	namespace           string
+	scheme              string
+	timeout             string
+	continuation        string
+	selection           string
+	selectionClause     whereParams
+	wantedDocumentCount int
+	cluster             string
+	headers             http.Header
+	concurrency         int
+}
+
+// NewVisitService will create and instance of VisitService
+func NewVisitService(client HTTPClient) *VisitService {
+	return &VisitService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+}
+
+// Namespace sets the namespace of the document. If function is not called, it
+// will use the default namespace.
+func (v *VisitService) Namespace(name string) *VisitService {
+	v.namespace = name
+	return v
+}
+
+// Scheme sets the name of the scheme.
+func (v *VisitService) Scheme(scheme string) *VisitService {
+	v.scheme = scheme
+	return v
+}
+
+// Continuation sets the continuation value to make a new request
+func (v *VisitService) Continuation(continuation string) *VisitService {
+	v.continuation = continuation
+	return v
+}
+
+// Selection sets the selection value to make a new request
+func (v *VisitService) Selection(where string, params ...interface{}) *VisitService {
+	v.selectionClause = whereParams{
+		where:  where,
+		params: params,
+	}
+	v.buildSelect()
+
+	return v
+}
+
+// WantedDocumentCount WantedDocumentCount defines the desired number of items
+// returned in the request. It can be understood as the limit in a normal offset
+// limit query. Use this in cases with limited amount of data inside of the
+// Cluster. Vespa currently limits this value to around 1024.
+// Note that the maximum value of wantedDocumentCount is bounded by an
+// implementation-specific limit to prevent excessive resource usage.
+func (v *VisitService) WantedDocumentCount(number int) *VisitService {
+	v.wantedDocumentCount = number
+	return v
+}
+
+// Cluster sets the cluster value to make a new request
+func (v *VisitService) Cluster(cluster string) *VisitService {
+	v.cluster = cluster
+	return v
+}
+
+// Concurrency sets the numbers of workers asigned to the visit operation. Limit is 100
+func (v *VisitService) Concurrency(concurrency int) *VisitService {
+	v.concurrency = concurrency
+	return v
+}
+
+// Timeout sets the Request timeout expresed in in seconds, or with optional ks, s, ms or µs unit.
+func (v *VisitService) Timeout(timeout string) *VisitService {
+	v.timeout = timeout
+	return v
+}
+
+// Validate checks if the operation is valid.
+func (v *VisitService) Validate() error {
+	var invalid []string
+
+	if v.scheme == "" {
+		invalid = append(invalid, "scheme")
+	}
+
+	if v.namespace == "" {
+		invalid = append(invalid, "namespace")
+	}
+
+	if len(invalid) > 0 {
+		return fmt.Errorf("missing required fields for operation: %v", invalid)
+	}
+
+	return nil
+}
+
+// Generate the YQL query
+func (v *VisitService) buildSelect() {
+	var selection string
+	var idx int
+
+	if v.selectionClause.where != "" {
+		selection = v.selectionClause.where
+
+		for _, val := range []byte(selection) {
+			if val == '?' && len(v.selectionClause.params) > idx {
+				selection = VisitReplace(selection, v.selectionClause.params[idx])
+				idx++
+			}
+		}
+	}
+
+	v.selection = selection
+}
+
+func (v *VisitService) buildURL() (method, path string, parameters url.Values) {
+
+	method = http.MethodGet
+	path = fmt.Sprintf("/document/v1/%s/%s/docid", v.namespace, v.scheme)
+
+	params := url.Values{}
+	if v.timeout != "" {
+		params.Set("timeout", v.timeout)
+	}
+
+	if v.selection != "" {
+		params.Set("selection", v.selection)
+	}
+
+	if v.continuation != "" {
+		params.Set("continuation", v.continuation)
+	}
+
+	if v.wantedDocumentCount > 0 {
+		strWantedDocCount := strconv.Itoa(v.wantedDocumentCount)
+		params.Set("wantedDocumentCount", strWantedDocCount)
+	}
+
+	if v.concurrency > 0 {
+		strConcurrency := strconv.Itoa(v.concurrency)
+		params.Set("concurrency", strConcurrency)
+	}
+
+	if v.cluster != "" {
+		path = "/document/v1"
+
+		params.Set("cluster", v.cluster)
+	}
+
+	return method, path, params
+}
+
+// Do executes the get operation. Returns a VisitResponse or an error.
+func (v *VisitService) Do(ctx context.Context) (*VisitResponse, error) {
+
+	if err := v.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Get URL for request
+	method, path, params := v.buildURL()
+
+	// Get HTTP response
+	res, err := v.client.PerformRequest(ctx, PerformRequest{
+		Method:  method,
+		Path:    path,
+		Params:  params,
+		Headers: v.headers,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			log.Print(err)
+		}
+	}()
+
+	var vr VisitResponse
+	vr.Status = res.StatusCode
+
+	err = json.NewDecoder(res.Body).Decode(&vr)
+
+	return &vr, err
+}
+
+// VisitResponse is the result for the visit endpoints from Vespa
+type VisitResponse struct {
+	Status        int             `json:"status,omitempty"`
+	ID            string          `json:"id,omitempty"`
+	Fields        json.RawMessage `json:"fields,omitempty"`
+	PathID        string          `json:"pathId,omitempty"`
+	Message       string          `json:"message,omitempty"`
+	Continuation  string          `json:"continuation,omitempty"`
+	Documents     json.RawMessage `json:"documents,omitempty"`
+	DocumentCount int             `json:"documentCount,omitempty"`
+}
+
+// VisitReplace replaces ? entries with correct params for the Visit API
+func VisitReplace(where string, in interface{}) string {
+	switch t := in.(type) {
+	case int, int32, int64:
+		where = strings.Replace(where, "?", fmt.Sprintf("%d", in), 1)
+	case float32, float64:
+		where = strings.Replace(where, "?", fmt.Sprintf("%.2f", in), 1)
+	case string:
+		where = strings.Replace(where, "?", fmt.Sprintf("%q", in), 1)
+	case bool:
+		where = strings.Replace(where, "?", fmt.Sprintf("%t", in), 1)
+	case []int, []int32, []int64, []float32, []float64, []string, []bool:
+		params := anythingToSlice(in)
+		values := VisitReplaceArray(params)
+		where = strings.Replace(where, "?", values, 1)
+	default:
+		fmt.Print("Different type", t)
+		where = strings.Replace(where, "?", fmt.Sprintf("%v", in), 1)
+	}
+
+	return where
+}
+
+// VisitReplaceArray replaces ? entries with correct params when the param is an array
+func VisitReplaceArray(params []interface{}) string {
+	arr := make([]string, 0, len(params))
+	for _, param := range params {
+		arr = append(arr, VisitReplace("?", param))
+	}
+
+	return strings.Join(arr, ",")
+}

--- a/client/go/api/visit_test.go
+++ b/client/go/api/visit_test.go
@@ -1,0 +1,715 @@
+package vespa
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNewVisitService(t *testing.T) {
+	client := &Client{}
+
+	want := &VisitService{
+		client:    client,
+		namespace: DefaultNamespace,
+	}
+
+	got := NewVisitService(client)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf(" expected NewVisitService() to return %+v, got %+v", want, got)
+	}
+}
+
+func TestVisitService_Namespace(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set the default value to namespace",
+			args: args{
+				name: "default",
+			},
+			want: &VisitService{
+				namespace: "default",
+			},
+		},
+		{
+			name: "Set a specific value to namespace",
+			args: args{
+				name: "specific",
+			},
+			want: &VisitService{
+				namespace: "specific",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Namespace(tt.args.name); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Namespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Scheme(t *testing.T) {
+	type args struct {
+		scheme string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set the job to scheme",
+			args: args{
+				scheme: "job",
+			},
+			want: &VisitService{
+				scheme: "job",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Scheme(tt.args.scheme); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Scheme() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Continuation(t *testing.T) {
+	type args struct {
+		continuation string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set a continuation value",
+			args: args{
+				continuation: "BGAAABEBEBC",
+			},
+			want: &VisitService{
+				continuation: "BGAAABEBEBC",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Continuation(tt.args.continuation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Continuation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type customType int
+
+func TestVisitService_Selection(t *testing.T) {
+	type args struct {
+		query  string
+		params []interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set the selection values",
+			args: args{
+				query: "music.author = ? and music.length <= ?",
+				params: []interface{}{
+					"Bon Jovi", 1000,
+				},
+			},
+			want: &VisitService{
+				selection: `music.author = "Bon Jovi" and music.length <= 1000`,
+			},
+		},
+		{
+			name: "With int value",
+			args: args{
+				query: "music.count = ?",
+				params: []interface{}{
+					23,
+				},
+			},
+			want: &VisitService{
+				selection: `music.count = 23`,
+			},
+		},
+		{
+			name: "With int64 value",
+			args: args{
+				query: "music.count = ?",
+				params: []interface{}{
+					int64(23),
+				},
+			},
+			want: &VisitService{
+				selection: `music.count = 23`,
+			},
+		},
+		{
+			name: "With bool",
+			args: args{
+				query: "music.active = ?",
+				params: []interface{}{
+					true,
+				},
+			},
+			want: &VisitService{
+				selection: `music.active = true`,
+			},
+		},
+		{
+			name: "With slice",
+			args: args{
+				query: "music.id IN(?)",
+				params: []interface{}{
+					[]int{1, 2, 3},
+				},
+			},
+			want: &VisitService{
+				selection: `music.id IN(1,2,3)`,
+			},
+		},
+		{
+			name: "With float",
+			args: args{
+				query: "music.rating = ?",
+				params: []interface{}{
+					0.51,
+				},
+			},
+			want: &VisitService{
+				selection: `music.rating = 0.51`,
+			},
+		},
+		{
+			name: "With different type",
+			args: args{
+				query: "music.rating = ?",
+				params: []interface{}{
+					0.51,
+				},
+			},
+			want: &VisitService{
+				selection: `music.rating = 0.51`,
+			},
+		},
+		{
+			name: "With custom type",
+			args: args{
+				query: "music.rating = ?",
+				params: []interface{}{
+					customType(1),
+				},
+			},
+			want: &VisitService{
+				selection: `music.rating = 1`,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			got := v.Selection(tt.args.query, tt.args.params...)
+			if got.selection != tt.want.selection {
+				t.Errorf("VisitService.Selection() = %v, want %v", got.selection, tt.want.selection)
+			}
+		})
+	}
+}
+
+func TestVisitService_WantedDocumentCount(t *testing.T) {
+	type args struct {
+		number int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set a wantedDocumentCount value",
+			args: args{
+				number: 1024,
+			},
+			want: &VisitService{
+				wantedDocumentCount: 1024,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.WantedDocumentCount(tt.args.number); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.WantedDocumentCount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Concurrency(t *testing.T) {
+	type args struct {
+		number int
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set a concurrency value",
+			args: args{
+				number: 100,
+			},
+			want: &VisitService{
+				concurrency: 100,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Concurrency(tt.args.number); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Concurrency() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Cluster(t *testing.T) {
+	type args struct {
+		cluster string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set a cluster value",
+			args: args{
+				cluster: "cluster-name",
+			},
+			want: &VisitService{
+				cluster: "cluster-name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Cluster(tt.args.cluster); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Cluster() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Timeout(t *testing.T) {
+	type args struct {
+		timeout string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *VisitService
+	}{
+		{
+			name: "Set a second value",
+			args: args{
+				timeout: "12s",
+			},
+			want: &VisitService{
+				timeout: "12s",
+			},
+		},
+		{
+			name: "Set a minute value",
+			args: args{
+				timeout: "1m",
+			},
+			want: &VisitService{
+				timeout: "1m",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{}
+
+			if got := v.Timeout(tt.args.timeout); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Timeout() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVisitService_Validate(t *testing.T) {
+	type fields struct {
+		client              HTTPClient
+		namespace           string
+		scheme              string
+		timeout             string
+		continuation        string
+		selection           string
+		selectionClause     whereParams
+		wantedDocumentCount int
+		cluster             string
+		headers             http.Header
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name:    "missing required fields should return error",
+			fields:  fields{},
+			wantErr: true,
+		},
+		{
+			name: "Missing one required field should return an error",
+			fields: fields{
+				namespace: "default",
+			},
+			wantErr: true,
+		},
+		{
+			name: "All fields set should return error nil",
+			fields: fields{
+				namespace: "default",
+				scheme:    "job",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{
+				client:              tt.fields.client,
+				namespace:           tt.fields.namespace,
+				scheme:              tt.fields.scheme,
+				timeout:             tt.fields.timeout,
+				continuation:        tt.fields.continuation,
+				selection:           tt.fields.selection,
+				selectionClause:     tt.fields.selectionClause,
+				wantedDocumentCount: tt.fields.wantedDocumentCount,
+				cluster:             tt.fields.cluster,
+				headers:             tt.fields.headers,
+			}
+			if err := v.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("VisitService.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVisitService_buildURL(t *testing.T) {
+	type fields struct {
+		client              HTTPClient
+		namespace           string
+		scheme              string
+		timeout             string
+		continuation        string
+		selection           string
+		selectionClause     whereParams
+		wantedDocumentCount int
+		cluster             string
+		headers             http.Header
+		concurrency         int
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		wantMethod     string
+		wantPath       string
+		wantParameters url.Values
+	}{
+		{
+			name: "when called, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+			},
+			wantMethod:     "GET",
+			wantPath:       "/document/v1/default/posts/docid",
+			wantParameters: url.Values{},
+		},
+		{
+			name: "when called with timeout, it should return the expected values",
+			fields: fields{
+				namespace:    "default",
+				scheme:       "posts",
+				continuation: "BGAAABEBEBC",
+				timeout:      "12s",
+			},
+			wantMethod: "GET",
+			wantPath:   "/document/v1/default/posts/docid",
+			wantParameters: url.Values{
+				"continuation": []string{"BGAAABEBEBC"},
+				"timeout":      []string{"12s"},
+			},
+		},
+		{
+			name: "when called with selection, it should return the expected values",
+			fields: fields{
+				namespace: "default",
+				scheme:    "posts",
+				selection: "music.author and music.length <= 1000",
+			},
+			wantMethod: "GET",
+			wantPath:   "/document/v1/default/posts/docid",
+			wantParameters: url.Values{
+				"selection": []string{"music.author and music.length <= 1000"},
+			},
+		},
+		{
+			name: "when called with selection and include a wantedDocumentCount value, it should return the expected values",
+			fields: fields{
+				namespace:           "default",
+				scheme:              "posts",
+				selection:           "music.author and music.length <= 1000",
+				wantedDocumentCount: 1024,
+			},
+			wantMethod: "GET",
+			wantPath:   "/document/v1/default/posts/docid",
+			wantParameters: url.Values{
+				"selection":           []string{"music.author and music.length <= 1000"},
+				"wantedDocumentCount": []string{"1024"},
+			},
+		},
+		{
+			name: "when called with selection and include a concurrency value, it should return the expected values",
+			fields: fields{
+				namespace:   "default",
+				scheme:      "posts",
+				selection:   "music.author and music.length <= 1000",
+				concurrency: 100,
+			},
+			wantMethod: "GET",
+			wantPath:   "/document/v1/default/posts/docid",
+			wantParameters: url.Values{
+				"selection":   []string{"music.author and music.length <= 1000"},
+				"concurrency": []string{"100"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{
+				client:              tt.fields.client,
+				namespace:           tt.fields.namespace,
+				scheme:              tt.fields.scheme,
+				timeout:             tt.fields.timeout,
+				continuation:        tt.fields.continuation,
+				selection:           tt.fields.selection,
+				selectionClause:     tt.fields.selectionClause,
+				wantedDocumentCount: tt.fields.wantedDocumentCount,
+				cluster:             tt.fields.cluster,
+				headers:             tt.fields.headers,
+				concurrency:         tt.fields.concurrency,
+			}
+			gotMethod, gotPath, gotParameters := v.buildURL()
+			if gotMethod != tt.wantMethod {
+				t.Errorf("VisitService.buildURL() gotMethod = %v, want %v", gotMethod, tt.wantMethod)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("VisitService.buildURL() gotPath = %v, want %v", gotPath, tt.wantPath)
+			}
+			if !reflect.DeepEqual(gotParameters, tt.wantParameters) {
+				t.Errorf("VisitService.buildURL() gotParameters = %v, want %v", gotParameters, tt.wantParameters)
+			}
+		})
+	}
+}
+
+func TestVisitService_Do(t *testing.T) {
+	ctx := context.Background()
+
+	type fields struct {
+		client              HTTPClient
+		namespace           string
+		scheme              string
+		timeout             string
+		continuation        string
+		selection           string
+		selectionClause     whereParams
+		wantedDocumentCount int
+		cluster             string
+		headers             http.Header
+	}
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *VisitResponse
+		wantErr bool
+	}{
+		{
+			name:   "when validate return error, it should return error",
+			fields: fields{},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request return error, it should return error",
+			fields: fields{
+				client: &httpClientMock{
+					err: errors.New("errors"),
+				},
+				continuation: "BGAAABEBEBC",
+				scheme:       "posts",
+				namespace:    "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "when perform request succeeds, it should return a VisitResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:post:001",
+						"pathId":  "/document/v1/default/jobs/docid"						
+					}
+					`)),
+				},
+				scheme:    "jobs",
+				namespace: "default",
+				cluster:   "cluster",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &VisitResponse{
+				Status:  200,
+				ID:      "id:default:post:001",
+				PathID:  "/document/v1/default/jobs/docid",
+				Message: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request succeeds and include a wantedDocumentCount, it should return a VisitResponse",
+			fields: fields{
+				client: &httpClientMock{
+					code: 200,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"id":      "id:default:post:001",
+						"pathId":  "/document/v1/default/job/docid"						
+					}
+					`)),
+				},
+				scheme:              "job",
+				namespace:           "default",
+				cluster:             "cluster",
+				wantedDocumentCount: 1024,
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &VisitResponse{
+				Status:  200,
+				ID:      "id:default:post:001",
+				PathID:  "/document/v1/default/job/docid",
+				Message: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "when perform request returns with an http error, we should return a message",
+			fields: fields{
+				client: &httpClientMock{
+					code: 400,
+					err:  nil,
+					body: ioutil.NopCloser(strings.NewReader(`
+					{
+						"pathId":  "/document/v1/default/jobs/docid/001",
+						"message":	"No field 'beat_that' in the structure of type 'work'"
+					}
+					`)),
+				},
+				scheme:    "jobs",
+				namespace: "default",
+			},
+			args: args{
+				ctx: ctx,
+			},
+			want: &VisitResponse{
+				Status:  400,
+				PathID:  "/document/v1/default/jobs/docid/001",
+				Message: "No field 'beat_that' in the structure of type 'work'",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &VisitService{
+				client:              tt.fields.client,
+				namespace:           tt.fields.namespace,
+				scheme:              tt.fields.scheme,
+				timeout:             tt.fields.timeout,
+				continuation:        tt.fields.continuation,
+				selection:           tt.fields.selection,
+				selectionClause:     tt.fields.selectionClause,
+				wantedDocumentCount: tt.fields.wantedDocumentCount,
+				cluster:             tt.fields.cluster,
+				headers:             tt.fields.headers,
+			}
+			got, err := v.Do(tt.args.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("VisitService.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("VisitService.Do() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/client/go/api/weakand.go
+++ b/client/go/api/weakand.go
@@ -1,0 +1,49 @@
+package vespa
+
+import "fmt"
+
+// WeakAnd represents the Vespa's WeakAnd function implementation
+type WeakAnd struct {
+	Hits    int
+	Entries []WeakAndEntry
+}
+
+// WeakAndEntry represents a single entry for the WeakAnd function
+type WeakAndEntry struct {
+	Field string
+	Value string
+}
+
+// NewWeakAnd creates a new *WeakAnd
+func NewWeakAnd(hits int) *WeakAnd {
+	return &WeakAnd{
+		Hits: hits,
+	}
+}
+
+// AddEntry adds an entry to the WeakAnd
+func (wa *WeakAnd) AddEntry(field, value string) {
+	wa.Entries = append(wa.Entries, WeakAndEntry{
+		Field: field,
+		Value: value,
+	})
+}
+
+// Source outputs the YQL representation of the WeakAnd
+func (wa *WeakAnd) Source() string {
+	query := fmt.Sprintf(`[{"targetHits":%d}]`, wa.Hits)
+
+	var entries string
+
+	for _, v := range wa.Entries {
+		if entries == "" {
+			entries = fmt.Sprintf("%s contains %q", v.Field, v.Value)
+			continue
+		}
+		entries = fmt.Sprintf("%s, %s contains %q", entries, v.Field, v.Value)
+	}
+
+	query = fmt.Sprintf("(%s weakAnd(%s))", query, entries)
+
+	return query
+}

--- a/client/go/api/weakand_test.go
+++ b/client/go/api/weakand_test.go
@@ -1,0 +1,108 @@
+package vespa
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewWeakAnd(t *testing.T) {
+	want := &WeakAnd{
+		Hits: 10,
+	}
+
+	got := NewWeakAnd(10)
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("NewCreateService() =  %+v, want %+v", got, want)
+	}
+}
+
+func TestWeakAnd_Source(t *testing.T) {
+	type fields struct {
+		hits    int
+		entries []WeakAndEntry
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "source should form the right output with 2 entries",
+			fields: fields{
+				hits: 10,
+				entries: []WeakAndEntry{
+					{Field: "title", Value: "software"},
+					{Field: "description", Value: "engineer"},
+				},
+			},
+			want: `([{"targetHits":10}] weakAnd(title contains "software", description contains "engineer"))`,
+		},
+		{
+			name: "source should form the right output with 3 entries",
+			fields: fields{
+				hits: 10,
+				entries: []WeakAndEntry{
+					{Field: "default", Value: "software"},
+					{Field: "default", Value: "engineer"},
+					{Field: "default", Value: "senior"},
+				},
+			},
+			want: `([{"targetHits":10}] weakAnd(default contains "software", default contains "engineer", default contains "senior"))`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wa := &WeakAnd{
+				Hits:    tt.fields.hits,
+				Entries: tt.fields.entries,
+			}
+			if got := wa.Source(); got != tt.want {
+				t.Errorf("WeakAnd.Source() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWeakAnd_AddEntry(t *testing.T) {
+	type fields struct {
+		Hits    int
+		Entries []WeakAndEntry
+	}
+	type args struct {
+		field string
+		value string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *WeakAnd
+	}{
+		{
+			name: "Adding a new entry should add to the entries array",
+			fields: fields{
+				Hits: 10,
+			},
+			args: args{
+				field: "default",
+				value: "software",
+			},
+			want: &WeakAnd{
+				Hits: 10,
+				Entries: []WeakAndEntry{
+					{Field: "default", Value: "software"},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wa := &WeakAnd{
+				Hits:    tt.fields.Hits,
+				Entries: tt.fields.Entries,
+			}
+			wa.AddEntry(tt.args.field, tt.args.value)
+		})
+	}
+}

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/vespa-engine/vespa/client/go
+module github.com/vespa-engine/client/go/api
 
 go 1.15
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## Vespa Go Client Proposal

For the past 8-12 months we have been building a Go Client for Vespa that we planned to share/donate/open source to Vespa and its community. We believe this is only a fraction of the work to be done, but it has served us well in production to date and we believe it is something we can build on top of.  We are proud to say that despite any potential shortcoming, anyone could use it in the current state to work with vespa's `/api/v1/document` api. 

The current implementation was inspired by [olivere/elastic](https://github.com/olivere/elastic) library, where a key element of the API is method chaining to describe a request.  This does conflict with the regular way go does error checking and bubbling technique, but in exchange, the API to our eyes seemed straightforward to follow. The errors are still properly exposed and can be handled by the end-user. 

The most basic use-case for search would look like:

```go
var opts []vespa.ClientOptionFunc
connStr := "http://localhost:8080"
opts = append(opts,
  vespa.SetURL(connStr),
)

client, err := vespa.NewClient(ctx, opts...)
if err != nil {
  panic(err)
}

res, err := vespa.NewSearchService(client).
  Scheme("docs").
  Query("Trucking Class B").
  Where("userQuery() AND status contains \"active\" AND geoLocation(location, 33.64, -84.33, \"25mi\") AND hidden = false").
  Timeout("5s").
  Ranking(vespa.Ranking{Profile: "bm25"}).
  Do(ctx)
```

The current implementation supports the following:
- Create
- Read
- Update
- Partial Update
- Delete
- Search
- Batch Create, Update. 
- HTTP2 support through official http2 implementation

One of the known shortcomings is that the Batch process sends one request per document, essentially making it a fake batch operation. What it does provide instead is an abstraction to a batch operation, where each request launches its own routine and they are synchronized again with the use of a wait-group. Good enough for anyone to use and get up to seen 3000qps for feed operations.

As stated, we don't believe this implementation is perfect by any means, but it has done the job for us for a while. We hope this becomes either something to build on or inspiration for the official library in the future. 

Thanks all,

Get.it Team