### PR TITLE
Remove unused method

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionRpcServer.java
@@ -4,23 +4,20 @@ package com.yahoo.vespa.config.proxy.filedistribution;
 import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.config.FileReference;
 import com.yahoo.jrt.DoubleArray;
-import com.yahoo.jrt.Int32Value;
 import com.yahoo.jrt.Method;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.StringArray;
 import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Supervisor;
-import java.util.logging.Level;
 import com.yahoo.vespa.filedistribution.FileDownloader;
-import com.yahoo.vespa.filedistribution.FileReferenceDownload;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -67,10 +64,6 @@ class FileDistributionRpcServer {
                                      .methodDesc("download status for file references")
                                      .returnDesc(0, "file references", "array of file references")
                                      .returnDesc(1, "download status", "percentage downloaded of each file reference in above array"));
-        supervisor.addMethod(new Method("filedistribution.setFileReferencesToDownload", "S", "i", this::setFileReferencesToDownload)
-                                     .methodDesc("set which file references to download")
-                                     .paramDesc(0, "file references", "file reference to download")
-                                     .returnDesc(0, "ret", "0 if success, 1 otherwise"));
     }
 
 
@@ -103,14 +96,6 @@ class FileDistributionRpcServer {
 
         req.returnValues().add(new StringArray(fileRefArray));
         req.returnValues().add(new DoubleArray(downloadStatusArray));
-    }
-
-    private void setFileReferencesToDownload(Request req) {
-        log.log(Level.FINE, () -> "Received method call '" + req.methodName() + "' with parameters : " + req.parameters());
-        Arrays.stream(req.parameters().get(0).asStringArray())
-                .map(FileReference::new)
-                .forEach(fileReference -> downloader.downloadIfNeeded(new FileReferenceDownload(fileReference)));
-        req.returnValues().add(new Int32Value(0));
     }
 
     private void downloadFile(Request req) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDistributionImpl.java
@@ -41,8 +41,8 @@ public class FileDistributionImpl implements FileDistribution, RequestWaiter {
         return fileReferencesDir;
     }
 
-    // Notifies config proxy which file references it should start downloading. It's OK if the call does not succeed,
-    // as downloading will then start synchronously when a service requests a file reference instead
+    // Notifies client which file references it should start downloading. It's OK if the call does not succeed,
+    // as this is just a hint to the client to start downloading. Currently the only client is the config server
     private void startDownloadingFileReferences(String hostName, int port, Set<FileReference> fileReferences) {
         Target target = supervisor.connect(new Spec(hostName, port));
         Request request = new Request("filedistribution.setFileReferencesToDownload");


### PR DESCRIPTION
RPC method filedistribution.setFileReferencesToDownload is only used
between config servers, remove config proxy implementation