### PR TITLE
Add custom `@Beta` annotation

### DIFF
--- a/annotations/src/main/java/com/yahoo/api/annotations/Beta.java
+++ b/annotations/src/main/java/com/yahoo/api/annotations/Beta.java
@@ -1,0 +1,23 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Signifies that the annotated Java type/method/constructor is under development and may still change before they stabilize.
+ * Should only be used on a type that part of a package annotated with {@link PublicApi}.
+ *
+ * @see <a href="https://docs.vespa.ai/en/vespa-versions.html">https://docs.vespa.ai/en/vespa-versions.html</a>
+ *
+ * @author bjorncs
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({
+        ElementType.CONSTRUCTOR,
+        ElementType.METHOD,
+        ElementType.TYPE
+})
+public @interface Beta {}

--- a/application/src/main/java/com/yahoo/application/Application.java
+++ b/application/src/main/java/com/yahoo/application/Application.java
@@ -7,7 +7,7 @@ import ai.vespa.rankingexpression.importer.onnx.OnnxImporter;
 import ai.vespa.rankingexpression.importer.tensorflow.TensorFlowImporter;
 import ai.vespa.rankingexpression.importer.vespa.VespaImporter;
 import ai.vespa.rankingexpression.importer.xgboost.XGBoostImporter;
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.application.container.JDisc;
 import com.yahoo.application.container.impl.StandaloneContainerRunner;
 import com.yahoo.application.content.ContentCluster;

--- a/application/src/main/java/com/yahoo/application/ApplicationBuilder.java
+++ b/application/src/main/java/com/yahoo/application/ApplicationBuilder.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.text.StringUtilities;
 import com.yahoo.text.Utf8;

--- a/application/src/main/java/com/yahoo/application/container/DocumentProcessing.java
+++ b/application/src/main/java/com/yahoo/application/container/DocumentProcessing.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.docproc.DocprocExecutor;
 import com.yahoo.docproc.DocprocService;

--- a/application/src/main/java/com/yahoo/application/container/JDisc.java
+++ b/application/src/main/java/com/yahoo/application/container/JDisc.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
 import com.google.inject.name.Names;

--- a/application/src/main/java/com/yahoo/application/container/Processing.java
+++ b/application/src/main/java/com/yahoo/application/container/Processing.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.chain.Chain;

--- a/application/src/main/java/com/yahoo/application/container/ProcessingBase.java
+++ b/application/src/main/java/com/yahoo/application/container/ProcessingBase.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.chain.Chain;

--- a/application/src/main/java/com/yahoo/application/container/Search.java
+++ b/application/src/main/java/com/yahoo/application/container/Search.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.chain.Chain;

--- a/application/src/main/java/com/yahoo/application/container/SynchronousRequestResponseHandler.java
+++ b/application/src/main/java/com/yahoo/application/container/SynchronousRequestResponseHandler.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.application.container.handler.Request;
 import com.yahoo.application.container.handler.Response;
 import com.yahoo.jdisc.handler.CompletionHandler;

--- a/application/src/main/java/com/yahoo/application/container/handler/Headers.java
+++ b/application/src/main/java/com/yahoo/application/container/handler/Headers.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container.handler;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.jdisc.HeaderFields;
 
 import javax.annotation.concurrent.NotThreadSafe;

--- a/application/src/main/java/com/yahoo/application/container/handler/Request.java
+++ b/application/src/main/java/com/yahoo/application/container/handler/Request.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container.handler;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import net.jcip.annotations.Immutable;
 
 import java.nio.charset.StandardCharsets;

--- a/application/src/main/java/com/yahoo/application/container/handler/Response.java
+++ b/application/src/main/java/com/yahoo/application/container/handler/Response.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container.handler;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.jdisc.http.HttpHeaders;
 import com.yahoo.text.Utf8;
 import net.jcip.annotations.Immutable;

--- a/application/src/main/java/com/yahoo/application/content/ContentCluster.java
+++ b/application/src/main/java/com/yahoo/application/content/ContentCluster.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.content;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 import java.nio.file.Path;
 import java.util.Collections;

--- a/application/src/test/java/com/yahoo/application/ApplicationFacade.java
+++ b/application/src/test/java/com/yahoo/application/ApplicationFacade.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.application.container.handler.Request;
 import com.yahoo.application.container.handler.Response;
 import com.yahoo.component.Component;

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.producer;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
 import com.yahoo.config.model.deploy.DeployState;

