### PR TITLE
Use removes_complete() instead of removeComplete() and removeBatchCom…

### DIFF
--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -900,7 +900,7 @@ assertThreadObserver(uint32_t masterExecuteCnt,
     return true;
 }
 
-TEST_F("require that remove() calls removeComplete() via delayed thread service",
+TEST_F("require that remove() calls removes_complete() via delayed thread service",
         SearchableFeedViewFixture)
 {
     EXPECT_TRUE(assertThreadObserver(0, 0, 0, f.writeServiceObserver()));
@@ -913,8 +913,9 @@ TEST_F("require that remove() calls removeComplete() via delayed thread service"
     // remove index fields handled in index thread
     // delayed remove complete handled in same index thread, then master thread
     EXPECT_TRUE(assertThreadObserver(5, 4, 4, f.writeServiceObserver()));
-    EXPECT_EQUAL(1u, f.metaStoreObserver()._removeCompleteCnt);
-    EXPECT_EQUAL(1u, f.metaStoreObserver()._removeCompleteLid);
+    EXPECT_EQUAL(1u, f.metaStoreObserver()._removes_complete_cnt);
+    ASSERT_FALSE(f.metaStoreObserver()._removes_complete_lids.empty());
+    EXPECT_EQUAL(1u, f.metaStoreObserver()._removes_complete_lids.back());
 }
 
 TEST_F("require that handleDeleteBucket() removes documents", SearchableFeedViewFixture)

--- a/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/maintenancecontroller/maintenancecontroller_test.cpp
@@ -477,7 +477,7 @@ MyDocumentSubDB::handlePruneRemovedDocuments(const PruneRemovedDocumentsOperatio
     const LidVectorContext &lidCtx = *op.getLidsToRemove();
     const LidVector &lidsToRemove(lidCtx.getLidVector());
     _metaStore.removeBatch(lidsToRemove, lidCtx.getDocIdLimit());
-    _metaStore.removeBatchComplete(lidsToRemove);
+    _metaStore.removes_complete(lidsToRemove);
     _metaStore.commit(serialNum);
     for (auto lid : lidsToRemove) {
         _docs.erase(lid);
@@ -517,7 +517,7 @@ MyDocumentSubDB::handlePut(PutOperation &op)
         bool remres = _metaStore.remove(op.getPrevLid(), 0u);
         assert(remres);
         (void) remres;
-        _metaStore.removeComplete(op.getPrevLid());
+        _metaStore.removes_complete({ op.getPrevLid() });
 
         _docs.erase(op.getPrevLid());
         needCommit = true;
@@ -564,7 +564,7 @@ MyDocumentSubDB::handleRemove(RemoveOperationWithDocId &op)
         assert(remres);
         (void) remres;
 
-        _metaStore.removeComplete(op.getPrevLid());
+        _metaStore.removes_complete({ op.getPrevLid() });
         _docs.erase(op.getPrevLid());
         needCommit = true;
     }
@@ -618,7 +618,7 @@ MyDocumentSubDB::handleMove(const MoveOperation &op)
         assert(remres);
         (void) remres;
 
-        _metaStore.removeComplete(op.getPrevLid());
+        _metaStore.removes_complete({ op.getPrevLid() });
         _docs.erase(op.getPrevLid());
         needCommit = true;
     }

--- a/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
@@ -341,7 +341,7 @@ TEST_F("require that handleMove() handles move within same subdb and propagates 
                       doc->getId().getGlobalId().convertToBucketId(),
                       Timestamp(10), docSize, 2, 0u); });
     f.runInMaster([&] () { f.metaStore->remove(1, 0u); });
-    f.metaStore->removeComplete(1);
+    f.metaStore->removes_complete({ 1 });
     MoveOperation::UP op = makeMoveOp(doc, DbDocumentId(subdb_id, 2), subdb_id);
     op->setTargetLid(1);
     TEST_DO(f.assertPutCount(0));

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -336,7 +336,7 @@ TEST(DocumentMetaStore, gids_can_be_cleared)
     assertLid(1, gid1, dms);
     EXPECT_EQ(1u, dms.getNumUsedLids());
     EXPECT_TRUE(dms.remove(1, 0u));
