### PR TITLE
Log JVM options [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1078,12 +1078,14 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                     String jvmArgs = nodesElement.getAttribute(VespaDomBuilder.JVMARGS_ATTRIB_NAME);
                     throw new IllegalArgumentException("You have specified both jvm-options='" + jvmOptions + "'" +
                                                                " and deprecated jvmargs='" + jvmArgs +
-                                                               "'. Merge jvmargs into 'options' in 'jvm' element.");
+                                                               "'. Merge jvmargs into 'options' in 'jvm' element." +
+                                                               " See https://docs.vespa.ai/en/reference/services-container.html#jvm");
                 }
             } else {
                 jvmOptions = nodesElement.getAttribute(VespaDomBuilder.JVMARGS_ATTRIB_NAME);
                 if (incompatibleGCOptions(jvmOptions)) {
-                    deployLogger.logApplicationPackage(WARNING, "You need to move your GC-related options from deprecated 'jvmargs' to 'gc-options' in 'jvm' element");
+                    deployLogger.logApplicationPackage(WARNING, "You need to move your GC-related options from deprecated 'jvmargs' to 'gc-options' in 'jvm' element." +
+                            " See https://docs.vespa.ai/en/reference/services-container.html#jvm");
                     cluster.setJvmGCOptions(ContainerCluster.G1GC);
                 }
             }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -683,12 +683,12 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             if (nodesElement.hasAttribute(VespaDomBuilder.JVMARGS_ATTRIB_NAME)) {
                 String jvmArgs = nodesElement.getAttribute(VespaDomBuilder.JVMARGS_ATTRIB_NAME);
                 throw new IllegalArgumentException("You have specified both jvm-options='" + jvmOptions + "'" +
-                        " and deprecated jvmargs='" + jvmArgs + "'. Merge jvmargs into jvm-options.");
+                        " and deprecated jvmargs='" + jvmArgs + "'. Merge jvmargs into 'options' in 'jvm' element.");
             }
         } else {
             jvmOptions = nodesElement.getAttribute(VespaDomBuilder.JVMARGS_ATTRIB_NAME);
             if (incompatibleGCOptions(jvmOptions)) {
-                deployLogger.logApplicationPackage(WARNING, "You need to move out your GC-related options from deprecated 'jvmargs' to 'jvm-gc-options'");
+                deployLogger.logApplicationPackage(WARNING, "You need to move your GC-related options from deprecated 'jvmargs' to 'gc-options' in 'jvm' element");
                 cluster.setJvmGCOptions(ContainerCluster.G1GC);
             }
         }

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1488,7 +1488,10 @@ public class ModelProvisioningTest {
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
-            assertEquals("You have specified both jvm-options='xyz' and deprecated jvmargs='abc'. Merge jvmargs into 'options' in 'jvm' element.", e.getMessage());
+            assertEquals("You have specified both jvm-options='xyz' and deprecated jvmargs='abc'. " +
+                                 "Merge jvmargs into 'options' in 'jvm' element. " +
+                                 "See https://docs.vespa.ai/en/reference/services-container.html#jvm",
+                         e.getMessage());
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1488,7 +1488,7 @@ public class ModelProvisioningTest {
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
-            assertEquals("You have specified both jvm-options='xyz' and deprecated jvmargs='abc'. Merge jvmargs into jvm-options.", e.getMessage());
+            assertEquals("You have specified both jvm-options='xyz' and deprecated jvmargs='abc'. Merge jvmargs into 'options' in 'jvm' element.", e.getMessage());
         }
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JvmOptionsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JvmOptionsTest.java
@@ -146,16 +146,16 @@ public class JvmOptionsTest extends ContainerModelBuilderTestBase {
 
     @Test
     public void requireThatJvmGcOptionsAreLogged()  throws IOException, SAXException {
-        verifyLoggingOfJvmGCOptions(true, "-XX:+UseCMSInitiatingOccupancyOnly foo     bar");
-        verifyLoggingOfJvmGCOptions(true, "-XX:+UseConcMarkSweepGC");
-        verifyLoggingOfJvmGCOptions(false, "-XX:+UseConcMarkSweepGC");
+        verifyLoggingOfJvmOptions(true, "gc-options", "-XX:+UseCMSInitiatingOccupancyOnly foo     bar");
+        verifyLoggingOfJvmOptions(true, "gc-options", "-XX:+UseConcMarkSweepGC");
+        verifyLoggingOfJvmOptions(false, "gc-options", "-XX:+UseConcMarkSweepGC");
     }
 
-    private void verifyLoggingOfJvmGCOptions(boolean isHosted, String override) throws IOException, SAXException  {
+    private void verifyLoggingOfJvmOptions(boolean isHosted, String optionName, String override) throws IOException, SAXException  {
         String servicesXml =
                 "<container version='1.0'>" +
                 "  <nodes>" +
-                "    <jvm gc-options='" + override + "'/>" +
+                "    <jvm " + optionName + "='" + override + "'/>" +
                 "    <node hostalias='mockhost'/>" +
                 "  </nodes>" +
                 "</container>";
@@ -169,11 +169,17 @@ public class JvmOptionsTest extends ContainerModelBuilderTestBase {
         if (isHosted) {
             Pair<Level, String> firstOption = logger.msgs.get(0);
             assertEquals(Level.INFO, firstOption.getFirst());
-            assertEquals("JVM GC options from services.xml: " + override, firstOption.getSecond());
+            assertEquals("JVM " + (optionName.equals("gc-options") ? "GC " : "") +
+                                 "options from services.xml: " + override, firstOption.getSecond());
         } else {
             assertEquals(0, logger.msgs.size());
         }
     }
 
+    @Test
+    public void requireThatJvmOptionsAreLogged()  throws IOException, SAXException {
+        verifyLoggingOfJvmOptions(true, "options", "-Xms2G");
+        verifyLoggingOfJvmOptions(false, "options", "-Xms2G");
+    }
 
 }


### PR DESCRIPTION
Prepare for validating JVM options. This PR starts logging them at info level to deploy log. This way we can gather information about which options are in use and how/when we can validate and eventually fail deployment for some of these options