### PR TITLE
Remove external trigger.

### DIFF
--- a/dist/release-vespa-rpm.sh
+++ b/dist/release-vespa-rpm.sh
@@ -27,13 +27,6 @@ git pull --rebase
 git tag -a "$RELEASE_TAG" -m "Release version $VERSION" $GITREF
 git push origin "$RELEASE_TAG"
 
-# Trig the build on Copr
-curl -X POST \
-     -H "Content-type: application/json" \
-     -H "X-GitHub-Event: create" \
-     -d '{ "ref": "$RELEASE_TAG", "ref_type": "tag", "repository": { "clone_url": "https://github.com/vespa-engine/vespa.git" } }' \
-     "$COPR_WEBHOOK"
-
 git reset --hard HEAD
 git checkout $CURRENT_BRANCH
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Github seems to be working fine now and the creation of the tag is enough to get Copr building.