-    dms.removeComplete(1);
+    dms.removes_complete({ 1 });
     EXPECT_EQ(0u, dms.getNumUsedLids());
     EXPECT_TRUE(!dms.getGid(1, gid));
     EXPECT_TRUE(!dms.getLid(gid1, lid));
@@ -346,7 +346,7 @@ TEST(DocumentMetaStore, gids_can_be_cleared)
     assertLid(1, gid2, dms);
     EXPECT_EQ(1u, dms.getNumUsedLids());
     EXPECT_TRUE(dms.remove(1, 0u));
-    dms.removeComplete(1);
+    dms.removes_complete({ 1 });
     EXPECT_EQ(0u, dms.getNumUsedLids());
     EXPECT_TRUE(!dms.getGid(1, gid));
     EXPECT_TRUE(!dms.getLid(gid2, lid));
@@ -374,7 +374,7 @@ TEST(DocumentMetaStore, generation_handling_is_working)
     }
     EXPECT_EQ(0u, gh.getGenerationRefCount());
     dms->remove(1, 0u);
-    dms->removeComplete(1);
+    dms->removes_complete({ 1 });
     EXPECT_EQ(3u, gh.getCurrentGeneration());
 }
 
@@ -391,7 +391,7 @@ TEST(DocumentMetaStoreTest, lid_and_gid_space_is_reused)
     EXPECT_EQ(3u, dms->getNumDocs());
     EXPECT_EQ(2u, dms->getNumUsedLids());
     dms->remove(2, 0u); // -> gen 3
-    dms->removeComplete(2); // -> gen 4
+    dms->removes_complete({ 2 }); // -> gen 4
     EXPECT_EQ(3u, dms->getNumDocs());
     EXPECT_EQ(1u, dms->getNumUsedLids());
     // -> gen 5 (reuse of lid 2)
@@ -402,7 +402,7 @@ TEST(DocumentMetaStoreTest, lid_and_gid_space_is_reused)
     {
         AttributeGuard g1(dms); // guard on gen 5
         dms->remove(2, 0u);
-        dms->removeComplete(2);
+        dms->removes_complete({ 2 });
         EXPECT_EQ(3u, dms->getNumDocs());
         EXPECT_EQ(1u, dms->getNumUsedLids()); // lid 2 free but guarded
         assertPut(bucketId4, time4, 3, gid4, *dms);
@@ -476,7 +476,7 @@ TEST(DocumentMetaStoreTest, gids_can_be_saved_and_loaded)
     }
     for (size_t i = 0; i < removeLids.size(); ++i) {
         dms1.remove(removeLids[i], 0u);
-        dms1.removeComplete(removeLids[i]);
+        dms1.removes_complete({ removeLids[i] });
     }
     uint64_t expSaveBytesSize = DocumentMetaStore::minHeaderLen +
                                 (1000 - 4) * DocumentMetaStore::entrySize;
@@ -660,7 +660,7 @@ requireThatBasicBucketInfoWorks()
         GlobalId gid = createGid(lid);
         BucketId bucketId(minNumBits, gid.convertToBucketId().getRawId());
         EXPECT_TRUE(dms.remove(lid, 0u));
-        dms.removeComplete(lid);
+        dms.removes_complete({ lid });
         m.erase(std::make_pair(bucketId, gid));
     }
     assert(!m.empty());
@@ -740,7 +740,7 @@ TEST(DocumentMetaStoreTest, can_retrieve_list_of_lids_from_bucket_id)
         const LidVector &expLids = itr->second;
         for (size_t i = 0; i < expLids.size(); ++i) {
             EXPECT_TRUE(dms.remove(expLids[i], 0u));
-            dms.removeComplete(expLids[i]);
+            dms.removes_complete({ expLids[i] });
         }
         LOG(info, "Verify that bucket id '%s' has 0 lids", bucketId.toString().c_str());
         LidVector actLids;
@@ -900,14 +900,14 @@ TEST(DocumentMetaStoreTest, removed_lids_are_cleared_as_active)
     assertActiveLids(BoolVector().T().T(), f.dms.getActiveLids());
     EXPECT_EQ(2u, f.dms.getNumActiveLids());
     f.dms.remove(2, 0u);
