### PR TITLE
If TLS buffer has more than 8x overhead, shrink it to fit prior to po…

### DIFF
--- a/searchlib/src/tests/transactionlog/chunks_test.cpp
+++ b/searchlib/src/tests/transactionlog/chunks_test.cpp
@@ -115,4 +115,25 @@ TEST("test multi element commitchunk") {
     }
     EXPECT_EQUAL(0u, counter);
 }
+
+TEST("shrinkToFit if difference is larger than 8x") {
+    Packet p(16000);
+    p.add(Packet::Entry(1, 3, ConstBufferRef(TEXT, strlen(TEXT))));
+    EXPECT_EQUAL(150u, p.sizeBytes());
+    EXPECT_EQUAL(16384u, p.getHandle().capacity());
+    p.shrinkToFit();
+    EXPECT_EQUAL(150u, p.sizeBytes());
+    EXPECT_EQUAL(150u, p.getHandle().capacity());
+}
+
+TEST("not shrinkToFit if difference is less than 8x") {
+    Packet p(1000);
+    p.add(Packet::Entry(1, 3, ConstBufferRef(TEXT, strlen(TEXT))));
+    EXPECT_EQUAL(150u, p.sizeBytes());
+    EXPECT_EQUAL(1024u, p.getHandle().capacity());
+    p.shrinkToFit();
+    EXPECT_EQUAL(150u, p.sizeBytes());
+    EXPECT_EQUAL(1024u, p.getHandle().capacity());
+}
+
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/vespa/searchlib/transactionlog/common.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/common.cpp
@@ -116,6 +116,14 @@ Packet::add(const Packet::Entry & e)
     _range.to(e.serial());
 }
 
+void
+Packet::shrinkToFit() {
+    if (_buf.size() * 8 < _buf.capacity()) {
+        nbostream::Buffer shrunkToFit(_buf.data(), _buf.data() + _buf.size());
+        _buf.swap(shrunkToFit);
+    }
+}
+
 Writer::CommitResult::CommitResult()
     : _callBacks()
 {}
@@ -149,6 +157,11 @@ CommitChunk::add(const Packet &packet, Writer::DoneCallback onDone) {
 Writer::CommitResult
 CommitChunk::createCommitResult() const {
     return Writer::CommitResult(_callBacks);
+}
+
+void
+CommitChunk::shrinkPayloadToFit() {
+    _data.shrinkToFit();
 }
 
 }

--- a/searchlib/src/vespa/searchlib/transactionlog/common.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/common.h
@@ -83,6 +83,7 @@ public:
     bool                   empty() const { return _count == 0; }
     size_t             sizeBytes() const { return _buf.size(); }
     void merge(const Packet & packet);
+    void shrinkToFit();
 private:
     size_t                            _count;
     SerialNumRange                    _range;
@@ -143,6 +144,7 @@ public:
     Writer::CommitResult createCommitResult() const;
     void setCommitDoneCallback(Writer::DoneCallback onDone) { _onCommitDone = std::move(onDone); }
     Writer::CommitPayload stealCallbacks() { return std::move(_callBacks); }
+    void shrinkPayloadToFit();
 private:
     Packet                 _data;
     Writer::CommitPayload  _callBacks;

--- a/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
@@ -396,6 +396,7 @@ void
 Domain::commitChunk(std::unique_ptr<CommitChunk> chunk, const UniqueLock & chunkOrderGuard) {
     assert(chunkOrderGuard.mutex() == &_currentChunkMonitor && chunkOrderGuard.owns_lock());
     if (chunk->getPacket().empty()) return;
+    chunk->shrinkPayloadToFit();
     std::promise<SerializedChunk> promise;
     std::future<SerializedChunk> future = promise.get_future();
     _executor.execute(makeLambdaTask([promise=std::move(promise), chunk = std::move(chunk),


### PR DESCRIPTION
…sting task for compression.

Intention to reduce amount of allocated memory in flight in the case there are cpu starvation, or something else causing hickups.

@toregge or @geirst PR