### PR TITLE
Revert "antlr4 4.5 -> 4.9.3"

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -238,7 +238,7 @@
                                         <include>net.java.dev.jna:jna:4.5.2:jar:test</include>
                                         <include>org.abego.treelayout:org.abego.treelayout.core:1.0.1:jar:test</include>
                                         <include>org.antlr:antlr-runtime:3.5.2:jar:test</include>
-                                        <include>org.antlr:antlr4-runtime:4.9.3:jar:test</include>
+                                        <include>org.antlr:antlr4-runtime:4.5:jar:test</include>
                                         <include>org.apache.commons:commons-exec:1.3:jar:test</include>
                                         <include>org.apache.commons:commons-math3:3.6.1:jar:test</include>
                                         <include>org.apache.httpcomponents:httpclient:4.5.12:jar:test</include>

--- a/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/ProgramParser.java
@@ -65,6 +65,8 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.TokenStream;
 import org.antlr.v4.runtime.atn.PredictionMode;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.antlr.v4.runtime.misc.Nullable;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.RuleNode;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -100,12 +102,12 @@ final class ProgramParser {
         lexer.addErrorListener(new BaseErrorListener() {
 
           @Override
-          public void syntaxError(Recognizer<?, ?> recognizer,
-                                  Object offendingSymbol,
+          public void syntaxError(@NotNull Recognizer<?, ?> recognizer,
+                                  @Nullable Object offendingSymbol,
                                   int line,
                                   int charPositionInLine,
-                                  String msg,
-                                  RecognitionException e) {
+                                  @NotNull String msg,
+                                  @Nullable RecognitionException e) {
             throw new ProgramCompileException(new Location(programName, line, charPositionInLine), "%s", msg);
           }
 
@@ -117,12 +119,12 @@ final class ProgramParser {
         parser.addErrorListener(new BaseErrorListener() {
 
           @Override
-          public void syntaxError(Recognizer<?, ?> recognizer,
-                                  Object offendingSymbol,
+          public void syntaxError(@NotNull Recognizer<?, ?> recognizer,
+                                  @Nullable Object offendingSymbol,
                                   int line,
                                   int charPositionInLine,
-                                  String msg,
-                                  RecognitionException e) {
+                                  @NotNull String msg,
+                                  @Nullable RecognitionException e) {
             throw new ProgramCompileException(new Location(programName, line, charPositionInLine), "%s", msg);
           }
 
@@ -193,6 +195,7 @@ final class ProgramParser {
         final Scope parent;
         Set<String> cursors = ImmutableSet.of();
         Set<String> variables = ImmutableSet.of();
+        Set<String> views = Sets.newHashSet();
         Map<String, Binding> bindings = Maps.newHashMap();
         final yqlplusParser parser;
         final String programName;
@@ -244,6 +247,13 @@ final class ProgramParser {
             return variables.contains(name) || (parent != null && parent.isVariable(name));
         }
 
+        public void bindModule(Location loc, List<String> binding, String symbolName) {
+            if (isBound(symbolName)) {
+                throw new ProgramCompileException(loc, "Name '%s' is already used.", symbolName);
+            }
+            root.bindings.put(symbolName, new Binding(binding));
+        }
+
         public void defineDataSource(Location loc, String name) {
             if (isCursor(name)) {
                 throw new ProgramCompileException(loc, "Alias '%s' is already used.", name);
@@ -263,6 +273,16 @@ final class ProgramParser {
             }
             variables.add(name);
 
+        }
+
+        public void defineView(Location loc, String text) {
+            if (this != root) {
+                throw new IllegalStateException("Views MUST be defined in 'root' scope only");
+            }
+            if (views.contains(text)) {
+                throw new ProgramCompileException(loc, "View '%s' already defined", text);
+            }
+            views.add(text);
         }
 
         Scope child() {
@@ -331,8 +351,8 @@ final class ProgramParser {
                     List<Orderby_fieldContext> orderFieds = ((OrderbyContext) child)
                             .orderby_fields().orderby_field();
                     orderby = Lists.newArrayListWithExpectedSize(orderFieds.size());
-                    for (var field: orderFieds) {
-                        orderby.add(convertSortKey(field, scope));
+                    for (int j = 0; j < orderFieds.size(); ++j) {
+                        orderby.add(convertSortKey(orderFieds.get(j), scope));
                     }
                     break;
                 case yqlplusParser.RULE_limit:
@@ -906,8 +926,8 @@ final class ProgramParser {
                 List<String> path = readName((Namespaced_nameContext) parseTree.getChild(0));
                 Location loc = toLocation(scope, parseTree.getChild(0));
                 String alias = path.get(0);
-                OperatorNode<ExpressionOperator> result;
-                int start;
+                OperatorNode<ExpressionOperator> result = null;
+                int start = 0;
                 if (scope.isCursor(alias)) {
                     if (path.size() > 1) {
                         result = OperatorNode.create(loc, ExpressionOperator.READ_FIELD, alias, path.get(1));

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -874,7 +874,7 @@
         <aircompressor.version>0.21</aircompressor.version>
         <airline.version>0.7</airline.version>
         <antlr.version>3.5.2</antlr.version>
-        <antlr4.version>4.9.3</antlr4.version>
+        <antlr4.version>4.5</antlr4.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <apache.httpcore.version>4.4.13</apache.httpcore.version>
         <apache.httpclient5.version>5.1.1</apache.httpclient5.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#20078
It seems handling of atleast 'æ' is broken on antlr 4.9 for reasons not yet known.