### PR TITLE
Revert "Fix VESPA_HOME permissions to VESPA_USER & VESPA_GROUP"

### DIFF
--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -78,9 +78,6 @@ findhost
 if [ "$VESPA_USER" = "" ]; then
     VESPA_USER=$(id -run)
 fi
-if [ "$VESPA_GROUP" = "" ]; then
-    $VESPA_GROUP=$(id -rgn)
-fi
 
 cd $VESPA_HOME || { echo "Cannot cd to $VESPA_HOME" 1>&2; exit 1; }
 
@@ -99,32 +96,32 @@ fixdir () {
 
 # BEGIN directory fixups
 
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  libexec/vespa/plugins/qrs
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/configserver
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/qrs
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/search
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  tmp
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  tmp/vespa
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/crash
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/config_server
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/config_server/serverdb
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/config_server/serverdb/tenants
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/filedistribution
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/index
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/logcontrol
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/search
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/tmp
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/jdisc_container
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/run
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/application
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/bundlecache
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/bundlecache/configserver
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/cache/config/
+fixdir   root        root  1777  logs
+fixdir   root        root  1777  tmp
+fixdir   root        root  1777  var/run
+fixdir ${VESPA_USER} root  1777  var/crash
+fixdir ${VESPA_USER} root  1777  logs/vespa
+fixdir ${VESPA_USER} root  1777  tmp/vespa
+fixdir   root        root   755  var
+fixdir ${VESPA_USER} root   755  libexec/vespa/plugins/qrs
+fixdir ${VESPA_USER} root   755  logs/vespa/configserver
+fixdir ${VESPA_USER} root   755  logs/vespa/qrs
+fixdir ${VESPA_USER} root   755  logs/vespa/search
+fixdir ${VESPA_USER} root   755  var/db/vespa
+fixdir ${VESPA_USER} root   755  var/db/vespa/tmp
+fixdir ${VESPA_USER} root   755  var/db/vespa/config_server
+fixdir ${VESPA_USER} root   755  var/db/vespa/config_server/serverdb
+fixdir ${VESPA_USER} root   755  var/db/vespa/config_server/serverdb/tenants
+fixdir ${VESPA_USER} root   755  var/db/vespa/filedistribution
+fixdir ${VESPA_USER} root   755  var/db/vespa/index
+fixdir ${VESPA_USER} root   755  var/db/vespa/logcontrol
+fixdir ${VESPA_USER} root   755  var/db/vespa/search
+fixdir ${VESPA_USER} root   755  var/jdisc_container
+fixdir ${VESPA_USER} root   755  var/vespa
+fixdir ${VESPA_USER} root   755  var/vespa/application
+fixdir ${VESPA_USER} root   755  var/vespa/bundlecache
+fixdir ${VESPA_USER} root   755  var/vespa/bundlecache/configserver
+fixdir ${VESPA_USER} root   755  var/vespa/cache/config/
 
 if [ "${VESPA_UNPRIVILEGED}" != yes ]; then
   chown -hR ${VESPA_USER} logs/vespa


### PR DESCRIPTION
Reverts vespa-engine/vespa#20055

Broke open source build:

12:40:25 [11:40:25.277] /opt/vespa/bin/vespa-prestart.sh: line 82: =root: command not found
12:40:25 [11:40:25.277] fixdir: Expected 4 params, got: vespa 755 libexec/vespa/plugins/qrs