### PR TITLE
Deprecate getConfigMd5() and setConfigMd5() [run-systemtest]

### DIFF
--- a/config-lib/src/main/java/com/yahoo/config/ConfigInstance.java
+++ b/config-lib/src/main/java/com/yahoo/config/ConfigInstance.java
@@ -110,11 +110,20 @@ public abstract class ConfigInstance extends InnerNode {
         }
     }
 
-
+    /**
+     * @deprecated do not use
+     */
+    @Deprecated
+    // TODO: Remove in Vespa 8
     public String getConfigMd5() {
         return configMd5;
     }
 
+    /**
+     * @deprecated do not use
+     */
+    @Deprecated
+    // TODO: Remove in Vespa 8
     public void setConfigMd5(String configMd5) {
         this.configMd5 = configMd5;
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -124,6 +124,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
      * @param jrtRequest a config request
      * @return an instance of a config class (subclass of ConfigInstance)
      */
+    @SuppressWarnings("deprecation")
     private T toConfigInstance(JRTClientConfigRequest jrtRequest) {
         Payload payload = jrtRequest.getNewPayload();
         ConfigPayload configPayload = ConfigPayload.fromUtf8Array(payload.withCompression(CompressionType.UNCOMPRESSED).getData());


### PR DESCRIPTION
We don't use md5 checksum for config anymore, methods will be removed
in Vespa 8.
