### PR TITLE
Add a metric for how many working days a worker in a thread pool has.

### DIFF
--- a/metrics/src/vespa/metrics/valuemetric.h
+++ b/metrics/src/vespa/metrics/valuemetric.h
@@ -37,7 +37,6 @@ protected:
 
     void logWarning(const char* msg, const char *op) const;
     void logNonFiniteValueWarning() const;
-    void sendLogEvent(Metric::String name, double value) const;
 };
 
 template<typename AvgVal, typename TotVal, bool SumOnAdd>
@@ -86,7 +85,7 @@ public:
     ~ValueMetric();
 
     MetricValueClass::UP getValues() const override {
-        return MetricValueClass::UP(new Values(_values.getValues()));
+        return std::make_unique<Values>(_values.getValues());
     }
 
     void unsetOnZeroValue() { _values.setFlag(UNSET_ON_ZERO_VALUE); }

--- a/metrics/src/vespa/metrics/valuemetric.hpp
+++ b/metrics/src/vespa/metrics/valuemetric.hpp
@@ -26,7 +26,7 @@ ValueMetric<AvgVal, TotVal, SumOnAdd>::ValueMetric(
 {}
 
 template<typename AvgVal, typename TotVal, bool SumOnAdd>
-ValueMetric<AvgVal, TotVal, SumOnAdd>::~ValueMetric() { }
+ValueMetric<AvgVal, TotVal, SumOnAdd>::~ValueMetric() = default;
 
 template<typename AvgVal, typename TotVal, bool SumOnAdd>
 void ValueMetric<AvgVal, TotVal, SumOnAdd>::inc(AvgVal incVal)
@@ -239,8 +239,7 @@ ValueMetric<AvgVal, TotVal, SumOnAdd>::getDoubleValue(stringref id) const
 
 template<typename AvgVal, typename TotVal, bool SumOnAdd>
 void
-ValueMetric<AvgVal, TotVal, SumOnAdd>::addMemoryUsage(
-        MemoryConsumption& mc) const
+ValueMetric<AvgVal, TotVal, SumOnAdd>::addMemoryUsage(MemoryConsumption& mc) const
 {
     ++mc._valueMetricCount;
     mc._valueMetricValues += _values.getMemoryUsageAllocatedInternally();

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -15,7 +15,6 @@
 #include <vespa/searchcore/proton/feedoperation/removeoperation.h>
 #include <vespa/searchcore/proton/server/blockable_maintenance_job.h>
 #include <vespa/searchcore/proton/server/executor_thread_service.h>
-#include <vespa/searchcore/proton/server/i_document_scan_iterator.h>
 #include <vespa/searchcore/proton/server/i_operation_storer.h>
 #include <vespa/searchcore/proton/server/ibucketmodifiedhandler.h>
 #include <vespa/searchcore/proton/server/idocumentmovehandler.h>
@@ -728,7 +727,7 @@ MyExecutor::isIdle()
 {
     (void) getStats();
     sync();
-    Stats stats(getStats());
+    auto stats = getStats();
     return stats.acceptedTasks == 0u;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -114,7 +114,7 @@ public:
      *
      * @return executor stats
      **/
-    vespalib::ThreadStackExecutor::Stats getExecutorStats() { return _executor.getStats(); }
+    vespalib::ExecutorStats getExecutorStats() { return _executor.getStats(); }
 
     /**
      * Returns the underlying executor. Only used for state explorers.

--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
@@ -62,7 +62,7 @@ public:
      *
      * @return executor stats
      **/
-    vespalib::ThreadStackExecutor::Stats getExecutorStats() { return _executor.getStats(); }
+    vespalib::ExecutorStats getExecutorStats() { return _executor.getStats(); }
 
     /**
      * Returns the underlying executor. Only used for state explorers.

--- a/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.cpp
@@ -5,12 +5,13 @@
 namespace proton {
 
 void
-ExecutorMetrics::update(const vespalib::ThreadStackExecutorBase::Stats &stats)
+ExecutorMetrics::update(const vespalib::ExecutorStats &stats)
 {
     maxPending.set(stats.queueSize.max());
     accepted.inc(stats.acceptedTasks);
     rejected.inc(stats.rejectedTasks);
     workingDays.inc(stats.workingDays);
+    dutyCycle.set(stats.getNormalizedDutyCycle());
     const auto & qSize = stats.queueSize;
     queueSize.addValueBatch(qSize.average(), qSize.count(), qSize.min(), qSize.max());
 }
@@ -21,6 +22,7 @@ ExecutorMetrics::ExecutorMetrics(const std::string &name, metrics::MetricSet *pa
       accepted("accepted", {}, "Number of accepted tasks", this),
       rejected("rejected", {}, "Number of rejected tasks", this),
       workingDays("workingdays", {}, "Number of days a worker showed up for work", this),
+      dutyCycle("dutycycle", {}, "percentage of time a thread has been active", this),
       queueSize("queuesize", {}, "Size of task queue", this)
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.cpp
@@ -10,6 +10,7 @@ ExecutorMetrics::update(const vespalib::ThreadStackExecutorBase::Stats &stats)
     maxPending.set(stats.queueSize.max());
     accepted.inc(stats.acceptedTasks);
     rejected.inc(stats.rejectedTasks);
+    workingDays.inc(stats.workingDays);
     const auto & qSize = stats.queueSize;
     queueSize.addValueBatch(qSize.average(), qSize.count(), qSize.min(), qSize.max());
 }
@@ -19,6 +20,7 @@ ExecutorMetrics::ExecutorMetrics(const std::string &name, metrics::MetricSet *pa
       maxPending("maxpending", {}, "Maximum number of pending (active + queued) tasks", this),
       accepted("accepted", {}, "Number of accepted tasks", this),
       rejected("rejected", {}, "Number of rejected tasks", this),
+      workingDays("workingdays", {}, "Number of days a worker showed up for work", this),
       queueSize("queuesize", {}, "Size of task queue", this)
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.h
@@ -5,7 +5,7 @@
 #include <vespa/metrics/metricset.h>
 #include <vespa/metrics/countmetric.h>
 #include <vespa/metrics/valuemetric.h>
-#include <vespa/vespalib/util/threadstackexecutorbase.h>
+#include <vespa/vespalib/util/executor_stats.h>
 
 namespace proton {
 
@@ -15,9 +15,10 @@ struct ExecutorMetrics : metrics::MetricSet
     metrics::LongCountMetric accepted;
     metrics::LongCountMetric rejected;
     metrics::LongCountMetric workingDays;
+    metrics::DoubleValueMetric dutyCycle;
     metrics::LongAverageMetric queueSize;
 
-    void update(const vespalib::ThreadStackExecutorBase::Stats &stats);
+    void update(const vespalib::ExecutorStats &stats);
     ExecutorMetrics(const std::string &name, metrics::MetricSet *parent);
     ~ExecutorMetrics();
 };

--- a/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/executor_metrics.h
@@ -14,6 +14,7 @@ struct ExecutorMetrics : metrics::MetricSet
     metrics::LongValueMetric maxPending; // TODO Remove on Vespa 8 or sooner if possible.
     metrics::LongCountMetric accepted;
     metrics::LongCountMetric rejected;
+    metrics::LongCountMetric workingDays;
     metrics::LongAverageMetric queueSize;
 
     void update(const vespalib::ThreadStackExecutorBase::Stats &stats);

--- a/searchcore/src/vespa/searchcore/proton/server/executor_thread_service.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/executor_thread_service.cpp
@@ -73,7 +73,7 @@ ExecutorThreadService::isCurrentThread() const
     return FastOS_Thread::CompareThreadIds(_threadId->_id, currentThreadId);
 }
 
-vespalib::ThreadExecutor::Stats ExecutorThreadService::getStats() {
+vespalib::ExecutorStats ExecutorThreadService::getStats() {
     return _executor.getStats();
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/executor_thread_service.h
+++ b/searchcore/src/vespa/searchcore/proton/server/executor_thread_service.h
@@ -21,7 +21,7 @@ public:
     ExecutorThreadService(vespalib::SyncableThreadExecutor &executor);
     ~ExecutorThreadService();
 
-    Stats getStats() override;
+    vespalib::ExecutorStats getStats() override;
 
     vespalib::Executor::Task::UP execute(vespalib::Executor::Task::UP task) override {
         return _executor.execute(std::move(task));

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -737,8 +737,7 @@ Proton::prepareRestart()
 namespace {
 
 void
-updateExecutorMetrics(ExecutorMetrics &metrics,
-                      const vespalib::ThreadStackExecutor::Stats &stats)
+updateExecutorMetrics(ExecutorMetrics &metrics, const vespalib::ExecutorStats &stats)
 {
     metrics.update(stats);
 }

--- a/searchcore/src/vespa/searchcore/proton/summaryengine/summaryengine.h
+++ b/searchcore/src/vespa/searchcore/proton/summaryengine/summaryengine.h
@@ -66,7 +66,7 @@ public:
      *
      * @return executor stats
      **/
-    vespalib::ThreadStackExecutor::Stats getExecutorStats() { return _executor.getStats(); }
+    vespalib::ExecutorStats getExecutorStats() { return _executor.getStats(); }
 
     /**
      * Returns the underlying executor. Only used for state explorers.

--- a/searchcore/src/vespa/searchcore/proton/test/thread_service_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/thread_service_observer.h
@@ -40,7 +40,7 @@ public:
     }
     size_t getNumThreads() const override { return _service.getNumThreads(); }
 
-    Stats getStats() override {
+    vespalib::ExecutorStats getStats() override {
         return _service.getStats();
     }
 

--- a/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.cpp
@@ -21,6 +21,7 @@ AdaptiveSequencedExecutor::Strand::~Strand()
 
 AdaptiveSequencedExecutor::Worker::Worker()
     : cond(),
+      wakeupTime(steady_clock::now()),
       state(State::RUNNING),
       strand(nullptr)
 {
@@ -151,9 +152,12 @@ AdaptiveSequencedExecutor::obtain_strand(Worker &worker, std::unique_lock<std::m
     } else {
         worker.state = Worker::State::BLOCKED;
         _worker_stack.push(&worker);
+        _stats.workingDays++;
+        _workingTime += steady_clock::now() - worker.wakeupTime;
         while (worker.state == Worker::State::BLOCKED) {
             worker.cond.wait(lock);
         }
+        worker.wakeupTime = steady_clock::now();
     }
     return (worker.state == Worker::State::RUNNING);
 }
@@ -233,6 +237,8 @@ AdaptiveSequencedExecutor::AdaptiveSequencedExecutor(size_t num_strands, size_t 
       _worker_stack(num_threads),
       _self(),
       _stats(),
+      _lastStatSampleTime(steady_clock::now()),
+      _workingTime(duration::zero()),
       _cfg(num_threads, max_waiting, max_pending)
 {
     _stats.queueSize.add(_self.pending_tasks);
@@ -293,7 +299,6 @@ AdaptiveSequencedExecutor::executeTask(ExecutorId id, Task::UP task)
             assert(worker->strand == nullptr);
             worker->state = Worker::State::RUNNING;
             worker->strand = &strand;
-            _stats.workingDays++;
             guard.unlock(); // UNLOCK
             worker->cond.notify_one();
         }
@@ -325,12 +330,16 @@ AdaptiveSequencedExecutor::setTaskLimit(uint32_t task_limit)
     }
 }
 
-AdaptiveSequencedExecutor::Stats
+ExecutorStats
 AdaptiveSequencedExecutor::getStats()
 {
     auto guard = std::lock_guard(_mutex);
-    Stats stats = _stats;
-    _stats = Stats();
+    ExecutorStats stats = _stats;
+    steady_time now = steady_clock::now();
+    _stats.dutyCycle = _workingTime / (now - _lastStatSampleTime);
+    _workingTime = duration::zero();
+    _lastStatSampleTime = now;
+    _stats = ExecutorStats();
     _stats.queueSize.add(_self.pending_tasks);
     return stats;
 }

--- a/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/adaptive_sequenced_executor.cpp
@@ -293,6 +293,7 @@ AdaptiveSequencedExecutor::executeTask(ExecutorId id, Task::UP task)
             assert(worker->strand == nullptr);
             worker->state = Worker::State::RUNNING;
             worker->strand = &strand;
+            _stats.workingDays++;
             guard.unlock(); // UNLOCK
             worker->cond.notify_one();
         }

--- a/staging_vespalib/src/vespa/vespalib/util/foreground_thread_executor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/foreground_thread_executor.h
@@ -23,7 +23,7 @@ public:
     }
     size_t getNumThreads() const override { return 0; }
     Stats getStats() override {
-        return ExecutorStats(ExecutorStats::QueueSizeT(), _accepted.load(std::memory_order_relaxed), 0);
+        return ExecutorStats(ExecutorStats::QueueSizeT(), _accepted.load(std::memory_order_relaxed), 0, 1);
     }
     void setTaskLimit(uint32_t taskLimit) override { (void) taskLimit; }
     uint32_t getTaskLimit() const override { return std::numeric_limits<uint32_t>::max(); }

--- a/staging_vespalib/src/vespa/vespalib/util/foreground_thread_executor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/foreground_thread_executor.h
@@ -22,8 +22,8 @@ public:
         return Task::UP();
     }
     size_t getNumThreads() const override { return 0; }
-    Stats getStats() override {
-        return ExecutorStats(ExecutorStats::QueueSizeT(), _accepted.load(std::memory_order_relaxed), 0, 1);
+    ExecutorStats getStats() override {
+        return ExecutorStats(1, ExecutorStats::QueueSizeT(), _accepted.load(std::memory_order_relaxed), 0, 1, 1.0);
     }
     void setTaskLimit(uint32_t taskLimit) override { (void) taskLimit; }
     uint32_t getTaskLimit() const override { return std::numeric_limits<uint32_t>::max(); }

--- a/staging_vespalib/src/vespa/vespalib/util/foregroundtaskexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/foregroundtaskexecutor.cpp
@@ -36,7 +36,7 @@ void ForegroundTaskExecutor::setTaskLimit(uint32_t) {
 }
 
 vespalib::ExecutorStats ForegroundTaskExecutor::getStats() {
-    return vespalib::ExecutorStats(vespalib::ExecutorStats::QueueSizeT(0) , _accepted.load(std::memory_order_relaxed), 0);
+    return vespalib::ExecutorStats(vespalib::ExecutorStats::QueueSizeT(0) , _accepted.load(std::memory_order_relaxed), 0, 1);
 }
 
 ISequencedTaskExecutor::ExecutorId

--- a/staging_vespalib/src/vespa/vespalib/util/foregroundtaskexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/foregroundtaskexecutor.cpp
@@ -36,7 +36,7 @@ void ForegroundTaskExecutor::setTaskLimit(uint32_t) {
 }
 
 vespalib::ExecutorStats ForegroundTaskExecutor::getStats() {
-    return vespalib::ExecutorStats(vespalib::ExecutorStats::QueueSizeT(0) , _accepted.load(std::memory_order_relaxed), 0, 1);
+    return vespalib::ExecutorStats(1, vespalib::ExecutorStats::QueueSizeT(0) , _accepted.load(std::memory_order_relaxed), 0, 1, 1.0);
 }
 
 ISequencedTaskExecutor::ExecutorId

--- a/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
@@ -29,7 +29,7 @@ public:
     uint32_t getTaskLimit() const override { return _taskLimit.load(std::memory_order_relaxed); }
     uint32_t get_watermark() const { return _watermark; }
     duration get_reaction_time() const { return _reactionTime; }
-    Stats getStats() override;
+    ExecutorStats getStats() override;
     SingleExecutor & shutdown() override;
 private:
     using Lock = std::unique_lock<std::mutex>;
@@ -54,9 +54,12 @@ private:
     std::condition_variable     _consumerCondition;
     std::condition_variable     _producerCondition;
     vespalib::Thread            _thread;
+    steady_time                 _lastStatSampleTime;
+    vespalib::steady_time       _lastWakeupTime;
+    vespalib::duration          _workingTime;
     uint64_t                    _workingDays;
     uint64_t                    _lastAccepted;
-    Stats::QueueSizeT           _queueSize;
+    ExecutorStats::QueueSizeT   _queueSize;
     std::atomic<uint64_t>       _wakeupConsumerAt;
     std::atomic<uint64_t>       _producerNeedWakeupAt;
     std::atomic<uint64_t>       _wp;

--- a/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/singleexecutor.h
@@ -54,6 +54,7 @@ private:
     std::condition_variable     _consumerCondition;
     std::condition_variable     _producerCondition;
     vespalib::Thread            _thread;
+    uint64_t                    _workingDays;
     uint64_t                    _lastAccepted;
     Stats::QueueSizeT           _queueSize;
     std::atomic<uint64_t>       _wakeupConsumerAt;

--- a/vespalib/src/tests/executor/threadstackexecutor_test.cpp
+++ b/vespalib/src/tests/executor/threadstackexecutor_test.cpp
@@ -71,7 +71,7 @@ struct MyState {
     {
         ASSERT_TRUE(!checked);
         checked = true;
-        ThreadStackExecutor::Stats stats = executor.getStats();
+        ExecutorStats stats = executor.getStats();
         EXPECT_EQUAL(expect_running + expect_deleted, MyTask::runCnt);
         EXPECT_EQUAL(expect_rejected + expect_deleted, MyTask::deleteCnt);
         EXPECT_EQUAL(expect_queue + expect_running + expect_deleted,stats.acceptedTasks);
@@ -190,12 +190,15 @@ TEST_F("require that executor thread stack tag can be set", ThreadStackExecutor(
 }
 
 TEST("require that stats can be accumulated") {
-    ThreadStackExecutor::Stats stats(ThreadExecutor::Stats::QueueSizeT(1) ,2,3,7);
+    ExecutorStats stats(3, ExecutorStats::QueueSizeT(1) ,2,3,7, 0.6);
     EXPECT_EQUAL(1u, stats.queueSize.max());
     EXPECT_EQUAL(2u, stats.acceptedTasks);
     EXPECT_EQUAL(3u, stats.rejectedTasks);
     EXPECT_EQUAL(7u, stats.workingDays);
-    stats += ThreadStackExecutor::Stats(ThreadExecutor::Stats::QueueSizeT(7),8,9,11);
+    EXPECT_EQUAL(3u, stats.executorCount);
+    EXPECT_EQUAL(0.6, stats.dutyCycle);
+    EXPECT_EQUAL(0.2, stats.getNormalizedDutyCycle());
+    stats += ExecutorStats(7, ExecutorStats::QueueSizeT(7),8,9,11, 1.9);
     EXPECT_EQUAL(2u, stats.queueSize.count());
     EXPECT_EQUAL(8u, stats.queueSize.total());
     EXPECT_EQUAL(8u, stats.queueSize.max());
@@ -203,10 +206,12 @@ TEST("require that stats can be accumulated") {
     EXPECT_EQUAL(8u, stats.queueSize.max());
     EXPECT_EQUAL(4.0, stats.queueSize.average());
 
+    EXPECT_EQUAL(10u, stats.executorCount);
     EXPECT_EQUAL(10u, stats.acceptedTasks);
     EXPECT_EQUAL(12u, stats.rejectedTasks);
     EXPECT_EQUAL(18u, stats.workingDays);
-
+    EXPECT_EQUAL(2.5, stats.dutyCycle);
+    EXPECT_EQUAL(0.25, stats.getNormalizedDutyCycle());
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/util/executor_stats.h
+++ b/vespalib/src/vespa/vespalib/util/executor_stats.h
@@ -56,9 +56,10 @@ struct ExecutorStats {
     QueueSizeT queueSize;
     size_t acceptedTasks;
     size_t rejectedTasks;
-    ExecutorStats() : ExecutorStats(QueueSizeT(), 0, 0) {}
-    ExecutorStats(QueueSizeT queueSize_in, size_t accepted, size_t rejected)
-        : queueSize(queueSize_in), acceptedTasks(accepted), rejectedTasks(rejected)
+    size_t workingDays; // Number of time a worker showed up for work,
+    ExecutorStats() : ExecutorStats(QueueSizeT(), 0, 0, 0) {}
+    ExecutorStats(QueueSizeT queueSize_in, size_t accepted, size_t rejected, size_t wakeupCount)
+        : queueSize(queueSize_in), acceptedTasks(accepted), rejectedTasks(rejected), workingDays(wakeupCount)
     {}
     ExecutorStats & operator += (const ExecutorStats & rhs) {
         queueSize = QueueSizeT(queueSize.count() + rhs.queueSize.count(),
@@ -67,6 +68,7 @@ struct ExecutorStats {
                                queueSize.max() + rhs.queueSize.max());
         acceptedTasks += rhs.acceptedTasks;
         rejectedTasks += rhs.rejectedTasks;
+        workingDays += rhs.workingDays;
         return *this;
     }
 };

--- a/vespalib/src/vespa/vespalib/util/threadexecutor.h
+++ b/vespalib/src/vespa/vespalib/util/threadexecutor.h
@@ -12,11 +12,6 @@ class ThreadExecutor : public Executor
 {
 public:
     /**
-     * Internal stats that we want to observe externally. Note that
-     * all stats are reset each time they are observed.
-     **/
-    using Stats = ExecutorStats;
-    /**
      * Get number of threads in the executor pool.
      * @return number of threads in the pool
      */
@@ -26,7 +21,7 @@ public:
      * Observe and reset stats for this object.
      * @return stats
      **/
-    virtual Stats getStats() = 0;
+    virtual ExecutorStats getStats() = 0;
 
     /**
      * Sets a new upper limit for accepted number of tasks.

--- a/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.cpp
+++ b/vespalib/src/vespa/vespalib/util/threadstackexecutorbase.cpp
@@ -103,6 +103,7 @@ ThreadStackExecutorBase::obtainTask(Worker &worker)
             return false;
         }
         _workers.push(&worker);
+        _stats.workingDays++;
     }
     {
         unique_lock guard(worker.lock);


### PR DESCRIPTION
A working day is after the worker has had a nap.
For most workers it also constitutes a day were at least one task was executed.

@havardpe PR for discussion
@geirst @vekterli FYI