### PR TITLE
Use the Instant as a timestamp to make it clear what it is instead of…

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/VespaMetrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/core/VespaMetrics.java
@@ -15,6 +15,7 @@ import ai.vespa.metricsproxy.metric.model.MetricsPacket;
 import ai.vespa.metricsproxy.service.MetricsParser;
 import ai.vespa.metricsproxy.service.VespaService;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -227,8 +228,8 @@ public class VespaMetrics {
         return definitions == null ? Collections.emptyList() : definitions;
     }
 
-    private static void setMetaInfo(MetricsPacket.Builder builder, long timestamp) {
-        builder.timestamp(timestamp)
+    private static void setMetaInfo(MetricsPacket.Builder builder, Instant timestamp) {
+        builder.timestamp(timestamp.getEpochSecond())
                 .statusCode(0)
                 .statusMessage("Data collected successfully");
     }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/Metric.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/Metric.java
@@ -5,6 +5,7 @@ import ai.vespa.metricsproxy.metric.model.ConsumerId;
 import ai.vespa.metricsproxy.metric.model.DimensionId;
 import ai.vespa.metricsproxy.metric.model.MetricId;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -14,7 +15,7 @@ import java.util.Set;
  */
 public class Metric {
 
-    private final long time;
+    private final Instant time;
     private final Number value;
     private final String description;
     private MetricId name;
@@ -28,7 +29,7 @@ public class Metric {
      * @param value The numeric value
      * @param time  The timestamp of this metric in seconds
      */
-    public Metric(MetricId name, Number value, long time, Map<DimensionId, String> dimensions, String description) {
+    public Metric(MetricId name, Number value, Instant time, Map<DimensionId, String> dimensions, String description) {
         this.time = time;
         this.value = value;
         this.name = name;
@@ -37,11 +38,15 @@ public class Metric {
     }
 
     public Metric(MetricId name, Number value, long timestamp) {
+        this(name, value, Instant.ofEpochSecond(timestamp), Map.of(), "");
+    }
+
+    public Metric(MetricId name, Number value, Instant timestamp) {
         this(name, value, timestamp, Map.of(), "");
     }
 
     public Metric(MetricId name, Number value) {
-        this(name, value, System.currentTimeMillis() / 1000);
+        this(name, value, Instant.now());
     }
 
     public void setDimensions(Map<DimensionId, String> dimensions) {
@@ -86,7 +91,7 @@ public class Metric {
     /**
      * @return The UTC timestamp for when this metric was collected
      */
-    public long getTimeStamp() {
+    public Instant getTimeStamp() {
         return this.time;
     }
 
@@ -112,7 +117,7 @@ public class Metric {
         return name.equals(rhs.name)
                 && description.equals(rhs.description)
                 && value.equals(rhs.value)
-                && (time == rhs.time)
+                && time.equals(rhs.time)
                 && Objects.equals(dimensions, rhs.dimensions)
                 && Objects.equals(consumers, rhs.consumers);
     }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/Metrics.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/Metrics.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.metricsproxy.metric;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -13,14 +14,14 @@ import java.util.List;
 public class Metrics {
 
     private final List<Metric> metrics = new ArrayList<>();
-    private long timestamp;
+    private Instant timestamp;
     private boolean isFrozen = false;
 
     public Metrics() {
-        this(System.currentTimeMillis() / 1000L);
+        this(Instant.now());
     }
 
-    public Metrics(long timestamp) {
+    public Metrics(Instant timestamp) {
         this.timestamp = timestamp;
     }
 
@@ -28,7 +29,7 @@ public class Metrics {
         if (isFrozen) throw new IllegalStateException("Frozen Metrics cannot be modified!");
     }
 
-    public long getTimeStamp() {
+    public Instant getTimeStamp() {
         return this.timestamp;
     }
 
@@ -37,7 +38,7 @@ public class Metrics {
      *
      * @param timestamp IN UTC seconds resolution
      */
-    public void setTimeStamp(long timestamp) {
+    public void setTimeStamp(Instant timestamp) {
         ensureNotFrozen();
         this.timestamp = timestamp;
     }

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/SystemPoller.java
@@ -161,7 +161,7 @@ public class SystemPoller {
         log.log(Level.FINE, () -> "Monitoring system metrics for " + services.size() + " services");
 
         boolean someAlive = services.stream().anyMatch(VespaService::isAlive);
-        lastTotalCpuJiffies = updateMetrics(lastTotalCpuJiffies, interval.getSeconds(), jiffiesInterface, services, lastCpuJiffiesMetrics);
+        lastTotalCpuJiffies = updateMetrics(lastTotalCpuJiffies, startTime, jiffiesInterface, services, lastCpuJiffiesMetrics);
 
         // If none of the services were alive, reschedule in a short time
         if (!someAlive) {
@@ -171,7 +171,7 @@ public class SystemPoller {
         }
     }
 
-    static JiffiesAndCpus updateMetrics(JiffiesAndCpus prevTotalJiffies, long timeStamp, GetJiffies getJiffies,
+    static JiffiesAndCpus updateMetrics(JiffiesAndCpus prevTotalJiffies, Instant timeStamp, GetJiffies getJiffies,
                                         List<VespaService> services, Map<VespaService, Long> lastCpuJiffiesMetrics) {
         Map<VespaService, Long> currentServiceJiffies = new HashMap<>();
         for (VespaService s : services) {

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MetricsFetcherTest.java
@@ -7,6 +7,7 @@ import ai.vespa.metricsproxy.metric.Metrics;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Instant;
 
 import static ai.vespa.metricsproxy.metric.model.MetricId.toMetricId;
 import static org.junit.Assert.assertEquals;
@@ -41,7 +42,7 @@ public class MetricsFetcherTest {
         assertEquals(10, metrics.size());
         assertEquals(28, getMetric("query_hits.count", metrics).getValue());
         assertEquals(0.4667, getMetric("queries.rate", metrics).getValue());
-        assertEquals(1334134700L, metrics.getTimeStamp());
+        assertEquals(Instant.ofEpochSecond(1334134700L), metrics.getTimeStamp());
     }
 
     @Test

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/SystemPollerTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -188,7 +189,7 @@ public class SystemPollerTest {
         List<VespaService> services = List.of(s1);
         lastCpuJiffiesMetrics.put(s1, SystemPoller.getPidJiffies(new BufferedReader(new StringReader(perProcStats[0]))));
 
-        SystemPoller.JiffiesAndCpus next = SystemPoller.updateMetrics(prev, 1,
+        SystemPoller.JiffiesAndCpus next = SystemPoller.updateMetrics(prev, Instant.ofEpochSecond(1),
                 new SystemPoller.GetJiffies() {
                     @Override
                     public SystemPoller.JiffiesAndCpus getTotalSystemJiffies() {


### PR DESCRIPTION
… just a generic long.

Make sure to use it correctly for the system metrics.

@hmusum PR