### PR TITLE
Complete wiring of OK/failure metric reporting during update write-repair [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
@@ -39,9 +39,14 @@ PersistenceFailuresMetricSet::PersistenceFailuresMetricSet(MetricSet* owner)
     sum.addMetricToSum(timeout);
     sum.addMetricToSum(busy);
     sum.addMetricToSum(inconsistent_bucket);
-    sum.addMetricToSum(notfound);
-    // TaS/concurrent mutation failures not added to the main failure metric, as they're not "failures" as per se.
-    // TODO introduce separate aggregate for such metrics
+    // We don't consider the following as explicit failures (even though they're in the failure set)
+    // and therefore don't count them as part of the aggregate sum:
+    //
+    //  - Test-and-set mismatches
+    //  - Concurrent mutation failures
+    //  - Document to be updated not found
+    //
+    // TODO introduce separate aggregate for such metrics. Presumably when we deprecate legacy metric paths.
 }
 
 PersistenceFailuresMetricSet::~PersistenceFailuresMetricSet() = default;


### PR DESCRIPTION
@geirst please review

This also changes the aggregation semantics of "not found" results.
An update reply indicating "not found" is protocol-wise reported back to
the client as successful but with a not-found field set that has to be
explicitly checked. But on the distributor the `notfound` metric is
under the `updates.failures` metric set, i.e. not counted as a success.

To avoid double bookkeeping caused by treating it as both OK and not,
we choose to not count "not found" updates under the `ok` metric. But to
avoid artificially inflating the `failures.sum` metric, we remove the
`notfound` metric from the implicit sum aggregation.

This means that visibility into "not found" updates requires explicitly
tracking the `notfound` metric as opposed to just the aggregate, but
this should be an acceptable tradeoff to avoid false failure positives.

