### PR TITLE
Adjust dummy persistence spi semantics towards proton spi semantics when

### DIFF
--- a/persistence/src/vespa/persistence/conformancetest/conformancetest.h
+++ b/persistence/src/vespa/persistence/conformancetest/conformancetest.h
@@ -153,7 +153,7 @@ protected:
 
     void test_iterate_empty_or_missing_bucket(bool bucket_exists);
 
-    void test_empty_bucket_info(bool bucket_exists);
+    void test_empty_bucket_info(bool bucket_exists, bool active);
 
     ConformanceTest();
     ConformanceTest(const std::string &docType);

--- a/persistence/src/vespa/persistence/dummyimpl/dummypersistence.h
+++ b/persistence/src/vespa/persistence/dummyimpl/dummypersistence.h
@@ -203,6 +203,7 @@ private:
     // Const since funcs only alter mutable field in BucketContent
     BucketContentGuard::UP acquireBucketWithLock(const Bucket& b, LockMode lock_mode = LockMode::Exclusive) const;
     void releaseBucketNoLock(const BucketContent& bc, LockMode lock_mode = LockMode::Exclusive) const noexcept;
+    void internal_create_bucket(const Bucket &b);
 
     mutable bool _initialized;
     std::shared_ptr<const document::DocumentTypeRepo> _repo;


### PR DESCRIPTION
bucket doesn't exist:
  setActiveState(), put(), remove() creates bucket if it doesn't already exist.

@baldersheim : please review
