### PR TITLE
Bump cache size

### DIFF
--- a/config-provisioning/src/main/resources/configdefinitions/config.provisioning.node-repository.def
+++ b/config-provisioning/src/main/resources/configdefinitions/config.provisioning.node-repository.def
@@ -11,4 +11,4 @@ tenantContainerImage string default=""
 useCuratorClientCache bool default=false
 
 # The number of Node objects to cache in-memory.
-nodeCacheSize long default=2000
+nodeCacheSize long default=3000

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -254,10 +254,10 @@ public class NodeSerializer {
     // ---------------- Deserialization --------------------------------------------------
 
     public Node fromJson(Node.State state, byte[] data) {
-        var key = Hashing.sipHash24().newHasher()
-                         .putString(state.name(), StandardCharsets.UTF_8)
-                         .putBytes(data).hash()
-                         .asLong();
+        long key = Hashing.sipHash24().newHasher()
+                          .putString(state.name(), StandardCharsets.UTF_8)
+                          .putBytes(data).hash()
+                          .asLong();
         try {
             return cache.get(key, () -> nodeFromSlime(state, SlimeUtils.jsonToSlime(data).get()));
         } catch (ExecutionException e) {


### PR DESCRIPTION
Makes all nodes fit in the cache, even in our largest zones. Today excessive
eviction happens because nodes are constantly shuffled in and out of the cache.

@hmusum