### PR TITLE
Remove add-opens for sun.security.util for standalone containers.

### DIFF
--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -177,7 +177,6 @@ vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
     --add-opens=java.base/java.nio=ALL-UNNAMED \
     --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
     --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
-    --add-opens=java.base/sun.security.util=ALL-UNNAMED  \
 	-Djava.io.tmpdir=${VESPA_HOME}/tmp \
 	-Djava.library.path=${VESPA_HOME}/lib64 \
 	-Djava.awt.headless=true \

--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -175,7 +175,6 @@ StartCommand() {
         --add-opens=java.base/java.nio=ALL-UNNAMED \
         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
-        --add-opens=java.base/sun.security.util=ALL-UNNAMED  \
         -Djava.library.path="$VESPA_HOME/lib64" \
         -Djava.awt.headless=true \
         -Dsun.rmi.dgc.client.gcInterval=3600000 \


### PR DESCRIPTION
- Only necessary (temporarily) for tenant containers.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
