### PR TITLE
Simplify MockConnection

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -157,7 +157,6 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     }
 
     @Override
-    @SuppressWarnings("serial")
     public void close() {
         super.close();
         reqQueue = new LinkedBlockingQueue<>() {

--- a/config/src/test/java/com/yahoo/config/subscription/impl/JRTConfigRequesterTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/impl/JRTConfigRequesterTest.java
@@ -4,6 +4,7 @@ package com.yahoo.config.subscription.impl;
 import com.yahoo.config.subscription.ConfigSourceSet;
 import com.yahoo.foo.SimpletypesConfig;
 import com.yahoo.jrt.Request;
+import com.yahoo.jrt.RequestWaiter;
 import com.yahoo.vespa.config.ConfigKey;
 import com.yahoo.vespa.config.ConnectionPool;
 import com.yahoo.vespa.config.ErrorCode;
@@ -209,10 +210,10 @@ public class JRTConfigRequesterTest {
         }
 
         @Override
-        public void run() {
+        public void handle(Request request, RequestWaiter requestWaiter) {
             System.out.println("Running error response handler");
-            request().setError(errorCode, "error");
-            requestWaiter().handleRequestDone(request());
+            request.setError(errorCode, "error");
+            requestWaiter.handleRequestDone(request);
         }
     }
 
@@ -224,16 +225,15 @@ public class JRTConfigRequesterTest {
         }
 
         @Override
-        public void run() {
-            System.out.println("Running delayed response handler (waiting " + waitTimeMilliSeconds +
-            ") before responding");
+        public void handle(Request request, RequestWaiter requestWaiter) {
+            System.out.println("Running delayed response handler (waiting " + waitTimeMilliSeconds + ") before responding");
             try {
                 Thread.sleep(waitTimeMilliSeconds);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
-            request().setError(com.yahoo.jrt.ErrorCode.TIMEOUT, "error");
-            requestWaiter().handleRequestDone(request());
+            request.setError(com.yahoo.jrt.ErrorCode.TIMEOUT, "error");
+            requestWaiter.handleRequestDone(request);
         }
     }
 

--- a/config/src/test/java/com/yahoo/vespa/config/protocol/JRTConfigRequestV3Test.java
+++ b/config/src/test/java/com/yahoo/vespa/config/protocol/JRTConfigRequestV3Test.java
@@ -203,7 +203,7 @@ public class JRTConfigRequestV3Test {
     public void created_from_existing_subscription() {
         MockConnection connection = new MockConnection(new MockConnection.AbstractResponseHandler() {
             @Override
-            public void createResponse() {
+            public void createResponse(Request request) {
                 JRTServerConfigRequest serverRequest = createReq(request);
                 serverRequest.addOkResponse(createPayload(), currentGeneration, false, payloadChecksums);
             }


### PR DESCRIPTION
No need to use thread, start() isn't called anyway.
Collapse methods into one to simplify.