### PR TITLE
Filter early on buffer id and pass vector of entries in normalize_values

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.cpp
@@ -311,6 +311,167 @@ EnumStoreDictionary<BTreeDictionaryT, HashDictionaryT>::normalize_posting_lists(
 }
 
 template <>
+bool
+EnumStoreDictionary<EnumTree>::normalize_posting_lists(std::function<void(std::vector<EntryRef>&)>, const std::vector<bool> &, uint32_t)
+{
+    LOG_ABORT("should not be reached");
+}
+
+namespace {
+
+template <typename HashDictionaryT>
+class ChangeWriterBase
+{
+protected:
+    HashDictionaryT* _hash_dict;
+    static constexpr bool has_hash_dictionary = true;
+    ChangeWriterBase()
+        : _hash_dict(nullptr)
+    {
+    }
+public:
+    void set_hash_dict(HashDictionaryT &hash_dict) { _hash_dict = &hash_dict; }
+};
+
+template <>
+class ChangeWriterBase<vespalib::datastore::NoHashDictionary>
+{
+protected:
+    static constexpr bool has_hash_dictionary = false;
+    ChangeWriterBase() = default;
+};
+
+template <typename HashDictionaryT>
+class ChangeWriter : public ChangeWriterBase<HashDictionaryT> {
+    using Parent = ChangeWriterBase<HashDictionaryT>;
+    using Parent::has_hash_dictionary;
+    std::vector<std::pair<EntryRef,uint32_t*>> _tree_refs;
+public:
+    ChangeWriter(uint32_t capacity);
+    ~ChangeWriter();
+    bool write(const std::vector<EntryRef>& refs);
+    void emplace_back(EntryRef key, uint32_t& tree_ref) { _tree_refs.emplace_back(std::make_pair(key, &tree_ref)); }
+};
+
+template <typename HashDictionaryT>
+ChangeWriter<HashDictionaryT>::ChangeWriter(uint32_t capacity)
+    : ChangeWriterBase<HashDictionaryT>(),
+      _tree_refs()
+{
+    _tree_refs.reserve(capacity);
+}
+
+template <typename HashDictionaryT>
+ChangeWriter<HashDictionaryT>::~ChangeWriter() = default;
+
+template <typename HashDictionaryT>
+bool
+ChangeWriter<HashDictionaryT>::write(const std::vector<EntryRef> &refs)
+{
+    bool changed = false;
+    assert(refs.size() == _tree_refs.size());
+    auto tree_ref = _tree_refs.begin();
+    for (auto ref : refs) {
+        EntryRef old_ref(*tree_ref->second);
+        if (ref != old_ref) {
+            if (!changed) {
+                // Note: Needs review when porting to other platforms
+                // Assumes that other CPUs observes stores from this CPU in order
+                std::atomic_thread_fence(std::memory_order_release);
+                changed = true;
+            }
+            *tree_ref->second = ref.ref();
+            if constexpr (has_hash_dictionary) {
+                auto find_result = this->_hash_dict->find(this->_hash_dict->get_default_comparator(), tree_ref->first);
+                assert(find_result != nullptr && find_result->first.load_relaxed() == tree_ref->first);
+                assert(find_result->second.load_relaxed() == old_ref);
+                find_result->second.store_release(ref);
+            }
+        }
+        ++tree_ref;
+    }
+    assert(tree_ref == _tree_refs.end());
+    _tree_refs.clear();
+    return changed;
+}
+
+}
+
+template <typename BTreeDictionaryT, typename HashDictionaryT>
+bool
+EnumStoreDictionary<BTreeDictionaryT, HashDictionaryT>::normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits)
+{
+    if constexpr (has_btree_dictionary) {
+        std::vector<EntryRef> refs;
+        refs.reserve(1024);
+        bool changed = false;
+        ChangeWriter<HashDictionaryT> change_writer(refs.capacity());
+        if constexpr (has_hash_dictionary) {
+            change_writer.set_hash_dict(this->_hash_dict);
+        }
+        auto& dict = this->_btree_dict;
+        for (auto itr = dict.begin(); itr.valid(); ++itr) {
+            EntryRef ref(itr.getData());
+            if (ref.valid()) {
+                uint32_t buffer_id = ref.buffer_id(entry_ref_offset_bits);
+                if (filter[buffer_id]) {
+                    refs.emplace_back(ref);
+                    change_writer.emplace_back(itr.getKey(), itr.getWData());
+                    if (refs.size() >= refs.capacity()) {
+                        normalize(refs);
+                        changed |= change_writer.write(refs);
+                        refs.clear();
+                    }
+                }
+            }
+        }
+        if (!refs.empty()) {
+            normalize(refs);
+            changed |= change_writer.write(refs);
+        }
+        return changed;
+    } else {
+        return this->_hash_dict.normalize_values(normalize, filter, entry_ref_offset_bits);
+    }
+}
+
+template <>
+void
+EnumStoreDictionary<EnumTree>::foreach_posting_list(std::function<void(const std::vector<EntryRef>&)>, const std::vector<bool>&, uint32_t)
+{
+    LOG_ABORT("should not be reached");
+}
+
+template <typename BTreeDictionaryT, typename HashDictionaryT>
+void
+EnumStoreDictionary<BTreeDictionaryT, HashDictionaryT>::foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits)
+{
+    if constexpr (has_btree_dictionary) {
+        std::vector<EntryRef> refs;
+        refs.reserve(1024);
+        auto& dict = this->_btree_dict;
+        for (auto itr = dict.begin(); itr.valid(); ++itr) {
+            EntryRef ref(itr.getData());
+            if (ref.valid()) {
+                uint32_t buffer_id = ref.buffer_id(entry_ref_offset_bits);
+                if (filter[buffer_id]) {
+                    refs.emplace_back(ref);
+                    if (refs.size() >= refs.capacity()) {
+                        callback(refs);
+                        refs.clear();
+                    }
+                }
+            }
+        }
+        if (!refs.empty()) {
+            callback(refs);
+        }
+    } else {
+        this->_hash_dict.foreach_value(callback, filter, entry_ref_offset_bits);
+    }
+}
+
+template <>
 const EnumPostingTree &
 EnumStoreDictionary<EnumTree>::get_posting_dictionary() const
 {

--- a/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.h
+++ b/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.h
@@ -54,6 +54,8 @@ public:
     void clear_all_posting_lists(std::function<void(EntryRef)> clearer) override;
     void update_posting_list(Index idx, const EntryComparator& cmp, std::function<EntryRef(EntryRef)> updater) override;
     bool normalize_posting_lists(std::function<EntryRef(EntryRef)> normalize) override;
+    bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) override;
+    void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) override;
     const EnumPostingTree& get_posting_dictionary() const override;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.h