-    f.dms.removeComplete(2);
+    f.dms.removes_complete({ 2 });
     assertActiveLids(BoolVector().T().F(), f.dms.getActiveLids());
     EXPECT_EQ(1u, f.dms.getNumActiveLids());
     f.addGlobalId(f.gids[2], 2); // from bid2
     assertActiveLids(BoolVector().T().F(), f.dms.getActiveLids());
     EXPECT_EQ(1u, f.dms.getNumActiveLids());
     f.dms.remove(2, 0u);
-    f.dms.removeComplete(2);
+    f.dms.removes_complete({ 2 });
     f.addGlobalId(f.gids[3], 2); // from bid1
     assertActiveLids(BoolVector().T().T(), f.dms.getActiveLids());
     EXPECT_EQ(2u, f.dms.getNumActiveLids());
@@ -942,7 +942,7 @@ TEST(DocumentMetaStoreTest, document_and_meta_entry_count_is_updated)
     EXPECT_EQ(3u, f.dms.getBucketDB().takeGuard()->get(f.bid2).getDocumentCount());
     EXPECT_EQ(3u, f.dms.getBucketDB().takeGuard()->get(f.bid2).getEntryCount());
     f.dms.remove(3, 0u); // from bid2
-    f.dms.removeComplete(3);
+    f.dms.removes_complete({ 3 });
     EXPECT_EQ(4u, f.dms.getBucketDB().takeGuard()->get(f.bid1).getDocumentCount());
     EXPECT_EQ(4u, f.dms.getBucketDB().takeGuard()->get(f.bid1).getEntryCount());
     EXPECT_EQ(2u, f.dms.getBucketDB().takeGuard()->get(f.bid2).getDocumentCount());
@@ -959,18 +959,18 @@ TEST(DocumentMetaStoreTest, empty_buckets_are_removed)
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid1));
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid2));
     f.dms.remove(3, 0u); // from bid2
-    f.dms.removeComplete(3);
+    f.dms.removes_complete({ 3 });
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid1));
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid2));
     EXPECT_EQ(0u, f.dms.getBucketDB().takeGuard()->get(f.bid2).getEntryCount());
     f._bucketDBHandler.handleDeleteBucket(f.bid2);
     EXPECT_FALSE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid2));
     f.dms.remove(1, 0u); // from bid1
-    f.dms.removeComplete(1);
+    f.dms.removes_complete({ 1 });
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid1));
     EXPECT_FALSE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid2));
     f.dms.remove(2, 0u); // from bid1
-    f.dms.removeComplete(2);
+    f.dms.removes_complete({ 2 });
     EXPECT_TRUE(f.dms.getBucketDB().takeGuard()->hasBucket(f.bid1));
     EXPECT_EQ(0u, f.dms.getBucketDB().takeGuard()->get(f.bid1).getEntryCount());
     f._bucketDBHandler.handleDeleteBucket(f.bid1);
@@ -1578,7 +1578,7 @@ TEST(DocumentMetaStoreTest, remove_changed_bucket_works)
     uint32_t addLid2 = addGid(f.dms, g.gid, g.bid2, Timestamp(0));
     EXPECT_TRUE(1u == addLid2);
     EXPECT_TRUE(f.dms.remove(1u, 0u));
-    f.dms.removeComplete(1u);
+    f.dms.removes_complete({ 1u });
 }
 
 TEST(DocumentMetaStoreTest, get_lid_usage_stats_works)
@@ -1618,7 +1618,7 @@ TEST(DocumentMetaStoreTest, get_lid_usage_stats_works)
     EXPECT_EQ(3u, s.getHighestUsedLid());
 
     dms.remove(1, 0u);
-    dms.removeComplete(1);
+    dms.removes_complete({ 1 });
     
     s = dms.getLidUsageStats();
     EXPECT_EQ(4u, s.getLidLimit());
@@ -1627,7 +1627,7 @@ TEST(DocumentMetaStoreTest, get_lid_usage_stats_works)
     EXPECT_EQ(3u, s.getHighestUsedLid());
 
     dms.remove(3, 0u);
