### PR TITLE
Dump pending GC state for nodes when update inconsistency is detected

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
@@ -49,6 +49,7 @@ private:
     const bool _is_auto_create_update;
 
     const DistributorNodeContext& _node_ctx;
+    DistributorStripeOperationContext& _op_ctx;
     DistributorBucketSpace &_bucketSpace;
     std::pair<document::BucketId, uint16_t> _newestTimestampLocation;
     api::BucketInfo _infoAtSendTime; // Should be same across all replicas
@@ -70,6 +71,9 @@ private:
     UpdateMetricSet& _metrics;
 
     api::Timestamp adjusted_received_old_timestamp(api::Timestamp old_ts_from_node) const;
+    void log_inconsistency_warning(const api::UpdateReply& reply,
+                                   const PreviousDocumentVersion& highest_timestamped_version,
+                                   const PreviousDocumentVersion& low_timestamped_version);
 };
 
 }


### PR DESCRIPTION
@geirst please review

This is to help debug a very rare edge case where the theory is that
an update operation may race with the implicit removal of said document
by asynchronous GC. By dumping the pending GC state for the bucket+node
we can get some good indications on whether this theory holds.
