### PR TITLE
Use a custom property for setting relase version for clients.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -16,12 +16,6 @@
   <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- TODO: Remove when we no longer support JDK 8 clients -->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>com.google.code.gson</groupId>
@@ -61,6 +55,13 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${vespaClients.jdk.releaseVersion}</release>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -12,12 +12,6 @@
   <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
 
-  <properties>
-    <!-- vespa-http-client targets jdk8 and uses this library -->
-    <!-- TODO remove once vespa-http-client no longer builds against jdk8 -->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <!-- provided -->
     <dependency>
@@ -73,11 +67,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <jdkToolchain>
-            <version>${java.version}</version>
-          </jdkToolchain>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${vespaClients.jdk.releaseVersion}</release>
           <showDeprecation>true</showDeprecation>
           <compilerArgs>
             <arg>-Xlint:all</arg>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -922,6 +922,7 @@
         <doclint>all</doclint>
         <test.hide>true</test.hide>
 
+        <vespaClients.jdk.releaseVersion>8</vespaClients.jdk.releaseVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -12,12 +12,6 @@
   <packaging>bundle</packaging>
   <version>7-SNAPSHOT</version>
 
-  <properties>
-    <!-- vespa-http-client targets jdk8 and uses this library -->
-    <!-- TODO remove once vespa-http-client no longer builds against jdk8 -->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <!-- provided -->
     <dependency>
@@ -73,11 +67,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <jdkToolchain>
-            <version>${java.version}</version>
-          </jdkToolchain>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${vespaClients.jdk.releaseVersion}</release>
           <showDeprecation>true</showDeprecation>
           <compilerArgs>
             <arg>-Xlint:all</arg>

--- a/vespa-feed-client-cli/pom.xml
+++ b/vespa-feed-client-cli/pom.xml
@@ -12,11 +12,6 @@
   <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
 
-  <properties>
-    <!-- Used by internal properties that are still using JDK8-->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <!-- compile scope -->
     <dependency>
@@ -56,11 +51,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <jdkToolchain>
-            <version>${java.version}</version>
-          </jdkToolchain>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${vespaClients.jdk.releaseVersion}</release>
           <showDeprecation>true</showDeprecation>
           <compilerArgs>
             <arg>-Xlint:all</arg>

--- a/vespa-feed-client/pom.xml
+++ b/vespa-feed-client/pom.xml
@@ -12,11 +12,6 @@
   <packaging>jar</packaging>
   <version>7-SNAPSHOT</version>
 
-  <properties>
-    <!-- Used by internal properties that are still using JDK8-->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
     <!-- compile scope -->
     <dependency>
@@ -54,11 +49,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <jdkToolchain>
-            <version>${java.version}</version>
-          </jdkToolchain>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${vespaClients.jdk.releaseVersion}</release>
           <showDeprecation>true</showDeprecation>
           <compilerArgs>
             <arg>-Xlint:all</arg>

--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -19,8 +19,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hadoop.version>2.8.0</hadoop.version>
         <pig.version>0.14.0</pig.version>
-        <!-- This is a client jar and should be compilable with jdk8 -->
-        <maven.compiler.release>8</maven.compiler.release>
     </properties>
 
     <dependencies>
@@ -186,10 +184,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <jdkToolchain>
-                        <version>${java.version}</version>
-                    </jdkToolchain>
-                    <release>${maven.compiler.release}</release>
+                    <release>${vespaClients.jdk.releaseVersion}</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -14,11 +14,6 @@
   <name>${project.artifactId}</name>
   <description>Independent external feeding API towards Vespa.</description>
 
-  <properties>
-    <!-- This is a client jar and should be compilable with jdk8 -->
-    <maven.compiler.release>8</maven.compiler.release>
-  </properties>
-
   <dependencies>
 
     <!-- NOTE: Adding dependencies here may break clients because this is used outside an OSGi container with
@@ -155,11 +150,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <jdkToolchain>
-            <version>${java.version}</version>
-          </jdkToolchain>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${vespaClients.jdk.releaseVersion}</release>
           <showDeprecation>true</showDeprecation>
           <compilerArgs>
             <arg>-Xlint:all</arg>


### PR DESCRIPTION
Other naming suggestions for the maven property?


- Always set release version via maven-compiler-plugin, instead
  of maven property which is overridden by compiler-plugin config.
- Using a custom property with self-explanatory name makes
  comments redundant.
- Remove explicit jdkToolchain config, as these modules no longer
  compile with jdk pre 9, due to the --release flag.

