### PR TITLE
Even if we do not filter by consumer on the services, we can do it ea…

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/ValuesFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/ValuesFetcher.java
@@ -41,7 +41,7 @@ public class ValuesFetcher {
     public List<MetricsPacket> fetch(String requestedConsumer) throws JsonRenderingException {
         ConsumerId consumer = getConsumerOrDefault(requestedConsumer, metricsConsumers);
 
-        return fetchAllMetrics()
+        return metricsManager.getMetrics(vespaServices.getVespaServices(), Instant.now(), consumer)
                 .stream()
                 .filter(metricsPacket -> metricsPacket.consumers().contains(consumer))
                 .collect(Collectors.toList());
@@ -50,7 +50,7 @@ public class ValuesFetcher {
     public MetricsPacket.Builder [] fetchMetricsAsBuilders(String requestedConsumer) throws JsonRenderingException {
         ConsumerId consumer = getConsumerOrDefault(requestedConsumer, metricsConsumers);
 
-        List<MetricsPacket.Builder> builders = metricsManager.getMetricsAsBuilders(vespaServices.getVespaServices(), Instant.now())
+        List<MetricsPacket.Builder> builders = metricsManager.getMetricsAsBuilders(vespaServices.getVespaServices(), Instant.now(), consumer)
                 .stream()
                 .filter(builder -> builder.hasConsumer(consumer))
                 .collect(Collectors.toList());


### PR DESCRIPTION
…rly in the metrics-proxy.

This is especially benefiscal for the most frequent requests like autoscaling which only looks at a small set (1%) of the metrics.
This both reduces memory footprint and saves cpu.

@gjoranv or @bjorncs PR