### PR TITLE
Remove explicit syncing of all write executors when handling DeleteBu…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_feed_view.cpp
@@ -175,7 +175,6 @@ void
 SearchableFeedView::internalDeleteBucket(const DeleteBucketOperation &delOp)
 {
     Parent::internalDeleteBucket(delOp);
-    _writeService.sync();
 }
 
 void


### PR DESCRIPTION
…cket operations.

This really hurts the performance of the feed pipeline (e.g. during merging buckets),
as all executor queues are drained and then the executors need time to rebuild momentum afterwards.
This is also not needed from a data consistency point of view, as the DeleteBucket operation is
ack'ed right after it has been written to the TLS.

@baldersheim and @toregge please review
@vekterli FYI
