### PR TITLE
Separate RankProfileRegistry from Application to  reduce its lifetime…

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/Application.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/Application.java
@@ -6,7 +6,6 @@ import com.yahoo.config.application.api.DeployLogger;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -19,22 +18,14 @@ import java.util.Map;
 public class Application {
 
     private final ApplicationPackage applicationPackage;
-    private final RankProfileRegistry rankProfileRegistry;
     private final Map<String, Schema> schemas = new LinkedHashMap<>();
 
     public Application(ApplicationPackage applicationPackage) {
-        this(applicationPackage, new RankProfileRegistry());
-    }
-
-    // TODO: Almost sure the rank profile registry passed is always new RankProfileRegistry() (apart from in some tests), so remove the parameter
-    public Application(ApplicationPackage applicationPackage, RankProfileRegistry rankProfileRegistry) {
         this.applicationPackage = applicationPackage;
-        this.rankProfileRegistry = rankProfileRegistry;
     }
 
     public ApplicationPackage applicationPackage() { return applicationPackage; }
 
-    public RankProfileRegistry rankProfileRegistry() { return rankProfileRegistry; }
 
     public void add(Schema schema) {
         if (schemas.containsKey(schema.getName()))

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfileRegistry.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfileRegistry.java
@@ -25,7 +25,7 @@ import java.util.Set;
 public class RankProfileRegistry {
 
     private final Map<String, Map<String, RankProfile>> rankProfiles = new LinkedHashMap<>();
-    private final String MAGIC_GLOBAL_RANKPROFILES = "[MAGIC_GLOBAL_RANKPROFILES]";
+    private static final String MAGIC_GLOBAL_RANKPROFILES = "[MAGIC_GLOBAL_RANKPROFILES]";
 
     /* These rank profiles can be overridden: 'default' rank profile, as that is documented to work. And 'unranked'. */
     static final Set<String> overridableRankProfileNames = new HashSet<>(Arrays.asList("default", "unranked"));

--- a/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
@@ -50,6 +50,7 @@ public class SchemaBuilder {
     private final DocumentTypeManager docTypeMgr = new DocumentTypeManager();
     private final DocumentModel model = new DocumentModel();
     private final Application application;
+    private final RankProfileRegistry rankProfileRegistry;
     private final QueryProfileRegistry queryProfileRegistry;
     private final FileRegistry fileRegistry;
     private final DeployLogger deployLogger;
@@ -119,7 +120,8 @@ public class SchemaBuilder {
                           RankProfileRegistry rankProfileRegistry,
                           QueryProfileRegistry queryProfileRegistry,
                           boolean documentsOnly) {
-        this.application = new Application(applicationPackage, rankProfileRegistry);
+        this.application = new Application(applicationPackage);
+        this.rankProfileRegistry = rankProfileRegistry;
         this.queryProfileRegistry = queryProfileRegistry;
         this.fileRegistry = fileRegistry;
         this.deployLogger = deployLogger;
@@ -172,7 +174,7 @@ public class SchemaBuilder {
         SimpleCharStream stream = new SimpleCharStream(str);
         try {
             return importRawSchema(new SDParser(stream, fileRegistry, deployLogger, properties, application,
-                                                application.rankProfileRegistry(), documentsOnly)
+                                                rankProfileRegistry, documentsOnly)
                                            .schema(docTypeMgr, searchDefDir));
         } catch (TokenMgrException e) {
             throw new ParseException("Unknown symbol: " + e.getMessage());
@@ -261,7 +263,7 @@ public class SchemaBuilder {
      * #build()} method so that subclasses can choose not to build anything.
      */
     private void process(Schema schema, QueryProfiles queryProfiles, boolean validate) {
-        new Processing().process(schema, deployLogger, application.rankProfileRegistry(), queryProfiles, validate,
+        new Processing().process(schema, deployLogger, rankProfileRegistry, queryProfiles, validate,
                                  documentsOnly, processorsToSkip);
     }
 
@@ -531,7 +533,7 @@ public class SchemaBuilder {
     }
 
     public RankProfileRegistry getRankProfileRegistry() {
-        return application.rankProfileRegistry();
+        return rankProfileRegistry;
     }
 
     public QueryProfileRegistry getQueryProfileRegistry() {

--- a/config-model/src/test/java/com/yahoo/searchdefinition/SchemaTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/SchemaTestCase.java
@@ -153,9 +153,9 @@ public class SchemaTestCase {
         assertNotNull(child.getField("child_field"));
         assertNotNull(child.getExtraField("parent_field"));
         assertNotNull(child.getExtraField("child_field"));
-        assertNotNull(application.rankProfileRegistry().get(child, "parent_profile"));
-        assertNotNull(application.rankProfileRegistry().get(child, "child_profile"));
-        assertEquals("parent_profile", application.rankProfileRegistry().get(child, "child_profile").getInheritedName());
+        assertNotNull(builder.getRankProfileRegistry().get(child, "parent_profile"));
+        assertNotNull(builder.getRankProfileRegistry().get(child, "child_profile"));
+        assertEquals("parent_profile", builder.getRankProfileRegistry().get(child, "child_profile").getInheritedName());
         assertNotNull(child.rankingConstants().get("parent_constant"));
         assertNotNull(child.rankingConstants().get("child_constant"));
         assertTrue(child.rankingConstants().asMap().containsKey("parent_constant"));
@@ -239,17 +239,17 @@ public class SchemaTestCase {
         builder.build(true);
         var application = builder.application();
 
-        assertInheritedFromParent(application.schemas().get("child"), application);
-        assertInheritedFromParent(application.schemas().get("grandchild"), application);
+        assertInheritedFromParent(application.schemas().get("child"), application, builder.getRankProfileRegistry());
+        assertInheritedFromParent(application.schemas().get("grandchild"), application, builder.getRankProfileRegistry());
     }
 
-    private void assertInheritedFromParent(Schema schema, Application application) {
+    private void assertInheritedFromParent(Schema schema, Application application, RankProfileRegistry rankProfileRegistry) {
         assertEquals("pf1", schema.fieldSets().userFieldSets().get("parent_set").getFieldNames().stream().findFirst().get());
         assertEquals(Stemming.NONE, schema.getStemming());
         assertEquals(Stemming.BEST, schema.getIndex("parent_index").getStemming());
         assertNotNull(schema.getField("parent_field"));
         assertNotNull(schema.getExtraField("parent_field"));
-        assertNotNull(application.rankProfileRegistry().get(schema, "parent_profile"));
+        assertNotNull(rankProfileRegistry.get(schema, "parent_profile"));
         assertNotNull(schema.rankingConstants().get("parent_constant"));
         assertTrue(schema.rankingConstants().asMap().containsKey("parent_constant"));
         assertNotNull(schema.onnxModels().get("parent_model"));


### PR DESCRIPTION
… to be only during model building.

Application is kept alive from Schema which is kept alive from NamedSchema and lives permanently in the model.

@hmusum or @bratseth PR