### PR TITLE
Remove config generation at :19050/clustercontroller-status/v1/<clustername>/state

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterController.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterController.java
@@ -53,7 +53,7 @@ public class ClusterController extends AbstractComponent
                 controllers.put(options.clusterName, controller);
                 status.put(options.clusterName, statusPageServer);
             } else {
-                controller.updateOptions(options, 0);
+                controller.updateOptions(options);
             }
         }
     }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/NodeHealthRequestHandler.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/NodeHealthRequestHandler.java
@@ -9,26 +9,17 @@ import com.yahoo.vespa.clustercontroller.core.status.statuspage.StatusPageServer
 */
 public class NodeHealthRequestHandler implements StatusPageServer.RequestHandler {
 
-    private final RunDataExtractor data;
-
-    public NodeHealthRequestHandler(RunDataExtractor data) {
-        this.data = data;
-    }
+    public NodeHealthRequestHandler() {}
 
     @Override
     public StatusPageResponse handle(StatusPageServer.HttpRequest request) {
         StatusPageResponse response = new StatusPageResponse();
         response.setContentType("application/json");
         response.writeContent("{\n" +
-                          "  \"status\" : {\n" +
-                          "    \"code\" : \"up\"\n" +
-                          "  },\n" +
-                          "  \"config\" : {\n" +
-                          "    \"component\" : {\n" +
-                          "      \"generation\" : " + data.getConfigGeneration() + "\n" +
-                          "    }\n" +
-                          "  }\n" +
-                          "}");
+                              "  \"status\" : {\n" +
+                              "    \"code\" : \"up\"\n" +
+                              "  }\n" +
+                              "}");
         return response;
     }
 

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/RunDataExtractor.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/RunDataExtractor.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.clustercontroller.core.FleetControllerOptions;
 public interface RunDataExtractor {
 
     FleetControllerOptions getOptions();
-    long getConfigGeneration();
     ContentCluster getCluster();
 
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
@@ -135,8 +135,7 @@ public class ClusterFeedBlockTest extends FleetControllerTest {
         assertTrue(ctrl.getClusterStateBundle().clusterFeedIsBlocked());
 
         // Increase cheese allowance. Should now automatically unblock since reported usage is lower.
-        int dummyConfigGeneration = 2;
-        ctrl.updateOptions(createOptions(mapOf(usage("cheese", 0.9), usage("wine", 0.4))), dummyConfigGeneration);
+        ctrl.updateOptions(createOptions(mapOf(usage("cheese", 0.9), usage("wine", 0.4))));
         ctrl.tick(); // Options propagation
         ctrl.tick(); // State recomputation
         assertFalse(ctrl.getClusterStateBundle().clusterFeedIsBlocked());

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionBitCountTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionBitCountTest.java
@@ -40,12 +40,12 @@ public class DistributionBitCountTest extends FleetControllerTest {
     public void testDistributionBitCountConfigIncrease() throws Exception {
         setUpSystem("DistributionBitCountTest::testDistributionBitCountConfigIncrease");
         options.distributionBits = 20;
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
         ClusterState currentState = waitForState("version:\\d+ bits:20 distributor:10 storage:10");
 
         int version = currentState.getVersion();
         options.distributionBits = 23;
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
         assertEquals(version, currentState.getVersion());
     }
 
@@ -56,7 +56,7 @@ public class DistributionBitCountTest extends FleetControllerTest {
     public void testDistributionBitCountConfigDecrease() throws Exception {
         setUpSystem("DistributionBitCountTest::testDistributionBitCountConfigDecrease");
         options.distributionBits = 12;
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
         waitForState("version:\\d+ bits:12 distributor:10 storage:10");
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownLiveConfigTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownLiveConfigTest.java
@@ -9,8 +9,6 @@ import static org.junit.Assert.assertFalse;
 
 public class GroupAutoTakedownLiveConfigTest extends FleetControllerTest {
 
-    private long mockConfigGeneration = 1;
-
     private static FleetControllerOptions createOptions(DistributionBuilder.GroupBuilder groupBuilder, double minNodeRatio) {
         FleetControllerOptions options = defaultOptions("mycluster");
         options.setStorageDistribution(DistributionBuilder.forHierarchicCluster(groupBuilder));
@@ -21,8 +19,7 @@ public class GroupAutoTakedownLiveConfigTest extends FleetControllerTest {
     }
 
     private void updateConfigLive(FleetControllerOptions newOptions) {
-        ++mockConfigGeneration;
-        this.fleetController.updateOptions(newOptions, mockConfigGeneration);
+        this.fleetController.updateOptions(newOptions);
     }
 
     private void reconfigureWithMinNodeRatio(double minNodeRatio) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/MasterElectionTest.java
@@ -296,7 +296,7 @@ public class MasterElectionTest extends FleetControllerTest {
         for (FleetController fc : fleetControllers) {
             FleetControllerOptions myoptions = fc.getOptions();
             myoptions.zooKeeperServerAddress = zooKeeperServer.getAddress();
-            fc.updateOptions(myoptions, 0);
+            fc.updateOptions(myoptions);
             log.log(Level.INFO, "Should now have sent out new zookeeper server address " + myoptions.zooKeeperServerAddress + " to fleetcontroller " + myoptions.fleetControllerIndex);
         }
         timer.advanceTime(10 * 1000); // Wait long enough for fleetcontroller wanting to retry zookeeper connection
@@ -447,7 +447,7 @@ public class MasterElectionTest extends FleetControllerTest {
         FleetControllerOptions newOptions = options.clone();
         for (int i=0; i<fleetControllers.size(); ++i) {
             FleetControllerOptions nodeOptions = adjustConfig(newOptions, i, fleetControllers.size());
-            fleetControllers.get(i).updateOptions(nodeOptions, 2);
+            fleetControllers.get(i).updateOptions(nodeOptions);
         }
         waitForMaster(0);
         log.log(Level.INFO, "SHUTTING DOWN FLEET CONTROLLER 0");

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeSlobrokConfigurationMembershipTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/NodeSlobrokConfigurationMembershipTest.java
@@ -46,7 +46,7 @@ public class NodeSlobrokConfigurationMembershipTest extends FleetControllerTest 
         // cluster. If we do not re-fetch state from slobrok we risk racing
         nodeIndices.add(foreignNode);
         options.nodes = asConfiguredNodes(nodeIndices);
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
         // Need to treat cluster as having 6 nodes due to ideal state algo semantics.
         // Note that we do not use subsetWaiter here since we want node 6 included.
         waitForState("version:\\d+ distributor:7 .4.s:d .5.s:d storage:7 .4.s:d .5.s:d");
@@ -65,13 +65,13 @@ public class NodeSlobrokConfigurationMembershipTest extends FleetControllerTest 
         assertTrue(configuredNodes.remove(new ConfiguredNode(0, false)));
         configuredNodes.add(new ConfiguredNode(0, true));
         options.nodes = configuredNodes;
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
 
         waitForState("version:\\d+ distributor:4 storage:4 .0.s:r");
 
         // Now remove the retired node entirely from config
         assertTrue(configuredNodes.remove(new ConfiguredNode(0, true)));
-        fleetController.updateOptions(options, 0);
+        fleetController.updateOptions(options);
 
         // The previously retired node should now be marked as down, as it no longer
         // exists from the point of view of the content cluster. We have to use a subset

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
@@ -346,7 +346,7 @@ public class RpcServerTest extends FleetControllerTest {
             options.slobrokConnectionSpecs = this.options.slobrokConnectionSpecs;
             this.options.maxInitProgressTime = 30000;
             this.options.stableStateTimePeriod = 60000;
-            fleetController.updateOptions(options, 0);
+            fleetController.updateOptions(options);
             waitForState("version:\\d+ distributor:7 storage:7 .0.s:m .1.s:m .2.s:r .3.s:r .4.s:r");
         }
 
@@ -376,7 +376,7 @@ public class RpcServerTest extends FleetControllerTest {
             options.slobrokConnectionSpecs = this.options.slobrokConnectionSpecs;
             this.options.maxInitProgressTime = 30000;
             this.options.stableStateTimePeriod = 60000;
-            fleetController.updateOptions(options, 0);
+            fleetController.updateOptions(options);
             waitForState("version:\\d+ distributor:7 storage:7 .0.s:m .1.s:m");
         }
 
@@ -415,7 +415,7 @@ public class RpcServerTest extends FleetControllerTest {
             options.slobrokConnectionSpecs = this.options.slobrokConnectionSpecs;
             this.options.maxInitProgressTime = 30000;
             this.options.stableStateTimePeriod = 60000;
-            fleetController.updateOptions(options, 0);
+            fleetController.updateOptions(options);
             waitForState("version:\\d+ distributor:5 storage:5");
         }
 
@@ -430,7 +430,7 @@ public class RpcServerTest extends FleetControllerTest {
             options.slobrokConnectionSpecs = this.options.slobrokConnectionSpecs;
             this.options.maxInitProgressTime = 30000;
             this.options.stableStateTimePeriod = 60000;
-            fleetController.updateOptions(options, 0);
+            fleetController.updateOptions(options);
             waitForState("version:\\d+ distributor:7 storage:7 .0.s:r .1.s:r .2.s:r .3.s:r .4.s:r");
         }
 
@@ -444,7 +444,7 @@ public class RpcServerTest extends FleetControllerTest {
             options.slobrokConnectionSpecs = this.options.slobrokConnectionSpecs;
             this.options.maxInitProgressTime = 30000;
             this.options.stableStateTimePeriod = 60000;
-            fleetController.updateOptions(options, 0);
+            fleetController.updateOptions(options);
             waitForState("version:\\d+ distributor:7 storage:7 .0.s:r .1.s:r .2.s:r .3.s:r .4.s:r");
         }
 


### PR DESCRIPTION
On an example node:

```
vespa-curl-wrapper https://localhost:19050/clustercontroller-status/v1/<clustername>/state
{
  "status" : {
    "code" : "up"
  },
  "config" : {
    "component" : {
      "generation" : -1
    }
  }
}
```

From the code, the generation may be either -1 or 0.  At no point does it show the config generation of any component.  It's unlikely anyone depends on this behavior.  So this PR removes it and we'll see how it goes...  If a client wants the config generation they should use the standard /state/v1/config.