### PR TITLE
Stop using XX:+UseOSErrorReporting, not supported in newer JDKs [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -20,7 +20,7 @@ public final class ApplicationContainer extends Container implements
         QrStartConfig.Producer,
         ZookeeperServerConfig.Producer {
 
-    private static final String defaultHostedJVMArgs = "-XX:+UseOSErrorReporting -XX:+SuppressFatalErrorMessage";
+    private static final String defaultHostedJVMArgs = "-XX:+SuppressFatalErrorMessage";
 
     private final boolean isHostedVespa;
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/ContainerClusterTest.java
@@ -136,7 +136,7 @@ public class ContainerClusterTest {
 
     private void verifyJvmArgs(boolean isHosted, boolean hasDocproc, String expectedArgs, String jvmArgs) {
         if (isHosted && hasDocproc) {
-            String defaultHostedJVMArgs = "-XX:+UseOSErrorReporting -XX:+SuppressFatalErrorMessage";
+            String defaultHostedJVMArgs = "-XX:+SuppressFatalErrorMessage";
             if ( ! "".equals(expectedArgs)) {
                 defaultHostedJVMArgs = defaultHostedJVMArgs + " ";
             }


### PR DESCRIPTION
Removed in JDK 16, reported to only be working on Windows as well:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8255571

@gjoranv or @baldersheim please review and merge