--- a/config-model/src/main/java/com/yahoo/config/model/test/TestDriver.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/TestDriver.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.test;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.Version;
 import com.yahoo.config.model.MapConfigModelRegistry;
 import com.yahoo.config.application.api.ApplicationPackage;

--- a/config-model/src/main/java/com/yahoo/config/model/test/TestRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/TestRoot.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.model.test;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.model.ConfigModel;
 import com.yahoo.vespa.model.HostResource;

--- a/container-core/src/main/java/com/yahoo/container/handler/Coverage.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/Coverage.java
@@ -2,7 +2,7 @@
 package com.yahoo.container.handler;
 
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * The coverage report for a result set.

--- a/container-core/src/main/java/com/yahoo/container/handler/test/MockService.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/test/MockService.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.handler.test;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.container.jdisc.LoggingRequestHandler;

--- a/container-core/src/main/java/com/yahoo/container/handler/test/MockServiceHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/test/MockServiceHandler.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.handler.test;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.container.jdisc.HttpRequest;
 
 /**

--- a/container-core/src/main/java/com/yahoo/container/jdisc/RequestHandlerTestDriver.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/RequestHandlerTestDriver.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.jdisc;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.application.ContainerBuilder;

--- a/container-core/src/main/java/com/yahoo/metrics/simple/Counter.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/Counter.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.metrics.simple;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.metrics.simple.UntypedMetric.AssumedType;
 
 /**

--- a/container-core/src/main/java/com/yahoo/metrics/simple/Gauge.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/Gauge.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.metrics.simple;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.metrics.simple.UntypedMetric.AssumedType;
 
 /**

--- a/container-core/src/main/java/com/yahoo/metrics/simple/MetricReceiver.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/MetricReceiver.java
@@ -6,7 +6,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.concurrent.ThreadLocalDirectory;
 

--- a/container-core/src/main/java/com/yahoo/metrics/simple/MetricSettings.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/MetricSettings.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.metrics.simple;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * All information needed for creating any extra data structures associated with

--- a/container-core/src/main/java/com/yahoo/metrics/simple/Point.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/Point.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import com.yahoo.collections.Tuple2;
 import com.yahoo.jdisc.Metric.Context;

--- a/container-core/src/main/java/com/yahoo/metrics/simple/PointBuilder.java
+++ b/container-core/src/main/java/com/yahoo/metrics/simple/PointBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.metrics.simple;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * Single-use builder for the immutable Point instances used to set dimensions

--- a/container-core/src/main/java/com/yahoo/processing/handler/ProcessingTestDriver.java
+++ b/container-core/src/main/java/com/yahoo/processing/handler/ProcessingTestDriver.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.handler;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.component.provider.ComponentRegistry;

--- a/container-search/src/main/java/com/yahoo/prelude/query/ToolBox.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/ToolBox.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.query;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * Query tree helper methods and factories.

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/ArrayAtLookup.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/ArrayAtLookup.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.request;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * Represents access of array element in a document attribute in a {@link GroupingExpression}.

--- a/container-search/src/main/java/com/yahoo/search/grouping/request/InterpolatedLookup.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/request/InterpolatedLookup.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.request;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * This class represents a lookup in a multivalue document

--- a/container-search/src/main/java/com/yahoo/search/result/Coverage.java
+++ b/container-search/src/main/java/com/yahoo/search/result/Coverage.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.result;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * The coverage report for a result set.

--- a/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ValidateNearestNeighborSearcher.java
@@ -2,7 +2,7 @@
 
 package com.yahoo.search.searchers;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.NearestNeighborItem;

--- a/container-search/src/main/java/com/yahoo/search/yql/FieldFiller.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/FieldFiller.java
@@ -6,7 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig.Documentdb;

--- a/container-search/src/main/java/com/yahoo/search/yql/FieldFilter.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/FieldFilter.java
@@ -5,7 +5,7 @@ import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
 import com.yahoo.prelude.fastsearch.FastHit;

--- a/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/MinimalQueryInserter.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.yql;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.inject.Inject;
 import com.yahoo.language.Linguistics;
 import com.yahoo.language.simple.SimpleLinguistics;

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Supplier;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.yahoo.collections.LazyMap;
 import com.yahoo.collections.LazySet;

--- a/document/src/main/java/com/yahoo/document/idstring/IdString.java
+++ b/document/src/main/java/com/yahoo/document/idstring/IdString.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.idstring;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.text.Text;
 import com.yahoo.text.Utf8String;
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/test/ServerProviderConformanceTest.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/test/ServerProviderConformanceTest.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.test;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
 import com.google.inject.Module;

--- a/linguistics-components/src/main/java/com/yahoo/language/sentencepiece/SentencePieceEmbedder.java
+++ b/linguistics-components/src/main/java/com/yahoo/language/sentencepiece/SentencePieceEmbedder.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.language.sentencepiece;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.inject.Inject;
 import com.yahoo.language.Language;
 import com.yahoo.language.process.Embedder;

--- a/model-evaluation/src/main/java/ai/vespa/models/evaluation/Model.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/evaluation/Model.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.models.evaluation;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.searchlib.rankingexpression.ExpressionFunction;

--- a/model-evaluation/src/main/java/ai/vespa/models/evaluation/ModelsEvaluator.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/evaluation/ModelsEvaluator.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.models.evaluation;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.yahoo.component.AbstractComponent;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/Config.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/Config.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/Hit.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/Hit.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * Represents a hit from the predicate search algorithm.

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndex.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndex.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.document.predicate.Predicate;
 import com.yahoo.search.predicate.index.*;
 import com.yahoo.search.predicate.index.conjunction.ConjunctionHit;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndexBuilder.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateIndexBuilder.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateQuery.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/PredicateQuery.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.predicate;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/ElementCompleteness.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/ElementCompleteness.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.ranking.features;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.searchlib.rankingexpression.evaluation.DoubleValue;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/Features.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/Features.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.ranking.features;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 
 import java.util.Collections;

--- a/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/FieldTermMatch.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/ranking/features/FieldTermMatch.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.ranking.features;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.searchlib.rankingexpression.evaluation.DoubleValue;
 import com.yahoo.searchlib.rankingexpression.evaluation.Value;
 

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/FeatureList.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/FeatureList.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.searchlib.rankingexpression.parser.ParseException;
 import com.yahoo.searchlib.rankingexpression.parser.RankingExpressionParser;
 import com.yahoo.searchlib.rankingexpression.parser.TokenMgrException;

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/TensorValue.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.evaluation;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.searchlib.rankingexpression.rule.Function;
 import com.yahoo.searchlib.rankingexpression.rule.TruthOperator;
 import com.yahoo.tensor.Tensor;

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.searchlib.rankingexpression.rule;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
 import com.yahoo.searchlib.rankingexpression.Reference;

--- a/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
+++ b/vespa-http-client/src/main/java/com/yahoo/vespa/http/client/config/FeedParams.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.http.client.config;
 
-import com.google.common.annotations.Beta;
-
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -54,7 +52,6 @@ public final class FeedParams {
          * @param silentUpgrade true for reducing "false" 4xx/5xx.
          * @return this, for chaining
          */
