### PR TITLE
Put node ID in the ID field

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -69,13 +69,13 @@ public final class Node implements Nodelike {
     }
 
     /** Creates a node builder in the initial state (provisioned) */
-    public static Node.Builder create(String openStackId, IP.Config ipConfig, String hostname, Flavor flavor, NodeType type) {
-        return new Node.Builder(openStackId, hostname, flavor, State.provisioned, type).ipConfig(ipConfig);
+    public static Node.Builder create(String id, IP.Config ipConfig, String hostname, Flavor flavor, NodeType type) {
+        return new Node.Builder(id, hostname, flavor, State.provisioned, type).ipConfig(ipConfig);
     }
 
     /** Creates a node builder */
-    public static Node.Builder create(String openStackId, String hostname, Flavor flavor, Node.State state, NodeType type) {
-        return new Node.Builder(openStackId, hostname, flavor, state, type);
+    public static Node.Builder create(String id, String hostname, Flavor flavor, Node.State state, NodeType type) {
+        return new Node.Builder(id, hostname, flavor, state, type);
     }
 
     /** DO NOT USE: public for serialization purposes. See {@code create} helper methods. */
@@ -328,9 +328,9 @@ public final class Node implements Nodelike {
                         allocation, history, type, reports, modelName, reservedTo, exclusiveToApplicationId, exclusiveToClusterType, switchHostname, trustStoreItems);
     }
 
-    /** Returns a copy of this with the openStackId set */
-    public Node withOpenStackId(String openStackId) {
-        return new Node(openStackId, ipConfig, hostname, parentHostname, flavor, status, state,
+    /** Returns a copy of this with given id set */
+    public Node withId(String id) {
+        return new Node(id, ipConfig, hostname, parentHostname, flavor, status, state,
                         allocation, history, type, reports, modelName, reservedTo, exclusiveToApplicationId, exclusiveToClusterType, switchHostname, trustStoreItems);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -174,8 +174,9 @@ public class NodePatcher {
                                              clock.instant());
             case "reports" :
                 return nodeWithPatchedReports(node, value);
-            case "openStackId" :
-                return node.withOpenStackId(asString(value));
+            case "id" :
+            case "openStackId" : // TODO(mpolden): Remove when clients stop sending this field
+                return node.withId(asString(value));
             case "diskGb":
             case "minDiskAvailableGb":
                 return node.with(node.flavor().with(node.flavor().resources().withDiskGb(value.asDouble())), Agent.operator, clock.instant());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -121,14 +121,14 @@ class NodesResponse extends SlimeJsonResponse {
 
         object.setString("url", nodeParentUrl + node.hostname());
         if ( ! allFields) return;
-        object.setString("id", node.hostname());
+        object.setString("id", node.id());
         object.setString("state", NodeSerializer.toString(node.state()));
         object.setString("type", NodeSerializer.toString(node.type()));
         object.setString("hostname", node.hostname());
         if (node.parentHostname().isPresent()) {
             object.setString("parentHostname", node.parentHostname().get());
         }
-        object.setString("openStackId", node.id());
+        object.setString("openStackId", node.id()); // TODO(mpolden): Remove this when all clients use "id"
         object.setString("flavor", node.flavor().name());
         node.reservedTo().ifPresent(reservedTo -> object.setString("reservedTo", reservedTo.value()));
         node.exclusiveToApplicationId().ifPresent(applicationId -> object.setString("exclusiveTo", applicationId.serializedForm()));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -267,7 +267,13 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
         inspector.field("additionalHostnames").traverse((ArrayTraverser) (i, item) ->
                 addressPool.add(new Address(item.asString())));
 
-        Node.Builder builder = Node.create(inspector.field("openStackId").asString(),
+        final String id;
+        if (inspector.field("id").valid()) {
+            id = inspector.field("id").asString();
+        } else {
+            id = inspector.field("openStackId").asString(); // TODO(mpolden): Remove when clients stop sending this field
+        }
+        Node.Builder builder = Node.create(id,
                                            IP.Config.of(ipAddresses, ipAddressPool, addressPool),
                                            inspector.field("hostname").asString(),
                                            flavorFromSlime(inspector),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -183,7 +183,7 @@ public class MetricsReporterTest {
         // Allow 4 containers
         Set<String> ipAddressPool = Set.of("::2", "::3", "::4", "::5");
 
-        Node dockerHost = Node.create("openStackId1", new IP.Config(Set.of("::1"), ipAddressPool), "dockerHost",
+        Node dockerHost = Node.create("node-id-1", new IP.Config(Set.of("::1"), ipAddressPool), "dockerHost",
                                       nodeFlavors.getFlavorOrThrow("host"), NodeType.host).build();
         nodeRepository.nodes().addNodes(List.of(dockerHost), Agent.system);
         nodeRepository.nodes().deallocateRecursively("dockerHost", Agent.system, getClass().getSimpleName());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -198,7 +198,7 @@ public class NodesV2ApiTest {
                         Utf8.toBytes("{\"currentVespaVersion\": \"6.43.0\",\"currentDockerImage\": \"docker-registry.domain.tld:8080/dist/vespa:6.45.0\"}"), Request.Method.PATCH),
                         "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-                        Utf8.toBytes("{\"openStackId\": \"patched-id\"}"), Request.Method.PATCH),
+                        Utf8.toBytes("{\"id\": \"patched-id\"}"), Request.Method.PATCH),
                 "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
                                    Utf8.toBytes("{\"modelName\": \"foo\"}"), Request.Method.PATCH),
@@ -383,7 +383,7 @@ public class NodesV2ApiTest {
 
     @Test
     public void post_controller_node() throws Exception {
-        String data = "[{\"hostname\":\"controller1.yahoo.com\", \"openStackId\":\"fake-controller1.yahoo.com\"," +
+        String data = "[{\"hostname\":\"controller1.yahoo.com\", \"id\":\"fake-controller1.yahoo.com\"," +
                       createIpAddresses("127.0.0.1") +
                       "\"flavor\":\"default\"" +
                       ", \"type\":\"controller\"}]";
@@ -873,14 +873,14 @@ public class NodesV2ApiTest {
         String host = "parent2.yahoo.com";
         // Test adding with overrides
         tester.assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                                          ("[{\"hostname\":\"" + host + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," +
+                                          ("[{\"hostname\":\"" + host + "\"," + createIpAddresses("::1") + "\"id\":\"osid-123\"," +
                                            "\"flavor\":\"large-variant\",\"resources\":{\"diskGb\":1234,\"memoryGb\":4321}}]").getBytes(StandardCharsets.UTF_8),
                                           Request.Method.POST),
                 400,
                 "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Can only override disk GB for configured flavor\"}");
 
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                        ("[{\"hostname\":\"" + host + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," +
+                        ("[{\"hostname\":\"" + host + "\"," + createIpAddresses("::1") + "\"id\":\"osid-123\"," +
                                 "\"flavor\":\"large-variant\",\"type\":\"host\",\"resources\":{\"diskGb\":1234}}]").
                                 getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
@@ -892,7 +892,7 @@ public class NodesV2ApiTest {
         String tenant = "node-1-3.yahoo.com";
         String resources = "\"resources\":{\"vcpu\":64.0,\"memoryGb\":128.0,\"diskGb\":1234.0,\"bandwidthGbps\":15.0,\"diskSpeed\":\"slow\",\"storageType\":\"remote\"}";
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                        ("[{\"hostname\":\"" + tenant + "\"," + createIpAddresses("::2") + "\"openStackId\":\"osid-124\"," +
+                        ("[{\"hostname\":\"" + tenant + "\"," + createIpAddresses("::2") + "\"id\":\"osid-124\"," +
                                 "\"type\":\"tenant\"," + resources + "}]").
                                 getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
@@ -920,14 +920,14 @@ public class NodesV2ApiTest {
         String resources = "\"resources\":{\"vcpu\":5.0,\"memoryGb\":4321.0,\"diskGb\":1234.0,\"bandwidthGbps\":0.3,\"diskSpeed\":\"slow\",\"storageType\":\"local\"}";
         // Test adding new node with resources
         tester.assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                                          ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," +
+                                          ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"id\":\"osid-123\"," +
                                            resources.replace("\"memoryGb\":4321.0,", "") + "}]").getBytes(StandardCharsets.UTF_8),
                                           Request.Method.POST),
                               400,
                               "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Required field 'memoryGb' is missing\"}");
 
         assertResponse(new Request("http://localhost:8080/nodes/v2/node",
-                        ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"openStackId\":\"osid-123\"," + resources + "}]")
+                        ("[{\"hostname\":\"" + hostname + "\"," + createIpAddresses("::1") + "\"id\":\"osid-123\"," + resources + "}]")
                                 .getBytes(StandardCharsets.UTF_8),
                         Request.Method.POST),
                 "{\"message\":\"Added 1 nodes to the provisioned state\"}");
@@ -1029,13 +1029,13 @@ public class NodesV2ApiTest {
     private static String asDockerNodeJson(String hostname, NodeType nodeType, String parentHostname, String... ipAddress) {
         return "{\"hostname\":\"" + hostname + "\", \"parentHostname\":\"" + parentHostname + "\"," +
                createIpAddresses(ipAddress) +
-               "\"openStackId\":\"" + hostname + "\",\"flavor\":\"d-1-1-100\"" +
+               "\"id\":\"" + hostname + "\",\"flavor\":\"d-1-1-100\"" +
                (nodeType != NodeType.tenant ? ",\"type\":\"" + nodeType +  "\"" : "") +
                "}";
     }
 
     private static String asNodeJson(String hostname, String flavor, String... ipAddress) {
-        return "{\"hostname\":\"" + hostname + "\", \"openStackId\":\"" + hostname + "\"," +
+        return "{\"hostname\":\"" + hostname + "\", \"id\":\"" + hostname + "\"," +
                 createIpAddresses(ipAddress) +
                 "\"flavor\":\"" + flavor + "\"}";
     }
@@ -1048,7 +1048,7 @@ public class NodesV2ApiTest {
     private static String asNodeJson(String hostname, NodeType nodeType, String flavor, Optional<TenantName> reservedTo,
                                      Optional<ApplicationId> exclusiveTo, Optional<String> switchHostname,
                                      List<String> additionalHostnames, String... ipAddress) {
-        return "{\"hostname\":\"" + hostname + "\", \"openStackId\":\"" + hostname + "\"," +
+        return "{\"hostname\":\"" + hostname + "\", \"id\":\"" + hostname + "\"," +
                createIpAddresses(ipAddress) +
                "\"flavor\":\"" + flavor + "\"" +
                (reservedTo.map(tenantName -> ", \"reservedTo\":\"" + tenantName.value() + "\"").orElse("")) +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -198,7 +198,7 @@ public class NodesV2ApiTest {
                         Utf8.toBytes("{\"currentVespaVersion\": \"6.43.0\",\"currentDockerImage\": \"docker-registry.domain.tld:8080/dist/vespa:6.45.0\"}"), Request.Method.PATCH),
                         "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-                        Utf8.toBytes("{\"openStackId\": \"patched-openstackid\"}"), Request.Method.PATCH),
+                        Utf8.toBytes("{\"openStackId\": \"patched-id\"}"), Request.Method.PATCH),
                 "{\"message\":\"Updated host4.yahoo.com\"}");
         assertResponse(new Request("http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
                                    Utf8.toBytes("{\"modelName\": \"foo\"}"), Request.Method.PATCH),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/cfg1.yahoo.com",
-  "id": "cfg1.yahoo.com",
+  "id": "cfg1",
   "state": "ready",
   "type": "config",
   "hostname": "cfg1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/cfg2.yahoo.com",
-  "id": "cfg2.yahoo.com",
+  "id": "cfg2",
   "state": "ready",
   "type": "config",
   "hostname": "cfg2.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/controller1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/controller1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/controller1.yahoo.com",
-  "id": "controller1.yahoo.com",
+  "id": "fake-controller1.yahoo.com",
   "state": "provisioned",
   "type": "controller",
   "hostname": "controller1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/test-node-pool-102-2",
-  "id": "test-node-pool-102-2",
+  "id": "fake-test-node-pool-102-2",
   "state": "active",
   "type": "tenant",
   "hostname": "test-node-pool-102-2",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-2.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-3.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports-4.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-reports.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost2.yahoo.com",
-  "id": "dockerhost2.yahoo.com",
+  "id": "dockerhost2",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost2.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node3.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost3.yahoo.com",
-  "id": "dockerhost3.yahoo.com",
+  "id": "dockerhost3",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost3.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node4.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost4.yahoo.com",
-  "id": "dockerhost4.yahoo.com",
+  "id": "dockerhost4",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost4.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node5.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost5.yahoo.com",
-  "id": "dockerhost5.yahoo.com",
+  "id": "dockerhost5",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost5.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost1.yahoo.com",
-  "id": "dockerhost1.yahoo.com",
+  "id": "dockerhost1",
   "state": "active",
   "type": "host",
   "hostname": "dockerhost1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost6.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/dockerhost6.yahoo.com",
-  "id": "dockerhost6.yahoo.com",
+  "id": "dockerhost6",
   "state": "deprovisioned",
   "type": "host",
   "hostname": "dockerhost6.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host1.yahoo.com",
-  "id": "host1.yahoo.com",
+  "id": "node1",
   "state": "active",
   "type": "tenant",
   "hostname": "host1.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node10.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host10.yahoo.com",
-  "id": "host10.yahoo.com",
+  "id": "node10",
   "state": "active",
   "type": "tenant",
   "hostname": "host10.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host13.yahoo.com",
-  "id": "host13.yahoo.com",
+  "id": "node13",
   "state": "active",
   "type": "tenant",
   "hostname": "host13.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host14.yahoo.com",
-  "id": "host14.yahoo.com",
+  "id": "node14",
   "state": "active",
   "type": "tenant",
   "hostname": "host14.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node2.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host2.yahoo.com",
-  "id": "host2.yahoo.com",
+  "id": "node2",
   "state": "active",
   "type": "tenant",
   "hostname": "host2.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node3.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host3.yahoo.com",
-  "id": "host3.yahoo.com",
+  "id": "node3",
   "state": "ready",
   "type": "tenant",
   "hostname": "host3.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-after-changes.json
@@ -1,11 +1,11 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-  "id": "host4.yahoo.com",
+  "id": "patched-id",
   "state": "active",
   "type": "tenant",
   "hostname": "host4.yahoo.com",
   "parentHostname": "parent.yahoo.com",
-  "openStackId": "patched-openstackid",
+  "openStackId": "patched-id",
   "flavor": "d-2-8-100",
   "cpuCores": 2.0,
   "resources":{"vcpu":2.0,"memoryGb":8.0,"diskGb":100.0,"bandwidthGbps":1.0,"diskSpeed":"fast","storageType":"remote"},

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-with-hostnames.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-  "id": "host4.yahoo.com",
+  "id": "node4",
   "state": "active",
   "type": "tenant",
   "hostname": "host4.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host4.yahoo.com",
-  "id": "host4.yahoo.com",
+  "id": "node4",
   "state": "active",
   "type": "tenant",
   "hostname": "host4.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host5.yahoo.com",
-  "id": "host5.yahoo.com",
+  "id": "node5",
   "state": "failed",
   "type": "tenant",
   "hostname": "host5.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host5.yahoo.com",
-  "id": "host5.yahoo.com",
+  "id": "node5",
   "state": "failed",
   "type": "tenant",
   "hostname": "host5.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host55.yahoo.com",
-  "id": "host55.yahoo.com",
+  "id": "node55",
   "state": "parked",
   "type": "tenant",
   "hostname": "host55.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node6.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host6.yahoo.com",
-  "id": "host6.yahoo.com",
+  "id": "node6",
   "state": "active",
   "type": "tenant",
   "hostname": "host6.yahoo.com",

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node7.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node7.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host7.yahoo.com",
-  "id": "host7.yahoo.com",
+  "id": "node7",
   "state": "provisioned",
   "type": "tenant",
   "hostname": "host7.yahoo.com",


### PR DESCRIPTION
I did not find any important usages of `id`, so let's use it for the node ID,
and eventually remove `openStackId`.

@freva