### PR TITLE
update icu4j to latest stable version

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/query/SortingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/SortingTestCase.java
@@ -63,8 +63,8 @@ public class SortingTestCase {
 
     private void requireThatChineseHasCorrectRules(Collator col) {
         final int reorderCodes [] = {UScript.HAN};
-        assertEquals("8.0.0.0", col.getUCAVersion().toString());
-        assertEquals("153.64.29.0", col.getVersion().toString());
+        assertEquals("14.0.0.0", col.getUCAVersion().toString());
+        assertEquals("153.112.40.0", col.getVersion().toString());
         assertEquals(Arrays.toString(reorderCodes), Arrays.toString(col.getReorderCodes()));
 
         assertNotEquals("", ((RuleBasedCollator) col).getRules());

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -474,7 +474,7 @@
             <dependency>
                 <groupId>com.ibm.icu</groupId>
                 <artifactId>icu4j</artifactId>
-                <version>57.2</version>
+                <version>70.1</version>
             </dependency>
             <dependency>
                 <groupId>com.infradna.tool</groupId>


### PR DESCRIPTION
* note: this adds support for newer Unicode versions, so will give
  changed collation for text that use characters that are newly
  added.  For example, Unicode 14 adds three glyphs U+9FFD, U+9FFE,
  and U+9FFF requested by the Macao Special Administrative Region:
  https://appsrv.cse.cuhk.edu.hk/~irg/irg/irg53/IRGN2430R.pdf

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@gv @bratseth FYI
