### PR TITLE
Add metric for max time since bucket GC was last run

### DIFF
--- a/storage/src/tests/distributor/simplemaintenancescannertest.cpp
+++ b/storage/src/tests/distributor/simplemaintenancescannertest.cpp
@@ -16,6 +16,7 @@ using document::BucketId;
 using document::test::makeBucketSpace;
 using Priority = MaintenancePriority;
 using namespace ::testing;
+using namespace std::chrono_literals;
 
 struct SimpleMaintenanceScannerTest : Test {
     using PendingStats = SimpleMaintenanceScanner::PendingMaintenanceStats;
@@ -255,6 +256,7 @@ TEST_F(SimpleMaintenanceScannerTest, merge_pending_maintenance_stats) {
     stats_a.perNodeStats.incCopyingIn(5, default_space);
     stats_a.perNodeStats.incCopyingOut(5, global_space);
     stats_a.perNodeStats.incTotal(5, default_space);
+    stats_a.perNodeStats.update_observed_time_since_last_gc(100s);
 
     PendingStats stats_b;
     stats_b.global.pending[MaintenanceOperation::DELETE_BUCKET] = 10;
@@ -268,6 +270,7 @@ TEST_F(SimpleMaintenanceScannerTest, merge_pending_maintenance_stats) {
     stats_b.perNodeStats.incCopyingIn(5, default_space);
     stats_b.perNodeStats.incCopyingOut(5, global_space);
     stats_b.perNodeStats.incTotal(5, default_space);
+    stats_b.perNodeStats.update_observed_time_since_last_gc(300s);
 
     PendingStats result;
     result.merge(stats_a);
@@ -290,6 +293,7 @@ TEST_F(SimpleMaintenanceScannerTest, merge_pending_maintenance_stats) {
     exp.perNodeStats.incTotal(5, default_space);
     exp.perNodeStats.incMovingOut(7, default_space);
     exp.perNodeStats.incSyncing(7, global_space);
+    exp.perNodeStats.update_observed_time_since_last_gc(300s);
     EXPECT_EQ(exp.global, result.global);
     EXPECT_EQ(exp.perNodeStats, result.perNodeStats);
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -566,6 +566,8 @@ DistributorStripe::propagateInternalScanMetricsToExternal()
         ideal_state_metrics.buckets_replicas_copying_out.set(total_stats.copyingOut);
         ideal_state_metrics.buckets_replicas_copying_in.set(total_stats.copyingIn);
         ideal_state_metrics.buckets_replicas_syncing.set(total_stats.syncing);
+        ideal_state_metrics.max_observed_time_since_last_gc_sec.set(
+                _maintenanceStats.perNodeStats.max_observed_time_since_last_gc().count());
     }
 }
 

--- a/storage/src/vespa/storage/distributor/idealstatemetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemetricsset.cpp
@@ -107,6 +107,10 @@ IdealStateMetricSet::IdealStateMetricSet()
       buckets_replicas_syncing("bucket_replicas_syncing",
             {{"logdefault"},{"yamasdefault"}},
             "Bucket replicas that need syncing due to mismatching metadata", this),
+      max_observed_time_since_last_gc_sec("max_observed_time_since_last_gc_sec",
+            {{"logdefault"},{"yamasdefault"}},
+            "Maximum time (in seconds) since GC was last successfully run for a bucket. "
+            "Aggregated max value across all buckets on the distributor.", this),
       nodesPerMerge("nodes_per_merge", {}, "The number of nodes involved in a single merge operation.", this)
 {
     createOperationMetrics();

--- a/storage/src/vespa/storage/distributor/idealstatemetricsset.h
+++ b/storage/src/vespa/storage/distributor/idealstatemetricsset.h
@@ -45,6 +45,7 @@ public:
     metrics::LongValueMetric buckets_replicas_copying_in;
     metrics::LongValueMetric buckets_replicas_copying_out;
     metrics::LongValueMetric buckets_replicas_syncing;
+    metrics::LongValueMetric max_observed_time_since_last_gc_sec;
     metrics::DoubleAverageMetric nodesPerMerge;
 
     void createOperationMetrics();

--- a/storage/src/vespa/storage/distributor/maintenance/node_maintenance_stats_tracker.cpp
+++ b/storage/src/vespa/storage/distributor/maintenance/node_maintenance_stats_tracker.cpp
@@ -10,11 +10,11 @@ const NodeMaintenanceStats NodeMaintenanceStatsTracker::_emptyNodeMaintenanceSta
 void
 NodeMaintenanceStats::merge(const NodeMaintenanceStats& rhs)
 {
-    movingOut += rhs.movingOut;
-    syncing += rhs.syncing;
-    copyingIn += rhs.copyingIn;
+    movingOut  += rhs.movingOut;
+    syncing    += rhs.syncing;
+    copyingIn  += rhs.copyingIn;
     copyingOut += rhs.copyingOut;
-    total += rhs.total;
+    total      += rhs.total;
 }
 
 namespace {
@@ -38,6 +38,8 @@ NodeMaintenanceStatsTracker::merge(const NodeMaintenanceStatsTracker& rhs)
         auto node_index = entry.first;
         merge_bucket_spaces_stats(_node_stats[node_index], entry.second);
     }
+    _max_observed_time_since_last_gc = std::max(_max_observed_time_since_last_gc,
+                                                rhs._max_observed_time_since_last_gc);
 }
 
 std::ostream&
@@ -53,7 +55,12 @@ operator<<(std::ostream& os, const NodeMaintenanceStats& stats)
     return os;
 }
 
-NodeMaintenanceStatsTracker::NodeMaintenanceStatsTracker() = default;
+NodeMaintenanceStatsTracker::NodeMaintenanceStatsTracker()
+    : _node_stats(),
+      _total_stats(),
+      _max_observed_time_since_last_gc(0)
+{}
+
 NodeMaintenanceStatsTracker::~NodeMaintenanceStatsTracker() = default;
 
 }

--- a/storage/src/vespa/storage/distributor/statecheckers.h
+++ b/storage/src/vespa/storage/distributor/statecheckers.h
@@ -108,9 +108,11 @@ class GarbageCollectionStateChecker : public StateChecker
 {
 public:
     std::string getStatusText() const override { return "Garbage collection"; }
-    bool needsGarbageCollection(const Context& c) const;
     Result check(Context& c) override;
     const char* getName() const override { return "GarbageCollection"; }
+private:
+    [[nodiscard]] bool garbage_collection_disabled(const Context& c) const noexcept;
+    [[nodiscard]] bool needs_garbage_collection(const Context& c, std::chrono::seconds time_since_epoch) const;
 };
 
 }


### PR DESCRIPTION
@geirst please review
@yngveaasheim FYI

Max time is aggregated across all buckets. If this metric value grows
substantially larger than the configured GC period it indicates that
GC is being starved.

Currently tracked as a single global value across all bucket spaces.
