### PR TITLE
Make active attribute on region tag optional

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/xml/DeploymentSpecXmlReader.java
@@ -477,9 +477,10 @@ public class DeploymentSpecXmlReader {
 
     private boolean readActive(Element regionTag) {
         String activeValue = regionTag.getAttribute("active");
+        if ("".equals(activeValue)) return true; // Default to active
         if ("true".equals(activeValue)) return true;
         if ("false".equals(activeValue)) return false;
-        throw new IllegalArgumentException("Region tags must have an 'active' attribute set to 'true' or 'false' " +
+        throw new IllegalArgumentException("Value of 'active' attribute in region tag must be 'true' or 'false' " +
                                            "to control whether this region should receive traffic from the global endpoint of this application");
     }
 

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -1162,8 +1162,8 @@ public class DeploymentSpecTest {
         var spec = DeploymentSpec.fromXml("<deployment>" +
                                           "   <instance id='default'>" +
                                           "      <prod>" +
-                                          "         <region active=\"true\">us-east</region>" +
-                                          "         <region active=\"true\">us-west</region>" +
+                                          "         <region>us-east</region>" +
+                                          "         <region>us-west</region>" +
                                           "      </prod>" +
                                           "      <endpoints>" +
                                           "         <endpoint id=\"foo\" container-id=\"bar\">" +


### PR DESCRIPTION
This allows tenants to stop specifying the attribute, as it's unnecessary when
declaring global endpoints with the current syntax (`<endpoints>`).

@tokle