-    dms.removeComplete(3);
+    dms.removes_complete({ 3 });
     
     s = dms.getLidUsageStats();
     EXPECT_EQ(4u, s.getLidLimit());
@@ -1636,7 +1636,7 @@ TEST(DocumentMetaStoreTest, get_lid_usage_stats_works)
     EXPECT_EQ(2u, s.getHighestUsedLid());
 
     dms.remove(2, 0u);
-    dms.removeComplete(2);
+    dms.removes_complete({ 2 });
     
     s = dms.getLidUsageStats();
     EXPECT_EQ(4u, s.getLidLimit());
@@ -1683,7 +1683,7 @@ TEST(DocumentMetaStoreTest, move_works)
     EXPECT_FALSE(dms.getGid(1u, gid));
     EXPECT_FALSE(dms.getGidEvenIfMoved(1u, gid));
     EXPECT_TRUE(dms.getGid(2u, gid));
-    dms.removeComplete(1u);
+    dms.removes_complete({ 1u });
     EXPECT_FALSE(dms.getGid(1u, gid));
     EXPECT_FALSE(dms.getGidEvenIfMoved(1u, gid));
     EXPECT_TRUE(dms.getGid(2u, gid));
@@ -1693,7 +1693,7 @@ TEST(DocumentMetaStoreTest, move_works)
     EXPECT_TRUE(dms.getGid(1u, gid));
     EXPECT_FALSE(dms.getGid(2u, gid));
     EXPECT_TRUE(dms.getGidEvenIfMoved(2u, gid));
-    dms.removeComplete(2u);
+    dms.removes_complete({ 2u });
     EXPECT_TRUE(dms.getGid(1u, gid));
     EXPECT_FALSE(dms.getGid(2u, gid));
     EXPECT_TRUE(dms.getGidEvenIfMoved(2u, gid));
@@ -1732,7 +1732,7 @@ remove(uint32_t startLid, uint32_t shrinkTarget, DocumentMetaStore &dms)
 {
     for (uint32_t lid = startLid; lid >= shrinkTarget; --lid) {
         dms.remove(lid, 0u);
-        dms.removeComplete(lid);
+        dms.removes_complete({ lid });
     }
 }
 
@@ -1830,7 +1830,7 @@ void
 removeLid(DocumentMetaStore &dms, uint32_t lid)
 {
     dms.remove(lid, 0u);
-    dms.removeComplete(lid);
+    dms.removes_complete({ lid });
 }
 
 void
@@ -1944,7 +1944,7 @@ TEST(DocumentMetaStoreTest, multiple_lids_can_be_removed_with_removeBatch)
     assertLidGidFound(4, dms);
 
     dms.removeBatch({1, 3}, 5);
-    dms.removeBatchComplete({1, 3});
+    dms.removes_complete({1, 3});
 
     assertLidGidNotFound(1, dms);
     assertLidGidFound(2, dms);

--- a/searchcore/src/tests/proton/reference/gid_to_lid_mapper/gid_to_lid_mapper_test.cpp
+++ b/searchcore/src/tests/proton/reference/gid_to_lid_mapper/gid_to_lid_mapper_test.cpp
@@ -110,7 +110,7 @@ struct Fixture
 
     void remove(uint32_t lid) {
         if (_dms->remove(lid, 0u)) {
-            _dms->removeComplete(lid);
+            _dms->removes_complete({ lid });
         }
         _dms->commit();
     }

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.cpp
@@ -604,11 +604,9 @@ DocumentMetaStore::remove(DocId lid, uint64_t prepare_serial_num)
 }
 
 void
-DocumentMetaStore::removeComplete(DocId lid)
+DocumentMetaStore::removes_complete(const std::vector<DocId>& lids)
 {
-    assert(lid != 0);
-    assert(lid < _metaDataStore.size());
-    _lidAlloc.holdLid(lid, _metaDataStore.size(), getCurrentGeneration());
+    _lidAlloc.holdLids(lids, _metaDataStore.size(), getCurrentGeneration());
     incGeneration();
 }
 
