### PR TITLE
Assign rotations on deployment

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -7,7 +7,6 @@ import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.DockerImage;
-import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -44,14 +43,14 @@ import com.yahoo.vespa.hosted.controller.api.integration.deployment.TesterId;
 import com.yahoo.vespa.hosted.controller.api.integration.noderepository.RestartFilter;
 import com.yahoo.vespa.hosted.controller.api.integration.secrets.TenantSecretStore;
 import com.yahoo.vespa.hosted.controller.application.ActivateResult;
-import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackage;
-import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackageValidator;
 import com.yahoo.vespa.hosted.controller.application.Deployment;
 import com.yahoo.vespa.hosted.controller.application.DeploymentMetrics;
 import com.yahoo.vespa.hosted.controller.application.DeploymentQuotaCalculator;
 import com.yahoo.vespa.hosted.controller.application.QuotaUsage;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
 import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
+import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackage;
+import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackageValidator;
 import com.yahoo.vespa.hosted.controller.athenz.impl.AthenzFacade;
 import com.yahoo.vespa.hosted.controller.certificate.EndpointCertificates;
 import com.yahoo.vespa.hosted.controller.concurrent.Once;
@@ -378,7 +377,7 @@ public class ApplicationController {
 
                 endpointCertificateMetadata = endpointCertificates.getMetadata(instance, zone, applicationPackage.deploymentSpec());
 
-                containerEndpoints = controller.routing().containerEndpointsOf(application.get(), job.application().instance(), zone);
+                containerEndpoints = controller.routing().containerEndpointsOf(application, job.application().instance(), zone);
 
             } // Release application lock while doing the deployment, which is a lengthy task.
 
@@ -433,10 +432,6 @@ public class ApplicationController {
         for (InstanceName name : existingInstances) {
             application = withoutDeletedDeployments(application, name);
         }
-
-        for (InstanceName instance : declaredInstances)
-            if (applicationPackage.deploymentSpec().requireInstance(instance).concerns(Environment.prod))
-                application = controller.routing().assignRotations(application, instance);
 
         // Validate new deployment spec thoroughly before storing it.
         controller.jobController().deploymentStatus(application.get());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Run.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Run.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.deployment;
 
-import com.google.common.collect.ImmutableList;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.RunId;
 
 import java.security.cert.X509Certificate;
@@ -267,26 +266,26 @@ public class Run {
 
     /** Returns the list of unfinished steps whose prerequisites have all succeeded. */
     private List<Step> normalSteps() {
-        return ImmutableList.copyOf(steps.entrySet().stream()
-                                         .filter(entry ->    entry.getValue().status() == unfinished
-                                                          && entry.getKey().prerequisites().stream()
-                                                                  .allMatch(step ->    steps.get(step) == null
-                                                                                    || steps.get(step).status() == succeeded))
-                                         .map(Map.Entry::getKey)
-                                         .iterator());
+        return steps.entrySet().stream()
+                    .filter(entry -> entry.getValue().status() == unfinished
+                                     && entry.getKey().prerequisites().stream()
+                                             .allMatch(step -> steps.get(step) == null
+                                                               || steps.get(step).status() == succeeded))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toUnmodifiableList());
     }
 
     /** Returns the list of not-yet-run run-always steps whose run-always prerequisites have all run. */
     private List<Step> forcedSteps() {
-        return ImmutableList.copyOf(steps.entrySet().stream()
-                                         .filter(entry ->    entry.getValue().status() == unfinished
-                                                          && entry.getKey().alwaysRun()
-                                                          && entry.getKey().prerequisites().stream()
-                                                                  .filter(Step::alwaysRun)
-                                                                  .allMatch(step ->    steps.get(step) == null
-                                                                                    || steps.get(step).status() != unfinished))
-                                         .map(Map.Entry::getKey)
-                                         .iterator());
+        return steps.entrySet().stream()
+                    .filter(entry -> entry.getValue().status() == unfinished
+                                     && entry.getKey().alwaysRun()
+                                     && entry.getKey().prerequisites().stream()
+                                             .filter(Step::alwaysRun)
+                                             .allMatch(step -> steps.get(step) == null
+                                                               || steps.get(step).status() != unfinished))
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toUnmodifiableList());
     }
 
     private void requireActive() {


### PR DESCRIPTION
Extracted this change from refactoring. Previously they were assigned when the
application package was submitted.

@tokle