### PR TITLE
Compression is not supported for a very long time.

### DIFF
--- a/document/src/tests/serialization/vespadocumentserializer_test.cpp
+++ b/document/src/tests/serialization/vespadocumentserializer_test.cpp
@@ -496,7 +496,7 @@ TEST("requireThatCompressedStructFieldValueCanBeSerialized") {
     checkStructSerialization(value, CompressionConfig::LZ4);
 }
 
-TEST("requireThatReserializationPreservesCompressionIfUnmodified") {
+TEST("requireThatReserializationIsUnompressedIfUnmodified") {
     StructDataType structType(getStructDataType());
     StructFieldValue value = getStructFieldValue(structType);
     const_cast<StructDataType *>(static_cast<const StructDataType *>(value.getDataType()))
@@ -514,7 +514,7 @@ TEST("requireThatReserializationPreservesCompressionIfUnmodified") {
     deserializer.read(value2);
     TEST_DO(checkStructSerialization(value, CompressionConfig::LZ4));
     // Lazy serialization of structs....
-    TEST_DO(checkStructSerialization(value2, CompressionConfig::LZ4));
+    TEST_DO(checkStructSerialization(value2, CompressionConfig::NONE));
     EXPECT_EQUAL(value, value2);
 }
 

--- a/document/src/vespa/document/fieldvalue/serializablearray.h
+++ b/document/src/vespa/document/fieldvalue/serializablearray.h
@@ -80,11 +80,9 @@ public:
 
     using CP = vespalib::CloneablePtr<SerializableArray>;
     using UP = std::unique_ptr<SerializableArray>;
-    using ByteBufferUP = std::unique_ptr<ByteBuffer>;
     using CompressionConfig = vespalib::compression::CompressionConfig;
-    using CompressionInfo = vespalib::compression::CompressionInfo;
 
-    SerializableArray() = default;
+    SerializableArray();
     SerializableArray(const SerializableArray&);
     SerializableArray& operator=(const SerializableArray&);
     SerializableArray(SerializableArray &&) noexcept;
@@ -129,57 +127,22 @@ public:
     /** Deletes all stored attributes. */
     void clear();
 
-    CompressionConfig::Type getCompression() const {
-        return _unlikely ? _unlikely->_serializedCompression : CompressionConfig::NONE;
-    }
-    CompressionInfo getCompressionInfo() const;
-
     bool empty() const { return _entries.empty(); }
 
     const ByteBuffer* getSerializedBuffer() const {
-        return CompressionConfig::isCompressed(getCompression())
-            ? &_unlikely->_compSerData
-            : &_uncompSerData;
+        return &_uncompSerData;
     }
 
     const EntryMap & getEntries() const { return _entries; }
 private:
-    bool shouldDecompress() const {
-        return _unlikely && (_unlikely->_compSerData.getRemaining() != 0) && (_uncompSerData.getBuffer() == 0);
-    }
-    bool maybeDecompressAndCatch() const {
-        if ( shouldDecompress() ) {
-            return deCompressAndCatch();
-        }
-        return false;
-    }
-
-    bool deCompressAndCatch() const;
-    void maybeDecompress() const {
-        if ( shouldDecompress() ) {
-            const_cast<SerializableArray *>(this)->deCompress();
-        }
-    }
-    void deCompress(); // throw (DeserializeException);
-
-    struct RarelyUsedBuffers {
-        /** The buffers we own. */
-        RarelyUsedBuffers();
-        RarelyUsedBuffers(const RarelyUsedBuffers &);
-        ~RarelyUsedBuffers();
-        std::unique_ptr<serializablearray::BufferMap> _owned;
-        ByteBuffer               _compSerData;
-        CompressionConfig::Type  _serializedCompression;
-        uint32_t                 _uncompressedLength;
-    };
     /** Contains the stored attributes, with reference to the real data.. */
     EntryMap                  _entries;
     /** Data we deserialized from, if applicable. */
     ByteBuffer                _uncompSerData;
-    std::unique_ptr<RarelyUsedBuffers> _unlikely;
+    std::unique_ptr<serializablearray::BufferMap> _owned;
 
 
-    VESPA_DLL_LOCAL void invalidate();
+    static ByteBuffer deCompress(CompressionConfig::Type compression, uint32_t uncompressedLength, ByteBuffer compressed); // throw (DeserializeException);
     VESPA_DLL_LOCAL EntryMap::const_iterator find(int id) const;
     VESPA_DLL_LOCAL EntryMap::iterator find(int id);
 };

--- a/document/src/vespa/document/serialization/vespadocumentserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentserializer.cpp
@@ -26,7 +26,6 @@
 #include <vespa/document/update/fieldpathupdates.h>
 #include <vespa/document/update/updates.h>
 #include <vespa/document/util/bytebuffer.h>
-#include <vespa/eval/eval/value.h>
 #include <vespa/eval/eval/value_codec.h>
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/data/slime/binary_format.h>
@@ -298,8 +297,7 @@ VespaDocumentSerializer::structNeedsReserialization(const StructFieldValue &valu
         return false;
     }
 
-    return (value.getFields().getCompression() != value.getCompressionConfig().type &&
-        value.getFields().getCompression() != CompressionConfig::UNCOMPRESSABLE);
+    return true;
 }
 
 void VespaDocumentSerializer::writeUnchanged(const SerializableArray &value) {
@@ -316,10 +314,7 @@ void VespaDocumentSerializer::writeUnchanged(const SerializableArray &value) {
     size_t estimatedRequiredSpace = sz + 4 + 1 + 8 + 4 + field_info.size()*12;
     _stream.reserve(_stream.size() + estimatedRequiredSpace);
     _stream << sz;
-    _stream << static_cast<uint8_t>(value.getCompression());
-    if (CompressionConfig::isCompressed(value.getCompression())) {
-        putInt2_4_8Bytes(_stream, value.getCompressionInfo().getUncompressedSize());
-    }
+    _stream << static_cast<uint8_t>(CompressionConfig::NONE);
     putFieldInfo(_stream, field_info);
     if (sz) {
         _stream.write(buffer->getBuffer(), buffer->getLength());


### PR DESCRIPTION
So drop lazy decompression support in favor of thread safe access to field values.

@vekterli or @toregge PR
@geirst FYI