### PR TITLE
Revert "Upgrade to a version that supports JDK 17 [run-systemtest]"

### DIFF
--- a/node-repository/pom.xml
+++ b/node-repository/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.questdb</groupId>
             <artifactId>questdb</artifactId>
-            <version>6.1</version>
+            <version>6.0.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts vespa-engine/vespa#19784

Version does not work with JDK 17 and an issue created for version 6.1 (https://github.com/questdb/questdb/issues/1493) indicates that there could be something wrong with this version. 

It could be that this downgrade does not happen automatically, so might need to do something manually when this rolls out to cd.