### PR TITLE
Arnej/deprecate vespalog internals

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EndpointCertificateMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EndpointCertificateMaintainer.java
@@ -6,7 +6,6 @@ import com.google.inject.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.container.jdisc.secretstore.SecretNotFoundException;
 import com.yahoo.container.jdisc.secretstore.SecretStore;
-import com.yahoo.log.LogLevel;
 import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.flags.BooleanFlag;
 import com.yahoo.vespa.flags.Flags;
@@ -71,7 +70,7 @@ public class EndpointCertificateMaintainer extends ControllerMaintainer {
             deleteUnusedCertificates();
             deleteOrReportUnmanagedCertificates();
         } catch (Exception e) {
-            log.log(LogLevel.ERROR, "Exception caught while maintaining endpoint certificates", e);
+            log.log(Level.SEVERE, "Exception caught while maintaining endpoint certificates", e);
             return 0.0;
         }
 

--- a/vespalog/src/main/java/com/yahoo/log/DefaultLevelController.java
+++ b/vespalog/src/main/java/com/yahoo/log/DefaultLevelController.java
@@ -1,18 +1,22 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
 import java.util.logging.Level;
 
 /**
  * a levelcontroller that just implements a simple default
  * (possibly controlled by a system property or environment)
- **/
+ * @deprecated Should only be used internally in the log library
+ */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 class DefaultLevelController implements LevelController {
     private String levelstring;
     private Level levelLimit = LogLevel.EVENT;
 
     DefaultLevelController(String env) {
-        if (LogUtil.empty(env)) {
+        if (LogUtils.empty(env)) {
             env = "all -debug -spam";
         }
 

--- a/vespalog/src/main/java/com/yahoo/log/FileLogTarget.java
+++ b/vespalog/src/main/java/com/yahoo/log/FileLogTarget.java
@@ -6,7 +6,10 @@ import java.io.*;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class FileLogTarget implements LogTarget {
     private final File file;
     private FileOutputStream fileOutputStream;

--- a/vespalog/src/main/java/com/yahoo/log/LevelController.java
+++ b/vespalog/src/main/java/com/yahoo/log/LevelController.java
@@ -10,7 +10,9 @@ import java.util.logging.Level;
  *
  * @author arnej27959
  *
+ * @deprecated Should only be used internally in the log library
  */
+@Deprecated(since = "7", forRemoval = true)
 public interface LevelController {
 
     /**

--- a/vespalog/src/main/java/com/yahoo/log/LevelControllerRepo.java
+++ b/vespalog/src/main/java/com/yahoo/log/LevelControllerRepo.java
@@ -7,7 +7,10 @@ package com.yahoo.log;
  *
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public interface LevelControllerRepo {
     /**
      * Return the level controller for a given component.

--- a/vespalog/src/main/java/com/yahoo/log/LogMessage.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogMessage.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
  * @author  Bjorn Borud
  * @author bjorncs
  */
+@SuppressWarnings("removal")
 public class LogMessage
 {
     private static Logger log = Logger.getLogger(LogMessage.class.getName());
@@ -188,7 +189,7 @@ public class LogMessage
                                 + component.length()
                                 + level.toString().length()
                                 + payload.length()
-                                + 1)
+                                + 7)
             .append(timeStr).append("\t")
             .append(host).append("\t")
             .append(threadProcess).append("\t")

--- a/vespalog/src/main/java/com/yahoo/log/LogMessageTimeComparator.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogMessageTimeComparator.java
@@ -12,8 +12,7 @@ import java.util.Comparator;
  * This is due to only looking at the timestamp, so two different messages with
  * the same timestamp would appear "equal" to this comparator.
  *
- * @author vlarsen
- *
+ * @author Vidar Larsen
  */
 public class LogMessageTimeComparator implements Comparator<LogMessage>, Serializable {
 	private static final long serialVersionUID = 1L;

--- a/vespalog/src/main/java/com/yahoo/log/LogSetup.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogSetup.java
@@ -1,12 +1,20 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Enumeration;
-import java.util.logging.*;
 import java.util.Timer;
+import java.util.logging.FileHandler;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 /**
  * Sets up Vespa logging. Call a setup method to set up this.
@@ -14,10 +22,16 @@ import java.util.Timer;
  * @author  Bjorn Borud
  * @author arnej27959
  */
+@SuppressWarnings("removal")
 public class LogSetup {
 
     private static Timer taskRunner = new Timer(true);
-    /** A global task thread */
+
+    /**
+     * A global task thread
+     * @deprecated Just construct a java.util.Timer instead
+     **/
+    @Deprecated(since = "7", forRemoval = true)
     public static Timer getTaskRunner() { return taskRunner; }
 
     /** The log handler used by this */
@@ -25,6 +39,7 @@ public class LogSetup {
 
     private static ZooKeeperFilter zooKeeperFilter = null;
 
+    /** Clear all handlers registered in java.util.logging framework */
     public static void clearHandlers () {
         Enumeration<String> names = LogManager.getLogManager().getLoggerNames();
         while (names.hasMoreElements()) {
@@ -155,14 +170,18 @@ public class LogSetup {
         Logger.getLogger("").addHandler(logHandler);
     }
 
-    /** Returns the log handler set up by this class */
+    /**
+     * Returns the log handler set up by this class
+     * @deprecated Should only be used internally in the log library
+     */
+    @Deprecated(since = "7", forRemoval = true)
     public static VespaLogHandler getLogHandler() {
         return logHandler;
     }
 
-    /** Returns the log handler set up by this class */
+    /** perform cleanup */
     public static void cleanup() {
-        if (zooKeeperFilter != null)
+         if (zooKeeperFilter != null)
             zooKeeperFilter.close();
     }
 

--- a/vespalog/src/main/java/com/yahoo/log/LogTarget.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogTarget.java
@@ -6,7 +6,9 @@ import java.io.OutputStream;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@Deprecated(since = "7", forRemoval = true)
 public interface LogTarget {
     /**
      * Opens an output stream for the target. If already open, the stream should be reopened.

--- a/vespalog/src/main/java/com/yahoo/log/LogUtil.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogUtil.java
@@ -4,7 +4,9 @@ package com.yahoo.log;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@Deprecated(since = "7", forRemoval = true)
 class LogUtil {
     static boolean empty(String s) {
         return (s == null || s.equals(""));

--- a/vespalog/src/main/java/com/yahoo/log/MappedLevelController.java
+++ b/vespalog/src/main/java/com/yahoo/log/MappedLevelController.java
@@ -9,7 +9,10 @@ import java.util.logging.Level;
 /**
  * a level controller that does lookup in a file via a memory-mapped
  * buffer for realtime logging control.
- **/
+ * @deprecated Should only be used internally in the log library
+ */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 class MappedLevelController implements LevelController {
     private static final int ONVAL  = 0x20204f4e; // equals "  ON" in file
     private static final int OFFVAL = 0x204f4646; // equals " OFF" in file

--- a/vespalog/src/main/java/com/yahoo/log/MappedLevelControllerRepo.java
+++ b/vespalog/src/main/java/com/yahoo/log/MappedLevelControllerRepo.java
@@ -12,7 +12,10 @@ import java.util.Map;
  *
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 class MappedLevelControllerRepo {
     private final Map<String, LevelController> levelControllerMap = new HashMap<>();
     private final MappedByteBuffer mapBuf;

--- a/vespalog/src/main/java/com/yahoo/log/RejectFilter.java
+++ b/vespalog/src/main/java/com/yahoo/log/RejectFilter.java
@@ -9,7 +9,9 @@ import java.util.List;
  *
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@Deprecated(since = "7", forRemoval = true)
 public class RejectFilter {
     private final List<String> rejectedMessages = new ArrayList<>();
 

--- a/vespalog/src/main/java/com/yahoo/log/StderrLogTarget.java
+++ b/vespalog/src/main/java/com/yahoo/log/StderrLogTarget.java
@@ -6,7 +6,10 @@ import java.io.OutputStream;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class StderrLogTarget implements LogTarget {
 
     @Override

--- a/vespalog/src/main/java/com/yahoo/log/StdoutLogTarget.java
+++ b/vespalog/src/main/java/com/yahoo/log/StdoutLogTarget.java
@@ -6,7 +6,10 @@ import java.io.OutputStream;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class StdoutLogTarget implements LogTarget {
 
     @Override

--- a/vespalog/src/main/java/com/yahoo/log/UncloseableOutputStream.java
+++ b/vespalog/src/main/java/com/yahoo/log/UncloseableOutputStream.java
@@ -7,7 +7,9 @@ import java.io.OutputStream;
 /**
  * @author Simon Thoresen Hult
  * @since 5.1.14
+ * @deprecated Should only be used internally in the log library
  */
+@Deprecated(since = "7", forRemoval = true)
 class UncloseableOutputStream extends OutputStream {
 
     private final OutputStream out;

--- a/vespalog/src/main/java/com/yahoo/log/VespaFormat.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaFormat.java
@@ -1,18 +1,23 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
 import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Vespa log formatting utility methods.
- * Contains some code based on Util.java in Cloudname https://github.com/Cloudname/cloudname
+ * Contains some code based on LogUtils.java in Cloudname https://github.com/Cloudname/cloudname
  * written by Bjørn Borud, licensed under the Apache 2.0 license.
- * 
+ *
  * @author arnej27959
  * @author bjorncs
+ *
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class VespaFormat {
 
     private static final Pattern special   = Pattern.compile("[\r\\\n\\\t\\\\]+");
@@ -25,8 +30,8 @@ public class VespaFormat {
     private static final String processID;
 
     static {
-        hostname = Util.getHostName();
-        processID = Util.getPID();
+        hostname = LogUtils.getHostName();
+        processID = LogUtils.getPID();
     }
 
     /**

--- a/vespalog/src/main/java/com/yahoo/log/VespaFormatter.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaFormatter.java
@@ -3,6 +3,7 @@
 package com.yahoo.log;
 
 import com.yahoo.log.event.Event;
+import com.yahoo.log.impl.LogUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -18,7 +19,10 @@ import java.util.regex.Pattern;
  * @author  Bjorn Borud
  * @author arnej27959
  *
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class VespaFormatter extends SimpleFormatter {
 
     private static final Pattern backSlash = Pattern.compile("\\\\");
@@ -34,8 +38,8 @@ public class VespaFormatter extends SimpleFormatter {
     public static final String serviceNameUnsetValue = "-";
 
     static {
-        hostname = Util.getHostName();
-        processID = Util.getPID();
+        hostname = LogUtils.getHostName();
+        processID = LogUtils.getPID();
     }
 
     private String serviceName;

--- a/vespalog/src/main/java/com/yahoo/log/VespaLevelControllerRepo.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaLevelControllerRepo.java
@@ -17,7 +17,10 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 /**
  * @author Ulf Lilleengen
  * @since 5.1
+ * @deprecated Should only be used internally in the log library
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 public class VespaLevelControllerRepo implements LevelControllerRepo {
 
     private RandomAccessFile ctlFile;

--- a/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
@@ -10,6 +10,8 @@ import java.util.logging.StreamHandler;
  * @author Bjorn Borud
  * @author arnej27959
  */
+@SuppressWarnings("removal")
+@Deprecated(since = "7", forRemoval = true)
 class VespaLogHandler extends StreamHandler {
 
     private final LogTarget logTarget;

--- a/vespalog/src/main/java/com/yahoo/log/impl/LogUtils.java
+++ b/vespalog/src/main/java/com/yahoo/log/impl/LogUtils.java
@@ -1,25 +1,23 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.log;
+package com.yahoo.log.impl;
 
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 
 /**
- *
+ * @author Ulf Lilleengen
  * @author Bjorn Borud
  * @author arnej27959
  * @author bjorncs
- *
- * @deprecated Should only be used internally in the log library
+ * TODO remove "public" keyword, should be package private
  */
-@Deprecated(since = "7", forRemoval = true)
-public class Util {
-
+public class LogUtils {
+    public static boolean empty(String s) {
+        return (s == null || s.equals(""));
+    }
     public static String getHostName () {
         return getDefaults().vespaHostname();
     }
-
     public static String getPID() {
         return Long.toString(ProcessHandle.current().pid());
     }
-
 }

--- a/vespalog/src/test/java/com/yahoo/log/FileLogTargetTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/FileLogTargetTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  * @since 5.1
  */
+@SuppressWarnings("removal")
 public class FileLogTargetTest {
     @Test(expected = RuntimeException.class)
     public void requireThatExceptionIsThrowIfFileNotFound() throws IOException {

--- a/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
@@ -1,6 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +25,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Bjorn Borud
  */
+@SuppressWarnings("removal")
 public class LogSetupTestCase {
     // For testing zookeeper log records
     protected static LogRecord zookeeperLogRecord;
@@ -51,8 +54,8 @@ public class LogSetupTestCase {
         curatorLogRecord.setLoggerName("org.apache.curator.utils.DefaultTracerDriver");
         curatorLogRecord.setInstant(Instant.ofEpochMilli(1107011348029L));
 
-        hostname = Util.getHostName();
-        pid = Util.getPID();
+        hostname = LogUtils.getHostName();
+        pid = LogUtils.getPID();
 
         zookeeperLogRecordString = "1107011348.029000\t"
                 + hostname

--- a/vespalog/src/test/java/com/yahoo/log/LogUtilTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogUtilTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertFalse;
  * @author Ulf Lilleengen
  * @since 5.1
  */
+@SuppressWarnings("removal")
 public class LogUtilTest {
     @Test
     public void testEmpty() {

--- a/vespalog/src/test/java/com/yahoo/log/RejectFilterTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/RejectFilterTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  * @since 5.1
  */
+@SuppressWarnings("removal")
 public class RejectFilterTest {
     @Test
     public void testBasicPatternMatching() {

--- a/vespalog/src/test/java/com/yahoo/log/UncloseableOutputStreamTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/UncloseableOutputStreamTestCase.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal")
 public class UncloseableOutputStreamTestCase {
 
     @Test

--- a/vespalog/src/test/java/com/yahoo/log/UtilTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/UtilTestCase.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.*;
 /**
  * @author  Bjorn Borud
  */
+@SuppressWarnings("removal")
 public class UtilTestCase {
 
     /**

--- a/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
@@ -1,6 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,6 +19,7 @@ import static org.junit.Assert.fail;
 /**
  * @author  Bjorn Borud
  */
+@SuppressWarnings("removal")
 public class VespaFormatterTestCase {
 
     private String hostname;
@@ -33,8 +36,8 @@ public class VespaFormatterTestCase {
 
     @Before
     public void setUp () {
-        hostname = Util.getHostName();
-        pid = Util.getPID();
+        hostname = LogUtils.getHostName();
+        pid = LogUtils.getPID();
 
         testRecord1 = new LogRecord(Level.INFO, "this is a test");
         testRecord1.setInstant(Instant.ofEpochMilli(1098709021843L));

--- a/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  * @since 5.1
  */
+@SuppressWarnings("removal")
 public class VespaLevelControllerRepoTest {
 
     static int findControlString(RandomAccessFile f, String s) {

--- a/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
@@ -1,6 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
+import com.yahoo.log.impl.LogUtils;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +32,7 @@ import static org.junit.Assert.fail;
 /**
  * @author  Bjorn Borud
  */
+@SuppressWarnings("removal")
 public class VespaLogHandlerTestCase {
     private final static String hostname;
     private final static String pid;
@@ -47,8 +50,8 @@ public class VespaLogHandlerTestCase {
     private static final String record4String;
 
     static {
-        hostname = Util.getHostName();
-        pid = Util.getPID();
+        hostname = LogUtils.getHostName();
+        pid = LogUtils.getPID();
 
         record1 = new LogRecord(Level.INFO, "This is a test");
         record1.setInstant(ofEpochSecond(1100011348L, 29_123_543));

--- a/vespalog/src/test/java/com/yahoo/log/event/EventTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/event/EventTestCase.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("removal")
 public class EventTestCase {
 
     Count     countEvent;

--- a/vespalog/src/test/java/com/yahoo/log/impl/LogUtilsTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/impl/LogUtilsTest.java
@@ -1,0 +1,36 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.log.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Ulf Lilleengen
+ * @author Bjorn Borud
+ */
+public class LogUtilsTest {
+
+    @Test
+    public void testEmpty() {
+        assertTrue(LogUtils.empty(null));
+        assertTrue(LogUtils.empty(""));
+        assertFalse(LogUtils.empty("f"));
+        assertFalse(LogUtils.empty("fo"));
+        assertFalse(LogUtils.empty("foo"));
+    }
+
+    /**
+     * Just make sure the static getHostName() method returns something
+     * that looks half sensible.
+     */
+    @Test
+    public void testSimple () {
+        String name = LogUtils.getHostName();
+        assertNotNull(name);
+        assertFalse(name.equals(""));
+    }
+
+}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@gjoranv please review
note: my plan is to move all the classes that are deprecated here to com.yahoo.log.vespa.internal (or something like that) after we branch for Vespa 8.
