### PR TITLE
Deprecate ctors and methods in 'searchlib' using Guava ImmutableMap

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -17,7 +17,6 @@ import com.yahoo.tensor.TensorType;
 import com.yahoo.tensor.evaluation.TypeContext;
 
 import java.util.ArrayDeque;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
@@ -65,7 +64,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
         globallyResolvedTypes = new HashMap<>();
     }
 
-    private MapEvaluationTypeContext(ImmutableMap<String, ExpressionFunction> functions,
+    private MapEvaluationTypeContext(Map<String, ExpressionFunction> functions,
                                      Map<String, String> bindings,
                                      Optional<MapEvaluationTypeContext> parent,
                                      Map<Reference, TensorType> featureTypes,
@@ -250,7 +249,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
 
     private Optional<ExpressionFunction> functionInvocation(Reference reference) {
         if (reference.output() != null) return Optional.empty();
-        ExpressionFunction function = functions().get(reference.name());
+        ExpressionFunction function = getFunctions().get(reference.name());
         if (function == null) return Optional.empty();
         if (function.arguments().size() != reference.arguments().size()) return Optional.empty();
         return Optional.of(function);
@@ -348,7 +347,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
 
     @Override
     public MapEvaluationTypeContext withBindings(Map<String, String> bindings) {
-        return new MapEvaluationTypeContext(functions(),
+        return new MapEvaluationTypeContext(getFunctions(),
                                             bindings,
                                             Optional.of(this),
                                             featureTypes,

--- a/searchlib/abi-spec.json
+++ b/searchlib/abi-spec.json
@@ -1457,6 +1457,7 @@
       "protected void <init>(com.google.common.collect.ImmutableMap, java.util.Map)",
       "public com.yahoo.searchlib.rankingexpression.ExpressionFunction getFunction(java.lang.String)",
       "protected com.google.common.collect.ImmutableMap functions()",
+      "protected java.util.Map getFunctions()",
       "public java.lang.String getBinding(java.lang.String)",
       "public com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withBindings(java.util.Map)",
       "public com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext withoutBindings()"
@@ -1611,6 +1612,7 @@
       "public void <init>(java.util.Map)",
       "public void <init>(java.util.Collection, java.util.Map)",
       "public void <init>(java.util.Collection, java.util.Map, java.util.Map)",
+      "public void <init>(java.util.Map, java.util.Map, java.util.Map)",
       "public void <init>(com.google.common.collect.ImmutableMap, java.util.Map, java.util.Map)",
       "public void addFunctionSerialization(java.lang.String, java.lang.String)",
       "public void addArgumentTypeSerialization(java.lang.String, java.lang.String, com.yahoo.tensor.TensorType)",

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/FunctionReferenceContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/FunctionReferenceContext.java
@@ -17,7 +17,7 @@ import java.util.Map;
 public class FunctionReferenceContext {
 
     /** Expression functions indexed by name */
-    private final ImmutableMap<String, ExpressionFunction> functions;
+    private final Map<String, ExpressionFunction> functions;
 
     /** Mapping from argument names to the expressions they resolve to */
     private final Map<String, String> bindings = new HashMap<>();
@@ -43,26 +43,32 @@ public class FunctionReferenceContext {
 
     /** Create a context for a single serialization task */
     public FunctionReferenceContext(Map<String, ExpressionFunction> functions, Map<String, String> bindings) {
-        this(ImmutableMap.copyOf(functions), bindings);
-    }
-
-    protected FunctionReferenceContext(ImmutableMap<String, ExpressionFunction> functions, Map<String, String> bindings) {
-        this.functions = functions;
+        this.functions = Map.copyOf(functions);
         if (bindings != null)
             this.bindings.putAll(bindings);
     }
 
-    private static ImmutableMap<String, ExpressionFunction> toMap(Collection<ExpressionFunction> list) {
-        ImmutableMap.Builder<String,ExpressionFunction> mapBuilder = new ImmutableMap.Builder<>();
+    /** @deprecated Use {@link #FunctionReferenceContext(Map, Map)} instead */
+    @Deprecated(forRemoval = true, since = "7")
+    protected FunctionReferenceContext(ImmutableMap<String, ExpressionFunction> functions, Map<String, String> bindings) {
+        this((Map<String, ExpressionFunction>)functions, bindings);
+    }
+
+    private static Map<String, ExpressionFunction> toMap(Collection<ExpressionFunction> list) {
+        Map<String, ExpressionFunction> mapBuilder = new HashMap<>();
         for (ExpressionFunction function : list)
             mapBuilder.put(function.getName(), function);
-        return mapBuilder.build();
+        return Map.copyOf(mapBuilder);
     }
 
     /** Returns a function or null if it isn't defined in this context */
     public ExpressionFunction getFunction(String name) { return functions.get(name); }
 
-    protected ImmutableMap<String, ExpressionFunction> functions() { return functions; }
+    /** @deprecated Use {@link #getFunctions()} instead */
+    @Deprecated(forRemoval = true, since = "7")
+    protected ImmutableMap<String, ExpressionFunction> functions() { return ImmutableMap.copyOf(functions); }
+
+    protected Map<String, ExpressionFunction> getFunctions() { return functions; }
 
     /** Returns the resolution of an identifier, or null if it isn't defined in this context */
     public String getBinding(String name) { return bindings.get(name); }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SerializationContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/SerializationContext.java
@@ -8,6 +8,7 @@ import com.yahoo.tensor.TensorType;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -54,11 +55,11 @@ public class SerializationContext extends FunctionReferenceContext {
         this(toMap(functions), bindings, serializedFunctions);
     }
 
-    private static ImmutableMap<String, ExpressionFunction> toMap(Collection<ExpressionFunction> list) {
-        ImmutableMap.Builder<String,ExpressionFunction> mapBuilder = new ImmutableMap.Builder<>();
+    private static Map<String, ExpressionFunction> toMap(Collection<ExpressionFunction> list) {
+        Map<String,ExpressionFunction> mapBuilder = new HashMap<>();
         for (ExpressionFunction function : list)
             mapBuilder.put(function.getName(), function);
-        return mapBuilder.build();
+        return Map.copyOf(mapBuilder);
     }
 
     /**
@@ -69,10 +70,17 @@ public class SerializationContext extends FunctionReferenceContext {
      * @param serializedFunctions a cache of serializedFunctions - the ownership of this map
      *        is <b>transferred</b> to this and will be modified in it
      */
-    public SerializationContext(ImmutableMap<String,ExpressionFunction> functions, Map<String, String> bindings,
+    public SerializationContext(Map<String,ExpressionFunction> functions, Map<String, String> bindings,
                                 Map<String, String> serializedFunctions) {
         super(functions, bindings);
         this.serializedFunctions = serializedFunctions;
+    }
+
+    /** @deprecated Use {@link #SerializationContext(Map, Map, Map) instead}*/
+    @Deprecated(forRemoval = true, since = "7")
+    public SerializationContext(ImmutableMap<String,ExpressionFunction> functions, Map<String, String> bindings,
+                                Map<String, String> serializedFunctions) {
+        this((Map<String, ExpressionFunction>)functions, bindings, serializedFunctions);
     }
 
     /** Adds the serialization of a function */
@@ -93,13 +101,13 @@ public class SerializationContext extends FunctionReferenceContext {
 
     @Override
     public SerializationContext withBindings(Map<String, String> bindings) {
-        return new SerializationContext(functions(), bindings, this.serializedFunctions);
+        return new SerializationContext(getFunctions(), bindings, this.serializedFunctions);
     }
 
     /** Returns a fresh context without bindings */
     @Override
     public SerializationContext withoutBindings() {
-        return new SerializationContext(functions(), null, this.serializedFunctions);
+        return new SerializationContext(getFunctions(), null, this.serializedFunctions);
     }
 
     public Map<String, String> serializedFunctions() { return serializedFunctions; }

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
@@ -328,7 +328,14 @@ public class TensorFunctionNode extends CompositeNode {
         /** Returns a function or null if it isn't defined in this context */
         public ExpressionFunction getFunction(String name) { return wrappedSerializationContext.getFunction(name); }
 
-        protected ImmutableMap<String, ExpressionFunction> functions() { return wrappedSerializationContext.functions(); }
+        /** @deprecated Use {@link #getFunctions()} instead */
+        @SuppressWarnings("removal")
+        @Deprecated(forRemoval = true, since = "7")
+        protected ImmutableMap<String, ExpressionFunction> functions() {
+            return ImmutableMap.copyOf(wrappedSerializationContext.getFunctions());
+        }
+
+        @Override protected Map<String, ExpressionFunction> getFunctions() { return wrappedSerializationContext.getFunctions(); }
 
         public ToStringContext parent() { return wrappedToStringContext; }
 
@@ -344,14 +351,14 @@ public class TensorFunctionNode extends CompositeNode {
         /** Returns a new context with the bindings replaced by the given bindings */
         @Override
         public ExpressionToStringContext withBindings(Map<String, String> bindings) {
-            SerializationContext serializationContext = new SerializationContext(functions(), bindings, serializedFunctions());
+            SerializationContext serializationContext = new SerializationContext(getFunctions(), bindings, serializedFunctions());
             return new ExpressionToStringContext(serializationContext, wrappedToStringContext, path, parent);
         }
 
         /** Returns a fresh context without bindings */
         @Override
         public SerializationContext withoutBindings() {
-            SerializationContext serializationContext = new SerializationContext(functions(), null, serializedFunctions());
+            SerializationContext serializationContext = new SerializationContext(getFunctions(), null, serializedFunctions());
             return new ExpressionToStringContext(serializationContext, null, path, parent);
         }
     }


### PR DESCRIPTION
- com.yahoo.searchlib.rankingexpression.rule.FunctionReferenceContext
- com.yahoo.searchlib.rankingexpression.rule.SerializationContext
- com.yahoo.searchlib.rankingexpression.rule.TensorFunctionNode

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
