### PR TITLE
onnxModel to onnx in summary/matchfeatures

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/MapEvaluationTypeContext.java
@@ -266,7 +266,7 @@ public class MapEvaluationTypeContext extends FunctionReferenceContext implement
             String modelConfigName = OnnxModelTransformer.getModelConfigName(reference);
             String modelOutput = OnnxModelTransformer.getModelOutput(reference, null);
 
-            reference = new Reference("onnxModel", new Arguments(new ReferenceNode(modelConfigName)), modelOutput);
+            reference = new Reference("onnx", new Arguments(new ReferenceNode(modelConfigName)), modelOutput);
             if ( ! featureTypes.containsKey(reference)) {
                 throw new IllegalArgumentException("Missing onnx-model config for '" + configOrFileName + "'");
             }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/RankProfile.java
@@ -1026,11 +1026,11 @@ public class RankProfile implements Cloneable {
             Map<String, TensorType> inputTypes = resolveOnnxInputTypes(model, context);
 
             TensorType defaultOutputType = model.getTensorType(model.getDefaultOutput(), inputTypes);
-            context.setType(new Reference("onnxModel", args, null), defaultOutputType);
+            context.setType(new Reference("onnx", args, null), defaultOutputType);
 
             for (Map.Entry<String, String> mapping : model.getOutputMap().entrySet()) {
                 TensorType type = model.getTensorType(mapping.getKey(), inputTypes);
-                context.setType(new Reference("onnxModel", args, mapping.getValue()), type);
+                context.setType(new Reference("onnx", args, mapping.getValue()), type);
             }
         }
         return context;

--- a/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/OnnxModelTransformer.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/expressiontransforms/OnnxModelTransformer.java
@@ -21,17 +21,16 @@ import java.util.List;
 /**
  * Transforms ONNX model features of the forms:
  *
- *     onnxModel(config_name)
- *     onnxModel(config_name).output
- *     onnxModel("path/to/model")
- *     onnxModel("path/to/model").output
- *     onnxModel("path/to/model", "path/to/output")
- *     onnxModel("path/to/model", "unused", "path/to/output")    // signature is unused
- *     onnx(...)   // same as with onnxModel, onnx is an alias of onnxModel
+ *     onnx(config_name)
+ *     onnx(config_name).output
+ *     onnx("path/to/model")
+ *     onnx("path/to/model").output
+ *     onnx("path/to/model", "path/to/output")
+ *     onnx("path/to/model", "unused", "path/to/output")    // signature is unused
  *
  * To the format expected by the backend:
  *
- *     onnxModel(config_name).output
+ *     onnx(config_name).output
  *
  * @author lesters
  */
@@ -86,7 +85,7 @@ public class OnnxModelTransformer extends ExpressionTransformer<RankProfileTrans
             throw new IllegalArgumentException(featureName + " argument '" + output +
                     "' output not found in model '" + onnxModel.getFileName() + "'");
         }
-        return new ReferenceNode("onnxModel", List.of(new ReferenceNode(modelConfigName)), output);
+        return new ReferenceNode("onnx", List.of(new ReferenceNode(modelConfigName)), output);
     }
 
     public static String getModelConfigName(Reference reference) {
@@ -95,7 +94,7 @@ public class OnnxModelTransformer extends ExpressionTransformer<RankProfileTrans
             if (expr instanceof ReferenceNode) {  // refers to onnx-model config
                 return expr.toString();
             }
-            if (expr instanceof ConstantNode) {  // refers to an file path
+            if (expr instanceof ConstantNode) {  // refers to a file path
                 return asValidIdentifier(expr);
             }
         }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/processing/RankingExpressionWithOnnxModelTestCase.java
@@ -129,7 +129,7 @@ public class RankingExpressionWithOnnxModelTestCase {
         assertEquals("vespa.rank.firstphase", config.rankprofile(2).fef().property(2).name());
         assertEquals("rankingExpression(firstphase)", config.rankprofile(2).fef().property(2).value());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(2).fef().property(3).name());
-        assertEquals("onnxModel(my_model).out{d0:1}", config.rankprofile(2).fef().property(3).value());
+        assertEquals("onnx(my_model).out{d0:1}", config.rankprofile(2).fef().property(3).value());
 
         assertEquals("test_generated_model_config", config.rankprofile(3).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(3).fef().property(0).name());
@@ -139,25 +139,25 @@ public class RankingExpressionWithOnnxModelTestCase {
         assertEquals("vespa.rank.firstphase", config.rankprofile(3).fef().property(8).name());
         assertEquals("rankingExpression(firstphase)", config.rankprofile(3).fef().property(8).value());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(3).fef().property(9).name());
-        assertEquals("onnxModel(files_model_onnx).path_to_output_1{d0:1}", config.rankprofile(3).fef().property(9).value());
+        assertEquals("onnx(files_model_onnx).path_to_output_1{d0:1}", config.rankprofile(3).fef().property(9).value());
 
         assertEquals("test_summary_features", config.rankprofile(4).name());
         assertEquals("rankingExpression(another_function).rankingScript", config.rankprofile(4).fef().property(0).name());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(4).fef().property(3).name());
         assertEquals("1", config.rankprofile(4).fef().property(3).value());
         assertEquals("vespa.summary.feature", config.rankprofile(4).fef().property(4).name());
