### PR TITLE
Improve shutdown logic for ClientFeederV3

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/FeedHandlerV3.java
@@ -104,7 +104,6 @@ public class FeedHandlerV3 extends ThreadedHttpRequestHandler {
         // This caused a deadlock when the single Messenger thread in MessageBus was the last one referring this
         // and started destructing something that required something only the messenger thread could provide.
         Thread destroyer = new Thread(() -> {
-            super.destroy();
             cron.shutdown();
             synchronized (monitor) {
                 for (var iterator = clientFeederByClientId.values().iterator(); iterator.hasNext(); ) {


### PR DESCRIPTION
Remove call to Object.wait(long). This call would always fail since
there was no monitor lock on the object being waited on.
The 'kill()' method should now longer throw exception and halt kill of
subsequent client feeder instances.

FYI @jonmv 