### PR TITLE
Revert "Reduce min memory from 4 to 2 Gb"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeResourceLimits.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeResourceLimits.java
@@ -73,7 +73,7 @@ public class NodeResourceLimits {
     private double minAdvertisedMemoryGb(ClusterSpec.Type clusterType) {
         if (zone().system() == SystemName.dev) return 1; // Allow small containers in dev system
         if (clusterType == ClusterSpec.Type.admin) return 1;
-        return 2;
+        return 4;
     }
 
     private double minAdvertisedDiskGb(NodeResources requested, boolean exclusive) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -470,9 +470,9 @@ public class AutoscalingTest {
         tester.deploy(application1, cluster1, 6, 1, hostResources.withVcpu(hostResources.vcpu() / 2));
         tester.clock().advance(Duration.ofDays(2));
         tester.addQueryRateMeasurements(application1, cluster1.id(), 100, t -> t == 0 ? 20.0 : 10.0); // Query traffic only
-        tester.addMemMeasurements(0.01f, 0.95f, 120, application1);
+        tester.addMemMeasurements(0.02f, 0.95f, 120, application1);
         tester.assertResources("Scaling down",
-                               7, 1, 2.5, 2.0, 79.2,
+                               6, 1, 2.9, 4.0, 95.0,
                                tester.autoscale(application1, cluster1.id(), min, max).target());
     }
 
@@ -500,7 +500,7 @@ public class AutoscalingTest {
         tester.clock().advance(Duration.ofMinutes(-10 * 5));
         tester.addQueryRateMeasurements(application1, cluster1.id(), 10, t -> t == 0 ? 20.0 : 10.0); // Query traffic only
         tester.assertResources("Scaling down",
-                               8, 1, 1.0, 2.2, 67.9,
+                               6, 1, 1.4, 4.0, 95.0,
                                tester.autoscale(application1, cluster1.id(), min, max).target());
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainerTest.java
@@ -85,7 +85,7 @@ public class ScalingSuggestionsMaintainerTest {
         addMeasurements(0.10f, 0.10f, 0.10f, 0, 500, app1, tester.nodeRepository());
         maintainer.maintain();
         assertEquals("Peak suggestion has been  outdated",
-                     "7 nodes with [vcpu: 1.2, memory: 2.0 Gb, disk 10.0 Gb, bandwidth: 0.1 Gbps]",
+                     "5 nodes with [vcpu: 1.8, memory: 4.0 Gb, disk 10.0 Gb, bandwidth: 0.1 Gbps]",
                      suggestionOf(app1, cluster1, tester).get().resources().toString());
         assertTrue(shouldSuggest(app1, cluster1, tester));
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -534,10 +534,10 @@ public class ProvisioningTest {
         tester.makeReadyHosts(10, defaultResources).activateTenantHosts();
         try {
             prepare(application, 2, 2, 3, 3,
-                    new NodeResources(2, 1, 10, 2), tester);
+                    new NodeResources(2, 2, 10, 2), tester);
         }
         catch (IllegalArgumentException e) {
-            assertEquals("container cluster 'container0': Min memoryGb size is 1.00 Gb but must be at least 2.00 Gb", e.getMessage());
+            assertEquals("container cluster 'container0': Min memoryGb size is 2.00 Gb but must be at least 4.00 Gb", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#19761

not sure if there were more commits we need we revert, @freva 