### PR TITLE
GC unused protobuf dependency

### DIFF
--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -71,12 +71,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.19.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <scope>compile</scope>


### PR DESCRIPTION
@lesters PR
It seems protobuf is not needed at all