### PR TITLE
Avoid clang warning when discarding values. DO NOT MERGE.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attributefilewriter.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributefilewriter.cpp
@@ -155,8 +155,8 @@ void
 AttributeFileWriter::close()
 {
     if (_file->IsOpened()) {
-        _file->Sync();
-        _file->Close();
+        (void) _file->Sync();
+        (void) _file->Close();
         updateHeader(_file->GetFileName(), _fileBitSize);
     }
 }

--- a/searchlib/src/vespa/searchlib/diskindex/pagedict4randread.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/pagedict4randread.cpp
@@ -255,9 +255,9 @@ PageDict4RandRead::close()
 
     _ssReadContext.dropComprBuf();
     _ssReadContext.setFile(nullptr);
-    _ssfile->Close();
-    _spfile->Close();
-    _pfile->Close();
+    (void) _ssfile->Close();
+    (void) _spfile->Close();
+    (void) _pfile->Close();
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/diskindex/zcposoccrandread.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/zcposoccrandread.cpp
@@ -175,7 +175,7 @@ open(const vespalib::string &name, const TuneFileRandRead &tuneFileRead)
 bool
 ZcPosOccRandRead::close()
 {
-    _file->Close();
+    (void) _file->Close();
     return true;
 }
 

--- a/searchlib/src/vespa/searchlib/util/file_with_header.cpp
+++ b/searchlib/src/vespa/searchlib/util/file_with_header.cpp
@@ -30,7 +30,7 @@ FileWithHeader::FileWithHeader(std::unique_ptr<FastOS_FileInterface> file_in)
         _header_len = _header.readFile(*_file);
         _file->SetPosition(_header_len);
         if (!extract_file_size(_header, *_file, _file_size)) {
-            _file->Close();
+            (void) _file->Close();
         }
     }
 }
@@ -52,7 +52,7 @@ FileWithHeader::rewind()
 void
 FileWithHeader::close()
 {
-    _file->Close();
+    (void) _file->Close();
 }
 
 


### PR DESCRIPTION
@baldersheim : here are the locations triggering clang warnings due to return values being discarded.