-        assertEquals("onnxModel(files_summary_model_onnx).path_to_output_2", config.rankprofile(4).fef().property(4).value());
+        assertEquals("onnx(another_model).out", config.rankprofile(4).fef().property(4).value());
         assertEquals("vespa.summary.feature", config.rankprofile(4).fef().property(5).name());
-        assertEquals("onnxModel(another_model).out", config.rankprofile(4).fef().property(5).value());
+        assertEquals("onnx(files_summary_model_onnx).path_to_output_2", config.rankprofile(4).fef().property(5).value());
 
         assertEquals("test_dynamic_model", config.rankprofile(5).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(5).fef().property(0).name());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(5).fef().property(3).name());
-        assertEquals("onnxModel(dynamic_model).my_output{d0:0, d1:1}", config.rankprofile(5).fef().property(3).value());
+        assertEquals("onnx(dynamic_model).my_output{d0:0, d1:1}", config.rankprofile(5).fef().property(3).value());
 
         assertEquals("test_dynamic_model_2", config.rankprofile(6).name());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(6).fef().property(5).name());
-        assertEquals("onnxModel(dynamic_model).my_output{d0:0, d1:2}", config.rankprofile(6).fef().property(5).value());
+        assertEquals("onnx(dynamic_model).my_output{d0:0, d1:2}", config.rankprofile(6).fef().property(5).value());
 
         assertEquals("test_dynamic_model_with_transformer_tokens", config.rankprofile(7).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(7).fef().property(1).name());
@@ -166,7 +166,7 @@ public class RankingExpressionWithOnnxModelTestCase {
         assertEquals("test_unbound_model", config.rankprofile(8).name());
         assertEquals("rankingExpression(my_function).rankingScript", config.rankprofile(8).fef().property(0).name());
         assertEquals("rankingExpression(firstphase).rankingScript", config.rankprofile(8).fef().property(3).name());
-        assertEquals("onnxModel(unbound_model).my_output{d0:0, d1:1}", config.rankprofile(8).fef().property(3).value());
+        assertEquals("onnx(unbound_model).my_output{d0:0, d1:1}", config.rankprofile(8).fef().property(3).value());
 
 
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/ModelEvaluationTest.java
@@ -167,7 +167,7 @@ public class ModelEvaluationTest {
     }
 
     private final String profile =
-            "rankingExpression(output).rankingScript: onnxModel(small_constants_and_functions).output\n" +
+            "rankingExpression(output).rankingScript: onnx(small_constants_and_functions).output\n" +
             "rankingExpression(output).type: tensor<float>(d0[3])\n";
 
     private RankProfilesConfig.Rankprofile.Fef findProfile(String name, RankProfilesConfig config) {

--- a/model-evaluation/src/main/java/ai/vespa/models/evaluation/LazyArrayContext.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/evaluation/LazyArrayContext.java
@@ -258,7 +258,7 @@ public final class LazyArrayContext extends Context implements ContextIndex {
         }
 
         /**
-         * Extract the feature used to evaluate the onnx model. e.g. onnxModel(name) and add
+         * Extract the feature used to evaluate the onnx model. e.g. onnx(name) and add
          * that as a bind target and argument. During evaluation, this will be evaluated before
          * the rest of the expression and the result is added to the context. Also extract the
          * inputs to the model and add them as bind targets and arguments.

--- a/model-integration/src/main/java/ai/vespa/rankingexpression/importer/onnx/OnnxImporter.java
+++ b/model-integration/src/main/java/ai/vespa/rankingexpression/importer/onnx/OnnxImporter.java
@@ -37,7 +37,7 @@ public class OnnxImporter extends ModelImporter {
             for (int i = 0; i < model.getGraph().getOutputCount(); ++i) {
                 Onnx.ValueInfoProto output = model.getGraph().getOutput(i);
                 String outputName = asValidIdentifier(output.getName());
-                importedModel.expression(outputName, "onnxModel(" + modelName + ")." + outputName);
+                importedModel.expression(outputName, "onnx(" + modelName + ")." + outputName);
             }
             return importedModel;
 


### PR DESCRIPTION
Fixes field name of `onnx` rank feature in summary- or matchfeatures to actually be `onnx` rather than `onnxModel` as it is today.