+++ b/searchlib/src/vespa/searchlib/attribute/enum_store_dictionary.h
@@ -16,6 +16,7 @@ template <typename BTreeDictionaryT, typename HashDictionaryT = vespalib::datast
 class EnumStoreDictionary : public vespalib::datastore::UniqueStoreDictionary<BTreeDictionaryT, IEnumStoreDictionary, HashDictionaryT> {
 protected:
     using EntryRef = IEnumStoreDictionary::EntryRef;
+    using EntryRefFilter = IEnumStoreDictionary::EntryRefFilter;
     using Index = IEnumStoreDictionary::Index;
     using BTreeDictionaryType = BTreeDictionaryT;
     using EntryComparator = IEnumStoreDictionary::EntryComparator;
@@ -54,8 +55,8 @@ public:
     void clear_all_posting_lists(std::function<void(EntryRef)> clearer) override;
     void update_posting_list(Index idx, const EntryComparator& cmp, std::function<EntryRef(EntryRef)> updater) override;
     bool normalize_posting_lists(std::function<EntryRef(EntryRef)> normalize) override;
-    bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) override;
-    void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) override;
+    bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const EntryRefFilter& filter) override;
+    void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const EntryRefFilter& filter) override;
     const EnumPostingTree& get_posting_dictionary() const override;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/i_enum_store_dictionary.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_enum_store_dictionary.h
@@ -53,6 +53,8 @@ public:
     virtual void clear_all_posting_lists(std::function<void(EntryRef)> clearer) = 0;
     virtual void update_posting_list(Index idx, const EntryComparator& cmp, std::function<EntryRef(EntryRef)> updater) = 0;
     virtual bool normalize_posting_lists(std::function<EntryRef(EntryRef)> normalize) = 0;
+    virtual bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) = 0;
+    virtual void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) = 0;
     virtual const EnumPostingTree& get_posting_dictionary() const = 0;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/i_enum_store_dictionary.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_enum_store_dictionary.h
@@ -30,6 +30,7 @@ class IEnumStoreDictionary : public vespalib::datastore::IUniqueStoreDictionary 
 public:
     using EntryRef = vespalib::datastore::EntryRef;
     using EntryComparator = vespalib::datastore::EntryComparator;
+    using EntryRefFilter = vespalib::datastore::EntryRefFilter;
     using EnumVector = IEnumStore::EnumVector;
     using Index = IEnumStore::Index;
     using IndexList = IEnumStore::IndexList;
@@ -52,9 +53,25 @@ public:
     virtual Index remap_index(Index idx) = 0;
     virtual void clear_all_posting_lists(std::function<void(EntryRef)> clearer) = 0;
     virtual void update_posting_list(Index idx, const EntryComparator& cmp, std::function<EntryRef(EntryRef)> updater) = 0;
+    /*
+     * Scan dictionary and call normalize function for each value. If
+     * returned value is different then write back the modified value to
+     * the dictionary. Only used by unit tests.
+     */
     virtual bool normalize_posting_lists(std::function<EntryRef(EntryRef)> normalize) = 0;
-    virtual bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) = 0;
-    virtual void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits) = 0;
+    /*
+     * Scan dictionary and call normalize function for batches of values
+     * that pass the filter. Write back modified values to the dictionary.
+     * Used by compaction of posting lists when moving short arrays,
+     * bitvectors or btree roots.
+     */
+    virtual bool normalize_posting_lists(std::function<void(std::vector<EntryRef>&)> normalize, const EntryRefFilter& filter) = 0;
+    /*
+     * Scan dictionary and call callback function for batches of values
+     * that pass the filter. Used by compaction of posting lists when
+     * moving btree nodes.
+     */
+    virtual void foreach_posting_list(std::function<void(const std::vector<EntryRef>&)> callback, const EntryRefFilter& filter) = 0;
     virtual const EnumPostingTree& get_posting_dictionary() const = 0;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -105,7 +105,7 @@ public:
     ~PostingStore();
 
     bool removeSparseBitVectors() override;
