### PR TITLE
Support aborting and rolling back incomplete upgrade

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
@@ -55,7 +55,7 @@ public interface NodeRepository {
     void removeArchiveUri(ZoneId zone, TenantName tenantName);
 
     /** Upgrade all nodes of given type to a new version */
-    void upgrade(ZoneId zone, NodeType type, Version version);
+    void upgrade(ZoneId zone, NodeType type, Version version, boolean allowDowngrade);
 
     /** Upgrade OS for all nodes of given type to a new version */
     void upgradeOs(ZoneId zone, NodeType type, Version version, Duration upgradeBudget);

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/SystemMonitor.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/organization/SystemMonitor.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.hosted.controller.api.integration.organization;
 import com.yahoo.component.Version;
 
 /**
- * Montitors a Vespa controller and its system.
+ * Monitors a Vespa controller and its system.
  *
  * @author jonmv
  */
@@ -14,7 +14,7 @@ public interface SystemMonitor {
     void reportSystemVersion(Version systemVersion, Confidence confidence);
 
     enum Confidence {
-        broken, low, normal, high;
+        aborted, broken, low, normal, high;
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -446,12 +446,12 @@ public class ApplicationController {
     }
 
     /** Deploy a system application to given zone */
-    public void deploy(SystemApplication application, ZoneId zone, Version version) {
+    public void deploy(SystemApplication application, ZoneId zone, Version version, boolean allowDowngrade) {
         if (application.hasApplicationPackage()) {
             deploySystemApplicationPackage(application, zone, version);
         } else {
             // Deploy by calling node repository directly
-            configServer.nodeRepository().upgrade(zone, application.nodeType(), version);
+            configServer.nodeRepository().upgrade(zone, application.nodeType(), version, allowDowngrade);
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.controller.ApplicationController;
@@ -31,7 +30,7 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
     private final CuratorArchiveBucketDb archiveBucketDb;
 
     public ArchiveUriUpdater(Controller controller, Duration duration) {
-        super(controller, duration, ArchiveUriUpdater.class.getSimpleName(), SystemName.all());
+        super(controller, duration);
         this.applications = controller.applications();
         this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.archiveBucketDb = controller.archiveBucketDb();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentMetricsMaintainer.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.maintenance;
 
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.text.Text;
 import com.yahoo.vespa.hosted.controller.ApplicationController;
 import com.yahoo.vespa.hosted.controller.Controller;
@@ -40,7 +39,7 @@ public class DeploymentMetricsMaintainer extends ControllerMaintainer {
     private final ApplicationController applications;
 
     public DeploymentMetricsMaintainer(Controller controller, Duration duration) {
-        super(controller, duration, DeploymentMetricsMaintainer.class.getSimpleName(), SystemName.all());
+        super(controller, duration);
         this.applications = controller.applications();
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EndpointCertificateMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EndpointCertificateMaintainer.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.controller.maintenance;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.container.jdisc.secretstore.SecretNotFoundException;
 import com.yahoo.container.jdisc.secretstore.SecretStore;
 import com.yahoo.log.LogLevel;
@@ -54,7 +53,7 @@ public class EndpointCertificateMaintainer extends ControllerMaintainer {
 
     @Inject
     public EndpointCertificateMaintainer(Controller controller, Duration interval) {
-        super(controller, interval, null, SystemName.all());
+        super(controller, interval);
         this.deploymentTrigger = controller.applications().deploymentTrigger();
         this.clock = controller.clock();
         this.secretStore = controller.secretStore();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -66,7 +66,7 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
     }
 
     @Override
-    protected Optional<OsVersionTarget> targetVersion() {
+    protected Optional<OsVersionTarget> target() {
         // Return target if we have nodes in this cloud on a lower version
         return controller().osVersionTarget(cloud)
                            .filter(target -> controller().osVersionStatus().nodesIn(cloud).stream()
@@ -90,7 +90,7 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
     /** Returns the available upgrade budget for given zone */
     private Duration zoneBudgetOf(Duration totalBudget, ZoneApi zone) {
         if (!spendBudgetOn(zone)) return Duration.ZERO;
-        long consecutiveZones = upgradePolicy.asList().stream()
+        long consecutiveZones = upgradePolicy.steps().stream()
                                              .filter(parallelZones -> parallelZones.stream().anyMatch(this::spendBudgetOn))
                                              .count();
         return totalBudget.dividedBy(consecutiveZones);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/SystemUpgrader.java
@@ -8,7 +8,9 @@ import com.yahoo.text.Text;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.Node;
 import com.yahoo.vespa.hosted.controller.application.SystemApplication;
+import com.yahoo.vespa.hosted.controller.versions.VersionStatus;
 import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
+import com.yahoo.vespa.hosted.controller.versions.VespaVersionTarget;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -20,7 +22,7 @@ import java.util.logging.Logger;
  *
  * @author mpolden
  */
-public class SystemUpgrader extends InfrastructureUpgrader<Version> {
+public class SystemUpgrader extends InfrastructureUpgrader<VespaVersionTarget> {
 
     private static final Logger log = Logger.getLogger(SystemUpgrader.class.getName());
 
@@ -31,19 +33,19 @@ public class SystemUpgrader extends InfrastructureUpgrader<Version> {
     }
 
     @Override
-    protected void upgrade(Version target, SystemApplication application, ZoneApi zone) {
+    protected void upgrade(VespaVersionTarget target, SystemApplication application, ZoneApi zone) {
         log.info(Text.format("Deploying %s version %s in %s", application.id(), target, zone.getId()));
-        controller().applications().deploy(application, zone.getId(), target);
+        controller().applications().deploy(application, zone.getId(), target.version(), target.downgrade());
     }
 
     @Override
-    protected boolean convergedOn(Version target, SystemApplication application, ZoneApi zone) {
+    protected boolean convergedOn(VespaVersionTarget target, SystemApplication application, ZoneApi zone) {
         Optional<Version> minVersion = minVersion(zone, application, Node::currentVersion);
         // Skip application convergence check if there are no nodes belonging to the application in the zone
         if (minVersion.isEmpty()) return true;
 
-        return minVersion.get().equals(target) &&
-               application.configConvergedIn(zone.getId(), controller(), Optional.of(target));
+        return minVersion.get().equals(target.version()) &&
+               application.configConvergedIn(zone.getId(), controller(), Optional.of(target.version()));
     }
 
     @Override
@@ -52,30 +54,41 @@ public class SystemUpgrader extends InfrastructureUpgrader<Version> {
     }
 
     @Override
-    protected Optional<Version> targetVersion() {
-        return controller().readVersionStatus().controllerVersion()
-                           .filter(vespaVersion -> !vespaVersion.isSystemVersion())
-                           .filter(vespaVersion -> vespaVersion.confidence() != VespaVersion.Confidence.broken)
-                           .map(VespaVersion::versionNumber);
+    protected Optional<VespaVersionTarget> target() {
+        VersionStatus status = controller().readVersionStatus();
+        Optional<VespaVersion> target = status.controllerVersion()
+                                              .filter(version -> {
+                                                  Version systemVersion = status.systemVersion()
+                                                                                .map(VespaVersion::versionNumber)
+                                                                                .orElse(Version.emptyVersion);
+                                                  return version.versionNumber().isAfter(systemVersion);
+                                              })
+                                              .filter(version -> version.confidence() != VespaVersion.Confidence.broken);
+        boolean downgrade = target.isPresent() && target.get().confidence() == VespaVersion.Confidence.aborted;
+        if (downgrade) {
+            target = status.systemVersion();
+        }
+        return target.map(VespaVersion::versionNumber)
+                     .map(version -> new VespaVersionTarget(version, downgrade));
     }
 
     @Override
-    protected boolean changeTargetTo(Version target, SystemApplication application, ZoneApi zone) {
+    protected boolean changeTargetTo(VespaVersionTarget target, SystemApplication application, ZoneApi zone) {
         if (application.hasApplicationPackage()) {
             // For applications with package we do not have a zone-wide version target. This means that we must check
             // the wanted version of each node.
             boolean zoneHasSharedRouting = controller().zoneRegistry().routingMethods(zone.getId()).stream()
                                                        .anyMatch(RoutingMethod::isShared);
             return minVersion(zone, application, Node::wantedVersion)
-                    .map(target::isAfter)          // Upgrade if target is after any wanted version
+                    .map(wantedVersion -> !wantedVersion.equals(target.version()))
                     .orElse(zoneHasSharedRouting); // Always upgrade if zone uses shared routing, but has no nodes allocated yet
 
         }
         return controller().serviceRegistry().configServer().nodeRepository()
                            .targetVersionsOf(zone.getId())
                            .vespaVersion(application.nodeType())
-                           .map(target::isAfter)                              // Upgrade if target is after current
-                           .orElse(true);                                     // Upgrade if target is unset
+                           .map(wantedVersion -> !wantedVersion.equals(target.version()))
+                           .orElse(true); // Always set target if there are no nodes
     }
 
     /** Returns whether node in application should be upgraded by this */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/Upgrader.java
@@ -174,6 +174,11 @@ public class Upgrader extends ControllerMaintainer {
 
     /** Override confidence for given version. This will cause the computed confidence to be ignored */
     public void overrideConfidence(Version version, Confidence confidence) {
+        if (confidence == Confidence.aborted && !version.isAfter(controller().readSystemVersion())) {
+            throw new IllegalArgumentException("Cannot override confidence to " + confidence +
+                                               " for version " + version.toFullString() +
+                                               ": Version may be in use by applications");
+        }
         try (Lock lock = curator.lockConfidenceOverrides()) {
             Map<Version, Confidence> overrides = new LinkedHashMap<>(curator.readConfidenceOverrides());
             overrides.put(version, confidence);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/VersionStatusUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/VersionStatusUpdater.java
@@ -14,6 +14,7 @@ import static com.yahoo.vespa.hosted.controller.api.integration.organization.Sys
 import static com.yahoo.vespa.hosted.controller.api.integration.organization.SystemMonitor.Confidence.high;
 import static com.yahoo.vespa.hosted.controller.api.integration.organization.SystemMonitor.Confidence.low;
 import static com.yahoo.vespa.hosted.controller.api.integration.organization.SystemMonitor.Confidence.normal;
+import static com.yahoo.vespa.hosted.controller.api.integration.organization.SystemMonitor.Confidence.aborted;
 
 /**
  * This maintenance job periodically updates the version status.
@@ -47,10 +48,11 @@ public class VersionStatusUpdater extends ControllerMaintainer {
 
     static SystemMonitor.Confidence convert(VespaVersion.Confidence confidence) {
         switch (confidence) {
-            case broken: return broken;
-            case low:    return low;
-            case normal: return normal;
-            case high:   return high;
+            case aborted: return aborted;
+            case broken:  return broken;
+            case low:     return low;
+            case normal:  return normal;
+            case high:    return high;
             default: throw new IllegalArgumentException("Unexpected confidence '" + confidence + "'");
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -89,7 +89,7 @@ public class OsVersionStatus {
 
     private static List<ZoneApi> zonesToUpgrade(Controller controller) {
         return controller.zoneRegistry().osUpgradePolicies().stream()
-                         .flatMap(upgradePolicy -> upgradePolicy.asList().stream())
+                         .flatMap(upgradePolicy -> upgradePolicy.steps().stream())
                          .flatMap(Collection::stream)
                          .collect(Collectors.toUnmodifiableList());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionTarget.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionTarget.java
@@ -1,16 +1,18 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.versions;
 
+import com.yahoo.component.Version;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 
 /**
- * An {@link OsVersion} and its upgrade budget.
+ * The OS version target for a cloud/system, containing the {@link OsVersion} and its upgrade budget.
  *
  * @author mpolden
  */
-public class OsVersionTarget implements Comparable<OsVersionTarget> {
+public class OsVersionTarget implements VersionTarget, Comparable<OsVersionTarget> {
 
     // WARNING: Since there are multiple servers in a ZooKeeper cluster and they upgrade one by one
     //          (and rewrite all nodes on startup), changes to the serialized format must be made
@@ -61,6 +63,16 @@ public class OsVersionTarget implements Comparable<OsVersionTarget> {
     @Override
     public int compareTo(OsVersionTarget o) {
         return osVersion.compareTo(o.osVersion);
+    }
+
+    @Override
+    public Version version() {
+        return osVersion.version();
+    }
+
+    @Override
+    public boolean downgrade() {
+        return false; // Not supported by this target type
     }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionTarget.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VersionTarget.java
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.versions;
+
+import com.yahoo.component.Version;
+
+/**
+ * Interface for a version target of some kind of upgrade.
+ *
+ * @author mpolden
+ */
+public interface VersionTarget {
+
+    /** The version of this target */
+    Version version();
+
+    /** Returns whether this target is potentially a downgrade */
+    boolean downgrade();
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersion.java
@@ -130,6 +130,9 @@ public class VespaVersion implements Comparable<VespaVersion> {
     /** The confidence of a version. */
     public enum Confidence {
 
+        /** Rollout was aborted. The system infrastructure should stay on, or roll back to, its current version */
+        aborted,
+
         /** This version has been proven defective */
         broken,
         

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersionTarget.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/VespaVersionTarget.java
@@ -1,0 +1,33 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.versions;
+
+import com.yahoo.component.Version;
+
+import java.util.Objects;
+
+/**
+ * The target Vespa version for a system.
+ *
+ * @author mpolden
+ */
+public class VespaVersionTarget implements VersionTarget {
+
+    private final Version version;
+    private final boolean downgrade;
+
+    public VespaVersionTarget(Version version, boolean downgrade) {
+        this.version = Objects.requireNonNull(version);
+        this.downgrade = downgrade;
+    }
+
+    @Override
+    public Version version() {
+        return version;
+    }
+
+    @Override
+    public boolean downgrade() {
+        return downgrade;
+    }
+
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/ControllerTester.java
@@ -251,7 +251,7 @@ public final class ControllerTester {
         for (ZoneApi zone : zoneRegistry().zones().all().zones()) {
             for (SystemApplication application : systemApplications) {
                 if (!application.hasApplicationPackage()) {
-                    configServer().nodeRepository().upgrade(zone.getId(), application.nodeType(), version);
+                    configServer().nodeRepository().upgrade(zone.getId(), application.nodeType(), version, false);
                 }
                 configServer().setVersion(version, application.id(), zone.getId());
                 configServer().convergeServices(application.id(), zone.getId());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
@@ -295,7 +295,7 @@ public class MetricsReporterTest {
         var tester = new ControllerTester();
         var reporter = createReporter(tester.controller());
         var zone = ZoneId.from("prod.eu-west-1");
-        tester.zoneRegistry().setUpgradePolicy(UpgradePolicy.create().upgrade(ZoneApiMock.from(zone)));
+        tester.zoneRegistry().setUpgradePolicy(UpgradePolicy.builder().upgrade(ZoneApiMock.from(zone)).build());
         var systemUpgrader = new SystemUpgrader(tester.controller(), Duration.ofDays(1)
         );
         tester.configServer().bootstrap(List.of(zone), SystemApplication.configServer);
@@ -352,7 +352,7 @@ public class MetricsReporterTest {
         var reporter = createReporter(tester.controller());
         var zone = ZoneId.from("prod.eu-west-1");
         var cloud = CloudName.defaultName();
-        tester.zoneRegistry().setOsUpgradePolicy(cloud, UpgradePolicy.create().upgrade(ZoneApiMock.from(zone)));
+        tester.zoneRegistry().setOsUpgradePolicy(cloud, UpgradePolicy.builder().upgrade(ZoneApiMock.from(zone)).build());
         var osUpgrader = new OsUpgrader(tester.controller(), Duration.ofDays(1), CloudName.defaultName());
         var statusUpdater = new OsVersionStatusUpdater(tester.controller(), Duration.ofDays(1)
         );

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -42,12 +42,13 @@ public class OsUpgraderTest {
         ZoneApi zone3 = zone("prod.us-central-1", cloud1);
         ZoneApi zone4 = zone("prod.us-east-3", cloud1);
         ZoneApi zone5 = zone("prod.us-north-1", cloud2);
-        UpgradePolicy upgradePolicy = UpgradePolicy.create()
+        UpgradePolicy upgradePolicy = UpgradePolicy.builder()
                                                    .upgrade(zone0)
                                                    .upgrade(zone1)
                                                    .upgradeInParallel(zone2, zone3)
                                                    .upgrade(zone5) // Belongs to a different cloud and is ignored by this upgrader
-                                                   .upgrade(zone4);
+                                                   .upgrade(zone4)
+                                                   .build();
         OsUpgrader osUpgrader = osUpgrader(upgradePolicy, cloud1, false);
 
         // Bootstrap system
@@ -125,11 +126,12 @@ public class OsUpgraderTest {
         ZoneApi zone2 = zone("prod.us-west-1", cloud);
         ZoneApi zone3 = zone("prod.us-central-1", cloud);
         ZoneApi zone4 = zone("prod.eu-west-1", cloud);
-        UpgradePolicy upgradePolicy = UpgradePolicy.create()
+        UpgradePolicy upgradePolicy = UpgradePolicy.builder()
                                                    .upgrade(zone0)
                                                    .upgrade(zone1)
                                                    .upgradeInParallel(zone2, zone3)
-                                                   .upgrade(zone4);
+                                                   .upgrade(zone4)
+                                                   .build();
         OsUpgrader osUpgrader = osUpgrader(upgradePolicy, cloud, true);
 
         // Bootstrap system
@@ -189,9 +191,10 @@ public class OsUpgraderTest {
         CloudName cloud = CloudName.from("cloud");
         ZoneApi zone1 = zone("dev.us-east-1", cloud);
         ZoneApi zone2 = zone("prod.us-west-1", cloud);
-        UpgradePolicy upgradePolicy = UpgradePolicy.create()
+        UpgradePolicy upgradePolicy = UpgradePolicy.builder()
                                                    .upgrade(zone1)
-                                                   .upgrade(zone2);
+                                                   .upgrade(zone2)
+                                                   .build();
         OsUpgrader osUpgrader = osUpgrader(upgradePolicy, cloud, false);
 
         // Bootstrap system
@@ -299,7 +302,7 @@ public class OsUpgraderTest {
     }
 
     private OsUpgrader osUpgrader(UpgradePolicy upgradePolicy, CloudName cloud, boolean reprovisionToUpgradeOs) {
-        var zones = upgradePolicy.asList().stream().flatMap(Collection::stream).collect(Collectors.toList());
+        var zones = upgradePolicy.steps().stream().flatMap(Collection::stream).collect(Collectors.toList());
         tester.zoneRegistry()
               .setZones(zones)
               .setOsUpgradePolicy(cloud, upgradePolicy);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
@@ -28,11 +28,11 @@ public class OsVersionStatusUpdaterTest {
         OsVersionStatusUpdater statusUpdater = new OsVersionStatusUpdater(tester.controller(), Duration.ofDays(1)
         );
         // Add all zones to upgrade policy
-        UpgradePolicy upgradePolicy = UpgradePolicy.create();
+        UpgradePolicy.Builder upgradePolicy = UpgradePolicy.builder();
         for (ZoneApi zone : tester.zoneRegistry().zones().controllerUpgraded().zones()) {
             upgradePolicy = upgradePolicy.upgrade(zone);
         }
-        tester.zoneRegistry().setOsUpgradePolicy(CloudName.defaultName(), upgradePolicy);
+        tester.zoneRegistry().setOsUpgradePolicy(CloudName.defaultName(), upgradePolicy.build());
 
         // Initially empty
         assertSame(OsVersionStatus.empty, tester.controller().osVersionStatus());

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -55,8 +55,8 @@ public class OsApiTest extends ControllerContainerTest {
         zoneRegistryMock().setSystemName(SystemName.cd)
                           .setZones(zone1, zone2, zone3)
                           .reprovisionToUpgradeOsIn(zone3)
-                          .setOsUpgradePolicy(cloud1, UpgradePolicy.create().upgrade(zone1).upgrade(zone2))
-                          .setOsUpgradePolicy(cloud2, UpgradePolicy.create().upgrade(zone3));
+                          .setOsUpgradePolicy(cloud1, UpgradePolicy.builder().upgrade(zone1).upgrade(zone2).build())
+                          .setOsUpgradePolicy(cloud2, UpgradePolicy.builder().upgrade(zone3).build());
         osUpgraders = List.of(
                 new OsUpgrader(tester.controller(), Duration.ofDays(1),
                                cloud1),


### PR DESCRIPTION
This adds limited support for aborting an ongoing upgrade and rolling back the
system.

For example:
1. System is on version v0
2. System has started rolling out v1, where some zones have completed upgrading
3. We discover that v1 is severely broken and we need to halt the upgrade, and
   downgrade any infrastructure that has completed upgrading
   
Merge with internal PR.

@jonmv