### PR TITLE
Use InfrastructureApplication, try 2

### DIFF
--- a/application-model/src/main/java/com/yahoo/vespa/applicationmodel/InfrastructureApplication.java
+++ b/application-model/src/main/java/com/yahoo/vespa/applicationmodel/InfrastructureApplication.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.applicationmodel;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeType;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -23,6 +25,13 @@ public enum InfrastructureApplication {
 
     private final ApplicationId id;
     private final NodeType nodeType;
+
+    /** Returns all applications that MAY be encountered in hosted Vespa, e.g. not DEV_HOST. */
+    public static List<InfrastructureApplication> inHosted() {
+        return Stream.of(values())
+                     .filter(application -> application != DEV_HOST)
+                     .collect(Collectors.toList());
+    }
 
     public static InfrastructureApplication withNodeType(NodeType nodeType) {
         return Stream.of(values())

--- a/controller-server/pom.xml
+++ b/controller-server/pom.xml
@@ -70,6 +70,13 @@
 
         <dependency>
             <groupId>com.yahoo.vespa</groupId>
+            <artifactId>application-model</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
             <artifactId>vespa-athenz</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/application/SystemApplication.java
@@ -3,11 +3,11 @@ package com.yahoo.vespa.hosted.controller.application;
 
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.text.Text;
+import com.yahoo.vespa.applicationmodel.InfrastructureApplication;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.ServiceConvergence;
@@ -26,33 +26,31 @@ import java.util.Optional;
  */
 public enum SystemApplication {
 
-    controllerHost("controller-host", NodeType.controllerhost),
-    configServerHost("configserver-host", NodeType.confighost),
-    configServer("zone-config-servers", NodeType.config),
-    proxyHost("proxy-host", NodeType.proxyhost),
-    proxy( "routing", NodeType.proxy, proxyHost, configServer),
-    tenantHost("tenant-host", NodeType.host);
+    controllerHost(InfrastructureApplication.CONTROLLER_HOST),
+    configServerHost(InfrastructureApplication.CONFIG_SERVER_HOST),
+    configServer(InfrastructureApplication.CONFIG_SERVER),
+    proxyHost(InfrastructureApplication.PROXY_HOST),
+    proxy(InfrastructureApplication.PROXY, proxyHost, configServer),
+    tenantHost(InfrastructureApplication.TENANT_HOST);
 
     /** The tenant owning all system applications */
     public static final TenantName TENANT = TenantName.from(Constants.TENANT_NAME);
 
-    private final ApplicationId id;
-    private final NodeType nodeType;
+    private final InfrastructureApplication application;
     private final List<SystemApplication> dependencies;
 
-    SystemApplication(String application, NodeType nodeType, SystemApplication... dependencies) {
-        this.id = ApplicationId.from(Constants.TENANT_NAME, application, InstanceName.defaultName().value());
-        this.nodeType = nodeType;
+    SystemApplication(InfrastructureApplication application, SystemApplication... dependencies) {
+        this.application = application;
         this.dependencies = List.of(dependencies);
     }
 
     public ApplicationId id() {
-        return id;
+        return application.id();
     }
 
     /** The node type that is implicitly allocated to this */
     public NodeType nodeType() {
-        return nodeType;
+        return application.nodeType();
     }
 
     /** Returns the system applications that should upgrade before this */
@@ -75,7 +73,7 @@ public enum SystemApplication {
 
     /** Returns whether this should receive OS upgrades */
     public boolean shouldUpgradeOs() {
-        return nodeType.isHost();
+        return nodeType().isHost();
     }
 
     /** Returns whether this has an endpoint */
@@ -106,7 +104,7 @@ public enum SystemApplication {
 
     @Override
     public String toString() {
-        return Text.format("system application %s of type %s", id, nodeType);
+        return Text.format("system application %s of type %s", id(), nodeType());
     }
 
     private static class Constants {

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -874,6 +874,7 @@ fi
 %dir %{_prefix}/lib/jars
 %{_prefix}/lib/jars/asm-*.jar
 %{_prefix}/lib/jars/aopalliance-repackaged-*.jar
+%{_prefix}/lib/jars/application-model-jar-with-dependencies.jar
 %{_prefix}/lib/jars/bcpkix-jdk15on-*.jar
 %{_prefix}/lib/jars/bcprov-jdk15on-*.jar
 %{_prefix}/lib/jars/config-bundle-jar-with-dependencies.jar

--- a/node-admin/CMakeLists.txt
+++ b/node-admin/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install(DIRECTORY DESTINATION logs/vespa/node-admin)
 install(FILES target/node-admin-jar-with-dependencies.jar DESTINATION conf/node-admin-app/components)
-install_symlink(lib/jars/application-model-jar-with-dependencies.jar conf/node-admin-app/components/application-model.jar)
+install_symlink(lib/jars/application-model-jar-with-dependencies.jar conf/node-admin-app/components/application-model-jar-with-dependencies.jar)
 install_symlink(lib/jars/flags-jar-with-dependencies.jar conf/node-admin-app/components/flags-jar-with-dependencies.jar)
 install(FILES src/main/application/services.xml DESTINATION conf/node-admin-app)
 install(PROGRAMS src/main/sh/node-admin.sh DESTINATION libexec/vespa)

--- a/node-admin/CMakeLists.txt
+++ b/node-admin/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 install(DIRECTORY DESTINATION logs/vespa/node-admin)
 install(FILES target/node-admin-jar-with-dependencies.jar DESTINATION conf/node-admin-app/components)
+install_symlink(lib/jars/application-model-jar-with-dependencies.jar conf/node-admin-app/components/application-model.jar)
 install_symlink(lib/jars/flags-jar-with-dependencies.jar conf/node-admin-app/components/flags-jar-with-dependencies.jar)
 install(FILES src/main/application/services.xml DESTINATION conf/node-admin-app)
 install(PROGRAMS src/main/sh/node-admin.sh DESTINATION libexec/vespa)


### PR DESCRIPTION
The original PR #20645 caused node-admin to fail to start because the application-model bundle was not found.  This PR extends the original by adding application-model to components.
