### PR TITLE
Balder/retry lidoperation until state is well defined

### DIFF
--- a/searchcore/src/tests/proton/documentdb/document_scan_iterator/document_scan_iterator_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_scan_iterator/document_scan_iterator_test.cpp
@@ -49,19 +49,19 @@ struct Fixture
         }
         LidSet retval;
         for (uint32_t i = 0; i < count; ++i) {
-            uint32_t lid = next(compactLidLimit, false);
+            uint32_t lid = next(compactLidLimit);
             retval.insert(lid);
             EXPECT_TRUE(_itr->valid() || lid <= compactLidLimit);
         }
-        EXPECT_EQUAL(0u, next(compactLidLimit, false));
+        EXPECT_EQUAL(0u, next(compactLidLimit));
         EXPECT_FALSE(_itr->valid());
         return retval;
     }
-    uint32_t next(uint32_t compactLidLimit, bool retry = false) {
+    uint32_t next(uint32_t compactLidLimit) {
         if (!_itr) {
             _itr = std::make_unique<DocumentScanIterator>(_metaStore);
         }
-        return _itr->next(compactLidLimit, retry).lid;
+        return _itr->next(compactLidLimit).lid;
     }
 };
 
@@ -80,14 +80,6 @@ TEST_F("require that only lids > lid limit are returned", Fixture)
 {
     f.add({1,2,3,4,5,6,7,8});
     assertLidSet({5,6,7,8}, f.scan(4, 4));
-}
-
-TEST_F("require that we start scan at previous doc if retry is set", Fixture)
-{
-    f.add({1,2,3,4,5,6,7,8});
-    uint32_t lid1 = f.next(4, false);
-    uint32_t lid2 = f.next(4, true);
-    EXPECT_EQUAL(lid1, lid2);
 }
 
 TEST_MAIN()

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.cpp
@@ -19,8 +19,8 @@ MyScanIterator::valid() const {
     return _validItr;
 }
 
-search::DocumentMetaData MyScanIterator::next(uint32_t compactLidLimit, bool retry) {
-    if (!retry && _itr != _lids.begin()) {
+search::DocumentMetaData MyScanIterator::next(uint32_t compactLidLimit) {
+    if (_itr != _lids.begin()) {
         ++_itr;
     }
     for (; _itr != _lids.end() && (*_itr) <= compactLidLimit; ++_itr) {}

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.h
@@ -56,7 +56,7 @@ struct MyScanIterator : public IDocumentScanIterator {
     explicit MyScanIterator(const MyHandler & handler, const LidVector &lids);
     ~MyScanIterator() override;
     bool valid() const override;
-    search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) override;
+    search::DocumentMetaData next(uint32_t compactLidLimit) override;
 };
 
 struct MyHandler : public ILidSpaceCompactionHandler {

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_compaction_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_compaction_test.cpp
@@ -250,6 +250,7 @@ TEST_F(MaxOutstandingJobTest, job_is_blocked_if_it_has_too_many_outstanding_move
     unblockJob(1);
     assertRunToNotBlocked();
     assertJobContext(4, 7, 3, 0, 0);
+    unblockJob(1);
     endScan().compact();
     assertJobContext(4, 7, 3, 7, 1);
     sync();

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.cpp
@@ -23,12 +23,9 @@ DocumentScanIterator::valid() const
 }
 
 DocumentMetaData
-DocumentScanIterator::next(uint32_t compactLidLimit, bool retry)
+DocumentScanIterator::next(uint32_t compactLidLimit)
 {
-    if (!retry) {
-        --_lastLid;
-    }
-    for (; _lastLid > compactLidLimit; --_lastLid) {
+    for (--_lastLid; _lastLid > compactLidLimit; --_lastLid) {
         if (_metaStore.validLid(_lastLid)) {
             const RawDocumentMetaData &metaData = _metaStore.getRawMetaData(_lastLid);
             return DocumentMetaData(_lastLid, metaData.getTimestamp(),

--- a/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/document_scan_iterator.h
@@ -21,7 +21,7 @@ private:
 public:
     DocumentScanIterator(const IDocumentMetaStore &_metaStore);
     bool valid() const override;
-    search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) override;
+    search::DocumentMetaData next(uint32_t compactLidLimit) override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_document_scan_iterator.h
@@ -27,9 +27,8 @@ struct IDocumentScanIterator
      * Returns an invalid document if no documents satisfy the limit.
      *
      * @param compactLidLimit The returned document must have lid larger than this limit.
-     * @param retry Whether we should start the scan with the previous returned document.
      */
-    virtual search::DocumentMetaData next(uint32_t compactLidLimit, bool retry) = 0;
+    virtual search::DocumentMetaData next(uint32_t compactLidLimit) = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
+++ b/searchcore/src/vespa/searchcore/proton/server/lid_space_compaction_job.h
@@ -58,7 +58,7 @@ private:
     void compactLidSpace(const search::LidUsageStats &stats);
     bool remove_batch_is_ongoing() const;
     bool remove_is_ongoing() const;
-    search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats, bool retryLastDocument);
+    search::DocumentMetaData getNextDocument(const search::LidUsageStats &stats);
 
     bool scanDocuments(const search::LidUsageStats &stats);
     static void moveDocument(std::shared_ptr<CompactionJob> job, const search::DocumentMetaData & metaThen,
@@ -98,4 +98,3 @@ public:
 };
 
 } // namespace proton
-


### PR DESCRIPTION
@geirst or @toregge PR
This is to prevent a race condition which is frequently triggered by
LidSpaceCompactionTest::test_shrink_memoryusage system test.
The last commit is the important one.