### PR TITLE
Expicitly reject "none"-fieldset for external visitors

### DIFF
--- a/storage/src/tests/distributor/visitoroperationtest.cpp
+++ b/storage/src/tests/distributor/visitoroperationtest.cpp
@@ -252,6 +252,20 @@ TEST_F(VisitorOperationTest, no_bucket) {
               runEmptyVisitor(msg));
 }
 
+TEST_F(VisitorOperationTest, none_fieldset_is_rejected) {
+    enable_cluster_state("distributor:1 storage:1");
+    auto msg = std::make_shared<api::CreateVisitorCommand>(
+            makeBucketSpace(), "dumpvisitor", "instance", "");
+    msg->addBucketToBeVisited(document::BucketId(16, 1));
+    msg->addBucketToBeVisited(nullId);
+    msg->setFieldSet("[none]");
+
+    EXPECT_EQ("CreateVisitorReply(last=BucketId(0x0000000000000000)) "
+              "ReturnCode(ILLEGAL_PARAMETERS, Field set '[none]' is not supported "
+              "for external visitor operations. Use '[id]' to return documents with no fields set.)",
+              runEmptyVisitor(msg));
+}
+
 TEST_F(VisitorOperationTest, only_super_bucket_and_progress_allowed) {
     enable_cluster_state("distributor:1 storage:1");
 

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.h
@@ -106,6 +106,7 @@ private:
     void verifyOperationContainsBuckets();
     void verifyOperationHasSuperbucketAndProgress();
     void verifyOperationSentToCorrectDistributor();
+    void verify_fieldset_makes_sense_for_visiting();
     bool verifyCreateVisitorCommand(DistributorStripeMessageSender& sender);
     bool pickBucketsToVisit(const std::vector<BucketDatabase::Entry>& buckets);
     bool expandBucketContaining();


### PR DESCRIPTION
@geirst please review
@arnej27959 FYI

It does not make sense for a client to run a visitor that inherently
cannot return any data at all. Explicitly check for, and reject, `[none]`
fieldsets and emit a hopefully helpful error message to use `[id]`
instead.
