### PR TITLE
Reapply "Make sure to consider all sessions in zookeeper when deleting [run-systemtest]"

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -346,16 +346,25 @@ public class SessionRepository {
     }
 
     public int deleteExpiredRemoteSessions(Clock clock, Duration expiryTime) {
+        List<Long> remoteSessionsFromZooKeeper = getRemoteSessionsFromZooKeeper();
+        log.log(Level.FINE, () -> "Remote sessions for tenant " + tenantName + ": " + remoteSessionsFromZooKeeper);
+
         int deleted = 0;
-        for (long sessionId : getRemoteSessionsFromZooKeeper()) {
+        for (long sessionId : remoteSessionsFromZooKeeper) {
             Session session = remoteSessionCache.get(sessionId);
-            if (session == null) continue; // Internal sessions not in sync with zk, continue
+            if (session == null) {
+                log.log(Level.FINE, () -> "Remote session " + sessionId + " is null, creating a new one");
+                session = new RemoteSession(tenantName, sessionId, createSessionZooKeeperClient(sessionId));
+            }
             if (session.getStatus() == Session.Status.ACTIVATE) continue;
             if (sessionHasExpired(session.getCreateTime(), expiryTime, clock)) {
                 log.log(Level.FINE, () -> "Remote session " + sessionId + " for " + tenantName + " has expired, deleting it");
                 deleteRemoteSessionFromZooKeeper(session);
                 deleted++;
             }
+            // Avoid deleting too many in one run
+            if (deleted > 100)
+                break;
         }
         return deleted;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -363,7 +363,7 @@ public class SessionRepository {
                 deleted++;
             }
             // Avoid deleting too many in one run
-            if (deleted > 100)
+            if (deleted >= 2)
                 break;
         }
         return deleted;


### PR DESCRIPTION
Same as https://github.com/vespa-engine/vespa/pull/20322, but now deletes maximum 2 sessions per run. Deleting 100 seems to delete so many nodes that it impacted operations of ZooKeeper cluster. Since the maintainer is run every 30 seconds per config server we should be able to delete what we want eventually with max. 2 per run as well.