### PR TITLE
Invalidate bucket DB replica statistics upon recovery mode entry [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/common/hostreporter/hostinfo.cpp
+++ b/storage/src/vespa/storage/common/hostreporter/hostinfo.cpp
@@ -9,8 +9,7 @@ HostInfo::HostInfo() {
     registerReporter(&versionReporter);
 }
 
-HostInfo::~HostInfo() {
-}
+HostInfo::~HostInfo() = default;
 
 void HostInfo::printReport(vespalib::JsonStream& report) {
     for (HostReporter* reporter : customReporters) {

--- a/storage/src/vespa/storage/common/hostreporter/hostreporter.h
+++ b/storage/src/vespa/storage/common/hostreporter/hostreporter.h
@@ -11,7 +11,7 @@ namespace storage {
 class HostReporter {
 public:
 	virtual void report(vespalib::JsonStream& jsonreport) = 0;
-	virtual ~HostReporter() {}
+	virtual ~HostReporter() = default;
 };
 }
 

--- a/storage/src/vespa/storage/distributor/distributor_stripe.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.h
@@ -259,7 +259,9 @@ private:
     BucketSpacesStatsProvider::BucketSpacesStats make_invalid_stats_per_configured_space() const;
     template <typename NodeFunctor>
     void for_each_available_content_node_in(const lib::ClusterState&, NodeFunctor&&);
-    void invalidate_bucket_spaces_stats();
+    void invalidate_internal_db_dependent_stats();
+    void invalidate_bucket_spaces_stats(std::lock_guard<std::mutex>& held_metric_lock);
+    void invalidate_min_replica_stats(std::lock_guard<std::mutex>& held_metric_lock);
     void send_updated_host_info_if_required();
     void propagate_config_snapshot_to_internal_components();
 

--- a/storage/src/vespa/storage/distributor/min_replica_provider.h
+++ b/storage/src/vespa/storage/distributor/min_replica_provider.h
@@ -9,7 +9,7 @@ namespace storage::distributor {
 class MinReplicaProvider
 {
 public:
-    virtual ~MinReplicaProvider() {}
+    virtual ~MinReplicaProvider() = default;
 
     /**
      * Get a snapshot of the minimum bucket replica for each of the nodes.

--- a/storage/src/vespa/storage/storageserver/statemanager.h
+++ b/storage/src/vespa/storage/storageserver/statemanager.h
@@ -51,6 +51,7 @@ class StateManager : public NodeStateUpdater,
     using ClusterStateBundle = lib::ClusterStateBundle;
     std::shared_ptr<const ClusterStateBundle> _systemState;
     std::shared_ptr<const ClusterStateBundle> _nextSystemState;
+    uint32_t _reported_host_info_cluster_state_version;
     std::list<StateListener*> _stateListeners;
     typedef std::pair<framework::MilliSecTime, api::GetNodeStateCommand::SP> TimeStatePair;
     std::list<TimeStatePair> _queuedStateRequests;


### PR DESCRIPTION
@geirst please review

The replica stats track the minimum replication factor for any bucket
for a given content node the distributor maintains buckets for. These
statistics may be asynchronously queried by the cluster controller
through the host info reporting API.

If we do not invalidate the statistics upon a cluster state change, there
is a very small window of time where the distributor may potentially
report back _stale_ statistics that were valid for the _prior_ cluster
state version but not for the new one. This can happen if the cluster
controller fetches host info from the node in between start of the recovery
period and the completion of the recovery mode DB scan. Receiving stale
replication statistics may cause the cluster controller to erroneously
believe that replication due to node retirements etc has completed earlier
than it really has, possibly impacting orchestration decisions in a sub-
optimal manner.