### PR TITLE
Don't allow pending ops in DynamicOperationThrottler when destroying instance.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.cpp
@@ -244,7 +244,10 @@ DynamicOperationThrottler::DynamicOperationThrottler(const DynamicThrottleParams
 {
 }
 
-DynamicOperationThrottler::~DynamicOperationThrottler() = default;
+DynamicOperationThrottler::~DynamicOperationThrottler()
+{
+    assert(_pending_ops == 0u);
+}
 
 bool
 DynamicOperationThrottler::has_spare_capacity_in_active_window() noexcept


### PR DESCRIPTION
@geirst : please review
@vekterli : FYI
