### PR TITLE
Warn upon undeclared components

### DIFF
--- a/configserver/src/main/resources/configserver-app/services.xml
+++ b/configserver/src/main/resources/configserver-app/services.xml
@@ -39,6 +39,7 @@
     <component id="com.yahoo.vespa.config.server.rpc.RpcRequestHandlerProvider" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.rpc.security.DummyNodeIdentifierProvider" bundle="configserver" />
     <component id="com.yahoo.vespa.config.server.rpc.security.DefaultRpcAuthorizerProvider" bundle="configserver" />
+    <component id="com.yahoo.vespa.config.server.http.TesterClient" bundle="configserver" />
 
     <components>
       <include dir="config-models" />

--- a/container-core/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
+++ b/container-core/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
@@ -259,7 +259,7 @@ public class ComponentGraph {
             Object instance;
             try {
                 Level level = hasExplicitBinding(fallbackInjector, key) ? Level.FINE : Level.WARNING;
-                log.log(level, () ->"Trying the fallback injector to create" + messageForNoGlobalComponent(clazz, node));
+                log.log(level, () -> "Trying the fallback injector to create" + messageForNoGlobalComponent(clazz, node));
                 if (level.intValue() > Level.INFO.intValue()) {
                     log.log(level, "A component of type " + key.getTypeLiteral() + " should probably be declared in services.xml. " +
                             "Not doing so may cause resource leaks and unnecessary reconstruction of components.");

--- a/container-core/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
+++ b/container-core/src/main/java/com/yahoo/container/di/componentgraph/core/ComponentGraph.java
@@ -258,10 +258,12 @@ public class ComponentGraph {
         if (component.isEmpty()) {
             Object instance;
             try {
-                // This is an indication that you have not set up your components correctly in the model
-                // And tit will cause unnecessary reconstruction of your components.
-                // TODO: this should perhaps bee a warning.
-                log.log(Level.INFO, () -> "Trying the fallback injector to create" + messageForNoGlobalComponent(clazz, node));
+                Level level = hasExplicitBinding(fallbackInjector, key) ? Level.FINE : Level.WARNING;
+                log.log(level, () ->"Trying the fallback injector to create" + messageForNoGlobalComponent(clazz, node));
+                if (level.intValue() > Level.INFO.intValue()) {
+                    log.log(level, "A component of type " + key.getTypeLiteral() + " should probably be declared in services.xml. " +
+                            "Not doing so may cause resource leaks and unnecessary reconstruction of components.");
+                }
                 instance = fallbackInjector.getInstance(key);
             } catch (ConfigurationException e) {
                 throw removeStackTrace(new IllegalStateException(
@@ -275,6 +277,11 @@ public class ComponentGraph {
             }));
         }
         return component.get();
+    }
+
+    private boolean hasExplicitBinding(Injector injector, Key<?> key) {
+        log.log(Level.FINE, () -> "Injector binding for " + key + ": " + injector.getExistingBinding(key));
+        return injector.getExistingBinding(key) != null;
     }
 
     private Node handleComponentParameter(Node node, Injector fallbackInjector, Class<?> clazz, Collection<Annotation> annotations) {


### PR DESCRIPTION
This will most likely generate log warnings for some user applications, on startup and every redeploy until the issue is fixed on their side.
