### PR TITLE
Add mutexes to protect metrics updated by MessageTracker.

### DIFF
--- a/storage/src/tests/common/metricstest.cpp
+++ b/storage/src/tests/common/metricstest.cpp
@@ -140,7 +140,10 @@ void MetricsTest::createFakeLoad()
         for (uint32_t j=0; j<disk.threads.size(); ++j) {
             FileStorThreadMetrics& thread(*disk.threads[j]);
             thread.operations.inc(120 * n);
-            thread.failedOperations.inc(2 * n);
+            {
+                std::lock_guard guard(thread._mutex);
+                thread.failedOperations.inc(2 * n);
+            }
 
             thread.put.count.inc(10 * n);
             thread.put.latency.addValue(5 * n);

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -11,6 +11,7 @@ using metrics::MetricSet;
 FileStorThreadMetrics::Op::Op(const std::string& id, const std::string& name, MetricSet* owner)
     : MetricSet(id, {}, name + " load in filestor thread", owner),
       _name(name),
+      _mutex(),
       count("count", {{"yamasdefault"}}, "Number of requests processed.", this),
       latency("latency", {{"yamasdefault"}}, "Latency of successful requests.", this),
       failed("failed", {{"yamasdefault"}}, "Number of failed requests.", this)
@@ -147,6 +148,7 @@ FileStorThreadMetrics::Visitor::clone(std::vector<Metric::UP>& ownerList,
 
 FileStorThreadMetrics::FileStorThreadMetrics(const std::string& name, const std::string& desc)
     : MetricSet(name, {{"filestor"},{"partofsum"}}, desc),
+      _mutex(),
       operations("operations", {}, "Number of operations processed.", this),
       failedOperations("failedoperations", {}, "Number of operations throwing exceptions.", this),
       put("put.sum", "Put", this),

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -13,6 +13,7 @@
 #include "merge_handler_metrics.h"
 #include <vespa/metrics/metricset.h>
 #include <vespa/metrics/summetric.h>
+#include <mutex>
 
 namespace storage {
 
@@ -22,6 +23,7 @@ struct FileStorThreadMetrics : public metrics::MetricSet
 
     struct Op : metrics::MetricSet {
         std::string _name;
+        std::mutex  _mutex; // protects writes to latency and failed
         metrics::LongCountMetric count;
         metrics::DoubleAverageMetric latency;
         metrics::LongCountMetric failed;
@@ -89,6 +91,7 @@ struct FileStorThreadMetrics : public metrics::MetricSet
     using GetMetricType    = OpWithRequestSize<OpWithNotFound>;
     using RemoveMetricType = OpWithTestAndSetFailed<OpWithRequestSize<OpWithNotFound>>;
 
+    std::mutex               _mutex; // protects writes to failedOperations
     metrics::LongCountMetric operations;
     metrics::LongCountMetric failedOperations;
     PutMetricType put;


### PR DESCRIPTION
@baldersheim : please review
@geirst , @vekterli : FYI
