### PR TITLE
Support glob-style credential matching of SAN_URI certificate fields [run-systemtest]

### DIFF
--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
@@ -10,9 +10,10 @@ namespace vespalib::net::tls {
 
 struct CredentialMatchPattern {
     virtual ~CredentialMatchPattern() = default;
-    [[nodiscard]] virtual bool matches(vespalib::stringref str) const = 0;
+    [[nodiscard]] virtual bool matches(vespalib::stringref str) const noexcept = 0;
 
-    static std::shared_ptr<const CredentialMatchPattern> create_from_glob(vespalib::stringref pattern);
+    static std::shared_ptr<const CredentialMatchPattern> create_from_dns_glob(vespalib::stringref glob_pattern);
+    static std::shared_ptr<const CredentialMatchPattern> create_from_uri_glob(vespalib::stringref glob_pattern);
     static std::shared_ptr<const CredentialMatchPattern> create_exact_match(vespalib::stringref pattern);
 };
 
@@ -37,7 +38,7 @@ public:
                 && (_original_pattern == rhs._original_pattern));
     }
 
-    [[nodiscard]] bool matches(vespalib::stringref str) const {
+    [[nodiscard]] bool matches(vespalib::stringref str) const noexcept {
         return (_match_pattern && _match_pattern->matches(str));
     }
 


### PR DESCRIPTION
@bjorncs please review

This is much like the `DNS_SAN` matching, but with two major differences:
 * Implicit delimiting around `/` characters instead of `.` characters.
 * Only wildcard `*` globbing is supported. `?` may be present in a valid
   URI (even though it's silly for this purpose) and is matched as a literal
   character instead of _any_ single char.