-        @Beta
         public Builder setSilentUpgrade(boolean silentUpgrade) {
             this.silentUpgrade = silentUpgrade;
             return this;
@@ -184,7 +181,6 @@ public final class FeedParams {
         /**
          * Set what frequency to poll for async responses. Default is 10hz (every 0.1s), but 1000hz  when using SyncFeedClient
          */
-        @Beta
         public Builder setIdlePollFrequency(Double idlePollFrequency) {
             this.idlePollFrequency = idlePollFrequency;
             return this;

--- a/vespajlib/src/main/java/com/yahoo/geo/DistanceParser.java
+++ b/vespajlib/src/main/java/com/yahoo/geo/DistanceParser.java
@@ -2,7 +2,7 @@
 
 package com.yahoo.geo;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 /**
  * Utility for parsing a geographical distance with unit.

--- a/vespajlib/src/main/java/com/yahoo/io/reader/NamedReader.java
+++ b/vespajlib/src/main/java/com/yahoo/io/reader/NamedReader.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.io.reader;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 
 import java.io.IOException;
 import java.io.Reader;

--- a/vespajlib/src/main/java/com/yahoo/path/Path.java
+++ b/vespajlib/src/main/java/com/yahoo/path/Path.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.path;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.google.common.collect.ImmutableList;
 
 import java.io.File;

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor.functions;
 
-import com.google.common.annotations.Beta;
+import com.yahoo.api.annotations.Beta;
 import com.yahoo.tensor.PartialAddress;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;


### PR DESCRIPTION
Replace use of Guava's `com.google.common.annotations.Beta` with custom annotation.

I'll update the documentation and internal repository in upcoming PRs.