### PR TITLE
Optimize handling of cleardoc updates to attributes with enum store

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -25,32 +25,32 @@ struct ChangeBase {
         DIV,
         CLEARDOC
     };
-    enum {UNSET_ENUM = 0xffffffffu};
+    enum {UNSET_ENTRY_REF = 0xffffffffu};
 
     ChangeBase() :
         _type(NOOP),
         _doc(0),
         _weight(1),
-        _enumScratchPad(UNSET_ENUM)
+        _cached_entry_ref(UNSET_ENTRY_REF)
     { }
 
     ChangeBase(Type type, uint32_t d, int32_t w = 1) :
         _type(type),
         _doc(d),
         _weight(w),
-        _enumScratchPad(UNSET_ENUM)
+        _cached_entry_ref(UNSET_ENTRY_REF)
     { }
 
     int cmp(const ChangeBase &b) const { int diff(_doc - b._doc); return diff; }
     bool operator <(const ChangeBase & b) const { return cmp(b) < 0; }
-    uint32_t getEnum() const { return _enumScratchPad; }
-    void setEnum(uint32_t value) const { _enumScratchPad = value; }
-    bool isEnumValid() const { return _enumScratchPad != UNSET_ENUM; }
+    uint32_t get_entry_ref() const { return _cached_entry_ref; }
+    void set_entry_ref(uint32_t entry_ref) const { _cached_entry_ref = entry_ref; }
+    bool has_entry_ref() const { return _cached_entry_ref != UNSET_ENTRY_REF; }
 
     Type               _type;
     uint32_t           _doc;
     int32_t            _weight;
-    mutable uint32_t   _enumScratchPad;
+    mutable uint32_t   _cached_entry_ref;
 };
 
 template <typename T>

--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -46,6 +46,7 @@ struct ChangeBase {
     uint32_t get_entry_ref() const { return _cached_entry_ref; }
     void set_entry_ref(uint32_t entry_ref) const { _cached_entry_ref = entry_ref; }
     bool has_entry_ref() const { return _cached_entry_ref != UNSET_ENTRY_REF; }
+    void clear_entry_ref() const { _cached_entry_ref = UNSET_ENTRY_REF; }
 
     Type               _type;
     uint32_t           _doc;

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.h
@@ -56,6 +56,7 @@ protected:
     virtual void considerAttributeChange(const Change & c, EnumStoreBatchUpdater & inserter) = 0;
     vespalib::MemoryUsage getEnumStoreValuesMemoryUsage() const override;
     void populate_address_space_usage(AddressSpaceUsage& usage) const override;
+    void cache_change_data_entry_ref(const Change& c) const;
 public:
     EnumAttribute(const vespalib::string & baseFileName, const AttributeVector::Config & cfg);
     ~EnumAttribute();

--- a/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumattribute.hpp
@@ -84,6 +84,15 @@ EnumAttribute<B>::populate_address_space_usage(AddressSpaceUsage& usage) const
     usage.set(AddressSpaceComponents::enum_store, _enumStore.get_values_address_space_usage());
 }
 
+template <typename B>
+void
+EnumAttribute<B>::cache_change_data_entry_ref(const Change& c) const
+{
+    EnumIndex new_idx;
+    _enumStore.find_index(c._data.raw(), new_idx);
+    c.set_entry_ref(new_idx.ref());
+}
+
 } // namespace search
 
 

