### PR TITLE
Revert "Use live gid to lid map when processing partial update."

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlyfeedview.cpp
@@ -489,12 +489,12 @@ StoreOnlyFeedView::makeUpdatedDocument(bool useDocStore, Lid lid, const Document
 bool
 StoreOnlyFeedView::lookupDocId(const DocumentId &docId, Lid &lid) const
 {
-    // This function should only be called by the document db main thread.
-    auto result = _metaStore.inspectExisting(docId.getGlobalId(), 0);
-    if (!result.ok()) {
+    // This function should only be called by the updater thread.
+    // Readers need to take a guard on the document meta store
+    // attribute before accessing.
+    if (!_metaStore.getLid(docId.getGlobalId(), lid)) {
         return false;
     }
-    lid = result.getLid();
     if (_params._subDbType == SubDbType::REMOVED)
         return false;
     return true;


### PR DESCRIPTION
Reverts vespa-engine/vespa#20083

Need a slightly different fix.
