### PR TITLE
ApplyBucketDiffState uses std::optional, add needed include.

### DIFF
--- a/storage/src/vespa/storage/persistence/apply_bucket_diff_state.h
+++ b/storage/src/vespa/storage/persistence/apply_bucket_diff_state.h
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/retain_guard.h>
 #include <future>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace document { class DocumentId; }


### PR DESCRIPTION
@geirst : please review
