### PR TITLE
add match-features in config-model

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -97,6 +97,7 @@ public class RankProfile implements Cloneable {
     private Set<ReferenceNode> summaryFeatures;
     private String inheritedSummaryFeatures;
 
+    private Set<ReferenceNode> matchFeatures;
     private Set<ReferenceNode> rankFeatures;
 
     /** The properties of this - a multimap */
@@ -518,6 +519,26 @@ public class RankProfile implements Cloneable {
         this.inheritedSummaryFeatures = parentProfile;
     }
 
+    /** Returns a read-only view of the match features to use in this profile. This is never null */
+    public Set<ReferenceNode> getMatchFeatures() {
+        if (matchFeatures != null) return Collections.unmodifiableSet(matchFeatures);
+        if (getInherited() != null) return getInherited().getMatchFeatures();
+        return Set.of();
+    }
+
+    private void addMatchFeature(ReferenceNode feature) {
+        if (matchFeatures == null)
+            matchFeatures = new LinkedHashSet<>();
+        matchFeatures.add(feature);
+    }
+
+    /** Adds the content of the given feature list to the internal list of summary features. */
+    public void addMatchFeatures(FeatureList features) {
+        for (ReferenceNode feature : features) {
+            addMatchFeature(feature);
+        }
+    }
+
     /** Returns a read-only view of the rank features to use in this profile. This is never null */
     public Set<ReferenceNode> getRankFeatures() {
         if (rankFeatures != null) return Collections.unmodifiableSet(rankFeatures);
@@ -817,6 +838,7 @@ public class RankProfile implements Cloneable {
             clone.rankSettings = new LinkedHashSet<>(this.rankSettings);
             clone.matchPhaseSettings = this.matchPhaseSettings; // hmm?
             clone.summaryFeatures = summaryFeatures != null ? new LinkedHashSet<>(this.summaryFeatures) : null;
+            clone.matchFeatures = matchFeatures != null ? new LinkedHashSet<>(this.matchFeatures) : null;
             clone.rankFeatures = rankFeatures != null ? new LinkedHashSet<>(this.rankFeatures) : null;
             clone.rankProperties = new LinkedHashMap<>(this.rankProperties);
             clone.inputFeatures = new LinkedHashMap<>(this.inputFeatures);

--- a/config-model/src/main/javacc/SDParser.jj
+++ b/config-model/src/main/javacc/SDParser.jj
@@ -355,6 +355,8 @@ TOKEN :
 | < DISTANCEMETRIC: "distance-metric" >
 | < NEIGHBORSTOEXPLOREATINSERT: "neighbors-to-explore-at-insert" >
 | < MULTITHREADEDINDEXING: "multi-threaded-indexing" >
+| < MATCHFEATURES_SL: "match-features" (" ")* ":" (~["}","\n"])* ("\n")? >
+| < MATCHFEATURES_ML: "match-features" (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
 | < SUMMARYFEATURES_SL: "summary-features" (" ")* ":" (~["}","\n"])* ("\n")? >
 | < SUMMARYFEATURES_ML: "summary-features" (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
 | < SUMMARYFEATURES_ML_INHERITS: "summary-features inherits " (<IDENTIFIER>) (<SEARCHLIB_SKIP>)? "{" (~["}"])* "}" >
@@ -2078,6 +2080,7 @@ Object rankProfileItem(RankProfile profile) : { }
       | secondPhase(profile)
       | rankDegradation(profile)
       | constants(profile)
+      | matchFeatures(profile)
       | summaryFeatures(profile) )
     { return null; }
 }
@@ -2315,6 +2318,26 @@ Object summaryFeatures(RankProfile profile) :
     )
     {
         profile.addSummaryFeatures(getFeatureList(features));
+        return null;
+    }
+}
+
+/**
+ * This rule consumes a match-features block of a rank profile.
+ *
+ * @param profile The rank profile to modify.
+ * @return Null.
+ */
+Object matchFeatures(RankProfile profile) :
+{
+    String features;
+}
+{
+    ( <MATCHFEATURES_SL> { features = token.image.substring(token.image.indexOf(":") + 1).trim(); } |
+      <MATCHFEATURES_ML> { features = token.image.substring(token.image.indexOf("{") + 1,
+                                                              token.image.lastIndexOf("}")).trim(); } ) 
+    {
+        profile.addMatchFeatures(getFeatureList(features));
         return null;
     }
 }


### PR DESCRIPTION
* extend parser with single-line and multi-line "match-features"
* add match features in RankProfile
* rewrite match features if necessary
* generate config for the backend

New code is similar to the way "summary-features" and "rank-features" are handled.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
@lesters @havardpe FYI
