### PR TITLE
Avoid clearing config response queue [run-systemtest]

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -434,8 +434,8 @@ public class ConfigSubscriber implements AutoCloseable {
     }
 
     /**
-     * Use this convenience method if you only want to subscribe on <em>one</em> config, and want generic error handling.
-     * Implement {@link SingleSubscriber} and pass to this method.
+     * Convenience method that can be used if you only want to subscribe to <em>one</em> config, and want generic error handling.
+     * Implement {@link SingleSubscriber} and pass it to this method.
      * You will get initial config, and a config thread will be started. The method will throw in your thread if initial
      * configuration fails, and the config thread will print a generic error message (but continue) if it fails thereafter. The config
      * thread will stop if you {@link #close()} this {@link ConfigSubscriber}.

--- a/config/src/test/java/com/yahoo/config/subscription/GenericConfigSubscriberTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/GenericConfigSubscriberTest.java
@@ -33,7 +33,7 @@ public class GenericConfigSubscriberTest {
     public void testSubscribeGeneric() throws InterruptedException {
         JRTConfigRequester requester = new JRTConfigRequester(new MockConnection(), tv);
         GenericConfigSubscriber sub = new GenericConfigSubscriber(requester);
-        final List<String> defContent = List.of("myVal int");
+        List<String> defContent = List.of("myVal int");
         GenericConfigHandle handle = sub.subscribe(new ConfigKey<>("simpletypes", "id", "config"),
                                                    defContent,
                                                    tv);
@@ -46,9 +46,9 @@ public class GenericConfigSubscriberTest {
         assertFalse(handle.isChanged());
 
         // Wait some time, config should be the same, but generation should be higher
-        Thread.sleep(tv.getFixedDelay() * 2);
+        Thread.sleep(tv.getFixedDelay() * 3);
         assertEquals("{}", getConfig(handle));
-        assertTrue(handle.getRawConfig().getGeneration() > 1);
+        assertTrue("Unexpected generation (not > 1): " + handle.getRawConfig().getGeneration(), handle.getRawConfig().getGeneration() > 1);
         assertFalse(sub.nextConfig(false));
         assertFalse(handle.isChanged());
     }


### PR DESCRIPTION
There have been races due to the fact that we used to clear the queue
when receiving a response, thus missing some of the responses. This
stops clearing the queue and handles several items on the queue by
polling until the queue is empty when a new item is found on the queue.