### PR TITLE
Use last access time to find file references in use [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -632,7 +632,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return fileReferencesOnDisk
                 .stream()
                 .filter(fileReference -> ! fileReferencesInUse.contains(fileReference))
-                .filter(fileReference -> isFileAccessedBefore(new File(fileReferencesPath, fileReference), instant))
+                .filter(fileReference -> isLastFileAccessBefore(new File(fileReferencesPath, fileReference), instant))
                 .sorted((a, b) -> lastAccessed(new File(fileReferencesPath, a)).isBefore(lastAccessed(new File(fileReferencesPath, b))) ? -1 : 1)
                 .collect(Collectors.toList());
     }
@@ -688,7 +688,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                 .collect(Collectors.toList());
     }
 
-    private boolean isFileAccessedBefore(File fileReference, Instant instant) {
+    private boolean isLastFileAccessBefore(File fileReference, Instant instant) {
         return lastAccessed(fileReference).isBefore(instant);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -587,11 +587,11 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return orchestrator.getAllSuspendedApplications().contains(application);
     }
 
-    public HttpResponse filedistributionStatus(ApplicationId applicationId, Duration timeout) {
+    public HttpResponse fileDistributionStatus(ApplicationId applicationId, Duration timeout) {
         return fileDistributionStatus.status(getApplication(applicationId), timeout);
     }
 
-    public List<String> deleteUnusedFiledistributionReferences(File fileReferencesPath,
+    public List<String> deleteUnusedFileDistributionReferences(File fileReferencesPath,
                                                                Duration keepFileReferencesDuration,
                                                                int numberToAlwaysKeep) {
         log.log(Level.FINE, () -> "Keep unused file references for " + keepFileReferencesDuration);
@@ -632,8 +632,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return fileReferencesOnDisk
                 .stream()
                 .filter(fileReference -> ! fileReferencesInUse.contains(fileReference))
-                .filter(fileReference -> isFileLastModifiedBefore(new File(fileReferencesPath, fileReference), instant))
-                .sorted((a, b) -> lastModified(new File(fileReferencesPath, a)).isBefore(lastModified(new File(fileReferencesPath, b))) ? -1 : 1)
+                .filter(fileReference -> isFileAccessedBefore(new File(fileReferencesPath, fileReference), instant))
+                .sorted((a, b) -> lastAccessed(new File(fileReferencesPath, a)).isBefore(lastAccessed(new File(fileReferencesPath, b))) ? -1 : 1)
                 .collect(Collectors.toList());
     }
 
@@ -688,15 +688,15 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
                 .collect(Collectors.toList());
     }
 
-    private boolean isFileLastModifiedBefore(File fileReference, Instant instant) {
-        return lastModified(fileReference).isBefore(instant);
+    private boolean isFileAccessedBefore(File fileReference, Instant instant) {
+        return lastAccessed(fileReference).isBefore(instant);
     }
 
-    private Instant lastModified(File fileReference) {
+    private Instant lastAccessed(File fileReference) {
         BasicFileAttributes fileAttributes;
         try {
             fileAttributes = readAttributes(fileReference.toPath(), BasicFileAttributes.class);
-            return fileAttributes.lastModifiedTime().toInstant();
+            return fileAttributes.lastAccessTime().toInstant();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -136,7 +136,7 @@ public class ApplicationHandler extends HttpHandler {
     }
 
     private HttpResponse filedistributionStatus(ApplicationId applicationId, HttpRequest request) {
-        return applicationRepository.filedistributionStatus(applicationId, getTimeoutFromRequest(request));
+        return applicationRepository.fileDistributionStatus(applicationId, getTimeoutFromRequest(request));
     }
 
     private HttpResponse logs(ApplicationId applicationId, HttpRequest request) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
@@ -20,7 +20,7 @@ import java.time.Duration;
  */
 public class FileDistributionMaintainer extends ConfigServerMaintainer {
 
-    private static final int numberToAlwaysKeep = 10;
+    private static final int numberToAlwaysKeep = 20;
 
     private final ApplicationRepository applicationRepository;
     private final File fileReferencesDir;
@@ -39,7 +39,7 @@ public class FileDistributionMaintainer extends ConfigServerMaintainer {
 
     @Override
     protected double maintain() {
-        applicationRepository.deleteUnusedFiledistributionReferences(fileReferencesDir, maxUnusedFileReferenceAge, numberToAlwaysKeep);
+        applicationRepository.deleteUnusedFileDistributionReferences(fileReferencesDir, maxUnusedFileReferenceAge, numberToAlwaysKeep);
         return 1.0;
     }
 


### PR DESCRIPTION
File references being used by active applications will never be deleted.
Use last access time instead of last modified time to find which ones to
delete or keep for the rest.