### PR TITLE
Deinline destructors for AttributeCollectionSpecFactory and

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/attribute/CMakeLists.txt
@@ -38,4 +38,5 @@ vespa_add_library(searchcore_attribute STATIC
     sequential_attributes_initializer.cpp
     DEPENDS
     searchcore_flushengine
+    searchcore_pcommon
 )

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.cpp
@@ -16,6 +16,8 @@ AttributeCollectionSpecFactory::AttributeCollectionSpecFactory(
 {
 }
 
+AttributeCollectionSpecFactory::~AttributeCollectionSpecFactory() = default;
+
 AttributeCollectionSpec::UP
 AttributeCollectionSpecFactory::create(const AttributesConfig &attrCfg,
                                        uint32_t docIdLimit,

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.h
@@ -25,6 +25,7 @@ private:
 public:
     AttributeCollectionSpecFactory(const AllocStrategy& alloc_strategy,
                                    bool fastAccessOnly);
+    ~AttributeCollectionSpecFactory();
 
     AttributeCollectionSpec::UP create(const AttributesConfig &attrCfg,
                                        uint32_t docIdLimit,

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.cpp
@@ -165,6 +165,8 @@ AttributeManagerInitializer::AttributeManagerInitializer(SerialNum configSerialN
     _attrMgr = std::make_shared<AttributeManager>(*baseAttrMgr, *attrSpec, tasksBuilder);
 }
 
+AttributeManagerInitializer::~AttributeManagerInitializer() = default;
+
 void
 AttributeManagerInitializer::run()
 {

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.h
@@ -42,6 +42,7 @@ public:
                                 bool fastAccessAttributesOnly,
                                 searchcorespi::index::IThreadService &master,
                                 std::shared_ptr<AttributeManager::SP> attrMgrResult);
+    ~AttributeManagerInitializer() override;
 
     virtual void run() override;
 };


### PR DESCRIPTION
AttributeManagerInitializer.  Add dependency on searchcore_pcommon.

@baldersheim : please review
