### PR TITLE
Move retired nodes to dirty if wantToDeprovision

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -819,6 +819,7 @@ public class Nodes {
     private static boolean parkOnDeallocationOf(Node node, Agent agent) {
         if (node.state() == Node.State.parked) return false;
         if (agent == Agent.operator) return false;
+        if (!node.type().isHost() && node.status().wantToDeprovision()) return false;
         boolean retirementRequestedByOperator = node.status().wantToRetire() &&
                                                 node.history().event(History.Event.Type.wantToRetire)
                                                     .map(History.Event::agent)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node55.json
@@ -1,7 +1,7 @@
 {
   "url": "http://localhost:8080/nodes/v2/node/host55.yahoo.com",
   "id": "node55",
-  "state": "parked",
+  "state": "dirty",
   "type": "tenant",
   "hostname": "host55.yahoo.com",
   "flavor": "[vcpu: 2.0, memory: 8.0 Gb, disk 50.0 Gb, bandwidth: 1.0 Gbps, storage type: local]",
@@ -22,7 +22,7 @@
       "agent": "system"
     },
     {
-      "event": "parked",
+      "event": "deallocated",
       "at": 123,
       "agent": "system"
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes-recursive-include-deprovisioned.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes-recursive-include-deprovisioned.json
@@ -17,8 +17,8 @@
     @include(node2.json),
     @include(docker-node1.json),
     @include(node1.json),
-    @include(node5.json),
     @include(node55.json),
+    @include(node5.json),
     @include(dockerhost6.json)
   ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes-recursive.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes-recursive.json
@@ -17,7 +17,7 @@
     @include(node2.json),
     @include(docker-node1.json),
     @include(node1.json),
-    @include(node5.json),
-    @include(node55.json)
+    @include(node55.json),
+    @include(node5.json)
   ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/nodes.json
@@ -52,10 +52,10 @@
       "url": "http://localhost:8080/nodes/v2/node/host1.yahoo.com"
     },
     {
-      "url": "http://localhost:8080/nodes/v2/node/host5.yahoo.com"
+      "url": "http://localhost:8080/nodes/v2/node/host55.yahoo.com"
     },
     {
-      "url": "http://localhost:8080/nodes/v2/node/host55.yahoo.com"
+      "url": "http://localhost:8080/nodes/v2/node/host5.yahoo.com"
     }
   ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/states-recursive.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/states-recursive.json
@@ -45,6 +45,7 @@
     "dirty": {
       "url": "http://localhost:8080/nodes/v2/state/dirty",
       "nodes": [
+        @include(node55.json)
       ]
     },
     "failed": {
@@ -56,7 +57,6 @@
     "parked": {
       "url": "http://localhost:8080/nodes/v2/state/parked",
       "nodes": [
-        @include(node55.json)
       ]
     },
     "deprovisioned": {


### PR DESCRIPTION
Currently there is no way for an operator to retire a node without it ending up in `parked`, this fixes it by moving the node to `dirty` if `wantToDeprovsion` is set.