### PR TITLE
Tune persistence dynamic throttling policy

### DIFF
--- a/storage/src/vespa/storage/persistence/shared_operation_throttler.cpp
+++ b/storage/src/vespa/storage/persistence/shared_operation_throttler.cpp
@@ -59,6 +59,8 @@ DynamicOperationThrottler::DynamicOperationThrottler(uint32_t min_size_and_windo
       _pending_ops(0),
       _waiting_threads(0)
 {
+    _throttle_policy.setWindowSizeDecrementFactor(1.2);
+    _throttle_policy.setWindowSizeBackOff(0.95);
 }
 
 DynamicOperationThrottler::~DynamicOperationThrottler() = default;


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Currently hardcoded to use values that have been empirically
observed to give good results. Can change this to be configurable
later if needed.
