### PR TITLE
Simplify ConfigSubscription [run-systemtest]

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
@@ -4,7 +4,6 @@ package com.yahoo.config.subscription.impl;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.subscription.ConfigSet;
 import com.yahoo.config.subscription.ConfigSource;
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.vespa.config.ConfigKey;
 
 import java.lang.reflect.Constructor;
@@ -19,8 +18,8 @@ public class ConfigSetSubscription<T extends ConfigInstance> extends ConfigSubsc
     private final ConfigSet set;
     private final ConfigKey<T> subKey;
 
-    ConfigSetSubscription(ConfigKey<T> key, ConfigSubscriber subscriber, ConfigSource cset) {
-        super(key, subscriber);
+    ConfigSetSubscription(ConfigKey<T> key, ConfigSource cset) {
+        super(key);
         if (!(cset instanceof ConfigSet)) throw new IllegalArgumentException("Source is not a ConfigSet: " + cset);
         this.set = (ConfigSet) cset;
         subKey = new ConfigKey<>(configClass, key.getConfigId());

--- a/config/src/main/java/com/yahoo/config/subscription/impl/FileConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/FileConfigSubscription.java
@@ -5,7 +5,6 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.subscription.CfgConfigPayloadBuilder;
 import com.yahoo.config.subscription.ConfigInterruptedException;
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
@@ -26,8 +25,8 @@ public class FileConfigSubscription<T extends ConfigInstance> extends ConfigSubs
     final File file;
     long ts;
 
-    FileConfigSubscription(ConfigKey<T> key, ConfigSubscriber subscriber, File f) {
-        super(key, subscriber);
+    FileConfigSubscription(ConfigKey<T> key, File f) {
+        super(key);
         setGeneration(0L);
         file = f;
         if (!file.exists() && !file.isFile())

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -34,6 +34,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
 
     private JRTConfigRequester requester;
     private final TimingValues timingValues;
+    private final ConfigSubscriber subscriber;
 
     // Last time we got an OK JRT callback
     private Instant lastOK = Instant.MIN;
@@ -46,8 +47,9 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     private ConfigSourceSet sources;
 
     public JRTConfigSubscription(ConfigKey<T> key, ConfigSubscriber subscriber, ConfigSource source, TimingValues timingValues) {
-        super(key, subscriber);
+        super(key);
         this.timingValues = timingValues;
+        this.subscriber = subscriber;
         if (source instanceof ConfigSourceSet) {
             this.sources = (ConfigSourceSet) source;
         }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
@@ -5,7 +5,6 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.subscription.CfgConfigPayloadBuilder;
 import com.yahoo.config.subscription.ConfigInterruptedException;
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.io.IOUtils;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
@@ -32,8 +31,8 @@ public class JarConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     private ZipEntry zipEntry = null;
 
     // jar:configs/app.jar!/configs/
-    JarConfigSubscription(ConfigKey<T> key, ConfigSubscriber subscriber, String jarName, String path) {
-        super(key, subscriber);
+    JarConfigSubscription(ConfigKey<T> key, String jarName, String path) {
+        super(key);
         this.jarName = jarName;
         this.path = path;
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
@@ -4,7 +4,6 @@ package com.yahoo.config.subscription.impl;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.subscription.CfgConfigPayloadBuilder;
 import com.yahoo.config.subscription.ConfigInterruptedException;
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConfigPayload;
 import com.yahoo.vespa.config.PayloadChecksums;
@@ -23,9 +22,9 @@ public class RawConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     final String inputPayload;
     String payload;
 
-    RawConfigSubscription(ConfigKey<T> key, ConfigSubscriber subscriber, String pl) {
-        super(key, subscriber);
-        this.inputPayload = pl;
+    RawConfigSubscription(ConfigKey<T> key, String payload) {
+        super(key);
+        this.inputPayload = payload;
     }
 
     @Override

--- a/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
@@ -1,15 +1,18 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
-import static org.junit.Assert.*;
-
+import com.yahoo.config.subscription.impl.ConfigSubscription;
 import com.yahoo.foo.AppConfig;
 import com.yahoo.foo.SimpletypesConfig;
 import com.yahoo.foo.StringConfig;
-import com.yahoo.config.subscription.impl.ConfigSubscription;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.TimingValues;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ConfigSetSubscriptionTest {
 

--- a/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
@@ -1,11 +1,10 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription.impl;
 
-import com.yahoo.foo.SimpletypesConfig;
-import com.yahoo.foo.TestReferenceConfig;
 import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.config.subscription.DirSource;
-import com.yahoo.config.subscription.FileSource;
+import com.yahoo.foo.SimpletypesConfig;
+import com.yahoo.foo.TestReferenceConfig;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.TimingValues;
 import org.junit.Before;
@@ -43,10 +42,8 @@ public class FileConfigSubscriptionTest {
     @Test
     public void require_that_new_config_is_detected_in_time() throws IOException, InterruptedException {
         writeConfig("intval", "23");
-        ConfigSubscriber subscriber = new ConfigSubscriber(new FileSource(TEST_TYPES_FILE));
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                subscriber,
                 TEST_TYPES_FILE);
         assertTrue(sub.nextConfig(1000));
         assertThat(sub.getConfigState().getConfig().intval(), is(23));
@@ -59,10 +56,8 @@ public class FileConfigSubscriptionTest {
     @Test
     public void require_that_new_config_is_detected_on_reload() throws IOException {
         writeConfig("intval", "23");
-        ConfigSubscriber subscriber = new ConfigSubscriber(new FileSource(TEST_TYPES_FILE));
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                subscriber,
                 TEST_TYPES_FILE);
         assertTrue(sub.nextConfig(1000));
         assertThat(sub.getConfigState().getConfig().intval(), is(23));
@@ -113,10 +108,8 @@ public class FileConfigSubscriptionTest {
     public void require_that_bad_file_throws_exception() throws IOException {
         // A little trick to ensure that we can create the subscriber, but that we get an error when reading.
         writeConfig("intval", "23");
-        ConfigSubscriber subscriber = new ConfigSubscriber(new FileSource(TEST_TYPES_FILE));
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                subscriber,
                 TEST_TYPES_FILE);
         sub.reload(1);
         Files.delete(TEST_TYPES_FILE.toPath()); // delete file so the below statement throws exception


### PR DESCRIPTION
COnfigSubscriber isn't needed for all subscription (used only in equals method,
whoch is only used by tests).