### PR TITLE
Fix compilation when using gcc 9:

### DIFF
--- a/searchlib/src/vespa/searchlib/common/unique_issues.h
+++ b/searchlib/src/vespa/searchlib/common/unique_issues.h
@@ -18,7 +18,8 @@ private:
 public:
     using UP = std::unique_ptr<UniqueIssues>;
     void handle(const vespalib::Issue &issue) override;
-    void for_each_message(auto fun) const {
+    template <class Function>
+    void for_each_message(Function fun) const {
         for (const auto &msg: _messages) {
             fun(msg);
         }

--- a/storage/src/vespa/storage/persistence/mergehandler.h
+++ b/storage/src/vespa/storage/persistence/mergehandler.h
@@ -21,6 +21,7 @@
 #include <vespa/storage/common/cluster_context.h>
 #include <vespa/storage/common/messagesender.h>
 #include <vespa/vespalib/util/monitored_refcount.h>
+#include <atomic>
 
 namespace vespalib { class ISequencedTaskExecutor; }
 

--- a/vespalib/src/tests/executor/threadstackexecutor_test.cpp
+++ b/vespalib/src/tests/executor/threadstackexecutor_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/backtrace.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include <atomic>
 #include <thread>
 
 using namespace vespalib;


### PR DESCRIPTION
  - Include header file for atomic when needed.
  - Use normal function template instead of abbreviated function template.

@baldersheim : please review
