### PR TITLE
Use EntryRefFilter to filter calls to UniqueStoreRemapper::remap() for

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.cpp
@@ -49,13 +49,16 @@ SingleValueEnumAttributeBase::remap_enum_store_refs(const EnumIndexRemapper& rem
 {
     // update _enumIndices with new EnumIndex values after enum store has been compacted.
     v.logEnumStoreEvent("reenumerate", "reserved");
-    auto new_indexes = std::make_unique<vespalib::Array<EnumIndex>>();
-    new_indexes->reserve(_enumIndices.capacity());
+    vespalib::Array<EnumIndex> new_indexes;
+    new_indexes.reserve(_enumIndices.capacity());
     v.logEnumStoreEvent("reenumerate", "start");
+    auto& filter = remapper.get_entry_ref_filter();
     for (uint32_t i = 0; i < _enumIndices.size(); ++i) {
-        EnumIndex old_index = _enumIndices[i];
-        EnumIndex new_index = remapper.remap(old_index);
-        new_indexes->push_back_fast(new_index);
+        EnumIndex ref = _enumIndices[i];
+        if (ref.valid() && filter.has(ref)) {
+            ref = remapper.remap(ref);
+        }
+        new_indexes.push_back_fast(ref);
     }
     v.logEnumStoreEvent("compactfixup", "drain");
     {

--- a/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
+++ b/vespalib/src/tests/util/rcuvector/rcuvector_test.cpp
@@ -19,19 +19,14 @@ assertUsage(const MemoryUsage & exp, const MemoryUsage & act)
 
 TEST("test generation holder")
 {
-    typedef std::unique_ptr<int32_t> IntPtr;
     GenerationHolder gh;
-    gh.hold(GenerationHeldBase::UP(new RcuVectorHeld<int32_t>(sizeof(int32_t),
-                                           IntPtr(new int32_t(0)))));
+    gh.hold(std::make_unique<RcuVectorHeld<int32_t>>(sizeof(int32_t), 0));
     gh.transferHoldLists(0);
-    gh.hold(GenerationHeldBase::UP(new RcuVectorHeld<int32_t>(sizeof(int32_t),
-                                           IntPtr(new int32_t(1)))));
+    gh.hold(std::make_unique<RcuVectorHeld<int32_t>>(sizeof(int32_t), 1));
     gh.transferHoldLists(1);
-    gh.hold(GenerationHeldBase::UP(new RcuVectorHeld<int32_t>(sizeof(int32_t),
-                                           IntPtr(new int32_t(2)))));
+    gh.hold(std::make_unique<RcuVectorHeld<int32_t>>(sizeof(int32_t), 2));
     gh.transferHoldLists(2);
-    gh.hold(GenerationHeldBase::UP(new RcuVectorHeld<int32_t>(sizeof(int32_t),
-                                           IntPtr(new int32_t(4)))));
+    gh.hold(std::make_unique<RcuVectorHeld<int32_t>>(sizeof(int32_t), 4));
     gh.transferHoldLists(4);
     EXPECT_EQUAL(4u * sizeof(int32_t), gh.getHeldBytes());
     gh.trimHoldLists(0);
@@ -40,8 +35,7 @@ TEST("test generation holder")
     EXPECT_EQUAL(3u * sizeof(int32_t), gh.getHeldBytes());
     gh.trimHoldLists(2);
     EXPECT_EQUAL(2u * sizeof(int32_t), gh.getHeldBytes());
-    gh.hold(GenerationHeldBase::UP(new RcuVectorHeld<int32_t>(sizeof(int32_t),
-                                       IntPtr(new int32_t(6)))));
+    gh.hold(std::make_unique<RcuVectorHeld<int32_t>>(sizeof(int32_t), 6));
     gh.transferHoldLists(6);
     EXPECT_EQUAL(3u * sizeof(int32_t), gh.getHeldBytes());
     gh.trimHoldLists(6);

--- a/vespalib/src/vespa/vespalib/util/rcuvector.h
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.h
@@ -13,10 +13,10 @@ namespace vespalib {
 template <typename T>
 class RcuVectorHeld : public GenerationHeldBase
 {
-    std::unique_ptr<T> _data;
+    T _data;
 
 public:
-    RcuVectorHeld(size_t size, std::unique_ptr<T> data);
+    RcuVectorHeld(size_t size, T&& data);
 
     ~RcuVectorHeld();
 };
@@ -121,7 +121,7 @@ public:
 
     void reset();
     void shrink(size_t newSize) __attribute__((noinline));
-    void replaceVector(std::unique_ptr<ArrayType> replacement);
+    void replaceVector(ArrayType replacement);
 };
 
 template <typename T>

--- a/vespalib/src/vespa/vespalib/util/rcuvector.hpp
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.hpp
@@ -9,7 +9,7 @@
 namespace vespalib {
 
 template <typename T>
-RcuVectorHeld<T>::RcuVectorHeld(size_t size, std::unique_ptr<T> data)
+RcuVectorHeld<T>::RcuVectorHeld(size_t size, T&& data)
     : GenerationHeldBase(size),
       _data(std::move(data))
 { }
@@ -52,20 +52,20 @@ RcuVectorBase<T>::~RcuVectorBase() = default;
 template <typename T>
 void
 RcuVectorBase<T>::expand(size_t newCapacity) {
-    std::unique_ptr<ArrayType> tmpData(new ArrayType());
-    tmpData->reserve(newCapacity);
+    ArrayType tmpData;
+    tmpData.reserve(newCapacity);
     for (const T & v : _data) {
-        tmpData->push_back_fast(v);
+        tmpData.push_back_fast(v);
     }
     replaceVector(std::move(tmpData));
 }
 
 template <typename T>
 void
-RcuVectorBase<T>::replaceVector(std::unique_ptr<ArrayType> replacement) {
-    replacement->swap(_data); // atomic switch of underlying data
-    size_t holdSize = replacement->capacity() * sizeof(T);
-    GenerationHeldBase::UP hold(new RcuVectorHeld<ArrayType>(holdSize, std::move(replacement)));
+RcuVectorBase<T>::replaceVector(ArrayType replacement) {
+    replacement.swap(_data); // atomic switch of underlying data
+    size_t holdSize = replacement.capacity() * sizeof(T);
+    auto hold = std::make_unique<RcuVectorHeld<ArrayType>>(holdSize, std::move(replacement));
     _genHolder.hold(std::move(hold));
     onReallocation();
 }
@@ -90,17 +90,17 @@ RcuVectorBase<T>::shrink(size_t newSize)
         return;
     }
     if (!_data.try_unreserve(wantedCapacity)) {
-        std::unique_ptr<ArrayType> tmpData(new ArrayType());
-        tmpData->reserve(wantedCapacity);
-        tmpData->resize(newSize);
+        ArrayType tmpData;
+        tmpData.reserve(wantedCapacity);
+        tmpData.resize(newSize);
         for (uint32_t i = 0; i < newSize; ++i) {
-            (*tmpData)[i] = _data[i];
+            tmpData[i] = _data[i];
         }
         // Users of RCU vector must ensure that no readers use old size
         // after swap.  Attribute vectors uses _committedDocIdLimit for this.
-        tmpData->swap(_data); // atomic switch of underlying data
-        size_t holdSize = tmpData->capacity() * sizeof(T);
-        GenerationHeldBase::UP hold(new RcuVectorHeld<ArrayType>(holdSize, std::move(tmpData)));
+        tmpData.swap(_data); // atomic switch of underlying data
+        size_t holdSize = tmpData.capacity() * sizeof(T);
+        auto hold = std::make_unique<RcuVectorHeld<ArrayType>>(holdSize, std::move(tmpData));
         _genHolder.hold(std::move(hold));
         onReallocation();
     }


### PR DESCRIPTION
single refs.
Use less indirection for RcuVectorHeld.

@geirst : please review
