### PR TITLE
Support additional model validators

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModelFactory.java
@@ -24,6 +24,7 @@ import com.yahoo.config.provision.TransientException;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.config.VespaVersion;
 import com.yahoo.vespa.model.application.validation.Validation;
+import com.yahoo.vespa.model.application.validation.Validator;
 import com.yahoo.yolean.Exceptions;
 import org.xml.sax.SAXException;
 
@@ -50,11 +51,13 @@ public class VespaModelFactory implements ModelFactory {
     private final Zone zone;
     private final Clock clock;
     private final Version version;
+    private final List<Validator> additionalValidators;
 
     /** Creates a factory for Vespa models for this version of the source */
     @Inject
     public VespaModelFactory(ComponentRegistry<ConfigModelPlugin> pluginRegistry,
                              ComponentRegistry<MlModelImporter> modelImporters,
+                             ComponentRegistry<Validator> additionalValidators,
                              Zone zone) {
         this.version = new Version(VespaVersion.major, VespaVersion.minor, VespaVersion.micro);
         List<ConfigModelBuilder> modelBuilders = new ArrayList<>();
@@ -66,6 +69,7 @@ public class VespaModelFactory implements ModelFactory {
         this.configModelRegistry = new MapConfigModelRegistry(modelBuilders);
         this.modelImporters = modelImporters.allComponents();
         this.zone = zone;
+        this.additionalValidators = List.copyOf(additionalValidators.allComponents());
 
         this.clock = Clock.systemUTC();
     }
@@ -91,6 +95,7 @@ public class VespaModelFactory implements ModelFactory {
             this.configModelRegistry = configModelRegistry;
         }
         this.modelImporters = Collections.emptyList();
+        this.additionalValidators = List.of();
         this.zone = zone;
         this.clock = clock;
     }
@@ -197,7 +202,7 @@ public class VespaModelFactory implements ModelFactory {
 
     private List<ConfigChangeAction> validateModel(VespaModel model, DeployState deployState, ValidationParameters validationParameters) {
         try {
-            return Validation.validate(model, validationParameters, deployState);
+            return new Validation(additionalValidators).validate(model, validationParameters, deployState);
         } catch (ValidationOverrides.ValidationException e) {
             if (deployState.isHosted() && zone.environment().isManuallyDeployed())
                 deployState.getDeployLogger().logApplicationPackage(Level.WARNING,

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ComplexAttributeFieldsValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ComplexAttributeFieldsValidatorTestCase.java
@@ -105,7 +105,7 @@ public class ComplexAttributeFieldsValidatorTestCase {
         DeployState deployState = createDeployState(servicesXml(), schema);
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         ValidationParameters validationParameters = new ValidationParameters(CheckRouting.FALSE);
-        Validation.validate(model, validationParameters, deployState);
+        new Validation().validate(model, validationParameters, deployState);
     }
 
     private static DeployState createDeployState(String servicesXml, String schema) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationOverridesValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationOverridesValidatorTest.java
@@ -37,7 +37,7 @@ public class ValidationOverridesValidatorTest {
 
         var deployState = createDeployState(validationOverridesXml);
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
-        Validation.validate(model, new ValidationParameters(), deployState);
+        new Validation().validate(model, new ValidationParameters(), deployState);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class ValidationOverridesValidatorTest {
         try {
             var deployState = createDeployState(validationOverridesXml);
             VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
-            Validation.validate(model, new ValidationParameters(), deployState);
+            new Validation().validate(model, new ValidationParameters(), deployState);
             fail("Did not get expected exception");
         } catch (IllegalArgumentException e) {
             assertEquals(message, e.getMessage());

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTestCase.java
@@ -242,7 +242,7 @@ public class VespaModelTestCase {
                 .build();
         DeployState deployState = builder.deployLogger(logger).applicationPackage(app).build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
-        Validation.validate(model, new ValidationParameters(ValidationParameters.IgnoreValidationErrors.TRUE), deployState);
+        new Validation().validate(model, new ValidationParameters(ValidationParameters.IgnoreValidationErrors.TRUE), deployState);
         assertFalse(logger.msgs.isEmpty());
     }
 
@@ -312,7 +312,7 @@ public class VespaModelTestCase {
                 .deployLogger(logger)
                 .build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
-        Validation.validate(model, new ValidationParameters(), deployState);
+        new Validation().validate(model, new ValidationParameters(), deployState);
         assertContainsWarning(logger.msgs, "Directory searchdefinitions/ should not be used for schemas, use schemas/ instead");
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithFilePkg.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithFilePkg.java
@@ -66,7 +66,7 @@ public class VespaModelCreatorWithFilePkg {
             // is constructed in a special way and cannot always be validated in
             // this step for unit tests)
             ValidationParameters validationParameters = new ValidationParameters(IgnoreValidationErrors.TRUE, FailOnIncompatibleChange.TRUE, CheckRouting.FALSE);
-            Validation.validate(model, validationParameters, deployState);
+            new Validation().validate(model, validationParameters, deployState);
             return model;
         } catch (Exception e) {
             throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithMockPkg.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/utils/VespaModelCreatorWithMockPkg.java
@@ -75,7 +75,7 @@ public class VespaModelCreatorWithMockPkg {
                 // is constructed in a special way and cannot always be validated in
                 // this step for unit tests)
                 ValidationParameters validationParameters = new ValidationParameters(CheckRouting.FALSE);
-                configChangeActions = Validation.validate(model, validationParameters, deployState);
+                configChangeActions = new Validation().validate(model, validationParameters, deployState);
             }
             return model;
         } catch (Exception e) {


### PR DESCRIPTION
Inject additional model validators through VespaModelFactory.
Useful for adding validators that are only relevant for hosted and cannot be open-sourced.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
