### PR TITLE
Add a vector of gids to remove to ReferenceAttribute::populateTargetL…

### DIFF
--- a/searchcore/src/tests/proton/reference/gid_to_lid_change_registrator/gid_to_lid_change_registrator_test.cpp
+++ b/searchcore/src/tests/proton/reference/gid_to_lid_change_registrator/gid_to_lid_change_registrator_test.cpp
@@ -26,7 +26,7 @@ public:
     ~MyListener() override { }
     void notifyPutDone(IDestructorCallbackSP, document::GlobalId, uint32_t) override { }
     void notifyRemove(IDestructorCallbackSP, document::GlobalId) override { }
-    void notifyRegistered() override { }
+    void notifyRegistered(const std::vector<document::GlobalId>&) override { }
     const vespalib::string &getName() const override { return _name; }
     const vespalib::string &getDocTypeName() const override { return _docTypeName; }
 };

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_handler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_handler.cpp
@@ -142,7 +142,13 @@ GidToLidChangeHandler::addListener(std::unique_ptr<IGidToLidChangeListener> list
             }
         }
         _listeners.emplace_back(std::move(listener));
-        _listeners.back()->notifyRegistered();
+        std::vector<GlobalId> removes;
+        for (auto& change : _pending_changes) {
+            if (change.is_remove()) {
+                removes.emplace_back(change.get_gid());
+            }
+        }
+        _listeners.back()->notifyRegistered(removes);
     } else {
         assert(_listeners.empty());
     }

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.cpp
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.cpp
@@ -46,13 +46,13 @@ GidToLidChangeListener::notifyRemove(IDestructorCallbackSP context, document::Gl
 }
 
 void
-GidToLidChangeListener::notifyRegistered()
+GidToLidChangeListener::notifyRegistered(const std::vector<document::GlobalId>& removes)
 {
     std::promise<void> promise;
     auto future = promise.get_future();
     _attributeFieldWriter.executeLambda(_executorId,
-                                        [this, &promise]() {
-                                            _attr->populateTargetLids();
+                                        [this, &promise, removes(std::move(removes))]() {
+                                            _attr->populateTargetLids(removes);
                                             promise.set_value();
                                         });
     future.wait();

--- a/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/gid_to_lid_change_listener.h
@@ -31,7 +31,7 @@ public:
     ~GidToLidChangeListener() override;
     void notifyPutDone(IDestructorCallbackSP context, document::GlobalId gid, uint32_t lid) override;
     void notifyRemove(IDestructorCallbackSP context, document::GlobalId gid) override;
-    void notifyRegistered() override;
+    void notifyRegistered(const std::vector<document::GlobalId>& removes) override;
     const vespalib::string &getName() const override;
     const vespalib::string &getDocTypeName() const override;
     const std::shared_ptr<search::attribute::ReferenceAttribute> &getReferenceAttribute() const { return _attr; }

--- a/searchcore/src/vespa/searchcore/proton/reference/i_gid_to_lid_change_listener.h
+++ b/searchcore/src/vespa/searchcore/proton/reference/i_gid_to_lid_change_listener.h
@@ -4,6 +4,7 @@
 
 #include <vespa/vespalib/util/idestructorcallback.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vector>
 
 namespace document { class GlobalId; }
 
@@ -20,7 +21,7 @@ public:
     virtual ~IGidToLidChangeListener() { }
     virtual void notifyPutDone(IDestructorCallbackSP context, document::GlobalId gid, uint32_t lid) = 0;
     virtual void notifyRemove(IDestructorCallbackSP context, document::GlobalId gid) = 0;
-    virtual void notifyRegistered() = 0;
+    virtual void notifyRegistered(const std::vector<document::GlobalId>& removes) = 0;
     virtual const vespalib::string &getName() const = 0;
     virtual const vespalib::string &getDocTypeName() const = 0;
 };

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.h
@@ -84,8 +84,9 @@ public:
 
     void notifyReferencedPutNoCommit(const GlobalId &gid, DocId targetLid);
     void notifyReferencedPut(const GlobalId &gid, DocId targetLid);
+    bool notifyReferencedRemoveNoCommit(const GlobalId &gid);
     void notifyReferencedRemove(const GlobalId &gid);
-    void populateTargetLids();
+    void populateTargetLids(const std::vector<GlobalId>& removes);
     void clearDocs(DocId lidLow, DocId lidLimit) override;
     void onShrinkLidSpace() override;
 


### PR DESCRIPTION
…ids()

signature. These gids represent the target documents removed since the last
feed view force commit where the live gid to lid mapping in the document
meta store was made available as a frozen tree.

@baldersheim : please review
@geirst : FYI
