### PR TITLE
Stop using USE_APPLICATION_LOCK_IN_MAINTENANCE_DEPLOYMENT feature flag

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -309,6 +309,7 @@ public class Flags {
             ZONE_ID, TENANT_ID
     );
 
+    // TODO: Delete when oldest model version in use is 7.486
     public static final UnboundBooleanFlag USE_APPLICATION_LOCK_IN_MAINTENANCE_DEPLOYMENT = defineFeatureFlag(
             "use-application-lock-in-maintenance-deployment", true,
             List.of("hmusum"), "2021-09-16", "2021-11-01",

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -24,8 +24,6 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.yahoo.vespa.flags.Flags.USE_APPLICATION_LOCK_IN_MAINTENANCE_DEPLOYMENT;
-
 /**
  * A wrapper of a deployment suitable for maintenance.
  * This is a single-use, single-thread object.
@@ -50,10 +48,7 @@ class MaintenanceDeployment implements Closeable {
         this.application = application;
         this.metric = metric;
 
-        Optional<Mutex> lock = USE_APPLICATION_LOCK_IN_MAINTENANCE_DEPLOYMENT.bindTo(nodeRepository.flagSource()).value()
-                ? tryLock(application, nodeRepository)
-                : Optional.of(() -> { });
-
+        Optional<Mutex> lock = tryLock(application, nodeRepository);
         try {
             deployment = tryDeployment(lock, application, deployer, nodeRepository);
             this.lock = lock;


### PR DESCRIPTION
Go back to always using application lock in maintenance deployments.