### PR TITLE
Remove merge performance flags that are no longer needed.

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -88,7 +88,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxUnCommittedMemory() { return 130000; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxConcurrentMergesPerNode() { return 16; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default int maxMergeQueueSize() { return 100; }
-        @ModelFeatureFlag(owners = {"vekterli", "geirst"}) default boolean ignoreMergeQueueLimit() { return true; }
+        @ModelFeatureFlag(owners = {"vekterli", "geirst"}, removeAfter = "7.528.3") default boolean ignoreMergeQueueLimit() { return true; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default boolean containerDumpHeapOnShutdownTimeout() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}) default double containerShutdownTimeout() { throw new UnsupportedOperationException("TODO specify default value"); }
         @ModelFeatureFlag(owners = {"baldersheim"}, removeAfter = "7.527") default double diskBloatFactor() { return 0.25; }
@@ -100,10 +100,10 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitDisk() { return 0.8; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitMemory() { return 0.8; }
         @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default double minNodeRatioPerGroup() { return 0.0; }
-        @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default int distributorMergeBusyWait() { return 1; }
-        @ModelFeatureFlag(owners = {"vekterli", "geirst"}) default boolean distributorEnhancedMaintenanceScheduling() { return true; }
+        @ModelFeatureFlag(owners = {"geirst", "vekterli"}, removeAfter = "7.528.3") default int distributorMergeBusyWait() { return 1; }
+        @ModelFeatureFlag(owners = {"vekterli", "geirst"}, removeAfter = "7.528.3") default boolean distributorEnhancedMaintenanceScheduling() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean forwardIssuesAsErrors() { return true; }
-        @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default boolean asyncApplyBucketDiff() { return true; }
+        @ModelFeatureFlag(owners = {"geirst", "vekterli"}, removeAfter = "7.528.3") default boolean asyncApplyBucketDiff() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean ignoreThreadStackSizes() { return false; }
         @ModelFeatureFlag(owners = {"vekterli", "geirst"}) default boolean unorderedMergeChaining() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean useV8GeoPositions() { return false; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -58,7 +58,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private String jvmOmitStackTraceInFastThrowOption;
     private int maxConcurrentMergesPerNode = 16;
     private int maxMergeQueueSize = 100;
-    private boolean ignoreMergeQueueLimit = true;
     private boolean allowDisableMtls = true;
     private List<X509Certificate> operatorCertificates = Collections.emptyList();
     private double resourceLimitDisk = 0.8;
@@ -66,10 +65,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private double minNodeRatioPerGroup = 0.0;
     private boolean containerDumpHeapOnShutdownTimeout = false;
     private double containerShutdownTimeout = 50.0;
-    private int distributorMergeBusyWait = 1;
     private int maxUnCommittedMemory = 123456;
-    private boolean distributorEnhancedMaintenanceScheduling = true;
-    private boolean asyncApplyBucketDiff = true;
     private boolean unorderedMergeChaining = true;
     private List<String> zoneDnsSuffixes = List.of();
     private int maxCompactBuffers = 1;
@@ -114,16 +110,12 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public List<X509Certificate> operatorCertificates() { return operatorCertificates; }
     @Override public int maxConcurrentMergesPerNode() { return maxConcurrentMergesPerNode; }
     @Override public int maxMergeQueueSize() { return maxMergeQueueSize; }
-    @Override public boolean ignoreMergeQueueLimit() { return ignoreMergeQueueLimit; }
     @Override public double resourceLimitDisk() { return resourceLimitDisk; }
     @Override public double resourceLimitMemory() { return resourceLimitMemory; }
     @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
     @Override public double containerShutdownTimeout() { return containerShutdownTimeout; }
     @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }
-    @Override public int distributorMergeBusyWait() { return distributorMergeBusyWait; }
-    @Override public boolean distributorEnhancedMaintenanceScheduling() { return distributorEnhancedMaintenanceScheduling; }
     @Override public int maxUnCommittedMemory() { return maxUnCommittedMemory; }
-    @Override public boolean asyncApplyBucketDiff() { return asyncApplyBucketDiff; }
     @Override public boolean unorderedMergeChaining() { return unorderedMergeChaining; }
     @Override public List<String> zoneDnsSuffixes() { return zoneDnsSuffixes; }
     @Override public int maxCompactBuffers() { return maxCompactBuffers; }
@@ -193,11 +185,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     }
     public TestProperties setMaxMergeQueueSize(int maxMergeQueueSize) {
         this.maxMergeQueueSize = maxMergeQueueSize;
-        return this;
-    }
-
-    public TestProperties setIgnoreMergeQueueLimit(boolean ignoreMergeQueueLimit) {
-        this.ignoreMergeQueueLimit = ignoreMergeQueueLimit;
         return this;
     }
 
@@ -298,21 +285,6 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setMinNodeRatioPerGroup(double value) {
         this.minNodeRatioPerGroup = value;
-        return this;
-    }
-
-    public TestProperties setDistributorMergeBusyWait(int value) {
-        distributorMergeBusyWait = value;
-        return this;
-    }
-
-    public TestProperties distributorEnhancedMaintenanceScheduling(boolean enhancedScheduling) {
-        distributorEnhancedMaintenanceScheduling = enhancedScheduling;
-        return this;
-    }
-
-    public TestProperties setAsyncApplyBucketDiff(boolean value) {
-        asyncApplyBucketDiff = value;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -42,8 +42,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
     private final boolean hasIndexedDocumentType;
     private final boolean useThreePhaseUpdates;
     private final int maxActivationInhibitedOutOfSyncGroups;
-    private final int mergeBusyWait;
-    private final boolean enhancedMaintenanceScheduling;
     private final boolean unorderedMergeChaining;
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<DistributorCluster> {
@@ -107,16 +105,12 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
             final boolean hasIndexedDocumentType = clusterContainsIndexedDocumentType(documentsNode);
             boolean useThreePhaseUpdates = deployState.getProperties().featureFlags().useThreePhaseUpdates();
             int maxInhibitedGroups = deployState.getProperties().featureFlags().maxActivationInhibitedOutOfSyncGroups();
-            int mergeBusyWait = deployState.getProperties().featureFlags().distributorMergeBusyWait();
-            boolean useEnhancedMaintenanceScheduling = deployState.getProperties().featureFlags().distributorEnhancedMaintenanceScheduling();
             boolean unorderedMergeChaining = deployState.getProperties().featureFlags().unorderedMergeChaining();
 
             return new DistributorCluster(parent,
                     new BucketSplitting.Builder().build(new ModelElement(producerSpec)), gc,
                     hasIndexedDocumentType, useThreePhaseUpdates,
-                    maxInhibitedGroups, mergeBusyWait,
-                    useEnhancedMaintenanceScheduling,
-                    unorderedMergeChaining);
+                    maxInhibitedGroups, unorderedMergeChaining);
         }
     }
 
