### PR TITLE
Adjust dummy persistence spi semantics towards proton spi semantics when

### DIFF
--- a/persistence/src/vespa/persistence/conformancetest/conformancetest.h
+++ b/persistence/src/vespa/persistence/conformancetest/conformancetest.h
@@ -151,6 +151,10 @@ protected:
             const Bucket& target,
             document::TestDocMan& testDocMan);
 
+    void test_iterate_empty_or_missing_bucket(bool bucket_exists);
+
+    void test_empty_bucket_info(bool bucket_exists);
+
     ConformanceTest();
     ConformanceTest(const std::string &docType);
 };

--- a/storage/src/tests/persistence/filestorage/sanitycheckeddeletetest.cpp
+++ b/storage/src/tests/persistence/filestorage/sanitycheckeddeletetest.cpp
@@ -84,10 +84,10 @@ TEST_F(SanityCheckedDeleteTest, differing_document_sizes_not_considered_out_of_s
 
     c.top.sendDown(delete_cmd);
     c.top.waitForMessages(1, MSG_WAIT_TIME);
-    // Bucket should now well and truly be gone. Will trigger a getBucketInfo error response.
-    spi::BucketInfoResult info_post_delete(
-            _node->getPersistenceProvider().getBucketInfo(spiBucket));
-    ASSERT_TRUE(info_post_delete.hasError()) << info_post_delete.getErrorMessage();
+    auto reply = c.top.getAndRemoveMessage(api::MessageType::DELETEBUCKET_REPLY);
+    auto delete_reply = std::dynamic_pointer_cast<api::DeleteBucketReply>(reply);
+    ASSERT_TRUE(delete_reply);
+    ASSERT_TRUE(delete_reply->getResult().success());
 }
 
 } // namespace storage


### PR DESCRIPTION
bucket doesn't exist:
 * getBucketInfo() returns success with empty bucket info
 * createIterator() returns success
 * iterate() returns empty complete result.

@geirst : please review
@vekterli , @baldersheim : FYI
