### PR TITLE
DocumentInverterContext uses std::optional. Add needed include.

### DIFF
--- a/searchlib/src/vespa/searchlib/memoryindex/document_inverter_context.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/document_inverter_context.cpp
@@ -2,6 +2,7 @@
 
 #include "document_inverter_context.h"
 #include <cassert>
+#include <optional>
 
 namespace search::memoryindex {
 


### PR DESCRIPTION
@baldersheim : please review
