### PR TITLE
Open java.base/java.io to the unnamed module (used by NativeIO)

### DIFF
--- a/vespajlib/pom.xml
+++ b/vespajlib/pom.xml
@@ -122,6 +122,16 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- Illegal reflective access by com.yahoo.io.NativeIO -->
+          <argLine>
+            --add-opens=java.base/java.io=ALL-UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.yahoo.vespa</groupId>
         <artifactId>abi-check-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
- Was already opened in vespa-start-container-daemon, so only
  caused a warning in vespajlib unit tests.

