### PR TITLE
vespalib::SequencedTaskExecutor uses std::optional. Add needed include.

### DIFF
--- a/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/sequencedtaskexecutor.h
@@ -4,6 +4,7 @@
 #include "isequencedtaskexecutor.h"
 #include <vespa/vespalib/util/time.h>
 #include <vespa/vespalib/util/runnable.h>
+#include <optional>
 
 namespace vespalib {
 


### PR DESCRIPTION
@baldersheim : please review
