### PR TITLE
Disable ciphers that are only supported by some JDK-11 versions

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
+++ b/security-utils/src/main/java/com/yahoo/security/tls/TlsContext.java
@@ -24,17 +24,18 @@ public interface TlsContext extends AutoCloseable {
      * For TLSv1.2 we only allow RSA and ECDSA with ephemeral key exchange and GCM.
      * For TLSv1.3 we allow the DEFAULT group ciphers.
      * Note that we _only_ allow AEAD ciphers for either TLS version.
+     *
+     * TODO(bjorncs) Add new ciphers once migrated to JDK-17 (also available in 11.0.13):
+     * - TLS_CHACHA20_POLY1305_SHA256, TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
      */
     Set<String> ALLOWED_CIPHER_SUITES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", // Java 12
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
             "TLS_AES_128_GCM_SHA256", // TLSv1.3
-            "TLS_AES_256_GCM_SHA384", // TLSv1.3
-            "TLS_CHACHA20_POLY1305_SHA256"))); // TLSv1.3, Java 12
+            "TLS_AES_256_GCM_SHA384" // TLSv1.3
+            )));
 
     // TODO Enable TLSv1.3 after upgrading to JDK 17
     Set<String> ALLOWED_PROTOCOLS = Collections.singleton("TLSv1.2");


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
