### PR TITLE
add special '[document]' fieldset

### DIFF
--- a/document/src/vespa/document/base/field.cpp
+++ b/document/src/vespa/document/base/field.cpp
@@ -79,6 +79,7 @@ Field::contains(const FieldSet& fields) const
         case Type::NONE:
         case Type::DOCID:
         return true;
+        case Type::DOCUMENT_ONLY:
         case Type::ALL:
         return false;
     }

--- a/document/src/vespa/document/datatype/documenttype.cpp
+++ b/document/src/vespa/document/datatype/documenttype.cpp
@@ -14,7 +14,29 @@ using vespalib::IllegalArgumentException;
 using vespalib::make_string;
 using vespalib::stringref;
 
+
 namespace document {
+
+namespace {
+FieldCollection build_field_collection(const std::set<vespalib::string> &fields,
+                                       const DocumentType &doc_type)
+{
+    Field::Set::Builder builder;
+    for (const auto & field_name : fields) {
+        if (doc_type.hasField(field_name)) {
+            builder.add(&doc_type.getField(field_name));
+        }
+    }
+    return FieldCollection(doc_type, builder.build());
+}
+} // namespace <unnamed>
+
+DocumentType::FieldSet::FieldSet(const vespalib::string & name, Fields fields,
+                                 const DocumentType & doc_type)
+    : _name(name),
+      _fields(fields),
+      _field_collection(build_field_collection(fields, doc_type))
+{}
 
 IMPLEMENT_IDENTIFIABLE(DocumentType, StructuredDataType);
 
@@ -75,7 +97,7 @@ DocumentType::~DocumentType() = default;
 DocumentType &
 DocumentType::addFieldSet(const vespalib::string & name, FieldSet::Fields fields)
 {
-    _fieldSets[name] = FieldSet(name, std::move(fields));
+    _fieldSets.emplace(name, FieldSet(name, std::move(fields), *this));
     return *this;
 }
 

--- a/document/src/vespa/document/datatype/documenttype.h
+++ b/document/src/vespa/document/datatype/documenttype.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <vespa/document/fieldset/fieldsets.h>
 #include <vespa/document/datatype/structdatatype.h>
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/stllike/string.h>
@@ -28,23 +29,19 @@ public:
     class FieldSet {
     public:
         using Fields = std::set<vespalib::string>;
-        FieldSet() = default;
-        explicit FieldSet(const vespalib::string & name) : _name(name), _fields() {}
-        FieldSet(const vespalib::string & name, Fields fields) : _name(name), _fields(std::move(fields)) {}
+        FieldSet(const vespalib::string & name, Fields fields,
+                 const DocumentType & doc_type);
+
         FieldSet(const FieldSet&) = default;
-        FieldSet& operator=(const FieldSet&) = default;
         FieldSet(FieldSet&&) noexcept = default;
-        FieldSet& operator=(FieldSet&&) noexcept = default;
 
         const vespalib::string & getName() const noexcept { return _name; }
         const Fields & getFields() const noexcept { return _fields; }
-        FieldSet & add(vespalib::string & field) {
-            _fields.insert(field);
-            return *this;
-        }
+        const FieldCollection & asCollection() const { return _field_collection; }
     private:
         vespalib::string _name;
         Fields           _fields;
+        FieldCollection  _field_collection;
     };
     using FieldSetMap = std::map<vespalib::string, FieldSet>;
     using ImportedFieldNames = vespalib::hash_set<vespalib::string>;

--- a/document/src/vespa/document/fieldset/fieldset.h
+++ b/document/src/vespa/document/fieldset/fieldset.h
@@ -20,7 +20,8 @@ public:
         SET,
         ALL,
         NONE,
-        DOCID
+        DOCID,
+        DOCUMENT_ONLY
     };
 
     using SP = std::shared_ptr<FieldSet>;

--- a/document/src/vespa/document/fieldset/fieldsetrepo.cpp
+++ b/document/src/vespa/document/fieldset/fieldsetrepo.cpp
@@ -28,10 +28,12 @@ parseSpecialValues(vespalib::stringref name)
         return std::make_shared<NoFields>();
     } else if ((name.size() == 7) && (name[1] == 'd') && (name[2] == 'o') && (name[3] == 'c') && (name[4] == 'i') && (name[5] == 'd') && (name[6] == ']')) {
         return std::make_shared<DocIdOnly>();
+    } else if (name.size() == 10 && name == DocumentOnly::NAME) {
+        return std::make_shared<DocumentOnly>();
     } else {
         throw vespalib::IllegalArgumentException(
                 "The only special names (enclosed in '[]') allowed are "
-                "id, all, none, not '" + name + "'.");
+                "id, all, none, docid, document; but not '" + name + "'.");
     }
 }
 
@@ -109,6 +111,8 @@ FieldSetRepo::serialize(const FieldSet& fieldSet)
             return NoFields::NAME;
         case FieldSet::Type::DOCID:
             return DocIdOnly::NAME;
+        case FieldSet::Type::DOCUMENT_ONLY:
+            return DocumentOnly::NAME;
         default:
             return "";
     }

--- a/document/src/vespa/document/fieldset/fieldsets.h
+++ b/document/src/vespa/document/fieldset/fieldsets.h
@@ -33,6 +33,18 @@ public:
     Type getType() const override { return Type::DOCID; }
 };
 
+class DocumentOnly final : public FieldSet
+{
+public:
+    static constexpr const char * NAME = "[document]";
+    bool contains(const FieldSet& fields) const override {
+        return fields.getType() == Type::DOCUMENT_ONLY
+            || fields.getType() == Type::DOCID
+            || fields.getType() == Type::NONE;
+    }
+    Type getType() const override { return Type::DOCUMENT_ONLY; }
+};
+
 class FieldCollection : public FieldSet
 {
 public:

--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
@@ -127,6 +127,7 @@ DocumentRetriever::needFetchFromDocStore(const FieldSet & fieldSet) const {
         case FieldSet::Type::NONE:
         case FieldSet::Type::DOCID:
             return false;
+        case FieldSet::Type::DOCUMENT_ONLY:
         case FieldSet::Type::ALL:
             return ! _areAllFieldsAttributes;
         case FieldSet::Type::FIELD: {
@@ -255,6 +256,14 @@ DocumentRetriever::getPartialDocument(search::DocumentIdT lid, const document::D
             case FieldSet::Type::SET: {
                 const auto &set = static_cast<const document::FieldCollection &>(fieldSet);
                 populate(lid, *doc, set.getFields());
+                break;
+            }
+            case FieldSet::Type::DOCUMENT_ONLY: {
+                const auto * actual = getDocumentType().getFieldSet(document::DocumentOnly::NAME);
+                if (actual != nullptr) {
+                    const auto &set = actual->asCollection();
+                    populate(lid, *doc, set.getFields());
+                }
                 break;
             }
             case FieldSet::Type::NONE:


### PR DESCRIPTION
* specially handled like [all] and [docid]
* depends on the document type having a configured fieldset named '[document]'
* should make it possible to run vespa-visit -l '[document]' and get only the
  fields declared inside the document for any and all document types.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli please review
@geirst please review
