### PR TITLE
Use given messagebus config also when slobroks config is self-sub

### DIFF
--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/NetworkMultiplexerProvider.java
@@ -30,7 +30,7 @@ public class NetworkMultiplexerProvider {
     }
 
     public NetworkMultiplexerProvider(NetworkMultiplexerHolder net, ContainerMbusConfig mbusConfig, String identity) {
-        this.nets = () -> net.get(asParameters(mbusConfig, identity).setSlobrokConfigId(identity));
+        this.nets = () -> net.get(asParameters(mbusConfig, identity));
     }
 
     public static RPCNetworkParams asParameters(ContainerMbusConfig mbusConfig, SlobroksConfig slobroksConfig, String identity) {

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
@@ -64,8 +64,9 @@ public class MessageBusDocumentAccess extends DocumentAccess {
                 bus = new NetworkMessageBus(network, new MessageBus(network, mbusParams));
             }
             else {
-                if (params.getRPCNetworkParams().getSlobroksConfig() != null && mbusParams.getMessageBusConfig() != null)
+                if (mbusParams.getMessageBusConfig() != null) {
                     bus = new RPCMessageBus(mbusParams, params.getRPCNetworkParams());
+                }
                 else {
                     log.log(Level.FINE, () -> "Setting up self-subscription to config because explicit config was missing; try to avoid this in containers");
                     bus = new RPCMessageBus(mbusParams, params.getRPCNetworkParams(), params.getRoutingConfigId());


### PR DESCRIPTION
@bjorncs please review and merge. 

Both these were either present or absent. With the move back to self-subscription for slobroks config, this was no longer true. We still don't want self-subscription for messagebus config, though.