### PR TITLE
Add metrics that offer insight into how throttling affects scheduling

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -190,7 +190,16 @@ FileStorThreadMetrics::~FileStorThreadMetrics() = default;
 
 FileStorStripeMetrics::FileStorStripeMetrics(const std::string& name, const std::string& description)
     : MetricSet(name, {{"partofsum"}}, description),
-      averageQueueWaitingTime("averagequeuewait", {}, "Average time an operation spends in input queue.", this)
+      averageQueueWaitingTime("averagequeuewait", {}, "Average time an operation spends in input queue.", this),
+      throttled_rpc_direct_dispatches("throttled_rpc_direct_dispatches", {},
+                                      "Number of times an RPC thread could not directly dispatch an async operation "
+                                      "directly to Proton because it was disallowed by the throttle policy", this),
+      throttled_persistence_thread_polls("throttled_persistence_thread_polls", {},
+                                         "Number of times a persistence thread could not immediately dispatch a "
+                                         "queued async operation because it was disallowed by the throttle policy", this),
+      timeouts_waiting_for_throttle_token("timeouts_waiting_for_throttle_token", {},
+                                          "Number of times a persistence thread timed out waiting for an available "
+                                          "throttle policy token", this)
 {
 }
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -131,6 +131,9 @@ class FileStorStripeMetrics : public metrics::MetricSet
 public:
     using SP = std::shared_ptr<FileStorStripeMetrics>;
     metrics::DoubleAverageMetric averageQueueWaitingTime;
+    metrics::LongCountMetric throttled_rpc_direct_dispatches;
+    metrics::LongCountMetric throttled_persistence_thread_polls;
+    metrics::LongCountMetric timeouts_waiting_for_throttle_token;
     FileStorStripeMetrics(const std::string& name, const std::string& description);
     ~FileStorStripeMetrics() override;
 };


### PR DESCRIPTION
@baldersheim and @geirst please review

Adds the following stripe-level metrics:
 * `throttled_rpc_direct_dispatches` - number of times an RPC thread
   could not directly dispatch an async operation directly to Proton
   because it was disallowed by the throttle policy.
 * `throttled_persistence_thread_polls` - number of times a persistence
   thread could not immediately dispatch a queued async operation because
   it was disallowed by the throttle policy.
 * `timeouts_waiting_for_throttle_token` - number of times a persistence
   thread timed out waiting for an available throttle policy token.

