### PR TITLE
the new protobuf protocol should have good performance now

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
@@ -43,12 +43,8 @@ public class RpcInvokerFactory extends InvokerFactory {
         Query query = result.getQuery();
 
         boolean summaryNeedsQuery = searcher.summaryNeedsQuery(query);
-        boolean useProtoBuf = query.properties().getBoolean(Dispatcher.dispatchProtobuf, true);
-        boolean useDispatchDotSummaries = query.properties().getBoolean(dispatchSummaries, false);
 
-        return  ((useDispatchDotSummaries || !useProtoBuf) && ! summaryNeedsQuery)
-                ? new RpcFillInvoker(rpcResourcePool, searcher.getDocumentDatabase(query))
-                : new RpcProtobufFillInvoker(rpcResourcePool, searcher.getDocumentDatabase(query), searcher.getServerId(), summaryNeedsQuery);
+        return new RpcProtobufFillInvoker(rpcResourcePool, searcher.getDocumentDatabase(query), searcher.getServerId(), summaryNeedsQuery);
     }
 
     // for testing


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

For discussion:

We want to get rid of the "extra" docsum fetching protocol.  From the code it looks like the default is to use the new protobuf protocol always, but I don't know if some customers override these defaults, and (if so) if there's any performance gain to get from it.

@baldersheim please review
@havardpe 