### PR TITLE
Add a fixed size table of 8 * num_exutors with 16 bit entries. Use th…

### DIFF
--- a/staging_vespalib/src/tests/sequencedtaskexecutor/sequencedtaskexecutor_test.cpp
+++ b/staging_vespalib/src/tests/sequencedtaskexecutor/sequencedtaskexecutor_test.cpp
@@ -242,11 +242,16 @@ TEST("require that you get correct number of executors") {
 TEST("require that you distribute well") {
     auto seven = SequencedTaskExecutor::create(sequenced_executor, 7);
     const SequencedTaskExecutor & seq = dynamic_cast<const SequencedTaskExecutor &>(*seven);
+    const uint32_t NUM_EXACT = 8 * seven->getNumExecutors();
     EXPECT_EQUAL(7u, seven->getNumExecutors());
     EXPECT_EQUAL(97u, seq.getComponentHashSize());
     EXPECT_EQUAL(0u, seq.getComponentEffectiveHashSize());
     for (uint32_t id=0; id < 1000; id++) {
-        EXPECT_EQUAL((id%97)%7, seven->getExecutorId(id).getId());
+        if (id < NUM_EXACT) {
+            EXPECT_EQUAL(id % seven->getNumExecutors(), seven->getExecutorId(id).getId());
+        } else {
+            EXPECT_EQUAL(((id - NUM_EXACT) % 97) % seven->getNumExecutors(), seven->getExecutorId(id).getId());
+        }
     }
     EXPECT_EQUAL(97u, seq.getComponentHashSize());
     EXPECT_EQUAL(97u, seq.getComponentEffectiveHashSize());
@@ -272,8 +277,8 @@ TEST("require that similar names gets 7/8 unique ids with 8 executors") {
     EXPECT_EQUAL(3u, four->getExecutorIdFromName("f4").getId());
     EXPECT_EQUAL(4u, four->getExecutorIdFromName("f5").getId());
     EXPECT_EQUAL(5u, four->getExecutorIdFromName("f6").getId());
-    EXPECT_EQUAL(2u, four->getExecutorIdFromName("f7").getId());
-    EXPECT_EQUAL(6u, four->getExecutorIdFromName("f8").getId());
+    EXPECT_EQUAL(6u, four->getExecutorIdFromName("f7").getId());
+    EXPECT_EQUAL(7u, four->getExecutorIdFromName("f8").getId());
 }
 
 TEST("Test creation of different types") {

--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.cpp
@@ -128,11 +128,11 @@ SequencedTaskExecutor::getStats()
 
 ISequencedTaskExecutor::ExecutorId
 SequencedTaskExecutor::getExecutorId(uint64_t componentId) const {
-    ValidId id = getExecutorIdPerfect(componentId);
-    return (id.valid()) ? id.id() : getExecutorIdImPerfect(componentId);
+    auto id = getExecutorIdPerfect(componentId);
+    return id ? id.value() : getExecutorIdImPerfect(componentId);
 }
 
-SequencedTaskExecutor::ValidId
+std::optional<ISequencedTaskExecutor::ExecutorId>
 SequencedTaskExecutor::getExecutorIdPerfect(uint64_t componentId) const {
     PerfectKeyT key = componentId & 0x7fff;
     ssize_t pos = find(key, _component2IdPerfect.get(), getNumExecutors() * NUM_PERFECT_PER_EXECUTOR);
@@ -145,11 +145,11 @@ SequencedTaskExecutor::getExecutorIdPerfect(uint64_t componentId) const {
                 _component2IdPerfect[pos] = key;
             } else {
                 // There was a race for the last spots
-                return ValidId();
+                return std::optional<ISequencedTaskExecutor::ExecutorId>();
             }
         }
     }
-    return ValidId(ExecutorId(pos % getNumExecutors()));
+    return std::optional<ISequencedTaskExecutor::ExecutorId>(ExecutorId(pos % getNumExecutors()));
 }
 
 ISequencedTaskExecutor::ExecutorId

--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
@@ -43,17 +43,27 @@ public:
     const vespalib::SyncableThreadExecutor* first_executor() const;
 
 private:
+    class ValidId {
+    public:
+        ValidId() : _id(), _valid(false) { }
+        explicit ValidId(ExecutorId id_in) : _id(id_in), _valid(true) { }
+        ExecutorId id() const { return _id; }
+        bool valid() const { return _valid; }
+    private:
+        ExecutorId _id;
+        bool       _valid;
+    };
     explicit SequencedTaskExecutor(std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> executor);
-    ExecutorId getExecutorIdPerfect(uint64_t componentId) const;
+    ValidId getExecutorIdPerfect(uint64_t componentId) const;
     ExecutorId getExecutorIdImPerfect(uint64_t componentId) const;
 
     std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> _executors;
     using PerfectKeyT = uint16_t;
-    const bool                       _lazyExecutors;
-    mutable std::vector<PerfectKeyT> _component2IdPerfect;
-    mutable std::vector<uint8_t>     _component2IdImperfect;
-    mutable std::mutex               _mutex;
-    mutable uint32_t                 _nextId;
+    const bool                             _lazyExecutors;
+    mutable std::unique_ptr<PerfectKeyT[]> _component2IdPerfect;
+    mutable std::vector<uint8_t>           _component2IdImperfect;
+    mutable std::mutex                     _mutex;
+    mutable uint32_t                       _nextId;
 
 };
 

