### PR TITLE
Deprecate c.y.log.LogLevel.

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLogger.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLogger.java
@@ -36,6 +36,7 @@ public class DeployHandlerLogger implements DeployLogger {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void log(Level level, String message) {
         if (level.intValue() <= LogLevel.DEBUG.intValue() && !verbose)
             return;
@@ -46,6 +47,7 @@ public class DeployHandlerLogger implements DeployLogger {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public void logApplicationPackage(Level level, String message) {
         if (level.intValue() <= LogLevel.DEBUG.intValue() && !verbose)
             return;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLoggerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployHandlerLoggerTest.java
@@ -39,6 +39,7 @@ public class DeployHandlerLoggerTest {
         assertTrue(Pattern.matches(expectedPattern, baos.toString()));
     }
 
+    @SuppressWarnings("deprecation")
     private void logMessages(DeployLogger logger) {
         logger.log(LogLevel.DEBUG, "foobar");
         logger.log(LogLevel.SPAM, "foobar");

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/LogEntry.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/LogEntry.java
@@ -57,6 +57,7 @@ public class LogEntry {
         return message;
     }
 
+    @SuppressWarnings("deprecation")
     public static List<LogEntry> parseVespaLog(InputStream log, Instant from) {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(log, UTF_8))) {
             return reader.lines()
@@ -104,6 +105,7 @@ public class LogEntry {
         return Objects.hash(id, at, type, message);
     }
 
+    @SuppressWarnings("deprecation")
     public static Type typeOf(Level level) {
         return    level.intValue() < Level.INFO.intValue() || level.intValue() == LogLevel.IntValEVENT ? Type.debug
                 : level.intValue() < Level.WARNING.intValue() ? Type.info

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -391,6 +391,8 @@ public class ApplicationController {
             // the source since it's the same application, so it should have the same warnings
             NotificationSource source = zone.environment().isManuallyDeployed() ?
                     NotificationSource.from(deployment) : NotificationSource.from(applicationId);
+
+            @SuppressWarnings("deprecation")
             List<String> warnings = Optional.ofNullable(result.prepareResponse().log)
                     .map(logs -> logs.stream()
                             .filter(log -> log.applicationPackage)

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -222,6 +222,7 @@ public class InternalStepRunner implements StepRunner {
                       logger);
     }
 
+    @SuppressWarnings("deprecation")
     private Optional<RunStatus> deploy(Supplier<ActivateResult> deployment, Instant startTime, DualLogger logger) {
         try {
             PrepareResponse prepareResponse = deployment.get().prepareResponse();

--- a/logserver/src/main/java/ai/vespa/logserver/protocol/ProtobufSerialization.java
+++ b/logserver/src/main/java/ai/vespa/logserver/protocol/ProtobufSerialization.java
@@ -79,6 +79,7 @@ class ProtobufSerialization {
                 .build();
     }
 
+    @SuppressWarnings("deprecation")
     private static Level fromLogMessageLevel(LogProtocol.LogMessage.Level level) {
         switch (level) {
             case FATAL:
@@ -104,6 +105,7 @@ class ProtobufSerialization {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static LogProtocol.LogMessage.Level toLogMessageLevel(Level level) {
         Level vespaLevel = LogLevel.getVespaLogLevel(level);
         if (vespaLevel.equals(LogLevel.FATAL)) {

--- a/logserver/src/main/java/com/yahoo/logserver/filter/LogFilterManager.java
+++ b/logserver/src/main/java/com/yahoo/logserver/filter/LogFilterManager.java
@@ -14,6 +14,7 @@ import java.util.Map;
  *
  * @author Bjorn Borud
  */
+@SuppressWarnings("deprecation")
 public class LogFilterManager {
     private static final LogFilterManager instance;
 

--- a/logserver/src/main/java/com/yahoo/logserver/handlers/logmetrics/LogMetricsHandler.java
+++ b/logserver/src/main/java/com/yahoo/logserver/handlers/logmetrics/LogMetricsHandler.java
@@ -33,6 +33,7 @@ public class LogMetricsHandler extends AbstractLogHandler {
     private final List<LevelCount> logMetrics = new ArrayList<LevelCount>();
 
     // The log levels that are handled by this plugin
+    @SuppressWarnings("deprecation")
     private static final Level[] levels = {LogLevel.INFO,
             LogLevel.WARNING,
             LogLevel.SEVERE,

--- a/logserver/src/main/java/com/yahoo/logserver/testutils/VerifyLogfile.java
+++ b/logserver/src/main/java/com/yahoo/logserver/testutils/VerifyLogfile.java
@@ -17,6 +17,7 @@ import com.yahoo.log.LogMessage;
  *
  * @author  Bjorn Borud
  */
+@SuppressWarnings("deprecation")
 public class VerifyLogfile {
 
     public static void main (String[] args) throws IOException {

--- a/logserver/src/test/java/ai/vespa/logserver/protocol/ArchiveLogMessagesMethodTest.java
+++ b/logserver/src/test/java/ai/vespa/logserver/protocol/ArchiveLogMessagesMethodTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author bjorncs
  */
+@SuppressWarnings("deprecation")
 public class ArchiveLogMessagesMethodTest {
 
     private static final LogMessage MESSAGE_1 =

--- a/vespalog/src/main/java/com/yahoo/log/LogLevel.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogLevel.java
@@ -1,10 +1,9 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.log;
 
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.logging.Level;
 
 
@@ -31,8 +30,11 @@ import java.util.logging.Level;
  *
  * @author  Bjorn Borud
  * @author arnej27959
+ *
+ * @deprecated  Use {@link java.util.logging.Level} instead.
  */
-
+// TODO Vespa 9: move to non-PublicApi package
+@Deprecated(since = "7")
 public class LogLevel extends Level {
     /** A map from the name of the log level to the instance */
     private static final Map<String, Level> nameToLevel;

--- a/vespalog/src/main/java/com/yahoo/log/LogMessage.java
+++ b/vespalog/src/main/java/com/yahoo/log/LogMessage.java
@@ -109,8 +109,9 @@ public class LogMessage
         if (! m.matches()) {
             throw new InvalidLogFormatException(msg);
         }
-
+        @SuppressWarnings("deprecation")
         Level msgLevel = LogLevel.parse(m.group(6));
+
         Instant timestamp = parseTimestamp(m.group(1));
         String threadProcess = m.group(3);
 
@@ -162,6 +163,7 @@ public class LogMessage
      *         it will return <code>null</code>.
      *
      */
+    @SuppressWarnings("deprecation")
     public Event getEvent () throws MalformedEventException {
         if ((level == LogLevel.EVENT) && (event == null)) {
             try {

--- a/vespalog/src/main/java/com/yahoo/log/event/Event.java
+++ b/vespalog/src/main/java/com/yahoo/log/event/Event.java
@@ -386,7 +386,9 @@ public abstract class Event implements Serializable {
      * the prettiest way to do it...
      */
     private static final void log(Logger logger, Object param) {
+        @SuppressWarnings("deprecation")
         LogRecord r = new LogRecord(LogLevel.EVENT, null);
+
         r.setParameters(new Object[] {param});
         r.setLoggerName(logger.getName());
         logger.log(r);

--- a/vespalog/src/test/java/com/yahoo/log/LogLevelTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogLevelTestCase.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.*;
  *
  * @author  Bjorn Borud
  */
+@SuppressWarnings("deprecation")
 public class LogLevelTestCase {
 
     /**

--- a/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Bjorn Borud
  */
-@SuppressWarnings("removal")
+@SuppressWarnings({"deprecation", "removal"})
 public class LogSetupTestCase {
     // For testing zookeeper log records
     protected static LogRecord zookeeperLogRecord;

--- a/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.fail;
 /**
  * @author  Bjorn Borud
  */
-@SuppressWarnings("removal")
+@SuppressWarnings({"deprecation", "removal"})
 public class VespaFormatterTestCase {
 
     private String hostname;

--- a/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLevelControllerRepoTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  * @since 5.1
  */
-@SuppressWarnings("removal")
+@SuppressWarnings({"deprecation", "removal"})
 public class VespaLevelControllerRepoTest {
 
     static int findControlString(RandomAccessFile f, String s) {


### PR DESCRIPTION
- Will remain PublicApi until Vespa 9

Please review, but don't merge. Need to update all internal usage first.