-    EntryRef consider_remove_sparse_bitvector(EntryRef ref);
+    void consider_remove_sparse_bitvector(std::vector<EntryRef> &refs);
     static bool isBitVector(uint32_t typeId) { return typeId == BUFFERTYPE_BITVECTOR; }
     static bool isBTree(uint32_t typeId) { return typeId == BUFFERTYPE_BTREE; }
     bool isBTree(RefType ref) const { return isBTree(getTypeId(ref)); }
@@ -188,8 +188,8 @@ public:
     vespalib::MemoryUsage getMemoryUsage() const;
     vespalib::MemoryUsage update_stat();
 
-    void move_btree_nodes(EntryRef ref);
-    EntryRef move(EntryRef ref);
+    void move_btree_nodes(const std::vector<EntryRef> &refs);
+    void move(std::vector<EntryRef>& refs);
 
     void compact_worst_btree_nodes();
     void compact_worst_buffers();

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -89,6 +89,7 @@ public:
     using Parent::getWTreeEntry;
     using Parent::getTreeEntry;
     using Parent::getKeyDataEntry;
+    using Parent::isBTree;
     using Parent::clusterLimit;
     using Parent::allocBTree;
     using Parent::allocBTreeCopy;
@@ -107,8 +108,6 @@ public:
     bool removeSparseBitVectors() override;
     void consider_remove_sparse_bitvector(std::vector<EntryRef> &refs);
     static bool isBitVector(uint32_t typeId) { return typeId == BUFFERTYPE_BITVECTOR; }
-    static bool isBTree(uint32_t typeId) { return typeId == BUFFERTYPE_BTREE; }
-    bool isBTree(RefType ref) const { return isBTree(getTypeId(ref)); }
 
     void applyNew(EntryRef &ref, AddIter a, AddIter ae);
 

--- a/vespalib/src/tests/btree/btree_store/btree_store_test.cpp
+++ b/vespalib/src/tests/btree/btree_store/btree_store_test.cpp
@@ -73,61 +73,112 @@ BTreeStoreTest::~BTreeStoreTest()
     inc_generation();
 }
 