--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
@@ -38,18 +38,22 @@ public:
     /**
      * For testing only
      */
-    uint32_t getComponentHashSize() const { return _component2Id.size(); }
+    uint32_t getComponentHashSize() const { return _component2IdImperfect.size(); }
     uint32_t getComponentEffectiveHashSize() const { return _nextId; }
     const vespalib::SyncableThreadExecutor* first_executor() const;
 
 private:
-    explicit SequencedTaskExecutor(std::unique_ptr<std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>>> executor);
+    explicit SequencedTaskExecutor(std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> executor);
+    ExecutorId getExecutorIdPerfect(uint64_t componentId) const;
+    ExecutorId getExecutorIdImPerfect(uint64_t componentId) const;
 
-    std::unique_ptr<std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>>> _executors;
-    const bool                   _lazyExecutors;
-    mutable std::vector<uint8_t> _component2Id;
-    mutable std::mutex           _mutex;
-    mutable uint32_t             _nextId;
+    std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> _executors;
+    using PerfectKeyT = uint16_t;
+    const bool                       _lazyExecutors;
+    mutable std::vector<PerfectKeyT> _component2IdPerfect;
+    mutable std::vector<uint8_t>     _component2IdImperfect;
+    mutable std::mutex               _mutex;
+    mutable uint32_t                 _nextId;
 
 };
 

--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
@@ -43,18 +43,8 @@ public:
     const vespalib::SyncableThreadExecutor* first_executor() const;
 
 private:
-    class ValidId {
-    public:
-        ValidId() : _id(), _valid(false) { }
-        explicit ValidId(ExecutorId id_in) : _id(id_in), _valid(true) { }
-        ExecutorId id() const { return _id; }
-        bool valid() const { return _valid; }
-    private:
-        ExecutorId _id;
-        bool       _valid;
-    };
     explicit SequencedTaskExecutor(std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> executor);
-    ValidId getExecutorIdPerfect(uint64_t componentId) const;
+    std::optional<ExecutorId> getExecutorIdPerfect(uint64_t componentId) const;
     ExecutorId getExecutorIdImPerfect(uint64_t componentId) const;
 
     std::vector<std::unique_ptr<vespalib::SyncableThreadExecutor>> _executors;


### PR DESCRIPTION
…is for mapping the first components exact.

With more components than 8x we fall abck to to using shrunk id of 8 bits as before.
This enables perfect distribution for the first 8x and then 'good enough' for the rest.
The more there are the less impact of imperfect distribution will be.

@geirst and @toregge PR