### PR TITLE
Jonmv/deployment orchestration for long pipelines

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -194,9 +194,10 @@
       "public"
     ],
     "methods": [
-      "public void <init>(com.yahoo.config.provision.InstanceName, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, java.util.List, java.util.Optional, java.util.Optional, com.yahoo.config.application.api.Notifications, java.util.List, java.time.Instant)",
+      "public void <init>(com.yahoo.config.provision.InstanceName, java.util.List, com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy, com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision, com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout, java.util.List, java.util.Optional, java.util.Optional, com.yahoo.config.application.api.Notifications, java.util.List, java.time.Instant)",
       "public com.yahoo.config.provision.InstanceName name()",
       "public com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy upgradePolicy()",
+      "public com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision upgradeRevision()",
       "public com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout upgradeRollout()",
       "public java.util.List changeBlocker()",
       "public java.util.Optional globalServiceId()",
@@ -363,6 +364,23 @@
       "public static final enum com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy canary",
       "public static final enum com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy defaultPolicy",
       "public static final enum com.yahoo.config.application.api.DeploymentSpec$UpgradePolicy conservative"
+    ]
+  },
+  "com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision": {
+    "superClass": "java.lang.Enum",
+    "interfaces": [],
+    "attributes": [
+      "public",
+      "final",
+      "enum"
+    ],
+    "methods": [
+      "public static com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision[] values()",
+      "public static com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision valueOf(java.lang.String)"
+    ],
+    "fields": [
+      "public static final enum com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision separate",
+      "public static final enum com.yahoo.config.application.api.DeploymentSpec$UpgradeRevision latest"
     ]
   },
   "com.yahoo.config.application.api.DeploymentSpec$UpgradeRollout": {

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentInstanceSpec.java
@@ -31,6 +31,7 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     private final InstanceName name;
 
     private final DeploymentSpec.UpgradePolicy upgradePolicy;
+    private final DeploymentSpec.UpgradeRevision upgradeRevision;
     private final DeploymentSpec.UpgradeRollout upgradeRollout;
     private final List<DeploymentSpec.ChangeBlocker> changeBlockers;
     private final Optional<String> globalServiceId;
@@ -41,6 +42,7 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     public DeploymentInstanceSpec(InstanceName name,
                                   List<DeploymentSpec.Step> steps,
                                   DeploymentSpec.UpgradePolicy upgradePolicy,
+                                  DeploymentSpec.UpgradeRevision upgradeRevision,
                                   DeploymentSpec.UpgradeRollout upgradeRollout,
                                   List<DeploymentSpec.ChangeBlocker> changeBlockers,
                                   Optional<String> globalServiceId,
@@ -51,6 +53,7 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
         super(steps);
         this.name = name;
         this.upgradePolicy = upgradePolicy;
+        this.upgradeRevision = upgradeRevision;
         this.upgradeRollout = upgradeRollout;
         this.changeBlockers = changeBlockers;
         this.globalServiceId = globalServiceId;
@@ -150,6 +153,9 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
     /** Returns the upgrade policy of this, which is defaultPolicy if none is specified */
     public DeploymentSpec.UpgradePolicy upgradePolicy() { return upgradePolicy; }
 
+    /** Returns the upgrade revision strategy of this, which is separate if none is specified */
+    public DeploymentSpec.UpgradeRevision upgradeRevision() { return upgradeRevision; }
+
     /** Returns the upgrade rollout strategy of this, which is separate if none is specified */
     public DeploymentSpec.UpgradeRollout upgradeRollout() { return upgradeRollout; }
 
@@ -198,6 +204,7 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
         DeploymentInstanceSpec other = (DeploymentInstanceSpec) o;
         return globalServiceId.equals(other.globalServiceId) &&
                upgradePolicy == other.upgradePolicy &&
+               upgradeRevision == other.upgradeRevision &&
                upgradeRollout == other.upgradeRollout &&
                changeBlockers.equals(other.changeBlockers) &&
                steps().equals(other.steps()) &&
@@ -208,7 +215,7 @@ public class DeploymentInstanceSpec extends DeploymentSpec.Steps {
 
     @Override
     public int hashCode() {
-        return Objects.hash(globalServiceId, upgradePolicy, upgradeRollout, changeBlockers, steps(), athenzService, notifications, endpoints);
+        return Objects.hash(globalServiceId, upgradePolicy, upgradeRevision, upgradeRollout, changeBlockers, steps(), athenzService, notifications, endpoints);
     }
 
     @Override

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/DeploymentSpec.java
@@ -550,6 +550,15 @@ public class DeploymentSpec {
     }
 
 
+    /** Determines when application changes deploy, when an older revision is already rolling out. */
+    public enum UpgradeRevision {
+        /** Separate: Application changes wait for previous application changes to complete, unless they fail. */
+        separate,
+        /** Latest: Application changes immediately supersede previous application changes, unless currently blocked. */
+        latest
+    }
+
+
     /** Determines when application changes deploy, when there is already an ongoing platform upgrade. */
     public enum UpgradeRollout {
         /** Separate: Application changes wait for upgrade to complete, unless upgrade fails. */

--- a/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
+++ b/config-model-api/src/test/java/com/yahoo/config/application/api/DeploymentSpecTest.java
@@ -121,6 +121,7 @@ public class DeploymentSpecTest {
         assertFalse(spec.requireInstance("default").globalServiceId().isPresent());
 
         assertEquals(DeploymentSpec.UpgradePolicy.defaultPolicy, spec.requireInstance("default").upgradePolicy());
+        assertEquals(DeploymentSpec.UpgradeRevision.separate, spec.requireInstance("default").upgradeRevision());
         assertEquals(DeploymentSpec.UpgradeRollout.separate, spec.requireInstance("default").upgradeRollout());
     }
 
@@ -364,6 +365,21 @@ public class DeploymentSpecTest {
     }
 
     @Test
+    public void productionSpecWithUpgradeRevision() {
+        StringReader r = new StringReader(
+                "<deployment>" +
+                "   <instance id='default'>" +
+                "      <upgrade revision='latest' />" +
+                "   </instance>" +
+                "   <instance id='custom'/>" +
+                "</deployment>"
+        );
+        DeploymentSpec spec = DeploymentSpec.fromXml(r);
+        assertEquals("latest", spec.requireInstance("default").upgradeRevision().toString());
+        assertEquals("separate", spec.requireInstance("custom").upgradeRevision().toString());
+    }
+
+    @Test
     public void productionSpecWithUpgradeRollout() {
         StringReader r = new StringReader(
                 "<deployment>" +
@@ -397,10 +413,10 @@ public class DeploymentSpecTest {
     public void upgradePolicyDefault() {
         StringReader r = new StringReader(
                 "<deployment version='1.0'>" +
-                "   <upgrade policy='canary' rollout='leading'/>" +
+                "   <upgrade policy='canary' rollout='leading' revision='latest' />" +
                 "   <instance id='instance1'/>" +
                 "   <instance id='instance2'>" +
-                "      <upgrade policy='conservative' rollout='separate'/>" +
+                "      <upgrade policy='conservative' rollout='separate' revision='separate'/>" +
                 "   </instance>" +
                 "</deployment>"
         );
@@ -408,6 +424,8 @@ public class DeploymentSpecTest {
         DeploymentSpec spec = DeploymentSpec.fromXml(r);
         assertEquals("canary", spec.requireInstance("instance1").upgradePolicy().toString());
         assertEquals("conservative", spec.requireInstance("instance2").upgradePolicy().toString());
+        assertEquals("latest", spec.requireInstance("instance1").upgradeRevision().toString());
+        assertEquals("separate", spec.requireInstance("instance2").upgradeRevision().toString());
         assertEquals("leading", spec.requireInstance("instance1").upgradeRollout().toString());
         assertEquals("separate", spec.requireInstance("instance2").upgradeRollout().toString());
     }

--- a/config-model/src/main/resources/schema/deployment.rnc
+++ b/config-model/src/main/resources/schema/deployment.rnc
@@ -52,6 +52,7 @@ ParallelInstances = element parallel {
 
 Upgrade = element upgrade {
     attribute policy { xsd:string }? &
+    attribute revision { xsd:string }? &
     attribute rollout { xsd:string }?
 }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Instance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Instance.java
@@ -188,7 +188,7 @@ public class Instance {
         return change;
     }
 
-    /** Returns the application version that last completedd roll-out to this instance. */
+    /** Returns the application version that last rolled out to this instance. */
     public Optional<ApplicationVersion> latestDeployed() {
         return latestDeployed;
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/ApplicationPackageBuilder.java
@@ -57,6 +57,7 @@ public class ApplicationPackageBuilder {
     private OptionalInt majorVersion = OptionalInt.empty();
     private String instances = "default";
     private String upgradePolicy = null;
+    private String upgradeRevision = "latest";
     private String upgradeRollout = null;
     private String globalServiceId = null;
     private String athenzIdentityAttributes = "athenz-domain='domain' athenz-service='service'";
@@ -77,6 +78,11 @@ public class ApplicationPackageBuilder {
 
     public ApplicationPackageBuilder upgradePolicy(String upgradePolicy) {
         this.upgradePolicy = upgradePolicy;
+        return this;
+    }
+
+    public ApplicationPackageBuilder upgradeRevision(String upgradeRevision) {
+        this.upgradeRevision = upgradeRevision;
         return this;
     }
 
@@ -253,9 +259,10 @@ public class ApplicationPackageBuilder {
         }
         xml.append(">\n");
         xml.append("  <instance id='").append(instances).append("'>\n");
-        if (upgradePolicy != null || upgradeRollout != null) {
+        if (upgradePolicy != null || upgradeRevision != null || upgradeRollout != null) {
             xml.append("    <upgrade ");
             if (upgradePolicy != null) xml.append("policy='").append(upgradePolicy).append("' ");
+            if (upgradeRevision != null) xml.append("revision='").append(upgradeRevision).append("' ");
             if (upgradeRollout != null) xml.append("rollout='").append(upgradeRollout).append("' ");
             xml.append("/>\n");
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -860,6 +860,7 @@ public class DeploymentTriggerTest {
         DeploymentContext i4 = tester.newDeploymentContext("t", "a", "i4");
         ApplicationPackage applicationPackage = ApplicationPackageBuilder
                 .fromDeploymentXml("<deployment version='1'>\n" +
+                                   "  <upgrade revision='separate' />\n" +
                                    "  <parallel>\n" +
                                    "    <instance id='i1'>\n" +
                                    "      <prod>\n" +
@@ -944,8 +945,7 @@ public class DeploymentTriggerTest {
         tester.clock().advance(Duration.ofHours(3));
 
         // v1 is all done in i1 and i2, but does not yet roll out in i3; v2 is not completely rolled out there yet.
-        // TODO jonmv: thie belowh new revision policy, but must be faked for now, as v1 would not wait for v0 to complete.
-        //tester.outstandingChangeDeployer().run();
+        tester.outstandingChangeDeployer().run();
         assertEquals(v0, i3.instance().change().application());
 
         // i3 completes v0, which rolls out to i4; v1 is ready for i3, but v2 is not.


### PR DESCRIPTION
@mpolden please review. We'll hold off documenting the new settings for now, and remove `latest` unless anyone requests it within a reasonable amount of time has passed with `sesparate` as the new default. 