+namespace {
+
+class ChangeWriter {
+    std::vector<EntryRef*> _old_refs;
+public:
+    ChangeWriter(uint32_t capacity);
+    ~ChangeWriter();
+    void write(const std::vector<EntryRef>& refs);
+    void emplace_back(EntryRef& ref) { _old_refs.emplace_back(&ref); }
+};
+
+ChangeWriter::ChangeWriter(uint32_t capacity)
+    : _old_refs()
+{
+    _old_refs.reserve(capacity);
+}
+
+ChangeWriter::~ChangeWriter() = default;
+
+void
+ChangeWriter::write(const std::vector<EntryRef> &refs)
+{
+    assert(refs.size() == _old_refs.size());
+    auto old_ref_itr = _old_refs.begin();
+    for (auto ref : refs) {
+        **old_ref_itr = ref;
+        ++old_ref_itr;
+    }
+    assert(old_ref_itr == _old_refs.end());
+    _old_refs.clear();
+}
+
+}
+
 void
 BTreeStoreTest::test_compact_sequence(uint32_t sequence_length)
 {
     auto &store = _store;
+    uint32_t entry_ref_offset_bits = TreeStore::RefType::offset_bits;
     EntryRef ref1 = add_sequence(4, 4 + sequence_length);
     EntryRef ref2 = add_sequence(5, 5 + sequence_length);
-    EntryRef old_ref1 = ref1;
-    EntryRef old_ref2 = ref2;
     std::vector<EntryRef> refs;
+    refs.reserve(2);
+    refs.emplace_back(ref1);
+    refs.emplace_back(ref2);
+    std::vector<EntryRef> temp_refs;
     for (int i = 0; i < 1000; ++i) {
-        refs.emplace_back(add_sequence(i + 6, i + 6 + sequence_length));
+        temp_refs.emplace_back(add_sequence(i + 6, i + 6 + sequence_length));
     }
-    for (auto& ref : refs) {
+    for (auto& ref : temp_refs) {
         store.clear(ref);
     }
     inc_generation();
+    ChangeWriter change_writer(refs.size());
+    std::vector<EntryRef> move_refs;
+    move_refs.reserve(refs.size());
     auto usage_before = store.getMemoryUsage();
     for (uint32_t pass = 0; pass < 15; ++pass) {
         auto to_hold = store.start_compact_worst_buffers();
-        ref1 = store.move(ref1);
-        ref2 = store.move(ref2);
+        std::vector<bool> filter(TreeStore::RefType::numBuffers());
+        for (auto buffer_id : to_hold) {
+            filter[buffer_id] = true;
+        }
+        for (auto& ref : refs) {
+            if (ref.valid() && filter[ref.buffer_id(entry_ref_offset_bits)]) {
+                move_refs.emplace_back(ref);
+                change_writer.emplace_back(ref);
+            }
+        }
+        store.move(move_refs);
+        change_writer.write(move_refs);
+        move_refs.clear();
         store.finishCompact(to_hold);
         inc_generation();
     }
-    EXPECT_NE(old_ref1, ref1);
-    EXPECT_NE(old_ref2, ref2);
-    EXPECT_EQ(make_exp_sequence(4, 4 + sequence_length), get_sequence(ref1));
-    EXPECT_EQ(make_exp_sequence(5, 5 + sequence_length), get_sequence(ref2));
+    EXPECT_NE(ref1, refs[0]);
+    EXPECT_NE(ref2, refs[1]);
+    EXPECT_EQ(make_exp_sequence(4, 4 + sequence_length), get_sequence(refs[0]));
+    EXPECT_EQ(make_exp_sequence(5, 5 + sequence_length), get_sequence(refs[1]));
     auto usage_after = store.getMemoryUsage();
     EXPECT_GT(usage_before.deadBytes(), usage_after.deadBytes());
-    store.clear(ref1);
-    store.clear(ref2);
+    store.clear(refs[0]);
+    store.clear(refs[1]);
 }
 
 TEST_F(BTreeStoreTest, require_that_nodes_for_multiple_btrees_are_compacted)
 {
     auto &store = this->_store;
-    EntryRef ref1 = add_sequence(4, 40);
-    EntryRef ref2 = add_sequence(100, 130);
+    std::vector<EntryRef> refs;
+    refs.emplace_back(add_sequence(4, 40));
+    refs.emplace_back(add_sequence(100, 130));
     store.clear(add_sequence(1000, 20000));
     inc_generation();
     auto usage_before = store.getMemoryUsage();
     for (uint32_t pass = 0; pass < 15; ++pass) {
         auto to_hold = store.start_compact_worst_btree_nodes();
-        store.move_btree_nodes(ref1);
-        store.move_btree_nodes(ref2);
+        store.move_btree_nodes(refs);
         store.finish_compact_worst_btree_nodes(to_hold);
         inc_generation();
     }
-    EXPECT_EQ(make_exp_sequence(4, 40), get_sequence(ref1));
-    EXPECT_EQ(make_exp_sequence(100, 130), get_sequence(ref2));
+    EXPECT_EQ(make_exp_sequence(4, 40), get_sequence(refs[0]));
+    EXPECT_EQ(make_exp_sequence(100, 130), get_sequence(refs[1]));
     auto usage_after = store.getMemoryUsage();
     EXPECT_GT(usage_before.deadBytes(), usage_after.deadBytes());
-    store.clear(ref1);
-    store.clear(ref2);
+    store.clear(refs[0]);
+    store.clear(refs[1]);
 }
 
 TEST_F(BTreeStoreTest, require_that_short_arrays_are_compacted)

--- a/vespalib/src/tests/datastore/sharded_hash_map/sharded_hash_map_test.cpp
+++ b/vespalib/src/tests/datastore/sharded_hash_map/sharded_hash_map_test.cpp
@@ -12,6 +12,7 @@
 #include <vespa/vespalib/gtest/gtest.h>
 
 #include <vespa/vespalib/datastore/unique_store_allocator.hpp>
+#include <iostream>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -26,6 +27,26 @@ using MyCompare = vespalib::datastore::UniqueStoreComparator<uint32_t, RefT>;
 using MyHashMap = vespalib::datastore::ShardedHashMap;
 using GenerationHandler = vespalib::GenerationHandler;
 using vespalib::makeLambdaTask;
+
+constexpr uint32_t small_population = 50;
+/*
+ * large_population should trigger multiple callbacks from normalize_values
+ * and foreach_value
+ */
+constexpr uint32_t large_population = 1200;
+
+namespace vespalib::datastore {
+
+/*
+ * Print EntryRef as RefT which is used by test_normalize_values and
+ * test_foreach_value to differentiate between buffers
+ */
+void PrintTo(const EntryRef &ref, std::ostream* os) {
+    RefT iref(ref);
+    *os << "RefT(" << iref.offset() << "," << iref.bufferId() << ")";
+}
+
+}
 
 namespace {
 
@@ -58,6 +79,19 @@ public:
     }
 };
 
+uint32_t select_buffer(uint32_t i) {
+    if ((i % 2) == 0) {
+        return 0;
+    }
+    if ((i % 3) == 0) {
+        return 1;
+    }
+    if ((i % 5) == 0) {
+        return 2;
+    }
+    return 3;
+}
+
 }
 
 struct DataStoreShardedHashTest : public ::testing::Test
@@ -86,7 +120,11 @@ struct DataStoreShardedHashTest : public ::testing::Test
     void read_work(uint32_t cnt);
     void read_work();
     void write_work(uint32_t cnt);
-    void populate_sample_data();
+    void populate_sample_data(uint32_t cnt);
+    void populate_sample_values(uint32_t cnt);
+    void clear_sample_values(uint32_t cnt);
+    void test_normalize_values(bool filter, bool one_filter);
+    void test_foreach_value(bool one_filter);
 };
 
 
@@ -213,11 +251,88 @@ DataStoreShardedHashTest::write_work(uint32_t cnt)
 }
 
 void
