### PR TITLE
Always set new config when updated generation, take 3

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/GenericJRTConfigSubscription.java
@@ -49,6 +49,17 @@ public class GenericJRTConfigSubscription extends JRTConfigSubscription<RawConfi
         }
     }
 
+    // Need to override this method, since we use RawConfig in this class,
+    @Override
+    protected void setNewConfigAndGeneration(JRTClientConfigRequest jrtReq) {
+        // Set generation first, as RawConfig contains generation and that
+        // will make configChanged in ConfigState always true otherwise
+        // (see equals usage in setConfigAndGeneration())
+        setGeneration(jrtReq.getNewGeneration());
+        RawConfig rawConfig = RawConfig.createFromResponseParameters(jrtReq);
+        setConfigAndGeneration(jrtReq.getNewGeneration(), jrtReq.responseIsApplyOnRestart(), rawConfig, jrtReq.getNewChecksums());
+    }
+
     // Override to propagate internal redeploy into the config value in addition to the config state
     @Override
     void setApplyOnRestart(boolean applyOnRestart) {

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -73,7 +73,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
             if (jrtReq.hasUpdatedConfig()) {
                 setNewConfig(jrtReq);
             } else {
-                setGeneration(jrtReq.getNewGeneration());
+                setNewConfigAndGeneration(jrtReq);
             }
         }
 
@@ -105,6 +105,18 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
         try {
             T configInstance = toConfigInstance(jrtReq);
             setConfig(jrtReq.getNewGeneration(), jrtReq.responseIsApplyOnRestart(), configInstance, jrtReq.getNewChecksums());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Bad config in response", e);
+        }
+    }
+
+    protected void setNewConfigAndGeneration(JRTClientConfigRequest jrtReq) {
+        try {
+            T configInstance = toConfigInstance(jrtReq);
+            setConfigAndGeneration(jrtReq.getNewGeneration(),
+                                   jrtReq.responseIsApplyOnRestart(),
+                                   configInstance,
+                                   jrtReq.getNewChecksums());
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Bad config in response", e);
         }


### PR DESCRIPTION
As https://github.com/vespa-engine/vespa/pull/19957, but with one added commit to make config proxy work.
We use RawConfig in GenericJRTConfigSubscription class, that does not work with code expecting ConfigInstance