### PR TITLE
Avoid assertion failure on aborted node startup

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.cpp
@@ -97,7 +97,9 @@ ModifiedBucketChecker::onClose()
     if (_singleThreadMode) {
         return;
     }
-    assert(_thread);
+    if (!_thread) {
+        return; // Aborted startup; onOpen() was never called so there's nothing to close.
+    }
     LOG(debug, "Interrupting modified bucket checker thread");
     _thread->interrupt();
     _cond.notify_one();


### PR DESCRIPTION
@baldersheim please review

If a node fails to completely start up due to e.g. failures
fetching bootstrap config, it's possible for the storage component
chain to have been created but not yet completely initialized.
Attempts to gracefully abort startup will still invoke the component
`onClose()` methods, at which point the components must be able to
handle a partially initialized state. Let `ModifiedBucketChecker`
handle that its worker thread was not created when closing, as
this will happen when `onOpen()` is never called.