### PR TITLE
Reduce default timeout for metrics requests from 300s to 25s to ensur…

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/metrics/HttpHandlerBase.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/metrics/HttpHandlerBase.java
@@ -11,6 +11,7 @@ import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.restapi.Path;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Executor;
@@ -28,12 +29,23 @@ import static java.util.logging.Level.WARNING;
 public abstract class HttpHandlerBase extends ThreadedHttpRequestHandler {
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
+    private final Duration defaultTimeout;
 
     protected HttpHandlerBase(Executor executor) {
+        this(executor, Duration.ofSeconds(25));
+    }
+
+    protected HttpHandlerBase(Executor executor, Duration defaultTimeout) {
         super(executor);
+        this.defaultTimeout = defaultTimeout;
     }
 
     protected abstract Optional<HttpResponse> doHandle(URI requestUri, Path apiPath, String consumer);
+
+    @Override
+    public Duration getTimeout() {
+        return defaultTimeout;
+    }
 
     @Override
     public final HttpResponse handle(HttpRequest request) {

--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/http/metrics/MetricsV2Handler.java
@@ -31,7 +31,6 @@ import static ai.vespa.metricsproxy.metric.model.processing.MetricsProcessor.app
 import static com.yahoo.jdisc.Response.Status.INTERNAL_SERVER_ERROR;
 import static com.yahoo.jdisc.Response.Status.OK;
 import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Http handler for the metrics/v2 rest api.


### PR DESCRIPTION
…e it is shorter than shutdown timeout targeted to be 30s

@bjorncs or @gjoranv PR