### PR TITLE
proton::BucketDB uses std::optional. Add needed include.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdb.cpp
@@ -4,6 +4,7 @@
 #include "remove_batch_entry.h"
 #include <cassert>
 #include <algorithm>
+#include <optional>
 
 using document::GlobalId;
 using storage::spi::BucketChecksum;


### PR DESCRIPTION
@baldersheim : please review
@geirst : FYI
