### PR TITLE
1 - Make the first sample period at least 5s long.

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPollerProvider.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPollerProvider.java
@@ -4,6 +4,8 @@ package ai.vespa.metricsproxy.service;
 import ai.vespa.metricsproxy.core.MonitoringConfig;
 import com.yahoo.container.di.componentgraph.Provider;
 
+import java.time.Duration;
+
 /**
  * @author gjoranv
  */
@@ -17,8 +19,9 @@ public class SystemPollerProvider implements Provider<SystemPoller> {
      */
     public SystemPollerProvider (VespaServices services, MonitoringConfig monitoringConfig) {
         if (runningOnLinux()) {
-            poller = new SystemPoller(services.getVespaServices(), 60 * monitoringConfig.intervalMinutes());
-            poller.poll();
+            Duration interval = Duration.ofMinutes(monitoringConfig.intervalMinutes());
+            poller = new SystemPoller(services.getVespaServices(), interval);
+            poller.schedule(Duration.ofSeconds(5));
         } else {
             poller = null;
         }


### PR DESCRIPTION
2 - Ensure that total cpu usage is sampled first on startup, and last on all remaining samples.
    This is to avoid the large skew you get when sample interval is shorter than the time used to collect the samples.
This should eliminate the sampling noise when metricsproxy is started.

@bjorncs or @gjoranv 