### PR TITLE
use less CPU in retention-enforcer

### DIFF
--- a/config-proxy/src/main/sh/vespa-config-ctl.sh
+++ b/config-proxy/src/main/sh/vespa-config-ctl.sh
@@ -106,7 +106,7 @@ export LD_LIBRARY_PATH="$VESPA_HOME/lib64"
 
 case $1 in
     start)
-        nohup sbin/vespa-retention-enforcer > ${LOGDIR}/vre-start.log 2>&1 </dev/null &
+        nohup nice sbin/vespa-retention-enforcer > ${LOGDIR}/vre-start.log 2>&1 </dev/null &
         configsources=`bin/vespa-print-default configservers_rpc`
         userargs=$VESPA_CONFIGPROXY_JVMARGS
         jvmopts="-Xms32M -Xmx128M -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=256 -XX:MaxJavaStackTraceDepth=1000 -XX:-OmitStackTraceInFastThrow"


### PR DESCRIPTION
* start it with "nice"
* put in "sleep 1" between each processing step, to make it
  less CPU intensive
* avoid doing work which can never be useful, by not looking
  at databases where the earliest possible timestamp is
  not older than the retention limit

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
