### PR TITLE
Extend test to cover case where we get new generation, but same config

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/MockConnection.java
@@ -83,11 +83,13 @@ public class MockConnection implements ConnectionPool, Connection {
 
     static class OKResponseHandler extends AbstractResponseHandler {
 
+        long generation = 1;
+
         protected void createResponse() {
             JRTServerConfigRequestV3 jrtReq = JRTServerConfigRequestV3.createFromRequest(request);
             Payload payload = Payload.from(ConfigPayload.empty());
-            long generation = 1;
             jrtReq.addOkResponse(payload, generation, false, PayloadChecksums.fromPayload(payload));
+            generation++;
         }
 
     }

--- a/config/src/test/java/com/yahoo/config/subscription/GenericConfigSubscriberTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/GenericConfigSubscriberTest.java
@@ -1,25 +1,23 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
 import com.yahoo.config.subscription.impl.GenericConfigHandle;
 import com.yahoo.config.subscription.impl.GenericConfigSubscriber;
 import com.yahoo.config.subscription.impl.JRTConfigRequester;
 import com.yahoo.config.subscription.impl.JRTConfigRequesterTest;
 import com.yahoo.config.subscription.impl.MockConnection;
 import com.yahoo.vespa.config.ConfigKey;
-import com.yahoo.vespa.config.JRTConnectionPool;
+import com.yahoo.vespa.config.TimingValues;
 import com.yahoo.vespa.config.protocol.CompressionType;
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.is;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -29,28 +27,45 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  */
 public class GenericConfigSubscriberTest {
+    private static final TimingValues tv = JRTConfigRequesterTest.getTestTimingValues();
 
     @Test
-    public void testSubscribeGeneric() {
+    public void testSubscribeGeneric() throws InterruptedException {
         Map<ConfigSourceSet, JRTConfigRequester> requesters = new HashMap<>();
         ConfigSourceSet sourceSet = new ConfigSourceSet("blabla");
-        requesters.put(sourceSet, new JRTConfigRequester(new MockConnection(), JRTConfigRequesterTest.getTestTimingValues()));
+        requesters.put(sourceSet, new JRTConfigRequester(new MockConnection(), tv));
         GenericConfigSubscriber sub = new GenericConfigSubscriber(requesters);
         final List<String> defContent = List.of("myVal int");
-        GenericConfigHandle handle = sub.subscribe(new ConfigKey<>("simpletypes", "id", "config"), defContent, sourceSet, JRTConfigRequesterTest.getTestTimingValues());
+        GenericConfigHandle handle = sub.subscribe(new ConfigKey<>("simpletypes", "id", "config"),
+                                                   defContent,
+                                                   sourceSet,
+                                                   tv);
         assertTrue(sub.nextConfig(false));
         assertTrue(handle.isChanged());
-        assertThat(handle.getRawConfig().getPayload().withCompression(CompressionType.UNCOMPRESSED).toString(), is("{}")); // MockConnection returns empty string
+        // MockConnection returns empty string
+        assertEquals("{}", getConfig(handle));
+        assertEquals(1L, handle.getRawConfig().getGeneration());
         assertFalse(sub.nextConfig(false));
         assertFalse(handle.isChanged());
+
+        // Wait some time, config should be the same, but generation should be higher
+        Thread.sleep(tv.getFixedDelay() * 2);
+        assertEquals("{}", getConfig(handle));
+        assertTrue(handle.getRawConfig().getGeneration() > 1);
+        assertFalse(sub.nextConfig(false));
+        assertFalse(handle.isChanged());
+    }
+
+    private String getConfig(GenericConfigHandle handle) {
+        return handle.getRawConfig().getPayload().withCompression(CompressionType.UNCOMPRESSED).toString();
     }
 
     @Test
     public void testGenericRequesterPooling() {
         ConfigSourceSet source1 = new ConfigSourceSet("tcp/foo:78");
         ConfigSourceSet source2 = new ConfigSourceSet("tcp/bar:79");
-        JRTConfigRequester req1 = JRTConfigRequester.create(source1, JRTConfigRequesterTest.getTestTimingValues());
-        JRTConfigRequester req2 = JRTConfigRequester.create(source2, JRTConfigRequesterTest.getTestTimingValues());
+        JRTConfigRequester req1 = JRTConfigRequester.create(source1, tv);
+        JRTConfigRequester req2 = JRTConfigRequester.create(source2, tv);
         Map<ConfigSourceSet, JRTConfigRequester> requesters = new LinkedHashMap<>();
         requesters.put(source1, req1);
         requesters.put(source2, req2);


### PR DESCRIPTION
With this we would have caught the issue that resulted in https://github.com/vespa-engine/vespa/pull/19960