### PR TITLE
Felix 7.0.1 take2 [run-systemtest]

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -22,7 +22,7 @@
         <aopalliance.version>1.0</aopalliance.version>
         <athenz.version>1.10.14</athenz.version>
         <bouncycastle.version>1.68</bouncycastle.version>
-        <felix.version>6.0.3</felix.version>
+        <felix.version>7.0.1</felix.version>
         <felix.log.version>1.0.1</felix.log.version>
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>20.0</guava.version>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -403,7 +403,7 @@
     <properties>
         <aopalliance.version>1.0</aopalliance.version>
         <bouncycastle.version>1.68</bouncycastle.version>
-        <felix.version>6.0.3</felix.version>
+        <felix.version>7.0.1</felix.version>
         <felix.log.version>1.0.1</felix.log.version>
         <findbugs.version>1.3.9</findbugs.version>
         <guava.version>20.0</guava.version>

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogHandler.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogHandler.java
@@ -168,5 +168,8 @@ class OsgiLogHandler extends Handler {
             return new Hashtable<>();
         }
 
+        @Override
+        public <A> A adapt(Class<A> aClass) { return null; }
+
     }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -891,7 +891,7 @@
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>

--- a/tenant-base/pom.xml
+++ b/tenant-base/pom.xml
@@ -144,7 +144,7 @@
                         <!-- dependencies, see (3) above -->
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.1.1</version>
+                        <version>3.2.0</version>
                         <executions>
                             <execution>
                                 <!-- JAR-like dependencies -->
@@ -155,6 +155,8 @@
                                 </goals>
                                 <configuration>
                                     <includeTypes>jar,test-jar</includeTypes>
+                                    <!-- felix is not needed in the fat jar, and felix-main:7.0.1 fails upon unpacking because of bogus timestamps -->
+                                    <excludeGroupIds>org.apache.felix</excludeGroupIds>
                                     <outputDirectory>target/fat-test-classes</outputDirectory>
                                     <!-- WARNING(2018-06-27): bcpkix-jdk15on-1.58.jar and
                                          bcprov-jdk15on-1.58.jar are pulled in via


### PR DESCRIPTION
The felix jars had to be excluded from the fat-test-application because of bogus timestamps in felix-main.jar.
https://issues.apache.org/jira/browse/FELIX-6468

The upgrading of maven-dependency-plugin wasn't necessary to fix the problem, but should be done anyway.

FYI: @hmusum 