### PR TITLE
added new rank feature "onnx(model_name)"

### DIFF
--- a/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
+++ b/searchlib/src/vespa/searchlib/features/onnx_feature.cpp
@@ -100,13 +100,14 @@ public:
     }
 };
 
-OnnxBlueprint::OnnxBlueprint()
-    : Blueprint("onnxModel"),
+OnnxBlueprint::OnnxBlueprint(vespalib::stringref baseName)
+    : Blueprint(baseName),
       _cache_token(),
       _debug_model(),
       _model(nullptr),
       _wire_info()
 {
+    assert((baseName == "onnx") || (baseName == "onnxModel"));
 }
 
 OnnxBlueprint::~OnnxBlueprint() = default;

--- a/searchlib/src/vespa/searchlib/features/onnx_feature.h
+++ b/searchlib/src/vespa/searchlib/features/onnx_feature.h
@@ -20,11 +20,11 @@ private:
     const Onnx *_model;
     Onnx::WireInfo _wire_info;
 public:
-    OnnxBlueprint();
+    OnnxBlueprint(vespalib::stringref baseName);
     ~OnnxBlueprint() override;
     void visitDumpFeatures(const fef::IIndexEnvironment &, fef::IDumpFeatureVisitor &) const override {}
     fef::Blueprint::UP createInstance() const override {
-        return std::make_unique<OnnxBlueprint>();
+        return std::make_unique<OnnxBlueprint>(getBaseName());
     }
     fef::ParameterDescriptions getDescriptions() const override {
         return fef::ParameterDescriptions().desc().string();

--- a/searchlib/src/vespa/searchlib/features/setup.cpp
+++ b/searchlib/src/vespa/searchlib/features/setup.cpp
@@ -124,7 +124,8 @@ void setup_search_features(fef::IBlueprintRegistry & registry)
     registry.addPrototype(std::make_shared<TermFieldMdBlueprint>());
     registry.addPrototype(std::make_shared<ConstantBlueprint>());
     registry.addPrototype(std::make_shared<GlobalSequenceBlueprint>());
-    registry.addPrototype(std::make_shared<OnnxBlueprint>());
+    registry.addPrototype(std::make_shared<OnnxBlueprint>("onnx"));
+    registry.addPrototype(std::make_shared<OnnxBlueprint>("onnxModel"));
 
     // Ranking Expression
     auto replacers = std::make_unique<ListExpressionReplacer>();


### PR DESCRIPTION
Works the same as "onnxModel(model_name)", but is not treated as the
exact same feature (features are currently not allowed to have
multiple base names). If both variants are used at the same time, the
model may be calculated twice, but the model cache will still make
sure that the model itself is only loaded once.

The plan is to deprecate and possibly remove the
"onnxModel(model_name)" variant at some point in the future.

@lesters please review

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
