### PR TITLE
Use lower timeout

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -217,7 +218,8 @@ public class FileServer {
         return new FileDownloader(configServers.isEmpty()
                                           ? FileDownloader.emptyConnectionPool()
                                           : createConnectionPool(configServers, supervisor),
-                                  supervisor);
+                                  supervisor,
+                                  Duration.ofSeconds(10)); // set this low, to make sure we don't wait a for a long time in this thread
     }
 
     private static ConnectionPool createConnectionPool(List<String> configServers, Supervisor supervisor) {

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -27,7 +27,6 @@ import java.util.logging.Logger;
 public class FileDownloader implements AutoCloseable {
 
     private static final Logger log = Logger.getLogger(FileDownloader.class.getName());
-    private static final Duration defaultTimeout = Duration.ofMinutes(3);
     private static final Duration defaultSleepBetweenRetries = Duration.ofSeconds(5);
     public static final File defaultDownloadDirectory = new File(Defaults.getDefaults().underVespaHome("var/db/vespa/filedistribution"));
 
@@ -37,10 +36,6 @@ public class FileDownloader implements AutoCloseable {
     private final Duration timeout;
     private final FileReferenceDownloader fileReferenceDownloader;
     private final Downloads downloads = new Downloads();
-
-    public FileDownloader(ConnectionPool connectionPool, Supervisor supervisor) {
-        this(connectionPool, supervisor, defaultDownloadDirectory, defaultTimeout, defaultSleepBetweenRetries);
-    }
 
     public FileDownloader(ConnectionPool connectionPool, Supervisor supervisor, Duration timeout) {
         this(connectionPool, supervisor, defaultDownloadDirectory, timeout, defaultSleepBetweenRetries);


### PR DESCRIPTION
If we get a request for a file reference we don't have, try to download
with 10 second timeout and reply with not found otherwise, otherwise
a thread might be busy for a long time and we might end up with all
threads being busy and no requests can be served.

Even if file is not downloaded within 10 seconds, download might have started (in another thread, so won't
be aborted either), so I think this is enough to make sure this is not a wasted effort.