### PR TITLE
Bratseth/match exactly

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -25,7 +25,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
 
     public static final Logger log = Logger.getLogger(DistributorCluster.class.getPackage().toString());
 
-
     private static class GcOptions {
 
         public final int interval;
@@ -55,8 +54,8 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
             this.parent = parent;
         }
 
-        private String prepareGCSelection(ModelElement documentNode, String selStr) throws ParseException {
-            DocumentSelector s = new DocumentSelector(selStr);
+        private String prepareGCSelection(ModelElement documentNode, String selectionString) throws ParseException {
+            DocumentSelector s = new DocumentSelector(selectionString);
             boolean enableGC = false;
             if (documentNode != null) {
                 enableGC = documentNode.booleanAttribute("garbage-collection", false);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DocumentTypeVisitor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DocumentTypeVisitor.java
@@ -14,6 +14,7 @@ import com.yahoo.document.select.rule.NowNode;
 import com.yahoo.document.select.rule.VariableNode;
 
 public abstract class DocumentTypeVisitor implements Visitor {
+
     @Override
     public void visit(ArithmeticNode arithmeticNode) {
         for (ArithmeticNode.NodeItem item : arithmeticNode.getItems()) {
@@ -64,4 +65,5 @@ public abstract class DocumentTypeVisitor implements Visitor {
     @Override
     public void visit(VariableNode variableNode) {
     }
+
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentSelectionConverter.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentSelectionConverter.java
@@ -6,11 +6,11 @@ import com.yahoo.document.select.convert.SelectionExpressionConverter;
 import com.yahoo.document.select.parser.ParseException;
 import java.util.Map;
 
-
 /**
  * @author Ulf Lilleengen
  */
-// TODO: Public methods only used in tests. What is this class for?
+// TODO: This should be renamed to reflect it is only a validator of expressions
+//       (in DocumentSelector and SelectionExpressionConverter)
 public class DocumentSelectionConverter {
 
     private final DocumentSelector selector;

--- a/document/src/main/java/com/yahoo/document/DocumentType.java
+++ b/document/src/main/java/com/yahoo/document/DocumentType.java
@@ -321,7 +321,7 @@ public class DocumentType extends StructuredDataType {
     /**
      * Return whether this document type inherits the given document type.
      *
-     * @param superType The documenttype to check if it inherits.
+     * @param superType the documenttype to check if it inherits
      * @return true if it inherits the superType, false if not
      */
     public boolean inherits(DocumentType superType) {
@@ -335,8 +335,8 @@ public class DocumentType extends StructuredDataType {
     /**
      * Gets the field matching a given name.
      *
-     * @param name the name of a field.
-     * @return returns the matching field, or null if not found.
+     * @param name the name of a field
+     * @return returns the matching field, or null if not found
      */
     public Field getField(String name) {
         Field field = headerType.getField(name);

--- a/document/src/main/java/com/yahoo/document/select/Context.java
+++ b/document/src/main/java/com/yahoo/document/select/Context.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class Context {
+
     private DocumentOperation documentOperation;
     private Map<String, Object> variables = new HashMap<>();
 

--- a/document/src/main/java/com/yahoo/document/select/DocumentSelector.java
+++ b/document/src/main/java/com/yahoo/document/select/DocumentSelector.java
@@ -9,17 +9,18 @@ import com.yahoo.document.select.parser.TokenMgrException;
 import com.yahoo.document.select.rule.ExpressionNode;
 
 /**
- * <p>A document selector is a filter which accepts or rejects documents
+ * A document selector is a filter which accepts or rejects documents
  * based on their type and content. A document selector has a textual
- * representation which is called the <i>Document Selection Language</i></p>
+ * representation which is called the
+ * <a href="https://docs.vespa.ai/en/reference/document-select-language.html">document selection language</a>.
  *
- * <p>Document selectors are multithread safe.</p>
+ * Document selectors are multithread safe.
  *
  * @author bratseth
  */
 public class DocumentSelector {
 
-    private ExpressionNode expression;
+    private final ExpressionNode expression;
 
     /**
      * Creates a document selector from a Document Selection Language string

--- a/document/src/main/java/com/yahoo/document/select/NowCheckVisitor.java
+++ b/document/src/main/java/com/yahoo/document/select/NowCheckVisitor.java
@@ -5,6 +5,7 @@ import com.yahoo.document.select.rule.ArithmeticNode;
 import com.yahoo.document.select.rule.AttributeNode;
 import com.yahoo.document.select.rule.ComparisonNode;
 import com.yahoo.document.select.rule.DocumentNode;
+import com.yahoo.document.select.rule.DocumentTypeNode;
 import com.yahoo.document.select.rule.EmbracedNode;
 import com.yahoo.document.select.rule.IdNode;
 import com.yahoo.document.select.rule.LiteralNode;
@@ -18,8 +19,8 @@ import com.yahoo.document.select.rule.VariableNode;
  *
  * @author Ulf Lilleengen
  */
-
 public class NowCheckVisitor implements Visitor {
+
     private int nowNodeCount = 0;
 
     public boolean requiresConversion() {
@@ -41,18 +42,17 @@ public class NowCheckVisitor implements Visitor {
         node.getRHS().accept(this);
     }
 
-    public void visit(DocumentNode node) {
-    }
+    public void visit(DocumentNode node) {}
+
+    public void visit(DocumentTypeNode node) {}
 
     public void visit(EmbracedNode node) {
         node.getNode().accept(this);
     }
 
-    public void visit(IdNode node) {
-    }
+    public void visit(IdNode node) {}
 
-    public void visit(LiteralNode node) {
-    }
+    public void visit(LiteralNode node) {}
 
     public void visit(LogicNode node) {
         for (LogicNode.NodeItem item : node.getItems()) {

--- a/document/src/main/java/com/yahoo/document/select/Visitor.java
+++ b/document/src/main/java/com/yahoo/document/select/Visitor.java
@@ -1,11 +1,11 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.select;
 
-
 import com.yahoo.document.select.rule.ArithmeticNode;
 import com.yahoo.document.select.rule.AttributeNode;
 import com.yahoo.document.select.rule.ComparisonNode;
 import com.yahoo.document.select.rule.DocumentNode;
+import com.yahoo.document.select.rule.DocumentTypeNode;
 import com.yahoo.document.select.rule.EmbracedNode;
 import com.yahoo.document.select.rule.IdNode;
 import com.yahoo.document.select.rule.LiteralNode;
@@ -15,16 +15,17 @@ import com.yahoo.document.select.rule.NowNode;
 import com.yahoo.document.select.rule.VariableNode;
 
 /**
- * This interface can be used to create custom visitors for the selection tree.
+ * A visitor of the document selection tree.
  *
  * @author Ulf Lilleengen
  */
-
 public interface Visitor {
+
     void visit(ArithmeticNode node);
     void visit(AttributeNode node);
     void visit(ComparisonNode node);
     void visit(DocumentNode node);
+    void visit(DocumentTypeNode node);
     void visit(EmbracedNode node);
     void visit(IdNode node);
     void visit(LiteralNode node);
@@ -32,4 +33,5 @@ public interface Visitor {
     void visit(NegationNode node);
     void visit(NowNode node);
     void visit(VariableNode node);
+
 }

--- a/document/src/main/java/com/yahoo/document/select/convert/NowQueryExpression.java
+++ b/document/src/main/java/com/yahoo/document/select/convert/NowQueryExpression.java
@@ -12,6 +12,7 @@ import com.yahoo.document.select.rule.ComparisonNode;
  * @author Ulf Lilleengen
  */
 public class NowQueryExpression {
+
     private final AttributeNode attribute;
     private final ComparisonNode comparison;
     private final NowQueryNode now;
@@ -33,7 +34,7 @@ public class NowQueryExpression {
             sb.append(item.getName()).append(".");
         }
         sb.deleteCharAt(sb.length() - 1);
-        return sb.toString() + ":" + comparison.getOperator() + now;
+        return sb + ":" + comparison.getOperator() + now;
     }
 
 }

--- a/document/src/main/java/com/yahoo/document/select/convert/SelectionExpressionConverter.java
+++ b/document/src/main/java/com/yahoo/document/select/convert/SelectionExpressionConverter.java
@@ -7,6 +7,7 @@ import com.yahoo.document.select.rule.ArithmeticNode;
 import com.yahoo.document.select.rule.AttributeNode;
 import com.yahoo.document.select.rule.ComparisonNode;
 import com.yahoo.document.select.rule.DocumentNode;
+import com.yahoo.document.select.rule.DocumentTypeNode;
 import com.yahoo.document.select.rule.EmbracedNode;
 import com.yahoo.document.select.rule.ExpressionNode;
 import com.yahoo.document.select.rule.IdNode;
@@ -27,13 +28,15 @@ import java.util.Map;
  */
 public class SelectionExpressionConverter implements Visitor {
 
-    private Map<String, NowQueryExpression> expressionMap = new HashMap<>();
+    private final Map<String, NowQueryExpression> expressionMap = new HashMap<>();
 
-    private class BuildState {
+    private static class BuildState {
+
         public AttributeNode attribute;
         public ComparisonNode comparison;
         public ArithmeticNode arithmetic;
         public NowNode now;
+
     }
 
     private BuildState state;
@@ -55,7 +58,6 @@ public class SelectionExpressionConverter implements Visitor {
         }
         return ret;
     }
-
 
     public void visit(ArithmeticNode node) {
         if (state == null ) return;
@@ -111,6 +113,10 @@ public class SelectionExpressionConverter implements Visitor {
     }
 
     public void visit(DocumentNode node) {
+        // Silently ignore
+    }
+
+    public void visit(DocumentTypeNode node) {
         // Silently ignore
     }
 

--- a/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/AttributeNode.java
@@ -27,18 +27,11 @@ import java.util.List;
 public class AttributeNode implements ExpressionNode {
 
     private ExpressionNode value;
-    private final List<Item> items = new ArrayList<>();
+    private final List<Item> items;
 
-    public AttributeNode(ExpressionNode value, List items) {
+    public AttributeNode(ExpressionNode value, List<Item> items) {
         this.value = value;
-        for (Object obj : items) {
-            if (obj instanceof Item) {
-                this.items.add((Item)obj);
-            } else {
-                throw new IllegalStateException("Can not add an instance of " + obj.getClass().getName() +
-                                                " as a function item.");
-            }
-        }
+        this.items = new ArrayList<>(items);
     }
 
     public ExpressionNode getValue() {
@@ -99,12 +92,14 @@ public class AttributeNode implements ExpressionNode {
     }
 
     static class IteratorHandler extends FieldPathIteratorHandler {
+
         VariableValueList values = new VariableValueList();
 
         @Override
         public void onPrimitive(FieldValue fv) {
             values.add(new ResultList.VariableValue((VariableMap)getVariables().clone(), fv));
         }
+
     }
 
     private static Object applyFunction(String function, Object value) {
@@ -153,7 +148,7 @@ public class AttributeNode implements ExpressionNode {
 
     private static Object evaluateFieldPath(String fieldPathStr, Object value) {
         if (value instanceof DocumentPut) {
-            final Document doc = ((DocumentPut) value).getDocument();
+            Document doc = ((DocumentPut) value).getDocument();
             if (isSimpleImportedField(fieldPathStr, doc.getDataType())) {
                 // Imported fields can only be meaningfully evaluated in the backend, so we
                 // explicitly treat them as if they are valid fields with missing values. This
@@ -211,6 +206,7 @@ public class AttributeNode implements ExpressionNode {
     }
 
     public static class Item {
+
         public static final int ATTRIBUTE = 0;
         public static final int FUNCTION = 1;
 
@@ -242,5 +238,7 @@ public class AttributeNode implements ExpressionNode {
         @Override public String toString() {
             return name + (type == FUNCTION ? "()" : "");
         }
+
     }
+
 }

--- a/document/src/main/java/com/yahoo/document/select/rule/DocumentNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/DocumentNode.java
@@ -43,21 +43,7 @@ public class DocumentNode implements ExpressionNode {
     }
 
     public Object evaluate(DocumentOperation op) {
-        DocumentType doct;
-        if (op instanceof DocumentPut) {
-            doct = ((DocumentPut)op).getDocument().getDataType();
-        } else if (op instanceof DocumentUpdate) {
-            doct = ((DocumentUpdate)op).getDocumentType();
-        } else if (op instanceof DocumentRemove) {
-            DocumentRemove removeOp = (DocumentRemove)op;
-            return (removeOp.getId().getDocType().equals(type) ? op : Boolean.FALSE);
-        } else if (op instanceof DocumentGet) {
-            DocumentGet getOp = (DocumentGet)op;
-            return (getOp.getId().getDocType().equals(type) ? op : Boolean.FALSE);
-        } else {
-            throw new IllegalStateException("Document class '" + op.getClass().getName() + "' is not supported.");
-        }
-        return doct.isA(this.type) ? op : Boolean.FALSE;
+        return op.getId().getDocType().equals(type) ? op : false;
     }
 
     public void accept(Visitor visitor) {

--- a/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
@@ -1,0 +1,58 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.select.rule;
+
+import com.yahoo.document.BucketIdFactory;
+import com.yahoo.document.DocumentOperation;
+import com.yahoo.document.DocumentPut;
+import com.yahoo.document.DocumentUpdate;
+import com.yahoo.document.select.BucketSet;
+import com.yahoo.document.select.Context;
+import com.yahoo.document.select.Visitor;
+
+/**
+ * A document type node which returns the document type if exactly the type sopecified or false otherwise:
+ * For using the exact document type as a condition.
+ *
+ * @author bratseth
+ */
+public class DocumentTypeNode implements ExpressionNode {
+
+    private String type;
+
+    public DocumentTypeNode(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public DocumentTypeNode setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    @Override
+    public BucketSet getBucketSet(BucketIdFactory factory) {
+        return null;
+    }
+
+    @Override
+    public Object evaluate(Context context) {
+        return evaluate(context.getDocumentOperation());
+    }
+
+    private Object evaluate(DocumentOperation op) {
+        return op.getId().getDocType().equals(type) ? op : false;
+    }
+
+    public void accept(Visitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+
+}

--- a/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
@@ -2,8 +2,11 @@
 package com.yahoo.document.select.rule;
 
 import com.yahoo.document.BucketIdFactory;
+import com.yahoo.document.DocumentGet;
 import com.yahoo.document.DocumentOperation;
 import com.yahoo.document.DocumentPut;
+import com.yahoo.document.DocumentRemove;
+import com.yahoo.document.DocumentType;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.select.BucketSet;
 import com.yahoo.document.select.Context;
@@ -43,7 +46,27 @@ public class DocumentTypeNode implements ExpressionNode {
     }
 
     private Object evaluate(DocumentOperation op) {
-        return op.getId().getDocType().equals(type) ? op : false;
+        // TODO Vespa 8: Uncomment the following line and remove the legacy one
+        // return op.getId().getDocType().equals(type) ? op : false;
+        return legacyEvaluate(op);
+    }
+
+    private Object legacyEvaluate(DocumentOperation op) {
+        DocumentType doct;
+        if (op instanceof DocumentPut) {
+            doct = ((DocumentPut) op).getDocument().getDataType();
+        } else if (op instanceof DocumentUpdate) {
+            doct = ((DocumentUpdate) op).getDocumentType();
+        } else if (op instanceof DocumentRemove) {
+            DocumentRemove removeOp = (DocumentRemove) op;
+            return (removeOp.getId().getDocType().equals(type) ? op : Boolean.FALSE);
+        } else if (op instanceof DocumentGet) {
+            DocumentGet getOp = (DocumentGet) op;
+            return (getOp.getId().getDocType().equals(type) ? op : Boolean.FALSE);
+        } else {
+            throw new IllegalStateException("Document class '" + op.getClass().getName() + "' is not supported.");
+        }
+        return doct.isA(this.type) ? op : Boolean.FALSE;
     }
 
     public void accept(Visitor visitor) {

--- a/document/src/main/java/com/yahoo/document/select/rule/ExpressionNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/ExpressionNode.java
@@ -7,7 +7,7 @@ import com.yahoo.document.select.Context;
 import com.yahoo.document.select.Visitor;
 
 /**
- * This is the interface of all expression nodes. It declares the methods requires by all expression nodes to maintain
+ * The interface of all expression nodes. It declares the methods requires by all expression nodes to maintain
  * a working document selector language.
  *
  * @author Simon Thoresen Hult
@@ -17,22 +17,22 @@ public interface ExpressionNode {
     /**
      * Evaluate the content of this node based on document object, and return that value.
      *
-     * @param doc the document to evaluate over.
-     * @return the value of this.
+     * @param doc the document to evaluate over
+     * @return the value of this
      */
     Object evaluate(Context doc);
 
     /**
      * Returns the set of bucket ids covered by this node.
      *
-     * @param factory the factory used by the current application.
+     * @param factory the factory used by the current application
      */
     BucketSet getBucketSet(BucketIdFactory factory);
 
     /**
      * Perform visitation of this node.
      *
-     * @param visitor the visitor that wishes to visit the node.
+     * @param visitor the visitor that wishes to visit the node
      */
     void accept(Visitor visitor);
 

--- a/document/src/main/javacc/SelectParser.jj
+++ b/document/src/main/javacc/SelectParser.jj
@@ -159,15 +159,23 @@ VariableNode variable() :
 
 ExpressionNode attribute() :
 {
-    ExpressionNode val;
+    ExpressionNode value;
     AttributeNode.Item item;
-    List lst = new ArrayList();
+    List items = new ArrayList();
 }
 {
-    ( val = value() ( <DOT> identifier()  { item = new AttributeNode.Item(token.image); }
-                      [ <LBRACE> <RBRACE> { item.setType(AttributeNode.Item.FUNCTION); } ]
-                                          { lst.add(item); } )* )
-    { return lst.size() > 0 ? new AttributeNode(val, lst) : val; }
+    ( value = value() ( <DOT> identifier()  { item = new AttributeNode.Item(token.image); }
+                        [ <LBRACE> <RBRACE> { item.setType(AttributeNode.Item.FUNCTION); } ]
+                                            { items.add(item); } )* )
+    {
+        if ( ! items.isEmpty()) // A value followed by dotted access/method call
+            return new AttributeNode(value, items);
+
+        if (value instanceof DocumentNode) // A standalone document type access: Convert to exact type matching
+            return new DocumentTypeNode(((DocumentNode)value).getType());
+
+        return value;
+     }
 }
 
 ExpressionNode value() :

--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -746,8 +746,14 @@ public class DocumentSelectorTestCase {
 
     @Test
     public void testInheritance() throws ParseException {
+        var s=new DocumentSelector("parent.parentField = \"parentValue\"");
         List<DocumentPut> documents = createDocs();
+        assertEquals(Result.TRUE, evaluate("test", documents.get(0)));
+        assertEquals("Matching on type is exact",
+                     Result.FALSE, evaluate("parent", documents.get(0)));
         assertEquals(Result.TRUE, evaluate("test.parentField = \"parentValue\"", documents.get(0)));
+        assertEquals("Fields may be accessed by parent type",
+                     Result.TRUE, evaluate("parent.parentField = \"parentValue\"", documents.get(0)));
     }
 
     @Test

--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -749,8 +749,9 @@ public class DocumentSelectorTestCase {
         var s=new DocumentSelector("parent.parentField = \"parentValue\"");
         List<DocumentPut> documents = createDocs();
         assertEquals(Result.TRUE, evaluate("test", documents.get(0)));
-        assertEquals("Matching on type is exact",
-                     Result.FALSE, evaluate("parent", documents.get(0)));
+        // TODO Vespa 8: Change the following assert (only) to expect Result.FALSE
+        assertEquals("Matching on type is [on Vespa 7, not] exact",
+                     Result.TRUE, evaluate("parent", documents.get(0)));
         assertEquals(Result.TRUE, evaluate("test.parentField = \"parentValue\"", documents.get(0)));
         assertEquals("Fields may be accessed by parent type",
                      Result.TRUE, evaluate("parent.parentField = \"parentValue\"", documents.get(0)));

--- a/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
+++ b/document/src/test/java/com/yahoo/document/select/DocumentSelectorTestCase.java
@@ -56,8 +56,12 @@ public class DocumentSelectorTestCase {
 
     @Before
     public void setUp() {
+        DocumentType parent = new DocumentType("parent");
+        parent.addField("parentField", DataType.STRING);
+
         var importedFields = new HashSet<>(List.of("my_imported_field"));
         DocumentType type = new DocumentType("test", importedFields);
+        type.inherit(parent);
         type.addField("hint", DataType.INT);
         type.addField("hfloat", DataType.FLOAT);
         type.addField("hstring", DataType.STRING);
@@ -79,6 +83,7 @@ public class DocumentSelectorTestCase {
         ArrayDataType intarray = new ArrayDataType(DataType.INT);
         type.addField("intarray", intarray);
 
+        manager.registerDocumentType(parent);
         manager.registerDocumentType(type);
 
         // Create strange doctypes using identifiers within them, which we
@@ -740,6 +745,12 @@ public class DocumentSelectorTestCase {
     }
 
     @Test
+    public void testInheritance() throws ParseException {
+        List<DocumentPut> documents = createDocs();
+        assertEquals(Result.TRUE, evaluate("test.parentField = \"parentValue\"", documents.get(0)));
+    }
+
+    @Test
     public void using_non_commutative_comparison_operator_with_field_value_is_well_defined() throws ParseException {
         var documents = createDocs();
         // Doc 0 contains 24 in `hint` field.
@@ -871,6 +882,7 @@ public class DocumentSelectorTestCase {
         if (hString != null)
             doc.setFieldValue("hstring", new StringFieldValue(hString));
         doc.setFieldValue("content", new StringFieldValue(content));
+        doc.setFieldValue("parentField", new StringFieldValue("parentValue"));
         return new DocumentPut(doc);
     }
 

--- a/document/src/vespa/document/select/doctype.cpp
+++ b/document/src/vespa/document/select/doctype.cpp
@@ -15,6 +15,7 @@ namespace {
                                 vespalib::stringref name)
     {
         if (type.getName() == name) return true;
+        // TODO Vespa 8: Remove this for look on Vespa 8
         for (std::vector<const DocumentType *>::const_iterator it
                 = type.getInheritedTypes().begin();
              it != type.getInheritedTypes().end(); ++it)

--- a/document/src/vespa/document/select/doctype.cpp
+++ b/document/src/vespa/document/select/doctype.cpp
@@ -15,7 +15,7 @@ namespace {
                                 vespalib::stringref name)
     {
         if (type.getName() == name) return true;
-        // TODO Vespa 8: Remove this for look on Vespa 8
+        // TODO Vespa 8: Remove this for loop on Vespa 8
         for (std::vector<const DocumentType *>::const_iterator it
                 = type.getInheritedTypes().begin();
              it != type.getInheritedTypes().end(); ++it)

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentRouteSelectorPolicy.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentRouteSelectorPolicy.java
@@ -39,10 +39,8 @@ public class DocumentRouteSelectorPolicy
                 selectors.put(name, new DocumentSelector(cluster.selector()));
             }
             catch (ParseException e) {
-                throw new IllegalArgumentException("Error parsing selector '" +
-                                                   cluster.selector() +
-                                                   "' for route '" + name +"'",
-                                                   e);
+                throw new IllegalArgumentException("Error parsing selector '" + cluster.selector() +
+                                                   "' for route '" + name +"'", e);
             }
         });
         this.config = Map.copyOf(selectors);
@@ -87,9 +85,9 @@ public class DocumentRouteSelectorPolicy
             DocumentSelector selector;
             try {
                 selector = new DocumentSelector(route.selector());
-                log.log(Level.CONFIG, "Selector for route '" + route.name() + "' is '" + selector + "'.");
+                log.log(Level.CONFIG, "Selector for route '" + route.name() + "' is '" + selector + "'");
             } catch (com.yahoo.document.select.parser.ParseException e) {
-                error = "Error parsing selector '" + route.selector() + "' for route '" + route.name() + "; " +
+                error = "Error parsing selector '" + route.selector() + "' for route '" + route.name() + ": " +
                         e.getMessage();
                 break;
             }


### PR DESCRIPTION
### Document selection type matching and document type inheritance

When evaluating the document selection expression "myType" on a document, we have the choice of returning _true_ only if the document is of type myType (_exact matching_), or if it's of any subtype of "myType" (_isa matching_).

The current state is this:
- In Java, where selection expressions are used for routing: Exact matching is used for _Get_ and _Remove_ document operations, and isa matching for _Put_ and _Update_ operations.
- In C++, where selection expressions are used for garbage collection and "where" expressions selecting or updating documents: Isa matching is always used.
- The documentation does not specify one way or the other.
- Internal inconsistency: Content clusters require all exact types to have a document db to be configured in the cluster, which means that adding a subtype to a document type configured in a content cluster will lead document writes of the subtype to fail since the writes are routed to that cluster but there is no document db for it.

We need to choose either exact or isa matching and implement it consistently, and make any changes needed either before or at Vespa 8 depending on compatibility requirements.

Some users will want exact matching, while others will appreciate the convenience of sust adding subtypes and having them automatically work like the parent type. If we choose exact matching and the user want the same behavior for each subtype it is achieved by adding each type to any content cluster and selection expression. If we choose isa matching and user does not want the same behavior for each subtype though, it is harder to achieve - we would need additional syntax.

Therefore we should choose exact matching.

### This PR 

This PR prepares changing to always use exact matching in Java (commit #1-3), but preserves the current behavior with Vespa 8 TODO's (commit #4). In C++ the change seems straightforward so this only adds the TODO.

@jonmv AND @vekterli AND @baldersheim please review the above description.
@jonmv please review the code changes.