### PR TITLE
Add configurable support for unordered merge forwarding [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/CMakeLists.txt
+++ b/storage/src/tests/distributor/CMakeLists.txt
@@ -25,6 +25,7 @@ vespa_add_executable(storage_distributor_gtest_runner_app TEST
     mergelimitertest.cpp
     mergeoperationtest.cpp
     multi_thread_stripe_access_guard_test.cpp
+    node_supported_features_repo_test.cpp
     nodeinfotest.cpp
     nodemaintenancestatstrackertest.cpp
     operation_sequencer_test.cpp

--- a/storage/src/tests/distributor/blockingoperationstartertest.cpp
+++ b/storage/src/tests/distributor/blockingoperationstartertest.cpp
@@ -100,6 +100,9 @@ struct FakeDistributorStripeOperationContext : public DistributorStripeOperation
     const BucketGcTimeCalculator::BucketIdHasher& bucket_id_hasher() const override {
         abort();
     }
+    const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept override {
+        abort();
+    }
 };
 
 struct BlockingOperationStarterTest : Test {

--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -185,6 +185,12 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         configure_stripe(builder);
     }
 
+    void configure_use_unordered_merge_chaining(bool use_unordered) {
+        ConfigBuilder builder;
+        builder.useUnorderedMergeChaining = use_unordered;
+        configure_stripe(builder);
+    }
+
     bool scheduler_has_implicitly_clear_priority_on_schedule_set() const noexcept {
         return _stripe->_scheduler->implicitly_clear_priority_on_schedule();
     }
@@ -980,6 +986,17 @@ TEST_F(DistributorStripeTest, closing_aborts_gets_started_outside_stripe_thread)
     _stripe->flush_and_close();
     ASSERT_EQ(1, _sender.replies().size());
     EXPECT_EQ(api::ReturnCode::ABORTED, _sender.reply(0)->getResult().getResult());
+}
+
+TEST_F(DistributorStripeTest, use_unordered_merge_chaining_config_is_propagated_to_internal_config)
+{
+    setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
+
+    configure_use_unordered_merge_chaining(true);
+    EXPECT_TRUE(getConfig().use_unordered_merge_chaining());
+
+    configure_use_unordered_merge_chaining(false);
+    EXPECT_FALSE(getConfig().use_unordered_merge_chaining());
 }
 
 }

--- a/storage/src/tests/distributor/distributor_stripe_test_util.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.cpp
@@ -9,8 +9,10 @@
 #include <vespa/storage/distributor/distributor_stripe_component.h>
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/ideal_state_total_metrics.h>
+#include <vespa/storage/distributor/node_supported_features_repo.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/text/stringtokenizer.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
 
 using document::test::makeBucketSpace;
 using document::test::makeDocumentBucket;
