### PR TITLE
Suppress valgrind errors on CentOS 8 / aarch64.

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -2,6 +2,13 @@
    NPTL keeps a cache of thread stacks, and metadata for thread local storage is not freed for threads in that cache
    Memcheck:Leak
    fun:calloc
+   fun:_dl_allocate_tls
+   fun:pthread_create@@GLIBC_2.17
+}
+{
+   NPTL keeps a cache of thread stacks, and metadata for thread local storage is not freed for threads in that cache
+   Memcheck:Leak
+   fun:calloc
    fun:UnknownInlinedFun
    fun:allocate_dtv
    fun:_dl_allocate_tls


### PR DESCRIPTION
@aressem : please review
