### PR TITLE
Misc. persistence dynamic throttling cleanup [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/common/dummy_mbus_messages.h
+++ b/storage/src/vespa/storage/common/dummy_mbus_messages.h
@@ -1,4 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
 #include <vespa/messagebus/message.h>
 
 /**

--- a/storage/src/vespa/storage/common/dummy_mbus_messages.h
+++ b/storage/src/vespa/storage/common/dummy_mbus_messages.h
@@ -1,0 +1,39 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include <vespa/messagebus/message.h>
+
+/**
+ * Dummy-implementation of mbus::Message and mbus::Reply to be used when interacting with
+ * MessageBus IThrottlePolicy subclasses, as these expect message instances as parameters.
+ */
+
+namespace storage {
+
+template <typename Base>
+class DummyMbusMessage : public Base {
+    static const mbus::string NAME;
+public:
+    const mbus::string& getProtocol() const override { return NAME; }
+    uint32_t getType() const override { return 0x1badb007; }
+    uint8_t priority() const override { return 255; }
+};
+
+template <typename Base>
+const mbus::string DummyMbusMessage<Base>::NAME = "FooBar";
+
+class DummyMbusRequest final : public DummyMbusMessage<mbus::Message> {
+public:
+    // getApproxSize() returns 1 by default.
+    // Approximate size of messages allowed by throttle policy is implicitly added to
+    // internal StaticThrottlePolicy pending size tracking and associated with the
+    // internal mbus context of the message.
+    // Since we have no connection between the request and reply instances used when
+    // interacting with the policy, we have to make sure they cancel each other out
+    // (i.e. += 0, -= 0).
+    // Not doing this would cause the StaticThrottlePolicy to keep adding a single byte
+    // of pending size for each message allowed by the policy.
+    uint32_t getApproxSize() const override { return 0; }
+};
+
+class DummyMbusReply final : public DummyMbusMessage<mbus::Reply> {};
+
+}

--- a/storage/src/vespa/storage/persistence/shared_operation_throttler.cpp
+++ b/storage/src/vespa/storage/persistence/shared_operation_throttler.cpp
@@ -149,7 +149,8 @@ DynamicOperationThrottler::release_one() noexcept
 {
     std::unique_lock lock(_mutex);
     subtract_one_from_active_window_size();
-    if (_waiting_threads > 0) {
+    // Only wake up a waiting thread if doing so would possibly result in success.
+    if ((_waiting_threads > 0) && has_spare_capacity_in_active_window()) {
         lock.unlock();
         _cond.notify_one();
     }

--- a/storage/src/vespa/storage/persistence/shared_operation_throttler.h
+++ b/storage/src/vespa/storage/persistence/shared_operation_throttler.h
@@ -60,8 +60,9 @@ public:
     // Exposed for unit testing only.
     [[nodiscard]] virtual uint32_t waiting_threads() const noexcept = 0;
 
+    // Creates a throttler that does exactly zero throttling (but also has zero overhead and locking)
     static std::unique_ptr<SharedOperationThrottler> make_unlimited_throttler();
-
+    // Creates a throttler that uses a MessageBus DynamicThrottlePolicy under the hood
     static std::unique_ptr<SharedOperationThrottler> make_dynamic_throttler(uint32_t min_size_and_window_increment);
 private:
     // Exclusively called from a valid Token. Thread safe.


### PR DESCRIPTION
@geirst please review.

Mostly just refactoring/cleanup, but with two changes in semantics:
* Only wake up a thread waiting for a throttle token if the throttle policy will accept the thread once woken up (policy might have shrunk the window size)
* Fix mismatch when counting pending byte size of requests vs responses inside `StaticThrottlePolicy` (transitively used by `DynamicThrottlePolicy`). This has actually been a "bug" in the merge throttler code since day 1, but the pending size value has never been used for anything so it hasn't mattered in practice. Fix the usage in both persistence throttler and merge throttler.