### PR TITLE
unify java warnings

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -38,12 +38,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/config-application-package/pom.xml
+++ b/config-application-package/pom.xml
@@ -127,10 +127,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <skip>false</skip>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-Werror</arg>
-                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>

--- a/config-lib/pom.xml
+++ b/config-lib/pom.xml
@@ -38,12 +38,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.yahoo.vespa</groupId>

--- a/config-model-api/pom.xml
+++ b/config-model-api/pom.xml
@@ -82,10 +82,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <skip>false</skip>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/config-model-fat/pom.xml
+++ b/config-model-fat/pom.xml
@@ -50,12 +50,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -85,12 +85,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/configdefinitions/pom.xml
+++ b/configdefinitions/pom.xml
@@ -30,12 +30,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.yahoo.vespa</groupId>

--- a/defaults/pom.xml
+++ b/defaults/pom.xml
@@ -61,12 +61,6 @@
 	    <plugin>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-compiler-plugin</artifactId>
-		<configuration>
-		    <compilerArgs>
-			<arg>-Xlint:all</arg>
-			<arg>-Werror</arg>
-		    </compilerArgs>
-		</configuration>
 	    </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/docprocs/pom.xml
+++ b/docprocs/pom.xml
@@ -117,12 +117,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Werror</arg>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/vespaclient-core/pom.xml
+++ b/vespaclient-core/pom.xml
@@ -29,12 +29,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-            <arg>-Werror</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
* these were stricter than in parent, but to simplify
  we can just use compiler args from parent

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
