### PR TITLE
Move context to superclass take2

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -171,6 +171,9 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         addCommonVespaBundles();
 
+        // TODO Vespa 8: remove LoggingRequestHandler.Context (replaced by ThreadedHttpRequestHandler.Context)
+        addSimpleComponent(com.yahoo.container.jdisc.LoggingRequestHandler.Context.class);
+
         addComponent(new StatisticsComponent());
         addSimpleComponent(AccessLog.class);
         addComponent(new DefaultThreadpoolProvider(this, deployState.featureFlags().metricsproxyNumThreads()));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -178,7 +178,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         addSimpleComponent("com.yahoo.container.jdisc.metric.MetricConsumerProviderProvider");
         addSimpleComponent("com.yahoo.container.jdisc.metric.MetricProvider");
         addSimpleComponent("com.yahoo.container.jdisc.metric.MetricUpdater");
-        addSimpleComponent(com.yahoo.container.jdisc.LoggingRequestHandler.Context.class);
+        addSimpleComponent(com.yahoo.container.jdisc.ThreadedHttpRequestHandler.Context.class);
         addSimpleComponent(com.yahoo.metrics.simple.MetricManager.class.getName(), null, MetricProperties.BUNDLE_SYMBOLIC_NAME);
         addSimpleComponent(com.yahoo.metrics.simple.jdisc.JdiscMetricsFactory.class.getName(), null, MetricProperties.BUNDLE_SYMBOLIC_NAME);
         addSimpleComponent("com.yahoo.container.jdisc.state.StateMonitor");

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -725,6 +725,22 @@
     ],
     "fields": []
   },
+  "com.yahoo.container.jdisc.LoggingRequestHandler$Context": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric)",
+      "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
+      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context)",
+      "public java.util.concurrent.Executor getExecutor()",
+      "public com.yahoo.container.logging.AccessLog getAccessLog()",
+      "public com.yahoo.jdisc.Metric getMetric()"
+    ],
+    "fields": []
+  },
   "com.yahoo.container.jdisc.LoggingRequestHandler": {
     "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
     "interfaces": [],
@@ -733,10 +749,11 @@
       "abstract"
     ],
     "methods": [
-      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context)",
+      "public static com.yahoo.container.jdisc.LoggingRequestHandler$Context testOnlyContext()",
+      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog)",
       "public void <init>(java.util.concurrent.Executor)",
-      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context, boolean)",
+      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context, boolean)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric, boolean)",
@@ -910,7 +927,7 @@
       "protected void addDateHeader(com.yahoo.container.jdisc.HttpResponse, long)",
       "protected com.yahoo.container.jdisc.LoggingCompletionHandler createLoggingCompletionHandler(long, long, com.yahoo.container.jdisc.HttpResponse, com.yahoo.container.jdisc.HttpRequest, com.yahoo.container.jdisc.ContentChannelOutputStream)",
       "protected com.yahoo.jdisc.http.HttpRequest asHttpRequest(com.yahoo.jdisc.Request)",
-      "public static com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context testOnlyContext()"
+      "public static com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context testContext()"
     ],
     "fields": [
       "public static final java.lang.String CONTENT_TYPE",

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -725,22 +725,6 @@
     ],
     "fields": []
   },
-  "com.yahoo.container.jdisc.LoggingRequestHandler$Context": {
-    "superClass": "java.lang.Object",
-    "interfaces": [],
-    "attributes": [
-      "public"
-    ],
-    "methods": [
-      "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric)",
-      "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
-      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context)",
-      "public java.util.concurrent.Executor getExecutor()",
-      "public com.yahoo.container.logging.AccessLog getAccessLog()",
-      "public com.yahoo.jdisc.Metric getMetric()"
-    ],
-    "fields": []
-  },
   "com.yahoo.container.jdisc.LoggingRequestHandler": {
     "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
     "interfaces": [],
@@ -749,11 +733,10 @@
       "abstract"
     ],
     "methods": [
-      "public static com.yahoo.container.jdisc.LoggingRequestHandler$Context testOnlyContext()",
-      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context)",
+      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog)",
       "public void <init>(java.util.concurrent.Executor)",
