### PR TITLE
Allow usage of both api-key and access-token

### DIFF
--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -48,6 +48,16 @@ var apiKeyCmd = &cobra.Command{
 		if err := ioutil.WriteFile(apiKeyFile, apiKey, 0600); err == nil {
 			printSuccess("API private key written to ", apiKeyFile)
 			printPublicKey(apiKeyFile, app.Tenant)
+			if vespa.Auth0AccessTokenEnabled() {
+				if err == nil {
+					if err := cfg.Set(cloudAuthFlag, "api-key"); err != nil {
+						fatalErr(err, "Could not write config")
+					}
+					if err := cfg.Write(); err != nil {
+						fatalErr(err)
+					}
+				}
+			}
 		} else {
 			fatalErr(err, "Failed to write ", apiKeyFile)
 		}

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -235,6 +235,12 @@ func (c *Config) Set(option, value string) error {
 			viper.Set(option, value)
 			return nil
 		}
+	case cloudAuthFlag:
+		switch value {
+		case "access-token", "api-key":
+			viper.Set(option, value)
+			return nil
+		}
 	}
 	return fmt.Errorf("invalid option or value: %q: %q", option, value)
 }

--- a/client/go/cmd/login.go
+++ b/client/go/cmd/login.go
@@ -29,6 +29,16 @@ var loginCmd = &cobra.Command{
 			return err
 		}
 		_, err = auth0.RunLogin(ctx, a, false)
+		if vespa.Auth0AccessTokenEnabled() {
+			if err == nil {
+				if err := cfg.Set(cloudAuthFlag, "access-token"); err != nil {
+					return err
+				}
+				if err := cfg.Write(); err != nil {
+					fatalErr(err)
+				}
+			}
+		}
 		return err
 	},
 }

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -51,6 +51,7 @@ const (
 	waitFlag        = "wait"
 	colorFlag       = "color"
 	quietFlag       = "quiet"
+	cloudAuthFlag   = "cloudAuth"
 )
 
 func isTerminal() bool {

--- a/client/go/vespa/deploy.go
+++ b/client/go/vespa/deploy.go
@@ -344,8 +344,10 @@ func checkDeploymentOpts(opts DeploymentOpts) error {
 	if !opts.ApplicationPackage.HasCertificate() {
 		return fmt.Errorf("%s: missing certificate in package", opts)
 	}
-	if !Auth0AccessTokenEnabled() && opts.APIKey == nil {
-		return fmt.Errorf("%s: missing api key", opts.String())
+	if !Auth0AccessTokenEnabled() {
+		if opts.APIKey == nil {
+			return fmt.Errorf("%s: missing api key", opts.String())
+		}
 	}
 	return nil
 }

--- a/client/go/vespa/target_test.go
+++ b/client/go/vespa/target_test.go
@@ -152,7 +152,7 @@ func createCloudTarget(t *testing.T, url string, logWriter io.Writer) Target {
 	target := CloudTarget("https://example.com", Deployment{
 		Application: ApplicationID{Tenant: "t1", Application: "a1", Instance: "i1"},
 		Zone:        ZoneID{Environment: "dev", Region: "us-north-1"},
-	}, apiKey, TLSOptions{KeyPair: x509KeyPair}, LogOptions{Writer: logWriter}, "", "")
+	}, apiKey, TLSOptions{KeyPair: x509KeyPair}, LogOptions{Writer: logWriter}, "", "", "")
 	if ct, ok := target.(*cloudTarget); ok {
 		ct.apiURL = url
 	} else {


### PR DESCRIPTION
Use either api-key or access-token based on previous authentication.
Ensure previous users of api-key are not forced to use new
authentication mechanism.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
