### PR TITLE
Deprecate methods using Guava ListenableFuture [run-systemtest]

### DIFF
--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -2839,6 +2839,7 @@
       "public void <init>(com.yahoo.processing.Request, com.yahoo.processing.request.ErrorMessage)",
       "public void mergeWith(com.yahoo.processing.Response)",
       "public com.yahoo.processing.response.DataList data()",
+      "public static java.util.concurrent.CompletableFuture recursiveFuture(com.yahoo.processing.response.DataList)",
       "public static com.google.common.util.concurrent.ListenableFuture recursiveComplete(com.yahoo.processing.response.DataList)"
     ],
     "fields": []
@@ -3390,7 +3391,7 @@
     "fields": []
   },
   "com.yahoo.processing.response.AbstractDataList$DrainOnGetFuture": {
-    "superClass": "com.google.common.util.concurrent.AbstractFuture",
+    "superClass": "com.yahoo.processing.impl.ProcessingFuture",
     "interfaces": [],
     "attributes": [
       "public",
@@ -3402,8 +3403,8 @@
       "public boolean isCancelled()",
       "public com.yahoo.processing.response.DataList get()",
       "public com.yahoo.processing.response.DataList get(long, java.util.concurrent.TimeUnit)",
-      "public bridge synthetic java.lang.Object get()",
-      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)"
+      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)",
+      "public bridge synthetic java.lang.Object get()"
     ],
     "fields": []
   },
@@ -3425,6 +3426,7 @@
       "public com.yahoo.processing.Request request()",
       "public com.yahoo.processing.response.IncomingData incoming()",
       "public com.google.common.util.concurrent.ListenableFuture complete()",
+      "public java.util.concurrent.CompletableFuture future()",
       "public boolean isOrdered()",
       "public boolean isStreamed()",
       "public java.lang.String toString()"
@@ -3483,6 +3485,7 @@
       "public abstract com.yahoo.processing.response.Data get(int)",
       "public abstract java.util.List asList()",
       "public abstract com.yahoo.processing.response.IncomingData incoming()",
+      "public abstract java.util.concurrent.CompletableFuture future()",
       "public abstract com.google.common.util.concurrent.ListenableFuture complete()",
       "public abstract void addDataListener(java.lang.Runnable)",
       "public void close()"
@@ -3503,6 +3506,7 @@
       "public final void assignOwner(com.yahoo.processing.response.DataList)",
       "public com.yahoo.processing.response.DataList getOwner()",
       "public com.google.common.util.concurrent.ListenableFuture completed()",
+      "public java.util.concurrent.CompletableFuture future()",
       "public synchronized boolean isComplete()",
       "public synchronized void addLast(com.yahoo.processing.response.Data)",
       "public synchronized void add(com.yahoo.processing.response.Data)",
@@ -3516,26 +3520,29 @@
     "fields": []
   },
   "com.yahoo.processing.response.FutureResponse": {
-    "superClass": "com.google.common.util.concurrent.ForwardingFuture",
-    "interfaces": [],
+    "superClass": "java.lang.Object",
+    "interfaces": [
+      "java.util.concurrent.Future"
+    ],
     "attributes": [
       "public"
     ],
     "methods": [
       "public void <init>(java.util.concurrent.Callable, com.yahoo.processing.execution.Execution, com.yahoo.processing.Request)",
-      "public com.google.common.util.concurrent.ListenableFutureTask delegate()",
+      "public java.util.concurrent.FutureTask delegate()",
+      "public boolean cancel(boolean)",
+      "public boolean isCancelled()",
+      "public boolean isDone()",
       "public com.yahoo.processing.Response get()",
       "public com.yahoo.processing.Response get(long, java.util.concurrent.TimeUnit)",
       "public com.yahoo.processing.Request getRequest()",
       "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)",
-      "public bridge synthetic java.lang.Object get()",
-      "public bridge synthetic java.util.concurrent.Future delegate()",
-      "public bridge synthetic java.lang.Object delegate()"
+      "public bridge synthetic java.lang.Object get()"
     ],
     "fields": []
   },
   "com.yahoo.processing.response.IncomingData$NullIncomingData$ImmediateFuture": {
-    "superClass": "com.google.common.util.concurrent.AbstractFuture",
+    "superClass": "com.yahoo.processing.impl.ProcessingFuture",
     "interfaces": [],
     "attributes": [
       "public"
@@ -3547,8 +3554,8 @@
       "public boolean isDone()",
       "public com.yahoo.processing.response.DataList get()",
       "public com.yahoo.processing.response.DataList get(long, java.util.concurrent.TimeUnit)",
-      "public bridge synthetic java.lang.Object get()",
-      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)"
+      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)",
+      "public bridge synthetic java.lang.Object get()"
     ],
     "fields": []
   },
