### PR TITLE
Move ActivationConflictException to config-provisioning [run-systemtest]

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/exception/ActivationConflictException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/exception/ActivationConflictException.java
@@ -1,5 +1,5 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.vespa.config.server;
+package com.yahoo.config.provision.exception;
 
 /**
  * Exception used when activation cannot be done because activation is for
@@ -9,7 +9,9 @@ package com.yahoo.vespa.config.server;
  * @author hmusum
  */
 public class ActivationConflictException extends RuntimeException {
-    public ActivationConflictException(String s) {
-        super(s);
-    }
+
+    public ActivationConflictException(String message) { super(message); }
+
+    public ActivationConflictException(String message, Throwable cause) { super(message, cause); }
+
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -22,6 +22,7 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.SecretStoreProvider;
 import com.yahoo.container.jdisc.secretstore.SecretStore;
@@ -486,7 +487,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     // Config generation is equal to session id, and config generation must be a monotonically increasing number
     static void checkIfActiveIsNewerThanSessionToBeActivated(long sessionId, long currentActiveSessionId) {
         if (sessionId < currentActiveSessionId) {
-            throw new ActivationConflictException("It is not possible to activate session " + sessionId +
+            throw new ActivationConflictException("Cannot activate session " + sessionId +
                                                   ", because it is older than current active session (" +
                                                   currentActiveSessionId + ")");
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -3,19 +3,19 @@ package com.yahoo.vespa.config.server.http;
 
 import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.config.provision.CertificateNotReadyException;
+import com.yahoo.config.provision.OutOfCapacityException;
 import com.yahoo.config.provision.ParentHostUnavailableException;
+import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.config.provision.exception.LoadBalancerServiceException;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;
-import java.util.logging.Level;
-import com.yahoo.config.provision.OutOfCapacityException;
-import com.yahoo.vespa.config.server.ActivationConflictException;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Duration;
+import java.util.logging.Level;
 
 /**
  * Super class for http handlers, that takes care of checking valid

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -17,6 +17,7 @@ import com.yahoo.config.provision.HostSpec;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NetworkPorts;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.io.IOUtils;
 import com.yahoo.jdisc.Metric;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -6,6 +6,7 @@ import com.yahoo.config.provision.ApplicationLockException;
 import com.yahoo.config.provision.Deployer;
 import com.yahoo.config.provision.Deployment;
 import com.yahoo.config.provision.TransientException;
+import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.transaction.Mutex;
 import com.yahoo.vespa.hosted.provision.Node;
@@ -95,7 +96,7 @@ class MaintenanceDeployment implements Closeable {
         if ( ! isValid()) return Optional.empty();
         try {
             return Optional.of(step.get());
-        } catch (TransientException e) {
+        } catch (TransientException | ActivationConflictException e) {
             metric.add("maintenanceDeployment.transientFailure", 1, metric.createContext(Map.of()));
             log.log(Level.INFO, "Failed to maintenance deploy " + application + " with a transient error: " +
                                    Exceptions.toMessageString(e));


### PR DESCRIPTION
Move, so that it can be used in MaintenanceDeployment

It would have been nice if ActivationConflictException could have subclassed TransientException, but TransientException is used when checking when it should wait for application resources to be available (parent host, load balancer, etc.) and will only retry activate, which is not enough when we get an ActivationConflictException, which would mean that one needs to retry prepare as well.