### PR TITLE
Reduce default bucket delete priority and fix priority inheritance for merge-triggered deletion [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/statecheckerstest.cpp
+++ b/storage/src/tests/distributor/statecheckerstest.cpp
@@ -858,7 +858,7 @@ TEST_F(StateCheckersTest, delete_extra_copies) {
 
     EXPECT_EQ("[Removing all copies since bucket is empty:node(idx=0,crc=0x0,"
               "docs=0/0,bytes=0/0,trusted=false,active=false,ready=false)]"
-              " (pri 100)",
+              " (pri 120)",
               testDeleteExtraCopies("0=0", 2, PendingMessage(), "", true)) << "Remove empty buckets";
 
     EXPECT_EQ("[Removing redundant in-sync copy from node 2]",

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -103,7 +103,7 @@ priority_activate_no_existing_active int default=100
 priority_activate_with_existing_active int default=100
 
 ## Deletion of bucket copy.
-priority_delete_bucket_copy int default=100
+priority_delete_bucket_copy int default=120
 
 ## Joining caused by bucket siblings getting sufficiently small to fit into a
 ## single bucket.

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -253,6 +253,7 @@ MergeOperation::deleteSourceOnlyNodes(
             return;
         }
         _removeOperation->setIdealStateManager(_manager);
+        _removeOperation->setPriority(getPriority());
         
         if (_removeOperation->onStartInternal(sender)) {
             _ok = _removeOperation->ok();


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Since deletes are now async in the backend, make them FIFO-order with
client feed by default to avoid swamping the queues with deletes.
Also, explicitly inherit priority for bucket deletion triggered by
bucket merging. This was actually missing previously and meant such
deletes got the default, very low priority.

