### PR TITLE
deprecate parts of DocumentTypeManager

### DIFF
--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/ScriptManagerTestCase.java
@@ -20,8 +20,7 @@ public class ScriptManagerTestCase {
 
     @Test
     public void requireThatScriptsAreAppliedToSubType() throws ParseException {
-        DocumentTypeManager typeMgr = new DocumentTypeManager();
-        typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
+        var typeMgr = DocumentTypeManager.fromFile("src/test/cfg/documentmanager_inherit.cfg");
         DocumentType docType = typeMgr.getDocumentType("newssummary");
         assertNotNull(docType);
 
@@ -36,8 +35,7 @@ public class ScriptManagerTestCase {
 
     @Test
     public void requireThatScriptsAreAppliedToSuperType() throws ParseException {
-        DocumentTypeManager typeMgr = new DocumentTypeManager();
-        typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
+        var typeMgr = DocumentTypeManager.fromFile("src/test/cfg/documentmanager_inherit.cfg");
         DocumentType docType = typeMgr.getDocumentType("newsarticle");
         assertNotNull(docType);
 
@@ -51,16 +49,14 @@ public class ScriptManagerTestCase {
 
     @Test
     public void requireThatEmptyConfigurationDoesNotThrow() {
-        DocumentTypeManager typeMgr = new DocumentTypeManager();
-        typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
+        var typeMgr = DocumentTypeManager.fromFile("src/test/cfg/documentmanager_inherit.cfg");
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(new IlscriptsConfig.Builder()), null, Embedder.throwsOnUse);
         assertNull(scriptMgr.getScript(new DocumentType("unknown")));
     }
 
     @Test
     public void requireThatUnknownDocumentTypeReturnsNull() {
-        DocumentTypeManager typeMgr = new DocumentTypeManager();
-        typeMgr.configure("file:src/test/cfg/documentmanager_inherit.cfg");
+        var typeMgr = DocumentTypeManager.fromFile("src/test/cfg/documentmanager_inherit.cfg");
         ScriptManager scriptMgr = new ScriptManager(typeMgr, new IlscriptsConfig(new IlscriptsConfig.Builder()), null, Embedder.throwsOnUse);
         for (Iterator<DocumentType> it = typeMgr.documentTypeIterator(); it.hasNext(); ) {
             assertNull(scriptMgr.getScript(it.next()));

--- a/document/abi-spec.json
+++ b/document/abi-spec.json
@@ -501,6 +501,7 @@
       "public void <init>(com.yahoo.document.config.DocumentmanagerConfig)",
       "public void assign(com.yahoo.document.DocumentTypeManager)",
       "public com.yahoo.document.DocumentTypeManager configure(java.lang.String)",
+      "public static com.yahoo.document.DocumentTypeManager fromFile(java.lang.String)",
       "public boolean hasDataType(java.lang.String)",
       "public boolean hasDataType(int)",
       "public com.yahoo.document.DataType getDataType(java.lang.String)",

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
@@ -65,9 +65,22 @@ public class DocumentTypeManager {
         annotationTypeRegistry = other.annotationTypeRegistry;
     }
 
+    /**
+     * For testing, use fromFile factory method instead
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
+     */
+    @Deprecated
     public DocumentTypeManager configure(String configId) {
         subscriber = DocumentTypeManagerConfigurer.configure(this, configId);
         return this;
+    }
+
+    /** Only for unit tests */
+    public static DocumentTypeManager fromFile(String fileName) {
+        var manager = new DocumentTypeManager();
+        var sub = DocumentTypeManagerConfigurer.configure(manager, "file:" + fileName);
+        sub.close();
+        return manager;
     }
 
     private void registerDefaultDataTypes() {
@@ -104,6 +117,10 @@ public class DocumentTypeManager {
         return false;
     }
 
+    /**
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
+     */
+    @Deprecated
     public boolean hasDataType(int code) {
         if (code == DataType.tensorDataTypeCode) return true; // built-in dynamic: Always present
         return dataTypes.containsKey(code);
@@ -140,6 +157,10 @@ public class DocumentTypeManager {
         return foundTypes.get(0);
     }
 
+    /**
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
+     */
+    @Deprecated
     public DataType getDataType(int code) { return getDataType(code, ""); }
 
     /**
@@ -148,7 +169,10 @@ public class DocumentTypeManager {
      * @param code the code of the data type to return, which must be either built in or present in this manager
      * @param detailedType detailed type information, or the empty string if none
      * @return the appropriate DataType instance
+     *
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
      */
+    @Deprecated
     public DataType getDataType(int code, String detailedType) {
         if (code == DataType.tensorDataTypeCode) // built-in dynamic
             return new TensorDataType(TensorType.fromSpec(detailedType));
@@ -165,7 +189,11 @@ public class DocumentTypeManager {
         }
     }
 
+    /**
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
+     */
     @SuppressWarnings("deprecation")
+    @Deprecated
     DataType getDataTypeAndReturnTemporary(int code, String detailedType) {
         if (hasDataType(code)) {
             return getDataType(code, detailedType);
@@ -277,6 +305,7 @@ public class DocumentTypeManager {
         DocumentDeserializer data = DocumentDeserializerFactory.create6(this, buf);
         return new Document(data);
     }
+
     public Document createDocument(DocumentDeserializer data) {
         return new Document(data);
     }
@@ -305,7 +334,10 @@ public class DocumentTypeManager {
     /**
      * Clears the DocumentTypeManager. After this operation,
      * only the default document type and data types are available.
+     *
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
      */
+    @Deprecated
     public void clear() {
         documentTypes.clear();
         dataTypes.clear();
@@ -316,6 +348,10 @@ public class DocumentTypeManager {
         return annotationTypeRegistry;
     }
 
+    /**
+     * @deprecated //TODO Will be package-private or removed on Vespa 8
+     */
+    @Deprecated
     public void shutdown() {
         if (subscriber!=null) subscriber.close();
     }

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
@@ -159,7 +159,7 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
             return type;
         }
 
-
+        @SuppressWarnings("deprecation")
         private DataType getOrCreateType(int id) {
             if (typesById.containsKey(id)) {
                 return typesById.get(id);
@@ -192,6 +192,7 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
             }
         }
 
+        @SuppressWarnings("deprecation")
         private void fillStructs(DocumentmanagerConfig config) {
             for (var thisDataType : config.datatype()) {
                 for (var struct : thisDataType.structtype()) {
@@ -292,6 +293,7 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
             }
         }
 
+        @SuppressWarnings("deprecation")
         private void addAnnotationTypePayloads(DocumentmanagerConfig config) {
             for (DocumentmanagerConfig.Annotationtype annType : config.annotationtype()) {
                 AnnotationType annotationType = manager.getAnnotationTypeRegistry().getType(annType.id());

--- a/document/src/test/java/com/yahoo/document/DocumentTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCase.java
@@ -100,6 +100,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
         return dcMan;
     }
 
+    @SuppressWarnings("deprecation")
     public void setUpSertestDocType() {
         docMan = new DocumentTypeManager();
 
@@ -877,6 +878,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
         doc.setFieldValue("something", testlist);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testCompressionConfiguredIsIgnored() {
 
@@ -1094,6 +1096,7 @@ public class DocumentTestCase extends DocumentTestCaseBase {
         assertEquals(doc, doc2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testUnknownFieldsDeserialization() {
         DocumentTypeManager docTypeManasjer = new DocumentTypeManager();

--- a/document/src/test/java/com/yahoo/document/DocumentTypeManagerTestCase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTypeManagerTestCase.java
@@ -59,6 +59,7 @@ public class DocumentTypeManagerTestCase {
         assertSame(DataType.DOUBLE, doubleType);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRecursiveRegister() {
         StructDataType struct = new StructDataType("mystruct");
@@ -87,6 +88,7 @@ public class DocumentTypeManagerTestCase {
         assertEquals(docType2, manager.getDocumentType(new DataTypeName("myotherdoc")));
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testMultipleDocuments() {
         DocumentType docType1 = new DocumentType("foo0");
@@ -120,6 +122,7 @@ public class DocumentTypeManagerTestCase {
         assertEquals(manager.getDocumentTypes().get(new DataTypeName("foo1")), docType2);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testReverseMapOrder() {
         DocumentTypeManager manager = createConfiguredManager("file:src/test/document/documentmanager.map.cfg");
@@ -501,6 +504,7 @@ search annotationsimplicitstruct {
         assertReferenceTypePresentInManager(manager, 12345678, "referenced_type");
     }
 
+    @SuppressWarnings("deprecation")
     private static void assertReferenceTypePresentInManager(DocumentTypeManager manager, int refTypeId,
                                                             String refTargetTypeName) {
         DataType type = manager.getDataType(refTypeId);

--- a/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
+++ b/vespa_feed_perf/src/main/java/com/yahoo/vespa/feed/perf/SimpleFeeder.java
@@ -349,6 +349,9 @@ public class SimpleFeeder implements ReplyHandler {
         }
         return new JsonDestination(params.getDumpStream(), failure, numReplies);
     }
+
+
+    @SuppressWarnings("deprecation")
     SimpleFeeder(FeederParams params) {
         inputStreams = params.getInputStreams();
         out = params.getStdOut();

--- a/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
+++ b/vespa_feed_perf/src/test/java/com/yahoo/vespa/feed/perf/SimpleServer.java
@@ -28,6 +28,7 @@ public class SimpleServer {
     private final MessageBus mbus;
     private final DestinationSession session;
 
+    @SuppressWarnings("deprecation")
     public SimpleServer(String configDir, MessageHandler msgHandler) throws IOException, ListenFailedException {
         slobrok = new Slobrok();
         documentMgr = new DocumentTypeManager();
@@ -53,6 +54,7 @@ public class SimpleServer {
         writer.close();
     }
 
+    @SuppressWarnings("deprecation")
     public final void close() {
         session.destroy();
         mbus.destroy();


### PR DESCRIPTION
* we want to stop using IDs as unique key for DataTypes;
  these methods are only used in our own config setup.
* nothing should setup a self-subscribing manager; add a
  convenience to create a manager from a config file
  to use from unit tests.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review

@gjoranv @bjorncs @jonmv @baldersheim FYI