### PR TITLE
Cover additional update failure edge cases with metrics

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -16,6 +16,7 @@ namespace storage {
 
 namespace api {
 class UpdateCommand;
+class UpdateReply;
 class CreateBucketReply;
 class ReturnCode;
 }
@@ -94,7 +95,7 @@ private:
     static const char* stateToString(SendState);
 
     void sendReply(DistributorStripeMessageSender&,
-                   std::shared_ptr<api::StorageReply>&);
+                   std::shared_ptr<api::UpdateReply>);
     void sendReplyWithResult(DistributorStripeMessageSender&, const api::ReturnCode&);
     void ensureUpdateReplyCreated();
 
@@ -144,7 +145,7 @@ private:
     PersistenceOperationMetricSet& _getMetric;
     PersistenceOperationMetricSet& _metadata_get_metrics;
     std::shared_ptr<api::UpdateCommand> _updateCmd;
-    std::shared_ptr<api::StorageReply> _updateReply;
+    std::shared_ptr<api::UpdateReply> _updateReply;
     const DistributorNodeContext& _node_ctx;
     DistributorStripeOperationContext& _op_ctx;
     const DocumentSelectionParser& _parser;


### PR DESCRIPTION
@geirst please review.

This change adds previously missing metric increments for test-and-set
condition failures when this happens in the context of a write-repair,
as well as adding missing wiring for the "notfound" failure metric.
The latter is incremented when an update is returned from the content
nodes having found no existing document, or when the read-phase of
a write-repair finds no document to update (and neither `create: true`
nor a TaS condition is set on the update).

Also remove some internal reply type erasure to make it more obvious
what the reply type must be.
