### PR TITLE
Use UUID for Linux container nodes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -63,7 +64,7 @@ public final class Node implements Nodelike {
 
     /** Creates a node builder in the initial state (reserved) */
     public static Node.Builder reserve(Set<String> ipAddresses, String hostname, String parentHostname, NodeResources resources, NodeType type) {
-        return new Node.Builder("fake-" + hostname, hostname, new Flavor(resources), State.reserved, type)
+        return new Node.Builder(UUID.randomUUID().toString(), hostname, new Flavor(resources), State.reserved, type)
                 .ipConfig(IP.Config.ofEmptyPool(ipAddresses))
                 .parentHostname(parentHostname);
     }
@@ -140,7 +141,7 @@ public final class Node implements Nodelike {
      *
      * - OpenStack: UUID
      * - AWS: Instance ID
-     * - Linux containers: fake-[hostname]
+     * - Linux containers: UUID
      */
     public String id() { return id; }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-container1.json
@@ -1,6 +1,6 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/test-node-pool-102-2",
-  "id": "fake-test-node-pool-102-2",
+  "id": "(ignore)",
   "state": "active",
   "type": "tenant",
   "hostname": "test-node-pool-102-2",


### PR DESCRIPTION
Motivation: We want to reset certain resources/caches in host-admin when a node is reallocated. Sometimes a node can be deallocated and allocated to a new application within a single host-admin tick so that it never sees the node unallocated. By using a unique ID, host-admin can simply compare against the node ID to find out when a node has been reallocated.