-      "public void <init>(com.yahoo.container.jdisc.LoggingRequestHandler$Context, boolean)",
+      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context, boolean)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric, boolean)",
@@ -875,6 +858,22 @@
     ],
     "fields": []
   },
+  "com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(java.util.concurrent.Executor, com.yahoo.container.logging.AccessLog, com.yahoo.jdisc.Metric)",
+      "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
+      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context)",
+      "public java.util.concurrent.Executor getExecutor()",
+      "public com.yahoo.container.logging.AccessLog getAccessLog()",
+      "public com.yahoo.jdisc.Metric getMetric()"
+    ],
+    "fields": []
+  },
   "com.yahoo.container.jdisc.ThreadedHttpRequestHandler$LazyContentChannel": {
     "superClass": "java.lang.Object",
     "interfaces": [
@@ -903,13 +902,15 @@
     "methods": [
       "public void <init>(java.util.concurrent.Executor)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric)",
+      "public void <init>(com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context)",
       "public void <init>(java.util.concurrent.Executor, com.yahoo.jdisc.Metric, boolean)",
       "public abstract com.yahoo.container.jdisc.HttpResponse handle(com.yahoo.container.jdisc.HttpRequest)",
       "public com.yahoo.container.jdisc.HttpResponse handle(com.yahoo.container.jdisc.HttpRequest, com.yahoo.jdisc.handler.ContentChannel)",
       "public final void handleRequest(com.yahoo.jdisc.Request, com.yahoo.jdisc.handler.BufferedContentChannel, com.yahoo.jdisc.handler.ResponseHandler)",
       "protected void addDateHeader(com.yahoo.container.jdisc.HttpResponse, long)",
       "protected com.yahoo.container.jdisc.LoggingCompletionHandler createLoggingCompletionHandler(long, long, com.yahoo.container.jdisc.HttpResponse, com.yahoo.container.jdisc.HttpRequest, com.yahoo.container.jdisc.ContentChannelOutputStream)",
-      "protected com.yahoo.jdisc.http.HttpRequest asHttpRequest(com.yahoo.jdisc.Request)"
+      "protected com.yahoo.jdisc.http.HttpRequest asHttpRequest(com.yahoo.jdisc.Request)",
+      "public static com.yahoo.container.jdisc.ThreadedHttpRequestHandler$Context testOnlyContext()"
     ],
     "fields": [
       "public static final java.lang.String CONTENT_TYPE",

--- a/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
@@ -29,44 +29,6 @@ import java.util.logging.Level;
 // TODO Vespa 8: Remove deprecated constructors
 public abstract class LoggingRequestHandler extends ThreadedHttpRequestHandler {
 
-    public static class Context {
-
-        final Executor executor;
-        final Metric metric;
-
-        /** @deprecated Use {@link #Context(Executor, Metric)} instead */
-        @Deprecated(forRemoval = true, since = "7")
-        public Context(Executor executor, AccessLog ignored, Metric metric) {
-            this(executor, metric);
-        }
-
-        @Inject
-        public Context(Executor executor, Metric metric) {
-            this.executor = executor;
-            this.metric = metric;
-        }
-
-        public Context(Context other) {
-            this.executor = other.executor;
-            this.metric = other.metric;
-        }
-
-        public Executor getExecutor() { return executor; }
-        @Deprecated(forRemoval = true, since = "7") public AccessLog getAccessLog() { return null; }
-        public Metric getMetric() { return metric; }
-
-    }
-
-    public static Context testOnlyContext() {
-        return new Context(new Executor() {
-                @Override
-                public void execute(Runnable command) {
-                    command.run();
-                }
-            },
-            null);
-    }
-
     @Inject
     public LoggingRequestHandler(Context ctx) {
         this(ctx.executor, ctx.metric);

--- a/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
@@ -29,6 +29,46 @@ import java.util.logging.Level;
 // TODO Vespa 8: Remove deprecated constructors
 public abstract class LoggingRequestHandler extends ThreadedHttpRequestHandler {
 
+    // TODO: Deprecate
+    public static class Context {
+
+        final Executor executor;
+        final Metric metric;
+
+        /** @deprecated Use {@link #Context(Executor, Metric)} instead */
+        @Deprecated(forRemoval = true, since = "7")
+        public Context(Executor executor, AccessLog ignored, Metric metric) {
+            this(executor, metric);
+        }
+
+        @Inject
+        public Context(Executor executor, Metric metric) {
+            this.executor = executor;
+            this.metric = metric;
+        }
+
+        public Context(Context other) {
+            this.executor = other.executor;
+            this.metric = other.metric;
+        }
+
+        public Executor getExecutor() { return executor; }
+        @Deprecated(forRemoval = true, since = "7") public AccessLog getAccessLog() { return null; }
+        public Metric getMetric() { return metric; }
+
+    }
+
+    // TODO: Deprecate
+    public static Context testOnlyContext() {
+        return new Context(new Executor() {
+                @Override
+                public void execute(Runnable command) {
+                    command.run();
+                }
+            },
+            null);
+    }
+
     @Inject
     public LoggingRequestHandler(Context ctx) {
         this(ctx.executor, ctx.metric);

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -2,6 +2,7 @@
 package com.yahoo.container.jdisc;
 
 import com.google.inject.Inject;
+import com.yahoo.container.logging.AccessLog;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.handler.BufferedContentChannel;
@@ -45,6 +46,11 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
     @Inject
     public ThreadedHttpRequestHandler(Executor executor, Metric metric) {
         this(executor, metric, false);
+    }
+
+    // TODO: move Inject annotation here!
+    public ThreadedHttpRequestHandler(Context context) {
+        this(context.executor, context.metric);
     }
 
     public ThreadedHttpRequestHandler(Executor executor, Metric metric, boolean allowAsyncResponse) {
@@ -249,5 +255,43 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         return (com.yahoo.jdisc.http.HttpRequest) request;
     }
 
+
+    public static Context testOnlyContext() {
+        return new Context(new Executor() {
+            @Override
+            public void execute(Runnable command) {
+                command.run();
+            }
+        },
+                           null);
+    }
+
+    public static class Context {
+
+        final Executor executor;
+        final Metric metric;
+
+        /** @deprecated Use {@link #Context(Executor, Metric)} instead */
+        @Deprecated(forRemoval = true, since = "7")
+        public Context(Executor executor, AccessLog ignored, Metric metric) {
+            this(executor, metric);
+        }
+
+        @Inject
+        public Context(Executor executor, Metric metric) {
+            this.executor = executor;
+            this.metric = metric;
+        }
+
+        public Context(Context other) {
+            this.executor = other.executor;
+            this.metric = other.metric;
+        }
+
+        public Executor getExecutor() { return executor; }
+        @Deprecated(forRemoval = true, since = "7") public AccessLog getAccessLog() { return null; }
+        public Metric getMetric() { return metric; }
+
+    }
 
 }

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -255,15 +255,8 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         return (com.yahoo.jdisc.http.HttpRequest) request;
     }
 
-
-    public static Context testOnlyContext() {
-        return new Context(new Executor() {
-            @Override
-            public void execute(Runnable command) {
-                command.run();
-            }
-        },
-                           null);
+    public static Context testContext() {
+        return new Context(Runnable::run, null);
     }
 
     public static class Context {


### PR DESCRIPTION
This time with binary compatibility for components built with older Vespa versions.

Deprecating the LoggingRequestHandler will be discussed soon.

FYI: @hmusum 