### PR TITLE
Introduce separate scope for internal region endpoint

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/pkg/ApplicationPackageValidator.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/pkg/ApplicationPackageValidator.java
@@ -102,7 +102,7 @@ public class ApplicationPackageValidator {
                                                                                                    instant));
     }
 
-    /** Verify that compactable endpoint parts (instance aname nd endpoint ID) do not clash */
+    /** Verify that compactable endpoint parts (instance name and endpoint ID) do not clash */
     private void validateCompactedEndpoint(ApplicationPackage applicationPackage) {
         Map<List<String>, InstanceEndpoint> instanceEndpoints = new HashMap<>();
         for (var instanceSpec : applicationPackage.deploymentSpec().instances()) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -2698,6 +2698,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
     private static String endpointScopeString(Endpoint.Scope scope) {
         switch (scope) {
             case region: return "region";
+            case regionSplit: return "regionSplit";
             case global: return "global";
             case zone: return "zone";
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
@@ -111,7 +111,7 @@ public class RoutingPolicy {
 
     /** Returns the region endpoint of this */
     public Endpoint regionEndpointIn(SystemName system, RoutingMethod routingMethod, boolean legacy) {
-        Endpoint.EndpointBuilder endpoint = endpoint(routingMethod).targetRegion(id.cluster(), id.zone());
+        Endpoint.EndpointBuilder endpoint = endpoint(routingMethod).targetRegionSplit(id.cluster(), id.zone());
         if (legacy) {
             endpoint = endpoint.legacy();
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
@@ -298,49 +298,66 @@ public class EndpointTest {
         var cluster = ClusterSpec.Id.from("default");
         var prodZone = ZoneId.from("prod", "us-north-2");
         Map<String, Endpoint> tests = Map.of(
-                "https://a1.t1.us-north-1-w.public.vespa.oath.cloud/",
-                Endpoint.of(instance1)
-                        .targetRegion(cluster, ZoneId.from("prod", "us-north-1a"))
-                        .routingMethod(RoutingMethod.exclusive)
-                        .on(Port.tls())
-                        .legacy()
-                        .in(SystemName.Public),
-                "https://a1.t1.us-north-2-w.public.vespa.oath.cloud/",
-                Endpoint.of(instance1)
-                        .targetRegion(cluster, prodZone)
-                        .routingMethod(RoutingMethod.exclusive)
-                        .on(Port.tls())
-                        .legacy()
-                        .in(SystemName.Public),
-                "https://a1.t1.us-north-2-w.test.public.vespa.oath.cloud/",
-                Endpoint.of(instance1)
-                        .targetRegion(cluster, ZoneId.from("test", "us-north-2"))
-                        .routingMethod(RoutingMethod.exclusive)
-                        .on(Port.tls())
-                        .legacy()
-                        .in(SystemName.Public),
-                "https://c1.a1.t1.us-north-2.r.vespa-app.cloud/",
-                Endpoint.of(instance1)
-                        .targetRegion(ClusterSpec.Id.from("c1"), prodZone)
-                        .routingMethod(RoutingMethod.exclusive)
-                        .on(Port.tls())
-                        .in(SystemName.Public),
-                "https://r0.a1.t1.us-north-2-w.vespa.oath.cloud/",
+                "https://r0.a1.t1.us-north-2-r.vespa.oath.cloud/",
                 Endpoint.of(app1)
                         .targetRegion(EndpointId.of("r0"), ClusterSpec.Id.from("c1"), prodZone)
                         .routingMethod(RoutingMethod.sharedLayer4)
                         .on(Port.tls())
                         .in(SystemName.main),
-                "https://r0.a2.t2.us-north-2.r.vespa-app.cloud/",
+                "https://r1.a2.t2.us-north-2.r.vespa-app.cloud/",
                 Endpoint.of(app2)
-                        .targetRegion(EndpointId.of("r0"), ClusterSpec.Id.from("c1"), prodZone)
+                        .targetRegion(EndpointId.of("r1"), ClusterSpec.Id.from("c1"), prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
                         .in(SystemName.Public)
         );
         tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
         Endpoint endpoint = Endpoint.of(instance1)
-                                    .targetRegion(cluster, ZoneId.from("prod", "us-north-1a"))
+                                    .targetRegionSplit(cluster, ZoneId.from("prod", "us-north-1a"))
+                                    .routingMethod(RoutingMethod.exclusive)
+                                    .on(Port.tls())
+                                    .in(SystemName.main);
+        assertEquals("Availability zone is removed from region",
+                     "us-north-1",
+                     endpoint.zones().get(0).region().value());
+    }
+
+    @Test
+    public void region_split_endpoints() {
+        var cluster = ClusterSpec.Id.from("default");
+        var prodZone = ZoneId.from("prod", "us-north-2");
+        Map<String, Endpoint> tests = Map.of(
+                "https://a1.t1.us-north-1-w.public.vespa.oath.cloud/",
+                Endpoint.of(instance1)
+                        .targetRegionSplit(cluster, ZoneId.from("prod", "us-north-1a"))
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .legacy()
+                        .in(SystemName.Public),
+                "https://a1.t1.us-north-2-w.public.vespa.oath.cloud/",
+                Endpoint.of(instance1)
+                        .targetRegionSplit(cluster, prodZone)
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .legacy()
+                        .in(SystemName.Public),
+                "https://a1.t1.us-north-2-w.test.public.vespa.oath.cloud/",
+                Endpoint.of(instance1)
+                        .targetRegionSplit(cluster, ZoneId.from("test", "us-north-2"))
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .legacy()
+                        .in(SystemName.Public),
+                "https://c1.a1.t1.us-north-2.w.vespa-app.cloud/",
+                Endpoint.of(instance1)
+                        .targetRegionSplit(ClusterSpec.Id.from("c1"), prodZone)
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .in(SystemName.Public)
+        );
+        tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
+        Endpoint endpoint = Endpoint.of(instance1)
+                                    .targetRegionSplit(cluster, ZoneId.from("prod", "us-north-1a"))
                                     .routingMethod(RoutingMethod.exclusive)
                                     .on(Port.tls())
                                     .in(SystemName.main);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/application/EndpointTest.java
@@ -20,8 +20,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class EndpointTest {
 
-    private static final ApplicationId app1 = ApplicationId.from("t1", "a1", "default");
-    private static final ApplicationId app2 = ApplicationId.from("t2", "a2", "i2");
+    private static final ApplicationId instance1 = ApplicationId.from("t1", "a1", "default");
+    private static final ApplicationId instance2 = ApplicationId.from("t2", "a2", "i2");
+    private static final TenantAndApplicationId app1 = TenantAndApplicationId.from(instance1);
+    private static final TenantAndApplicationId app2 = TenantAndApplicationId.from(instance2);
 
     @Test
     public void global_endpoints() {
@@ -30,62 +32,62 @@ public class EndpointTest {
         Map<String, Endpoint> tests = Map.of(
                 // Legacy endpoint
                 "http://a1.t1.global.vespa.yahooapis.com:4080/",
-                Endpoint.of(app1).target(endpointId).on(Port.plain(4080)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.plain(4080)).legacy().in(SystemName.main),
 
                 // Legacy endpoint with TLS
                 "https://a1--t1.global.vespa.yahooapis.com:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).legacy().in(SystemName.main),
 
                 // Main endpoint
                 "https://a1--t1.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).in(SystemName.main),
 
                 // Main endpoint in CD
                 "https://cd--a1--t1.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
 
                 // Main endpoint in CD
                 "https://cd--i2--a2--t2.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app2).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
+                Endpoint.of(instance2).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
 
                 // Main endpoint with direct routing and default TLS port
                 "https://a1.t1.global.vespa.oath.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint with custom rotation name
                 "https://r1.a1.t1.global.vespa.oath.cloud/",
-                Endpoint.of(app1).target(EndpointId.of("r1")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance1).target(EndpointId.of("r1")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint for custom instance in default rotation
                 "https://i2.a2.t2.global.vespa.oath.cloud/",
-                Endpoint.of(app2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint for custom instance with custom rotation name
                 "https://r2.i2.a2.t2.global.vespa.oath.cloud/",
-                Endpoint.of(app2).target(EndpointId.of("r2")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance2).target(EndpointId.of("r2")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint in public system (legacy)
                 "https://a1.t1.global.public.vespa.oath.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public)
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public)
         );
         tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
 
         Map<String, Endpoint> tests2 = Map.of(
                 // Main endpoint in public CD system (legacy)
                 "https://publiccd.a1.t1.global.public-cd.vespa.oath.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
 
                 // Default endpoint in public system
                 "https://a1.t1.g.vespa-app.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
 
                 // Default endpoint in public CD system
                 "https://a1.t1.g.cd.vespa-app.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.PublicCd),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.PublicCd),
 
                 // Custom instance in public system
                 "https://i2.a2.t2.g.vespa-app.cloud/",
-                Endpoint.of(app2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public)
+                Endpoint.of(instance2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public)
         );
         tests2.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
     }
@@ -97,54 +99,54 @@ public class EndpointTest {
         Map<String, Endpoint> tests = Map.of(
                 // Legacy endpoint
                 "http://a1.t1.global.vespa.yahooapis.com:4080/",
-                Endpoint.of(app1).target(endpointId).on(Port.plain(4080)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.plain(4080)).legacy().in(SystemName.main),
 
                 // Legacy endpoint with TLS
                 "https://a1--t1.global.vespa.yahooapis.com:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).legacy().in(SystemName.main),
 
                 // Main endpoint
                 "https://a1--t1.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).in(SystemName.main),
 
                 // Main endpoint in CD
                 "https://cd--i2--a2--t2.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app2).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
+                Endpoint.of(instance2).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
 
                 // Main endpoint in CD
                 "https://cd--a1--t1.global.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls(4443)).in(SystemName.cd),
 
                 // Main endpoint with direct routing and default TLS port
                 "https://a1.t1.global.vespa.oath.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint with custom rotation name
                 "https://r1.a1.t1.global.vespa.oath.cloud/",
-                Endpoint.of(app1).target(EndpointId.of("r1")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance1).target(EndpointId.of("r1")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint for custom instance in default rotation
                 "https://i2.a2.t2.global.vespa.oath.cloud/",
-                Endpoint.of(app2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance2).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint for custom instance with custom rotation name
                 "https://r2.i2.a2.t2.global.vespa.oath.cloud/",
-                Endpoint.of(app2).target(EndpointId.of("r2")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
+                Endpoint.of(instance2).target(EndpointId.of("r2")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.main),
 
                 // Main endpoint in public system (legacy)
                 "https://a1.t1.global.public.vespa.oath.cloud/",
-                Endpoint.of(app1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public)
+                Endpoint.of(instance1).target(endpointId).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public)
         );
         tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
 
         Map<String, Endpoint> tests2 = Map.of(
                 // Custom endpoint and instance in public CD system (legacy)
                 "https://foo.publiccd.i2.a2.t2.global.public-cd.vespa.oath.cloud/",
-                Endpoint.of(app2).target(EndpointId.of("foo")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
+                Endpoint.of(instance2).target(EndpointId.of("foo")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
 
                 // Custom endpoint and instance in public system
                 "https://foo.i2.a2.t2.g.vespa-app.cloud/",
-                Endpoint.of(app2).target(EndpointId.of("foo")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public)
+                Endpoint.of(instance2).target(EndpointId.of("foo")).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public)
         );
         tests2.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
     }
@@ -158,62 +160,62 @@ public class EndpointTest {
         Map<String, Endpoint> tests = Map.of(
                 // Legacy endpoint (always contains environment)
                 "http://a1.t1.us-north-1.prod.vespa.yahooapis.com:4080/",
-                Endpoint.of(app1).target(cluster, prodZone).on(Port.plain(4080)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(cluster, prodZone).on(Port.plain(4080)).legacy().in(SystemName.main),
 
                 // Secure legacy endpoint
                 "https://a1--t1.us-north-1.prod.vespa.yahooapis.com:4443/",
-                Endpoint.of(app1).target(cluster, prodZone).on(Port.tls(4443)).legacy().in(SystemName.main),
+                Endpoint.of(instance1).target(cluster, prodZone).on(Port.tls(4443)).legacy().in(SystemName.main),
 
                 // Prod endpoint in main
                 "https://a1--t1.us-north-1.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance1).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.main),
 
                 // Prod endpoint in CD
                 "https://cd--a1--t1.us-north-1.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.cd),
+                Endpoint.of(instance1).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.cd),
 
                 // Test endpoint in main
                 "https://a1--t1.us-north-2.test.vespa.oath.cloud:4443/",
-                Endpoint.of(app1).target(cluster, testZone).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance1).target(cluster, testZone).on(Port.tls(4443)).in(SystemName.main),
 
                 // Non-default cluster in main
                 "https://c1--a1--t1.us-north-1.vespa.oath.cloud/",
-                Endpoint.of(app1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).in(SystemName.main),
+                Endpoint.of(instance1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).in(SystemName.main),
 
                 // Non-default instance in main
                 "https://i2--a2--t2.us-north-1.vespa.oath.cloud:4443/",
-                Endpoint.of(app2).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance2).target(cluster, prodZone).on(Port.tls(4443)).in(SystemName.main),
 
                 // Non-default cluster in public (legacy)
                 "https://c1.a1.t1.us-north-1.public.vespa.oath.cloud/",
-                Endpoint.of(app1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public),
+                Endpoint.of(instance1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public),
 
                 // Non-default cluster and instance in public (legacy)
                 "https://c2.i2.a2.t2.us-north-1.public.vespa.oath.cloud/",
-                Endpoint.of(app2).target(ClusterSpec.Id.from("c2"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public),
+                Endpoint.of(instance2).target(ClusterSpec.Id.from("c2"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.Public),
 
                 // Endpoint in main using shared layer 4
                 "https://a1.t1.us-north-1.vespa.oath.cloud/",
-                Endpoint.of(app1).target(cluster, prodZone).on(Port.tls()).routingMethod(RoutingMethod.sharedLayer4).in(SystemName.main)
+                Endpoint.of(instance1).target(cluster, prodZone).on(Port.tls()).routingMethod(RoutingMethod.sharedLayer4).in(SystemName.main)
         );
         tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
 
         Map<String, Endpoint> tests2 = Map.of(
                 // Non-default cluster and instance in public CD (legacy)
                 "https://c2.publiccd.i2.a2.t2.us-north-1.public-cd.vespa.oath.cloud/",
-                Endpoint.of(app2).target(ClusterSpec.Id.from("c2"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
+                Endpoint.of(instance2).target(ClusterSpec.Id.from("c2"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).legacy().in(SystemName.PublicCd),
 
                 // Custom cluster name in public
                 "https://c1.a1.t1.us-north-1.z.vespa-app.cloud/",
-                Endpoint.of(app1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
+                Endpoint.of(instance1).target(ClusterSpec.Id.from("c1"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
 
                 // Default cluster name in non-production zone in public
                 "https://a1.t1.us-north-2.test.z.vespa-app.cloud/",
-                Endpoint.of(app1).target(ClusterSpec.Id.from("default"), testZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
+                Endpoint.of(instance1).target(ClusterSpec.Id.from("default"), testZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.Public),
 
                 // Default cluster name in public CD
                 "https://a1.t1.us-north-1.z.cd.vespa-app.cloud/",
-                Endpoint.of(app1).target(ClusterSpec.Id.from("default"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.PublicCd)
+                Endpoint.of(instance1).target(ClusterSpec.Id.from("default"), prodZone).on(Port.tls()).routingMethod(RoutingMethod.exclusive).in(SystemName.PublicCd)
         );
         tests2.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
     }
@@ -227,7 +229,7 @@ public class EndpointTest {
         var tests = Map.of(
                 // Default rotation
                 "https://a1.t1.global.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .target(EndpointId.defaultId())
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -236,7 +238,7 @@ public class EndpointTest {
 
                 // Wildcard to match other rotations
                 "https://*.a1.t1.global.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .wildcard()
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -245,7 +247,7 @@ public class EndpointTest {
 
                 // Default cluster in zone
                 "https://a1.t1.us-north-1.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .target(defaultCluster, prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -254,7 +256,7 @@ public class EndpointTest {
 
                 // Wildcard to match other clusters in zone
                 "https://*.a1.t1.us-north-1.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .wildcard(prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -263,7 +265,7 @@ public class EndpointTest {
 
                 // Default cluster in test zone
                 "https://a1.t1.us-north-2.test.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .target(defaultCluster, testZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -272,7 +274,7 @@ public class EndpointTest {
 
                 // Wildcard to match other clusters in test zone
                 "https://*.a1.t1.us-north-2.test.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .wildcard(testZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -281,7 +283,7 @@ public class EndpointTest {
 
                 // Wildcard to match other clusters in zone
                 "https://*.a1.t1.us-north-1.z.vespa-app.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .wildcard(prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
@@ -297,35 +299,47 @@ public class EndpointTest {
         var prodZone = ZoneId.from("prod", "us-north-2");
         Map<String, Endpoint> tests = Map.of(
                 "https://a1.t1.us-north-1-w.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .targetRegion(cluster, ZoneId.from("prod", "us-north-1a"))
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
                         .legacy()
                         .in(SystemName.Public),
                 "https://a1.t1.us-north-2-w.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .targetRegion(cluster, prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
                         .legacy()
                         .in(SystemName.Public),
                 "https://a1.t1.us-north-2-w.test.public.vespa.oath.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .targetRegion(cluster, ZoneId.from("test", "us-north-2"))
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
                         .legacy()
                         .in(SystemName.Public),
                 "https://c1.a1.t1.us-north-2.r.vespa-app.cloud/",
-                Endpoint.of(app1)
+                Endpoint.of(instance1)
                         .targetRegion(ClusterSpec.Id.from("c1"), prodZone)
+                        .routingMethod(RoutingMethod.exclusive)
+                        .on(Port.tls())
+                        .in(SystemName.Public),
+                "https://r0.a1.t1.us-north-2-w.vespa.oath.cloud/",
+                Endpoint.of(app1)
+                        .targetRegion(EndpointId.of("r0"), ClusterSpec.Id.from("c1"), prodZone)
+                        .routingMethod(RoutingMethod.sharedLayer4)
+                        .on(Port.tls())
+                        .in(SystemName.main),
+                "https://r0.a2.t2.us-north-2.r.vespa-app.cloud/",
+                Endpoint.of(app2)
+                        .targetRegion(EndpointId.of("r0"), ClusterSpec.Id.from("c1"), prodZone)
                         .routingMethod(RoutingMethod.exclusive)
                         .on(Port.tls())
                         .in(SystemName.Public)
         );
         tests.forEach((expected, endpoint) -> assertEquals(expected, endpoint.url().toString()));
-        Endpoint endpoint = Endpoint.of(app1)
+        Endpoint endpoint = Endpoint.of(instance1)
                                     .targetRegion(cluster, ZoneId.from("prod", "us-north-1a"))
                                     .routingMethod(RoutingMethod.exclusive)
                                     .on(Port.tls())
@@ -341,23 +355,23 @@ public class EndpointTest {
         var tests1 = Map.of(
                 // With default cluster
                 "a1.t1.us-north-1.prod",
-                Endpoint.of(app1).target(EndpointId.defaultId()).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance1).target(EndpointId.defaultId()).on(Port.tls(4443)).in(SystemName.main),
 
                 // With non-default cluster
                 "c1.a1.t1.us-north-1.prod",
-                Endpoint.of(app1).target(EndpointId.of("ignored1"), ClusterSpec.Id.from("c1"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main)
+                Endpoint.of(instance1).target(EndpointId.of("ignored1"), ClusterSpec.Id.from("c1"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main)
         );
         var tests2 = Map.of(
                 // With non-default instance and default cluster
                 "i2.a2.t2.us-north-1.prod",
-                Endpoint.of(app2).target(EndpointId.defaultId(), ClusterSpec.Id.from("default"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main),
+                Endpoint.of(instance2).target(EndpointId.defaultId(), ClusterSpec.Id.from("default"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main),
 
                 // With non-default instance and cluster
                 "c2.i2.a2.t2.us-north-1.prod",
-                Endpoint.of(app2).target(EndpointId.of("ignored2"), ClusterSpec.Id.from("c2"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main)
+                Endpoint.of(instance2).target(EndpointId.of("ignored2"), ClusterSpec.Id.from("c2"), List.of(zone)).on(Port.tls(4443)).in(SystemName.main)
         );
-        tests1.forEach((expected, endpoint) -> assertEquals(expected, endpoint.upstreamIdOf(new DeploymentId(app1, zone))));
-        tests2.forEach((expected, endpoint) -> assertEquals(expected, endpoint.upstreamIdOf(new DeploymentId(app2, zone))));
+        tests1.forEach((expected, endpoint) -> assertEquals(expected, endpoint.upstreamIdOf(new DeploymentId(instance1, zone))));
+        tests2.forEach((expected, endpoint) -> assertEquals(expected, endpoint.upstreamIdOf(new DeploymentId(instance2, zone))));
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -364,11 +364,11 @@ public class RoutingPoliciesTest {
                              Map.of(zone1, 1L, zone2, 1L), true);
         assertEquals("Registers expected DNS names",
                      Set.of("app1.tenant1.aws-eu-west-1-w.public.vespa.oath.cloud",
-                            "app1.tenant1.aws-eu-west-1.r.vespa-app.cloud",
+                            "app1.tenant1.aws-eu-west-1.w.vespa-app.cloud",
                             "app1.tenant1.aws-eu-west-1a.public.vespa.oath.cloud",
                             "app1.tenant1.aws-eu-west-1a.z.vespa-app.cloud",
                             "app1.tenant1.aws-us-east-1-w.public.vespa.oath.cloud",
-                            "app1.tenant1.aws-us-east-1.r.vespa-app.cloud",
+                            "app1.tenant1.aws-us-east-1.w.vespa-app.cloud",
                             "app1.tenant1.aws-us-east-1c.public.vespa.oath.cloud",
                             "app1.tenant1.aws-us-east-1c.z.vespa-app.cloud",
                             "app1.tenant1.g.vespa-app.cloud",
@@ -837,7 +837,7 @@ public class RoutingPoliciesTest {
                 DeploymentId deployment = new DeploymentId(application, zone);
                 EndpointList regionEndpoints = tester.controller().routing().endpointsOf(deployment)
                                                     .cluster(cluster)
-                                                    .scope(Endpoint.Scope.region);
+                                                    .scope(Endpoint.Scope.regionSplit);
                 if (!legacy) {
                     regionEndpoints = regionEndpoints.not().legacy();
                 }


### PR DESCRIPTION
For global endpoints that point to zones in the same region (e.g. aws-us-east-1a
and aws-us-east-1b) we are required to create an implicit region endpoint with
equal weights for both zones. Unfortunately, we used `.r.vespa-app.cloud` for
those endpoints and we now want that suffix for user-configured region endpoints
instead.

With this change we will switch to `.w.vespa-app.cloud` for internal region
endpoints in public (scope `regionSplit`), freeing up `.r.vespa-app.cloud`.

On-premise the scope part for internal region endpoints is already
`.<region>-w.`, so no change here. For user-configured region endpoints
on-premise the scope part will become `.<region>-r.`

@oyving

FYI @tokle