### PR TITLE
generate "jsonstring" as config value

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/SummaryClassField.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/SummaryClassField.java
@@ -111,11 +111,7 @@ public class SummaryClassField {
         } else if (fval instanceof TensorFieldValue) {
             return Type.TENSOR;
         } else if (fieldType instanceof CollectionDataType) {
-            if (transform != null && transform.equals(SummaryTransform.POSITIONS)) {
-                return Type.XMLSTRING;
-            } else {
-                return Type.JSONSTRING;
-            }
+            return Type.JSONSTRING;
         } else if (fieldType instanceof MapDataType) {
             return Type.JSONSTRING;
         } else if (fieldType instanceof ReferenceDataType) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/CreatePositionZCurve.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/CreatePositionZCurve.java
@@ -65,7 +65,7 @@ public class CreatePositionZCurve extends Processor {
             Collection<String> summaryTo = removeSummaryTo(field);
             ensureCompatibleSummary(field, zName,
                                     PositionDataType.getPositionSummaryFieldName(fieldName),
-                                    DataType.getArray(DataType.STRING), // will become "xmlstring"
+                                    DataType.getArray(DataType.STRING), // will become "jsonstring"
                                     SummaryTransform.POSITIONS, summaryTo, validate);
             ensureCompatibleSummary(field, zName,
                                     PositionDataType.getDistanceSummaryFieldName(fieldName),

--- a/config-model/src/test/derived/advanced/summary.cfg
+++ b/config-model/src/test/derived/advanced/summary.cfg
@@ -1,6 +1,6 @@
-defaultsummaryid 1271952241
+defaultsummaryid 673702455
 usev8geopositions false
-classes[].id 1271952241
+classes[].id 673702455
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "debug"
@@ -14,7 +14,7 @@ classes[].fields[].type "longstring"
 classes[].fields[].name "product3"
 classes[].fields[].type "longstring"
 classes[].fields[].name "location.position"
-classes[].fields[].type "xmlstring"
+classes[].fields[].type "jsonstring"
 classes[].fields[].name "location.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "mysummary"

--- a/config-model/src/test/derived/imported_position_field_summary/summary.cfg
+++ b/config-model/src/test/derived/imported_position_field_summary/summary.cfg
@@ -1,6 +1,6 @@
-defaultsummaryid 1194448774
+defaultsummaryid 1886149151
 usev8geopositions false
-classes[].id 1194448774
+classes[].id 1886149151
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "parent_ref"
@@ -12,12 +12,12 @@ classes[].fields[].type "featuredata"
 classes[].fields[].name "my_pos"
 classes[].fields[].type "jsonstring"
 classes[].fields[].name "my_pos.position"
-classes[].fields[].type "xmlstring"
+classes[].fields[].type "jsonstring"
 classes[].fields[].name "my_pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "documentid"
 classes[].fields[].type "longstring"
-classes[].id 890647799
+classes[].id 939841157
 classes[].name "mysummary"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "my_pos"
@@ -27,7 +27,7 @@ classes[].fields[].type "featuredata"
 classes[].fields[].name "summaryfeatures"
 classes[].fields[].type "featuredata"
 classes[].fields[].name "my_pos.position"
-classes[].fields[].type "xmlstring"
+classes[].fields[].type "jsonstring"
 classes[].fields[].name "my_pos.distance"
 classes[].fields[].type "integer"
 classes[].id 1274088866

--- a/config-model/src/test/derived/position_nosummary/summary.cfg
+++ b/config-model/src/test/derived/position_nosummary/summary.cfg
@@ -1,10 +1,10 @@
-defaultsummaryid 1727020212
+defaultsummaryid 1110900627
 usev8geopositions false
-classes[].id 1727020212
+classes[].id 1110900627
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "pos.position"
-classes[].fields[].type "xmlstring"
+classes[].fields[].type "jsonstring"
 classes[].fields[].name "pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "rankfeatures"

--- a/config-model/src/test/derived/position_summary/summary.cfg
+++ b/config-model/src/test/derived/position_summary/summary.cfg
@@ -1,12 +1,12 @@
-defaultsummaryid 230670304
+defaultsummaryid 1462909474
 usev8geopositions false
-classes[].id 230670304
+classes[].id 1462909474
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "pos"
 classes[].fields[].type "jsonstring"
 classes[].fields[].name "pos.position"
-classes[].fields[].type "xmlstring"
+classes[].fields[].type "jsonstring"
 classes[].fields[].name "pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "rankfeatures"


### PR DESCRIPTION
* the backend will in any case treat "xmlstring" and "jsonstring"
  as meaning "structured data", but let us get rid of this remnant
  from when we put XML data in a summary field.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havardpe  please review