@@ -697,13 +695,6 @@ DocumentMetaStore::removeBatch(const std::vector<DocId> &lidsToRemove, const uin
     if (_op_listener) {
         _op_listener->notify_remove_batch();
     }
-}
-
-void
-DocumentMetaStore::removeBatchComplete(const std::vector<DocId> &lidsToRemove)
-{
-    _lidAlloc.holdLids(lidsToRemove, _metaDataStore.size(), getCurrentGeneration());
-    incGeneration();
 }
 
 bool

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastore.h
@@ -167,21 +167,17 @@ public:
     vespalib::GenerationHandler::Guard getGuard() const override;
 
     /**
-     * Put lid on a hold list, for later reuse.  Typically called
-     * after remove() has been called and related structures for
-     * document has been torn down (memory index, attribute vectors,
+     * Put lids on a hold list, for later reuse.  Typically called
+     * after remove() or removeBatch() has been called and related structures for
+     * documents have been torn down (memory index, attribute vectors,
      * document store).
      */
-    void removeComplete(DocId lid) override;
+    void removes_complete(const std::vector<DocId>& lids) override;
     void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override;
     bool validButMaybeUnusedLid(DocId lid) const { return _lidAlloc.validButMaybeUnusedLid(lid); }
     bool validLidFast(DocId lid) const { return _lidAlloc.validLid(lid); }
     bool validLid(DocId lid) const override { return validLidFast(lid); }
     void removeBatch(const std::vector<DocId> &lidsToRemove, const DocId docIdLimit) override;
-    /**
-     * Put lids on a hold list, for laster reuse.
-     */
-    void removeBatchComplete(const std::vector<DocId> &lidsToRemove) override;
     const RawDocumentMetaData & getRawMetaData(DocId lid) const override { return _metaDataStore[lid]; }
 
     /**

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/i_store.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/i_store.h
@@ -89,21 +89,23 @@ struct IStore
      * Removes the <lid, meta data> pair with the given lid from this
      * store. Returns false if the <lid, meta data> pair was not
      * found or could not be removed.
-     * The caller must call removeComplete() after document removal is done.
+     * The caller must call removes_complete() after document removal is done.
      **/
     virtual bool remove(DocId lid, uint64_t prepare_serial_num) = 0;
 
     /**
-     * Signal that the removal of the document associated with this lid is complete.
-     * This is typically called after the document has been removed from all
-     * other data structures. The lid is now a candidate for later reuse.
+     * Signal that the removal of the documents associated with these lid is complete.
+     * This is typically called after the documents have been removed from all
+     * other data structures. The lids are now candidates for later reuse.
+     * Both remove() and removeBatch() will trigger a later call to removes_complete()
+     * at the next force commit, cf. ForceCommitDoneTask.
      */
-    virtual void removeComplete(DocId lid) = 0;
+    virtual void removes_complete(const std::vector<DocId>& lids) = 0;
 
     /**
      * Move meta data for fromLid to toLid. Mapping from gid to lid
      * is updated atomically from fromLid to toLid.
-     * The caller must call removeComplete() with fromLid after document move is done.
+     * The caller must call removes_complete() with fromLid after document move is done.
      */
     virtual void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) = 0;
 
@@ -115,14 +117,9 @@ struct IStore
 
     /**
      * Removes a list of lids.
-     * The caller must call removeBatchComplete() after documents removal is done.
+     * The caller must call removes_complete() after documents removal is done.
      */
     virtual void removeBatch(const std::vector<DocId> &lidsToRemove, const DocId docIdLimit) = 0;
