### PR TITLE
Remove implicit write to tmp as part of cluster controller health ping

### DIFF
--- a/storage/src/vespa/storage/storageserver/statemanager.cpp
+++ b/storage/src/vespa/storage/storageserver/statemanager.cpp
@@ -577,21 +577,6 @@ StateManager::sendGetNodeStateReplies(framework::MilliSecTime olderThanTime, uin
     return true;
 }
 
-namespace {
-    std::string getHostInfoFilename(bool advanceCount) {
-        static uint32_t fileCounter = 0;
-        static pid_t pid = getpid();
-        if (advanceCount) {
-            ++fileCounter;
-        }
-        uint32_t fileIndex = fileCounter % 8;
-        std::ostringstream fileName;
-        fileName << vespa::Defaults::underVespaHome("tmp/hostinfo")
-                 << "." << pid << "." << fileIndex << ".report";
-        return fileName.str();
-    }
-}
-
 std::string
 StateManager::getNodeInfo() const
 {
@@ -631,15 +616,6 @@ StateManager::getNodeInfo() const
     stream << End();
     stream.finalize();
 
-    // Dump report to new report file.
-    std::string oldFile(getHostInfoFilename(false));
-    std::string newFile(getHostInfoFilename(true));
-    std::ofstream of(newFile.c_str());
-    of << json.str();
-    of.close();
-    // If dumping went ok, delete old report file
-    vespalib::unlink(oldFile);
-    // Return report
     return json.str();
 }
 


### PR DESCRIPTION
@geirst please review

This was a feature tracing its lineage back to ye olde VDS days where we
had a dusty root drive holding the OS and Vespa and a dozen spinning rust
drives storing the actual data. The health ping would confirm that the
root drive was still functioning properly by triggering a write to it,
as the node would swiftly bail if any of the I/O operations failed.

Today's access patterns are wildly different so we'll detect disk problems
quickly anyway, not to mention Vespa Cloud has disk health monitoring built in.