### PR TITLE
Prioritize forwarded merges in MergeThrottler queue

### DIFF
--- a/storage/src/vespa/storage/storageserver/mergethrottler.cpp
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.cpp
@@ -395,7 +395,8 @@ MergeThrottler::enqueueMerge(
     if (!validateNewMerge(mergeCmd, nodeSeq, msgGuard)) {
         return;
     }
-    _queue.emplace(msg, _queueSequence++);
+    const bool is_forwarded_merge = _disable_queue_limits_for_chained_merges && !mergeCmd.getChain().empty();
+    _queue.emplace(msg, _queueSequence++, is_forwarded_merge);
     _metrics->queueSize.set(_queue.size());
 }
 

--- a/storage/src/vespa/storage/storageserver/mergethrottler.h
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.h
@@ -80,20 +80,24 @@ private:
         MessageType _msg;
         metrics::MetricTimer _startTimer;
         uint64_t _sequence;
+        bool _is_forwarded_merge;
 
-        StablePriorityOrderingWrapper(const MessageType& msg, uint64_t sequence)
-            : _msg(msg), _startTimer(), _sequence(sequence)
+        StablePriorityOrderingWrapper(const MessageType& msg,
+                                      uint64_t sequence,
+                                      bool is_forwarded_merge) noexcept
+            : _msg(msg),
+              _startTimer(),
+              _sequence(sequence),
+              _is_forwarded_merge(is_forwarded_merge)
         {
         }
 
-        bool operator==(const StablePriorityOrderingWrapper& other) const {
-            return (*_msg == *other._msg
-                    && _sequence == other._sequence);
-        }
-
-        bool operator<(const StablePriorityOrderingWrapper& other) const {
+        bool operator<(const StablePriorityOrderingWrapper& other) const noexcept {
             if (_msg->getPriority() < other._msg->getPriority()) {
                 return true;
+            }
+            if (_is_forwarded_merge != other._is_forwarded_merge) {
+                return _is_forwarded_merge; // Forwarded merges sort before non-forwarded merges.
             }
             return (_sequence < other._sequence);
         }


### PR DESCRIPTION
@geirst please review
@baldersheim @toregge FYI

Rationale: merges that already are part of an active merge window
are taking up logical resources on one or more nodes in the cluster
and we should prefer completing these before starting new merges
queued from distributors.
