### PR TITLE
Use zero as unset entry ref as that matches an invalid entry ref.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/changevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/changevector.h
@@ -25,7 +25,7 @@ struct ChangeBase {
         DIV,
         CLEARDOC
     };
-    enum {UNSET_ENTRY_REF = 0xffffffffu};
+    enum {UNSET_ENTRY_REF = 0};
 
     ChangeBase() :
         _type(NOOP),


### PR DESCRIPTION
The previous value was within the range of valid entry refs and we could (very rarely) consider a set entry ref to not being set.

@toregge please review