### PR TITLE
Don't trigger implicit ContentPolicy random send fallback on expected transient errors [run-systemtest]

### DIFF
--- a/documentapi/abi-spec.json
+++ b/documentapi/abi-spec.json
@@ -1565,6 +1565,20 @@
       "protected final java.util.Random randomizer"
     ]
   },
+  "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$InstabilityChecker": {
+    "superClass": "java.lang.Object",
+    "interfaces": [],
+    "attributes": [
+      "public",
+      "interface",
+      "abstract"
+    ],
+    "methods": [
+      "public abstract boolean tooManyFailures(int)",
+      "public abstract void addFailure(java.lang.Integer)"
+    ],
+    "fields": []
+  },
   "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$Parameters": {
     "superClass": "java.lang.Object",
     "interfaces": [],
@@ -1576,7 +1590,8 @@
       "public java.lang.String getClusterName()",
       "public com.yahoo.documentapi.messagebus.protocol.ContentPolicy$SlobrokHostPatternGenerator createPatternGenerator()",
       "public com.yahoo.documentapi.messagebus.protocol.ContentPolicy$HostFetcher createHostFetcher(com.yahoo.documentapi.messagebus.protocol.SlobrokPolicy, int)",
-      "public com.yahoo.vdslib.distribution.Distribution createDistribution(com.yahoo.documentapi.messagebus.protocol.SlobrokPolicy)"
+      "public com.yahoo.vdslib.distribution.Distribution createDistribution(com.yahoo.documentapi.messagebus.protocol.SlobrokPolicy)",
+      "public com.yahoo.documentapi.messagebus.protocol.ContentPolicy$InstabilityChecker createInstabilityChecker()"
     ],
     "fields": [
       "protected final java.lang.String clusterName",
@@ -1584,6 +1599,21 @@
       "protected final com.yahoo.vespa.config.content.DistributionConfig distributionConfig",
       "protected final com.yahoo.documentapi.messagebus.protocol.ContentPolicy$SlobrokHostPatternGenerator slobrokHostPatternGenerator"
     ]
+  },
+  "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$PerNodeCountingInstabilityChecker": {
+    "superClass": "java.lang.Object",
+    "interfaces": [
+      "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$InstabilityChecker"
+    ],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>(int)",
+      "public boolean tooManyFailures(int)",
+      "public void addFailure(java.lang.Integer)"
+    ],
+    "fields": []
   },
   "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$SlobrokHostFetcher": {
     "superClass": "com.yahoo.documentapi.messagebus.protocol.ContentPolicy$HostFetcher",

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/storagepolicy/Simulator.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/storagepolicy/Simulator.java
@@ -188,7 +188,7 @@ public abstract class Simulator extends ContentPolicyTestEnvironment {
                 if (badNode != null && randomizer.nextDouble() < badNode.getFailureRate()) {
                     ++failed[half];
                     switch (badNode.getFailureType()) {
-                        case TRANSIENT_ERROR: replyError(target, new com.yahoo.messagebus.Error(DocumentProtocol.ERROR_BUSY, "Transient error")); break;
+                        case TRANSIENT_ERROR: replyError(target, new com.yahoo.messagebus.Error(DocumentProtocol.ERROR_ABORTED, "Transient error")); break;
                         case FATAL_ERROR: replyError(target, new com.yahoo.messagebus.Error(DocumentProtocol.ERROR_UNPARSEABLE, "Fatal error")); break;
                         case OLD_CLUSTER_STATE:
                         case RESET_CLUSTER_STATE:


### PR DESCRIPTION
@jonmv please review. I started looking at the existing "simulator" tests, then wisely retreated and left them alone in favor of some refactoring to be able to do explicit testing 😬
@yngveaasheim FYI

The `ContentPolicy` has a failure handling policy where more than _n_ error
replies (a small number in practice) will trigger an implicit random send instead
of using the cached cluster state. This is to force rediscovery of the actual
cluster state, and is useful if a node is bad but we're not sending feed to enough
other nodes to figure it out from them.

However, certain error codes may be used frequently by the content layer for
purposes that do _not_ indicate that a change in cluster state may have happened,
and should therefore not be counted as errors that may indicate a bad node:
 * `ERROR_TEST_AND_SET_CONDITION_FAILED`: may happen for any mutating operation
   that has an associated TaS condition. Technically an `APP_FATAL_ERROR` since
   resending doesn't make sense.
 * `ERROR_BUSY`: may happen for concurrent mutations and if distributors are
   in the process of changing bucket ownership and the grace period hasn't
   passed yet. Also sent if queues are full and client policy should back off
   a bit. None of these are errors as per se.