@@ -124,8 +118,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
                                GcOptions gc, boolean hasIndexedDocumentType,
                                boolean useThreePhaseUpdates,
                                int maxActivationInhibitedOutOfSyncGroups,
-                               int mergeBusyWait,
-                               boolean enhancedMaintenanceScheduling,
                                boolean unorderedMergeChaining)
     {
         super(parent, "distributor");
@@ -135,8 +127,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
         this.hasIndexedDocumentType = hasIndexedDocumentType;
         this.useThreePhaseUpdates = useThreePhaseUpdates;
         this.maxActivationInhibitedOutOfSyncGroups = maxActivationInhibitedOutOfSyncGroups;
-        this.mergeBusyWait = mergeBusyWait;
-        this.enhancedMaintenanceScheduling = enhancedMaintenanceScheduling;
         this.unorderedMergeChaining = unorderedMergeChaining;
     }
 
@@ -151,8 +141,6 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
         builder.disable_bucket_activation(hasIndexedDocumentType == false);
         builder.enable_metadata_only_fetch_phase_for_inconsistent_updates(useThreePhaseUpdates);
         builder.max_activation_inhibited_out_of_sync_groups(maxActivationInhibitedOutOfSyncGroups);
-        builder.inhibit_merge_sending_on_busy_node_duration_sec(mergeBusyWait);
-        builder.implicitly_clear_bucket_priority_on_schedule(enhancedMaintenanceScheduling);
         builder.use_unordered_merge_chaining(unorderedMergeChaining);
 
         bucketSplitting.getConfig(builder);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/FileStorProducer.java
@@ -48,7 +48,6 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
     private final StorFilestorConfig.Response_sequencer_type.Enum responseSequencerType;
     private final StorFilestorConfig.Async_operation_throttler_type.Enum asyncOperationThrottlerType;
     private final boolean useAsyncMessageHandlingOnSchedule;
