### PR TITLE
empty hostname means "localhost"

### DIFF
--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_crypto_codec_impl.cpp
@@ -269,6 +269,9 @@ void OpenSslCryptoCodecImpl::enable_hostname_validation_if_requested() {
 void OpenSslCryptoCodecImpl::set_server_name_indication_extension() {
     if (_peer_spec.valid()) {
         vespalib::string host = _peer_spec.host();
+        if (host.empty()) {
+            host = "localhost";
+        }
         // OpenSSL tries to cast const char* to void* in a macro, even on 1.1.1. GCC is not overly impressed,
         // so to satiate OpenSSL's quirks we pre-cast away the constness.
         auto* host_cstr_that_trusts_openssl_not_to_mess_up = const_cast<char*>(host.c_str());


### PR DESCRIPTION
* avoid core-dump with short RPC spec

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe please review
FYI: I tried `vespa-rpc-invoke tcp/19099 ...` and got a crypto exception because of empty hostname.
