### PR TITLE
Eliminate Clang 12 warning about explicit qualification required to use

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -43,7 +43,7 @@ SingleValueNumericAttribute<B>::onCommit()
                 _data[change._doc] = change._data;
             } else if (change._type >= ChangeBase::ADD && change._type <= ChangeBase::DIV) {
                 std::atomic_thread_fence(std::memory_order_release);
-                _data[change._doc] = applyArithmetic<T, typename B::Change::DataType>(_data[change._doc], change._data.getArithOperand(), change._type);
+                _data[change._doc] = this->template applyArithmetic<T, typename B::Change::DataType>(_data[change._doc], change._data.getArithOperand(), change._type);
             } else if (change._type == ChangeBase::CLEARDOC) {
                 std::atomic_thread_fence(std::memory_order_release);
                 _data[change._doc] = this->_defaultValue._data;

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
@@ -34,7 +34,7 @@ SingleValueNumericEnumAttribute<B>::considerArithmeticAttributeChange(const Chan
         oldValue = get(c._doc);
     }
 
-    T newValue = applyArithmetic<T, typename Change::DataType>(oldValue, c._data.getArithOperand(), c._type);
+    T newValue = this->template applyArithmetic<T, typename Change::DataType>(oldValue, c._data.getArithOperand(), c._type);
 
     EnumIndex idx;
     if (!this->_enumStore.find_index(newValue, idx)) {
@@ -52,7 +52,7 @@ SingleValueNumericEnumAttribute<B>::applyArithmeticValueChange(const Change& c, 
 {
     EnumIndex oldIdx = this->_enumIndices[c._doc];
     EnumIndex newIdx;
-    T newValue = applyArithmetic<T, typename Change::DataType>(get(c._doc), c._data.getArithOperand(), c._type);
+    T newValue = this->template applyArithmetic<T, typename Change::DataType>(get(c._doc), c._data.getArithOperand(), c._type);
     this->_enumStore.find_index(newValue, newIdx);
 
     this->updateEnumRefCounts(c, newIdx, oldIdx, updater);

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
@@ -102,7 +102,7 @@ SingleValueNumericPostingAttribute<B>::applyValueChanges(EnumStoreBatchUpdater& 
         } else if (change._type >= ChangeBase::ADD && change._type <= ChangeBase::DIV) {
             if (oldIdx.valid()) {
                 T oldValue = enumStore.get_value(oldIdx);
-                T newValue = applyArithmetic<T, typename Change::DataType>(oldValue, change._data.getArithOperand(), change._type);
+                T newValue = this->template applyArithmetic<T, typename Change::DataType>(oldValue, change._data.getArithOperand(), change._type);
                 EnumIndex newIdx;
                 (void) dictionary.find_index(enumStore.make_comparator(newValue), newIdx);
                 currEnumIndices[change._doc] = newIdx;


### PR DESCRIPTION
member 'applyArithmetic' from dependent base class.

@baldersheim : please review
