### PR TITLE
Stop reporting back full dump of grouping.

### DIFF
--- a/searchcore/src/vespa/searchcore/grouping/groupingmanager.cpp
+++ b/searchcore/src/vespa/searchcore/grouping/groupingmanager.cpp
@@ -60,7 +60,7 @@ GroupingManager::init(const IAttributeContext &attrCtx)
             grouping.configureStaticStuff(stuff);
             list.push_back(groupingList[i]);
         } catch (const std::exception & e) {
-            Issue::report("Could not locate attribute for grouping number %ld : %s. Ignoring grouping '%s'", i, e.what(), grouping.asString().c_str());
+            Issue::report("Could not locate attribute for grouping number %ld : %s. Ignoring this grouping.", i, e.what());
         }
     }
     std::swap(list, groupingList);


### PR DESCRIPTION
* the QRS already knows what "grouping number 0" means, so no need
  to report back the full, detailed dump.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@havardpe FYI
