### PR TITLE
Reduce log level from error to warning for update inconsistency message

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
@@ -155,13 +155,13 @@ UpdateOperation::onReceive(DistributorStripeMessageSender& sender,
 
                 for (uint32_t i = 0; i < _results.size(); i++) {
                     if (_results[i].oldTs < oldTs) {
-                        LOG(error, "Update operation for '%s' in bucket %s updated documents with different timestamps. "
-                                   "This should not happen and may indicate undetected replica divergence. "
-                                   "Found ts=%" PRIu64 " on node %u, ts=%" PRIu64 " on node %u",
-                                   reply.getDocumentId().toString().c_str(),
-                                   reply.getBucket().toString().c_str(),
-                                   _results[i].oldTs, _results[i].nodeId,
-                                   _results[goodNode].oldTs, _results[goodNode].nodeId);
+                        LOG(warning, "Update operation for '%s' in bucket %s updated documents with different timestamps. "
+                                     "This should not happen and may indicate undetected replica divergence. "
+                                     "Found ts=%" PRIu64 " on node %u, ts=%" PRIu64 " on node %u",
+                                     reply.getDocumentId().toString().c_str(),
+                                     reply.getBucket().toString().c_str(),
+                                     _results[i].oldTs, _results[i].nodeId,
+                                     _results[goodNode].oldTs, _results[goodNode].nodeId);
                         _metrics.diverging_timestamp_updates.inc();
 
                         replyToSend.setNodeWithNewestTimestamp(_results[goodNode].nodeId);


### PR DESCRIPTION
@baldersheim please review

`error` level is for the "node is on fire and falling down an elevator
shaft" type of messages, not for operation inconsistencies. Reduce
to `warning` accordingly.

