### PR TITLE
Deprecate DocumentTypeManager and DocumentTypeManagerConfigurer. They…

### DIFF
--- a/application/src/main/java/com/yahoo/application/container/DocumentProcessing.java
+++ b/application/src/main/java/com/yahoo/application/container/DocumentProcessing.java
@@ -23,6 +23,7 @@ import java.util.Map;
  * @author Einar M R Rosenvinge
  */
 @Beta
+@SuppressWarnings("deprecation")
 public final class DocumentProcessing {
 
     private final DocumentProcessingHandler handler;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/SDDocumentTypeOrderer.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/SDDocumentTypeOrderer.java
@@ -21,6 +21,7 @@ public class SDDocumentTypeOrderer {
     List<SDDocumentType> processingOrder = new LinkedList<>();
     private final DeployLogger deployLogger;
 
+    @SuppressWarnings("deprecation")
     public SDDocumentTypeOrderer(List<SDDocumentType> sdTypes, DeployLogger deployLogger) {
         this.deployLogger = deployLogger;
         for (SDDocumentType type : sdTypes) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
@@ -45,6 +45,7 @@ import java.util.Set;
  * search objects using the {@link #getSchema(String)} method.
  */
 // NOTE: Since this was created we have added Application, and much of the content in this should migrate there.
+@SuppressWarnings("deprecation")
 public class SchemaBuilder {
 
     private final DocumentTypeManager docTypeMgr = new DocumentTypeManager();

--- a/config-model/src/main/java/com/yahoo/vespa/documentmodel/SearchDef.java
+++ b/config-model/src/main/java/com/yahoo/vespa/documentmodel/SearchDef.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
  * @author    baldersheim
  * @since     2010-02-19
  */
+@SuppressWarnings("deprecation")
 public class SearchDef {
     private final static Logger log = Logger.getLogger(SearchDef.class.getName());
     /// Name of the searchdefinition

--- a/config-model/src/test/java/com/yahoo/searchdefinition/FieldOfTypeDocumentTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/FieldOfTypeDocumentTestCase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertSame;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class FieldOfTypeDocumentTestCase extends AbstractSchemaTestCase {
 
     @Test

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/DeriverTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/DeriverTestCase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class DeriverTestCase extends AbstractSchemaTestCase {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testDeriveDocManager() {
         DocumentTypeManager dtm = new DocumentTypeManager(new DocumentmanagerConfig(
                 Deriver.getDocumentManagerConfig(List.of(

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/SessionCache.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/SessionCache.java
@@ -79,6 +79,7 @@ public final class SessionCache extends AbstractComponent {
 
     }
 
+    @SuppressWarnings("deprecation")
     public SessionCache(Supplier<NetworkMultiplexer> net, ContainerMbusConfig containerMbusConfig,
                         DocumentmanagerConfig documentmanagerConfig,
                         LoadTypeConfig loadTypeConfig, MessagebusConfig messagebusConfig,

--- a/docproc/src/main/java/com/yahoo/docproc/DocprocService.java
+++ b/docproc/src/main/java/com/yahoo/docproc/DocprocService.java
@@ -44,6 +44,7 @@ public class DocprocService extends AbstractComponent {
     /** The current state of this service */
     private boolean acceptingNewProcessings = true;
     public static SchemaMap schemaMap = new SchemaMap();
+    @SuppressWarnings("deprecation")
     private DocumentTypeManager documentTypeManager = null;
 
     private DocprocService(ComponentId id, int numThreads) {
@@ -68,6 +69,7 @@ public class DocprocService extends AbstractComponent {
      * @param mgr the document type manager to use.
      * @param numThreads to have in the thread pool
      */
+    @SuppressWarnings("deprecation")
     public DocprocService(ComponentId id, CallStack stack, DocumentTypeManager mgr, int numThreads) {
         this(id, numThreads);
         setCallStack(stack);
@@ -94,10 +96,12 @@ public class DocprocService extends AbstractComponent {
         threadPool.shutdown();
     }
 
+    @Deprecated
     public DocumentTypeManager getDocumentTypeManager() {
         return documentTypeManager;
     }
 
+    @Deprecated
     public void setDocumentTypeManager(DocumentTypeManager documentTypeManager) {
         this.documentTypeManager = documentTypeManager;
     }

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
@@ -40,6 +40,7 @@ import static com.yahoo.component.chain.model.ChainsModelBuilder.buildFromConfig
  *
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class DocumentProcessingHandler extends AbstractRequestHandler {
 
     private static final Logger log = Logger.getLogger(DocumentProcessingHandler.class.getName());

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerParameters.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerParameters.java
@@ -14,6 +14,7 @@ import com.yahoo.jdisc.Metric;
  * @author Einar M R Rosenvinge
  * @see com.yahoo.docproc.jdisc.DocumentProcessingHandler
  */
+@SuppressWarnings("deprecation")
 public class DocumentProcessingHandlerParameters {
 
     private int maxNumThreads = 0;

--- a/docproc/src/main/java/com/yahoo/docproc/util/JoinerDocumentProcessor.java
+++ b/docproc/src/main/java/com/yahoo/docproc/util/JoinerDocumentProcessor.java
@@ -15,12 +15,10 @@ import java.util.logging.Level;
 
 import java.util.logging.Logger;
 
-import static com.yahoo.docproc.util.SplitterDocumentProcessor.validate;
-import static com.yahoo.docproc.util.SplitterDocumentProcessor.doProcessOuterDocument;
-
 /**
  * @author Einar M R Rosenvinge
  */
+@Deprecated
 public class JoinerDocumentProcessor extends DocumentProcessor {
 
     private static Logger log = Logger.getLogger(JoinerDocumentProcessor.class.getName());
@@ -35,12 +33,12 @@ public class JoinerDocumentProcessor extends DocumentProcessor {
         this.arrayFieldName = cfg.arrayFieldName();
         this.contextFieldName = cfg.contextFieldName();
         manager = DocumentTypeManagerConfigurer.configureNewManager(documentmanagerConfig);
-        validate(manager, documentTypeName, arrayFieldName);
+        com.yahoo.docproc.util.SplitterDocumentProcessor.validate(manager, documentTypeName, arrayFieldName);
     }
 
     @Override
     public Progress process(Processing processing) {
-        if ( ! doProcessOuterDocument(processing.getVariable(contextFieldName), documentTypeName)) {
+        if ( ! com.yahoo.docproc.util.SplitterDocumentProcessor.doProcessOuterDocument(processing.getVariable(contextFieldName), documentTypeName)) {
             return Progress.DONE;
         }
 

--- a/docproc/src/main/java/com/yahoo/docproc/util/SplitterDocumentProcessor.java
+++ b/docproc/src/main/java/com/yahoo/docproc/util/SplitterDocumentProcessor.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 /**
  * @author Einar M R Rosenvinge
  */
+@Deprecated
 public class SplitterDocumentProcessor extends DocumentProcessor {
 
     private static Logger log = Logger.getLogger(SplitterDocumentProcessor.class.getName());

--- a/docproc/src/main/java/com/yahoo/docproc/util/package-info.java
+++ b/docproc/src/main/java/com/yahoo/docproc/util/package-info.java
@@ -1,4 +1,5 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// TODO Remove as public api
 @ExportPackage
 @PublicApi
 package com.yahoo.docproc.util;

--- a/docproc/src/test/java/com/yahoo/docproc/ProcessingUpdateTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/ProcessingUpdateTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
  *
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class ProcessingUpdateTestCase {
 
     private DocumentPut put;

--- a/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.docproc.jdisc;
 
-import com.yahoo.cloud.config.SlobroksConfig;
 import com.yahoo.collections.Pair;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.provider.ComponentRegistry;
@@ -16,11 +15,9 @@ import com.yahoo.docproc.jdisc.messagebus.MbusRequestContext;
 
 import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentTypeManager;
-import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadType;
 import com.yahoo.documentapi.messagebus.protocol.DocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
-import com.yahoo.documentapi.messagebus.protocol.DocumentProtocolPoliciesConfig;
 import com.yahoo.jdisc.AbstractResource;
 import com.yahoo.jdisc.ReferencedResource;
 import com.yahoo.jdisc.application.ContainerBuilder;
@@ -34,8 +31,6 @@ import com.yahoo.messagebus.network.NetworkMultiplexer;
 import com.yahoo.messagebus.network.rpc.RPCNetwork;
 import com.yahoo.messagebus.routing.Route;
 import com.yahoo.messagebus.shared.SharedSourceSession;
-import com.yahoo.vespa.config.content.DistributionConfig;
-import com.yahoo.vespa.config.content.LoadTypeConfig;
 import org.junit.After;
 import org.junit.Before;
 
@@ -45,6 +40,7 @@ import java.util.List;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public abstract class DocumentProcessingHandlerTestBase {
 
     protected DocumentProcessingHandler handler;

--- a/docproc/src/test/java/com/yahoo/docproc/util/SplitterJoinerTestCase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/util/SplitterJoinerTestCase.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Einar M R Rosenvinge
  */
-@SuppressWarnings({"unchecked"})
+@SuppressWarnings({"unchecked", "deprecation"})
 public class SplitterJoinerTestCase {
 
     @Test

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -33,6 +33,7 @@ import com.yahoo.vespa.indexinglanguage.expressions.Expression;
 @Provides({ IndexingProcessor.PROVIDED_NAME })
 @Before({ IndexingProcessor.INDEXING_END })
 @After({ IndexingProcessor.INDEXING_START, "*" })
+@SuppressWarnings("deprecation")
 public class IndexingProcessor extends DocumentProcessor {
 
     public final static String PROVIDED_NAME = "indexedDocument";

--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/ScriptManager.java
@@ -21,6 +21,7 @@ import java.util.*;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("deprecation")
 public class ScriptManager {
 
     private static final FastLogger log = FastLogger.getLogger(ScriptManager.class.getName());

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
@@ -5,7 +5,6 @@ import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.language.process.Embedder;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
-import com.yahoo.vespa.indexinglanguage.parser.ParseException;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -16,10 +15,11 @@ import static org.junit.Assert.assertNull;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("deprecation")
 public class ScriptManagerTestCase {
 
     @Test
-    public void requireThatScriptsAreAppliedToSubType() throws ParseException {
+    public void requireThatScriptsAreAppliedToSubType() {
         DocumentTypeManager typeMgr = new DocumentTypeManager();
         typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
         DocumentType docType = typeMgr.getDocumentType("newssummary");
@@ -35,7 +35,7 @@ public class ScriptManagerTestCase {
     }
 
     @Test
-    public void requireThatScriptsAreAppliedToSuperType() throws ParseException {
+    public void requireThatScriptsAreAppliedToSuperType() {
         DocumentTypeManager typeMgr = new DocumentTypeManager();
         typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
         DocumentType docType = typeMgr.getDocumentType("newsarticle");

--- a/document/src/main/java/com/yahoo/document/CollectionDataType.java
+++ b/document/src/main/java/com/yahoo/document/CollectionDataType.java
@@ -62,6 +62,7 @@ public abstract class CollectionDataType extends DataType {
     }
 
     @Override
+    @Deprecated
     protected void register(DocumentTypeManager manager, List<DataType> seenTypes) {
         seenTypes.add(this);
         if (!seenTypes.contains(getNestedType())) {

--- a/document/src/main/java/com/yahoo/document/DataType.java
+++ b/document/src/main/java/com/yahoo/document/DataType.java
@@ -240,11 +240,13 @@ public abstract class DataType extends Identifiable implements Serializable, Com
      * Registers this type in the given document manager.
      *
      * @param manager the DocumentTypeManager to register in.
+     * @deprecated Will become non-public on Vespa 8
      */
+    @Deprecated
     public final void register(DocumentTypeManager manager) {
         register(manager, new LinkedList<>());
     }
-
+    @Deprecated
     protected void register(DocumentTypeManager manager, List<DataType> seenTypes) {
         manager.registerSingleType(this);
     }

--- a/document/src/main/java/com/yahoo/document/DocumentType.java
+++ b/document/src/main/java/com/yahoo/document/DocumentType.java
@@ -145,6 +145,7 @@ public class DocumentType extends StructuredDataType {
     }
 
     @Override
+    @Deprecated
     protected void register(DocumentTypeManager manager, List<DataType> seenTypes) {
         seenTypes.add(this);
         for (DocumentType type : getInheritedTypes()) {

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
@@ -3,7 +3,6 @@ package com.yahoo.document;
 
 import com.google.inject.Inject;
 import com.yahoo.config.subscription.ConfigSubscriber;
-import com.yahoo.document.annotation.AnnotationReferenceDataType;
 import com.yahoo.document.annotation.AnnotationType;
 import com.yahoo.document.annotation.AnnotationTypeRegistry;
 import com.yahoo.document.annotation.AnnotationTypes;
@@ -14,7 +13,14 @@ import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.tensor.TensorType;
 
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -29,7 +35,9 @@ import java.util.logging.Logger;
  * or as XML.
  *
  * @author Thomas Gundersen
+ *  @deprecated Will become non-public on Vespa 8
  */
+@Deprecated
 public class DocumentTypeManager {
 
     private final static Logger log = Logger.getLogger(DocumentTypeManager.class.getName());
@@ -95,7 +103,7 @@ public class DocumentTypeManager {
     }
 
     public boolean hasDataType(String name) {
-        if (name.startsWith("tensor(")) return true; // built-in dynamic: Always present
+        if (name.startsWith("tensor(")) return true; // built-in dynamic: Always present
         for (DataType type : dataTypes.values()) {
             if (type.getName().equalsIgnoreCase(name)) {
                 return true;
@@ -165,14 +173,6 @@ public class DocumentTypeManager {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    DataType getDataTypeAndReturnTemporary(int code, String detailedType) {
-        if (hasDataType(code)) {
-            return getDataType(code, detailedType);
-        }
-        return new TemporaryDataType(code, detailedType);
-    }
-
     /**
      * Register a data type of any sort, including document types.
      * @param type The datatype to register
@@ -187,7 +187,6 @@ public class DocumentTypeManager {
      *
      * @param type The datatype to register
      */
-    @SuppressWarnings("deprecation")
     void registerSingleType(DataType type) {
         if (type instanceof TensorDataType) return; // built-in dynamic: Created on the fly
         if (type instanceof TemporaryDataType) {

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
@@ -7,7 +7,6 @@ import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.document.annotation.AnnotationReferenceDataType;
 import com.yahoo.document.annotation.AnnotationType;
 import java.util.logging.Level;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,7 +17,9 @@ import java.util.stream.Collectors;
  * Configures the Vespa document manager from a config id.
  *
  * @author Einar M R Rosenvinge
+ * @deprecated Will become non-public on Vespa 8
  */
+@Deprecated
 public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSubscriber<DocumentmanagerConfig>{
 
     private final static Logger log = Logger.getLogger(DocumentTypeManagerConfigurer.class.getName());
@@ -76,9 +77,9 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
             }
         }
 
-        private Map<Integer, DataType> typesById = new HashMap<>();
-        private Map<String, DataType> typesByName = new HashMap<>();
-        private Map<Integer, DocumentmanagerConfig.Datatype> configMap = new HashMap<>();
+        private final Map<Integer, DataType> typesById = new HashMap<>();
+        private final Map<String, DataType> typesByName = new HashMap<>();
+        private final Map<Integer, DocumentmanagerConfig.Datatype> configMap = new HashMap<>();
 
         private void inProgress(DataType type) {
             var old = typesById.put(type.getId(), type);

--- a/document/src/main/java/com/yahoo/document/MapDataType.java
+++ b/document/src/main/java/com/yahoo/document/MapDataType.java
@@ -79,6 +79,7 @@ public class MapDataType extends DataType {
     }
 
     @Override
+    @Deprecated
     protected void register(DocumentTypeManager manager,
             List<DataType> seenTypes) {
         seenTypes.add(this);

--- a/document/src/main/java/com/yahoo/document/StructuredDataType.java
+++ b/document/src/main/java/com/yahoo/document/StructuredDataType.java
@@ -76,6 +76,7 @@ public abstract class StructuredDataType extends DataType {
     }
 
     @Override
+    @Deprecated
     protected void register(DocumentTypeManager manager, List<DataType> seenTypes) {
         seenTypes.add(this);
         for (Field field : getFields()) {

--- a/document/src/main/java/com/yahoo/document/datatypes/FieldValue.java
+++ b/document/src/main/java/com/yahoo/document/datatypes/FieldValue.java
@@ -95,7 +95,7 @@ public abstract class FieldValue extends Identifiable implements Comparable<Fiel
         return this;
     }
 
-    class RecursiveIteratorHandler extends FieldPathIteratorHandler {
+    static class RecursiveIteratorHandler extends FieldPathIteratorHandler {
         FieldValue retVal = null;
         boolean multiValue = false;
 

--- a/document/src/main/java/com/yahoo/document/fieldset/FieldSetRepo.java
+++ b/document/src/main/java/com/yahoo/document/fieldset/FieldSetRepo.java
@@ -31,6 +31,7 @@ public class FieldSetRepo {
         }
     }
 
+    @SuppressWarnings("deprecation")
     FieldSet parseFieldCollection(DocumentTypeManager docMan, String docType, String fieldNames) {
         DocumentType type = docMan.getDocumentType(docType);
         if (type == null) {
@@ -55,6 +56,7 @@ public class FieldSetRepo {
         return collection;
     }
 
+    @Deprecated
     public FieldSet parse(DocumentTypeManager docMan, String fieldSet) {
         if (fieldSet.length() == 0) {
             throw new IllegalArgumentException("Illegal field set value \"\"");

--- a/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
@@ -26,12 +26,14 @@ import java.io.InputStream;
  *
  * @author Steinar Knutsen
  */
+
 public class JsonFeedReader implements FeedReader {
 
     private final JsonReader reader;
     private InputStream stream;
     private static final JsonFactory jsonFactory = new JsonFactoryBuilder().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES).build();
 
+    @SuppressWarnings("deprecation")
     public JsonFeedReader(InputStream stream, DocumentTypeManager docMan) {
         reader = new JsonReader(docMan, stream, jsonFactory);
         this.stream = stream;

--- a/document/src/main/java/com/yahoo/document/json/JsonReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonReader.java
@@ -27,6 +27,7 @@ import static com.yahoo.document.json.readers.JsonParserHelpers.expectArrayStart
  * @author Steinar Knutsen
  * @author dybis
  */
+@SuppressWarnings("deprecation")
 public class JsonReader {
 
     public Optional<DocumentParseInfo> parseDocument() throws IOException {

--- a/document/src/main/java/com/yahoo/document/serialization/DocumentDeserializerFactory.java
+++ b/document/src/main/java/com/yahoo/document/serialization/DocumentDeserializerFactory.java
@@ -9,6 +9,7 @@ import com.yahoo.io.GrowableByteBuffer;
  *
  * @author geirst
  */
+@SuppressWarnings("deprecation")
 public class DocumentDeserializerFactory {
 
     /**

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializer6.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializer6.java
@@ -58,7 +58,6 @@ import com.yahoo.document.update.RemoveValueUpdate;
 import com.yahoo.document.update.ValueUpdate;
 import com.yahoo.document.WeightedSetDataType;
 import com.yahoo.io.GrowableByteBuffer;
-import com.yahoo.tensor.serialization.TypedBinaryFormat;
 import com.yahoo.text.Utf8;
 import com.yahoo.text.Utf8Array;
 import com.yahoo.text.Utf8String;
@@ -79,6 +78,7 @@ import static com.yahoo.text.Utf8.calculateStringPositions;
  *
  * @author baldersheim
  */
+@SuppressWarnings("deprecation")
 public class VespaDocumentDeserializer6 extends BufferSerializer implements DocumentDeserializer {
 
     private final Compressor compressor = new Compressor();

--- a/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializerHead.java
+++ b/document/src/main/java/com/yahoo/document/serialization/VespaDocumentDeserializerHead.java
@@ -17,6 +17,7 @@ import com.yahoo.tensor.TensorType;
  *
  * @author baldersheim
  */
+@SuppressWarnings("deprecation")
 public class VespaDocumentDeserializerHead extends VespaDocumentDeserializer6 {
 
     public VespaDocumentDeserializerHead(DocumentTypeManager manager, GrowableByteBuffer buffer) {

--- a/document/src/main/java/com/yahoo/document/serialization/package-info.java
+++ b/document/src/main/java/com/yahoo/document/serialization/package-info.java
@@ -1,4 +1,5 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+// Todo: Will become non-public on Vespa 8
 @ExportPackage
 @PublicApi
 package com.yahoo.document.serialization;

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLDocumentReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLDocumentReader.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
  *
  * @author thomasg
  */
+@Deprecated
 public class VespaXMLDocumentReader extends VespaXMLFieldReader implements DocumentReader {
 
     /**

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFeedReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFeedReader.java
@@ -26,6 +26,7 @@ import java.util.Optional;
  * If you are looking to parse only a single document or update, use VespaXMLDocumentReader
  * or VespaXMLUpdateReader respectively.
  */
+@Deprecated
 public class VespaXMLFeedReader extends VespaXMLReader implements FeedReader {
 
     /**

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFieldReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLFieldReader.java
@@ -30,6 +30,7 @@ import java.util.Optional;
  * All read methods assume that the stream is currently positioned at the start element of the relevant field.
  *
  */
+@Deprecated
 public class VespaXMLFieldReader extends VespaXMLReader implements FieldReader {
     private static final BigInteger UINT_MAX = new BigInteger("4294967296");
     private static final BigInteger ULONG_MAX = new BigInteger("18446744073709551616");

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLReader.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 /**
  * @author thomasg
  */
+@Deprecated
 public class VespaXMLReader {
     DocumentTypeManager docTypeManager;
     XMLStreamReader reader;

--- a/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLUpdateReader.java
+++ b/document/src/main/java/com/yahoo/vespaxmlparser/VespaXMLUpdateReader.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Optional;
 
+@Deprecated
 public class VespaXMLUpdateReader extends VespaXMLFieldReader implements DocumentUpdateReader {
     public VespaXMLUpdateReader(String fileName, DocumentTypeManager docTypeManager) throws Exception {
         super(fileName, docTypeManager);

--- a/document/src/test/java/com/yahoo/document/DataTypeTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DataTypeTestCase.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.*;
 /**
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class DataTypeTestCase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/DocInDocTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocInDocTestCase.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertNotSame;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class DocInDocTestCase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/DocumentCalculatorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentCalculatorTestCase.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author thomasg
  */
+@SuppressWarnings("deprecation")
 public class DocumentCalculatorTestCase {
 
     DocumentType testDocType = null;

--- a/document/src/test/java/com/yahoo/document/DocumentIdTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentIdTestCase.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("deprecation")
 public class DocumentIdTestCase {
 
     DocumentTypeManager manager = new DocumentTypeManager();

--- a/document/src/test/java/com/yahoo/document/DocumentPathUpdateTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentPathUpdateTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.fail;
  *
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class DocumentPathUpdateTestCase {
 
     DocumentTypeManager docMan;

--- a/document/src/test/java/com/yahoo/document/DocumentTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCase.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.fail;
  * @author <a href="thomasg@yahoo-inc.com>Thomas Gundersen</a>
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class DocumentTestCase extends DocumentTestCaseBase {
 
     private static final String SERTEST_DOC_AS_XML_HEAD =

--- a/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 
 import static org.junit.Assert.assertNotNull;
 
+@SuppressWarnings("deprecation")
 public class DocumentTestCaseBase {
 
     protected Field byteField = null;

--- a/document/src/test/java/com/yahoo/document/DocumentTypeManagerTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTypeManagerTestCase.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Thomas Gundersen
  */
+@SuppressWarnings("deprecation")
 public class DocumentTypeManagerTestCase {
 
     // Verify that we can register and retrieve fields.

--- a/document/src/test/java/com/yahoo/document/DocumentTypeTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTypeTestCase.java
@@ -44,6 +44,7 @@ public class DocumentTypeTestCase {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testInheritance() {
         DocumentTypeManager typeManager = new DocumentTypeManager();
 

--- a/document/src/test/java/com/yahoo/document/DocumentUpdateTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentUpdateTestCase.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.fail;
  *
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class DocumentUpdateTestCase {
 
     private DocumentTypeManager docMan;

--- a/document/src/test/java/com/yahoo/document/annotation/AbstractTypesTest.java
+++ b/document/src/test/java/com/yahoo/document/annotation/AbstractTypesTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  */
+@SuppressWarnings("deprecation")
 public abstract class AbstractTypesTest {
 
     protected DocumentTypeManager man;

--- a/document/src/test/java/com/yahoo/document/annotation/Bug4259784TestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/Bug4259784TestCase.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class Bug4259784TestCase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/annotation/Bug4261985TestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/Bug4261985TestCase.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class Bug4261985TestCase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/annotation/Bug4475379TestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/Bug4475379TestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  */
+@SuppressWarnings("deprecation")
 public class Bug4475379TestCase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/annotation/Bug6394548TestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/Bug6394548TestCase.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.*;
 
 public class Bug6394548TestCase {
     @Test
+    @SuppressWarnings("deprecation")
     public void testSerializeAndDeserializeMultipleAdjacentStructAnnotations() {
         DocumentTypeManager manager = new DocumentTypeManager();
         var sub = DocumentTypeManagerConfigurer.configure

--- a/document/src/test/java/com/yahoo/document/annotation/Bug6425939TestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/Bug6425939TestCase.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+@SuppressWarnings("deprecation")
 public class Bug6425939TestCase {
     private DocumentTypeManager man;
     private StructDataType person;

--- a/document/src/test/java/com/yahoo/document/annotation/DocTestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/DocTestCase.java
@@ -29,6 +29,7 @@ public class DocTestCase {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private class Service {
         private DocumentTypeManager getDocumentTypeManager() {
             return null;
@@ -231,6 +232,7 @@ public class DocTestCase {
         text.setSpanTree(tree);
     }
 
+    @SuppressWarnings("deprecation")
     public void simple5() {
         //the following two lines work inside process(Document, Arguments, Processing) in a DocumentProcessor
         DocumentTypeManager dtm = processing.getService().getDocumentTypeManager();

--- a/document/src/test/java/com/yahoo/document/annotation/SpanTreeTestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/SpanTreeTestCase.java
@@ -810,6 +810,7 @@ public class SpanTreeTestCase extends AbstractTypesTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void testCyclicReferences() {
         DocumentTypeManager docMan = new DocumentTypeManager();
         AnnotationTypeRegistry reg = docMan.getAnnotationTypeRegistry();

--- a/document/src/test/java/com/yahoo/document/annotation/SystemTestCase.java
+++ b/document/src/test/java/com/yahoo/document/annotation/SystemTestCase.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class SystemTestCase {
 
     DocumentTypeManager manager;

--- a/document/src/test/java/com/yahoo/document/datatypes/MapTestCase.java
+++ b/document/src/test/java/com/yahoo/document/datatypes/MapTestCase.java
@@ -139,6 +139,7 @@ public class MapTestCase {
         assertCorrectSerialization(floatToTwoDimArray, map);
     }
 
+    @SuppressWarnings("deprecation")
     private void assertCorrectSerialization(MapDataType mapType, MapFieldValue<? extends FieldValue, ? extends FieldValue> map) {
         Field f = new Field("", mapType);
         DocumentTypeManager man = new DocumentTypeManager();

--- a/document/src/test/java/com/yahoo/document/datatypes/StringTestCase.java
+++ b/document/src/test/java/com/yahoo/document/datatypes/StringTestCase.java
@@ -197,6 +197,7 @@ public class StringTestCase extends AbstractTypesTest {
      * Test for bug 4066566. No assertions, but works if it runs without exceptions.
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void testAnnotatorConsumer() {
         DocumentTypeManager manager = new DocumentTypeManager();
         DocumentTypeManagerConfigurer
@@ -214,6 +215,7 @@ public class StringTestCase extends AbstractTypesTest {
         doc = serializeAndDeserialize(doc, manager);
     }
 
+    @SuppressWarnings("deprecation")
     private Document serializeAndDeserialize(Document doc, DocumentTypeManager manager) {
         GrowableByteBuffer buffer = new GrowableByteBuffer(1024);
         DocumentSerializer serializer = DocumentSerializerFactory.create6(buffer);
@@ -224,6 +226,7 @@ public class StringTestCase extends AbstractTypesTest {
         return new Document(deserializer);
     }
 
+    @SuppressWarnings("deprecation")
     public Document annotate(Document document, DocumentTypeManager manager) {
         AnnotationTypeRegistry registry = manager.getAnnotationTypeRegistry();
 

--- a/document/src/test/java/com/yahoo/document/fieldset/FieldSetTestCase.java
+++ b/document/src/test/java/com/yahoo/document/fieldset/FieldSetTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 /**
  * Test for field sets
  */
+@SuppressWarnings("deprecation")
 public class FieldSetTestCase extends DocumentTestCaseBase {
 
     @Test

--- a/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
+++ b/document/src/test/java/com/yahoo/document/json/DocumentUpdateJsonSerializerTest.java
@@ -35,6 +35,7 @@ import static com.yahoo.test.json.JsonTestHelper.inputJson;
  *
  * @author Vegard Sjonfjell
  */
+@SuppressWarnings("deprecation")
 public class DocumentUpdateJsonSerializerTest {
 
     final static TensorType sparseTensorType = new TensorType.Builder().mapped("x").mapped("y").build();

--- a/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonReaderTestCase.java
@@ -91,6 +91,7 @@ import static org.junit.Assert.fail;
  * @author Steinar Knutsen
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class JsonReaderTestCase {
 
     private DocumentTypeManager types;

--- a/document/src/test/java/com/yahoo/document/json/JsonWriterTestCase.java
+++ b/document/src/test/java/com/yahoo/document/json/JsonWriterTestCase.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Steinar Knutsen
  */
+@SuppressWarnings("deprecation")
 public class JsonWriterTestCase {
 
     private static final JsonFactory parserFactory = new JsonFactory();

--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -47,6 +47,7 @@ import static org.junit.Assert.fail;
  * @author Simon Thoresen Hult
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class DocumentSelectorTestCase {
 
     @Rule

--- a/document/src/test/java/com/yahoo/document/serialization/ReferenceFieldValueSerializationTestCase.java
+++ b/document/src/test/java/com/yahoo/document/serialization/ReferenceFieldValueSerializationTestCase.java
@@ -18,6 +18,7 @@ import java.io.IOException;
  */
 public class ReferenceFieldValueSerializationTestCase {
 
+    @SuppressWarnings("deprecation")
     static class Fixture {
         final TestDocumentFactory documentFactory;
         // Note: these must match their C++ serialization test counterparts.

--- a/document/src/test/java/com/yahoo/document/serialization/TestDocumentFactory.java
+++ b/document/src/test/java/com/yahoo/document/serialization/TestDocumentFactory.java
@@ -10,6 +10,7 @@ import com.yahoo.document.DocumentTypeManager;
  *
  * @author geirst
  */
+@SuppressWarnings("deprecation")
 public class TestDocumentFactory {
 
     private final DocumentTypeManager typeManager;

--- a/document/src/test/java/com/yahoo/document/update/FieldUpdateTestCase.java
+++ b/document/src/test/java/com/yahoo/document/update/FieldUpdateTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("deprecation")
 public class FieldUpdateTestCase {
 
     private Field strfoo;

--- a/document/src/test/java/com/yahoo/document/update/SerializationTestCase.java
+++ b/document/src/test/java/com/yahoo/document/update/SerializationTestCase.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertNotEquals;
  *
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class SerializationTestCase {
 
     private DocumentType documentType;

--- a/document/src/test/java/com/yahoo/vespaxmlparser/PositionParserTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/PositionParserTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
 public class PositionParserTestCase {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void requireThatPositionStringsCanBeParsed() throws Exception {
         DocumentTypeManager mgr = new DocumentTypeManager();
         mgr.register(PositionDataType.INSTANCE);

--- a/document/src/test/java/com/yahoo/vespaxmlparser/UriParserTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/UriParserTestCase.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.*;
 public class UriParserTestCase {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void requireThatUriFieldsCanBeParsed() throws Exception {
         DocumentTypeManager mgr = new DocumentTypeManager();
         DocumentType docType = new DocumentType("my_doc");

--- a/document/src/test/java/com/yahoo/vespaxmlparser/VespaXMLReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/VespaXMLReaderTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.*;
  *
  * @author sveina
  */
+@SuppressWarnings("deprecation")
 public class VespaXMLReaderTestCase {
 
     private final DocumentTypeManager manager = new DocumentTypeManager();

--- a/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlFieldReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlFieldReaderTestCase.java
@@ -80,6 +80,7 @@ public class VespaXmlFieldReaderTestCase {
                      "Field 'my_tensor': XML input for fields of type TENSOR is not supported. Please use JSON input instead.");
     }
 
+    @SuppressWarnings("deprecation")
     private class MockedReaderFixture {
         public DocumentTypeManager mgr;
         public DocumentType docType;
@@ -135,6 +136,7 @@ public class VespaXmlFieldReaderTestCase {
         fixture.assertReadPositionEquals(3000000, 4000000);
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertThrows(Field field, String fieldXml, String expected) throws Exception {
         DocumentTypeManager docManager = new DocumentTypeManager();
         DocumentType docType = new DocumentType("my_type");
@@ -166,6 +168,7 @@ public class VespaXmlFieldReaderTestCase {
                    "</document>");
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertRead(Predicate expected, String documentXml) throws Exception {
         DocumentTypeManager docManager = new DocumentTypeManager();
         DocumentType docType = new DocumentType("my_type");

--- a/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlUpdateReaderTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/VespaXmlUpdateReaderTestCase.java
@@ -240,6 +240,7 @@ public class VespaXmlUpdateReaderTestCase {
         return readUpdateHelper(null, documentXml);
     }
 
+    @SuppressWarnings("deprecation")
     private static DocumentUpdate readUpdateHelper(Field field, String documentXml) throws Exception {
         DocumentTypeManager docManager = new DocumentTypeManager();
         DocumentType docType = new DocumentType("my_type");

--- a/document/src/test/java/com/yahoo/vespaxmlparser/XMLNumericFieldErrorMsgTestCase.java
+++ b/document/src/test/java/com/yahoo/vespaxmlparser/XMLNumericFieldErrorMsgTestCase.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.fail;
  * @author <a href="mailto:einarmr@yahoo-inc.com">Einar M R Rosenvinge</a>
  * @since 5.1.29
  */
+@SuppressWarnings("deprecation")
 public class XMLNumericFieldErrorMsgTestCase {
 
     private static DocumentTypeManager setupTypes() {

--- a/documentapi/src/main/java/com/yahoo/documentapi/DocumentAccess.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/DocumentAccess.java
@@ -46,6 +46,7 @@ import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
  */
 public abstract class DocumentAccess {
 
+    @SuppressWarnings("deprecation")
     private final DocumentTypeManager documentTypeManager;
     private final ConfigSubscriber documentTypeConfigSubscriber;
 
@@ -86,6 +87,7 @@ public abstract class DocumentAccess {
      *
      * @param params the parameters to use for setup
      */
+    @SuppressWarnings("deprecation")
     protected DocumentAccess(DocumentAccessParams params) {
         if (params.documentmanagerConfig().isPresent()) { // our config has been injected into the creator
             documentTypeManager = new DocumentTypeManager(params.documentmanagerConfig().get());
@@ -170,6 +172,7 @@ public abstract class DocumentAccess {
     }
 
     /** Returns the {@link DocumentTypeManager} used by this DocumentAccess. */
+    @SuppressWarnings("deprecation")
     public DocumentTypeManager getDocumentTypeManager() { return documentTypeManager; }
 
 }

--- a/documentapi/src/main/java/com/yahoo/documentapi/local/LocalVisitorSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/local/LocalVisitorSession.java
@@ -47,6 +47,7 @@ public class LocalVisitorSession implements VisitorSession {
     private final AtomicReference<Phaser> phaser;
     private final ProgressToken token;
 
+    @SuppressWarnings("deprecation")
     public LocalVisitorSession(LocalDocumentAccess access, VisitorParameters parameters) throws ParseException {
         this.selector = new DocumentSelector(parameters.getDocumentSelection());
         this.fieldSet = new FieldSetRepo().parse(access.getDocumentTypeManager(), parameters.fieldSet());

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
@@ -53,6 +53,7 @@ public class MessageBusDocumentAccess extends DocumentAccess {
      *
      * @param params All parameters for construction.
      */
+    @SuppressWarnings("deprecation")
     public MessageBusDocumentAccess(MessageBusParams params) {
         super(params);
         this.params = params;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
@@ -37,6 +37,7 @@ public class DocumentProtocol implements Protocol {
     private static final Logger log = Logger.getLogger(DocumentProtocol.class.getName());
     private final RoutingPolicyRepository routingPolicyRepository = new RoutingPolicyRepository();
     private final RoutableRepository routableRepository;
+    @SuppressWarnings("deprecation")
     private final DocumentTypeManager docMan;
 
     /** The name of this protocol. */
@@ -238,24 +239,29 @@ public class DocumentProtocol implements Protocol {
         return Priority.valueOf(name);
     }
 
+    @Deprecated
     public DocumentProtocol(DocumentTypeManager docMan) {
         this(docMan, null, new LoadTypeSet());
     }
 
+    @Deprecated
     public DocumentProtocol(DocumentTypeManager docMan, String configId) {
         this(docMan, configId, new LoadTypeSet());
     }
 
+    @Deprecated
     public DocumentProtocol(DocumentTypeManager documentTypeManager, LoadTypeSet loadTypes,
                             DocumentProtocolPoliciesConfig policiesConfig, DistributionConfig distributionConfig) {
         this(requireNonNull(documentTypeManager), null, requireNonNull(loadTypes),
         requireNonNull(policiesConfig), requireNonNull(distributionConfig));
     }
 
+    @Deprecated
     public DocumentProtocol(DocumentTypeManager docMan, String configId, LoadTypeSet set) {
         this(docMan, configId == null ? "client" : configId, set, null, null);
     }
 
+    @Deprecated
     private DocumentProtocol(DocumentTypeManager docMan, String configId, LoadTypeSet set,
                              DocumentProtocolPoliciesConfig policiesConfig, DistributionConfig distributionConfig) {
         if (docMan != null)
@@ -540,6 +546,7 @@ public class DocumentProtocol implements Protocol {
         return routableRepository.getRoutableTypes(version);
     }
 
+    @Deprecated
     final public DocumentTypeManager getDocumentTypeManager() { return docMan; }
 
 }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
@@ -49,6 +49,7 @@ final class RoutableRepository {
      * @param data    The byte array containing the encoded routable.
      * @return The decoded routable.
      */
+    @SuppressWarnings("deprecation")
     Routable decode(DocumentTypeManager docMan, Version version, byte[] data) {
         if (data == null || data.length == 0) {
             log.log(Level.SEVERE, "Received empty byte array for deserialization.");

--- a/documentapi/src/test/java/com/yahoo/documentapi/VisitorDataQueueTest.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/VisitorDataQueueTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class VisitorDataQueueTest {
 
     private final DocumentTypeManager docMan = new DocumentTypeManager();

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/Messages60TestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/Messages60TestCase.java
@@ -605,6 +605,7 @@ public class Messages60TestCase extends MessagesTestBase {
     public class testPutDocumentMessage implements RunnableTest {
 
         @Override
+        @SuppressWarnings("deprecation")
         public void run() {
             PutDocumentMessage msg = new PutDocumentMessage(new DocumentPut(new Document(protocol.getDocumentTypeManager().getDocumentType("testdoc"), "id:ns:testdoc::")));
 
@@ -643,6 +644,7 @@ public class Messages60TestCase extends MessagesTestBase {
     public class testUpdateDocumentMessage implements RunnableTest {
 
         @Override
+        @SuppressWarnings("deprecation")
         public void run() {
             DocumentType docType = protocol.getDocumentTypeManager().getDocumentType("testdoc");
             DocumentUpdate update = new DocumentUpdate(docType, new DocumentId("id:ns:testdoc::"));
@@ -883,6 +885,7 @@ public class Messages60TestCase extends MessagesTestBase {
 
     public class testGetDocumentReply implements RunnableTest {
 
+        @SuppressWarnings("deprecation")
         public void run() {
             GetDocumentReply reply = new GetDocumentReply(new Document(protocol.getDocumentTypeManager().getDocumentType("testdoc"), "id:ns:testdoc::"));
             assertEquals(47, serialize("GetDocumentReply", reply));

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/MessagesTestBase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/MessagesTestBase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("deprecation")
 public abstract class MessagesTestBase {
 
     protected enum Language {

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PolicyFactoryTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PolicyFactoryTestCase.java
@@ -39,6 +39,7 @@ public class PolicyFactoryTestCase {
     private SourceSession src;
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setUp() throws ListenFailedException {
         slobrok = new Slobrok();
         srv = new TestServer(new MessageBusParams().addProtocol(new DocumentProtocol(new DocumentTypeManager())),

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PolicyTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/PolicyTestCase.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.assertTrue;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("deprecation")
 public class PolicyTestCase {
 
     private static final int TIMEOUT = 300;

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/RoutableFactoryTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/RoutableFactoryTestCase.java
@@ -46,6 +46,7 @@ public class RoutableFactoryTestCase {
     private DestinationSession dstSession;
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setUp() throws ListenFailedException {
         slobrok = new Slobrok();
         DocumentTypeManager docMan = new DocumentTypeManager();

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/storagepolicy/ContentPolicyTestEnvironment.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/storagepolicy/ContentPolicyTestEnvironment.java
@@ -47,6 +47,7 @@ public abstract class ContentPolicyTestEnvironment {
     protected boolean debug = true;
 
     @Before
+    @SuppressWarnings("deprecation")
     public void setUp() throws Exception {
         DocumentTypeManager manager = new DocumentTypeManager();
         DocumentTypeManagerConfigurer.configure(manager, "file:./test/cfg/testdoc.cfg");

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/Destination.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/Destination.java
@@ -40,6 +40,7 @@ public class Destination implements MessageHandler {
     private final SyncSession local;
     private final RPCMessageBus bus;
 
+    @SuppressWarnings("deprecation")
     public Destination(String slobrokConfigId, String documentManagerConfigId) {
 
         DocumentAccessParams params = new DocumentAccessParams();

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -96,7 +96,7 @@
         <configuration>
           <instructions>
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
-            <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
+            <Bundle-Version>7.0.0</Bundle-Version>
             <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
             <_nouses>true</_nouses> <!-- Don't include 'uses' directives for package exports -->
             <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages> <!-- Hide warnings for bouncycastle multi-release jars -->

--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
@@ -62,8 +62,7 @@ import java.util.stream.Stream;
  * @author Simon Thoresen Hult
  */
 public class SimpleFeeder implements ReplyHandler {
-
-
+    @SuppressWarnings("deprecation")
     private final DocumentTypeManager docTypeMgr = new DocumentTypeManager();
     private final List<InputStream> inputStreams;
     private final PrintStream out;
@@ -268,6 +267,7 @@ public class SimpleFeeder implements ReplyHandler {
         return in.readNBytes(buf, 0, buf.length);
     }
 
+    @SuppressWarnings("deprecation")
     static class VespaV1FeedReader implements FeedReader {
         private final InputStream in;
         private final DocumentTypeManager mgr;
@@ -364,6 +364,7 @@ public class SimpleFeeder implements ReplyHandler {
     }
 
     SourceSession getSourceSession() { return session; }
+    @SuppressWarnings("deprecation")
     private FeedReader createFeedReader(InputStream in) throws Exception {
         in.mark(8);
         byte [] b = new byte[2];
@@ -488,6 +489,7 @@ public class SimpleFeeder implements ReplyHandler {
         return out.toString();
     }
 
+    @SuppressWarnings("deprecation")
     private static RPCMessageBus newMessageBus(DocumentTypeManager docTypeMgr, FeederParams params) {
         return new RPCMessageBus(new MessageBusParams().addProtocol(new DocumentProtocol(docTypeMgr)),
                                  new RPCNetworkParams().setSlobrokConfigId(params.getConfigId())

--- a/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
+++ b/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
@@ -21,6 +21,7 @@ import java.io.PrintWriter;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("deprecation")
 public class SimpleServer {
 
     private final DocumentTypeManager documentMgr;

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/FeedContext.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/FeedContext.java
@@ -7,6 +7,7 @@ import com.yahoo.clientmetrics.ClientMetrics;
 import java.util.Map;
 import java.util.TreeMap;
 
+@SuppressWarnings("deprecation")
 public class FeedContext {
     
     private final SessionFactory factory;

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/Feeder.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/Feeder.java
@@ -20,6 +20,7 @@ import com.yahoo.vespaxmlparser.FeedReader;
  * @author Thomas Gundersen
  * @author steinar
  */
+@SuppressWarnings("deprecation")
 public abstract class Feeder {
 
     protected final InputStream stream;

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/JsonFeeder.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/JsonFeeder.java
@@ -12,6 +12,7 @@ import com.yahoo.vespaxmlparser.FeedReader;
  *
  * @author steinar
  */
+@SuppressWarnings("deprecation")
 public class JsonFeeder extends Feeder {
     public JsonFeeder(DocumentTypeManager docMan, SimpleFeedAccess sender, InputStream stream) {
         super(docMan, new VespaFeedSender(sender), stream);

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/XMLFeeder.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/XMLFeeder.java
@@ -14,6 +14,7 @@ import java.io.InputStream;
  * @author Thomas Gundersen
  * @author Steinar Knutsen
  */
+@SuppressWarnings("deprecation")
 public class XMLFeeder extends Feeder {
     public XMLFeeder(DocumentTypeManager docMan, SimpleFeedAccess sender, InputStream stream) {
         super(docMan, new VespaFeedSender(sender), stream);

--- a/vespaclient-core/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerBase.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedhandler/VespaFeedHandlerBase.java
@@ -10,7 +10,7 @@ import com.yahoo.search.query.ParameterParser;
 
 
 import java.io.InputStream;
-
+@SuppressWarnings("deprecation")
 public abstract class VespaFeedHandlerBase {
 
     protected FeedContext context;

--- a/vespaclient-java/src/main/java/com/yahoo/vespafeeder/VespaFeeder.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespafeeder/VespaFeeder.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class VespaFeeder {
 
     private final Arguments args;

--- a/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class VespaFeederTestCase {
 
     @Rule


### PR DESCRIPTION
… should not be used directly by applications.

We should make a new one with an interface that preserves the type hierachy.

@arnej27959 and @bratseth @jonmv PR