### PR TITLE
Continue serving search queries when in Maintenance node state [run-systemtest]

### DIFF
--- a/persistence/src/tests/spi/clusterstatetest.cpp
+++ b/persistence/src/tests/spi/clusterstatetest.cpp
@@ -233,4 +233,31 @@ TEST(ClusterStateTest, can_infer_own_node_retired_state)
     EXPECT_TRUE(!node_marked_as_retired_in_state("distributor:3 storage:3 .1.s:r", d, 0));
 }
 
+namespace {
+
+bool
+node_marked_as_maintenance_in_state(const std::string& stateStr,
+                                    const lib::Distribution& d,
+                                    uint16_t node)
+{
+    lib::ClusterState s(stateStr);
+    ClusterState state(s, node, d);
+    return state.nodeMaintenance();
+}
+
+}
+
+TEST(ClusterStateTest, can_infer_own_node_maintenance_state)
+{
+    lib::Distribution d(lib::Distribution::getDefaultDistributionConfig(3, 3));
+
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3", d, 0));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:i", d, 0));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:d", d, 0));
+    EXPECT_TRUE( node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:m", d, 0));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:r", d, 0));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:m", d, 1));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .1.s:m", d, 0));
+}
+
 }

--- a/persistence/src/tests/spi/clusterstatetest.cpp
+++ b/persistence/src/tests/spi/clusterstatetest.cpp
@@ -238,26 +238,26 @@ namespace {
 bool
 node_marked_as_maintenance_in_state(const std::string& stateStr,
                                     const lib::Distribution& d,
-                                    uint16_t node)
+                                    uint16_t node,
+                                    bool maintenance_in_all_spaces)
 {
     lib::ClusterState s(stateStr);
-    ClusterState state(s, node, d);
+    ClusterState state(s, node, d, maintenance_in_all_spaces);
     return state.nodeMaintenance();
 }
 
 }
 
-TEST(ClusterStateTest, can_infer_own_node_maintenance_state)
+// We want to track the maintenance state for the _node_, not just the _bucket space_.
+TEST(ClusterStateTest, node_maintenance_state_is_set_independent_of_bucket_space_state_string)
 {
     lib::Distribution d(lib::Distribution::getDefaultDistributionConfig(3, 3));
 
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3", d, 0));
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:i", d, 0));
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:d", d, 0));
-    EXPECT_TRUE( node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:m", d, 0));
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:r", d, 0));
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:m", d, 1));
-    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .1.s:m", d, 0));
+    // Note: it doesn't actually matter what the cluster state string itself says here
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3", d, 0, false));
+    EXPECT_TRUE(node_marked_as_maintenance_in_state("distributor:3 storage:3", d, 0, true));
+    EXPECT_TRUE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:d", d, 0, true));
+    EXPECT_FALSE(node_marked_as_maintenance_in_state("distributor:3 storage:3 .0.s:m", d, 0, false));
 }
 
 }

--- a/persistence/src/vespa/persistence/spi/clusterstate.cpp
+++ b/persistence/src/vespa/persistence/spi/clusterstate.cpp
@@ -68,26 +68,30 @@ ClusterState::shouldBeReady(const Bucket& b) const {
     return Trinary::False;
 }
 
