### PR TITLE
Use unique node ID from node-repo

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AddNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/AddNode.java
@@ -15,7 +15,7 @@ import java.util.Set;
 public class AddNode {
 
     public final String hostname;
-    public final Optional<String> id;
+    public final String id;
     public final Optional<String> parentHostname;
     public final Optional<String> nodeFlavor;
     public final Optional<FlavorOverrides> flavorOverrides;
@@ -24,15 +24,15 @@ public class AddNode {
     public final Set<String> ipAddresses;
     public final Set<String> additionalIpAddresses;
 
-    public static AddNode forHost(String hostname, Optional<String> id, String nodeFlavor, Optional<FlavorOverrides> flavorOverrides, NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {
+    public static AddNode forHost(String hostname, String id, String nodeFlavor, Optional<FlavorOverrides> flavorOverrides, NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {
         return new AddNode(hostname, id, Optional.empty(), Optional.of(nodeFlavor), flavorOverrides, Optional.empty(), nodeType, ipAddresses, additionalIpAddresses);
     }
 
-    public static AddNode forNode(String hostname, String parentHostname, NodeResources nodeResources, NodeType nodeType, Set<String> ipAddresses) {
-        return new AddNode(hostname, Optional.empty(), Optional.of(parentHostname), Optional.empty(), Optional.empty(), Optional.of(nodeResources), nodeType, ipAddresses, Set.of());
+    public static AddNode forNode(String hostname, String id, String parentHostname, NodeResources nodeResources, NodeType nodeType, Set<String> ipAddresses) {
+        return new AddNode(hostname, id, Optional.of(parentHostname), Optional.empty(), Optional.empty(), Optional.of(nodeResources), nodeType, ipAddresses, Set.of());
     }
 
-    private AddNode(String hostname, Optional<String> id, Optional<String> parentHostname,
+    private AddNode(String hostname, String id, Optional<String> parentHostname,
                     Optional<String> nodeFlavor, Optional<FlavorOverrides> flavorOverrides,
                     Optional<NodeResources> nodeResources,
                     NodeType nodeType, Set<String> ipAddresses, Set<String> additionalIpAddresses) {

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -26,7 +26,7 @@ import static com.yahoo.config.provision.NodeResources.DiskSpeed.slow;
 public class NodeSpec {
 
     private final String hostname;
-    private final Optional<String> id;
+    private final String id;
     private final NodeState state;
     private final NodeType type;
     private final String flavor;
@@ -72,7 +72,7 @@ public class NodeSpec {
 
     public NodeSpec(
             String hostname,
-            Optional<String> id,
+            String id,
             Optional<DockerImage> wantedDockerImage,
             Optional<DockerImage> currentDockerImage,
             NodeState state,
@@ -148,8 +148,8 @@ public class NodeSpec {
         return hostname;
     }
 
-    /** Returns the cloud-specific ID of the host. */
-    public Optional<String> id() {
+    /** Returns unique node ID */
+    public String id() {
         return id;
     }
 
@@ -406,7 +406,7 @@ public class NodeSpec {
 
     public static class Builder {
         private String hostname;
-        private Optional<String> id = Optional.empty();
+        private String id;
         private NodeState state;
         private NodeType type;
         private String flavor;
@@ -441,6 +441,7 @@ public class NodeSpec {
 
         public Builder(NodeSpec node) {
             hostname(node.hostname);
+            id(node.id);
             state(node.state);
             type(node.type);
             flavor(node.flavor);
@@ -477,7 +478,7 @@ public class NodeSpec {
         }
 
         public Builder id(String id) {
-            this.id = Optional.of(id);
+            this.id = id;
             return this;
         }
 
@@ -786,6 +787,7 @@ public class NodeSpec {
          */
         public static Builder testSpec(String hostname, NodeState state) {
             Builder builder = new Builder()
+                    .id(hostname)
                     .hostname(hostname)
                     .state(state)
                     .type(NodeType.tenant)

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -162,7 +162,7 @@ public class RealNodeRepository implements NodeRepository {
 
         return new NodeSpec(
                 node.hostname,
-                Optional.ofNullable(node.id),
+                node.id,
                 Optional.ofNullable(node.wantedDockerImage).map(DockerImage::fromString),
                 Optional.ofNullable(node.currentDockerImage).map(DockerImage::fromString),
                 nodeState,
@@ -244,7 +244,7 @@ public class RealNodeRepository implements NodeRepository {
 
     private static NodeRepositoryNode nodeRepositoryNodeFromAddNode(AddNode addNode) {
         NodeRepositoryNode node = new NodeRepositoryNode();
-        node.id = addNode.id.orElse("fake-" + addNode.hostname);
+        node.id = addNode.id;
         node.hostname = addNode.hostname;
         node.parentHostname = addNode.parentHostname.orElse(null);
         addNode.nodeFlavor.ifPresent(f -> node.flavor = f);

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -79,7 +79,7 @@ public class NodeAdminImpl implements NodeAdmin {
     @Override
     public void refreshContainersToRun(Set<NodeAgentContext> nodeAgentContexts) {
         Map<String, NodeAgentContext> nodeAgentContextsByHostname = nodeAgentContexts.stream()
-                .collect(Collectors.toMap(NodeAdminImpl::nodeAgentId, Function.identity()));
+                .collect(Collectors.toMap(ctx -> ctx.node().id(), Function.identity()));
 
         // Stop and remove NodeAgents that should no longer be running
         diff(nodeAgentWithSchedulerByHostname.keySet(), nodeAgentContextsByHostname.keySet())
@@ -221,15 +221,5 @@ public class NodeAdminImpl implements NodeAdmin {
         NodeAgentContextManager contextManager = new NodeAgentContextManager(clock, context);
         NodeAgent nodeAgent = nodeAgentFactory.create(contextManager, context);
         return new NodeAgentWithScheduler(nodeAgent, contextManager);
-    }
-
-    private static String nodeAgentId(NodeAgentContext nac) {
-        // NodeAgentImpl has some internal state that should not be reused when the same hostname is re-allocated
-        // to a different application/cluster, solve this by including reservation timestamp in the key.
-        return nac.hostname().value() + "-" + nac.node().events().stream()
-                .filter(event -> "reserved".equals(event.type()))
-                .findFirst()
-                .map(event -> Long.toString(event.at().toEpochMilli()))
-                .orElse("");
     }
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -161,20 +161,20 @@ public class RealNodeRepositoryTest {
     @Test
     public void testAddNodes() {
         AddNode host = AddNode.forHost("host123.domain.tld",
-                                       Optional.of("id1"),
+                                       "id1",
                                        "default",
                                        Optional.of(FlavorOverrides.ofDisk(123)),
                                        NodeType.confighost,
                                        Set.of("::1"), Set.of("::2", "::3"));
 
         NodeResources nodeResources = new NodeResources(1, 2, 3, 4, NodeResources.DiskSpeed.slow, NodeResources.StorageType.local);
-        AddNode node = AddNode.forNode("host123-1.domain.tld", "host123.domain.tld", nodeResources, NodeType.config, Set.of("::2", "::3"));
+        AddNode node = AddNode.forNode("host123-1.domain.tld", "id1", "host123.domain.tld", nodeResources, NodeType.config, Set.of("::2", "::3"));
 
         assertFalse(nodeRepositoryApi.getOptionalNode("host123.domain.tld").isPresent());
         nodeRepositoryApi.addNodes(List.of(host, node));
 
         NodeSpec hostSpec = nodeRepositoryApi.getOptionalNode("host123.domain.tld").orElseThrow();
-        assertEquals("id1", hostSpec.id().orElseThrow());
+        assertEquals("id1", hostSpec.id());
         assertEquals("default", hostSpec.flavor());
         assertEquals(123, hostSpec.diskGb(), 0);
         assertEquals(NodeType.confighost, hostSpec.type());


### PR DESCRIPTION
Must be merged with internal PR.

Node-repo started assigning unique IDs to new nodes in #20684. The ID field is always set in node-response, so no need to use `Optional`.