### PR TITLE
Use slf4j SimpleLogger instead of log4j

### DIFF
--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -15,6 +15,17 @@
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
       <version>${zookeeper.client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- This is the log4j 1.2 binding for slf4j. Must not be used with log4j-over-slf4j (see below) -->
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
@@ -38,6 +49,19 @@
        <artifactId>slf4j-api</artifactId>
        <scope>compile</scope>
     </dependency>
+    <dependency>
+      <!-- Bind to slf4j's SimpleLogger -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <!-- slf4j's replacement for log4j. See http://www.slf4j.org/legacy.html#log4j-over-slf4j -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
   </dependencies>
   <build>
     <plugins>

--- a/zookeeper-command-line-client/src/main/java/com/yahoo/vespa/zookeeper/cli/Main.java
+++ b/zookeeper-command-line-client/src/main/java/com/yahoo/vespa/zookeeper/cli/Main.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.zookeeper.cli;
 
 import com.yahoo.vespa.zookeeper.client.ZkClientConfigBuilder;
 import org.apache.zookeeper.ZooKeeperMain;
+import org.slf4j.impl.SimpleLogger;
 
 import java.io.IOException;
 
@@ -10,6 +11,11 @@ import java.io.IOException;
  * @author bjorncs
  */
 public class Main {
+
+    static {
+        System.setProperty(SimpleLogger.DEFAULT_LOG_LEVEL_KEY, "WARN");
+    }
+
     public static void main(String[] args) throws IOException, InterruptedException {
         new ZkClientConfigBuilder()
                 .toConfigProperties()


### PR DESCRIPTION
This introduces a new dependency on slf4j-simple, but the zk-command-line-client module has no dependents, so it does not spread into other parts of Vespa. Besides, the slf4j-simple artifact seems innocent with just a handful of classes and a total of 15 KB.

I could not find a way to filter out the excessive INFO logging from zk with slf4j-jdk14 (its java.util.logging bridge)

FYI: @bratseth 