### PR TITLE
Revert "Prepare for extracting field value in attribute writer thread."

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -63,7 +63,7 @@ AttributeWriter::WriteField::WriteField(AttributeVector &attribute)
 AttributeWriter::WriteField::~WriteField() = default;
 
 void
-AttributeWriter::WriteField::buildFieldPath(const DocumentType &docType) const
+AttributeWriter::WriteField::buildFieldPath(const DocumentType &docType)
 {
     const vespalib::string &name = _attribute.getName();
     FieldPath fp;
@@ -80,8 +80,6 @@ AttributeWriter::WriteField::buildFieldPath(const DocumentType &docType) const
 AttributeWriter::WriteContext::WriteContext(ExecutorId executorId) noexcept
     : _executorId(executorId),
       _fields(),
-      _data_type(nullptr),
-      _two_phase_put_field_path(),
       _hasStructFieldAttribute(false),
       _use_two_phase_put(false)
 {
@@ -110,18 +108,10 @@ AttributeWriter::WriteContext::add(AttributeVector &attr)
 }
 
 void
-AttributeWriter::WriteContext::consider_build_field_paths(const Document& doc) const
+AttributeWriter::WriteContext::buildFieldPaths(const DocumentType &docType)
 {
-    auto data_type = doc.getDataType();
-    if (_data_type != data_type) {
-        _data_type = data_type;
-        auto& doc_type = doc.getType();
-        for (auto &field : _fields) {
-            field.buildFieldPath(doc_type);
-        }
-        if (_use_two_phase_put) {
-            _two_phase_put_field_path = std::make_shared<const FieldPath>(_fields[0].getFieldPath());
-        }
+    for (auto &field : _fields) {
+        field.buildFieldPath(docType);
     }
 }
 
@@ -164,43 +154,18 @@ applyPutToAttribute(SerialNum serialNum, const FieldValue::UP &fieldValue, Docum
     attr.commitIfChangeVectorTooLarge();
 }
 
-class FieldValueAndPrepareResult {
-    std::unique_ptr<const FieldValue> _field_value;
-    std::unique_ptr<PrepareResult>    _prepare_result;
-public:
-    FieldValueAndPrepareResult(std::unique_ptr<const FieldValue> field_value,
-                               std::unique_ptr<PrepareResult> prepare_result)
-        : _field_value(std::move(field_value)),
-          _prepare_result(std::move(prepare_result))
-    {
-    }
-    FieldValueAndPrepareResult()
-        : _field_value(),
-          _prepare_result()
-    {
-    }
-    ~FieldValueAndPrepareResult();
-    FieldValueAndPrepareResult(FieldValueAndPrepareResult&&);
-    const std::unique_ptr<const FieldValue>& get_field_value() const noexcept { return _field_value; }
-    std::unique_ptr<PrepareResult> steal_prepare_result() { return std::move(_prepare_result); }
-};
-
-FieldValueAndPrepareResult::~FieldValueAndPrepareResult() = default;
-
-FieldValueAndPrepareResult::FieldValueAndPrepareResult(FieldValueAndPrepareResult&&) = default;
-
 void
 complete_put_to_attribute(SerialNum serial_num,
                           uint32_t docid,
                           AttributeVector& attr,
-                          std::future<FieldValueAndPrepareResult> result_future,
+                          const FieldValue::SP& field_value,
+                          std::future<std::unique_ptr<PrepareResult>>& result_future,
                           AttributeWriter::OnWriteDoneType)
 {
     ensureLidSpace(serial_num, docid, attr);
-    auto result = result_future.get();
-    auto& field_value = result.get_field_value();
-    if (field_value) {
-        AttributeUpdater::complete_set_value(attr, docid, *field_value, result.steal_prepare_result());
+    if (field_value.get()) {
+        auto result = result_future.get();
+        AttributeUpdater::complete_set_value(attr, docid, *field_value, std::move(result));
     } else {
         attr.clearDoc(docid);
     }
@@ -338,30 +303,28 @@ class PutTask : public vespalib::Executor::Task
     const uint32_t       _lid;
     const bool           _allAttributes;
     std::remove_reference_t<AttributeWriter::OnWriteDoneType> _onWriteDone;
-    const Document&      _doc;
+    std::shared_ptr<DocumentFieldExtractor> _fieldExtractor;
     std::vector<FieldValue::UP> _fieldValues;
 public:
-    PutTask(const AttributeWriter::WriteContext &wc, SerialNum serialNum, const Document& doc, uint32_t lid, bool allAttributes, AttributeWriter::OnWriteDoneType onWriteDone);
+    PutTask(const AttributeWriter::WriteContext &wc, SerialNum serialNum, std::shared_ptr<DocumentFieldExtractor> fieldExtractor, uint32_t lid, bool allAttributes, AttributeWriter::OnWriteDoneType onWriteDone);
     ~PutTask() override;
     void run() override;
 };
 
-PutTask::PutTask(const AttributeWriter::WriteContext &wc, SerialNum serialNum, const Document& doc, uint32_t lid, bool allAttributes, AttributeWriter::OnWriteDoneType onWriteDone)
+PutTask::PutTask(const AttributeWriter::WriteContext &wc, SerialNum serialNum, std::shared_ptr<DocumentFieldExtractor> fieldExtractor, uint32_t lid, bool allAttributes, AttributeWriter::OnWriteDoneType onWriteDone)
     : _wc(wc),
       _serialNum(serialNum),
       _lid(lid),
       _allAttributes(allAttributes),
       _onWriteDone(onWriteDone),
-      _doc(doc),
+      _fieldExtractor(std::move(fieldExtractor)),
       _fieldValues()
 {
-    _wc.consider_build_field_paths(_doc);
-    DocumentFieldExtractor field_extractor(_doc);
     const auto &fields = _wc.getFields();
     _fieldValues.reserve(fields.size());
-    for (const auto& field : fields) {
+    for (const auto &field : fields) {
         if (_allAttributes || field.isStructFieldAttribute()) {
-            FieldValue::UP fv = field_extractor.getFieldValue(field.getFieldPath());
+            FieldValue::UP fv = _fieldExtractor->getFieldValue(field.getFieldPath());
             _fieldValues.emplace_back(std::move(fv));
         }
     }
@@ -385,21 +348,20 @@ PutTask::run()
     }
 }
 
+
 class PreparePutTask : public vespalib::Executor::Task {
 private:
     const SerialNum _serial_num;
     const uint32_t _docid;
     AttributeVector& _attr;
-    std::shared_ptr<const FieldPath> _field_path;
-    const Document* const _doc;
-    std::unique_ptr<FieldValue> _field_value;
-    std::promise<FieldValueAndPrepareResult> _result_promise;
+    FieldValue::SP _field_value;
+    std::promise<std::unique_ptr<PrepareResult>> _result_promise;
 
 public:
     PreparePutTask(SerialNum serial_num,
                    uint32_t docid,
-                   const AttributeWriter::WriteContext& wc,
-                   const Document& doc);
+                   const AttributeWriter::WriteField& field,
+                   std::shared_ptr<DocumentFieldExtractor> field_extractor);
     PreparePutTask(SerialNum serial_num,
                    uint32_t docid,
                    AttributeVector& attr,
@@ -409,27 +371,25 @@ public:
     SerialNum serial_num() const { return _serial_num; }
     uint32_t docid() const { return _docid; }
     AttributeVector& attr() { return _attr; }
-    std::future<FieldValueAndPrepareResult> result_future() {
+    FieldValue::SP field_value() { return _field_value; }
+    std::future<std::unique_ptr<PrepareResult>> result_future() {
         return _result_promise.get_future();
     }
 };
 
 PreparePutTask::PreparePutTask(SerialNum serial_num,
                                uint32_t docid,
-                               const AttributeWriter::WriteContext& wc,
-                               const Document& doc)
+                               const AttributeWriter::WriteField& field,
+                               std::shared_ptr<DocumentFieldExtractor> field_extractor)
     : _serial_num(serial_num),
       _docid(docid),
-      _attr(wc.getFields()[0].getAttribute()),
-      _field_path(wc.get_two_phase_put_field_path()),
-      _doc(&doc),
+      _attr(field.getAttribute()),
       _field_value(),
       _result_promise()
 {
-    if (_field_path) {
-        DocumentFieldExtractor field_extractor(*_doc);
-        _field_value = field_extractor.getFieldValue(*_field_path);
-    }
+    // Note: No need to store the field extractor as we are not extracting struct fields.
+    auto value = field_extractor->getFieldValue(field.getFieldPath());
+    _field_value.reset(value.release());
 }
 
 PreparePutTask::PreparePutTask(SerialNum serial_num,
@@ -439,8 +399,6 @@ PreparePutTask::PreparePutTask(SerialNum serial_num,
     : _serial_num(serial_num),
       _docid(docid),
       _attr(attr),
-      _field_path(),
-      _doc(nullptr),
       _field_value(field_value.clone()),
       _result_promise()
 {
@@ -453,10 +411,7 @@ PreparePutTask::run()
 {
     if (_attr.getStatus().getLastSyncToken() < _serial_num) {
         if (_field_value.get()) {
-            auto& fv = *_field_value;
-            _result_promise.set_value(FieldValueAndPrepareResult(std::move(_field_value), AttributeUpdater::prepare_set_value(_attr, _docid, fv)));
-        } else {
-            _result_promise.set_value(FieldValueAndPrepareResult());
+            _result_promise.set_value(AttributeUpdater::prepare_set_value(_attr, _docid, *_field_value));
         }
     }
 }
@@ -467,7 +422,7 @@ private:
     const uint32_t _docid;
     AttributeVector& _attr;
     FieldValue::SP _field_value;
-    std::future<FieldValueAndPrepareResult> _result_future;
+    std::future<std::unique_ptr<PrepareResult>> _result_future;
     std::remove_reference_t<AttributeWriter::OnWriteDoneType> _on_write_done;
 
 public:
@@ -482,6 +437,7 @@ CompletePutTask::CompletePutTask(PreparePutTask& prepare_task,
     : _serial_num(prepare_task.serial_num()),
       _docid(prepare_task.docid()),
       _attr(prepare_task.attr()),
+      _field_value(prepare_task.field_value()),
       _result_future(prepare_task.result_future()),
       _on_write_done(on_write_done)
 {
@@ -493,7 +449,7 @@ void
 CompletePutTask::run()
 {
     if (_attr.getStatus().getLastSyncToken() < _serial_num) {
-        complete_put_to_attribute(_serial_num, _docid, _attr, std::move(_result_future), _on_write_done);
+        complete_put_to_attribute(_serial_num, _docid, _attr, _field_value, _result_future, _on_write_done);
     }
 }
 
@@ -631,20 +587,33 @@ AttributeWriter::setupWriteContexts()
 }
 
 void
+AttributeWriter::buildFieldPaths(const DocumentType & docType, const DataType *dataType)
+{
+    for (auto &wc : _writeContexts) {
+        wc.buildFieldPaths(docType);
+    }
+    _dataType = dataType;
+}
+
+void
 AttributeWriter::internalPut(SerialNum serialNum, const Document &doc, DocumentIdT lid,
                              bool allAttributes, OnWriteDoneType onWriteDone)
 {
+    const DataType *dataType(doc.getDataType());
+    if (_dataType != dataType) {
+        buildFieldPaths(doc.getType(), dataType);
+    }
+    auto extractor = std::make_shared<DocumentFieldExtractor>(doc);
     for (const auto &wc : _writeContexts) {
         if (wc.use_two_phase_put()) {
             assert(wc.getFields().size() == 1);
-            wc.consider_build_field_paths(doc);
-            auto prepare_task = std::make_unique<PreparePutTask>(serialNum, lid, wc, doc);
+            auto prepare_task = std::make_unique<PreparePutTask>(serialNum, lid, wc.getFields()[0], extractor);
             auto complete_task = std::make_unique<CompletePutTask>(*prepare_task, onWriteDone);
             _shared_executor.execute(std::move(prepare_task));
             _attributeFieldWriter.executeTask(wc.getExecutorId(), std::move(complete_task));
         } else {
             if (allAttributes || wc.hasStructFieldAttribute()) {
-                auto putTask = std::make_unique<PutTask>(wc, serialNum, doc, lid, allAttributes, onWriteDone);
+                auto putTask = std::make_unique<PutTask>(wc, serialNum, extractor, lid, allAttributes, onWriteDone);
                 _attributeFieldWriter.executeTask(wc.getExecutorId(), std::move(putTask));
             }
         }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.h
@@ -32,7 +32,7 @@ public:
      * Represents an attribute vector for a field and details about how to write to it.
      */
     class WriteField {
-        mutable FieldPath _fieldPath;
+        FieldPath        _fieldPath;
         AttributeVector &_attribute;
         bool             _structFieldAttribute; // in array/map of struct
         bool             _use_two_phase_put;
@@ -41,7 +41,7 @@ public:
         ~WriteField();
         AttributeVector &getAttribute() const { return _attribute; }
         const FieldPath &getFieldPath() const { return _fieldPath; }
-        void buildFieldPath(const DocumentType &docType) const;
+        void buildFieldPath(const DocumentType &docType);
         bool isStructFieldAttribute() const { return _structFieldAttribute; }
         bool use_two_phase_put() const { return _use_two_phase_put; }
     };
@@ -52,8 +52,6 @@ public:
     class WriteContext {
         ExecutorId _executorId;
         std::vector<WriteField> _fields;
-        mutable const DataType* _data_type;
-        mutable std::shared_ptr<const FieldPath> _two_phase_put_field_path;
         bool _hasStructFieldAttribute;
         // When this is true, the context only contains a single field.
         bool _use_two_phase_put;
@@ -62,13 +60,12 @@ public:
         WriteContext(WriteContext &&rhs) noexcept;
         ~WriteContext();
         WriteContext &operator=(WriteContext &&rhs) noexcept;
-        void consider_build_field_paths(const Document& doc) const;
+        void buildFieldPaths(const DocumentType &docType);
         void add(AttributeVector &attr);
         ExecutorId getExecutorId() const { return _executorId; }
         const std::vector<WriteField> &getFields() const { return _fields; }
         bool hasStructFieldAttribute() const { return _hasStructFieldAttribute; }
         bool use_two_phase_put() const { return _use_two_phase_put; }
-        std::shared_ptr<const FieldPath> get_two_phase_put_field_path() const noexcept { return _two_phase_put_field_path; }
     };
 
     struct AttributeWithInfo {


### PR DESCRIPTION
Reverts vespa-engine/vespa#19934

By the elimination method I think this may have broken a number of struct system tests.