### PR TITLE
Revert "Use ZooKeeper server 3.7.0 [run-systemtest]"

### DIFF
--- a/zookeeper-server/zookeeper-server-3.6.3/CMakeLists.txt
+++ b/zookeeper-server/zookeeper-server-3.6.3/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(zookeeper-server-3.6.3)
 # Needs to be included when this is the wanted default version (and symlinks for other versions need to be removed)
-#install_symlink(lib/jars/zookeeper-server-3.6.3-jar-with-dependencies.jar lib/jars/zookeeper-server-jar-with-dependencies.jar)
+install_symlink(lib/jars/zookeeper-server-3.6.3-jar-with-dependencies.jar lib/jars/zookeeper-server-jar-with-dependencies.jar)

--- a/zookeeper-server/zookeeper-server-3.7.0/CMakeLists.txt
+++ b/zookeeper-server/zookeeper-server-3.7.0/CMakeLists.txt
@@ -1,4 +1,4 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install_fat_java_artifact(zookeeper-server-3.7.0)
 # Needs to be included when this is the wanted default version (and symlinks for other versions need to be removed)
-install_symlink(lib/jars/zookeeper-server-3.7.0-jar-with-dependencies.jar lib/jars/zookeeper-server-jar-with-dependencies.jar)
+#install_symlink(lib/jars/zookeeper-server-3.7.0-jar-with-dependencies.jar lib/jars/zookeeper-server-jar-with-dependencies.jar)


### PR DESCRIPTION
Reverts vespa-engine/vespa#19856

Please review only, will merge when we have done a few runs. Considering not merging this at all, as 3.7.0 seems tro work well