### PR TITLE
Improve download of application package in maintainer [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -16,6 +16,7 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.filedistribution.Downloads;
 import com.yahoo.vespa.filedistribution.FileDownloader;
+import com.yahoo.vespa.filedistribution.FileReferenceDownload;
 import com.yahoo.vespa.flags.FlagSource;
 
 import java.io.File;
@@ -74,7 +75,10 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
                     if (! fileReferenceExistsOnDisk(downloadDirectory, applicationPackage)) {
                         log.fine(() -> "Downloading missing application package for application " + applicationId + " (session " + sessionId + ")");
 
-                        if (fileDownloader.getFile(applicationPackage).isEmpty()) {
+                        FileReferenceDownload download = new FileReferenceDownload(applicationPackage,
+                                                                                   false,
+                                                                                   this.getClass().getSimpleName());
+                        if (fileDownloader.getFile(download).isEmpty()) {
                             failures++;
                             log.warning("Failed to download application package for application " + applicationId + " (session " + sessionId + ")");
                             continue;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -57,7 +57,7 @@ public class FileServerTest {
     public void requireThatNonExistingFileWillBeDownloaded() throws IOException {
         String dir = "123";
         assertFalse(fileServer.hasFile(dir));
-        FileReferenceDownload foo = new FileReferenceDownload(new FileReference(dir), true, "foo");
+        FileReferenceDownload foo = new FileReferenceDownload(new FileReference(dir));
         assertFalse(fileServer.hasFileDownloadIfNeeded(foo));
         writeFile(dir);
         assertTrue(fileServer.hasFileDownloadIfNeeded(foo));

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -41,8 +41,8 @@ public class FileDownloader implements AutoCloseable {
     private final FileReferenceDownloader fileReferenceDownloader;
     private final Downloads downloads;
 
-    public FileDownloader(List<String> configservers, Supervisor supervisor) {
-        this(getConnectionPool(configservers, supervisor), supervisor);
+    public FileDownloader(List<String> configServers, Supervisor supervisor) {
+        this(getConnectionPool(configServers, supervisor), supervisor);
     }
 
     public FileDownloader(ConnectionPool connectionPool, Supervisor supervisor) {

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownload.java
@@ -13,7 +13,7 @@ public class FileReferenceDownload {
     private final FileReference fileReference;
     private final CompletableFuture<Optional<File>> future;
     // If a config server wants to download from another config server (because it does not have the
-    // file itself) we set this flag to true to avoid an eternal loop
+    // file itself) we set this flag to false to avoid an eternal loop
     private final boolean downloadFromOtherSourceIfNotFound;
     private final String client;
 


### PR DESCRIPTION
Set downloadFromOtherSourceIfNotFound to false, so that the config server
that receives the request don't try to download a file reference from another config server.
This will be done by the ApplicationPackageMaintainer on the other servers anyway.
