### PR TITLE
Reapply "Remove JVM option that is unsupported on JDK 17"

### DIFF
--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -171,7 +171,6 @@ vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
 	-XX:-OmitStackTraceInFastThrow \
 	-XX:MaxJavaStackTraceDepth=1000000 \
 	$jvmargs \
-    --illegal-access=warn \
     --add-opens=java.base/java.io=ALL-UNNAMED \
     --add-opens=java.base/java.lang=ALL-UNNAMED \
     --add-opens=java.base/java.net=ALL-UNNAMED \

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -260,7 +260,6 @@ exec $numactlcmd $envcmd java \
         -XX:HeapDumpPath="${VESPA_HOME}/var/crash" \
         -XX:ErrorFile="${VESPA_HOME}/var/crash/hs_err_pid%p.log" \
         -XX:+ExitOnOutOfMemoryError \
-        --illegal-access=warn \
         --add-opens=java.base/java.io=ALL-UNNAMED \
         --add-opens=java.base/java.lang=ALL-UNNAMED \
         --add-opens=java.base/java.net=ALL-UNNAMED \

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -163,7 +163,6 @@ StartCommand() {
         -XX:+HeapDumpOnOutOfMemoryError \
         -XX:HeapDumpPath="$VESPA_HOME/var/crash" \
         -XX:+ExitOnOutOfMemoryError \
-        --illegal-access=warn \
         --add-opens=java.base/java.io=ALL-UNNAMED \
         --add-opens=java.base/java.lang=ALL-UNNAMED \
         --add-opens=java.base/java.net=ALL-UNNAMED \


### PR DESCRIPTION
Reverts vespa-engine/vespa#19812

#19812 was made because this was thought to be a regression, but this should be OK. Will merge after 7.493 has been released