### PR TITLE
Let bucket maintenance priority queue be FIFO ordered within priority class [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/simplebucketprioritydatabasetest.cpp
+++ b/storage/src/tests/distributor/simplebucketprioritydatabasetest.cpp
@@ -6,101 +6,109 @@
 #include <string>
 
 using document::test::makeDocumentBucket;
+using namespace ::testing;
 
 namespace storage::distributor {
 
 using document::BucketId;
 using Priority = MaintenancePriority;
 
-TEST(SimpleBucketPriorityDatabaseTest, iterator_range_is_equal_on_empty_database) {
-    SimpleBucketPriorityDatabase queue;
-    auto begin = queue.begin();
-    auto end = queue.end();
+struct SimpleBucketPriorityDatabaseTest : Test {
+    SimpleBucketPriorityDatabase _queue;
+};
+
+TEST_F(SimpleBucketPriorityDatabaseTest, iterator_range_is_equal_on_empty_database) {
+    auto begin = _queue.begin();
+    auto end = _queue.end();
 
     EXPECT_TRUE(begin == end);
     EXPECT_TRUE(begin == begin);
     EXPECT_TRUE(end == end);
 }
 
-TEST(SimpleBucketPriorityDatabaseTest, can_get_prioritized_bucket) {
-    SimpleBucketPriorityDatabase queue;
-
+TEST_F(SimpleBucketPriorityDatabaseTest, can_get_prioritized_bucket) {
     PrioritizedBucket lowPriBucket(makeDocumentBucket(BucketId(16, 1234)), Priority::VERY_LOW);
-    queue.setPriority(lowPriBucket);
+    _queue.setPriority(lowPriBucket);
 
-    PrioritizedBucket highest(*queue.begin());
+    PrioritizedBucket highest(*_queue.begin());
     EXPECT_EQ(lowPriBucket, highest);
 }
 
-TEST(SimpleBucketPriorityDatabaseTest, iterate_over_multiple_priorities) {
-    SimpleBucketPriorityDatabase queue;
-
+TEST_F(SimpleBucketPriorityDatabaseTest, iterate_over_multiple_priorities) {
     PrioritizedBucket lowPriBucket(makeDocumentBucket(BucketId(16, 1234)), Priority::LOW);
     PrioritizedBucket highPriBucket(makeDocumentBucket(BucketId(16, 4321)), Priority::HIGH);
-    queue.setPriority(lowPriBucket);
-    queue.setPriority(highPriBucket);
+    _queue.setPriority(lowPriBucket);
+    _queue.setPriority(highPriBucket);
 
-    auto iter = queue.begin();
+    auto iter = _queue.begin();
     ASSERT_EQ(highPriBucket, *iter);
     ++iter;
-    ASSERT_TRUE(iter != queue.end());
+    ASSERT_TRUE(iter != _queue.end());
     ASSERT_EQ(lowPriBucket, *iter);
     ++iter;
-    ASSERT_TRUE(iter == queue.end());
+    ASSERT_TRUE(iter == _queue.end());
 }
 
-TEST(SimpleBucketPriorityDatabaseTest, multiple_set_priority_for_one_bucket) {
-    SimpleBucketPriorityDatabase queue;
-
+TEST_F(SimpleBucketPriorityDatabaseTest, multiple_set_priority_for_one_bucket) {
     PrioritizedBucket lowPriBucket(makeDocumentBucket(BucketId(16, 1234)), Priority::LOW);
     PrioritizedBucket highPriBucket(makeDocumentBucket(BucketId(16, 1234)), Priority::HIGH);
 
-    queue.setPriority(lowPriBucket);
-    queue.setPriority(highPriBucket);
+    _queue.setPriority(lowPriBucket);
+    _queue.setPriority(highPriBucket);
 
-    auto iter = queue.begin();
+    auto iter = _queue.begin();
     ASSERT_EQ(highPriBucket, *iter);
     ++iter;
-    ASSERT_TRUE(iter == queue.end());
+    ASSERT_TRUE(iter == _queue.end());
 }
 
-TEST(SimpleBucketPriorityDatabaseTest, no_maintenance_needed_clears_bucket_from_database) {
-    SimpleBucketPriorityDatabase queue;
-
+TEST_F(SimpleBucketPriorityDatabaseTest, no_maintenance_needed_clears_bucket_from_database) {
     PrioritizedBucket highPriBucket(makeDocumentBucket(BucketId(16, 1234)), Priority::HIGH);
     PrioritizedBucket noPriBucket(makeDocumentBucket(BucketId(16, 1234)),
                                   Priority::NO_MAINTENANCE_NEEDED);
-    queue.setPriority(highPriBucket);
-    queue.setPriority(noPriBucket);
+    _queue.setPriority(highPriBucket);
+    _queue.setPriority(noPriBucket);
 
-    auto iter = queue.begin();
-    ASSERT_TRUE(iter == queue.end());
+    auto iter = _queue.begin();
+    ASSERT_TRUE(iter == _queue.end());
 }
 
-TEST(SimpleBucketPriorityDatabaseTest, iterate_over_multiple_buckets_with_multiple_priorities) {
-    SimpleBucketPriorityDatabase queue;
-
+TEST_F(SimpleBucketPriorityDatabaseTest, iterate_over_multiple_buckets_with_multiple_priorities) {
     PrioritizedBucket lowPriBucket1(makeDocumentBucket(BucketId(16, 1)), Priority::LOW);
     PrioritizedBucket lowPriBucket2(makeDocumentBucket(BucketId(16, 2)), Priority::LOW);
     PrioritizedBucket mediumPriBucket(makeDocumentBucket(BucketId(16, 3)), Priority::MEDIUM);
     PrioritizedBucket highPriBucket1(makeDocumentBucket(BucketId(16, 4)), Priority::HIGH);
     PrioritizedBucket highPriBucket2(makeDocumentBucket(BucketId(16, 5)), Priority::HIGH);
 
-    queue.setPriority(highPriBucket1);
-    queue.setPriority(lowPriBucket2);
-    queue.setPriority(mediumPriBucket);
-    queue.setPriority(highPriBucket2);
-    queue.setPriority(lowPriBucket1);
+    _queue.setPriority(highPriBucket1);
+    _queue.setPriority(lowPriBucket2);
+    _queue.setPriority(mediumPriBucket);
+    _queue.setPriority(highPriBucket2);
+    _queue.setPriority(lowPriBucket1);
 
-    auto iter = queue.begin();
+    auto iter = _queue.begin();
     PrioritizedBucket lastBucket(makeDocumentBucket(BucketId()), Priority::PRIORITY_LIMIT);
     for (int i = 0; i < 5; ++i) {
-        ASSERT_TRUE(iter != queue.end());
+        ASSERT_TRUE(iter != _queue.end());
         ASSERT_FALSE(iter->moreImportantThan(lastBucket));
         lastBucket = *iter;
         ++iter;
     }
-    ASSERT_TRUE(iter == queue.end());
+    ASSERT_TRUE(iter == _queue.end());
+}
+
+TEST_F(SimpleBucketPriorityDatabaseTest, buckets_within_same_priority_class_are_fifo_ordered) {
+    // We want FIFO order (2, 1) within the same priority class, not bucket ID order (1, 2).
+    PrioritizedBucket first_bucket(makeDocumentBucket(BucketId(16, 2)), Priority::LOW);
+    PrioritizedBucket second_bucket(makeDocumentBucket(BucketId(16, 1)), Priority::LOW);
+
+    _queue.setPriority(first_bucket);
+    _queue.setPriority(second_bucket);
+
+    auto iter = _queue.begin();
+    EXPECT_EQ(first_bucket, *iter);
+    ++iter;
+    EXPECT_EQ(second_bucket, *iter);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/maintenance/bucketprioritydatabase.h
+++ b/storage/src/vespa/storage/distributor/maintenance/bucketprioritydatabase.h
@@ -13,11 +13,9 @@ protected:
     class ConstIteratorImpl
     {
     public:
-        virtual ~ConstIteratorImpl() { }
+        virtual ~ConstIteratorImpl() = default;
         virtual void increment() = 0;
-
         virtual bool equal(const ConstIteratorImpl& other) const = 0;
-
         virtual PrioritizedBucket dereference() const = 0;
     };
 
@@ -33,13 +31,13 @@ public:
     {
         ConstIteratorImplPtr _impl;
     public:
-        ConstIterator(ConstIteratorImplPtr impl)
+        explicit ConstIterator(ConstIteratorImplPtr impl)
             : _impl(std::move(impl))
         {}
         ConstIterator(const ConstIterator &) = delete;
         ConstIterator(ConstIterator &&) = default;
 
-        virtual ~ConstIterator() {}
+        virtual ~ConstIterator() = default;
     private:
         friend class boost::iterator_core_access;
 
@@ -61,9 +59,7 @@ public:
     virtual ~BucketPriorityDatabase() = default;
     
     virtual const_iterator begin() const = 0;
-
     virtual const_iterator end() const  = 0;
-
     virtual void setPriority(const PrioritizedBucket&) = 0;
 };
 

--- a/storage/src/vespa/storage/distributor/maintenance/simplebucketprioritydatabase.h
+++ b/storage/src/vespa/storage/distributor/maintenance/simplebucketprioritydatabase.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "bucketprioritydatabase.h"
+#include <vespa/vespalib/stllike/hash_map.h>
 #include <set>
 #include <map>
 
@@ -10,45 +11,50 @@ namespace storage::distributor {
 class SimpleBucketPriorityDatabase : public BucketPriorityDatabase
 {
 public:
-    virtual ~SimpleBucketPriorityDatabase();
+    SimpleBucketPriorityDatabase();
+    ~SimpleBucketPriorityDatabase() override;
     using Priority = PrioritizedBucket::Priority;
 
-    virtual void setPriority(const PrioritizedBucket&) override;
-    virtual const_iterator begin() const override;
-    virtual const_iterator end() const override;
+    void setPriority(const PrioritizedBucket&) override;
+    const_iterator begin() const override;
+    const_iterator end() const override;
 
     std::string toString() const;
 
 private:
-    using BucketSet   = std::set<document::Bucket>;
-    using PriorityMap = std::map<Priority, BucketSet>;
+    struct PriFifoCompositeKey {
+        Priority _pri;
+        uint64_t _seq_num;
 
-    class SimpleConstIteratorImpl : public ConstIteratorImpl
-    {
-        PriorityMap::const_reverse_iterator _priorityIter;
-        PriorityMap::const_reverse_iterator _priorityEnd;
-        BucketSet::const_iterator _bucketIter;
-    public:
-        SimpleConstIteratorImpl(PriorityMap::const_reverse_iterator first,
-                                PriorityMap::const_reverse_iterator end)
-            : _priorityIter(first),
-              _priorityEnd(end),
-              _bucketIter()
-        {
-            if (!atEnd()) {
-                initializeBucketIterToFirstAvailableEntry();
+        constexpr PriFifoCompositeKey() noexcept : _pri(Priority::VERY_LOW), _seq_num(0) {}
+        constexpr PriFifoCompositeKey(Priority pri, uint64_t seq_num) noexcept
+            : _pri(pri),
+              _seq_num(seq_num)
+        {}
+
+        constexpr bool operator<(const PriFifoCompositeKey& rhs) const noexcept {
+            if (_pri != rhs._pri) {
+                // Unlike StorageAPI priorities, MaintenancePriority is higher value == higher priority
+                return (_pri > rhs._pri);
             }
+            return _seq_num < rhs._seq_num;
         }
-        SimpleConstIteratorImpl(const SimpleConstIteratorImpl&) = delete;
-        SimpleConstIteratorImpl& operator=(const SimpleConstIteratorImpl&) = delete;
-    private:
-        void initializeBucketIterToFirstAvailableEntry();
+    };
 
-        bool atEnd() const;
-        void stepWithinCurrentPriority();
-        bool currentPriorityAtEnd() const;
-        void stepToNextPriority();
-        void step();
+    using PriFifoBucketMap = std::map<PriFifoCompositeKey, document::Bucket>;
+    // Important: the map iterator instances MUST be stable in the presence of other inserts/erases!
+    using BucketToPriIteratorMap = vespalib::hash_map<document::Bucket, PriFifoBucketMap::iterator, document::Bucket::hash>;
+
+    class PriFifoMappingConstIteratorImpl final : public ConstIteratorImpl {
+        PriFifoBucketMap::const_iterator _pri_fifo_iter;
+        PriFifoBucketMap::const_iterator _pri_fifo_end;
+    public:
+        PriFifoMappingConstIteratorImpl(PriFifoBucketMap::const_iterator pri_fifo_iter,
+                                        PriFifoBucketMap::const_iterator pri_fifo_end)
+            : _pri_fifo_iter(pri_fifo_iter),
+              _pri_fifo_end(pri_fifo_end)
+        {}
+        ~PriFifoMappingConstIteratorImpl() override = default;
 
         void increment() override;
         bool equal(const ConstIteratorImpl& other) const override;
@@ -57,7 +63,9 @@ private:
 
     void clearAllEntriesForBucket(const document::Bucket &bucket);
 
-    PriorityMap _prioritizedBuckets;
+    PriFifoBucketMap       _pri_fifo_buckets;
+    BucketToPriIteratorMap _bucket_to_pri_iterators;
+    uint64_t               _fifo_seq_num;
 };
 
 }


### PR DESCRIPTION
@geirst please review

This avoids a potential starvation issue caused by the existing
implementation, which is bucket ID ordered within a given priority
class. The latter has the unfortunate effect that frequently reinserting
buckets that sort before buckets that are already in the queue may
starve these from being popped from the queue.

Move to a composite key that first sorts on priority, then on a strictly
increasing sequence number. Add a secondary index into this structure
that allows for lookups on bucket IDs as before.