@@ -524,6 +526,13 @@ DistributorStripeTestUtil::pending_message_tracker() noexcept {
 std::chrono::steady_clock::duration
 DistributorStripeTestUtil::db_memory_sample_interval() const noexcept {
     return _stripe->db_memory_sample_interval();
+}
+
+void
+DistributorStripeTestUtil::set_node_supported_features(uint16_t node, const NodeSupportedFeatures& features) {
+    vespalib::hash_map<uint16_t, NodeSupportedFeatures> new_features;
+    new_features[node] = features;
+    _stripe->update_node_supported_features_repo(_stripe->node_supported_features_repo().make_union_of(new_features));
 }
 
 const lib::Distribution&

--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -26,6 +26,7 @@ class DocumentSelectionParser;
 class ExternalOperationHandler;
 class IdealStateManager;
 class IdealStateMetricSet;
+class NodeSupportedFeatures;
 class Operation;
 class StripeBucketDBUpdater;
 
@@ -150,6 +151,7 @@ public:
     [[nodiscard]] const PendingMessageTracker& pending_message_tracker() const noexcept;
     [[nodiscard]] PendingMessageTracker& pending_message_tracker() noexcept;
     [[nodiscard]] std::chrono::steady_clock::duration db_memory_sample_interval() const noexcept;
+    void set_node_supported_features(uint16_t node, const NodeSupportedFeatures& features);
 
     const lib::Distribution& getDistribution() const;
 

--- a/storage/src/tests/distributor/mock_tickable_stripe.h
+++ b/storage/src/tests/distributor/mock_tickable_stripe.h
@@ -33,6 +33,10 @@ struct MockTickableStripe : TickableStripe {
     void update_read_snapshot_after_activation(const lib::ClusterStateBundle&) override { abort(); }
     void clear_read_only_bucket_repo_databases() override { abort(); }
 
+    void update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo>) override {
+        abort();
+    }
+
     void report_bucket_db_status(document::BucketSpace, std::ostream&) const override { abort(); }
     StripeAccessGuard::PendingOperationStats pending_operation_stats() const override { abort(); }
     void report_single_bucket_requests(vespalib::xml::XmlOutputStream&) const override { abort(); }

--- a/storage/src/tests/distributor/node_supported_features_repo_test.cpp
+++ b/storage/src/tests/distributor/node_supported_features_repo_test.cpp
@@ -1,0 +1,52 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/storage/distributor/node_supported_features_repo.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace storage::distributor {
+
+struct NodeSupportedFeaturesRepoTest : Test {
+    using FeatureMap = vespalib::hash_map<uint16_t, NodeSupportedFeatures>;
+    NodeSupportedFeaturesRepo _repo;
+
+    static NodeSupportedFeatures set_features() noexcept {
+        NodeSupportedFeatures f;
+        f.unordered_merge_chaining = true;
+        return f;
+    }
+
+    static NodeSupportedFeatures unset_features() noexcept {
+        return {};
+    }
+};
+
+TEST_F(NodeSupportedFeaturesRepoTest, feature_set_is_empty_by_default) {
+    EXPECT_EQ(_repo.node_supported_features(0), unset_features());
+    EXPECT_EQ(_repo.node_supported_features(12345), unset_features());
+}
+
+TEST_F(NodeSupportedFeaturesRepoTest, make_union_of_can_add_new_feature_mapping) {
+    FeatureMap fm;
+    fm[1] = set_features();
+    fm[60] = set_features();
+    auto new_repo = _repo.make_union_of(fm);
+    EXPECT_EQ(new_repo->node_supported_features(0), unset_features());
+    EXPECT_EQ(new_repo->node_supported_features(1), set_features());
+    EXPECT_EQ(new_repo->node_supported_features(60), set_features());
+}
+
+TEST_F(NodeSupportedFeaturesRepoTest, make_union_of_updates_existing_feature_mappings) {
+    FeatureMap fm;
+    fm[1] = set_features();
+    fm[60] = set_features();
+    auto new_repo = _repo.make_union_of(fm);
+    fm[1] = unset_features();
+    new_repo = new_repo->make_union_of(fm);
+    EXPECT_EQ(new_repo->node_supported_features(1), unset_features());
+    EXPECT_EQ(new_repo->node_supported_features(60), set_features());
+}
+
+}

--- a/storage/src/tests/distributor/top_level_distributor_test_util.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.cpp
@@ -115,13 +115,13 @@ TopLevelDistributorTestUtil::handle_top_level_message(const std::shared_ptr<api:
 void
 TopLevelDistributorTestUtil::close()
 {
-    _component.reset(0);
-    if (_distributor.get()) {
+    _component.reset();
+    if (_distributor) {
         _stripe_pool->stop_and_join(); // Must be tagged as stopped prior to onClose
         _distributor->onClose();
     }
     _sender.clear();
-    _node.reset(0);
+    _node.reset();
     _config = getStandardConfig(false);
 }
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -50,6 +50,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _prioritize_global_bucket_merges(true),
       _enable_revert(true),
       _implicitly_clear_priority_on_schedule(false),
+      _use_unordered_merge_chaining(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
 }
@@ -171,6 +172,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_revert = config.enableRevert;
     _implicitly_clear_priority_on_schedule = config.implicitlyClearBucketPriorityOnSchedule;
+    _use_unordered_merge_chaining = config.useUnorderedMergeChaining;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -267,6 +267,12 @@ public:
     [[nodiscard]] bool implicitly_clear_priority_on_schedule() const noexcept {
         return _implicitly_clear_priority_on_schedule;
     }
+    void set_use_unordered_merge_chaining(bool unordered) noexcept {
+        _use_unordered_merge_chaining = unordered;
+    }
+    [[nodiscard]] bool use_unordered_merge_chaining() const noexcept {
+        return _use_unordered_merge_chaining;
+    }
 
     uint32_t num_distributor_stripes() const noexcept { return _num_distributor_stripes; }
 
@@ -324,6 +330,7 @@ private:
     bool _prioritize_global_bucket_merges;
     bool _enable_revert;
     bool _implicitly_clear_priority_on_schedule;
+    bool _use_unordered_merge_chaining;
 
     DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -287,8 +287,9 @@ num_distributor_stripes int default=0 restart
 ## blocking of later buckets in the priority database.
 implicitly_clear_bucket_priority_on_schedule bool default=false
 
-## Enables sending merges that are not forwarded between content nodes in strictly
-## increasing node key order. Even if this config is set to true, unordered merges
-## will only be sent if _all_ nodes involved in a given merge have previously
-## reported (as part of bucket info fetching) that they support the unordered merge feature.
+## Enables sending merges that are forwarded between content nodes in ideal state node key
+## order, instead of strictly increasing node key order (which is the default).
+## Even if this config is set to true, unordered merges will only be sent if _all_ nodes
+## involved in a given merge have previously reported (as part of bucket info fetching)
+## that they support the unordered merge feature.
 use_unordered_merge_chaining bool default=false

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -286,3 +286,9 @@ num_distributor_stripes int default=0 restart
 ## bucket due to being blocked by concurrent operations. This avoids potential head-of-line
 ## blocking of later buckets in the priority database.
 implicitly_clear_bucket_priority_on_schedule bool default=false
+
+## Enables sending merges that are not forwarded between content nodes in strictly
+## increasing node key order. Even if this config is set to true, unordered merges
+## will only be sent if _all_ nodes involved in a given merge have previously
+## reported (as part of bucket info fetching) that they support the unordered merge feature.
+use_unordered_merge_chaining bool default=false

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -32,6 +32,7 @@ vespa_add_library(storage_distributor
     messagetracker.cpp
     min_replica_provider.cpp
     multi_threaded_stripe_access_guard.cpp
+    node_supported_features_repo.cpp
     nodeinfo.cpp
     operation_routing_snapshot.cpp
     operation_sequencer.cpp

--- a/storage/src/vespa/storage/distributor/distributor_operation_context.h
+++ b/storage/src/vespa/storage/distributor/distributor_operation_context.h
@@ -17,7 +17,7 @@ class DistributorBucketSpaceRepo;
  */
 class DistributorOperationContext {
 public:
-    virtual ~DistributorOperationContext() {}
+    virtual ~DistributorOperationContext() = default;
     virtual api::Timestamp generate_unique_timestamp() = 0;
     virtual const BucketSpaceStateMap& bucket_space_states() const noexcept = 0;
     virtual BucketSpaceStateMap& bucket_space_states() noexcept = 0;

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -6,6 +6,7 @@
 #include "distributor_stripe.h"
 #include "distributormetricsset.h"
 #include "idealstatemetricsset.h"
+#include "node_supported_features_repo.h"
 #include "operation_sequencer.h"
 #include "ownership_transfer_safe_time_point_calculator.h"
 #include "storage_node_up_states.h"
@@ -68,6 +69,7 @@ DistributorStripe::DistributorStripe(DistributorComponentRegister& compReg,
       _recoveryTimeStarted(_component.getClock()),
       _tickResult(framework::ThreadWaitInfo::NO_MORE_CRITICAL_WORK_KNOWN),
       _bucketIdHasher(std::make_unique<BucketGcTimeCalculator::BucketIdIdentityHasher>()),
+      _node_supported_features_repo(std::make_shared<const NodeSupportedFeaturesRepo>()),
       _metricLock(),
       _maintenanceStats(),
       _bucketSpacesStats(),
@@ -872,6 +874,12 @@ DistributorStripe::clear_read_only_bucket_repo_databases()
 }
 
 void
+DistributorStripe::update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo)
+{
+    _node_supported_features_repo = std::move(features_repo);
+}
+
+void
 DistributorStripe::report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const
 {
     ideal_state_manager().dump_bucket_space_db_status(bucket_space, out);
@@ -887,6 +895,12 @@ void
 DistributorStripe::report_delayed_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const
 {
     bucket_db_updater().report_delayed_single_bucket_requests(xos);
+}
+
+const NodeSupportedFeaturesRepo&
+DistributorStripe::node_supported_features_repo() const noexcept
+{
+    return *_node_supported_features_repo;
 }
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -160,6 +160,8 @@ public:
         return *_bucketIdHasher;
     }
 
+    const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept override;
+
     StripeBucketDBUpdater& bucket_db_updater() { return _bucketDBUpdater; }
     const StripeBucketDBUpdater& bucket_db_updater() const { return _bucketDBUpdater; }
     IdealStateManager& ideal_state_manager() { return _idealStateManager; }
@@ -283,6 +285,7 @@ private:
     void update_read_snapshot_after_db_pruning(const lib::ClusterStateBundle& new_state) override;
     void update_read_snapshot_after_activation(const lib::ClusterStateBundle& activated_state) override;
     void clear_read_only_bucket_repo_databases() override;
+    void update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo) override;
     void report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const override;
     void report_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const override;
     void report_delayed_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const override;
@@ -338,6 +341,7 @@ private:
     framework::ThreadWaitInfo _tickResult;
     BucketDBMetricUpdater _bucketDBMetricUpdater;
     std::unique_ptr<BucketGcTimeCalculator::BucketIdHasher> _bucketIdHasher;
+    std::shared_ptr<const NodeSupportedFeaturesRepo> _node_supported_features_repo;
     mutable std::mutex _metricLock;
     /**
      * Maintenance stats for last completed database scan iteration.

--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
@@ -277,6 +277,12 @@ DistributorStripeComponent::storage_node_is_up(document::BucketSpace bucket_spac
     return ns.getState().oneOf(storage_node_up_states());
 }
 
+const NodeSupportedFeaturesRepo&
+DistributorStripeComponent::node_supported_features_repo() const noexcept
+{
+    return _distributor.node_supported_features_repo();
+}
+
 std::unique_ptr<document::select::Node>
 DistributorStripeComponent::parse_selection(const vespalib::string& selection) const
 {

--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.h
@@ -70,7 +70,7 @@ public:
      */
     void update_bucket_database(const document::Bucket& bucket,
                                 const BucketCopy& changed_node,
-                                uint32_t update_flags = 0) override {
+                                uint32_t update_flags) override {
         update_bucket_database(bucket,
                                toVector<BucketCopy>(changed_node),
                                update_flags);
@@ -79,9 +79,9 @@ public:
     /**
      * Adds the given copies to the bucket database.
      */
-    virtual void update_bucket_database(const document::Bucket& bucket,
-                                        const std::vector<BucketCopy>& changed_nodes,
-                                        uint32_t update_flags = 0) override;
+    void update_bucket_database(const document::Bucket& bucket,
+                                const std::vector<BucketCopy>& changed_nodes,
+                                uint32_t update_flags) override;
 
     /**
      * Removes a copy from the given bucket from the bucket database.
@@ -164,6 +164,8 @@ public:
     const BucketGcTimeCalculator::BucketIdHasher& bucket_id_hasher() const override {
         return getDistributor().getBucketIdHasher();
     }
+
+    const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept override;
 
     // Implements DocumentSelectionParser
     std::unique_ptr<document::select::Node> parse_selection(const vespalib::string& selection) const override;

--- a/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
@@ -16,6 +16,7 @@ namespace storage {
 namespace storage::distributor {
 
 class DistributorMetricSet;
+class NodeSupportedFeaturesRepo;
 class PendingMessageTracker;
 
 /**
@@ -61,6 +62,7 @@ public:
     virtual const DistributorConfiguration& getConfig() const = 0;
     virtual ChainedMessageSender& getMessageSender() = 0;
     virtual const BucketGcTimeCalculator::BucketIdHasher& getBucketIdHasher() const = 0;
+    virtual const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/distributor_stripe_operation_context.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_operation_context.h
@@ -16,6 +16,7 @@ namespace storage::lib { class ClusterStateBundle; }
 namespace storage::distributor {
 
 class PendingMessageTracker;
+class NodeSupportedFeaturesRepo;
 
 /**
  * Interface with functionality that is used when handling distributor stripe operations.
@@ -57,6 +58,7 @@ public:
     virtual const lib::ClusterStateBundle& cluster_state_bundle() const = 0;
     virtual bool storage_node_is_up(document::BucketSpace bucket_space, uint32_t node_index) const = 0;
     virtual const BucketGcTimeCalculator::BucketIdHasher& bucket_id_hasher() const = 0;
+    virtual const NodeSupportedFeaturesRepo& node_supported_features_repo() const noexcept = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.cpp
@@ -132,6 +132,14 @@ void MultiThreadedStripeAccessGuard::clear_read_only_bucket_repo_databases() {
     });
 }
 
+void MultiThreadedStripeAccessGuard::update_node_supported_features_repo(
+        std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo)
+{
+    for_each_stripe([&](TickableStripe& stripe) {
+        stripe.update_node_supported_features_repo(features_repo);
+    });
+}
+
 void MultiThreadedStripeAccessGuard::report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const {
     for_each_stripe([&](TickableStripe& stripe) {
         stripe.report_bucket_db_status(bucket_space, out);

--- a/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/multi_threaded_stripe_access_guard.h
@@ -54,6 +54,8 @@ public:
     void update_read_snapshot_after_activation(const lib::ClusterStateBundle& activated_state) override;
     void clear_read_only_bucket_repo_databases() override;
 
+    void update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo) override;
+
     void report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const override;
     PendingOperationStats pending_operation_stats() const override;
     void report_single_bucket_requests(vespalib::xml::XmlOutputStream& xos) const override;

--- a/storage/src/vespa/storage/distributor/node_supported_features.h
+++ b/storage/src/vespa/storage/distributor/node_supported_features.h
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace storage::distributor {
+
+/**
+ * Collection of distinct features supported by a particular content node.
+ *
+ * Communicated to a distributor via bucket info exchanges. All features
+ * are initially expected to be unsupported.
+ */
+struct NodeSupportedFeatures {
+    bool unordered_merge_chaining = false;
+
+    bool operator==(const NodeSupportedFeatures&) const noexcept = default;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/node_supported_features_repo.cpp
+++ b/storage/src/vespa/storage/distributor/node_supported_features_repo.cpp
@@ -1,0 +1,37 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "node_supported_features_repo.h"
+#include <vespa/vespalib/stllike/hash_map.hpp>
+
+namespace storage::distributor {
+
+NodeSupportedFeaturesRepo::NodeSupportedFeaturesRepo() = default;
+
+NodeSupportedFeaturesRepo::NodeSupportedFeaturesRepo(
+        vespalib::hash_map<uint16_t, NodeSupportedFeatures> features,
+        PrivateCtorTag)
+    : _node_features(std::move(features))
+{}
+
+NodeSupportedFeaturesRepo::~NodeSupportedFeaturesRepo() = default;
+
+const NodeSupportedFeatures&
+NodeSupportedFeaturesRepo::node_supported_features(uint16_t node_idx) const noexcept
+{
+    static const NodeSupportedFeatures default_features;
+    const auto iter = _node_features.find(node_idx);
+    return (iter != _node_features.end() ? iter->second : default_features);
+}
+
+std::shared_ptr<const NodeSupportedFeaturesRepo>
+NodeSupportedFeaturesRepo::make_union_of(const vespalib::hash_map<uint16_t, NodeSupportedFeatures>& node_features) const
+{
+    auto new_features = _node_features; // Must be by copy.
+    // We always let the _new_ features update any existing mapping.
+    for (const auto& nf : node_features) {
+        new_features[nf.first] = nf.second;
+    }
+    return std::make_shared<NodeSupportedFeaturesRepo>(std::move(new_features), PrivateCtorTag{});
+}
+
+}

--- a/storage/src/vespa/storage/distributor/node_supported_features_repo.h
+++ b/storage/src/vespa/storage/distributor/node_supported_features_repo.h
@@ -1,0 +1,37 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "node_supported_features.h"
+#include <vespa/vespalib/stllike/hash_map.h>
+#include <memory>
+
+namespace storage::distributor {
+
+/**
+ * Repo of known mappings from node distribution key to feature set supported by
+ * the content node with the given distribution key.
+ *
+ * Entirely immutable; copy-on-write via make_union_of().
+ */
+class NodeSupportedFeaturesRepo {
+    const vespalib::hash_map<uint16_t, NodeSupportedFeatures> _node_features;
+    struct PrivateCtorTag {};
+public:
+    NodeSupportedFeaturesRepo();
+
+    NodeSupportedFeaturesRepo(vespalib::hash_map<uint16_t, NodeSupportedFeatures> features, PrivateCtorTag);
+    ~NodeSupportedFeaturesRepo();
+
+    // Returns supported node features for node with distribution key node_idx, or a default feature set
+    // with all features unset if node has no known mapping.
+    [[nodiscard]] const NodeSupportedFeatures& node_supported_features(uint16_t node_idx) const noexcept;
+
+    // Returns a new repo instance containing the union key->features set of self and node_features.
+    // If there is a duplicate mapping between the two, the features in node_features take precedence
+    // and will be stored in the new repo.
+    [[nodiscard]] std::shared_ptr<const NodeSupportedFeaturesRepo>
+    make_union_of(const vespalib::hash_map<uint16_t, NodeSupportedFeatures>& node_features) const;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -64,6 +64,7 @@ private:
     void deleteSourceOnlyNodes(const BucketDatabase::Entry& currentState,
                                DistributorStripeMessageSender& sender);
     bool is_global_bucket_merge() const noexcept;
+    bool all_involved_nodes_support_unordered_merge_chaining() const noexcept;
     MergeBucketMetricSet* get_merge_metrics();
 };
 

--- a/storage/src/vespa/storage/distributor/stripe_access_guard.h
+++ b/storage/src/vespa/storage/distributor/stripe_access_guard.h
@@ -20,6 +20,8 @@ namespace vespalib::xml { class XmlOutputStream; }
 
 namespace storage::distributor {
 
+class NodeSupportedFeaturesRepo;
+
 /**
  * A stripe access guard guarantees that the holder of a guard can access underlying
  * stripes via it in a thread safe manner. In particular, while any access guard is
@@ -56,6 +58,8 @@ public:
     virtual void update_read_snapshot_after_db_pruning(const lib::ClusterStateBundle& new_state) = 0;
     virtual void update_read_snapshot_after_activation(const lib::ClusterStateBundle& activated_state) = 0;
     virtual void clear_read_only_bucket_repo_databases() = 0;
+
+    virtual void update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo) = 0;
 
     struct PendingOperationStats {
         size_t external_load_operations;

--- a/storage/src/vespa/storage/distributor/tickable_stripe.h
+++ b/storage/src/vespa/storage/distributor/tickable_stripe.h
@@ -15,6 +15,8 @@ namespace vespalib::xml { class XmlOutputStream; }
 
 namespace storage::distributor {
 
+class NodeSupportedFeaturesRepo;
+
 /**
  * A tickable stripe is the minimal binding glue between the stripe's worker thread and
  * the actual implementation. Primarily allows for easier testing without having to
@@ -58,6 +60,8 @@ public:
     virtual void update_read_snapshot_after_db_pruning(const lib::ClusterStateBundle& new_state) = 0;
     virtual void update_read_snapshot_after_activation(const lib::ClusterStateBundle& activated_state) = 0;
     virtual void clear_read_only_bucket_repo_databases() = 0;
+    virtual void update_node_supported_features_repo(std::shared_ptr<const NodeSupportedFeaturesRepo> features_repo) = 0;
+
     // Functions used for state reporting
     virtual void report_bucket_db_status(document::BucketSpace bucket_space, std::ostream& out) const = 0;
     virtual StripeAccessGuard::PendingOperationStats pending_operation_stats() const = 0;

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
@@ -30,6 +30,7 @@ struct BucketSpaceDistributionConfigs;
 class BucketSpaceDistributionContext;
 class ClusterStateBundleActivationListener;
 class DistributorInterface;
+class NodeSupportedFeaturesRepo;
 class StripeAccessor;
 class StripeAccessGuard;
 
@@ -122,6 +123,7 @@ private:
     ChainedMessageSender& _chained_sender;
     OutdatedNodesMap         _outdated_nodes_map;
     framework::MilliSecTimer _transition_timer;
+    std::shared_ptr<const NodeSupportedFeaturesRepo> _node_supported_features_repo;
     std::atomic<bool> _stale_reads_enabled;
 };
 

--- a/storage/src/vespa/storage/storageserver/mergethrottler.cpp
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.cpp
@@ -113,21 +113,28 @@ MergeThrottler::MergeOperationMetrics::MergeOperationMetrics(const std::string& 
 }
 MergeThrottler::MergeOperationMetrics::~MergeOperationMetrics() = default;
 
-MergeThrottler::MergeNodeSequence::MergeNodeSequence(
-        const api::MergeBucketCommand& cmd,
-        uint16_t thisIndex)
+MergeThrottler::MergeNodeSequence::MergeNodeSequence(const api::MergeBucketCommand& cmd, uint16_t thisIndex)
     : _cmd(cmd),
       _sortedNodes(cmd.getNodes()),
-      _sortedIndex(std::numeric_limits<std::size_t>::max()),
-      _thisIndex(thisIndex)
+      _sortedIndex(UINT16_MAX),
+      _unordered_index(UINT16_MAX),
+      _thisIndex(thisIndex),
+      _use_unordered_forwarding(cmd.use_unordered_forwarding())
 {
     // Sort the node vector so that we can find out if we're the
     // last node in the chain or if we should forward the merge
     std::sort(_sortedNodes.begin(), _sortedNodes.end(), NodeComparator());
-    assert(!_sortedNodes.empty());
-    for (std::size_t i = 0; i < _sortedNodes.size(); ++i) {
+    assert(!_sortedNodes.empty() && (_sortedNodes.size() < UINT16_MAX));
+    for (uint16_t i = 0; i < static_cast<uint16_t>(_sortedNodes.size()); ++i) {
         if (_sortedNodes[i].index == _thisIndex) {
             _sortedIndex = i;
+            break;
+        }
+    }
+    const auto& nodes = unordered_nodes();
+    for (uint16_t i = 0; i < static_cast<uint16_t>(nodes.size()); ++i) {
+        if (nodes[i].index == _thisIndex) {
+            _unordered_index = i;
             break;
         }
     }
@@ -137,6 +144,9 @@ uint16_t
 MergeThrottler::MergeNodeSequence::getNextNodeInChain() const
 {
     assert(_cmd.getChain().size() < _sortedNodes.size());
+    if (_use_unordered_forwarding) {
+        return unordered_nodes()[_cmd.getChain().size() + 1].index;
+    }
     // assert(_sortedNodes[_cmd.getChain().size()].index == _thisIndex);
     if (_sortedNodes[_cmd.getChain().size()].index != _thisIndex) {
         // Some added paranoia output
@@ -153,7 +163,11 @@ MergeThrottler::MergeNodeSequence::isChainCompleted() const
 {
     if (_cmd.getChain().size() != _sortedNodes.size()) return false;
 
-    for (std::size_t i = 0; i < _cmd.getChain().size(); ++i) {
+    if (_use_unordered_forwarding) {
+        return true; // Expect chain to be correct if size matches node sequence size. TODO can't we always do this?
+    }
+
+    for (size_t i = 0; i < _cmd.getChain().size(); ++i) {
         if (_cmd.getChain()[i] != _sortedNodes[i].index) {
             return false;
         }
@@ -162,10 +176,10 @@ MergeThrottler::MergeNodeSequence::isChainCompleted() const
 }
 
 bool
-MergeThrottler::MergeNodeSequence::chainContainsIndex(uint16_t idx) const
+MergeThrottler::MergeNodeSequence::chain_contains_this_node() const noexcept
 {
-    for (std::size_t i = 0; i < _cmd.getChain().size(); ++i) {
-        if (_cmd.getChain()[i] == idx) {
+    for (size_t i = 0; i < _cmd.getChain().size(); ++i) {
+        if (_cmd.getChain()[i] == _thisIndex) {
             return true;
         }
     }
@@ -358,6 +372,7 @@ MergeThrottler::forwardCommandToNode(
     fwdMerge->setSourceIndex(mergeCmd.getSourceIndex());
     fwdMerge->setPriority(mergeCmd.getPriority());
     fwdMerge->setTimeout(mergeCmd.getTimeout());
+    fwdMerge->set_use_unordered_forwarding(mergeCmd.use_unordered_forwarding());
     msgGuard.sendUp(fwdMerge);
 }
 
@@ -374,7 +389,7 @@ api::StorageMessage::SP
 MergeThrottler::getNextQueuedMerge()
 {
     if (_queue.empty()) {
-        return api::StorageMessage::SP();
+        return {};
     }
 
     auto iter = _queue.begin();
@@ -385,7 +400,7 @@ MergeThrottler::getNextQueuedMerge()
 }
 
 void
-MergeThrottler::enqueueMerge(
+MergeThrottler::enqueue_merge_for_later_processing(
         const api::StorageMessage::SP& msg,
         MessageGuard& msgGuard)
 {
@@ -395,9 +410,10 @@ MergeThrottler::enqueueMerge(
     if (!validateNewMerge(mergeCmd, nodeSeq, msgGuard)) {
         return;
     }
+    // TODO remove once unordered merges are default, since forwarded unordered merges are never enqueued
     const bool is_forwarded_merge = _disable_queue_limits_for_chained_merges && !mergeCmd.getChain().empty();
     _queue.emplace(msg, _queueSequence++, is_forwarded_merge);
-    _metrics->queueSize.set(_queue.size());
+    _metrics->queueSize.set(static_cast<int64_t>(_queue.size()));
 }
 
 bool
@@ -682,11 +698,29 @@ bool MergeThrottler::backpressure_mode_active() const {
     return backpressure_mode_active_no_lock();
 }
 
-bool MergeThrottler::allow_merge_with_queue_full(const api::MergeBucketCommand& cmd) const noexcept {
-    // We let any merge through that has already passed through at least one other node's merge
-    // window, as that has already taken up a logical resource slot on all those nodes. Busy-bouncing
-    // a merge at that point would undo a great amount of thumb-twiddling and waiting.
-    return (_disable_queue_limits_for_chained_merges && !cmd.getChain().empty());
+bool MergeThrottler::allow_merge_despite_full_window(const api::MergeBucketCommand& cmd) noexcept {
+    // We cannot let forwarded unordered merges fall into the queue, as that might lead to a deadlock.
+    // See comment in may_allow_into_queue() for rationale.
+    return (cmd.use_unordered_forwarding() && !cmd.getChain().empty());
+}
+
+bool MergeThrottler::may_allow_into_queue(const api::MergeBucketCommand& cmd) const noexcept {
+    // We cannot let forwarded unordered merges fall into the queue, as that might lead to a deadlock.
+    // Consider the following scenario, with two nodes C0 and C1, each with a low window size of 1 (low
+    // limit chosen for demonstration purposes, but is entirely generalizable):
+    //  1. Node 0 receives merge M_x for nodes [0, 1], places in active window, forwards to node 1
+    //  2. Node 1 receives merge M_y for nodes [1, 0], places in active window, forwards to node 0
+    //  3. Node 0 receives merge M_y from node 1. Active window is full, so places in queue
+    //  4. Node 1 receives merge M_x from node 0. Active window is full, so places in queue
+    //  5. Neither M_x nor M_y will ever complete since they're waiting for resources that cannot be
+    //     freed up before they themselves complete. Classic deadlock(tm).
+    //
+    // We do, however, allow enqueueing unordered merges that come straight from the distributor, as
+    // those cannot cause a deadlock at that point in time.
+    return (((_queue.size() < _maxQueueSize)
+             || (_disable_queue_limits_for_chained_merges && !cmd.getChain().empty()))
+            && (!cmd.use_unordered_forwarding()
+                || (cmd.use_unordered_forwarding() && cmd.getChain().empty())));
 }
 
 // Must be run from worker thread
@@ -716,10 +750,10 @@ MergeThrottler::handleMessageDown(
 
         if (isMergeAlreadyKnown(msg)) {
             processCycledMergeCommand(msg, msgGuard);
-        } else if (canProcessNewMerge()) {
+        } else if (canProcessNewMerge() || allow_merge_despite_full_window(mergeCmd)) {
             processNewMergeCommand(msg, msgGuard);
-        } else if ((_queue.size() < _maxQueueSize) || allow_merge_with_queue_full(mergeCmd)) {
-            enqueueMerge(msg, msgGuard); // Queue for later processing
+        } else if (may_allow_into_queue(mergeCmd)) {
+            enqueue_merge_for_later_processing(msg, msgGuard);
         } else {
             // No more room at the inn. Return BUSY so that the
             // distributor will wait a bit before retrying
@@ -773,7 +807,7 @@ MergeThrottler::validateNewMerge(
             << _component.getIndex()
             << ", which is not in its forwarding chain";
         LOG(error, "%s", oss.str().data());
-    } else if (mergeCmd.getChain().size() >= nodeSeq.getSortedNodes().size()) {
+    } else if (mergeCmd.getChain().size() >= nodeSeq.unordered_nodes().size()) {
         // Chain is full but we haven't seen the merge! This means
         // the node has probably gone down with a merge it previously
         // forwarded only now coming back to haunt it.
@@ -781,7 +815,7 @@ MergeThrottler::validateNewMerge(
             << " is not in node's internal state, but has a "
             << "full chain, meaning it cannot be forwarded.";
         LOG(debug, "%s", oss.str().data());
-    } else if (nodeSeq.chainContainsIndex(nodeSeq.getThisNodeIndex())) {
+    } else if (nodeSeq.chain_contains_this_node()) {
         oss << mergeCmd.toString()
             << " is not in node's internal state, but contains "
             << "this node in its non-full chain. This should not happen!";
@@ -831,7 +865,9 @@ MergeThrottler::processNewMergeCommand(
     // If chain is empty and this node is not the lowest
     // index in the nodeset, immediately execute. Required for
     // backwards compatibility with older distributor versions.
+    // TODO remove this
     if (mergeCmd.getChain().empty()
+        && !mergeCmd.use_unordered_forwarding()
         && (nodeSeq.getSortedNodes()[0].index != _component.getIndex()))
     {
         LOG(debug, "%s has empty chain and was sent to node that "
@@ -1039,7 +1075,6 @@ bool
 MergeThrottler::onSetSystemState(
         const std::shared_ptr<api::SetSystemStateCommand>& stateCmd)
 {
-
     LOG(debug,
         "New cluster state arrived with version %u, flushing "
         "all outdated queued merges",

--- a/storageapi/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
+++ b/storageapi/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
@@ -38,6 +38,7 @@ message MergeBucketRequest {
     uint64             max_timestamp         = 3;
     repeated MergeNode nodes                 = 4;
     repeated uint32    node_chain            = 5;
+    bool               unordered_forwarding  = 6;
 }
 
 message MergeBucketResponse {
@@ -108,8 +109,14 @@ message BucketAndBucketInfo {
     BucketInfo bucket_info = 2;
 }
 
+message SupportedNodeFeatures {
+    bool unordered_merge_chaining = 1;
+}
+
 message RequestBucketInfoResponse {
     repeated BucketAndBucketInfo bucket_infos = 1;
+    // Only present for full bucket info fetches (not for explicit buckets)
+    SupportedNodeFeatures supported_node_features = 2;
 }
 
 message NotifyBucketChangeRequest {

--- a/storageapi/src/vespa/storageapi/message/bucket.cpp
+++ b/storageapi/src/vespa/storageapi/message/bucket.cpp
@@ -107,7 +107,8 @@ MergeBucketCommand::MergeBucketCommand(
       _nodes(nodes),
       _maxTimestamp(maxTimestamp),
       _clusterStateVersion(clusterStateVersion),
-      _chain(chain)
+      _chain(chain),
+      _use_unordered_forwarding(false)
 {}
 
 MergeBucketCommand::~MergeBucketCommand() = default;
@@ -128,6 +129,9 @@ MergeBucketCommand::print(std::ostream& out, bool verbose, const std::string& in
         out << _chain[i];
     }
     out << "]";
+    if (_use_unordered_forwarding) {
+        out << " (unordered forwarding)";
+    }
     out << ", reasons to start: " << _reason;
     out << ")";
     if (verbose) {

--- a/storageapi/src/vespa/storageapi/message/bucket.h
+++ b/storageapi/src/vespa/storageapi/message/bucket.h
@@ -118,6 +118,7 @@ private:
     Timestamp _maxTimestamp;
     uint32_t _clusterStateVersion;
     std::vector<uint16_t> _chain;
+    bool _use_unordered_forwarding;
 
 public:
     MergeBucketCommand(const document::Bucket &bucket,
@@ -133,6 +134,10 @@ public:
     uint32_t getClusterStateVersion() const { return _clusterStateVersion; }
     void setClusterStateVersion(uint32_t version) { _clusterStateVersion = version; }
     void setChain(const std::vector<uint16_t>& chain) { _chain = chain; }
+    void set_use_unordered_forwarding(bool unordered_forwarding) noexcept {
+        _use_unordered_forwarding = unordered_forwarding;
+    }
+    [[nodiscard]] bool use_unordered_forwarding() const noexcept { return _use_unordered_forwarding; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGECOMMAND(MergeBucketCommand, onMergeBucket)
 };
@@ -385,19 +390,30 @@ public:
             : _bucketId(id), _info(info) {}
         friend std::ostream& operator<<(std::ostream& os, const Entry&);
     };
-    typedef vespalib::Array<Entry> EntryVector;
+    struct SupportedNodeFeatures {
+        bool unordered_merge_chaining = false;
+    };
+    using EntryVector = vespalib::Array<Entry>;
 private:
-    EntryVector _buckets;
-    bool _full_bucket_fetch;
-    document::BucketId _super_bucket_id;
+    EntryVector           _buckets;
+    bool                  _full_bucket_fetch;
+    document::BucketId    _super_bucket_id;
+    SupportedNodeFeatures _supported_node_features;
 
 public:
 
     explicit RequestBucketInfoReply(const RequestBucketInfoCommand& cmd);
-    ~RequestBucketInfoReply();
+    ~RequestBucketInfoReply() override;
     const EntryVector & getBucketInfo() const { return _buckets; }
     EntryVector & getBucketInfo() { return _buckets; }
     [[nodiscard]] bool full_bucket_fetch() const noexcept { return _full_bucket_fetch; }
+    // Only contains useful information if full_bucket_fetch() == true
+    [[nodiscard]] const SupportedNodeFeatures& supported_node_features() const noexcept {
+        return _supported_node_features;
+    }
+    [[nodiscard]] SupportedNodeFeatures& supported_node_features() noexcept {
+        return _supported_node_features;
+    }
     const document::BucketId& super_bucket_id() const { return _super_bucket_id; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGEREPLY(RequestBucketInfoReply, onRequestBucketInfoReply)

--- a/storageapi/src/vespa/storageapi/message/bucket.h
+++ b/storageapi/src/vespa/storageapi/message/bucket.h
@@ -138,6 +138,7 @@ public:
         _use_unordered_forwarding = unordered_forwarding;
     }
     [[nodiscard]] bool use_unordered_forwarding() const noexcept { return _use_unordered_forwarding; }
+    [[nodiscard]] bool from_distributor() const noexcept { return _chain.empty(); }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGECOMMAND(MergeBucketCommand, onMergeBucket)
 };


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Historically the MergeThrottler component has required a deterministic
forwarding of merges between nodes in strictly increasing distribution
key order. This is to avoid distributed deadlocks caused by ending up
with two or more nodes waiting for each other to release merge resources,
where releasing one depends on releasing the other. This works well,
but has the downside that there's an inherent pressure of merges towards
nodes with lower distribution keys. These often become a bottleneck.

This commit lifts this ordering restriction, by allowing forwarded,
unordered merges to immediately enter the active merge window. By doing
this we remove the deadlock potential, since nodes will longer be waiting
on resources freed by other nodes.

Since the legacy MergeThrottler has a lot of invariant checking around
strictly increasing merge chains, we only allow unordered merges to be
scheduled towards node sets where _all_ nodes are on a Vespa version
that explicitly understands unordered merges (and thus do not self-
obliterate upon seeing one). To communicate this, full bucket fetches
will now piggy-back version-specific feature sets as part of the response
protocol. Distributors then aggregate this information internally.