### PR TITLE
Dispatch one request per second of dispatcher interval

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceQueue.java
@@ -4,12 +4,10 @@ package com.yahoo.vespa.hosted.controller.dns;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.yolean.Exceptions;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.UnaryOperator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -28,17 +26,16 @@ public class NameServiceQueue {
 
     private static final Logger log = Logger.getLogger(NameServiceQueue.class.getName());
 
-    private final LinkedBlockingDeque<NameServiceRequest> requests;
+    private final LinkedList<NameServiceRequest> requests;
 
     /** DO NOT USE. Public for serialization purposes */
-    public NameServiceQueue(Collection<NameServiceRequest> requests) {
-        this.requests = new LinkedBlockingDeque<>();
-        this.requests.addAll(Objects.requireNonNull(requests, "requests must be non-null"));
+    public NameServiceQueue(List<NameServiceRequest> requests) {
+        this.requests = new LinkedList<>(Objects.requireNonNull(requests, "requests must be non-null"));
     }
 
     /** Returns a view of requests in this queue */
-    public Collection<NameServiceRequest> requests() {
-        return Collections.unmodifiableCollection(requests);
+    public List<NameServiceRequest> requests() {
+        return Collections.unmodifiableList(requests);
     }
 
     /** Returns a copy of this containing the last n requests */
@@ -99,7 +96,6 @@ public class NameServiceQueue {
     private NameServiceQueue resize(int n, UnaryOperator<List<NameServiceRequest>> resizer) {
         requireNonNegative(n);
         if (requests.size() <= n) return this;
-        List<NameServiceRequest> requests = new ArrayList<>(this.requests);
         return new NameServiceQueue(resizer.apply(requests));
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -152,7 +152,7 @@ public class ControllerMaintenance extends AbstractComponent {
             this.resourceMeterMaintainer = duration(3, MINUTES);
             this.cloudEventReporter = duration(30, MINUTES);
             this.resourceTagMaintainer = duration(30, MINUTES);
-            this.systemRoutingPolicyMaintainer = duration(10, MINUTES);
+            this.systemRoutingPolicyMaintainer = duration(15, MINUTES);
             this.applicationMetaDataGarbageCollector = duration(12, HOURS);
             this.containerImageExpirer = duration(12, HOURS);
             this.hostInfoUpdater = duration(12, HOURS);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/NameServiceDispatcher.java
@@ -1,7 +1,6 @@
 // Copyright 2019 Oath Inc. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.vespa.hosted.controller.dns.NameServiceQueue;
@@ -12,8 +11,8 @@ import java.time.Duration;
 import java.util.logging.Level;
 
 /**
- * This consumes requests from the {@link NameServiceQueue} by submitting them to a {@link NameService}. Successfully
- * consumed requests are removed from the queue.
+ * This dispatches requests from {@link NameServiceQueue} to a {@link NameService}. Successfully dispatched requests are
+ * removed from the queue.
  *
  * @author mpolden
  */
@@ -22,22 +21,17 @@ public class NameServiceDispatcher extends ControllerMaintainer {
     private final Clock clock;
     private final CuratorDb db;
     private final NameService nameService;
-    private final int requestCount;
 
     public NameServiceDispatcher(Controller controller, Duration interval) {
-        this(controller, interval, requestCount(controller.system()));
-    }
-
-    public NameServiceDispatcher(Controller controller, Duration interval, int requestCount) {
         super(controller, interval);
         this.clock = controller.clock();
         this.db = controller.curator();
         this.nameService = controller.serviceRegistry().nameService();
-        this.requestCount = requestCount;
     }
 
     @Override
     protected double maintain() {
+        int requestCount = trueIntervalInSeconds(); // Dispatch 1 request per second
         try (var lock = db.lockNameServiceQueue()) {
             var queue = db.readNameServiceQueue();
             var instant = clock.instant();
@@ -56,9 +50,9 @@ public class NameServiceDispatcher extends ControllerMaintainer {
         return 1.0;
     }
 
-    private static int requestCount(SystemName system) {
-        // Dispatch more requests at a time in CD as integration tests expect reasonably quick DNS changes
-        return system.isCd() ? 3 : 1;
+    /** The true interval at which this runs in this cluster */
+    private int trueIntervalInSeconds() {
+        return (int) interval().dividedBy(db.cluster().size()).getSeconds();
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -227,7 +227,7 @@ public class DeploymentContext {
 
     /** Flush count pending DNS updates */
     public DeploymentContext flushDnsUpdates(int count) {
-        var dispatcher = new NameServiceDispatcher(tester.controller(), Duration.ofDays(1), count);
+        var dispatcher = new NameServiceDispatcher(tester.controller(), Duration.ofSeconds(count));
         dispatcher.run();
         return this;
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemRoutingPolicyMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/SystemRoutingPolicyMaintainerTest.java
@@ -28,7 +28,7 @@ public class SystemRoutingPolicyMaintainerTest {
     public void maintain() {
         var tester = new ControllerTester();
         var updater = new SystemRoutingPolicyMaintainer(tester.controller(), Duration.ofDays(1));
-        var dispatcher = new NameServiceDispatcher(tester.controller(), Duration.ofDays(1), Integer.MAX_VALUE);
+        var dispatcher = new NameServiceDispatcher(tester.controller(), Duration.ofSeconds(Integer.MAX_VALUE));
 
         var zone = ZoneId.from("prod", "us-west-1");
         tester.zoneRegistry().exclusiveRoutingIn(ZoneApiMock.from(zone));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -699,7 +699,7 @@ public class RoutingPoliciesTest {
 
         tester.provisionLoadBalancers(1, app, zone1);
         tester.routingPolicies().refresh(app, DeploymentSpec.empty, zone1);
-        new NameServiceDispatcher(tester.tester.controller(), Duration.ofDays(1), Integer.MAX_VALUE).run();
+        new NameServiceDispatcher(tester.tester.controller(), Duration.ofSeconds(Integer.MAX_VALUE)).run();
 
         List<Record> records = tester.controllerTester().nameService().findRecords(Record.Type.CNAME, name);
         assertEquals(1, records.size());


### PR DESCRIPTION
This together with removal of legacy public endpoints should alleviate some of
the DNS queue pressure.

@tokle

FYI @kkraune