### PR TITLE
Use release flag to ensure jdk8.

### DIFF
--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -211,8 +211,7 @@
                     <jdkToolchain>
                         <version>${java.version}</version>
                     </jdkToolchain>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
- release flag in parent pom overrides source/target in this pom.