-    private final boolean asyncApplyBucketDiff;
 
     private static StorFilestorConfig.Response_sequencer_type.Enum convertResponseSequencerType(String sequencerType) {
         try {
@@ -73,7 +72,6 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
         this.responseSequencerType = convertResponseSequencerType(featureFlags.responseSequencerType());
         this.asyncOperationThrottlerType = toAsyncOperationThrottlerType(featureFlags.persistenceAsyncThrottling());
         useAsyncMessageHandlingOnSchedule = featureFlags.useAsyncMessageHandlingOnSchedule();
-        asyncApplyBucketDiff = featureFlags.asyncApplyBucketDiff();
     }
 
     @Override
@@ -85,7 +83,6 @@ public class FileStorProducer implements StorFilestorConfig.Producer {
         builder.num_response_threads(reponseNumThreads);
         builder.response_sequencer_type(responseSequencerType);
         builder.use_async_message_handling_on_schedule(useAsyncMessageHandlingOnSchedule);
-        builder.async_apply_bucket_diff(asyncApplyBucketDiff);
         builder.async_operation_throttler_type(asyncOperationThrottlerType);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorServerProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorServerProducer.java
@@ -32,7 +32,6 @@ public class StorServerProducer implements StorServerConfig.Producer {
     private Integer maxMergesPerNode;
     private Integer queueSize;
     private Integer bucketDBStripeBits;
-    private Boolean ignoreMergeQueueLimit;
 
     private StorServerProducer setMaxMergesPerNode(Integer value) {
         if (value != null) {
@@ -55,7 +54,6 @@ public class StorServerProducer implements StorServerConfig.Producer {
         this.clusterName = clusterName;
         maxMergesPerNode = featureFlags.maxConcurrentMergesPerNode();
         queueSize = featureFlags.maxMergeQueueSize();
-        ignoreMergeQueueLimit = featureFlags.ignoreMergeQueueLimit();
     }
 
     @Override
@@ -74,9 +72,6 @@ public class StorServerProducer implements StorServerConfig.Producer {
         }
         if (bucketDBStripeBits != null) {
             builder.content_node_bucket_db_stripe_bits(bucketDBStripeBits);
-        }
-        if (ignoreMergeQueueLimit != null) {
-            builder.disable_queue_limits_for_chained_merges(ignoreMergeQueueLimit);
         }
     }
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1120,40 +1120,6 @@ public class ContentClusterTest extends ContentBaseTest {
     }
 
     @Test
-    public void distributor_merge_busy_wait_controlled_by_properties() throws Exception {
-        assertEquals(1, resolveDistributorMergeBusyWaitConfig(Optional.empty()));
-        assertEquals(5, resolveDistributorMergeBusyWaitConfig(Optional.of(5)));
-    }
-
-    private int resolveDistributorMergeBusyWaitConfig(Optional<Integer> mergeBusyWait) throws Exception {
-        var props = new TestProperties();
-        if (mergeBusyWait.isPresent()) {
-            props.setDistributorMergeBusyWait(mergeBusyWait.get());
-        }
-        var cluster = createOneNodeCluster(props);
-        var builder = new StorDistributormanagerConfig.Builder();
-        cluster.getDistributorNodes().getConfig(builder);
-        return (new StorDistributormanagerConfig(builder)).inhibit_merge_sending_on_busy_node_duration_sec();
-    }
-
-    @Test
-    public void distributor_enhanced_maintenance_scheduling_controlled_by_properties() throws Exception {
-        assertFalse(resolveDistributorEnhancedSchedulingConfig(Optional.of(false)));
-        assertTrue(resolveDistributorEnhancedSchedulingConfig(Optional.empty()));
-    }
-
-    private boolean resolveDistributorEnhancedSchedulingConfig(Optional<Boolean> enhancedScheduling) throws Exception {
-        var props = new TestProperties();
-        if (enhancedScheduling.isPresent()) {
-            props.distributorEnhancedMaintenanceScheduling(enhancedScheduling.get());
-        }
-        var cluster = createOneNodeCluster(props);
-        var builder = new StorDistributormanagerConfig.Builder();
-        cluster.getDistributorNodes().getConfig(builder);
-        return (new StorDistributormanagerConfig(builder)).implicitly_clear_bucket_priority_on_schedule();
-    }
-
-    @Test
     public void unordered_merge_chaining_config_controlled_by_properties() throws Exception {
         assertFalse(resolveUnorderedMergeChainingConfig(Optional.of(false)));
         assertTrue(resolveUnorderedMergeChainingConfig(Optional.empty()));

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
@@ -160,24 +160,6 @@ public class StorageClusterTest {
     }
 
     @Test
-    public void ignore_merge_queue_limit_can_be_controlled_by_feature_flag() {
-        var config = configFromProperties(new TestProperties().setIgnoreMergeQueueLimit(true));
-        assertTrue(config.disable_queue_limits_for_chained_merges());
-
-        config = configFromProperties(new TestProperties().setIgnoreMergeQueueLimit(false));
-        assertFalse(config.disable_queue_limits_for_chained_merges());
-    }
-
-    @Test
-    public void async_apply_bucket_diff_can_be_controlled_by_feature_flag() {
-        var config = filestorConfigFromProperties(new TestProperties());
-        assertTrue(config.async_apply_bucket_diff());
-
-        config = filestorConfigFromProperties(new TestProperties().setAsyncApplyBucketDiff(false));
-        assertFalse(config.async_apply_bucket_diff());
-    }
-
-    @Test
     public void testVisitors() {
         StorVisitorConfig.Builder builder = new StorVisitorConfig.Builder();
         parse(cluster("bees",

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -183,18 +183,14 @@ public class ModelContextImpl implements ModelContext {
         private final ToIntFunction<ClusterSpec.Type> jvmOmitStackTraceInFastThrow;
         private final int maxConcurrentMergesPerContentNode;
         private final int maxMergeQueueSize;
-        private final boolean ignoreMergeQueueLimit;
         private final double resourceLimitDisk;
         private final double resourceLimitMemory;
         private final double minNodeRatioPerGroup;
         private final int metricsproxyNumThreads;
         private final boolean containerDumpHeapOnShutdownTimeout;
         private final double containerShutdownTimeout;
-        private final int distributorMergeBusyWait;
-        private final boolean distributorEnhancedMaintenanceScheduling;
         private final int maxUnCommittedMemory;
         private final boolean forwardIssuesAsErrors;
-        private final boolean asyncApplyBucketDiff;
         private final boolean ignoreThreadStackSizes;
         private final boolean unorderedMergeChaining;
         private final boolean useV8GeoPositions;
@@ -225,18 +221,14 @@ public class ModelContextImpl implements ModelContext {
             this.jvmOmitStackTraceInFastThrow = type -> flagValueAsInt(source, appId, type, PermanentFlags.JVM_OMIT_STACK_TRACE_IN_FAST_THROW);
             this.maxConcurrentMergesPerContentNode = flagValue(source, appId, Flags.MAX_CONCURRENT_MERGES_PER_NODE);
             this.maxMergeQueueSize = flagValue(source, appId, Flags.MAX_MERGE_QUEUE_SIZE);
-            this.ignoreMergeQueueLimit = flagValue(source, appId, Flags.IGNORE_MERGE_QUEUE_LIMIT);
             this.resourceLimitDisk = flagValue(source, appId, PermanentFlags.RESOURCE_LIMIT_DISK);
             this.resourceLimitMemory = flagValue(source, appId, PermanentFlags.RESOURCE_LIMIT_MEMORY);
             this.minNodeRatioPerGroup = flagValue(source, appId, Flags.MIN_NODE_RATIO_PER_GROUP);
             this.metricsproxyNumThreads = flagValue(source, appId, Flags.METRICSPROXY_NUM_THREADS);
             this.containerDumpHeapOnShutdownTimeout = flagValue(source, appId, Flags.CONTAINER_DUMP_HEAP_ON_SHUTDOWN_TIMEOUT);
             this.containerShutdownTimeout = flagValue(source, appId,Flags.CONTAINER_SHUTDOWN_TIMEOUT);
-            this.distributorMergeBusyWait = flagValue(source, appId, Flags.DISTRIBUTOR_MERGE_BUSY_WAIT);
-            this.distributorEnhancedMaintenanceScheduling = flagValue(source, appId, Flags.DISTRIBUTOR_ENHANCED_MAINTENANCE_SCHEDULING);
             this.maxUnCommittedMemory = flagValue(source, appId, Flags.MAX_UNCOMMITTED_MEMORY);;
             this.forwardIssuesAsErrors = flagValue(source, appId, PermanentFlags.FORWARD_ISSUES_AS_ERRORS);
-            this.asyncApplyBucketDiff = flagValue(source, appId, Flags.ASYNC_APPLY_BUCKET_DIFF);
             this.ignoreThreadStackSizes = flagValue(source, appId, Flags.IGNORE_THREAD_STACK_SIZES);
             this.unorderedMergeChaining = flagValue(source, appId, Flags.UNORDERED_MERGE_CHAINING);
             this.useV8GeoPositions = flagValue(source, appId, Flags.USE_V8_GEO_POSITIONS);
@@ -269,18 +261,14 @@ public class ModelContextImpl implements ModelContext {
         }
         @Override public int maxConcurrentMergesPerNode() { return maxConcurrentMergesPerContentNode; }
         @Override public int maxMergeQueueSize() { return maxMergeQueueSize; }
-        @Override public boolean ignoreMergeQueueLimit() { return ignoreMergeQueueLimit; }
         @Override public double resourceLimitDisk() { return resourceLimitDisk; }
         @Override public double resourceLimitMemory() { return resourceLimitMemory; }
         @Override public double minNodeRatioPerGroup() { return minNodeRatioPerGroup; }
         @Override public int defaultPoolNumThreads() { return metricsproxyNumThreads; }
         @Override public double containerShutdownTimeout() { return containerShutdownTimeout; }
         @Override public boolean containerDumpHeapOnShutdownTimeout() { return containerDumpHeapOnShutdownTimeout; }
-        @Override public int distributorMergeBusyWait() { return distributorMergeBusyWait; }
-        @Override public boolean distributorEnhancedMaintenanceScheduling() { return distributorEnhancedMaintenanceScheduling; }
         @Override public int maxUnCommittedMemory() { return maxUnCommittedMemory; }
         @Override public boolean forwardIssuesAsErrors() { return forwardIssuesAsErrors; }
-        @Override public boolean asyncApplyBucketDiff() { return asyncApplyBucketDiff; }
         @Override public boolean ignoreThreadStackSizes() { return ignoreThreadStackSizes; }
         @Override public boolean unorderedMergeChaining() { return unorderedMergeChaining; }
         @Override public boolean useV8GeoPositions() { return useV8GeoPositions; }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -208,14 +208,6 @@ public class Flags {
             "Takes effect at redeploy",
             ZONE_ID, APPLICATION_ID);
 
-    public static final UnboundBooleanFlag IGNORE_MERGE_QUEUE_LIMIT = defineFeatureFlag(
-            "ignore-merge-queue-limit", true,
-            List.of("vekterli", "geirst"), "2021-10-06", "2022-03-01",
-            "Specifies if merges that are forwarded (chained) from another content node are always " +
-                    "allowed to be enqueued even if the queue is otherwise full.",
-            "Takes effect at redeploy",
-            ZONE_ID, APPLICATION_ID);
-
     public static final UnboundDoubleFlag MIN_NODE_RATIO_PER_GROUP = defineDoubleFlag(
             "min-node-ratio-per-group", 0.0,
             List.of("geirst", "vekterli"), "2021-07-16", "2022-03-01",
@@ -276,28 +268,6 @@ public class Flags {
             "Takes effect on subsequent maintainer invocation",
             TENANT_ID
     );
-
-    public static final UnboundIntFlag DISTRIBUTOR_MERGE_BUSY_WAIT = defineIntFlag(
-            "distributor-merge-busy-wait", 1,
-            List.of("geirst", "vekterli"), "2021-10-04", "2022-03-01",
-            "Number of seconds that scheduling of new merge operations in the distributor should be inhibited " +
-                    "towards a content node that has indicated merge busy",
-            "Takes effect at redeploy",
-            ZONE_ID, APPLICATION_ID);
-
-    public static final UnboundBooleanFlag DISTRIBUTOR_ENHANCED_MAINTENANCE_SCHEDULING = defineFeatureFlag(
-            "distributor-enhanced-maintenance-scheduling", true,
-            List.of("vekterli", "geirst"), "2021-10-14", "2022-01-31",
-            "Enable enhanced maintenance operation scheduling semantics on the distributor",
-            "Takes effect at redeploy",
-            ZONE_ID, APPLICATION_ID);
-
-    public static final UnboundBooleanFlag ASYNC_APPLY_BUCKET_DIFF = defineFeatureFlag(
-            "async-apply-bucket-diff", true,
-            List.of("geirst", "vekterli"), "2021-10-22", "2022-01-31",
-            "Whether portions of apply bucket diff handling will be performed asynchronously",
-            "Takes effect at redeploy",
-            ZONE_ID, APPLICATION_ID);
 
     public static final UnboundBooleanFlag UNORDERED_MERGE_CHAINING = defineFeatureFlag(
             "unordered-merge-chaining", true,


### PR DESCRIPTION
The functions in ModelContext.java can be removed when applications are on 7.528.3.

@baldersheim please review