### PR TITLE
Discard 2x the warmup window

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterNodesTimeseries.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterNodesTimeseries.java
@@ -31,7 +31,7 @@ public class ClusterNodesTimeseries {
         // If none can be detected we assume the node is new/was down.
         // If either this is the case, or there is a generation change, we ignore
         // the first warmupWindow metrics
-        var timeseries = db.getNodeTimeseries(period.plus(warmupDuration.multipliedBy(4)), clusterNodes);
+        var timeseries = db.getNodeTimeseries(period.plus(warmupDuration.multipliedBy(8)), clusterNodes);
         if (cluster.lastScalingEvent().isPresent()) {
             long currentGeneration = cluster.lastScalingEvent().get().generation();
             timeseries = keepCurrentGenerationAfterWarmup(timeseries, currentGeneration);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeTimeseries.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/NodeTimeseries.java
@@ -85,7 +85,7 @@ public class NodeTimeseries {
         if (snapshot.generation() < 0) return true; // Content nodes do not yet send generation
         if (snapshot.generation() < currentGeneration) return false;
         if (generationChange.isEmpty()) return true;
-        return ! snapshot.at().isBefore(generationChange.get().plus(warmupDuration));
+        return ! snapshot.at().isBefore(generationChange.get().plus(warmupDuration.multipliedBy(2)));
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTest.java
@@ -211,6 +211,7 @@ public class AutoscalingMaintainerTest {
         tester.deploy(app1, cluster1, capacity);
         // fast completion
         tester.addMeasurements(1.0f, 0.3f, 0.3f, 0, 1, app1);
+        tester.clock().advance(Duration.ofSeconds(150));
         tester.addMeasurements(1.0f, 0.3f, 0.3f, 0, 1, app1);
         tester.maintainer().maintain();
         assertEquals("Scale up: " + tester.cluster(app1, cluster1).autoscalingStatus(),
@@ -219,6 +220,7 @@ public class AutoscalingMaintainerTest {
 
         // fast completion, with initially overloaded cpu
         tester.addMeasurements(3.0f, 0.3f, 0.3f, 1, 1, app1);
+        tester.clock().advance(Duration.ofSeconds(150));
         tester.addMeasurements(0.2f, 0.3f, 0.3f, 1, 1, app1);
         tester.maintainer().maintain();
         assertEquals("No autoscaling since we ignore the (first) data point in the warup period",


### PR DESCRIPTION
Discarding metrics for the warmup window period does not seem to be sufficient.