### PR TITLE
Revert "Print go version for debugging"

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -97,7 +97,6 @@ endif
 #
 
 install:
-	go version
 	env GOBIN=$(BIN) go install $(GO_FLAGS) ./...
 
 manpages: install


### PR DESCRIPTION
Reverts vespa-engine/vespa#20202

No longer needed