### PR TITLE
Revert "generate "jsonstring" as config value"

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/SummaryClassField.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/SummaryClassField.java
@@ -111,7 +111,11 @@ public class SummaryClassField {
         } else if (fval instanceof TensorFieldValue) {
             return Type.TENSOR;
         } else if (fieldType instanceof CollectionDataType) {
-            return Type.JSONSTRING;
+            if (transform != null && transform.equals(SummaryTransform.POSITIONS)) {
+                return Type.XMLSTRING;
+            } else {
+                return Type.JSONSTRING;
+            }
         } else if (fieldType instanceof MapDataType) {
             return Type.JSONSTRING;
         } else if (fieldType instanceof ReferenceDataType) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/CreatePositionZCurve.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/CreatePositionZCurve.java
@@ -65,7 +65,7 @@ public class CreatePositionZCurve extends Processor {
             Collection<String> summaryTo = removeSummaryTo(field);
             ensureCompatibleSummary(field, zName,
                                     PositionDataType.getPositionSummaryFieldName(fieldName),
-                                    DataType.getArray(DataType.STRING), // will become "jsonstring"
+                                    DataType.getArray(DataType.STRING), // will become "xmlstring"
                                     SummaryTransform.POSITIONS, summaryTo, validate);
             ensureCompatibleSummary(field, zName,
                                     PositionDataType.getDistanceSummaryFieldName(fieldName),

--- a/config-model/src/test/derived/advanced/summary.cfg
+++ b/config-model/src/test/derived/advanced/summary.cfg
@@ -1,6 +1,6 @@
-defaultsummaryid 673702455
+defaultsummaryid 1271952241
 usev8geopositions false
-classes[].id 673702455
+classes[].id 1271952241
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "debug"
@@ -14,7 +14,7 @@ classes[].fields[].type "longstring"
 classes[].fields[].name "product3"
 classes[].fields[].type "longstring"
 classes[].fields[].name "location.position"
-classes[].fields[].type "jsonstring"
+classes[].fields[].type "xmlstring"
 classes[].fields[].name "location.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "mysummary"

--- a/config-model/src/test/derived/imported_position_field_summary/summary.cfg
+++ b/config-model/src/test/derived/imported_position_field_summary/summary.cfg
@@ -1,6 +1,6 @@
-defaultsummaryid 1886149151
+defaultsummaryid 1194448774
 usev8geopositions false
-classes[].id 1886149151
+classes[].id 1194448774
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "parent_ref"
@@ -12,12 +12,12 @@ classes[].fields[].type "featuredata"
 classes[].fields[].name "my_pos"
 classes[].fields[].type "jsonstring"
 classes[].fields[].name "my_pos.position"
-classes[].fields[].type "jsonstring"
+classes[].fields[].type "xmlstring"
 classes[].fields[].name "my_pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "documentid"
 classes[].fields[].type "longstring"
-classes[].id 939841157
+classes[].id 890647799
 classes[].name "mysummary"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "my_pos"
@@ -27,7 +27,7 @@ classes[].fields[].type "featuredata"
 classes[].fields[].name "summaryfeatures"
 classes[].fields[].type "featuredata"
 classes[].fields[].name "my_pos.position"
-classes[].fields[].type "jsonstring"
+classes[].fields[].type "xmlstring"
 classes[].fields[].name "my_pos.distance"
 classes[].fields[].type "integer"
 classes[].id 1274088866

--- a/config-model/src/test/derived/position_nosummary/summary.cfg
+++ b/config-model/src/test/derived/position_nosummary/summary.cfg
@@ -1,10 +1,10 @@
-defaultsummaryid 1110900627
+defaultsummaryid 1727020212
 usev8geopositions false
-classes[].id 1110900627
+classes[].id 1727020212
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "pos.position"
-classes[].fields[].type "jsonstring"
+classes[].fields[].type "xmlstring"
 classes[].fields[].name "pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "rankfeatures"

--- a/config-model/src/test/derived/position_summary/summary.cfg
+++ b/config-model/src/test/derived/position_summary/summary.cfg
@@ -1,12 +1,12 @@
-defaultsummaryid 1462909474
+defaultsummaryid 230670304
 usev8geopositions false
-classes[].id 1462909474
+classes[].id 230670304
 classes[].name "default"
 classes[].omitsummaryfeatures false
 classes[].fields[].name "pos"
 classes[].fields[].type "jsonstring"
 classes[].fields[].name "pos.position"
-classes[].fields[].type "jsonstring"
+classes[].fields[].type "xmlstring"
 classes[].fields[].name "pos.distance"
 classes[].fields[].type "integer"
 classes[].fields[].name "rankfeatures"


### PR DESCRIPTION
Reverts vespa-engine/vespa#20834

While backend treats this the same, container-search has a special-case for "xmlstring" when rendering XML.