-
-    /**
-     * Signal that the removal of the documents associated with these lids is complete.
-     */
-    virtual void removeBatchComplete(const std::vector<DocId> &lidsToRemove) = 0;
 
     /**
      * Returns the raw meta data stored for the given lid.

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -122,21 +122,6 @@ LidAllocator::moveLidEnd(DocId fromLid, DocId toLid)
 }
 
 void
-LidAllocator::holdLid(DocId lid,
-                      DocId lidLimit,
-                      generation_t currentGeneration)
-{
-    (void) lidLimit;
-    assert(holdLidOK(lid, lidLimit));
-    assert(isFreeListConstructed());
-    assert(lid < _usedLids.size());
-    assert(lid < _pendingHoldLids.size());
-    assert(_pendingHoldLids.testBit(lid));
-    _pendingHoldLids.clearBit(lid);
-    _holdLids.add(lid, currentGeneration);
-}
-
-void
 LidAllocator::holdLids(const std::vector<DocId> &lids,
                        DocId lidLimit,
                        generation_t currentGeneration)

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.h
@@ -45,7 +45,6 @@ public:
     }
     void moveLidBegin(DocId fromLid, DocId toLid);
     void moveLidEnd(DocId fromLid, DocId toLid);
-    void holdLid(DocId lid, DocId lidLimit, generation_t currentGeneration);
     void holdLids(const std::vector<DocId> &lids, DocId lidLimit,
                   generation_t currentGeneration);
     bool holdLidOK(DocId lid, DocId lidLimit) const;

--- a/searchcore/src/vespa/searchcore/proton/server/forcecommitdonetask.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/forcecommitdonetask.cpp
@@ -30,11 +30,7 @@ ForceCommitDoneTask::run()
         _pending_gid_to_lid_changes->notify_done();
     }
     if (!_lidsToReuse.empty()) {
-        if (_lidsToReuse.size() == 1) {
-            _documentMetaStore.removeComplete(_lidsToReuse[0]);
-        } else {
-            _documentMetaStore.removeBatchComplete(_lidsToReuse);
-        }
+        _documentMetaStore.removes_complete(_lidsToReuse);
     }
     if (_holdUnblockShrinkLidSpace) {
         _documentMetaStore.holdUnblockShrinkLidSpace();

--- a/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
+++ b/searchcore/src/vespa/searchcore/proton/test/document_meta_store_observer.h
@@ -10,15 +10,15 @@ namespace proton::test {
 struct DocumentMetaStoreObserver : public IDocumentMetaStore
 {
     IDocumentMetaStore &_store;
-    uint32_t _removeCompleteCnt;
-    DocId _removeCompleteLid;
+    uint32_t _removes_complete_cnt;
+    std::vector<DocId> _removes_complete_lids;
     DocId _compactLidSpaceLidLimit;
     uint32_t _holdUnblockShrinkLidSpaceCnt;
 
     DocumentMetaStoreObserver(IDocumentMetaStore &store) noexcept
         : _store(store),
-          _removeCompleteCnt(0),
-          _removeCompleteLid(0),
+          _removes_complete_cnt(0),
+          _removes_complete_lids(0),
           _compactLidSpaceLidLimit(0),
           _holdUnblockShrinkLidSpaceCnt(0)
     {}
@@ -76,10 +76,10 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
     bool remove(DocId lid, uint64_t prepare_serial_num) override {
         return _store.remove(lid, prepare_serial_num);
     }
-    void removeComplete(DocId lid) override {
-        ++_removeCompleteCnt;
-        _removeCompleteLid = lid;
-        _store.removeComplete(lid);
+    void removes_complete(const std::vector<DocId>& lids) override {
+        ++_removes_complete_cnt;
+        _removes_complete_lids.insert(_removes_complete_lids.end(), lids.cbegin(), lids.cend());
+        _store.removes_complete(lids);
     }
     void move(DocId fromLid, DocId toLid, uint64_t prepare_serial_num) override {
         _store.move(fromLid, toLid, prepare_serial_num);
@@ -90,9 +90,6 @@ struct DocumentMetaStoreObserver : public IDocumentMetaStore
      void removeBatch(const std::vector<DocId> &lidsToRemove,
                              const DocId docIdLimit) override {
         _store.removeBatch(lidsToRemove, docIdLimit);
-    }
-    void removeBatchComplete(const std::vector<DocId> &lidsToRemove) override {
-        _store.removeBatchComplete(lidsToRemove);
     }
     const RawDocumentMetaData &getRawMetaData(DocId lid) const override {
         return _store.getRawMetaData(lid);


### PR DESCRIPTION
…plete().

Remove unused holdLid() method.

@baldersheim : please review
@geirst : FYI
