### PR TITLE
Ignore the current active file when computing spread.

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.cpp
@@ -335,9 +335,11 @@ LogDataStore::getMaxBucketSpread() const
 {
     double maxSpread(1.0);
     MonitorGuard guard(_updateLock);
-    for (const auto & fc : _fileChunks) {
-        if (fc) {
-            if (_bucketizer && fc->frozen()) {
+    for (FileId i(0); i < FileId(_fileChunks.size()); i = i.next()) {
+        /// Ignore the the active file
+        if (i != _active) {
+            const auto & fc = _fileChunks[i.getId()];
+            if (fc && _bucketizer && fc->frozen()) {
                 maxSpread = std::max(maxSpread, fc->getBucketSpread());
             }
         }


### PR DESCRIPTION
@geirst PR