-DataStoreShardedHashTest::populate_sample_data()
+DataStoreShardedHashTest::populate_sample_data(uint32_t cnt)
 {
-    for (uint32_t i = 0; i < 50; ++i) {
+    for (uint32_t i = 0; i < cnt; ++i) {
         insert(i);
     }
+}
+
+void
+DataStoreShardedHashTest::populate_sample_values(uint32_t cnt)
+{
+    for (uint32_t i = 0; i < cnt; ++i) {
+        MyCompare comp(_store, i);
+        auto result = _hash_map.find(comp, EntryRef());
+        ASSERT_NE(result, nullptr);
+        EXPECT_EQ(i, _allocator.get_wrapped(result->first.load_relaxed()).value());
+        result->second.store_relaxed(RefT(i + 200, select_buffer(i)));
+    }
+}
+
+void
+DataStoreShardedHashTest::clear_sample_values(uint32_t cnt)
+{
+    for (uint32_t i = 0; i < cnt; ++i) {
+        MyCompare comp(_store, i);
+        auto result = _hash_map.find(comp, EntryRef());
+        ASSERT_NE(result, nullptr);
+        EXPECT_EQ(i, _allocator.get_wrapped(result->first.load_relaxed()).value());
+        result->second.store_relaxed(EntryRef());
+    }
+}
+
+void
+DataStoreShardedHashTest::test_normalize_values(bool filter, bool one_filter)
+{
+    populate_sample_data(large_population);
+    populate_sample_values(large_population);
+    if (filter) {
+        std::vector<bool> bfilter;
+        if (one_filter) {
+            bfilter = std::vector<bool>(RefT::numBuffers());
+            bfilter[3] = true;
+        } else {
+            bfilter = std::vector<bool>(RefT::numBuffers(), true);
+        }
+        EXPECT_TRUE(_hash_map.normalize_values([](std::vector<EntryRef> &refs) noexcept { for (auto &ref : refs) { RefT iref(ref); ref = RefT(iref.offset() + 300, iref.bufferId()); } }, bfilter, RefT::offset_bits));
+    } else {
+        EXPECT_TRUE(_hash_map.normalize_values([](EntryRef ref) noexcept { RefT iref(ref); return RefT(iref.offset() + 300, iref.bufferId()); }));
+    }
+    for (uint32_t i = 0; i < large_population; ++i) {
+        MyCompare comp(_store, i);
+        auto result = _hash_map.find(comp, EntryRef());
+        ASSERT_NE(result, nullptr);
+        EXPECT_EQ(i, _allocator.get_wrapped(result->first.load_relaxed()).value());
+        ASSERT_EQ(select_buffer(i), RefT(result->second.load_relaxed()).bufferId());
+        if (filter && one_filter && select_buffer(i) != 3) {
+            ASSERT_EQ(i + 200, RefT(result->second.load_relaxed()).offset());
+        } else {
+            ASSERT_EQ(i + 500, RefT(result->second.load_relaxed()).offset());
+        }
+        result->second.store_relaxed(EntryRef());
+    }
+}
+
+void
+DataStoreShardedHashTest::test_foreach_value(bool one_filter)
+{
+    populate_sample_data(large_population);
+    populate_sample_values(large_population);
+
+    std::vector<bool> bfilter;
+    if (one_filter) {
+        bfilter = std::vector<bool>(RefT::numBuffers());
+        bfilter[3] = true;
+    } else {
+        bfilter = std::vector<bool>(RefT::numBuffers(), true);
+    }
+    std::vector<EntryRef> exp_refs;
+    EXPECT_FALSE(_hash_map.normalize_values([&exp_refs](std::vector<EntryRef>& refs) { exp_refs.insert(exp_refs.end(), refs.begin(), refs.end()); }, bfilter, RefT::offset_bits));
+    std::vector<EntryRef> act_refs;
+    _hash_map.foreach_value([&act_refs](const std::vector<EntryRef> &refs) { act_refs.insert(act_refs.end(), refs.begin(), refs.end()); }, bfilter, RefT::offset_bits);
+    EXPECT_EQ(exp_refs, act_refs);
+    clear_sample_values(large_population);
 }
 
 TEST_F(DataStoreShardedHashTest, single_threaded_reader_without_updates)
@@ -254,7 +369,7 @@ TEST_F(DataStoreShardedHashTest, memory_usage_is_reported)
     EXPECT_EQ(0, initial_usage.deadBytes());
     EXPECT_EQ(0, initial_usage.allocatedBytesOnHold());
     auto guard = _generationHandler.takeGuard();
-    for (uint32_t i = 0; i < 50; ++i) {
+    for (uint32_t i = 0; i < small_population; ++i) {
         insert(i);
     }
     auto usage = _hash_map.get_memory_usage();
@@ -264,19 +379,19 @@ TEST_F(DataStoreShardedHashTest, memory_usage_is_reported)
 
 TEST_F(DataStoreShardedHashTest, foreach_key_works)
 {
-    populate_sample_data();
+    populate_sample_data(small_population);
     std::vector<uint32_t> keys;
     _hash_map.foreach_key([this, &keys](EntryRef ref) { keys.emplace_back(_allocator.get_wrapped(ref).value()); });
     std::sort(keys.begin(), keys.end());
-    EXPECT_EQ(50, keys.size());
-    for (uint32_t i = 0; i < 50; ++i) {
+    EXPECT_EQ(small_population, keys.size());
+    for (uint32_t i = 0; i < small_population; ++i) {
         EXPECT_EQ(i, keys[i]);
     }
 }
 
 TEST_F(DataStoreShardedHashTest, move_keys_works)
 {
-    populate_sample_data();
+    populate_sample_data(small_population);
     std::vector<EntryRef> refs;
     _hash_map.foreach_key([&refs](EntryRef ref) { refs.emplace_back(ref); });
     std::vector<EntryRef> new_refs;
@@ -284,10 +399,10 @@ TEST_F(DataStoreShardedHashTest, move_keys_works)
     _hash_map.move_keys(my_compactable, std::vector<bool>(RefT::numBuffers(), true), RefT::offset_bits);
     std::vector<EntryRef> verify_new_refs;
     _hash_map.foreach_key([&verify_new_refs](EntryRef ref) { verify_new_refs.emplace_back(ref); });
-    EXPECT_EQ(50u, refs.size());
+    EXPECT_EQ(small_population, refs.size());
     EXPECT_NE(refs, new_refs);
     EXPECT_EQ(new_refs, verify_new_refs);
-    for (uint32_t i = 0; i < 50; ++i) {
+    for (uint32_t i = 0; i < small_population; ++i) {
         EXPECT_NE(refs[i], new_refs[i]);
         auto value = _allocator.get_wrapped(refs[i]).value();
         auto new_value = _allocator.get_wrapped(refs[i]).value();
@@ -297,29 +412,33 @@ TEST_F(DataStoreShardedHashTest, move_keys_works)
 
 TEST_F(DataStoreShardedHashTest, normalize_values_works)
 {
-    populate_sample_data();
-    for (uint32_t i = 0; i < 50; ++i) {
-        MyCompare comp(_store, i);
-        auto result = _hash_map.find(comp, EntryRef());
-        ASSERT_NE(result, nullptr);
-        EXPECT_EQ(i, _allocator.get_wrapped(result->first.load_relaxed()).value());
-        result->second.store_relaxed(EntryRef(i + 200));
-    }
-    _hash_map.normalize_values([](EntryRef ref) noexcept { return EntryRef(ref.ref() + 300); });
-    for (uint32_t i = 0; i < 50; ++i) {
-        MyCompare comp(_store, i);
-        auto result = _hash_map.find(comp, EntryRef());
-        ASSERT_NE(result, nullptr);
-        EXPECT_EQ(i, _allocator.get_wrapped(result->first.load_relaxed()).value());
-        ASSERT_EQ(i + 500, result->second.load_relaxed().ref());
-        result->second.store_relaxed(EntryRef());
-    }
+    test_normalize_values(false, false);
+}
+
+TEST_F(DataStoreShardedHashTest, normalize_values_all_filter_works)
+{
+    test_normalize_values(true, false);
+}
+
+TEST_F(DataStoreShardedHashTest, normalize_values_one_filter_works)
+{
+    test_normalize_values(true, true);
+}
+
+TEST_F(DataStoreShardedHashTest, foreach_value_all_filter_works)
+{
+    test_foreach_value(false);
+}
+
+TEST_F(DataStoreShardedHashTest, foreach_value_one_filter_works)
+{
+    test_foreach_value(true);
 }
 
 TEST_F(DataStoreShardedHashTest, compact_worst_shard_works)
 {
-    populate_sample_data();
-    for (uint32_t i = 10; i < 50; ++i) {
+    populate_sample_data(small_population);
+    for (uint32_t i = 10; i < small_population; ++i) {
         remove(i);
     }
     commit();

--- a/vespalib/src/vespa/vespalib/btree/btreeiterator.h
+++ b/vespalib/src/vespa/vespalib/btree/btreeiterator.h
@@ -113,6 +113,9 @@ public:
         return _node->getData(_idx);
     }
 
+    // Only use during compaction when changing reference to moved value
+    DataType &getWData() { return getWNode()->getWData(_idx); }
+
     bool
     valid() const
     {
@@ -880,6 +883,9 @@ public:
     {
         _leaf.getWNode()->writeData(_leaf.getIdx(), data);
     }
+
+    // Only use during compaction when changing reference to moved value
+    DataType &getWData() { return _leaf.getWData(); }
 
     /**
      * Set a new key for the current iterator position.

--- a/vespalib/src/vespa/vespalib/btree/btreenode.h
+++ b/vespalib/src/vespa/vespalib/btree/btreenode.h
@@ -99,6 +99,8 @@ public:
     }
 
     const DataT &getData(uint32_t idx) const { return _data[idx]; }
+    // Only use during compaction when changing reference to moved value
+    DataT &getWData(uint32_t idx) { return _data[idx]; }
     void setData(uint32_t idx, const DataT &data) { _data[idx] = data; }
     static bool hasData() { return true; }
 };
@@ -119,6 +121,9 @@ public:
         (void) idx;
         return BTreeNoLeafData::_instance;
     }
+
+    // Only use during compaction when changing reference to moved value
+    BTreeNoLeafData &getWData(uint32_t) const { return BTreeNoLeafData::_instance; }
 
     void setData(uint32_t idx, const BTreeNoLeafData &data) {
         (void) idx;

--- a/vespalib/src/vespa/vespalib/btree/btreestore.h
+++ b/vespalib/src/vespa/vespalib/btree/btreestore.h
@@ -298,6 +298,9 @@ public:
     bool
     isSmallArray(const EntryRef ref) const;
 
+    static bool isBTree(uint32_t typeId) { return typeId == BUFFERTYPE_BTREE; }
+    bool isBTree(RefType ref) const { return isBTree(getTypeId(ref)); }
+
     /**
      * Returns the cluster size for the type id.
      * Cluster size == 0 means we have a tree for the given reference.
@@ -391,10 +394,10 @@ public:
 
     std::vector<uint32_t> start_compact_worst_btree_nodes();
     void finish_compact_worst_btree_nodes(const std::vector<uint32_t>& to_hold);
-    void move_btree_nodes(EntryRef ref);
+    void move_btree_nodes(const std::vector<EntryRef>& refs);
 
     std::vector<uint32_t> start_compact_worst_buffers();
-    EntryRef move(EntryRef ref);
+    void move(std::vector<EntryRef>& refs);
 
 private:
     static constexpr size_t MIN_BUFFER_ARRAYS = 128u;

--- a/vespalib/src/vespa/vespalib/datastore/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/datastore/CMakeLists.txt
@@ -8,6 +8,7 @@ vespa_add_library(vespalib_vespalib_datastore OBJECT
     datastore.cpp
     datastorebase.cpp
     entryref.cpp
+    entry_ref_filter.cpp
     fixed_size_hash_map.cpp
     sharded_hash_map.cpp
     unique_store.cpp

--- a/vespalib/src/vespa/vespalib/datastore/entry_ref_filter.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/entry_ref_filter.cpp
@@ -1,0 +1,28 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "entry_ref_filter.h"
+
+namespace vespalib::datastore {
+
+EntryRefFilter::EntryRefFilter(std::vector<bool> filter, uint32_t offset_bits)
+    : _filter(std::move(filter)),
+      _offset_bits(offset_bits)
+{
+}
+
+EntryRefFilter::EntryRefFilter(uint32_t num_buffers, uint32_t offset_bits)
+    : _filter(num_buffers),
+      _offset_bits(offset_bits)
+{
+}
+
+EntryRefFilter::~EntryRefFilter() = default;
+
+EntryRefFilter
+EntryRefFilter::create_all_filter(uint32_t num_buffers, uint32_t offset_bits)
+{
+    std::vector<bool> filter(num_buffers, true);
+    return EntryRefFilter(std::move(filter), offset_bits);
+}
+
+}

--- a/vespalib/src/vespa/vespalib/datastore/entry_ref_filter.h
+++ b/vespalib/src/vespa/vespalib/datastore/entry_ref_filter.h
@@ -1,0 +1,35 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "entryref.h"
+#include <vector>
+
+namespace vespalib::datastore {
+
+/*
+ * Class to filter entry refs based on which buffer the entry is referencing.
+ *
+ * Buffers being allowed have corresponding bit in _filter set.
+ */
+class EntryRefFilter {
+    std::vector<bool> _filter;
+    uint32_t          _offset_bits;
+    EntryRefFilter(std::vector<bool> filter, uint32_t offset_bits);
+public:
+    EntryRefFilter(uint32_t num_buffers, uint32_t offset_bits);
+    ~EntryRefFilter();
+    bool has(EntryRef ref) const {
+        uint32_t buffer_id = ref.buffer_id(_offset_bits);
+        return _filter[buffer_id];
+    }
+    void add_buffer(uint32_t buffer_id) { _filter[buffer_id] = true; }
+    void add_buffers(const std::vector<uint32_t>& ids) {
+        for (auto buffer_id : ids) {
+            _filter[buffer_id] = true;
+        }
+    }
+    static EntryRefFilter create_all_filter(uint32_t num_buffers, uint32_t offset_bits);
+};
+
+}

--- a/vespalib/src/vespa/vespalib/datastore/fixed_size_hash_map.h
+++ b/vespalib/src/vespa/vespalib/datastore/fixed_size_hash_map.h
@@ -160,6 +160,8 @@ public:
     void foreach_key(const std::function<void(EntryRef)>& callback) const;
     void move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits);
     bool normalize_values(const std::function<EntryRef(EntryRef)>& normalize);
+    bool normalize_values(const std::function<void(std::vector<EntryRef>&)>& normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
+    void foreach_value(const std::function<void(const std::vector<EntryRef>&)>& callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
 };
 
 }

--- a/vespalib/src/vespa/vespalib/datastore/i_unique_store_dictionary.h
+++ b/vespalib/src/vespa/vespalib/datastore/i_unique_store_dictionary.h
@@ -11,6 +11,7 @@
 namespace vespalib::datastore {
 
 class EntryComparator;
+class EntryRefFilter;
 struct ICompactable;
 class IUniqueStoreDictionaryReadSnapshot;
 class UniqueStoreAddResult;
@@ -28,7 +29,7 @@ public:
     virtual UniqueStoreAddResult add(const EntryComparator& comp, std::function<EntryRef(void)> insertEntry) = 0;
     virtual EntryRef find(const EntryComparator& comp) = 0;
     virtual void remove(const EntryComparator& comp, EntryRef ref) = 0;
-    virtual void move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits) = 0;
+    virtual void move_keys(ICompactable& compactable, const EntryRefFilter& compacting_buffers) = 0;
     virtual uint32_t get_num_uniques() const = 0;
     virtual vespalib::MemoryUsage get_memory_usage() const = 0;
     virtual void build(vespalib::ConstArrayRef<EntryRef>, vespalib::ConstArrayRef<uint32_t> ref_counts, std::function<void(EntryRef)> hold) = 0;

--- a/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.cpp
@@ -171,12 +171,12 @@ ShardedHashMap::foreach_key(std::function<void(EntryRef)> callback) const
 }
 
 void
-ShardedHashMap::move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits)
+ShardedHashMap::move_keys(ICompactable& compactable, const EntryRefFilter& compacting_buffers)
 {
     for (size_t i = 0; i < num_shards; ++i) {
         auto map = _maps[i].load(std::memory_order_relaxed);
         if (map != nullptr) {
-            map->move_keys(compactable, compacting_buffers, entry_ref_offset_bits);
+            map->move_keys(compactable, compacting_buffers);
         }
     }
 }
@@ -195,25 +195,25 @@ ShardedHashMap::normalize_values(std::function<EntryRef(EntryRef)> normalize)
 }
 
 bool
-ShardedHashMap::normalize_values(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits)
+ShardedHashMap::normalize_values(std::function<void(std::vector<EntryRef>&)> normalize, const EntryRefFilter& filter)
 {
     bool changed = false;
     for (size_t i = 0; i < num_shards; ++i) {
         auto map = _maps[i].load(std::memory_order_relaxed);
         if (map != nullptr) {
-            changed |= map->normalize_values(normalize, filter, entry_ref_offset_bits);
+            changed |= map->normalize_values(normalize, filter);
         }
     }
     return changed;
 }
 
 void
-ShardedHashMap::foreach_value(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits)
+ShardedHashMap::foreach_value(std::function<void(const std::vector<EntryRef>&)> callback, const EntryRefFilter& filter)
 {
     for (size_t i = 0; i < num_shards; ++i) {
         auto map = _maps[i].load(std::memory_order_relaxed);
         if (map != nullptr) {
-            map->foreach_value(callback, filter, entry_ref_offset_bits);
+            map->foreach_value(callback, filter);
         }
     }
 }

--- a/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.h
+++ b/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.h
@@ -59,6 +59,8 @@ public:
     void foreach_key(std::function<void(EntryRef)> callback) const;
     void move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits);
     bool normalize_values(std::function<EntryRef(EntryRef)> normalize);
+    bool normalize_values(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
+    void foreach_value(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
     bool has_held_buffers() const;
     void compact_worst_shard();
 };

--- a/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.h
+++ b/vespalib/src/vespa/vespalib/datastore/sharded_hash_map.h
@@ -11,6 +11,7 @@ namespace vespalib { class MemoryUsage; }
 namespace vespalib::datastore {
 
 class EntryComparator;
+class EntryRefFilter;
 class FixedSizeHashMap;
 struct ICompactable;
 
@@ -57,10 +58,10 @@ public:
     const EntryComparator &get_default_comparator() const noexcept { return *_comp; }
     MemoryUsage get_memory_usage() const;
     void foreach_key(std::function<void(EntryRef)> callback) const;
-    void move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits);
+    void move_keys(ICompactable& compactable, const EntryRefFilter& compacting_buffers);
     bool normalize_values(std::function<EntryRef(EntryRef)> normalize);
-    bool normalize_values(std::function<void(std::vector<EntryRef>&)> normalize, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
-    void foreach_value(std::function<void(const std::vector<EntryRef>&)> callback, const std::vector<bool>& filter, uint32_t entry_ref_offset_bits);
+    bool normalize_values(std::function<void(std::vector<EntryRef>&)> normalize, const EntryRefFilter& filter);
+    void foreach_value(std::function<void(const std::vector<EntryRef>&)> callback, const EntryRefFilter& filter);
     bool has_held_buffers() const;
     void compact_worst_shard();
 };

--- a/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
@@ -102,11 +102,9 @@ private:
     std::vector<uint32_t> _bufferIdsToCompact;
 
     void allocMapping() {
-        _compacting_buffer.resize(RefT::numBuffers());
         _mapping.resize(RefT::numBuffers());
         for (const auto bufferId : _bufferIdsToCompact) {
             BufferState &state = _dataStore.getBufferState(bufferId);
-            _compacting_buffer[bufferId] = true;
             _mapping[bufferId].resize(state.get_used_arrays());
         }
     }
@@ -124,7 +122,7 @@ private:
     }
     
     void fillMapping() {
-        _dict.move_keys(*this, _compacting_buffer, RefT::offset_bits);
+        _dict.move_keys(*this, _compacting_buffer);
     }
 
 public:
@@ -140,6 +138,7 @@ public:
           _bufferIdsToCompact(std::move(bufferIdsToCompact))
     {
         if (!_bufferIdsToCompact.empty()) {
+            _compacting_buffer.add_buffers(_bufferIdsToCompact);
             allocMapping();
             fillMapping();
         }

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_dictionary.h
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_dictionary.h
@@ -79,7 +79,7 @@ public:
     UniqueStoreAddResult add(const EntryComparator& comp, std::function<EntryRef(void)> insertEntry) override;
     EntryRef find(const EntryComparator& comp) override;
     void remove(const EntryComparator& comp, EntryRef ref) override;
-    void move_keys(ICompactable& compactable, const std::vector<bool>& compacting_buffers, uint32_t entry_ref_offset_bits) override;
+    void move_keys(ICompactable& compactable, const EntryRefFilter& compacting_buffers) override;
     uint32_t get_num_uniques() const override;
     vespalib::MemoryUsage get_memory_usage() const override;
     void build(vespalib::ConstArrayRef<EntryRef>, vespalib::ConstArrayRef<uint32_t> ref_counts, std::function<void(EntryRef)> hold) override;


### PR DESCRIPTION
and foreach_value ShardedHashMap member functions to limit number of callbacks.

@geirst : please review