--- a/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattribute.hpp
@@ -25,10 +25,10 @@ template <typename B, typename M>
 bool
 MultiValueEnumAttribute<B, M>::extractChangeData(const Change & c, EnumIndex & idx)
 {
-    if ( ! c.isEnumValid() ) {
+    if ( ! c.has_entry_ref() ) {
         return this->_enumStore.find_index(c._data.raw(), idx);
     }
-    idx = EnumIndex(vespalib::datastore::EntryRef(c.getEnum()));
+    idx = EnumIndex(vespalib::datastore::EntryRef(c.get_entry_ref()));
     return true;
 }
 
@@ -42,9 +42,9 @@ MultiValueEnumAttribute<B, M>::considerAttributeChange(const Change & c, EnumSto
     {
         EnumIndex idx;
         if (!this->_enumStore.find_index(c._data.raw(), idx)) {
-            c.setEnum(inserter.insert(c._data.raw()).ref());
+            c.set_entry_ref(inserter.insert(c._data.raw()).ref());
         } else {
-            c.setEnum(idx.ref());
+            c.set_entry_ref(idx.ref());
         }
     }
 }

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -140,9 +140,9 @@ SingleValueEnumAttribute<B>::considerUpdateAttributeChange(const Change & c, Enu
 {
     EnumIndex idx;
     if (!this->_enumStore.find_index(c._data.raw(), idx)) {
-        c.setEnum(inserter.insert(c._data.raw()).ref());
+        c.set_entry_ref(inserter.insert(c._data.raw()).ref());
     } else {
-        c.setEnum(idx.ref());
+        c.set_entry_ref(idx.ref());
     }
     considerUpdateAttributeChange(c); // for numeric
 }
@@ -168,8 +168,8 @@ SingleValueEnumAttribute<B>::applyUpdateValueChange(const Change& c, EnumStoreBa
 {
     EnumIndex oldIdx = _enumIndices[c._doc];
     EnumIndex newIdx;
-    if (c.isEnumValid()) {
-        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.getEnum()));
+    if (c.has_entry_ref()) {
+        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.get_entry_ref()));
     } else {
         this->_enumStore.find_index(c._data.raw(), newIdx);
     }

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.hpp
@@ -181,6 +181,8 @@ void
 SingleValueEnumAttribute<B>::applyValueChanges(EnumStoreBatchUpdater& updater)
 {
     ValueModifier valueGuard(this->getValueModifier());
+    // This avoids searching for the defaultValue in the enum store for each CLEARDOC in the change vector.
+    this->cache_change_data_entry_ref(this->_defaultValue);
     for (const auto& change : this->_changes.getInsertOrder()) {
         if (change._type == ChangeBase::UPDATE) {
             applyUpdateValueChange(change, updater);
@@ -192,6 +194,8 @@ SingleValueEnumAttribute<B>::applyValueChanges(EnumStoreBatchUpdater& updater)
             applyUpdateValueChange(clearDoc, updater);
         }
     }
+    // We must clear the cached entry ref as the defaultValue might be located in another data buffer on later invocations.
+    this->_defaultValue.clear_entry_ref();
 }
 
 template <typename B>

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
@@ -38,9 +38,9 @@ SingleValueNumericEnumAttribute<B>::considerArithmeticAttributeChange(const Chan
 
     EnumIndex idx;
     if (!this->_enumStore.find_index(newValue, idx)) {
-        c.setEnum(inserter.insert(newValue).ref());
+        c.set_entry_ref(inserter.insert(newValue).ref());
     } else {
-        c.setEnum(idx.ref());
+        c.set_entry_ref(idx.ref());
     }
 
     _currDocValues[c._doc] = newValue;

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
@@ -89,6 +89,8 @@ SingleValueNumericPostingAttribute<B>::applyValueChanges(EnumStoreBatchUpdater& 
     // used to make sure several arithmetic operations on the same document in a single commit works
     std::map<DocId, EnumIndex> currEnumIndices;
 
+    // This avoids searching for the defaultValue in the enum store for each CLEARDOC in the change vector.
+    this->cache_change_data_entry_ref(this->_defaultValue);
     for (const auto& change : this->_changes.getInsertOrder()) {
         auto enumIter = currEnumIndices.find(change._doc);
         EnumIndex oldIdx;
@@ -114,6 +116,8 @@ SingleValueNumericPostingAttribute<B>::applyValueChanges(EnumStoreBatchUpdater& 
             applyUpdateValueChange(clearDoc, enumStore, currEnumIndices);
         }
     }
+    // We must clear the cached entry ref as the defaultValue might be located in another data buffer on later invocations.
+    this->_defaultValue.clear_entry_ref();
 
     makePostingChange(enumStore.get_comparator(), currEnumIndices, changePost);
 

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
@@ -47,8 +47,8 @@ SingleValueNumericPostingAttribute<B>::applyUpdateValueChange(const Change & c,
                                                               std::map<DocId, EnumIndex> & currEnumIndices)
 {
     EnumIndex newIdx;
-    if (c.isEnumValid()) {
-        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.getEnum()));
+    if (c.has_entry_ref()) {
+        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.get_entry_ref()));
     } else {
         enumStore.find_index(c._data.raw(), newIdx);
     }

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
@@ -45,8 +45,8 @@ SingleValueStringPostingAttributeT<B>::applyUpdateValueChange(const Change & c,
                                                               std::map<DocId, EnumIndex> &currEnumIndices)
 {
     EnumIndex newIdx;
-    if (c.isEnumValid()) {
-        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.getEnum()));
+    if (c.has_entry_ref()) {
+        newIdx = EnumIndex(vespalib::datastore::EntryRef(c.get_entry_ref()));
     } else {
         enumStore.find_index(c._data.raw(), newIdx);
     }

--- a/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringpostattribute.hpp
@@ -90,6 +90,8 @@ SingleValueStringPostingAttributeT<B>::applyValueChanges(EnumStoreBatchUpdater& 
     // used to make sure several arithmetic operations on the same document in a single commit works
     std::map<DocId, EnumIndex> currEnumIndices;
 
+    // This avoids searching for the defaultValue in the enum store for each CLEARDOC in the change vector.
+    this->cache_change_data_entry_ref(this->_defaultValue);
     for (const auto& change : this->_changes.getInsertOrder()) {
         auto enumIter = currEnumIndices.find(change._doc);
         EnumIndex oldIdx;
@@ -105,6 +107,8 @@ SingleValueStringPostingAttributeT<B>::applyValueChanges(EnumStoreBatchUpdater& 
             applyUpdateValueChange(this->_defaultValue, enumStore, currEnumIndices);
         }
     }
+    // We must clear the cached entry ref as the defaultValue might be located in another data buffer on later invocations.
+    this->_defaultValue.clear_entry_ref();
 
     makePostingChange(enumStore.get_folded_comparator(), dictionary, currEnumIndices, changePost);
 


### PR DESCRIPTION
@baldersheim please review

When retiring a content node a huge amount of cleardoc updates towards attributes are issued as part of deleteBucket operations. For some applications this has been observed as a bottleneck leading to increased latencies on client operations on the retired node. This optimization should fix that problem.