### PR TITLE
deprecate Execution.fillAttributes()

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -348,7 +348,7 @@ public class ClusterSearcher extends Searcher {
             if (query.getOffset() > 0 || query.getHits() < mergedResult.hits().size()) {
                 if (mergedResult.getHitOrderer() != null) {
                     // Make sure we have the necessary data for sorting
-                    searcher.fill(mergedResult, Execution.ATTRIBUTEPREFETCH, execution);
+                    searcher.fill(mergedResult, VespaBackEndSearcher.SORTABLE_ATTRIBUTES_SUMMARY_CLASS, execution);
                 }
                 mergedResult.hits().trim(query.getOffset(), query.getHits());
                 query.setOffset(0); // Needed when doing a trim

--- a/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/fastsearch/VespaBackEndSearcher.java
@@ -37,6 +37,9 @@ import java.util.logging.Logger;
  */
 public abstract class VespaBackEndSearcher extends PingableSearcher {
 
+    /** for vespa-internal use only; consider renaming the summary class */
+    public static final String SORTABLE_ATTRIBUTES_SUMMARY_CLASS = "attributeprefetch";
+
     private static final CompoundName TRACE_DISABLE = new CompoundName("trace.disable");
 
     private String serverId;

--- a/container-search/src/main/java/com/yahoo/prelude/searcher/BlendingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/BlendingSearcher.java
@@ -8,6 +8,7 @@ import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.component.chain.dependencies.Before;
 import com.yahoo.component.chain.dependencies.Provides;
 import com.yahoo.container.QrSearchersConfig;
+import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
@@ -113,7 +114,8 @@ public class BlendingSearcher extends Searcher {
 
     private Result sortAndTrimResults(Result result, Query q, int offset, int hits, Execution execution) {
         if (q.getRanking().getSorting() != null) {
-            execution.fillAttributes(result); // Always correct as we can only sort on attributes
+            // TODO: remove or rename this internal summary class for Vespa 9
+            execution.fill(result, VespaBackEndSearcher.SORTABLE_ATTRIBUTES_SUMMARY_CLASS);
             result.hits().sort();
         }
         result.hits().trim(offset, hits);

--- a/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/Execution.java
@@ -8,6 +8,7 @@ import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.Ping;
 import com.yahoo.prelude.Pong;
 import com.yahoo.language.process.SpecialTokenRegistry;
+import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.processing.Processor;
 import com.yahoo.processing.Request;
 import com.yahoo.processing.Response;
@@ -18,7 +19,6 @@ import com.yahoo.search.cluster.PingableSearcher;
 import com.yahoo.search.rendering.Renderer;
 import com.yahoo.search.rendering.RendererRegistry;
 import com.yahoo.search.statistics.TimeTracker;
-
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -41,6 +41,8 @@ import java.util.concurrent.Executors;
  */
 public class Execution extends com.yahoo.processing.execution.Execution {
 
+    /** @deprecated - applications should define their own summary class instead */
+    @Deprecated(since = "7", forRemoval = true)
     public static final String ATTRIBUTEPREFETCH = "attributeprefetch";
 
     /**
@@ -532,18 +534,23 @@ public class Execution extends com.yahoo.processing.execution.Execution {
     }
 
     /**
-     * Fill hit properties with values from all in-memory attributes.
-     * This can be done with good performance on many more hits than
-     * those for which fill is called with the final summary class, so
-     * if filtering can be done using only in-memory attribute data,
-     * this method should be preferred over {@link #fill} to get that data for filtering.
-     * <p>
-     * Calling this on already filled results has no cost.
+     * Fill hit properties with values from some in-memory attributes.
+     * Not all attributes are included, and *which* attributes are
+     * subject to change depending on what Vespa needs internally.
      *
+     * Applications should prefer to define their own summary class
+     * with only the in-memory attributes they need, and call
+     * fill(result, "foo") with the name of their own summary class
+     * instead of "foo".
+     *
+     * @deprecated use fill(Result, String)
+     * 
+     * TODO Remove on Vespa 9.
      * @param result the result to fill
      */
+    @Deprecated
     public void fillAttributes(Result result) {
-        fill(result, ATTRIBUTEPREFETCH);
+        fill(result, VespaBackEndSearcher.SORTABLE_ATTRIBUTES_SUMMARY_CLASS);
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/yql/FieldFiller.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/FieldFiller.java
@@ -12,6 +12,7 @@ import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig.Documentdb;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig.Documentdb.Summaryclass;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig.Documentdb.Summaryclass.Fields;
+import static com.yahoo.prelude.fastsearch.VespaBackEndSearcher.SORTABLE_ATTRIBUTES_SUMMARY_CLASS;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
@@ -95,7 +96,7 @@ public class FieldFiller extends Searcher {
         for (Documentdb db : config.documentdb()) {
             for (Summaryclass summary : db.summaryclass()) {
                 Set<String> attributes;
-                if (Execution.ATTRIBUTEPREFETCH.equals(summary.name())) {
+                if (SORTABLE_ATTRIBUTES_SUMMARY_CLASS.equals(summary.name())) {
                     attributes = new HashSet<>(summary.fields().size());
                     for (Fields f : summary.fields()) {
                         attributes.add(f.name());
@@ -134,11 +135,11 @@ public class FieldFiller extends Searcher {
         }
 
         if (intersectionOfAttributes.containsAll(summaryFields)) {
-            if ( ! Execution.ATTRIBUTEPREFETCH.equals(summaryClass)) {
-                execution.fill(result, Execution.ATTRIBUTEPREFETCH);
+            if (! SORTABLE_ATTRIBUTES_SUMMARY_CLASS.equals(summaryClass)) {
+                execution.fill(result, SORTABLE_ATTRIBUTES_SUMMARY_CLASS);
             }
         } else {
-            // Yes, summaryClass may be Execution.ATTRIBUTEPREFETCH here
+            // Yes, summaryClass may be SORTABLE_ATTRIBUTES_SUMMARY_CLASS here
             if ( ! summaryDb.hasAll(summaryFields, summaryClass, result.getQuery().getModel().getRestrict())) {
                 execution.fill(result, null);
             }

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlFieldAndSourceTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlFieldAndSourceTestCase.java
@@ -24,7 +24,9 @@ import com.yahoo.search.Searcher;
 import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.testutil.DocumentSourceSearcher;
-import static com.yahoo.search.searchchain.testutil.DocumentSourceSearcher.DEFAULT_SUMMARY_CLASS;;
+import static com.yahoo.search.searchchain.testutil.DocumentSourceSearcher.DEFAULT_SUMMARY_CLASS;
+import static com.yahoo.prelude.fastsearch.VespaBackEndSearcher.SORTABLE_ATTRIBUTES_SUMMARY_CLASS;
+
 
 /**
  * Test translation of fields and sources in YQL to the associated concepts in Vespa.
@@ -52,7 +54,7 @@ public class YqlFieldAndSourceTestCase {
         mockBackend.addResult(query, result);
 
         mockBackend.addSummaryClassByCopy(DEFAULT_SUMMARY_CLASS, Arrays.asList(FIELD1, FIELD2));
-        mockBackend.addSummaryClassByCopy(Execution.ATTRIBUTEPREFETCH, Arrays.asList(FIELD2));
+        mockBackend.addSummaryClassByCopy(SORTABLE_ATTRIBUTES_SUMMARY_CLASS, Arrays.asList(FIELD2));
         mockBackend.addSummaryClassByCopy(THIRD_OPTION, Arrays.asList(FIELD3));
 
         DocumentdbInfoConfig config = new DocumentdbInfoConfig(new DocumentdbInfoConfig.Builder()
@@ -90,7 +92,7 @@ public class YqlFieldAndSourceTestCase {
                                               new Fields.Builder().name(FIELD2).type("string"))),
                 new Summaryclass.Builder()
                         .id(1)
-                        .name(Execution.ATTRIBUTEPREFETCH)
+                        .name(SORTABLE_ATTRIBUTES_SUMMARY_CLASS)
                         .fields(Arrays.asList(new Fields.Builder().name(FIELD2).type("string"))),
                 new Summaryclass.Builder()
                         .id(2)
@@ -112,7 +114,7 @@ public class YqlFieldAndSourceTestCase {
         execution.fill(result);
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertFalse(result.hits().get(0).isFilled(Execution.ATTRIBUTEPREFETCH));
+        assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
     }
 
     @Test
@@ -123,7 +125,7 @@ public class YqlFieldAndSourceTestCase {
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(THIRD_OPTION));
         assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertTrue(result.hits().get(0).isFilled(Execution.ATTRIBUTEPREFETCH));
+        assertTrue(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
     }
 
     @Test
@@ -134,7 +136,7 @@ public class YqlFieldAndSourceTestCase {
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(THIRD_OPTION));
         assertFalse(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertFalse(result.hits().get(0).isFilled(Execution.ATTRIBUTEPREFETCH));
+        assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
     }
 
     @Test
@@ -145,7 +147,7 @@ public class YqlFieldAndSourceTestCase {
         assertEquals(1, result.getConcreteHitCount());
         assertTrue(result.hits().get(0).isFilled(THIRD_OPTION));
         assertTrue(result.hits().get(0).isFilled(DEFAULT_SUMMARY_CLASS));
-        assertFalse(result.hits().get(0).isFilled(Execution.ATTRIBUTEPREFETCH));
+        assertFalse(result.hits().get(0).isFilled(SORTABLE_ATTRIBUTES_SUMMARY_CLASS));
     }
 
 }


### PR DESCRIPTION
* we want to make some slight changes here for Vespa 8, and
  hopefully get rid of this completely for Vespa 9.  Prepare
  for this by marking the old method (and public constant)
  as deprecated, and explain what should be used instead.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
@gjoranv FYI
