### PR TITLE
Delay registration of read listener until failure wiring is complete

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -100,6 +100,8 @@ class HttpRequestDispatch {
                     if (t != null) requestCompletion.completeExceptionally(t);
                     else requestCompletion.complete(null);
                 });
+        // Start the reader after wiring of "finished futures" are complete
+        servletRequestReader.start();
     }
 
     ContentChannel dispatchFilterRequest(Response response) {
@@ -217,11 +219,7 @@ class HttpRequestDispatch {
             HttpRequestFactory.copyHeaders(jettyRequest, jdiscRequest);
             requestContentChannel = requestHandler.handleRequest(jdiscRequest, servletResponseController.responseHandler());
         }
-        //TODO If the below method throws servletRequestReader will not complete and
-        // requestContentChannel will not be closed and there is a reference leak
-        // Ditto for the servletInputStream
-        return new ServletRequestReader(
-                jettyRequest.getInputStream(), requestContentChannel, jDiscContext.janitor, metricReporter);
+        return new ServletRequestReader(jettyRequest, requestContentChannel, jDiscContext.janitor, metricReporter);
     }
 
     private static RequestHandler newRequestHandler(JDiscContext context,


### PR DESCRIPTION
Handle exceptions from getInputStream() and setReadListener() equally to
exceptions from listener's onError(). By delaying registration
the completion of finishedFuture will trigger an error response immediately.
