### PR TITLE
pick the right attribute for streaming

### DIFF
--- a/searchlib/src/vespa/searchlib/features/distancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.cpp
@@ -225,9 +225,10 @@ DistanceBlueprint::setup(const IIndexEnvironment & env,
             _attr_id = fi->id();
             return setup_nns(env, arg);
         }
-        // could check if dt is DataType::INT64
         // could check if ct is CollectionType::SINGLE or CollectionType::ARRAY)
-        return setup_geopos(env, arg);
+        if (dt == DataType::INT64) {
+            return setup_geopos(env, arg);
+        }
     }
     vespalib::string z = document::PositionDataType::getZCurveFieldName(arg);
     fi = env.getFieldByName(z);


### PR DESCRIPTION
* This would detect the wrong field name because with
  SearchVisitor all fields are available as attributes;
  SearchVisitor::PositionInserter would not be triggered
  because the wrong field name was hinted for attribute access.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
