### PR TITLE
Store temporary service dump files in a unique directory

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImpl.java
@@ -88,7 +88,7 @@ public class VespaServiceDumperImpl implements VespaServiceDumper {
             handleFailure(context, request, startedAt, "No artifacts requested");
             return;
         }
-        ContainerPath directory = context.paths().underVespaHome("tmp/vespa-service-dump");
+        ContainerPath directory = context.paths().underVespaHome("tmp/vespa-service-dump-" + request.getCreatedMillisOrNull());
         UnixPath unixPathDirectory = new UnixPath(directory);
         try {
             context.log(log, Level.INFO,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImplTest.java
@@ -81,11 +81,11 @@ class VespaServiceDumperImplTest {
         verify(operations).executeCommandInContainer(
                 context, context.users().vespa(), "/opt/vespa/libexec/vespa/find-pid", "default/container.1");
         verify(operations).executeCommandInContainer(
-                context, context.users().vespa(), "perf", "record", "-g", "--output=/opt/vespa/tmp/vespa-service-dump/perf-record.bin",
+                context, context.users().vespa(), "perf", "record", "-g", "--output=/opt/vespa/tmp/vespa-service-dump-1600000000000/perf-record.bin",
                 "--pid=12345", "sleep", "45");
         verify(operations).executeCommandInContainer(
-                context, context.users().vespa(), "bash", "-c", "perf report --input=/opt/vespa/tmp/vespa-service-dump/perf-record.bin" +
-                        " > /opt/vespa/tmp/vespa-service-dump/perf-report.txt");
+                context, context.users().vespa(), "bash", "-c", "perf report --input=/opt/vespa/tmp/vespa-service-dump-1600000000000/perf-record.bin" +
+                        " > /opt/vespa/tmp/vespa-service-dump-1600000000000/perf-report.txt");
 
         String expectedJson = "{\"createdMillis\":1600000000000,\"startedAt\":1600001000000,\"completedAt\":1600001000000," +
                 "\"location\":\"s3://uri-1/tenant1/service-dump/default-container-1-1600000000000/\"," +
@@ -124,7 +124,7 @@ class VespaServiceDumperImplTest {
                 context, context.users().vespa(), "/opt/vespa/libexec/vespa/find-pid", "default/container.1");
         verify(operations).executeCommandInContainer(
                 context, context.users().vespa(), "jcmd", "12345", "JFR.start", "name=host-admin", "path-to-gc-roots=true", "settings=profile",
-                "filename=/opt/vespa/tmp/vespa-service-dump/recording.jfr", "duration=30s");
+                "filename=/opt/vespa/tmp/vespa-service-dump-1600000000000/recording.jfr", "duration=30s");
         verify(operations).executeCommandInContainer(context, context.users().vespa(), "jcmd", "12345", "JFR.check", "name=host-admin");
 
         String expectedJson = "{\"createdMillis\":1600000000000,\"startedAt\":1600001000000," +


### PR DESCRIPTION
Otherwise the sync file cache will believe files are already uploaded for subsequent service dumps.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