-bool ClusterState::clusterUp() const {
+bool ClusterState::clusterUp() const noexcept {
     return _state && _state->getClusterState() == lib::State::UP;
 }
 
-bool ClusterState::nodeHasStateOneOf(const char* states) const {
+bool ClusterState::nodeHasStateOneOf(const char* states) const noexcept {
     return _state &&
            _state->getNodeState(lib::Node(lib::NodeType::STORAGE, _nodeIndex)).
                    getState().oneOf(states);
 }
 
-bool ClusterState::nodeUp() const {
+bool ClusterState::nodeUp() const noexcept {
     return nodeHasStateOneOf("uir");
 }
 
-bool ClusterState::nodeInitializing() const {
+bool ClusterState::nodeInitializing() const noexcept {
     return nodeHasStateOneOf("i");
 }
 
-bool ClusterState::nodeRetired() const {
+bool ClusterState::nodeRetired() const noexcept {
     return nodeHasStateOneOf("r");
+}
+
+bool ClusterState::nodeMaintenance() const noexcept {
+    return nodeHasStateOneOf("m");
 }
 
 void ClusterState::serialize(vespalib::nbostream& o) const {

--- a/persistence/src/vespa/persistence/spi/clusterstate.cpp
+++ b/persistence/src/vespa/persistence/spi/clusterstate.cpp
@@ -14,10 +14,12 @@ namespace storage::spi {
 
 ClusterState::ClusterState(const lib::ClusterState& state,
                            uint16_t nodeIndex,
-                           const lib::Distribution& distribution)
+                           const lib::Distribution& distribution,
+                           bool maintenanceInAllSpaces)
     : _state(std::make_unique<lib::ClusterState>(state)),
       _distribution(std::make_unique<lib::Distribution>(distribution.serialize())),
-      _nodeIndex(nodeIndex)
+      _nodeIndex(nodeIndex),
+      _maintenanceInAllSpaces(maintenanceInAllSpaces)
 {
 }
 
@@ -33,14 +35,11 @@ void ClusterState::deserialize(vespalib::nbostream& i) {
     _distribution = std::make_unique<lib::Distribution>(distribution);
 }
 
-ClusterState::ClusterState(vespalib::nbostream& i) {
-    deserialize(i);
-}
-
 ClusterState::ClusterState(const ClusterState& other) {
     vespalib::nbostream o;
     other.serialize(o);
     deserialize(o);
+    _maintenanceInAllSpaces = other._maintenanceInAllSpaces;
 }
 
 ClusterState::~ClusterState() = default;
@@ -91,7 +90,7 @@ bool ClusterState::nodeRetired() const noexcept {
 }
 
 bool ClusterState::nodeMaintenance() const noexcept {
-    return nodeHasStateOneOf("m");
+    return _maintenanceInAllSpaces;
 }
 
 void ClusterState::serialize(vespalib::nbostream& o) const {

--- a/persistence/src/vespa/persistence/spi/clusterstate.h
+++ b/persistence/src/vespa/persistence/spi/clusterstate.h
@@ -45,23 +45,28 @@ public:
      * compared to the complete list of nodes, and deigns the system to be
      * unusable.
      */
-    bool clusterUp() const;
+    bool clusterUp() const noexcept;
 
     /**
      * Returns false if this node has been set in a state where it should not
      * receive external load.
      */
-    bool nodeUp() const;
+    bool nodeUp() const noexcept;
 
     /**
      * Returns true iff this node is marked as Initializing in the cluster state.
      */
-    bool nodeInitializing() const;
+    bool nodeInitializing() const noexcept;
 
     /**
      * Returns true iff this node is marked as Retired in the cluster state.
      */
-    bool nodeRetired() const;
+    bool nodeRetired() const noexcept;
+
+    /**
+     * Returns true iff this node is marked as Maintenance in the cluster state.
+     */
+    bool nodeMaintenance() const noexcept;
 
     /**
      * Returns a serialized form of this object.
@@ -74,7 +79,7 @@ private:
     uint16_t _nodeIndex;
 
     void deserialize(vespalib::nbostream&);
-    bool nodeHasStateOneOf(const char* states) const;
+    bool nodeHasStateOneOf(const char* states) const noexcept;
 };
 
 }

--- a/persistence/src/vespa/persistence/spi/clusterstate.h
+++ b/persistence/src/vespa/persistence/spi/clusterstate.h
@@ -23,9 +23,9 @@ public:
 
     ClusterState(const lib::ClusterState& state,
                  uint16_t nodeIndex,
-                 const lib::Distribution& distribution);
+                 const lib::Distribution& distribution,
+                 bool maintenanceInAllSpaces = false);
 
-    ClusterState(vespalib::nbostream& i);
     ClusterState(const ClusterState& other);
     ClusterState& operator=(const ClusterState& other) = delete;
     ~ClusterState();
@@ -45,28 +45,32 @@ public:
      * compared to the complete list of nodes, and deigns the system to be
      * unusable.
      */
-    bool clusterUp() const noexcept;
+    [[nodiscard]] bool clusterUp() const noexcept;
 
     /**
      * Returns false if this node has been set in a state where it should not
      * receive external load.
+     *
+     * TODO rename to indicate bucket space affinity.
      */
-    bool nodeUp() const noexcept;
+    [[nodiscard]] bool nodeUp() const noexcept;
 
     /**
      * Returns true iff this node is marked as Initializing in the cluster state.
+     *
+     * TODO remove, init no longer used internally.
      */
-    bool nodeInitializing() const noexcept;
+    [[nodiscard]] bool nodeInitializing() const noexcept;
 
     /**
      * Returns true iff this node is marked as Retired in the cluster state.
      */
-    bool nodeRetired() const noexcept;
+    [[nodiscard]] bool nodeRetired() const noexcept;
 
     /**
-     * Returns true iff this node is marked as Maintenance in the cluster state.
+     * Returns true iff this node is marked as Maintenance in all bucket space cluster states.
      */
-    bool nodeMaintenance() const noexcept;
+    [[nodiscard]] bool nodeMaintenance() const noexcept;
 
     /**
      * Returns a serialized form of this object.
@@ -77,6 +81,7 @@ private:
     std::unique_ptr<lib::ClusterState> _state;
     std::unique_ptr<lib::Distribution> _distribution;
     uint16_t _nodeIndex;
+    bool _maintenanceInAllSpaces;
 
     void deserialize(vespalib::nbostream&);
     bool nodeHasStateOneOf(const char* states) const noexcept;

--- a/searchcore/src/tests/proton/documentdb/buckethandler/buckethandler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/buckethandler/buckethandler_test.cpp
@@ -281,6 +281,19 @@ TEST_F("node going from maintenance to up state deactivates all buckets", Fixtur
     EXPECT_FALSE(f._bucketInfo.getInfo().isActive());
 }
 
+TEST_F("node going from maintenance to down state deactivates all buckets", Fixture)
+{
+    f._handler.handleSetCurrentState(f._ready.bucket(2),
+                                     BucketInfo::ACTIVE, f._genResult);
+    f.sync();
+    f.setNodeMaintenance(true);
+    f.sync();
+    f.setNodeUp(false);
+    f.sync();
+    f.handleGetBucketInfo(f._ready.bucket(2));
+    EXPECT_FALSE(f._bucketInfo.getInfo().isActive());
+}
+
 TEST_MAIN()
 {
     TEST_RUN_ALL();

--- a/searchcore/src/tests/proton/documentdb/buckethandler/buckethandler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/buckethandler/buckethandler_test.cpp
@@ -140,6 +140,11 @@ struct Fixture
     setNodeUp(bool value)
     {
         _calc->setNodeUp(value);
+        _calc->setNodeMaintenance(false);
+        _handler.notifyClusterStateChanged(_calc);
+    }
+    void setNodeMaintenance(bool value) {
+        _calc->setNodeMaintenance(value);
         _handler.notifyClusterStateChanged(_calc);
     }
 };
@@ -223,7 +228,7 @@ TEST_F("require that unready bucket can be reported as active", Fixture)
 }
 
 
-TEST_F("require that node being down deactivates buckets", Fixture)
+TEST_F("node going down (but not into maintenance state) deactivates all buckets", Fixture)
 {
     f._handler.handleSetCurrentState(f._ready.bucket(2),
                                      BucketInfo::ACTIVE, f._genResult);
@@ -252,6 +257,29 @@ TEST_F("require that node being down deactivates buckets", Fixture)
     EXPECT_EQUAL(true, f._bucketInfo.getInfo().isActive());
 }
 
+TEST_F("node going into maintenance state does _not_ deactivate any buckets", Fixture)
+{
+    f._handler.handleSetCurrentState(f._ready.bucket(2),
+                                     BucketInfo::ACTIVE, f._genResult);
+    f.sync();
+    f.setNodeMaintenance(true);
+    f.sync();
+    f.handleGetBucketInfo(f._ready.bucket(2));
+    EXPECT_TRUE(f._bucketInfo.getInfo().isActive());
+}
+
+TEST_F("node going from maintenance to up state deactivates all buckets", Fixture)
+{
+    f._handler.handleSetCurrentState(f._ready.bucket(2),
+                                     BucketInfo::ACTIVE, f._genResult);
+    f.sync();
+    f.setNodeMaintenance(true);
+    f.sync();
+    f.setNodeUp(true);
+    f.sync();
+    f.handleGetBucketInfo(f._ready.bucket(2));
+    EXPECT_FALSE(f._bucketInfo.getInfo().isActive());
+}
 
 TEST_MAIN()
 {

--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
@@ -26,6 +26,7 @@ private:
     vespalib::ThreadStackExecutor      _executor;
     vespalib::SimpleThreadBundle::Pool _threadBundlePool;
     bool                               _nodeUp;
+    bool                               _nodeMaintenance;
 
 public:
     /**
@@ -130,6 +131,13 @@ public:
      * Set node up/down, based on info from cluster controller.
      */
     void setNodeUp(bool nodeUp);
+
+    /**
+     * Set node into maintenance, based on info from cluster controller. Note that
+     * nodeMaintenance == true also implies setNodeUp(false), as the node is technically
+     * not in a Up state.
+     */
+    void setNodeMaintenance(bool nodeMaintenance);
 
     StatusReport::UP reportStatus() const;
 

--- a/searchcore/src/vespa/searchcore/proton/server/buckethandler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/buckethandler.h
@@ -25,6 +25,7 @@ private:
     documentmetastore::IBucketHandler        *_ready;
     std::vector<IBucketStateChangedHandler *> _changedHandlers;
     bool                                      _nodeUp;
+    bool                                      _nodeMaintenance;
 
     void performSetCurrentState(document::BucketId bucketId,
                                 storage::spi::BucketInfo::ActiveState newState,

--- a/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
@@ -27,6 +27,7 @@ private:
     bool _nodeUp;
     bool _nodeInitializing;
     bool _nodeRetired;
+    bool _nodeMaintenance;
 
 public:
     ClusterStateAdapter(const ClusterState &calc)
@@ -34,7 +35,8 @@ public:
           _clusterUp(_calc.clusterUp()),
           _nodeUp(_calc.nodeUp()),
           _nodeInitializing(_calc.nodeInitializing()),
-          _nodeRetired(_calc.nodeRetired())
+          _nodeRetired(_calc.nodeRetired()),
+          _nodeMaintenance(_calc.nodeMaintenance())
     {
     }
     vespalib::Trinary shouldBeReady(const document::Bucket &bucket) const override {
@@ -44,6 +46,7 @@ public:
     bool nodeUp() const override { return _nodeUp; }
     bool nodeInitializing() const override { return _nodeInitializing; }
     bool nodeRetired() const override { return _nodeRetired; }
+    bool nodeMaintenance() const noexcept override { return _nodeMaintenance; }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
@@ -56,11 +56,12 @@ ClusterStateHandler::performSetClusterState(const ClusterState *calc, IGenericRe
 {
     LOG(debug,
         "performSetClusterState(): "
-        "clusterUp(%s), nodeUp(%s), nodeInitializing(%s)"
+        "clusterUp(%s), nodeUp(%s), nodeInitializing(%s), nodeMaintenance(%s)"
         "changedHandlers.size() = %zu",
         (calc->clusterUp() ? "true" : "false"),
         (calc->nodeUp() ? "true" : "false"),
         (calc->nodeInitializing() ? "true" : "false"),
+        (calc->nodeMaintenance() ? "true" : "false"),
         _changedHandlers.size());
     if (!_changedHandlers.empty()) {
         auto newCalc = std::make_shared<ClusterStateAdapter>(*calc);

--- a/searchcore/src/vespa/searchcore/proton/server/ibucketstatecalculator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ibucketstatecalculator.h
@@ -15,6 +15,7 @@ struct IBucketStateCalculator
     virtual bool nodeUp() const = 0;
     virtual bool nodeInitializing() const = 0;
     virtual bool nodeRetired() const = 0;
+    virtual bool nodeMaintenance() const noexcept = 0;
     virtual ~IBucketStateCalculator() = default;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -869,6 +869,7 @@ Proton::setClusterState(BucketSpace bucketSpace, const storage::spi::ClusterStat
     bool nodeRetired(calc.nodeRetired());
     bool nodeUp = updateNodeUp(bucketSpace, nodeUpInBucketSpace);
     _matchEngine->setNodeUp(nodeUp);
+    _matchEngine->setNodeMaintenance(calc.nodeMaintenance());
     if (_memoryFlushConfigUpdater) {
         _memoryFlushConfigUpdater->setNodeRetired(nodeRetired);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -865,11 +865,11 @@ Proton::setClusterState(BucketSpace bucketSpace, const storage::spi::ClusterStat
     // forward info sent by cluster controller to persistence engine
     // about whether node is supposed to be up or not.  Match engine
     // needs to know this in order to stop serving queries.
-    bool nodeUpInBucketSpace(calc.nodeUp());
+    bool nodeUpInBucketSpace(calc.nodeUp()); // TODO rename calculator function to imply bucket space affinity
     bool nodeRetired(calc.nodeRetired());
     bool nodeUp = updateNodeUp(bucketSpace, nodeUpInBucketSpace);
     _matchEngine->setNodeUp(nodeUp);
-    _matchEngine->setNodeMaintenance(calc.nodeMaintenance());
+    _matchEngine->setNodeMaintenance(calc.nodeMaintenance()); // Note: _all_ bucket spaces in maintenance
     if (_memoryFlushConfigUpdater) {
         _memoryFlushConfigUpdater->setNodeRetired(nodeRetired);
     }

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -133,6 +133,7 @@ private:
     uint32_t getDistributionKey() const override { return _distributionKey; }
     BootstrapConfig::SP getActiveConfigSnapshot() const;
     std::shared_ptr<IDocumentDBReferenceRegistry> getDocumentDBReferenceRegistry() const override;
+    // Returns true if the node is up in _any_ bucket space
     bool updateNodeUp(BucketSpace bucketSpace, bool nodeUpInBucketSpace);
     void closeDocumentDBs(vespalib::ThreadStackExecutorBase & executor);
 public:

--- a/searchcore/src/vespa/searchcore/proton/test/bucketstatecalculator.h
+++ b/searchcore/src/vespa/searchcore/proton/test/bucketstatecalculator.h
@@ -20,6 +20,7 @@ private:
     bool                   _clusterUp;
     bool                   _nodeUp;
     bool                   _nodeRetired;
+    bool                   _nodeMaintenance;
 
 public:
     typedef std::shared_ptr<BucketStateCalculator> SP;
@@ -28,7 +29,8 @@ public:
         _asked(),
         _clusterUp(true),
         _nodeUp(true),
-        _nodeRetired(false)
+        _nodeRetired(false),
+        _nodeMaintenance(false)
     {
     }
     BucketStateCalculator &addReady(const document::BucketId &bucket) {
@@ -54,6 +56,15 @@ public:
         return *this;
     }
 
+    BucketStateCalculator& setNodeMaintenance(bool maintenance) noexcept {
+        _nodeMaintenance = maintenance;
+        if (maintenance) {
+            _nodeUp = false;
+            _nodeRetired = false;
+        }
+        return *this;
+    }
+
     const BucketIdVector &asked() const noexcept { return _asked; }
     void resetAsked() { _asked.clear(); }
 
@@ -67,6 +78,7 @@ public:
     bool nodeUp() const override { return _nodeUp; }
     bool nodeRetired() const override { return _nodeRetired; }
     bool nodeInitializing() const override { return false; }
+    bool nodeMaintenance() const noexcept override { return _nodeMaintenance; }
 };
 
 }

--- a/storage/src/tests/persistence/filestorage/deactivatebucketstest.cpp
+++ b/storage/src/tests/persistence/filestorage/deactivatebucketstest.cpp
@@ -14,11 +14,46 @@ using namespace ::testing;
 namespace storage {
 
 struct DeactivateBucketsTest : FileStorTestFixture {
-    bool isActive(const document::BucketId&) const;
+    std::unique_ptr<TestFileStorComponents> _c;
+
+    [[nodiscard]] bool is_active(const document::BucketId&) const;
+
+    void SetUp() override {
+        FileStorTestFixture::SetUp();
+        _c = std::make_unique<TestFileStorComponents>(*this);
+
+        std::string up_state("storage:2 distributor:2");
+        _node->getStateUpdater().setClusterState(
+                std::make_shared<const lib::ClusterState>(up_state));
+
+        createBucket(test_bucket());
+
+        api::BucketInfo serviceLayerInfo(1, 2, 3, 4, 5, true, true);
+        {
+            StorBucketDatabase::WrappedEntry entry(
+                    _node->getStorageBucketDatabase().get(test_bucket(), "foo",
+                                                          StorBucketDatabase::CREATE_IF_NONEXISTING));
+            entry->info = serviceLayerInfo;
+            entry.write();
+        }
+    }
+
+    void TearDown() override {
+        _c.reset();
+        FileStorTestFixture::TearDown();
+    }
+
+    static document::BucketId test_bucket() noexcept {
+        return {8, 123};
+    }
+
+    static std::shared_ptr<const lib::ClusterState> state_of(const char* str) {
+        return std::make_shared<const lib::ClusterState>(str);
+    }
 };
 
 bool
-DeactivateBucketsTest::isActive(const document::BucketId& bucket) const
+DeactivateBucketsTest::is_active(const document::BucketId& bucket) const
 {
     StorBucketDatabase::WrappedEntry entry(
             _node->getStorageBucketDatabase().get(bucket, "foo"));
@@ -26,31 +61,53 @@ DeactivateBucketsTest::isActive(const document::BucketId& bucket) const
     return entry->info.isActive();
 }
 
-TEST_F(DeactivateBucketsTest, buckets_in_database_deactivated_when_node_down_in_cluster_state) {
-    TestFileStorComponents c(*this);
-    // Must set state to up first, or down-edge case won't trigger.
-    std::string upState("storage:2 distributor:2");
-    _node->getStateUpdater().setClusterState(
-            lib::ClusterState::CSP(new lib::ClusterState(upState)));
-
-    document::BucketId bucket(8, 123);
-
-    createBucket(bucket);
-    api::BucketInfo serviceLayerInfo(1, 2, 3, 4, 5, true, true);
-    {
-        StorBucketDatabase::WrappedEntry entry(
-                _node->getStorageBucketDatabase().get(bucket, "foo",
-                        StorBucketDatabase::CREATE_IF_NONEXISTING));
-        entry->info = serviceLayerInfo;
-        entry.write();
-    }
-    EXPECT_TRUE(isActive(bucket));
-    std::string downState("storage:2 .1.s:d distributor:2");
-    _node->getStateUpdater().setClusterState(
-            lib::ClusterState::CSP(new lib::ClusterState(downState)));
-
+TEST_F(DeactivateBucketsTest, buckets_deactivated_when_node_marked_down)
+{
+    EXPECT_TRUE(is_active(test_bucket()));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 .1.s:d distributor:2"));
     // Buckets should have been deactivated in content layer
-    EXPECT_FALSE(isActive(bucket));
+    EXPECT_FALSE(is_active(test_bucket()));
 }
+
+TEST_F(DeactivateBucketsTest, buckets_not_deactivated_when_node_marked_maintenance)
+{
+    EXPECT_TRUE(is_active(test_bucket()));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 .1.s:m distributor:2"));
+    EXPECT_TRUE(is_active(test_bucket()));
+}
+
+TEST_F(DeactivateBucketsTest, buckets_deactivated_when_node_goes_from_maintenance_to_up)
+{
+    EXPECT_TRUE(is_active(test_bucket()));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 .1.s:m distributor:2"));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 distributor:2"));
+    EXPECT_FALSE(is_active(test_bucket()));
+}
+
+TEST_F(DeactivateBucketsTest, buckets_deactivated_when_node_goes_from_maintenance_to_down)
+{
+    EXPECT_TRUE(is_active(test_bucket()));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 .1.s:m distributor:2"));
+    _node->getStateUpdater().setClusterState(state_of("storage:2 distributor:2"));
+    EXPECT_FALSE(is_active(test_bucket()));
+}
+
+// If we only have a subset of the bucket spaces in maintenance mode (i.e. global
+// bucket merge enforcement), we treat this as the node being down from the perspective
+// of default space bucket deactivation.
+TEST_F(DeactivateBucketsTest, bucket_space_subset_in_maintenance_deactivates_buckets)
+{
+    EXPECT_TRUE(is_active(test_bucket()));
+    auto derived = lib::ClusterStateBundle::BucketSpaceStateMapping({
+        {document::FixedBucketSpaces::default_space(), state_of("storage:2 .1.s:m distributor:2")},
+        {document::FixedBucketSpaces::global_space(),  state_of("storage:2 distributor:2")}
+    });
+    _node->getStateUpdater().setClusterStateBundle(
+            std::make_shared<const lib::ClusterStateBundle>(*state_of("storage:2 .1.s:m distributor:2"),
+                                                            std::move(derived)));
+    EXPECT_FALSE(is_active(test_bucket()));
+}
+
+// TODO should also test SPI interaction
 
 } // namespace storage

--- a/storage/src/vespa/storage/common/content_bucket_space.cpp
+++ b/storage/src/vespa/storage/common/content_bucket_space.cpp
@@ -57,4 +57,18 @@ ContentBucketSpace::setNodeUpInLastNodeStateSeenByProvider(bool nodeUpInLastNode
     _nodeUpInLastNodeStateSeenByProvider = nodeUpInLastNodeStateSeenByProvider;
 }
 
+bool
+ContentBucketSpace::getNodeMaintenanceInLastNodeStateSeenByProvider() const
+{
+    std::lock_guard guard(_lock);
+    return _nodeMaintenanceInLastNodeStateSeenByProvider;
+}
+
+void
+ContentBucketSpace::setNodeMaintenanceInLastNodeStateSeenByProvider(bool nodeMaintenanceInLastNodeStateSeenByProvider)
+{
+    std::lock_guard guard(_lock);
+    _nodeMaintenanceInLastNodeStateSeenByProvider = nodeMaintenanceInLastNodeStateSeenByProvider;
+}
+
 }

--- a/storage/src/vespa/storage/common/content_bucket_space.h
+++ b/storage/src/vespa/storage/common/content_bucket_space.h
@@ -23,6 +23,7 @@ private:
     std::shared_ptr<const lib::ClusterState> _clusterState;
     std::shared_ptr<const lib::Distribution> _distribution;
     bool _nodeUpInLastNodeStateSeenByProvider;
+    bool _nodeMaintenanceInLastNodeStateSeenByProvider;
 
 public:
     using UP = std::unique_ptr<ContentBucketSpace>;
@@ -36,6 +37,8 @@ public:
     std::shared_ptr<const lib::Distribution> getDistribution() const;
     bool getNodeUpInLastNodeStateSeenByProvider() const;
     void setNodeUpInLastNodeStateSeenByProvider(bool nodeUpInLastNodeStateSeenByProvider);
+    bool getNodeMaintenanceInLastNodeStateSeenByProvider() const;
+    void setNodeMaintenanceInLastNodeStateSeenByProvider(bool nodeMaintenanceInLastNodeStateSeenByProvider);
 };
 
 }

--- a/storage/src/vespa/storage/common/content_bucket_space_repo.h
+++ b/storage/src/vespa/storage/common/content_bucket_space_repo.h
@@ -21,8 +21,8 @@ private:
 public:
     explicit ContentBucketSpaceRepo(const ContentBucketDbOptions&);
     ContentBucketSpace &get(document::BucketSpace bucketSpace) const;
-    BucketSpaceMap::const_iterator begin() const { return _map.begin(); }
-    BucketSpaceMap::const_iterator end() const { return _map.end(); }
+    BucketSpaceMap::const_iterator begin() const noexcept { return _map.begin(); }
+    BucketSpaceMap::const_iterator end() const noexcept { return _map.end(); }
 
     BucketSpaces getBucketSpaces() const;
     size_t getBucketMemoryUsage() const;

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -39,6 +39,7 @@ namespace api {
 }
 namespace spi { struct PersistenceProvider; }
 
+class ContentBucketSpace;
 struct FileStorManagerTest;
 class ReadBucketList;
 class BucketOwnershipNotifier;
@@ -170,6 +171,11 @@ private:
     void onFlush(bool downwards) override;
     void reportHtmlStatus(std::ostream&, const framework::HttpUrlPath&) const override;
     void storageDistributionChanged() override;
+    [[nodiscard]] static bool should_deactivate_buckets(const ContentBucketSpace& space,
+                                                        bool node_up_in_space,
+                                                        bool maintenance_in_all_spaces) noexcept;
+    [[nodiscard]] bool maintenance_in_all_spaces(const lib::Node& node) const noexcept;
+    void maybe_log_received_cluster_state();
     void updateState();
     void propagateClusterStates();
     void update_reported_state_after_db_init();


### PR DESCRIPTION
@geirst @baldersheim @toregge please review.

Previously, entering maintenance state would implicitly deactivate
all buckets on the searchnode and cause empty responses to be returned
for searches.

However, container query dispatch uses async health pings to decide
which nodes to route queries to, so it would be possible for a node to
still be used for queries for a few seconds until the ping discovered
that the node should not be used. In the case of multiple groups without
multiple ready replicas within the group, this would cause transient
coverage loss since the dispatcher would not realize it should route
queries to other groups instead.

With this commit, maintenance edge behavior is changed as follows:

 - Buckets are _not_ deactivated when going from an available state
   to the maintenance state. However, they _are_ deactivate when going
   from maintenance state to an available state in order to avoid transient
   query duplicates immediately after the change.
 - Searches are executed as normal instead of returning empty replies
   when the node is in maintenance state.

The following behavior is intentionally _not_ changed:

 - The search interface is still marked as offline when in maintenance
   state, as this signals that the node should be taken out of rotation.
   In particular, it's critical that the RPC health ping response is
   explicitly tagged as having zero active docs when the search interface
   is offline, even though many buckets may now actually be active.
   Otherwise, queries would not be gracefully drained from the node.
