### PR TITLE
Upgrade minor version of icu4j.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -481,7 +481,7 @@
             <dependency>
                 <groupId>com.ibm.icu</groupId>
                 <artifactId>icu4j</artifactId>
-                <version>57.1</version>
+                <version>57.2</version>
             </dependency>
             <dependency>
                 <groupId>com.infradna.tool</groupId>


### PR DESCRIPTION
- Upgrading major beyond 57 breaks container-search:SortingTestCase

57.2 is from Apr-2019, while latest is 70.1 (Oct-2021)

FYI: @arnej27959, @bratseth 
