### PR TITLE
Decrement persistence thread merge counter when syncronous processing is complete [run-systemtest]

### DIFF
--- a/storage/src/tests/persistence/persistencetestutils.h
+++ b/storage/src/tests/persistence/persistencetestutils.h
@@ -50,6 +50,8 @@ public:
         api::LockingRequirements lockingRequirements() const noexcept override {
             return api::LockingRequirements::Shared;
         }
+        void signal_operation_sync_phase_done() noexcept override {}
+        bool wants_sync_phase_done_notification() const noexcept override { return false; }
         static std::shared_ptr<NoBucketLock> make(document::Bucket bucket) {
             return std::make_shared<NoBucketLock>(bucket);
         }
@@ -78,6 +80,8 @@ public:
         api::LockingRequirements lockingRequirements() const noexcept override {
             return api::LockingRequirements::Exclusive;
         }
+        void signal_operation_sync_phase_done() noexcept override {}
+        bool wants_sync_phase_done_notification() const noexcept override { return false; }
         static std::shared_ptr<MockBucketLock> make(document::Bucket bucket, MockBucketLocks& locks) {
             return std::make_shared<MockBucketLock>(bucket, locks);
         }

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -1054,7 +1054,8 @@ message_type_is_merge_related(api::MessageType::Id msg_type_id) {
 void
 FileStorHandlerImpl::Stripe::release(const document::Bucket & bucket,
                                      api::LockingRequirements reqOfReleasedLock,
-                                     api::StorageMessage::Id lockMsgId)
+                                     api::StorageMessage::Id lockMsgId,
+                                     bool was_active_merge)
 {
     std::unique_lock guard(*_lock);
     auto iter = _lockedBuckets.find(bucket);
@@ -1065,7 +1066,7 @@ FileStorHandlerImpl::Stripe::release(const document::Bucket & bucket,
     if (reqOfReleasedLock == api::LockingRequirements::Exclusive) {
         assert(entry._exclusiveLock);
         assert(entry._exclusiveLock->msgId == lockMsgId);
-        if (message_type_is_merge_related(entry._exclusiveLock->msgType)) {
+        if (was_active_merge) {
             assert(_active_merges > 0);
             --_active_merges;
         }
@@ -1089,13 +1090,27 @@ FileStorHandlerImpl::Stripe::release(const document::Bucket & bucket,
 }
 
 void
+FileStorHandlerImpl::Stripe::decrease_active_sync_merges_counter() noexcept
+{
+    std::unique_lock guard(*_lock);
+    assert(_active_merges > 0);
+    const bool may_have_blocked_merge = (_active_merges == _owner._max_active_merges_per_stripe);
+    --_active_merges;
+    if (may_have_blocked_merge) {
+        guard.unlock();
+        _cond->notify_all();
+    }
+}
+
+void
 FileStorHandlerImpl::Stripe::lock(const monitor_guard &, const document::Bucket & bucket,
-                                  api::LockingRequirements lockReq, const LockEntry & lockEntry) {
+                                  api::LockingRequirements lockReq, bool count_as_active_merge,
+                                  const LockEntry & lockEntry) {
     auto& entry = _lockedBuckets[bucket];
     assert(!entry._exclusiveLock);
     if (lockReq == api::LockingRequirements::Exclusive) {
         assert(entry._sharedLocks.empty());
-        if (message_type_is_merge_related(lockEntry.msgType)) {
+        if (count_as_active_merge) {
             ++_active_merges;
         }
         entry._exclusiveLock = lockEntry;
@@ -1151,28 +1166,43 @@ FileStorHandlerImpl::Stripe::get_active_operations_stats(bool reset_min_max) con
     return result;
 }
 
-FileStorHandlerImpl::BucketLock::BucketLock(const monitor_guard & guard, Stripe& stripe,
-                                            const document::Bucket &bucket, uint8_t priority,
+FileStorHandlerImpl::BucketLock::BucketLock(const monitor_guard& guard, Stripe& stripe,
+                                            const document::Bucket& bucket, uint8_t priority,
                                             api::MessageType::Id msgType, api::StorageMessage::Id msgId,
                                             api::LockingRequirements lockReq)
     : _stripe(stripe),
       _bucket(bucket),
       _uniqueMsgId(msgId),
-      _lockReq(lockReq)
+      _lockReq(lockReq),
+      _counts_towards_merge_limit(false)
 {
     if (_bucket.getBucketId().getRawId() != 0) {
-        _stripe.lock(guard, _bucket, lockReq, Stripe::LockEntry(priority, msgType, msgId));
+        _counts_towards_merge_limit = message_type_is_merge_related(msgType);
+        _stripe.lock(guard, _bucket, lockReq, _counts_towards_merge_limit, Stripe::LockEntry(priority, msgType, msgId));
         LOG(spam, "Locked bucket %s for message %" PRIu64 " with priority %u in mode %s",
-            bucket.getBucketId().toString().c_str(), msgId, priority, api::to_string(lockReq));
+            bucket.toString().c_str(), msgId, priority, api::to_string(lockReq));
     }
 }
 
 
 FileStorHandlerImpl::BucketLock::~BucketLock() {
     if (_bucket.getBucketId().getRawId() != 0) {
-        _stripe.release(_bucket, _lockReq, _uniqueMsgId);
+        _stripe.release(_bucket, _lockReq, _uniqueMsgId, _counts_towards_merge_limit);
         LOG(spam, "Unlocked bucket %s for message %" PRIu64 " in mode %s",
-            _bucket.getBucketId().toString().c_str(), _uniqueMsgId, api::to_string(_lockReq));
+            _bucket.toString().c_str(), _uniqueMsgId, api::to_string(_lockReq));
+    }
+}
+
+void
+FileStorHandlerImpl::BucketLock::signal_operation_sync_phase_done() noexcept
+{
+    // Not atomic, only destructor can read/write this other than this function, and since
+    // a strong ref must already be held to this object by the caller, we cannot race with it.
+    if (_counts_towards_merge_limit){
+        LOG(spam, "Synchronous phase for bucket %s is done; reducing active count proactively",
+            _bucket.toString().c_str());
+        _stripe.decrease_active_sync_merges_counter();
+        _counts_towards_merge_limit = false;
     }
 }
 

--- a/storage/src/vespa/storage/persistence/persistenceutil.cpp
+++ b/storage/src/vespa/storage/persistence/persistenceutil.cpp
@@ -155,6 +155,15 @@ MessageTracker::generateReply(api::StorageCommand& cmd)
     }
 }
 
+std::shared_ptr<FileStorHandler::OperationSyncPhaseDoneNotifier>
+MessageTracker::sync_phase_done_notifier_or_nullptr() const
+{
+    if (_bucketLock->wants_sync_phase_done_notification()) {
+        return _bucketLock;
+    }
+    return {};
+}
+
 PersistenceUtil::PersistenceUtil(const ServiceLayerComponent& component, FileStorHandler& fileStorHandler,
                                  FileStorThreadMetrics& metrics, spi::PersistenceProvider& provider)
     : _component(component),

--- a/storage/src/vespa/storage/persistence/persistenceutil.h
+++ b/storage/src/vespa/storage/persistence/persistenceutil.h
@@ -27,7 +27,7 @@ class PersistenceUtil;
 
 class MessageTracker : protected Types {
 public:
-    typedef std::unique_ptr<MessageTracker> UP;
+    using UP = std::unique_ptr<MessageTracker>;
 
     MessageTracker(const framework::MilliSecTimer & timer, const PersistenceUtil & env, MessageSender & replySender,
                    FileStorHandler::BucketLockInterface::SP bucketLock, std::shared_ptr<api::StorageMessage> msg);
@@ -80,6 +80,10 @@ public:
     void sendReply();
 
     bool checkForError(const spi::Result& response);
+
+    // Returns a non-nullptr notifier instance iff the underlying operation wants to be notified
+    // when the sync phase is complete. Otherwise returns a nullptr shared_ptr.
+    std::shared_ptr<FileStorHandler::OperationSyncPhaseDoneNotifier> sync_phase_done_notifier_or_nullptr() const;
 
     static MessageTracker::UP
     createForTesting(const framework::MilliSecTimer & timer, PersistenceUtil & env, MessageSender & replySender,


### PR DESCRIPTION
@geirst @baldersheim please review.

Add a generic interface for letting an operation know that the synchronous
parts of its processing in the persistence thread is complete. This allows
a potentially longer-running async operation to free up any limits that
were put in place when it was taking up synchronous thread resources.

Currently only used by merge-related operations (that may dispatch many
async ops). Since we have a max upper bound for how many threads in a stripe
may be processing merge ops at the same time (to avoid blocking client ops),
we previously could effectively stall the pipelining of merges caused by
hitting the concurrency limit even if all persistence threads were otherwise
idle (waiting for prior async merge ops to complete).
We now explicitly decrease the merge concurrency counter once the synchronous
processing is done, allowing us to take on further merges immediately.
