### PR TITLE
Check if optional is present

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -87,7 +87,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -440,7 +439,8 @@ public class ApplicationController {
         for (Notification notification : controller.notificationsDb().listNotifications(NotificationSource.from(application.get().id()), true)) {
             if ( ! notification.source().instance().map(declaredInstances::contains).orElse(false))
                 controller.notificationsDb().removeNotifications(notification.source());
-            if ( ! notification.source().zoneId().map(application.get().require(notification.source().instance().get()).deployments()::containsKey).orElse(false))
+            if (notification.source().instance().isPresent() &&
+                    ! notification.source().zoneId().map(application.get().require(notification.source().instance().get()).deployments()::containsKey).orElse(false))
                 controller.notificationsDb().removeNotifications(notification.source());
         }
 


### PR DESCRIPTION
There's 30 exceptions across 3 main controllers like this:
```
Unexpected error handling 'https://[main]/application/v4/tenant/X/application/Y/submit'
exception=
java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:148)
        at com.yahoo.vespa.hosted.controller.ApplicationController.storeWithUpdatedConfig(ApplicationController.java:443)
        at com.yahoo.vespa.hosted.controller.deployment.JobController.lambda$submit$41(JobController.java:463)
        at com.yahoo.vespa.hosted.controller.ApplicationController.lockApplicationOrThrow(ApplicationController.java:657)
        at com.yahoo.vespa.hosted.controller.deployment.JobController.submit(JobController.java:432)
        at com.yahoo.vespa.hosted.controller.restapi.application.JobControllerApiHandlerHelper.submitResponse(JobControllerApiHandlerHelper.java:206)
        at com.yahoo.vespa.hosted.controller.restapi.application.ApplicationApiHandler.submit(ApplicationApiHandler.java:2627)
        at com.yahoo.vespa.hosted.controller.restapi.application.ApplicationApiHandler.handlePOST(ApplicationApiHandler.java:305)
        at com.yahoo.vespa.hosted.controller.restapi.application.ApplicationApiHandler.auditAndHandle(ApplicationApiHandler.java:197)
        at com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler.handle(AuditLoggingRequestHandler.java:26)
        at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.handle(ThreadedHttpRequestHandler.java:74)
        at com.yahoo.vespa.hosted.controller.auditlog.AuditLoggingRequestHandler.handle(AuditLoggingRequestHandler.java:31)
        at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.handleRequest(ThreadedHttpRequestHandler.java:85)
        at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.processRequest(ThreadedRequestHandler.java:191)
        at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.run(ThreadedRequestHandler.java:185)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```
First at 2021-12-20T08:46:51Z. Bug introduced in #20575