### PR TITLE
Preserve change flag for concurrent config updates [run-systemtest]

### DIFF
--- a/config/src/vespa/config/common/configvalue.cpp
+++ b/config/src/vespa/config/common/configvalue.cpp
@@ -55,7 +55,7 @@ ConfigValue::getLegacyFormat() const
     return lines;
 }
 
-const vespalib::string
+vespalib::string
 ConfigValue::asJson() const {
     if (_payload) {
         const vespalib::slime::Inspector & payload(_payload->getSlimePayload());

--- a/config/src/vespa/config/common/configvalue.h
+++ b/config/src/vespa/config/common/configvalue.h
@@ -35,8 +35,8 @@ public:
     const vespalib::string & getLine(int i) const { return _lines.at(i);  }
     const std::vector<vespalib::string> & getLines() const { return _lines;  }
     std::vector<vespalib::string> getLegacyFormat() const;
-    const vespalib::string asJson() const;
-    const vespalib::string getXxhash64() const { return _xxhash64; }
+    vespalib::string asJson() const;
+    const vespalib::string& getXxhash64() const { return _xxhash64; }
 
     void serializeV1(::vespalib::slime::Cursor & cursor) const;
     void serializeV2(::vespalib::slime::Cursor & cursor) const;

--- a/config/src/vespa/config/frt/frtconfigagent.cpp
+++ b/config/src/vespa/config/frt/frtconfigagent.cpp
@@ -71,7 +71,7 @@ FRTConfigAgent::handleUpdatedGeneration(const ConfigKey & key, const ConfigState
     if (LOG_WOULD_LOG(spam)) {
         LOG(spam, "updating holder for key %s,", key.toString().c_str());
     }
-    _holder->handle(ConfigUpdate::UP(new ConfigUpdate(_latest, changed, newState.generation)));
+    _holder->handle(std::make_unique<ConfigUpdate>(_latest, changed, newState.generation));
     _numConfigured++;
 }
 

--- a/config/src/vespa/config/subscription/configsubscription.cpp
+++ b/config/src/vespa/config/subscription/configsubscription.cpp
@@ -102,7 +102,7 @@ ConfigSubscription::flip()
         _current = std::move(_next);
         _lastGenerationChanged = _current->getGeneration();
     } else {
-        _current.reset(new ConfigUpdate(_current->getValue(), false, _next->getGeneration()));
+        _current = std::make_unique<ConfigUpdate>(_current->getValue(), false, _next->getGeneration());
     }
     _isChanged = change;
 }

--- a/config/src/vespa/config/subscription/configsubscription.cpp
+++ b/config/src/vespa/config/subscription/configsubscription.cpp
@@ -31,7 +31,11 @@ ConfigSubscription::nextUpdate(int64_t generation, std::chrono::milliseconds tim
     if (_closed || !_holder->poll()) {
         return false;
     }
+    auto old = std::move(_next);
     _next = _holder->provide();
+    if (old) {
+        _next->merge(*old);
+    }
     if (isGenerationNewer(_next->getGeneration(), generation)) {
         return true;
     }


### PR DESCRIPTION
@baldersheim @hmusum please review

This should avoid the following race condition between two config updates
arriving within a very short interval:

 1. Config generation _n-1_ contains changes to payload
 2. Subscriber thread does not apply config _n-1_ internally before
    generation _n_ arrives
 3. Config generation _n_ does not contain changes to payload. Overwrites
    change flag of generation _n-1_
 4. Change status lost, subscriber does not update internal config