### PR TITLE
Remove use of Guava ListenableFuture from com.yahoo.jdisc.handler [run-systemtest]

### DIFF
--- a/application/src/test/java/com/yahoo/application/container/docprocs/MockDispatchDocproc.java
+++ b/application/src/test/java/com/yahoo/application/container/docprocs/MockDispatchDocproc.java
@@ -1,10 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application.container.docprocs;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.docproc.DocumentProcessor;
 import com.yahoo.docproc.Processing;
-import com.yahoo.document.Document;
 import com.yahoo.document.DocumentOperation;
 import com.yahoo.document.DocumentPut;
 import com.yahoo.documentapi.messagebus.protocol.DocumentMessage;
@@ -40,7 +38,7 @@ public class MockDispatchDocproc extends DocumentProcessor {
     public Progress process(Processing processing) {
         for (DocumentOperation op : processing.getDocumentOperations()) {
             PutDocumentMessage message = new PutDocumentMessage((DocumentPut)op);
-            ListenableFuture<Response> future = createRequest(message).dispatch();
+            var future = createRequest(message).dispatch();
             try {
                 responses.add(future.get());
             } catch (ExecutionException | InterruptedException e) {

--- a/container-messagebus/src/test/java/com/yahoo/messagebus/jdisc/MbusRequestHandlerTestCase.java
+++ b/container-messagebus/src/test/java/com/yahoo/messagebus/jdisc/MbusRequestHandlerTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.messagebus.jdisc;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.application.ContainerBuilder;
@@ -14,6 +13,7 @@ import com.yahoo.messagebus.test.SimpleMessage;
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -81,7 +81,7 @@ public class MbusRequestHandlerTestCase {
         return driver;
     }
 
-    private static ListenableFuture<Response> dispatchMessage(final TestDriver driver, final Message msg) {
+    private static CompletableFuture<Response> dispatchMessage(final TestDriver driver, final Message msg) {
         return new RequestDispatch() {
 
             @Override

--- a/jdisc_core/abi-spec.json
+++ b/jdisc_core/abi-spec.json
@@ -531,7 +531,7 @@
   "com.yahoo.jdisc.handler.FastContentOutputStream": {
     "superClass": "com.yahoo.jdisc.handler.AbstractContentOutputStream",
     "interfaces": [
-      "com.google.common.util.concurrent.ListenableFuture"
+      "java.util.concurrent.Future"
     ],
     "attributes": [
       "public"
@@ -553,9 +553,8 @@
     "fields": []
   },
   "com.yahoo.jdisc.handler.FastContentWriter": {
-    "superClass": "java.lang.Object",
+    "superClass": "java.util.concurrent.CompletableFuture",
     "interfaces": [
-      "com.google.common.util.concurrent.ListenableFuture",
       "java.lang.AutoCloseable"
     ],
     "attributes": [
@@ -570,17 +569,12 @@
       "public void close()",
       "public void addListener(java.lang.Runnable, java.util.concurrent.Executor)",
       "public boolean cancel(boolean)",
-      "public boolean isCancelled()",
-      "public boolean isDone()",
-      "public java.lang.Boolean get()",
-      "public java.lang.Boolean get(long, java.util.concurrent.TimeUnit)",
-      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)",
-      "public bridge synthetic java.lang.Object get()"
+      "public boolean isCancelled()"
     ],
     "fields": []
   },
   "com.yahoo.jdisc.handler.FutureCompletion": {
-    "superClass": "com.google.common.util.concurrent.AbstractFuture",
+    "superClass": "java.util.concurrent.CompletableFuture",
     "interfaces": [
       "com.yahoo.jdisc.handler.CompletionHandler"
     ],
@@ -593,12 +587,13 @@
       "public void completed()",
       "public void failed(java.lang.Throwable)",
       "public final boolean cancel(boolean)",
-      "public final boolean isCancelled()"
+      "public final boolean isCancelled()",
+      "public void addListener(java.lang.Runnable, java.util.concurrent.Executor)"
     ],
     "fields": []
   },
   "com.yahoo.jdisc.handler.FutureResponse": {
-    "superClass": "com.google.common.util.concurrent.AbstractFuture",
+    "superClass": "java.util.concurrent.CompletableFuture",
     "interfaces": [
       "com.yahoo.jdisc.handler.ResponseHandler"
     ],
@@ -609,6 +604,7 @@
     "methods": [
       "public void <init>()",
       "public void <init>(com.yahoo.jdisc.handler.ContentChannel)",
+      "public void addListener(java.lang.Runnable, java.util.concurrent.Executor)",
       "public void <init>(com.yahoo.jdisc.handler.ResponseHandler)",
       "public com.yahoo.jdisc.handler.ContentChannel handleResponse(com.yahoo.jdisc.Response)",
       "public final boolean cancel(boolean)",
@@ -682,7 +678,7 @@
   "com.yahoo.jdisc.handler.RequestDispatch": {
     "superClass": "java.lang.Object",
     "interfaces": [
-      "com.google.common.util.concurrent.ListenableFuture",
+      "java.util.concurrent.Future",
       "com.yahoo.jdisc.handler.ResponseHandler"
     ],
     "attributes": [
@@ -695,7 +691,7 @@
       "protected java.lang.Iterable requestContent()",
       "public final com.yahoo.jdisc.handler.ContentChannel connect()",
       "public final com.yahoo.jdisc.handler.FastContentWriter connectFastWriter()",
-      "public final com.google.common.util.concurrent.ListenableFuture dispatch()",
+      "public final java.util.concurrent.CompletableFuture dispatch()",
       "public void addListener(java.lang.Runnable, java.util.concurrent.Executor)",
       "public final boolean cancel(boolean)",
       "public final boolean isCancelled()",
@@ -725,8 +721,10 @@
     "fields": []
   },
   "com.yahoo.jdisc.handler.ResponseDispatch": {
-    "superClass": "com.google.common.util.concurrent.ForwardingListenableFuture",
-    "interfaces": [],
+    "superClass": "java.lang.Object",
+    "interfaces": [
+      "java.util.concurrent.Future"
+    ],
     "attributes": [
       "public",
       "abstract"
@@ -737,16 +735,18 @@
       "protected java.lang.Iterable responseContent()",
       "public final com.yahoo.jdisc.handler.ContentChannel connect(com.yahoo.jdisc.handler.ResponseHandler)",
       "public final com.yahoo.jdisc.handler.FastContentWriter connectFastWriter(com.yahoo.jdisc.handler.ResponseHandler)",
-      "public final com.google.common.util.concurrent.ListenableFuture dispatch(com.yahoo.jdisc.handler.ResponseHandler)",
-      "protected final com.google.common.util.concurrent.ListenableFuture delegate()",
+      "public final java.util.concurrent.CompletableFuture dispatch(com.yahoo.jdisc.handler.ResponseHandler)",
       "public final boolean cancel(boolean)",
       "public final boolean isCancelled()",
+      "public boolean isDone()",
+      "public java.lang.Boolean get()",
+      "public java.lang.Boolean get(long, java.util.concurrent.TimeUnit)",
       "public static varargs com.yahoo.jdisc.handler.ResponseDispatch newInstance(int, java.nio.ByteBuffer[])",
       "public static com.yahoo.jdisc.handler.ResponseDispatch newInstance(int, java.lang.Iterable)",
       "public static varargs com.yahoo.jdisc.handler.ResponseDispatch newInstance(com.yahoo.jdisc.Response, java.nio.ByteBuffer[])",
       "public static com.yahoo.jdisc.handler.ResponseDispatch newInstance(com.yahoo.jdisc.Response, java.lang.Iterable)",
-      "protected bridge synthetic java.util.concurrent.Future delegate()",
-      "protected bridge synthetic java.lang.Object delegate()"
+      "public bridge synthetic java.lang.Object get(long, java.util.concurrent.TimeUnit)",
+      "public bridge synthetic java.lang.Object get()"
     ],
     "fields": []
   },

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FastContentOutputStream.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FastContentOutputStream.java
@@ -1,12 +1,11 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.ListenableFuture;
-
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -20,7 +19,7 @@ import java.util.concurrent.TimeoutException;
  *
  * @author Simon Thoresen Hult
  */
-public class FastContentOutputStream extends AbstractContentOutputStream implements ListenableFuture<Boolean> {
+public class FastContentOutputStream extends AbstractContentOutputStream implements Future<Boolean> {
 
     private final FastContentWriter out;
 
@@ -78,7 +77,6 @@ public class FastContentOutputStream extends AbstractContentOutputStream impleme
         return out.get(timeout, unit);
     }
 
-    @Override
     public void addListener(Runnable listener, Executor executor) {
         out.addListener(listener, executor);
     }

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FutureCompletion.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FutureCompletion.java
@@ -1,7 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.AbstractFuture;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * <p>This class provides an implementation of {@link CompletionHandler} that allows you to wait for either {@link
@@ -13,16 +14,16 @@ import com.google.common.util.concurrent.AbstractFuture;
  *
  * @author Simon Thoresen Hult
  */
-public final class FutureCompletion extends AbstractFuture<Boolean> implements CompletionHandler {
+public final class FutureCompletion extends CompletableFuture<Boolean> implements CompletionHandler {
 
     @Override
     public void completed() {
-        set(true);
+        complete(true);
     }
 
     @Override
     public void failed(Throwable t) {
-        setException(t);
+        completeExceptionally(t);
     }
 
     @Override
@@ -34,4 +35,6 @@ public final class FutureCompletion extends AbstractFuture<Boolean> implements C
     public final boolean isCancelled() {
         return false;
     }
+
+    public void addListener(Runnable r, Executor e) { whenCompleteAsync((__, ___) -> r.run(), e); }
 }

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FutureResponse.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/handler/FutureResponse.java
@@ -1,8 +1,10 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.AbstractFuture;
 import com.yahoo.jdisc.Response;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 /**
  * This class provides an implementation of {@link ResponseHandler} that allows you to wait for a {@link Response} to
@@ -10,7 +12,7 @@ import com.yahoo.jdisc.Response;
  *
  * @author Simon Thoresen Hult
  */
-public final class FutureResponse extends AbstractFuture<Response> implements ResponseHandler {
+public final class FutureResponse extends CompletableFuture<Response> implements ResponseHandler {
 
     private final ResponseHandler handler;
 
@@ -38,6 +40,8 @@ public final class FutureResponse extends AbstractFuture<Response> implements Re
         });
     }
 
+    public void addListener(Runnable r, Executor e) { whenCompleteAsync((__, ___) -> r.run(), e); }
+
     /**
      * <p>Constructs a new FutureResponse that calls the given {@link ResponseHandler} when {@link
      * #handleResponse(Response)} is invoked.</p>
@@ -50,7 +54,7 @@ public final class FutureResponse extends AbstractFuture<Response> implements Re
 
     @Override
     public ContentChannel handleResponse(Response response) {
-        set(response);
+        complete(response);
         return handler.handleResponse(response);
     }
 

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FastContentWriterTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FastContentWriterTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -188,7 +187,7 @@ public class FastContentWriterTestCase {
         ReadableContentChannel buf = new ReadableContentChannel();
         FastContentWriter out = new FastContentWriter(buf);
         RunnableLatch listener = new RunnableLatch();
-        out.addListener(listener, MoreExecutors.directExecutor());
+        out.addListener(listener, Runnable::run);
 
         out.write(new byte[] { 6, 9 });
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FutureCompletionTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FutureCompletionTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -91,14 +90,14 @@ public class FutureCompletionTestCase {
     public void requireThatCompletionCanBeListenedTo() throws InterruptedException {
         FutureCompletion completion = new FutureCompletion();
         RunnableLatch listener = new RunnableLatch();
-        completion.addListener(listener, MoreExecutors.directExecutor());
+        completion.addListener(listener, Runnable::run);
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));
         completion.completed();
         assertTrue(listener.await(600, TimeUnit.SECONDS));
 
         completion = new FutureCompletion();
         listener = new RunnableLatch();
-        completion.addListener(listener, MoreExecutors.directExecutor());
+        completion.addListener(listener, Runnable::run);
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));
         completion.failed(new Throwable());
         assertTrue(listener.await(600, TimeUnit.SECONDS));

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FutureResponseTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/FutureResponseTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.test.NonWorkingContentChannel;
 import org.junit.Test;
@@ -73,7 +72,7 @@ public class FutureResponseTestCase {
     public void requireThatResponseCanBeListenedTo() throws InterruptedException {
         FutureResponse response = new FutureResponse();
         RunnableLatch listener = new RunnableLatch();
-        response.addListener(listener, MoreExecutors.directExecutor());
+        response.addListener(listener, Runnable::run);
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));
         response.handleResponse(new Response(Response.Status.OK));
         assertTrue(listener.await(600, TimeUnit.SECONDS));

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/RequestDispatchTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/RequestDispatchTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.application.ContainerBuilder;
@@ -17,12 +16,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Simon Thoresen Hult
@@ -218,7 +217,7 @@ public class RequestDispatchTestCase {
             protected Request newRequest() {
                 return new Request(driver, URI.create("http://localhost/"));
             }
-        }.dispatch().addListener(listener, MoreExecutors.directExecutor());
+        }.dispatch().whenComplete((__, ___) -> listener.run());
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));
         ContentChannel responseContent = ResponseDispatch.newInstance(Response.Status.OK)
                                                          .connect(requestHandler.responseHandler);

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/ResponseDispatchTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/ResponseDispatchTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.MoreExecutors;
 import com.yahoo.jdisc.Response;
 import org.junit.Test;
 
@@ -14,13 +13,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Simon Thoresen Hult
@@ -179,7 +178,7 @@ public class ResponseDispatchTestCase {
         ReadableContentChannel responseContent = new ReadableContentChannel();
         ResponseDispatch.newInstance(6, ByteBuffer.allocate(9))
                         .dispatch(new MyResponseHandler(responseContent))
-                        .addListener(listener, MoreExecutors.directExecutor());
+                        .whenComplete((__, ___) -> listener.run());
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));
         assertNotNull(responseContent.read());
         assertFalse(listener.await(100, TimeUnit.MILLISECONDS));

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/handler/ThreadedRequestHandlerTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/handler/ThreadedRequestHandlerTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.jdisc.handler;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.application.ContainerBuilder;
@@ -12,18 +11,19 @@ import org.junit.Test;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Simon Thoresen Hult
@@ -159,8 +159,8 @@ public class ThreadedRequestHandlerTestCase {
         return driver;
     }
 
-    private static ListenableFuture<Response> dispatchRequest(final CurrentContainer container, final String uri,
-                                                              final ByteBuffer... content) {
+    private static CompletableFuture<Response> dispatchRequest(final CurrentContainer container, final String uri,
+                                                               final ByteBuffer... content) {
         return new RequestDispatch() {
 
             @Override


### PR DESCRIPTION
This change is not 100% API compatible. Many classes from this package inherited types from Guava.
The classes will have the same methods as before, but their type has obviously changed.
Two options; merge now with the small risk of breakage or wait for Vespa 8 branch.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
