### PR TITLE
Subtract transient resource usage from the absolute usage before repo…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/resource_usage_tracker.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/resource_usage_tracker.cpp
@@ -94,8 +94,13 @@ void
 ResourceUsageTracker::notifyDiskMemUsage(DiskMemUsageState state)
 {
     std::lock_guard guard(_lock);
-    // TODO: Subtract transient resource (memory and disk) usage from the absolute numbers.
-    _resource_usage = ResourceUsage(state.diskState().usage(), state.memoryState().usage(), _resource_usage.get_attribute_address_space_usage());
+    // The transient resource usage is subtracted from the absolute resource usage
+    // before it eventually is reported to the cluster controller (to decide whether to block client feed).
+    // This ensures that the transient resource usage is covered by the resource headroom on the content node,
+    // instead of leading to feed blocked due to natural fluctuations.
+    double adj_disk_usage = std::max(0.0, state.diskState().usage() - state.transient_disk_usage());
+    double adj_memory_usage = std::max(0.0, state.memoryState().usage() - state.transient_memory_usage());
+    _resource_usage = ResourceUsage(adj_disk_usage, adj_memory_usage, _resource_usage.get_attribute_address_space_usage());
     if (_listener != nullptr) {
         _listener->update_resource_usage(_resource_usage);
     }


### PR DESCRIPTION
…rting to the cluster controller.

This ensures that the transient resource usage is covered by the resource headroom on the content node,
instead of leading to feed blocked due to natural fluctuations.

@baldersheim please review
@toregge FYI
