### PR TITLE
let a schema Processor receive ModelContext.Properties as needed

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/SchemaBuilder.java
@@ -101,6 +101,7 @@ public class SchemaBuilder {
     public SchemaBuilder(RankProfileRegistry rankProfileRegistry, QueryProfileRegistry queryProfileRegistry) {
         this(rankProfileRegistry, queryProfileRegistry, new TestProperties());
     }
+
     public SchemaBuilder(RankProfileRegistry rankProfileRegistry, QueryProfileRegistry queryProfileRegistry, ModelContext.Properties properties) {
         this(MockApplicationPackage.createEmpty(), new MockFileRegistry(), new BaseDeployLogger(), properties, rankProfileRegistry, queryProfileRegistry);
     }
@@ -113,6 +114,7 @@ public class SchemaBuilder {
                          QueryProfileRegistry queryProfileRegistry) {
         this(app, fileRegistry, deployLogger, properties, rankProfileRegistry, queryProfileRegistry, false);
     }
+
     private SchemaBuilder(ApplicationPackage applicationPackage,
                           FileRegistry fileRegistry,
                           DeployLogger deployLogger,
@@ -265,8 +267,10 @@ public class SchemaBuilder {
      * #build()} method so that subclasses can choose not to build anything.
      */
     private void process(Schema schema, QueryProfiles queryProfiles, boolean validate) {
-        new Processing().process(schema, deployLogger, rankProfileRegistry, queryProfiles, validate,
-                                 documentsOnly, processorsToSkip);
+        new Processing(properties).process(schema, deployLogger,
+                                           rankProfileRegistry, queryProfiles,
+                                           validate, documentsOnly,
+                                           processorsToSkip);
     }
 
     /**
@@ -541,7 +545,9 @@ public class SchemaBuilder {
     public QueryProfileRegistry getQueryProfileRegistry() {
         return queryProfileRegistry;
     }
+
     public ModelContext.Properties getProperties() { return properties; }
+
     public DeployLogger getDeployLogger() { return deployLogger; }
 
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/Processor.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/Processor.java
@@ -2,6 +2,7 @@
 package com.yahoo.searchdefinition.processing;
 
 import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.document.DataType;
 import com.yahoo.document.Field;
 import com.yahoo.searchdefinition.Index;
@@ -58,6 +59,13 @@ public abstract class Processor {
      *                      of aspects not relating to document definitions (e.g rank profiles)
      */
     public abstract void process(boolean validate, boolean documentsOnly);
+
+    /**
+     * As above, possibly with properties from a context.  Override if needed.
+     **/
+    public void process(boolean validate, boolean documentsOnly, ModelContext.Properties properties) {
+        process(validate, documentsOnly);
+    }
 
     /**
      * Convenience method for adding a no-strings-attached implementation field for a regular field


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
Note: this makes it possible to use feature flags in a Processor.
