### PR TITLE
Deprecate logging request handler [run-systemtest]

### DIFF
--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/IdentityProviderRequestHandler.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/athenz/instanceproviderservice/IdentityProviderRequestHandler.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.inject.Inject;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiException;
 import com.yahoo.restapi.RestApiRequestHandler;
@@ -27,7 +27,7 @@ public class IdentityProviderRequestHandler extends RestApiRequestHandler<Identi
     private final InstanceValidator instanceValidator;
 
     @Inject
-    public IdentityProviderRequestHandler(LoggingRequestHandler.Context context,
+    public IdentityProviderRequestHandler(ThreadedHttpRequestHandler.Context context,
                                           IdentityDocumentGenerator documentGenerator,
                                           InstanceValidator instanceValidator) {
         super(context, IdentityProviderRequestHandler::createRestApi);

--- a/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/ca/restapi/CertificateAuthorityApiHandler.java
+++ b/athenz-identity-provider-service/src/main/java/com/yahoo/vespa/hosted/ca/restapi/CertificateAuthorityApiHandler.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.hosted.ca.restapi;
 import com.google.inject.Inject;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.jdisc.secretstore.SecretStore;
 import com.yahoo.jdisc.http.server.jetty.RequestUtils;
 
@@ -50,7 +50,7 @@ import java.util.stream.Stream;
  *
  * @author mpolden
  */
-public class CertificateAuthorityApiHandler extends LoggingRequestHandler {
+public class CertificateAuthorityApiHandler extends ThreadedHttpRequestHandler {
 
     private final SecretStore secretStore;
     private final Certificates certificates;

--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apputil/communication/http/JDiscHttpRequestHandler.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apputil/communication/http/JDiscHttpRequestHandler.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.apputil.communication.http;
 
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.HeaderFields;
 import com.yahoo.jdisc.Response;
 import com.yahoo.jdisc.handler.CompletionHandler;
@@ -22,12 +22,12 @@ import java.util.logging.Logger;
  * @author Harald Musum
  * @author Vegard Sjonfjell
  */
-public class JDiscHttpRequestHandler extends LoggingRequestHandler {
+public class JDiscHttpRequestHandler extends ThreadedHttpRequestHandler {
 
     private static final Logger log = Logger.getLogger(JDiscHttpRequestHandler.class.getName());
     private final HttpRequestHandler requestHandler;
 
-    public JDiscHttpRequestHandler(HttpRequestHandler handler, LoggingRequestHandler.Context parentCtx) {
+    public JDiscHttpRequestHandler(HttpRequestHandler handler, ThreadedHttpRequestHandler.Context parentCtx) {
         super(parentCtx);
         this.requestHandler = handler;
     }

--- a/clustercontroller-apps/src/test/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StateRestApiV2HandlerTest.java
+++ b/clustercontroller-apps/src/test/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StateRestApiV2HandlerTest.java
@@ -18,7 +18,7 @@ public class StateRestApiV2HandlerTest {
         ClusterInfoConfig config = new ClusterInfoConfig(
                 new ClusterInfoConfig.Builder().clusterId("cluster-id").nodeCount(1));
         ClusterInfoConfig.Builder clusterConfig = new ClusterInfoConfig.Builder();
-        new StateRestApiV2Handler(controller, config, StateRestApiV2Handler.testOnlyContext());
+        new StateRestApiV2Handler(controller, config, StateRestApiV2Handler.testContext());
     }
 
     @Test

--- a/clustercontroller-apps/src/test/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StatusHandlerTest.java
+++ b/clustercontroller-apps/src/test/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/StatusHandlerTest.java
@@ -8,7 +8,7 @@ public class StatusHandlerTest {
     @Test
     public void testSimple() {
         ClusterController controller = new ClusterController();
-        StatusHandler handler = new StatusHandler(controller, StatusHandler.testOnlyContext());
+        StatusHandler handler = new StatusHandler(controller, StatusHandler.testContext());
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -171,8 +171,9 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         addCommonVespaBundles();
 
-        // TODO Vespa 8: remove LoggingRequestHandler.Context (replaced by ThreadedHttpRequestHandler.Context)
-        addSimpleComponent(com.yahoo.container.jdisc.LoggingRequestHandler.Context.class);
+        // TODO Vespa 8: remove LoggingRequestHandler.Context component if we can break binary compatibility
+        //               (ThreadedHttpRequestHandler.Context is source compatible.)
+        addSimpleComponent("com.yahoo.container.jdisc.LoggingRequestHandler$Context");
 
         addComponent(new StatisticsComponent());
         addSimpleComponent(AccessLog.class);

--- a/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/http/FlagsHandler.java
+++ b/configserver-flags/src/main/java/com/yahoo/vespa/configserver/flags/http/FlagsHandler.java
@@ -4,8 +4,7 @@ package com.yahoo.vespa.configserver.flags.http;
 import com.google.inject.Inject;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
-import java.util.logging.Level;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
 import com.yahoo.vespa.configserver.flags.FlagsDb;
@@ -18,18 +17,19 @@ import com.yahoo.yolean.Exceptions;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.util.Objects;
+import java.util.logging.Level;
 
 /**
  * Handles /flags/v1 requests
  *
  * @author hakonhall
  */
-public class FlagsHandler extends LoggingRequestHandler {
+public class FlagsHandler extends ThreadedHttpRequestHandler {
 
     private final FlagsDb flagsDb;
 
     @Inject
-    public FlagsHandler(LoggingRequestHandler.Context context, FlagsDb flagsDb) {
+    public FlagsHandler(ThreadedHttpRequestHandler.Context context, FlagsDb flagsDb) {
         super(context);
         this.flagsDb = flagsDb;
     }

--- a/configserver-flags/src/test/java/com/yahoo/vespa/configserver/flags/http/FlagsHandlerTest.java
+++ b/configserver-flags/src/test/java/com/yahoo/vespa/configserver/flags/http/FlagsHandlerTest.java
@@ -41,7 +41,7 @@ public class FlagsHandlerTest {
     private static final String FLAGS_V1_URL = "https://foo.com:4443/flags/v1";
 
     private final FlagsDb flagsDb = new FlagsDbImpl(new MockCurator());
-    private final FlagsHandler handler = new FlagsHandler(FlagsHandler.testOnlyContext(), flagsDb);
+    private final FlagsHandler handler = new FlagsHandler(FlagsHandler.testContext(), flagsDb);
 
     @Test
     public void testV1() {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/HttpHandler.java
@@ -9,8 +9,8 @@ import com.yahoo.config.provision.exception.ActivationConflictException;
 import com.yahoo.config.provision.exception.LoadBalancerServiceException;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
 import com.yahoo.vespa.config.server.application.ConfigNotConvergedException;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.yolean.Exceptions;
 
 import java.io.PrintWriter;
@@ -25,7 +25,7 @@ import java.util.logging.Level;
  *
  * @author hmusum
  */
-public class HttpHandler extends LoggingRequestHandler {
+public class HttpHandler extends ThreadedHttpRequestHandler {
 
     public HttpHandler(HttpHandler.Context ctx) {
         super(ctx);

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.serviceview;
 
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiRequestHandler;
 import com.yahoo.restapi.UriBuilder;
@@ -57,7 +57,7 @@ public class StateRequestHandler extends RestApiRequestHandler<StateRequestHandl
     }
 
     @Inject
-    public StateRequestHandler(LoggingRequestHandler.Context context,
+    public StateRequestHandler(ThreadedHttpRequestHandler.Context context,
                                ConfigserverConfig configserverConfig) {
         super(context, StateRequestHandler::createRestApiDefinition);
         this.restApiPort = configserverConfig.httpport();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpGetConfigHandlerTest.java
@@ -63,7 +63,7 @@ public class HttpGetConfigHandlerTest {
                 .withOrchestrator(new OrchestratorMock())
                 .withConfigserverConfig(configserverConfig)
                 .build();
-        handler = new HttpGetConfigHandler(HttpGetConfigHandler.testOnlyContext(), tenantRepository);
+        handler = new HttpGetConfigHandler(HttpGetConfigHandler.testContext(), tenantRepository);
         applicationRepository.deploy(testApp, prepareParams());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpHandlerTest.java
@@ -45,7 +45,7 @@ public class HttpHandlerTest {
     private static class HttpTestHandler extends HttpHandler {
         private final RuntimeException exception;
         HttpTestHandler(RuntimeException exception) {
-            super(HttpHandler.testOnlyContext());
+            super(HttpHandler.testContext());
             this.exception = exception;
         }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/HttpListConfigsHandlerTest.java
@@ -70,7 +70,7 @@ public class HttpListConfigsHandlerTest {
                 .build();
         applicationRepository.deploy(testApp, prepareParams());
 
-        HttpListConfigsHandler.Context ctx = HttpListConfigsHandler.testOnlyContext();
+        HttpListConfigsHandler.Context ctx = HttpListConfigsHandler.testContext();
         handler = new HttpListConfigsHandler(ctx, tenantRepository);
         namedHandler = new HttpListNamedConfigsHandler(ctx, tenantRepository);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/status/StatusHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/status/StatusHandlerTest.java
@@ -29,7 +29,7 @@ public class StatusHandlerTest {
     public void require_that_handler_works() throws IOException {
         ModelFactoryRegistry modelFactoryRegistry = new ModelFactoryRegistry(List.of(new VespaModelFactory(new NullConfigModelRegistry())));
         ConfigserverConfig configserverConfig = new ConfigserverConfig.Builder().build();
-        StatusHandler handler = new StatusHandler(StatusHandler.testOnlyContext(), modelFactoryRegistry, configserverConfig);
+        StatusHandler handler = new StatusHandler(StatusHandler.testContext(), modelFactoryRegistry, configserverConfig);
 
         HttpResponse response = handler.handle(HttpRequest.createTestRequest("/status", GET));
         JsonNode jsonNode = mapper.readTree(SessionHandlerTest.getRenderedString(response));

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationContentHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationContentHandlerTest.java
@@ -69,7 +69,7 @@ public class ApplicationContentHandlerTest extends ContentHandlerTestBase {
                 .build();
 
         applicationRepository.deploy(testApp, prepareParams(appId1));
-        handler = new ApplicationHandler(ApplicationHandler.testOnlyContext(),
+        handler = new ApplicationHandler(ApplicationHandler.testContext(),
                                          Zone.defaultZone(),
                                          applicationRepository);
         pathPrefix = createPath(appId1, Zone.defaultZone());

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandlerTest.java
@@ -756,7 +756,7 @@ public class ApplicationHandlerTest {
                           "/environment/" + zone.environment().value() +
                           "/region/" + zone.region().value() +
                           "/instance/" + applicationId.instance().value() + "\"]";
-        ListApplicationsHandler listApplicationsHandler = new ListApplicationsHandler(ListApplicationsHandler.testOnlyContext(),
+        ListApplicationsHandler listApplicationsHandler = new ListApplicationsHandler(ListApplicationsHandler.testContext(),
                                                                                       tenantRepository,
                                                                                       Zone.defaultZone());
         ListApplicationsHandlerTest.assertResponse(listApplicationsHandler,
@@ -808,7 +808,7 @@ public class ApplicationHandlerTest {
     }
 
     private ApplicationHandler createApplicationHandler(ApplicationRepository applicationRepository) {
-        return new ApplicationHandler(ApplicationHandler.testOnlyContext(), Zone.defaultZone(), applicationRepository);
+        return new ApplicationHandler(ApplicationHandler.testContext(), Zone.defaultZone(), applicationRepository);
     }
 
     private PrepareParams prepareParams(ApplicationId applicationId) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HostHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HostHandlerTest.java
@@ -62,7 +62,7 @@ public class HostHandlerTest {
                 .withOrchestrator(new OrchestratorMock())
                 .withConfigserverConfig(configserverConfig)
                 .build();
-        handler = new HostHandler(HostHandler.testOnlyContext(), applicationRepository);
+        handler = new HostHandler(HostHandler.testContext(), applicationRepository);
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpGetConfigHandlerTest.java
@@ -72,7 +72,7 @@ public class HttpGetConfigHandlerTest {
                 .withOrchestrator(new OrchestratorMock())
                 .withConfigserverConfig(configserverConfig)
                 .build();
-        handler = new HttpGetConfigHandler(HttpGetConfigHandler.testOnlyContext(), tenantRepository);
+        handler = new HttpGetConfigHandler(HttpGetConfigHandler.testContext(), tenantRepository);
         applicationRepository.deploy(testApp, prepareParams());
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/HttpListConfigsHandlerTest.java
@@ -76,10 +76,10 @@ public class HttpListConfigsHandlerTest {
                 .withConfigserverConfig(configserverConfig)
                 .build();
         applicationRepository.deploy(testApp, prepareParams());
-        handler = new HttpListConfigsHandler(HttpListConfigsHandler.testOnlyContext(),
+        handler = new HttpListConfigsHandler(HttpListConfigsHandler.testContext(),
                                              tenantRepository,
                                              Zone.defaultZone());
-        namedHandler = new HttpListNamedConfigsHandler(HttpListConfigsHandler.testOnlyContext(),
+        namedHandler = new HttpListNamedConfigsHandler(HttpListConfigsHandler.testContext(),
                                                        tenantRepository,
                                                        Zone.defaultZone());
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/ListApplicationsHandlerTest.java
@@ -55,7 +55,7 @@ public class ListApplicationsHandlerTest {
         tenantRepository.addTenant(foobar);
         applicationRepo = tenantRepository.getTenant(mytenant).getApplicationRepo();
         applicationRepo2 = tenantRepository.getTenant(foobar).getApplicationRepo();
-        handler = new ListApplicationsHandler(ListApplicationsHandler.testOnlyContext(),
+        handler = new ListApplicationsHandler(ListApplicationsHandler.testContext(),
                                               tenantRepository,
                                               new Zone(Environment.dev, RegionName.from("us-east")));
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -164,7 +164,7 @@ public class SessionActiveHandlerTest {
     }
 
     private SessionActiveHandler createHandler() {
-        return new SessionActiveHandler(SessionActiveHandler.testOnlyContext(),
+        return new SessionActiveHandler(SessionActiveHandler.testContext(),
                                         applicationRepository,
                                         Zone.defaultZone());
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionContentHandlerTest.java
@@ -183,7 +183,7 @@ public class SessionContentHandlerTest extends ContentHandlerTestBase {
 
     private SessionContentHandler createHandler() {
         return new SessionContentHandler(
-                SessionContentHandler.testOnlyContext(),
+                SessionContentHandler.testContext(),
                 new ApplicationRepository.Builder()
                         .withTenantRepository(tenantRepository)
                         .withProvisioner(new MockProvisioner())

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionCreateHandlerTest.java
@@ -195,7 +195,7 @@ public class SessionCreateHandlerTest extends SessionHandlerTest {
     }
 
     private SessionCreateHandler createHandler() {
-        return new SessionCreateHandler(SessionCreateHandler.testOnlyContext(),
+        return new SessionCreateHandler(SessionCreateHandler.testContext(),
                                         applicationRepository,
                                         configserverConfig);
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -247,7 +247,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     public void test_out_of_capacity_response() throws IOException {
         long sessionId = applicationRepository.createSession(applicationId(), timeoutBudget, app);
         String exceptionMessage = "Out of capacity";
-        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testOnlyContext(),
+        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testContext(),
                                                                                 applicationRepository,
                                                                                 configserverConfig,
                                                                                 new OutOfCapacityException(exceptionMessage));
@@ -262,7 +262,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     public void test_that_nullpointerexception_gives_internal_server_error() throws IOException {
         long sessionId = applicationRepository.createSession(applicationId(), timeoutBudget, app);
         String exceptionMessage = "nullpointer thrown in test handler";
-        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testOnlyContext(),
+        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testContext(),
                                                                                 applicationRepository,
                                                                                 configserverConfig,
                                                                                 new NullPointerException(exceptionMessage));
@@ -277,7 +277,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     public void test_application_lock_failure() throws IOException {
         String exceptionMessage = "Timed out after waiting PT1M to acquire lock '/provision/v1/locks/foo/bar/default'";
         long sessionId = applicationRepository.createSession(applicationId(), timeoutBudget, app);
-        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testOnlyContext(),
+        FailingSessionPrepareHandler handler = new FailingSessionPrepareHandler(SessionPrepareHandler.testContext(),
                                                                                 applicationRepository,
                                                                                 configserverConfig,
                                                                                 new ApplicationLockException(new UncheckedTimeoutException(exceptionMessage)));
@@ -314,7 +314,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     }
 
     private SessionHandler createHandler() {
-        return new SessionPrepareHandler(SessionPrepareHandler.testOnlyContext(), applicationRepository, configserverConfig);
+        return new SessionPrepareHandler(SessionPrepareHandler.testContext(), applicationRepository, configserverConfig);
     }
 
     private HttpResponse request(HttpRequest.Method put, long l) {

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -2968,7 +2968,7 @@
     "fields": []
   },
   "com.yahoo.processing.handler.AbstractProcessingHandler": {
-    "superClass": "com.yahoo.container.jdisc.LoggingRequestHandler",
+    "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
     "interfaces": [],
     "attributes": [
       "public",

--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -2968,7 +2968,7 @@
     "fields": []
   },
   "com.yahoo.processing.handler.AbstractProcessingHandler": {
-    "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
+    "superClass": "com.yahoo.container.jdisc.LoggingRequestHandler",
     "interfaces": [],
     "attributes": [
       "public",

--- a/container-core/src/main/java/com/yahoo/container/handler/test/MockService.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/test/MockService.java
@@ -4,7 +4,7 @@ package com.yahoo.container.handler.test;
 import com.yahoo.api.annotations.Beta;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.filedistribution.fileacquirer.FileAcquirer;
 import com.yahoo.jdisc.Metric;
 
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
  * @author Ulf Lilleengen
  */
 @Beta
-public class MockService extends LoggingRequestHandler {
+public class MockService extends ThreadedHttpRequestHandler {
 
     private final MockServiceHandler handler;
 

--- a/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/LoggingRequestHandler.java
@@ -25,8 +25,11 @@ import java.util.logging.Level;
  * ThreadedHttpRequestHandler with access logging.
  *
  * @author Steinar Knutsen
+ *
+ * @deprecated  Use {@link ThreadedHttpRequestHandler}, which provides the same level of functionality.
  */
 // TODO Vespa 8: Remove deprecated constructors
+@Deprecated
 public abstract class LoggingRequestHandler extends ThreadedHttpRequestHandler {
 
     // TODO: Deprecate
@@ -58,7 +61,6 @@ public abstract class LoggingRequestHandler extends ThreadedHttpRequestHandler {
 
     }
 
-    // TODO: Deprecate
     public static Context testOnlyContext() {
         return new Context(new Executor() {
                 @Override

--- a/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
+++ b/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
@@ -43,6 +43,7 @@ import static com.yahoo.component.chain.ChainsConfigurer.prepareChainRegistry;
  * @author Tony Vaagenes
  * @author Steinar Knutsen
  */
+@SuppressWarnings("deprecation") // super class is deprecated
 public abstract class AbstractProcessingHandler<COMPONENT extends Processor> extends LoggingRequestHandler {
 
     private final static CompoundName freezeListenerKey =new CompoundName("processing.freezeListener");

--- a/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
+++ b/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
@@ -12,7 +12,7 @@ import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.jdisc.ContentChannelOutputStream;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
+import com.yahoo.container.jdisc.LoggingRequestHandler;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.handler.ContentChannel;
@@ -43,7 +43,7 @@ import static com.yahoo.component.chain.ChainsConfigurer.prepareChainRegistry;
  * @author Tony Vaagenes
  * @author Steinar Knutsen
  */
-public abstract class AbstractProcessingHandler<COMPONENT extends Processor> extends ThreadedHttpRequestHandler {
+public abstract class AbstractProcessingHandler<COMPONENT extends Processor> extends LoggingRequestHandler {
 
     private final static CompoundName freezeListenerKey =new CompoundName("processing.freezeListener");
 

--- a/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
+++ b/container-core/src/main/java/com/yahoo/processing/handler/AbstractProcessingHandler.java
@@ -12,7 +12,7 @@ import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.jdisc.ContentChannelOutputStream;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.logging.AccessLog;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.handler.ContentChannel;
@@ -43,7 +43,7 @@ import static com.yahoo.component.chain.ChainsConfigurer.prepareChainRegistry;
  * @author Tony Vaagenes
  * @author Steinar Knutsen
  */
-public abstract class AbstractProcessingHandler<COMPONENT extends Processor> extends LoggingRequestHandler {
+public abstract class AbstractProcessingHandler<COMPONENT extends Processor> extends ThreadedHttpRequestHandler {
 
     private final static CompoundName freezeListenerKey =new CompoundName("processing.freezeListener");
 

--- a/container-core/src/main/java/com/yahoo/restapi/RestApiRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/restapi/RestApiRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.restapi;
 
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.jdisc.RequestHandlerSpec;
 import com.yahoo.jdisc.Metric;
 
@@ -12,7 +12,7 @@ import java.util.concurrent.Executor;
 /**
  * @author bjorncs
  */
-public abstract class RestApiRequestHandler<T extends RestApiRequestHandler<T>> extends LoggingRequestHandler {
+public abstract class RestApiRequestHandler<T extends RestApiRequestHandler<T>> extends ThreadedHttpRequestHandler {
 
     private final RestApi restApi;
 
@@ -24,7 +24,7 @@ public abstract class RestApiRequestHandler<T extends RestApiRequestHandler<T>> 
      * Caller must ensure that provider instance does not try to access any uninitialized fields.
      */
     @SuppressWarnings("unchecked")
-    protected RestApiRequestHandler(LoggingRequestHandler.Context context, RestApiProvider<T> provider) {
+    protected RestApiRequestHandler(ThreadedHttpRequestHandler.Context context, RestApiProvider<T> provider) {
         super(context);
         this.restApi = provider.createRestApi((T)this);
     }
@@ -38,7 +38,7 @@ public abstract class RestApiRequestHandler<T extends RestApiRequestHandler<T>> 
         this.restApi = provider.createRestApi((T)this);
     }
 
-    protected RestApiRequestHandler(LoggingRequestHandler.Context context, RestApi restApi) {
+    protected RestApiRequestHandler(ThreadedHttpRequestHandler.Context context, RestApi restApi) {
         super(context);
         this.restApi = restApi;
     }

--- a/container-core/src/main/java/com/yahoo/restapi/RestApiTestDriver.java
+++ b/container-core/src/main/java/com/yahoo/restapi/RestApiTestDriver.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.http.server.jetty.testutils.TestDriver;
 import com.yahoo.jdisc.test.MockMetric;
 
@@ -34,11 +34,11 @@ public class RestApiTestDriver implements AutoCloseable {
 
     public static Builder newBuilder(RestApiRequestHandler<?> handler) { return new Builder(handler); }
 
-    @FunctionalInterface public interface RestApiRequestHandlerFactory { RestApiRequestHandler<?> create(LoggingRequestHandler.Context context); }
+    @FunctionalInterface public interface RestApiRequestHandlerFactory { RestApiRequestHandler<?> create(ThreadedHttpRequestHandler.Context context); }
     public static Builder newBuilder(RestApiRequestHandlerFactory factory) { return new Builder(factory); }
 
-    public static LoggingRequestHandler.Context createHandlerTestContext() {
-        return new LoggingRequestHandler.Context(Executors.newSingleThreadExecutor(), new MockMetric());
+    public static ThreadedHttpRequestHandler.Context createHandlerTestContext() {
+        return new ThreadedHttpRequestHandler.Context(Executors.newSingleThreadExecutor(), new MockMetric());
     }
 
     public OptionalInt listenPort() {

--- a/container-core/src/test/java/com/yahoo/container/jdisc/LoggingRequestHandlerTestCase.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/LoggingRequestHandlerTestCase.java
@@ -97,7 +97,7 @@ public class LoggingRequestHandlerTestCase {
         }
     }
 
-    static final class AccessLogTestHandler extends LoggingRequestHandler {
+    static final class AccessLogTestHandler extends ThreadedHttpRequestHandler {
 
         public AccessLogTestHandler(Executor executor) {
             super(executor);

--- a/container-search-gui/src/main/java/com/yahoo/search/query/gui/GUIHandler.java
+++ b/container-search-gui/src/main/java/com/yahoo/search/query/gui/GUIHandler.java
@@ -8,7 +8,7 @@ import com.google.inject.Inject;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.querytransform.RecallSearcher;
 import com.yahoo.restapi.Path;
@@ -36,7 +36,7 @@ import java.util.logging.Level;
  *
  * @author  Henrik Høiness
  */
-public class GUIHandler extends LoggingRequestHandler {
+public class GUIHandler extends ThreadedHttpRequestHandler {
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -4321,7 +4321,7 @@
     "fields": []
   },
   "com.yahoo.search.handler.SearchHandler": {
-    "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
+    "superClass": "com.yahoo.container.jdisc.LoggingRequestHandler",
     "interfaces": [],
     "attributes": [
       "public"

--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -4321,7 +4321,7 @@
     "fields": []
   },
   "com.yahoo.search.handler.SearchHandler": {
-    "superClass": "com.yahoo.container.jdisc.LoggingRequestHandler",
+    "superClass": "com.yahoo.container.jdisc.ThreadedHttpRequestHandler",
     "interfaces": [],
     "attributes": [
       "public"

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -73,6 +73,7 @@ import java.util.logging.Logger;
  * @author Steinar Knutsen
  * @author bratseth
  */
+@SuppressWarnings("deprecation") // super class is deprecated
 public class SearchHandler extends LoggingRequestHandler {
 
     private static final Logger log = Logger.getLogger(SearchHandler.class.getName());

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -15,7 +15,7 @@ import com.yahoo.container.jdisc.AclMapping;
 import com.yahoo.container.jdisc.HttpMethodAclMapping;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
+import com.yahoo.container.jdisc.LoggingRequestHandler;
 import com.yahoo.container.jdisc.RequestHandlerSpec;
 import com.yahoo.container.jdisc.VespaHeaders;
 import com.yahoo.container.logging.AccessLog;
@@ -73,7 +73,7 @@ import java.util.logging.Logger;
  * @author Steinar Knutsen
  * @author bratseth
  */
-public class SearchHandler extends ThreadedHttpRequestHandler {
+public class SearchHandler extends LoggingRequestHandler {
 
     private static final Logger log = Logger.getLogger(SearchHandler.class.getName());
 

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.handler;
 
-import ai.vespa.cloud.Environment;
-import ai.vespa.cloud.Zone;
 import com.google.inject.Inject;
 import com.yahoo.collections.Tuple2;
 import com.yahoo.component.ComponentSpecification;
@@ -17,7 +15,7 @@ import com.yahoo.container.jdisc.AclMapping;
 import com.yahoo.container.jdisc.HttpMethodAclMapping;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.jdisc.RequestHandlerSpec;
 import com.yahoo.container.jdisc.VespaHeaders;
 import com.yahoo.container.logging.AccessLog;
@@ -75,7 +73,7 @@ import java.util.logging.Logger;
  * @author Steinar Knutsen
  * @author bratseth
  */
-public class SearchHandler extends LoggingRequestHandler {
+public class SearchHandler extends ThreadedHttpRequestHandler {
 
     private static final Logger log = Logger.getLogger(SearchHandler.class.getName());
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggingRequestHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/auditlog/AuditLoggingRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.hosted.controller.auditlog;
 
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.handler.ContentChannel;
 
 /**
@@ -12,7 +12,7 @@ import com.yahoo.jdisc.handler.ContentChannel;
  *
  * @author mpolden
  */
-public abstract class AuditLoggingRequestHandler extends LoggingRequestHandler {
+public abstract class AuditLoggingRequestHandler extends ThreadedHttpRequestHandler {
 
     private final AuditLogger auditLogger;
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -23,7 +23,7 @@ import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.handler.metrics.JsonResponse;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.io.IOUtils;
 import com.yahoo.restapi.ByteArrayResponse;
 import com.yahoo.restapi.ErrorResponse;
@@ -172,7 +172,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
     private final TestConfigSerializer testConfigSerializer;
 
     @Inject
-    public ApplicationApiHandler(LoggingRequestHandler.Context parentCtx,
+    public ApplicationApiHandler(ThreadedHttpRequestHandler.Context parentCtx,
                                  Controller controller,
                                  AccessControlRequests accessControlRequests) {
         super(parentCtx, controller.auditLogger());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandler.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.hosted.controller.restapi.billing;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.JacksonJsonResponse;
 import com.yahoo.restapi.MessageResponse;
@@ -49,7 +49,7 @@ import java.util.stream.Collectors;
  * @author andreer
  * @author olaa
  */
-public class BillingApiHandler extends LoggingRequestHandler {
+public class BillingApiHandler extends ThreadedHttpRequestHandler {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.hosted.controller.restapi.billing;
 
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.MessageResponse;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiException;
@@ -48,7 +48,7 @@ public class BillingApiHandlerV2 extends RestApiRequestHandler<BillingApiHandler
     private final BillingController billing;
     private final Clock clock;
 
-    public BillingApiHandlerV2(LoggingRequestHandler.Context context, Controller controller) {
+    public BillingApiHandlerV2(ThreadedHttpRequestHandler.Context context, Controller controller) {
         super(context, BillingApiHandlerV2::createRestApi);
         this.applications = controller.applications();
         this.tenants = controller.tenants();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/changemanagement/ChangeManagementApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/changemanagement/ChangeManagementApiHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
 import com.yahoo.restapi.SlimeJsonResponse;
@@ -37,7 +37,7 @@ public class ChangeManagementApiHandler extends AuditLoggingRequestHandler {
     private final ChangeManagementAssessor assessor;
     private final Controller controller;
 
-    public ChangeManagementApiHandler(LoggingRequestHandler.Context ctx, Controller controller) {
+    public ChangeManagementApiHandler(ThreadedHttpRequestHandler.Context ctx, Controller controller) {
         super(ctx, controller.auditLogger());
         this.assessor = new ChangeManagementAssessor(controller.serviceRegistry().configServer().nodeRepository());
         this.controller = controller;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.io.IOUtils;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.MessageResponse;
@@ -51,7 +51,7 @@ public class ControllerApiHandler extends AuditLoggingRequestHandler {
     private final ControllerMaintenance maintenance;
     private final Controller controller;
 
-    public ControllerApiHandler(LoggingRequestHandler.Context parentCtx, Controller controller, ControllerMaintenance maintenance) {
+    public ControllerApiHandler(ThreadedHttpRequestHandler.Context parentCtx, Controller controller, ControllerMaintenance maintenance) {
         super(parentCtx, controller.auditLogger());
         this.controller = controller;
         this.maintenance = maintenance;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/BadgeApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/BadgeApiHandler.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.hosted.controller.restapi.deployment;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.http.HttpRequest.Method;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
@@ -36,7 +36,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @author jonmv
  */
 @SuppressWarnings("unused") // Handler
-public class BadgeApiHandler extends LoggingRequestHandler {
+public class BadgeApiHandler extends ThreadedHttpRequestHandler {
 
     private final static Logger log = Logger.getLogger(BadgeApiHandler.class.getName());
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
 import com.yahoo.restapi.SlimeJsonResponse;
@@ -47,11 +47,11 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
  * @author bratseth
  */
 @SuppressWarnings("unused") // Injected
-public class DeploymentApiHandler extends LoggingRequestHandler {
+public class DeploymentApiHandler extends ThreadedHttpRequestHandler {
 
     private final Controller controller;
 
-    public DeploymentApiHandler(LoggingRequestHandler.Context parentCtx, Controller controller) {
+    public DeploymentApiHandler(ThreadedHttpRequestHandler.Context parentCtx, Controller controller) {
         super(parentCtx);
         this.controller = controller;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/horizon/HorizonApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/horizon/HorizonApiHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
 import com.yahoo.vespa.flags.BooleanFlag;
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
  *
  * @author valerijf
  */
-public class HorizonApiHandler extends LoggingRequestHandler {
+public class HorizonApiHandler extends ThreadedHttpRequestHandler {
 
     private final SystemName systemName;
     private final HorizonClient client;
@@ -46,7 +46,7 @@ public class HorizonApiHandler extends LoggingRequestHandler {
             EnumSet.of(RoleDefinition.hostedOperator, RoleDefinition.hostedSupporter);
 
     @Inject
-    public HorizonApiHandler(LoggingRequestHandler.Context parentCtx, Controller controller, FlagSource flagSource) {
+    public HorizonApiHandler(ThreadedHttpRequestHandler.Context parentCtx, Controller controller, FlagSource flagSource) {
         super(parentCtx);
         this.systemName = controller.system();
         this.client = controller.serviceRegistry().horizonClient();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/systemflags/SystemFlagsHandler.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.hosted.controller.restapi.systemflags;
 import com.google.inject.Inject;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.JacksonJsonResponse;
 import com.yahoo.restapi.Path;
@@ -22,7 +22,7 @@ import java.util.logging.Level;
  * @author bjorncs
  */
 @SuppressWarnings("unused") // Request handler listed in controller's services.xml
-public class SystemFlagsHandler extends LoggingRequestHandler {
+public class SystemFlagsHandler extends ThreadedHttpRequestHandler {
 
     private static final String API_PREFIX = "/system-flags/v1";
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/user/UserApiHandler.java
@@ -7,7 +7,7 @@ import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.io.IOUtils;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.MessageResponse;
@@ -62,7 +62,7 @@ import java.util.stream.Collectors;
  * @author jonmv
  */
 @SuppressWarnings("unused") // Handler
-public class UserApiHandler extends LoggingRequestHandler {
+public class UserApiHandler extends ThreadedHttpRequestHandler {
 
     private final static Logger log = Logger.getLogger(UserApiHandler.class.getName());
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v1/ZoneApiHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.hosted.controller.api.integration.ServiceRegistry;
@@ -27,11 +27,11 @@ import java.util.stream.Collectors;
  * @author mpolden
  */
 @SuppressWarnings("unused")
-public class ZoneApiHandler extends LoggingRequestHandler {
+public class ZoneApiHandler extends ThreadedHttpRequestHandler {
 
     private final ZoneRegistry zoneRegistry;
 
-    public ZoneApiHandler(LoggingRequestHandler.Context parentCtx, ServiceRegistry serviceRegistry) {
+    public ZoneApiHandler(ThreadedHttpRequestHandler.Context parentCtx, ServiceRegistry serviceRegistry) {
         super(parentCtx);
         this.zoneRegistry = serviceRegistry.zoneRegistry();
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/zone/v2/ZoneApiHandler.java
@@ -5,7 +5,7 @@ import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.config.provision.zone.ZoneList;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.Path;
 import com.yahoo.restapi.SlimeJsonResponse;
@@ -34,7 +34,7 @@ public class ZoneApiHandler extends AuditLoggingRequestHandler {
     private final ZoneRegistry zoneRegistry;
     private final ConfigServerRestExecutor proxy;
 
-    public ZoneApiHandler(LoggingRequestHandler.Context parentCtx, ServiceRegistry serviceRegistry,
+    public ZoneApiHandler(ThreadedHttpRequestHandler.Context parentCtx, ServiceRegistry serviceRegistry,
                           ConfigServerRestExecutor proxy, Controller controller) {
         super(parentCtx, controller.auditLogger());
         this.zoneRegistry = serviceRegistry.zoneRegistry();

--- a/jdisc-cloud-aws/src/main/java/com/yahoo/jdisc/cloud/aws/AwsParameterStoreValidationHandler.java
+++ b/jdisc-cloud-aws/src/main/java/com/yahoo/jdisc/cloud/aws/AwsParameterStoreValidationHandler.java
@@ -4,14 +4,14 @@ package com.yahoo.jdisc.cloud.aws;
 import com.google.inject.Inject;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.io.IOUtils;
+import com.yahoo.jdisc.cloud.aws.AwsParameterStore.AwsSettings;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Slime;
 import com.yahoo.slime.SlimeUtils;
 import com.yahoo.yolean.Exceptions;
-import com.yahoo.jdisc.cloud.aws.AwsParameterStore.AwsSettings;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
  *
  * @author ogronnesby
  */
-public class AwsParameterStoreValidationHandler extends LoggingRequestHandler {
+public class AwsParameterStoreValidationHandler extends ThreadedHttpRequestHandler {
 
     private static final Logger log = Logger.getLogger(AwsParameterStoreValidationHandler.class.getName());
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiHandler.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.hosted.provision.restapi;
 
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiRequestHandler;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
@@ -18,7 +18,7 @@ public class LoadBalancersV1ApiHandler extends RestApiRequestHandler<LoadBalance
     private final NodeRepository nodeRepository;
 
     @Inject
-    public LoadBalancersV1ApiHandler(LoggingRequestHandler.Context parentCtx, NodeRepository nodeRepository) {
+    public LoadBalancersV1ApiHandler(ThreadedHttpRequestHandler.Context parentCtx, NodeRepository nodeRepository) {
         super(parentCtx, LoadBalancersV1ApiHandler::createRestApiDefinition);
         this.nodeRepository = nodeRepository;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -11,7 +11,7 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.io.IOUtils;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.MessageResponse;
@@ -67,7 +67,7 @@ import static com.yahoo.slime.SlimeUtils.optionalString;
  *
  * @author bratseth
  */
-public class NodesV2ApiHandler extends LoggingRequestHandler {
+public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
 
     private final Orchestrator orchestrator;
     private final NodeRepository nodeRepository;
@@ -75,7 +75,7 @@ public class NodesV2ApiHandler extends LoggingRequestHandler {
     private final NodeFlavors nodeFlavors;
 
     @Inject
-    public NodesV2ApiHandler(LoggingRequestHandler.Context parentCtx, Orchestrator orchestrator,
+    public NodesV2ApiHandler(ThreadedHttpRequestHandler.Context parentCtx, Orchestrator orchestrator,
                              NodeRepository nodeRepository, MetricsDb metricsDb, NodeFlavors flavors) {
         super(parentCtx);
         this.orchestrator = orchestrator;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ApplicationSuspensionRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/ApplicationSuspensionRequestHandler.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jdisc.EmptyResponse;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.http.HttpResponse.Status;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiException;
@@ -31,7 +31,7 @@ public class ApplicationSuspensionRequestHandler extends RestApiRequestHandler<A
     private final Orchestrator orchestrator;
 
     @Inject
-    public ApplicationSuspensionRequestHandler(LoggingRequestHandler.Context context, Orchestrator orchestrator) {
+    public ApplicationSuspensionRequestHandler(ThreadedHttpRequestHandler.Context context, Orchestrator orchestrator) {
         super(context, ApplicationSuspensionRequestHandler::createRestApiDefinition);
         this.orchestrator = orchestrator;
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HealthRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HealthRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.orchestrator.resources;
 
 import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiRequestHandler;
 import com.yahoo.vespa.applicationmodel.ServiceStatusInfo;
@@ -27,7 +27,7 @@ public class HealthRequestHandler extends RestApiRequestHandler<HealthRequestHan
     private final HealthMonitorApi healthMonitorApi;
 
     @Inject
-    public HealthRequestHandler(LoggingRequestHandler.Context context,
+    public HealthRequestHandler(ThreadedHttpRequestHandler.Context context,
                                 HealthMonitorApi healthMonitorApi) {
         super(context, HealthRequestHandler::createRestApiDefinition);
         this.healthMonitorApi = healthMonitorApi;

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.orchestrator.resources;
 
 import com.google.inject.Inject;
 import com.yahoo.concurrent.UncheckedTimeoutException;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.Response;
 import com.yahoo.restapi.JacksonJsonResponse;
 import com.yahoo.restapi.RestApi;
@@ -42,7 +42,7 @@ public class HostRequestHandler extends RestApiRequestHandler<HostRequestHandler
     private final Orchestrator orchestrator;
 
     @Inject
-    public HostRequestHandler(LoggingRequestHandler.Context context, Orchestrator orchestrator) {
+    public HostRequestHandler(ThreadedHttpRequestHandler.Context context, Orchestrator orchestrator) {
         super(context, HostRequestHandler::createRestApiDefinition);
         this.orchestrator = orchestrator;
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostSuspensionRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/HostSuspensionRequestHandler.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.orchestrator.resources;
 
 import com.google.inject.Inject;
 import com.yahoo.concurrent.UncheckedTimeoutException;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.Response;
 import com.yahoo.restapi.JacksonJsonResponse;
 import com.yahoo.restapi.RestApi;
@@ -32,7 +32,7 @@ public class HostSuspensionRequestHandler extends RestApiRequestHandler<HostSusp
     private final Orchestrator orchestrator;
 
     @Inject
-    public HostSuspensionRequestHandler(LoggingRequestHandler.Context context, Orchestrator orchestrator) {
+    public HostSuspensionRequestHandler(ThreadedHttpRequestHandler.Context context, Orchestrator orchestrator) {
         super(context, HostSuspensionRequestHandler::createRestApiDefinition);
         this.orchestrator = orchestrator;
     }

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/InstanceRequestHandler.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/resources/InstanceRequestHandler.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jrt.slobrok.api.Mirror;
 import com.yahoo.restapi.RestApi;
 import com.yahoo.restapi.RestApiException;
@@ -56,7 +56,7 @@ public class InstanceRequestHandler extends RestApiRequestHandler<InstanceReques
     private final ServiceMonitor serviceMonitor;
 
     @Inject
-    public InstanceRequestHandler(LoggingRequestHandler.Context context,
+    public InstanceRequestHandler(ThreadedHttpRequestHandler.Context context,
                                   ServiceMonitor serviceMonitor,
                                   StatusService statusService,
                                   SlobrokApi slobrokApi,

--- a/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/TestRunnerHandler.java
+++ b/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/TestRunnerHandler.java
@@ -6,7 +6,7 @@ import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.jdisc.EmptyResponse;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.exception.ExceptionUtils;
 import com.yahoo.restapi.MessageResponse;
 import com.yahoo.restapi.SlimeJsonResponse;
@@ -30,7 +30,7 @@ import static com.yahoo.jdisc.Response.Status;
  * @author jvenstad
  * @author mortent
  */
-public class TestRunnerHandler extends LoggingRequestHandler {
+public class TestRunnerHandler extends ThreadedHttpRequestHandler {
 
     private final TestRunner testRunner;
 

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/RestApi.java
@@ -4,7 +4,7 @@ package com.yahoo.document.restapi.resource;
 import com.google.inject.Inject;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.Metric;
 
 /**
@@ -12,7 +12,7 @@ import com.yahoo.jdisc.Metric;
  *
  * @author jonmv
  */
-public class RestApi extends LoggingRequestHandler {
+public class RestApi extends ThreadedHttpRequestHandler {
 
     @Inject
     public RestApi() {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandler.java
@@ -5,7 +5,7 @@ import com.yahoo.collections.Tuple2;
 import com.yahoo.container.handler.threadpool.ContainerThreadPool;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.jdisc.messagebus.SessionCache;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.documentapi.metrics.DocumentApiMetrics;
@@ -34,7 +34,7 @@ import java.util.zip.GZIPInputStream;
  *
  * @author Steinar Knutsen
  */
-public class FeedHandler extends LoggingRequestHandler {
+public class FeedHandler extends ThreadedHttpRequestHandler {
 
     protected final ReplyHandler feedReplyHandler;
     private static final List<Integer> serverSupportedVersions = Collections.unmodifiableList(Arrays.asList(3));

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.http.server;
 import com.yahoo.concurrent.ThreadFactoryFactory;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
-import com.yahoo.container.jdisc.LoggingRequestHandler;
+import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.container.jdisc.messagebus.SessionCache;
 import com.yahoo.document.DocumentTypeManager;
 import com.yahoo.document.config.DocumentmanagerConfig;
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
  *
  * @author dybis
  */
-public class FeedHandlerV3 extends LoggingRequestHandler {
+public class FeedHandlerV3 extends ThreadedHttpRequestHandler {
 
     private DocumentTypeManager docTypeManager;
     private final Map<String, ClientFeederV3> clientFeederByClientId = new HashMap<>();


### PR DESCRIPTION
Base class is unchanged for SearchHandler and AbstractProcessingHandler. There should be no changes to public APIs here.

FYI: @bratseth