@@ -3564,6 +3571,7 @@
     "methods": [
       "public void <init>(com.yahoo.processing.response.DataList)",
       "public com.google.common.util.concurrent.ListenableFuture completed()",
+      "public java.util.concurrent.CompletableFuture future()",
       "public com.yahoo.processing.response.DataList getOwner()",
       "public boolean isComplete()",
       "public void addLast(com.yahoo.processing.response.Data)",
@@ -3587,6 +3595,7 @@
     ],
     "methods": [
       "public abstract com.yahoo.processing.response.DataList getOwner()",
+      "public abstract java.util.concurrent.CompletableFuture future()",
       "public abstract com.google.common.util.concurrent.ListenableFuture completed()",
       "public abstract boolean isComplete()",
       "public abstract void addLast(com.yahoo.processing.response.Data)",

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -3426,7 +3426,7 @@
       "public com.yahoo.processing.Request request()",
       "public com.yahoo.processing.response.IncomingData incoming()",
       "public com.google.common.util.concurrent.ListenableFuture complete()",
-      "public java.util.concurrent.CompletableFuture future()",
+      "public java.util.concurrent.CompletableFuture completeFuture()",
       "public boolean isOrdered()",
       "public boolean isStreamed()",
       "public java.lang.String toString()"
@@ -3485,7 +3485,7 @@
       "public abstract com.yahoo.processing.response.Data get(int)",
       "public abstract java.util.List asList()",
       "public abstract com.yahoo.processing.response.IncomingData incoming()",
-      "public abstract java.util.concurrent.CompletableFuture future()",
+      "public abstract java.util.concurrent.CompletableFuture completeFuture()",
       "public abstract com.google.common.util.concurrent.ListenableFuture complete()",
       "public abstract void addDataListener(java.lang.Runnable)",
       "public void close()"

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -3506,7 +3506,7 @@
       "public final void assignOwner(com.yahoo.processing.response.DataList)",
       "public com.yahoo.processing.response.DataList getOwner()",
       "public com.google.common.util.concurrent.ListenableFuture completed()",
-      "public java.util.concurrent.CompletableFuture future()",
+      "public java.util.concurrent.CompletableFuture completedFuture()",
       "public synchronized boolean isComplete()",
       "public synchronized void addLast(com.yahoo.processing.response.Data)",
       "public synchronized void add(com.yahoo.processing.response.Data)",
@@ -3571,7 +3571,7 @@
     "methods": [
       "public void <init>(com.yahoo.processing.response.DataList)",
       "public com.google.common.util.concurrent.ListenableFuture completed()",
-      "public java.util.concurrent.CompletableFuture future()",
+      "public java.util.concurrent.CompletableFuture completedFuture()",
       "public com.yahoo.processing.response.DataList getOwner()",
       "public boolean isComplete()",
       "public void addLast(com.yahoo.processing.response.Data)",
@@ -3595,7 +3595,7 @@
     ],
     "methods": [
       "public abstract com.yahoo.processing.response.DataList getOwner()",
-      "public abstract java.util.concurrent.CompletableFuture future()",
+      "public abstract java.util.concurrent.CompletableFuture completedFuture()",
       "public abstract com.google.common.util.concurrent.ListenableFuture completed()",
       "public abstract boolean isComplete()",
       "public abstract void addLast(com.yahoo.processing.response.Data)",

--- a/container-core/src/main/java/com/yahoo/processing/Response.java
+++ b/container-core/src/main/java/com/yahoo/processing/Response.java
@@ -111,7 +111,7 @@ public class Response extends ListenableFreezableClass {
 
     @SuppressWarnings("unchecked")
     private static <D extends Data> void collectCompletionFutures(DataList<D> dataList, List<CompletableFuture<DataList<D>>> futures) {
-        futures.add(dataList.future());
+        futures.add(dataList.completeFuture());
         for (D data : dataList.asList()) {
             if (data instanceof DataList)
                 collectCompletionFutures((DataList<D>) data, futures);

--- a/container-core/src/main/java/com/yahoo/processing/Response.java
+++ b/container-core/src/main/java/com/yahoo/processing/Response.java
@@ -1,12 +1,12 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing;
 
-import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.component.provider.ListenableFreezableClass;
+import com.yahoo.concurrent.CompletableFutures;
 import com.yahoo.concurrent.SystemTimer;
 import com.yahoo.processing.execution.ResponseReceiver;
+import com.yahoo.processing.impl.ProcessingFuture;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.processing.request.ErrorMessage;
 import com.yahoo.processing.response.ArrayDataList;
@@ -15,8 +15,8 @@ import com.yahoo.processing.response.DataList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -57,7 +57,7 @@ public class Response extends ListenableFreezableClass {
         if (freezeListener != null) {
             if (freezeListener instanceof ResponseReceiver)
                 ((ResponseReceiver)freezeListener).setResponse(this);
-            data.addFreezeListener(freezeListener, MoreExecutors.directExecutor());
+            data.addFreezeListener(freezeListener, Runnable::run);
         }
     }
 
@@ -96,15 +96,22 @@ public class Response extends ListenableFreezableClass {
      * @param rootDataList the list to complete recursively
      * @return the future in which all data in and below this list is complete, as the given root dataList for convenience
      */
-    public static <D extends Data> ListenableFuture<DataList<D>> recursiveComplete(DataList<D> rootDataList) {
-        List<ListenableFuture<DataList<D>>> futures = new ArrayList<>();
+    public static <D extends Data> CompletableFuture<DataList<D>> recursiveFuture(DataList<D> rootDataList) {
+        List<CompletableFuture<DataList<D>>> futures = new ArrayList<>();
         collectCompletionFutures(rootDataList, futures);
         return new CompleteAllOnGetFuture<D>(futures);
     }
 
+    /** @deprecated Use {@link #recursiveFuture(DataList)} instead */
+    @Deprecated(forRemoval = true, since = "7")
+    @SuppressWarnings("removal")
+    public static <D extends Data> ListenableFuture<DataList<D>> recursiveComplete(DataList<D> rootDataList) {
+        return CompletableFutures.toGuavaListenableFuture(recursiveFuture(rootDataList));
+    }
+
     @SuppressWarnings("unchecked")
-    private static <D extends Data> void collectCompletionFutures(DataList<D> dataList, List<ListenableFuture<DataList<D>>> futures) {
-        futures.add(dataList.complete());
+    private static <D extends Data> void collectCompletionFutures(DataList<D> dataList, List<CompletableFuture<DataList<D>>> futures) {
+        futures.add(dataList.future());
         for (D data : dataList.asList()) {
             if (data instanceof DataList)
                 collectCompletionFutures((DataList<D>) data, futures);
@@ -115,24 +122,24 @@ public class Response extends ListenableFreezableClass {
      * A future which on get calls get on all its given futures and sets the value returned from the
      * first given future as its result.
      */
-    private static class CompleteAllOnGetFuture<D extends Data> extends AbstractFuture<DataList<D>> {
+    private static class CompleteAllOnGetFuture<D extends Data> extends ProcessingFuture<DataList<D>> {
 
-        private final List<ListenableFuture<DataList<D>>> futures;
+        private final List<CompletableFuture<DataList<D>>> futures;
 
-        public CompleteAllOnGetFuture(List<ListenableFuture<DataList<D>>> futures) {
+        public CompleteAllOnGetFuture(List<CompletableFuture<DataList<D>>> futures) {
             this.futures = new ArrayList<>(futures);
         }
 
         @Override
             public DataList<D> get() throws InterruptedException, ExecutionException {
             DataList<D> result = null;
-            for (ListenableFuture<DataList<D>> future : futures) {
+            for (CompletableFuture<DataList<D>> future : futures) {
                 if (result == null)
                     result = future.get();
                 else
                     future.get();
             }
-            set(result);
+            complete(result);
             return result;
         }
 
@@ -141,7 +148,7 @@ public class Response extends ListenableFreezableClass {
             DataList<D> result = null;
             long timeLeft = unit.toMillis(timeout);
             long currentCallStart = SystemTimer.INSTANCE.milliTime();
-            for (ListenableFuture<DataList<D>> future : futures) {
+            for (CompletableFuture<DataList<D>> future : futures) {
                 if (result == null)
                     result = future.get(timeLeft, TimeUnit.MILLISECONDS);
                 else
@@ -151,7 +158,7 @@ public class Response extends ListenableFreezableClass {
                 if (timeLeft <= 0) break;
                 currentCallStart = currentCallEnd;
             }
-            set(result);
+            complete(result);
             return result;
         }
 

--- a/container-core/src/main/java/com/yahoo/processing/impl/ProcessingFuture.java
+++ b/container-core/src/main/java/com/yahoo/processing/impl/ProcessingFuture.java
@@ -1,0 +1,31 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.processing.impl;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A {@link CompletableFuture} where {@link #get()}/{@link #get(long, TimeUnit)} may have side-effects (e.g trigger the underlying computation).
+ *
+ * @author bjorncs
+ */
+// TODO Vespa 8 remove ListenableFuture implementation
+public abstract class ProcessingFuture<V> extends CompletableFuture<V> implements ListenableFuture<V> {
+
+    @Override public boolean cancel(boolean mayInterruptIfRunning) { return false; }
+    @Override public boolean isCancelled() { return false; }
+
+    @Override public abstract V get() throws InterruptedException, ExecutionException;
+    @Override public abstract V get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException;
+
+    @Override
+    public void addListener(Runnable listener, Executor executor) {
+        whenCompleteAsync((__, ___) -> listener.run(), executor);
+    }
+
+}

--- a/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
+++ b/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
@@ -359,10 +359,10 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
                 return; // Called on completion of a list which is not frozen yet - hold off until frozen
 
             if ( ! beforeHandoverMode)
-                list.future().get(); // trigger completion if not done already to invoke any listeners on that event
+                list.completeFuture().get(); // trigger completion if not done already to invoke any listeners on that event
             boolean startedRendering = renderData();
             if ( ! startedRendering || uncompletedChildren > 0) return; // children must render to completion first
-            if (list.future().isDone()) // might not be when in before handover mode
+            if (list.completeFuture().isDone()) // might not be when in before handover mode
                 endListLevel();
             else
                 stream.flush();
@@ -444,7 +444,7 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
             flushIfLikelyToSuspend(subList);
 
             subList.addFreezeListener(listListener, getExecutor());
-            subList.future().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
+            subList.completeFuture().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
             subList.incoming().future().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
         }
 

--- a/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
+++ b/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
@@ -2,7 +2,6 @@
 package com.yahoo.processing.rendering;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.concurrent.CompletableFutures;
 import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.jdisc.handler.CompletionHandler;
@@ -257,7 +256,7 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
      * inadvertently work ends up in async data producing threads in some cases.
      */
     Executor getExecutor() {
-        return beforeHandoverMode ? MoreExecutors.directExecutor() : renderingExecutor;
+        return beforeHandoverMode ? Runnable::run : renderingExecutor;
     }
     /** For inspection only; use getExecutor() for execution */
     Executor getRenderingExecutor() { return renderingExecutor; }    
@@ -360,10 +359,10 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
                 return; // Called on completion of a list which is not frozen yet - hold off until frozen
 
             if ( ! beforeHandoverMode)
-                list.complete().get(); // trigger completion if not done already to invoke any listeners on that event
+                list.future().get(); // trigger completion if not done already to invoke any listeners on that event
             boolean startedRendering = renderData();
             if ( ! startedRendering || uncompletedChildren > 0) return; // children must render to completion first
-            if (list.complete().isDone()) // might not be when in before handover mode
+            if (list.future().isDone()) // might not be when in before handover mode
                 endListLevel();
             else
                 stream.flush();
@@ -445,8 +444,8 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
             flushIfLikelyToSuspend(subList);
 
             subList.addFreezeListener(listListener, getExecutor());
-            subList.complete().addListener(listListener, getExecutor());
-            subList.incoming().completed().addListener(listListener, getExecutor());
+            subList.future().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
+            subList.incoming().future().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
         }
 
         private boolean isOrdered(DataList dataList) {

--- a/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
+++ b/container-core/src/main/java/com/yahoo/processing/rendering/AsynchronousSectionedRenderer.java
@@ -445,7 +445,7 @@ public abstract class AsynchronousSectionedRenderer<RESPONSE extends Response> e
 
             subList.addFreezeListener(listListener, getExecutor());
             subList.completeFuture().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
-            subList.incoming().future().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
+            subList.incoming().completedFuture().whenCompleteAsync((__, ___) -> listListener.run(), getExecutor());
         }
 
         private boolean isOrdered(DataList dataList) {

--- a/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
@@ -99,7 +99,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
         return CompletableFutures.toGuavaListenableFuture(completedFuture);
     }
 
-    @Override public CompletableFuture<DataList<DATATYPE>> future() { return completedFuture; }
+    @Override public CompletableFuture<DataList<DATATYPE>> completeFuture() { return completedFuture; }
 
     @Override
     public boolean isOrdered() { return ordered; }

--- a/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
@@ -1,15 +1,13 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.response;
 
-import com.google.common.util.concurrent.AbstractFuture;
-import com.google.common.util.concurrent.ExecutionList;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.component.provider.ListenableFreezableClass;
+import com.yahoo.concurrent.CompletableFutures;
 import com.yahoo.processing.Request;
+import com.yahoo.processing.impl.ProcessingFuture;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -34,7 +32,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
      */
     private final IncomingData<DATATYPE> incomingData;
 
-    private final ListenableFuture<DataList<DATATYPE>> completedFuture;
+    private final CompletableFuture<DataList<DATATYPE>> completedFuture;
 
     /**
      * Creates a simple data list which does not allow late incoming data
@@ -94,9 +92,14 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
         return incomingData;
     }
 
+    @Override
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "7")
     public ListenableFuture<DataList<DATATYPE>> complete() {
-        return completedFuture;
+        return CompletableFutures.toGuavaListenableFuture(completedFuture);
     }
+
+    @Override public CompletableFuture<DataList<DATATYPE>> future() { return completedFuture; }
 
     @Override
     public boolean isOrdered() { return ordered; }
@@ -108,7 +111,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
         return super.toString() + (complete().isDone() ? " [completed]" : " [incomplete, " + incoming() + "]");
     }
 
-    public static final class DrainOnGetFuture<DATATYPE extends Data> extends AbstractFuture<DataList<DATATYPE>> {
+    public static final class DrainOnGetFuture<DATATYPE extends Data> extends ProcessingFuture<DataList<DATATYPE>> {
 
         private final DataList<DATATYPE> owner;
 
@@ -137,7 +140,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
          */
         @Override
         public DataList<DATATYPE> get() throws InterruptedException, ExecutionException {
-            return drain(owner.incoming().completed().get());
+            return drain(owner.incoming().future().get());
         }
 
         /**
@@ -146,13 +149,13 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
          */
         @Override
         public DataList<DATATYPE> get(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
-            return drain(owner.incoming().completed().get(timeout, timeUnit));
+            return drain(owner.incoming().future().get(timeout, timeUnit));
         }
 
         private DataList<DATATYPE> drain(DataList<DATATYPE> dataList) {
             for (DATATYPE item : dataList.incoming().drain())
                 dataList.add(item);
-            set(dataList); // Signal completion to listeners
+            complete(dataList); // Signal completion to listeners
             return dataList;
         }
 

--- a/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/AbstractDataList.java
@@ -140,7 +140,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
          */
         @Override
         public DataList<DATATYPE> get() throws InterruptedException, ExecutionException {
-            return drain(owner.incoming().future().get());
+            return drain(owner.incoming().completedFuture().get());
         }
 
         /**
@@ -149,7 +149,7 @@ public abstract class AbstractDataList<DATATYPE extends Data> extends Listenable
          */
         @Override
         public DataList<DATATYPE> get(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
-            return drain(owner.incoming().future().get(timeout, timeUnit));
+            return drain(owner.incoming().completedFuture().get(timeout, timeUnit));
         }
 
         private DataList<DATATYPE> drain(DataList<DATATYPE> dataList) {

--- a/container-core/src/main/java/com/yahoo/processing/response/DataList.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/DataList.java
@@ -72,9 +72,9 @@ public interface DataList<DATATYPE extends Data> extends Data {
      * Making this call on a list which does not support future data always returns immediately and
      * causes no memory synchronization cost.
      */
-    CompletableFuture<DataList<DATATYPE>> future();
+    CompletableFuture<DataList<DATATYPE>> completeFuture();
 
-    /** @deprecated Use {@link #future()} instead */
+    /** @deprecated Use {@link #completeFuture()} instead */
     @Deprecated(forRemoval = true, since = "7")
     ListenableFuture<DataList<DATATYPE>> complete();
 

--- a/container-core/src/main/java/com/yahoo/processing/response/DataList.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/DataList.java
@@ -1,11 +1,10 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.response;
 
-import com.google.common.util.concurrent.ExecutionList;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
-import java.util.concurrent.Executor;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * A list of data items created due to a processing request.
@@ -73,6 +72,10 @@ public interface DataList<DATATYPE extends Data> extends Data {
      * Making this call on a list which does not support future data always returns immediately and
      * causes no memory synchronization cost.
      */
+    CompletableFuture<DataList<DATATYPE>> future();
+
+    /** @deprecated Use {@link #future()} instead */
+    @Deprecated(forRemoval = true, since = "7")
     ListenableFuture<DataList<DATATYPE>> complete();
 
     /**

--- a/container-core/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
@@ -2,12 +2,13 @@
 package com.yahoo.processing.response;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.collections.Tuple2;
+import com.yahoo.concurrent.CompletableFutures;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 /**
@@ -19,7 +20,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
 
     private DataList<DATATYPE> owner = null;
 
-    private final SettableFuture<DataList<DATATYPE>> completionFuture;
+    private final CompletableFuture<DataList<DATATYPE>> completionFuture;
 
     private final List<DATATYPE> dataList = new ArrayList<>();
 
@@ -35,7 +36,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
 
     public DefaultIncomingData(DataList<DATATYPE> owner) {
         assignOwner(owner);
-        completionFuture = SettableFuture.create();
+        completionFuture = new CompletableFuture<>();
     }
 
     /** Assigns the owner of this. Throws an exception if the owner is already set. */
@@ -50,9 +51,13 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
     }
 
     @Override
+    @Deprecated(forRemoval = true, since = "7")
+    @SuppressWarnings("removal")
     public ListenableFuture<DataList<DATATYPE>> completed() {
-        return completionFuture;
+        return CompletableFutures.toGuavaListenableFuture(completionFuture);
     }
+
+    @Override public CompletableFuture<DataList<DATATYPE>> future() { return completionFuture; }
 
     /** Returns whether the data in this is complete */
     @Override
@@ -92,7 +97,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
     @Override
     public synchronized void markComplete() {
         complete = true;
-        completionFuture.set(owner);
+        completionFuture.complete(owner);
     }
 
     /**

--- a/container-core/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/DefaultIncomingData.java
@@ -57,7 +57,7 @@ public class DefaultIncomingData<DATATYPE extends Data> implements IncomingData<
         return CompletableFutures.toGuavaListenableFuture(completionFuture);
     }
 
-    @Override public CompletableFuture<DataList<DATATYPE>> future() { return completionFuture; }
+    @Override public CompletableFuture<DataList<DATATYPE>> completedFuture() { return completionFuture; }
 
     /** Returns whether the data in this is complete */
     @Override

--- a/container-core/src/main/java/com/yahoo/processing/response/IncomingData.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/IncomingData.java
@@ -1,11 +1,13 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.response;
 
-import com.google.common.util.concurrent.AbstractFuture;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.yahoo.concurrent.CompletableFutures;
+import com.yahoo.processing.impl.ProcessingFuture;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -35,6 +37,10 @@ public interface IncomingData<DATATYPE extends Data> {
      * <p>
      * This return the list owning this for convenience.
      */
+    CompletableFuture<DataList<DATATYPE>> future();
+
+    /** @deprecated Use {@link #future()} instead */
+    @Deprecated(forRemoval = true, since = "7")
     ListenableFuture<DataList<DATATYPE>> completed();
 
     /**
@@ -108,9 +114,14 @@ public interface IncomingData<DATATYPE extends Data> {
             completionFuture = new ImmediateFuture<>(owner);
         }
 
+        @Override
+        @SuppressWarnings("removal")
+        @Deprecated(forRemoval = true, since = "7")
         public ListenableFuture<DataList<DATATYPE>> completed() {
-            return completionFuture;
+            return CompletableFutures.toGuavaListenableFuture(completionFuture);
         }
+
+        @Override public CompletableFuture<DataList<DATATYPE>> future() { return completionFuture; }
 
         @Override
         public DataList<DATATYPE> getOwner() {
@@ -178,13 +189,13 @@ public interface IncomingData<DATATYPE extends Data> {
          * This is semantically the same as Futures.immediateFuture but contrary to it,
          * this never causes any memory synchronization when accessed.
          */
-        public static class ImmediateFuture<DATATYPE extends Data> extends AbstractFuture<DataList<DATATYPE>> {
+        public static class ImmediateFuture<DATATYPE extends Data> extends ProcessingFuture<DataList<DATATYPE>> {
 
-            private DataList<DATATYPE> owner;
+            private final DataList<DATATYPE> owner;
 
             public ImmediateFuture(DataList<DATATYPE> owner) {
                 this.owner = owner; // keep here to avoid memory synchronization for access
-                set(owner); // Signal completion (for future listeners)
+                complete(owner); // Signal completion (for future listeners)
             }
 
             @Override

--- a/container-core/src/main/java/com/yahoo/processing/response/IncomingData.java
+++ b/container-core/src/main/java/com/yahoo/processing/response/IncomingData.java
@@ -37,9 +37,9 @@ public interface IncomingData<DATATYPE extends Data> {
      * <p>
      * This return the list owning this for convenience.
      */
-    CompletableFuture<DataList<DATATYPE>> future();
+    CompletableFuture<DataList<DATATYPE>> completedFuture();
 
-    /** @deprecated Use {@link #future()} instead */
+    /** @deprecated Use {@link #completedFuture()} instead */
     @Deprecated(forRemoval = true, since = "7")
     ListenableFuture<DataList<DATATYPE>> completed();
 
@@ -121,7 +121,7 @@ public interface IncomingData<DATATYPE extends Data> {
             return CompletableFutures.toGuavaListenableFuture(completionFuture);
         }
 
-        @Override public CompletableFuture<DataList<DATATYPE>> future() { return completionFuture; }
+        @Override public CompletableFuture<DataList<DATATYPE>> completedFuture() { return completionFuture; }
 
         @Override
         public DataList<DATATYPE> getOwner() {

--- a/container-core/src/main/java/com/yahoo/processing/test/ProcessorLibrary.java
+++ b/container-core/src/main/java/com/yahoo/processing/test/ProcessorLibrary.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.processing.test;
 
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.common.util.concurrent.SettableFuture;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Request;
@@ -15,6 +13,7 @@ import com.yahoo.processing.request.ErrorMessage;
 import com.yahoo.processing.response.*;
 
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -288,7 +287,7 @@ public class ProcessorLibrary {
         private final boolean ordered, streamed;
 
         /** The incoming data this has created */
-        public final SettableFuture<IncomingData> incomingData = SettableFuture.create();
+        public final CompletableFuture<IncomingData> incomingData = new CompletableFuture<>();
 
         /** Create an instance which returns ordered, streamable data */
         public ListenableFutureDataSource() { this(true, true); }
@@ -307,7 +306,7 @@ public class ProcessorLibrary {
                 dataList = ArrayDataList.createAsyncNonstreamed(request);
             else
                 dataList = ArrayDataList.createAsync(request);
-            incomingData.set(dataList.incoming());
+            incomingData.complete(dataList.incoming());
             return new Response(dataList);
         }
 
@@ -317,12 +316,12 @@ public class ProcessorLibrary {
     public static class RequestCounter extends Processor {
 
         /** The incoming data this has created */
-        public final SettableFuture<IncomingData> incomingData = SettableFuture.create();
+        public final CompletableFuture<IncomingData> incomingData = new CompletableFuture<>();
 
         @Override
         public Response process(Request request, Execution execution) {
             ArrayDataList dataList = ArrayDataList.createAsync(request);
-            incomingData.set(dataList.incoming());
+            incomingData.complete(dataList.incoming());
             return new Response(dataList);
         }
 
@@ -354,7 +353,7 @@ public class ProcessorLibrary {
 
                 // wait for other executions and merge the responses
                 for (Response additionalResponse : AsyncExecution.waitForAll(futures, 1000)) {
-                    additionalResponse.data().complete().get(); // block until we have all the data elements
+                    additionalResponse.data().future().get(); // block until we have all the data elements
                     for (Object item : additionalResponse.data().asList())
                         response.data().add((Data) item);
                     response.mergeWith(additionalResponse);
@@ -382,9 +381,10 @@ public class ProcessorLibrary {
         public Response process(Request request, Execution execution) {
             Response response = execution.process(request);
             // TODO: Consider for to best provide helpers for this
-            response.data().complete().addListener(new RunnableExecution(request,
-                    new ExecutionWithResponse(asyncChain, response, execution)),
-                    MoreExecutors.directExecutor());
+            response.data().future().whenComplete(
+                    (__, ___) ->
+                            new RunnableExecution(request, new ExecutionWithResponse(asyncChain, response, execution))
+                                    .run());
             return response;
         }
 

--- a/container-core/src/main/java/com/yahoo/processing/test/ProcessorLibrary.java
+++ b/container-core/src/main/java/com/yahoo/processing/test/ProcessorLibrary.java
@@ -353,7 +353,7 @@ public class ProcessorLibrary {
 
                 // wait for other executions and merge the responses
                 for (Response additionalResponse : AsyncExecution.waitForAll(futures, 1000)) {
-                    additionalResponse.data().future().get(); // block until we have all the data elements
+                    additionalResponse.data().completeFuture().get(); // block until we have all the data elements
                     for (Object item : additionalResponse.data().asList())
                         response.data().add((Data) item);
                     response.mergeWith(additionalResponse);
@@ -381,7 +381,7 @@ public class ProcessorLibrary {
         public Response process(Request request, Execution execution) {
             Response response = execution.process(request);
             // TODO: Consider for to best provide helpers for this
-            response.data().future().whenComplete(
+            response.data().completeFuture().whenComplete(
                     (__, ___) ->
                             new RunnableExecution(request, new ExecutionWithResponse(asyncChain, response, execution))
                                     .run());

--- a/container-core/src/test/java/com/yahoo/processing/ResponseTestCase.java
+++ b/container-core/src/test/java/com/yahoo/processing/ResponseTestCase.java
@@ -22,7 +22,7 @@ public class ResponseTestCase {
      * Check the recursive toString printing along the way.
      * List variable names ends by numbers specifying the index of the list at each level.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testRecursiveCompletionAndToString() throws InterruptedException, ExecutionException {
         // create lists

--- a/container-core/src/test/java/com/yahoo/processing/execution/test/FutureDataTestCase.java
+++ b/container-core/src/test/java/com/yahoo/processing/execution/test/FutureDataTestCase.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
 public class FutureDataTestCase {
 
     /** Run a chain which ends in a processor which returns a response containing future data. */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testFutureDataPassThrough() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up
@@ -52,7 +52,7 @@ public class FutureDataTestCase {
     }
 
     /** Federate to one source which returns data immediately and one who return future data */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testFederateSyncAndAsyncData() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up
@@ -88,7 +88,7 @@ public class FutureDataTestCase {
     }
 
     /** Register a chain which will be called when some async data is available */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testAsyncDataProcessing() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up
@@ -120,7 +120,7 @@ public class FutureDataTestCase {
      * When the first of the futures are done one additional chain is to be run.
      * When both are done another chain is to be run.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testAsyncDataProcessingOfFederatedResult() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up

--- a/container-core/src/test/java/com/yahoo/processing/execution/test/StreamingTestCase.java
+++ b/container-core/src/test/java/com/yahoo/processing/execution/test/StreamingTestCase.java
@@ -13,7 +13,6 @@ import com.yahoo.processing.test.ProcessorLibrary;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -27,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 public class StreamingTestCase {
 
     /** Tests adding a chain which is called every time new data is added to a data list */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "removal"})
     @Test
     public void testStreamingData() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up

--- a/container-core/src/test/java/com/yahoo/processing/rendering/AsynchronousSectionedRendererTest.java
+++ b/container-core/src/test/java/com/yahoo/processing/rendering/AsynchronousSectionedRendererTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -407,6 +408,7 @@ public class AsynchronousSectionedRendererTest {
         }
 
         @Override
+        @SuppressWarnings("removal")
         public ListenableFuture<DataList<StringData>> complete() {
             return new ListenableFuture<DataList<StringData>>() {
                 @Override
@@ -439,6 +441,11 @@ public class AsynchronousSectionedRendererTest {
                     return StringDataList.this;
                 }
             };
+        }
+
+        @Override
+        public CompletableFuture<DataList<StringData>> future() {
+            return CompletableFuture.completedFuture(this);
         }
 
         @Override

--- a/container-core/src/test/java/com/yahoo/processing/rendering/AsynchronousSectionedRendererTest.java
+++ b/container-core/src/test/java/com/yahoo/processing/rendering/AsynchronousSectionedRendererTest.java
@@ -444,7 +444,7 @@ public class AsynchronousSectionedRendererTest {
         }
 
         @Override
-        public CompletableFuture<DataList<StringData>> future() {
+        public CompletableFuture<DataList<StringData>> completeFuture() {
             return CompletableFuture.completedFuture(this);
         }
 

--- a/container-core/src/test/java/com/yahoo/processing/test/documentation/AsyncDataProcessingInitiator.java
+++ b/container-core/src/test/java/com/yahoo/processing/test/documentation/AsyncDataProcessingInitiator.java
@@ -3,8 +3,12 @@ package com.yahoo.processing.test.documentation;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.component.chain.Chain;
-import com.yahoo.processing.*;
-import com.yahoo.processing.execution.*;
+import com.yahoo.processing.Processor;
+import com.yahoo.processing.Request;
+import com.yahoo.processing.Response;
+import com.yahoo.processing.execution.Execution;
+import com.yahoo.processing.execution.ExecutionWithResponse;
+import com.yahoo.processing.execution.RunnableExecution;
 
 /**
  * A processor which registers a listener on the future completion of
@@ -18,6 +22,7 @@ public class AsyncDataProcessingInitiator extends Processor {
         this.asyncChain=asyncChain;
     }
 
+    @SuppressWarnings({"removal"})
     @Override
     public Response process(Request request, Execution execution) {
         Response response=execution.process(request);

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7705,6 +7705,7 @@
       "public java.util.Set getFilled()",
       "public com.yahoo.processing.response.IncomingData incoming()",
       "public com.google.common.util.concurrent.ListenableFuture complete()",
+      "public java.util.concurrent.CompletableFuture future()",
       "public void addDataListener(java.lang.Runnable)",
       "public void close()",
       "public bridge synthetic com.yahoo.search.result.Hit clone()",

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7705,7 +7705,7 @@
       "public java.util.Set getFilled()",
       "public com.yahoo.processing.response.IncomingData incoming()",
       "public com.google.common.util.concurrent.ListenableFuture complete()",
-      "public java.util.concurrent.CompletableFuture future()",
+      "public java.util.concurrent.CompletableFuture completeFuture()",
       "public void addDataListener(java.lang.Runnable)",
       "public void close()",
       "public bridge synthetic com.yahoo.search.result.Hit clone()",

--- a/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
+++ b/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
@@ -973,7 +973,7 @@ public class HitGroup extends Hit implements DataList<Hit>, Cloneable, Iterable<
         return CompletableFutures.toGuavaListenableFuture(completedFuture);
     }
 
-    @Override public CompletableFuture<DataList<Hit>> future() { return completedFuture; }
+    @Override public CompletableFuture<DataList<Hit>> completeFuture() { return completedFuture; }
 
     @Override
     public void addDataListener(Runnable runnable) {

--- a/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
+++ b/container-search/src/main/java/com/yahoo/search/result/HitGroup.java
@@ -5,6 +5,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.collections.ListenableArrayList;
+import com.yahoo.concurrent.CompletableFutures;
 import com.yahoo.net.URI;
 import com.yahoo.prelude.fastsearch.SortDataHitSorter;
 import com.yahoo.processing.response.ArrayDataList;
@@ -19,6 +20,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 /**
@@ -84,7 +86,7 @@ public class HitGroup extends Hit implements DataList<Hit>, Cloneable, Iterable<
      */
     private DefaultErrorHit errorHit = null;
 
-    private final ListenableFuture<DataList<Hit>> completedFuture;
+    private final CompletableFuture<DataList<Hit>> completedFuture;
 
     private final IncomingData<Hit> incomingHits;
 
@@ -965,7 +967,13 @@ public class HitGroup extends Hit implements DataList<Hit>, Cloneable, Iterable<
     public IncomingData<Hit> incoming() { return incomingHits; }
 
     @Override
-    public ListenableFuture<DataList<Hit>> complete() { return completedFuture; }
+    @SuppressWarnings("removal")
+    @Deprecated(forRemoval = true, since = "7")
+    public ListenableFuture<DataList<Hit>> complete() {
+        return CompletableFutures.toGuavaListenableFuture(completedFuture);
+    }
+
+    @Override public CompletableFuture<DataList<Hit>> future() { return completedFuture; }
 
     @Override
     public void addDataListener(Runnable runnable) {

--- a/container-search/src/test/java/com/yahoo/search/rendering/AsyncGroupPopulationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/AsyncGroupPopulationTestCase.java
@@ -1,10 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.rendering;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.concurrent.Receiver;
 import com.yahoo.processing.response.Data;
 import com.yahoo.processing.response.DataList;
@@ -21,10 +18,12 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -35,18 +34,20 @@ import static org.junit.Assert.assertTrue;
  * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 public class AsyncGroupPopulationTestCase {
-    private static class WrappedFuture<F> implements ListenableFuture<F> {
+    private static class WrappedFuture<F> extends CompletableFuture<F> {
         Receiver<Boolean> isListening = new Receiver<>();
 
-        private ListenableFuture<F> wrapped;
+        private final CompletableFuture<F> wrapped;
 
-        WrappedFuture(ListenableFuture<F> wrapped) {
+        WrappedFuture(CompletableFuture<F> wrapped) {
             this.wrapped = wrapped;
         }
 
-        public void addListener(Runnable listener, Executor executor) {
-            wrapped.addListener(listener, executor);
+        @Override
+        public CompletableFuture<F> whenCompleteAsync(BiConsumer<? super F, ? super Throwable> action, Executor executor) {
+            wrapped.whenCompleteAsync(action);
             isListening.put(Boolean.TRUE);
+            return this;
         }
 
         public boolean cancel(boolean mayInterruptIfRunning) {
@@ -72,14 +73,14 @@ public class AsyncGroupPopulationTestCase {
     }
 
     private static class ObservableIncoming<DATATYPE extends Data> extends DefaultIncomingData<DATATYPE> {
-        WrappedFuture<DataList<DATATYPE>> waitForIt = null;
+        volatile WrappedFuture<DataList<DATATYPE>> waitForIt = null;
         private final Object lock = new Object();
 
         @Override
-        public ListenableFuture<DataList<DATATYPE>> completed() {
+        public CompletableFuture<DataList<DATATYPE>> future() {
             synchronized (lock) {
                 if (waitForIt == null) {
-                    waitForIt = new WrappedFuture<>(super.completed());
+                    waitForIt = new WrappedFuture<>(super.future());
                 }
             }
             return waitForIt;
@@ -97,9 +98,8 @@ public class AsyncGroupPopulationTestCase {
     }
 
     @Test
-    @SuppressWarnings("removal")
     public final void test() throws InterruptedException, ExecutionException,
-            JsonParseException, JsonMappingException, IOException {
+            IOException {
         String rawExpected = "{"
                 + "    \"root\": {"
                 + "        \"children\": ["
@@ -125,10 +125,10 @@ public class AsyncGroupPopulationTestCase {
         JsonRenderer renderer = new JsonRenderer();
         Result result = new Result(new Query(), h);
         renderer.init();
-        ListenableFuture<Boolean> f = renderer.render(out, result,
+        CompletableFuture<Boolean> f = renderer.renderResponse(out, result,
                 new Execution(Execution.Context.createContextStub()),
                 result.getQuery());
-        WrappedFuture<DataList<Hit>> x = (WrappedFuture<DataList<Hit>>) h.incoming().completed();
+        WrappedFuture<DataList<Hit>> x = (WrappedFuture<DataList<Hit>>) h.incoming().future();
         x.isListening.get(86_400_000);
         h.incoming().add(new Hit("yahoo2"));
         h.incoming().markComplete();

--- a/container-search/src/test/java/com/yahoo/search/rendering/AsyncGroupPopulationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/AsyncGroupPopulationTestCase.java
@@ -77,10 +77,10 @@ public class AsyncGroupPopulationTestCase {
         private final Object lock = new Object();
 
         @Override
-        public CompletableFuture<DataList<DATATYPE>> future() {
+        public CompletableFuture<DataList<DATATYPE>> completedFuture() {
             synchronized (lock) {
                 if (waitForIt == null) {
-                    waitForIt = new WrappedFuture<>(super.future());
+                    waitForIt = new WrappedFuture<>(super.completedFuture());
                 }
             }
             return waitForIt;
@@ -128,7 +128,7 @@ public class AsyncGroupPopulationTestCase {
         CompletableFuture<Boolean> f = renderer.renderResponse(out, result,
                 new Execution(Execution.Context.createContextStub()),
                 result.getQuery());
-        WrappedFuture<DataList<Hit>> x = (WrappedFuture<DataList<Hit>>) h.incoming().future();
+        WrappedFuture<DataList<Hit>> x = (WrappedFuture<DataList<Hit>>) h.incoming().completedFuture();
         x.isListening.get(86_400_000);
         h.incoming().add(new Hit("yahoo2"));
         h.incoming().markComplete();

--- a/container-search/src/test/java/com/yahoo/search/searchchain/test/FutureDataTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchchain/test/FutureDataTestCase.java
@@ -2,7 +2,8 @@
 package com.yahoo.search.searchchain.test;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.processing.response.*;
+import com.yahoo.component.chain.Chain;
+import com.yahoo.processing.response.IncomingData;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
@@ -11,18 +12,18 @@ import com.yahoo.search.federation.sourceref.SearchChainResolver;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.result.HitGroup;
 import com.yahoo.search.searchchain.Execution;
-
 import com.yahoo.search.searchchain.SearchChainRegistry;
 import com.yahoo.search.searchchain.model.federation.FederationOptions;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import com.yahoo.component.chain.Chain;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests using the async capabilities of the Processing parent framework of searchers.
@@ -31,6 +32,7 @@ import com.yahoo.component.chain.Chain;
  */
 public class FutureDataTestCase {
 
+    @SuppressWarnings("removal")
     @Test
     public void testAsyncFederation() throws InterruptedException, ExecutionException {
         // Setup environment
@@ -77,6 +79,7 @@ public class FutureDataTestCase {
         assertEquals("async:1", asyncGroup.get(1).getId().toString());
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testFutureData() throws InterruptedException, ExecutionException, TimeoutException {
         // Set up

--- a/vespajlib/src/main/java/com/yahoo/concurrent/CompletableFutures.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/CompletableFutures.java
@@ -74,8 +74,12 @@ public class CompletableFutures {
      * Helper for migrating from {@link ListenableFuture} to {@link CompletableFuture} in Vespa public apis
      * @deprecated to be removed in Vespa 8
      */
+    @SuppressWarnings("unchecked")
     @Deprecated(forRemoval = true, since = "7")
     public static <V> ListenableFuture<V> toGuavaListenableFuture(CompletableFuture<V> future) {
+        if (future instanceof ListenableFuture) {
+            return ((ListenableFuture<V>) future);
+        }
         SettableFuture<V> guavaFuture = SettableFuture.create();
         future.whenComplete((result, error) -> {
             if (result != null) guavaFuture.set(result);


### PR DESCRIPTION
- com.yahoo.processing.Response.recursiveComplete()
- com.yahoo.processing.response.DataList.complete()
- com.yahoo.processing.response.IncomingData.completed()

Also fixes bug in FutureResponse where `get()` does not return value produced by async task.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
