### PR TITLE
Use half of available cores to compile query profiles.

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -6244,7 +6244,7 @@
       "public"
     ],
     "methods": [
-      "public void <init>(com.yahoo.search.query.profile.config.QueryProfilesConfig)",
+      "public void <init>(com.yahoo.search.query.profile.config.QueryProfilesConfig, java.util.concurrent.Executor)",
       "public void <init>()",
       "public void <init>(com.yahoo.search.query.profile.types.QueryProfileTypeRegistry)",
       "public final void register(com.yahoo.search.query.profile.compiled.CompiledQueryProfile)",

--- a/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistry.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistry.java
@@ -12,6 +12,10 @@ import com.yahoo.search.query.profile.config.QueryProfilesConfig;
 import com.yahoo.search.query.profile.types.QueryProfileTypeRegistry;
 import com.yahoo.yolean.UncheckedInterruptedException;
 
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.LinkedBlockingQueue;
+
 /**
  * A set of compiled query profiles.
  *
@@ -25,12 +29,28 @@ public class CompiledQueryProfileRegistry extends ComponentRegistry<CompiledQuer
     private final QueryProfileTypeRegistry typeRegistry;
 
     @Inject
-    public CompiledQueryProfileRegistry(QueryProfilesConfig config) {
+    public CompiledQueryProfileRegistry(QueryProfilesConfig config, Executor executor) {
         QueryProfileRegistry registry = QueryProfileConfigurer.createFromConfig(config);
         typeRegistry = registry.getTypeRegistry();
-        for (QueryProfile inputProfile : registry.allComponents()) {
-            abortIfInterrupted();
-            register(QueryProfileCompiler.compile(inputProfile, this));
+        int maxConcurrent = Math.max(1, Runtime.getRuntime().availableProcessors()/2);
+        BlockingQueue<CompiledQueryProfile> doneQ = new LinkedBlockingQueue<>();
+        int started = 0;
+        int completed = 0;
+        try {
+            for (QueryProfile inputProfile : registry.allComponents()) {
+                abortIfInterrupted();
+                if (started++ >= maxConcurrent) {
+                    register(doneQ.take());
+                    completed++;
+                }
+                executor.execute(() -> doneQ.add(QueryProfileCompiler.compile(inputProfile, this)));
+            }
+            while (completed < started) {
+                register(doneQ.take());
+                completed++;
+            }
+        } catch (InterruptedException e) {
+            throw new UncheckedInterruptedException("Interrupted while waiting for compiled query profiles", true);
         }
     }
 

--- a/container-search/src/test/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistryTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import java.util.concurrent.Executors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author gjoranv
@@ -23,7 +24,9 @@ public class CompiledQueryProfileRegistryTest {
                                                         .value("5")))
                 .build();
 
-        var registry = new CompiledQueryProfileRegistry(config, Executors.newCachedThreadPool());
+        var executor = Executors.newCachedThreadPool();
+        var registry = new CompiledQueryProfileRegistry(config, executor);
+        assertTrue(executor.shutdownNow().isEmpty());
         var profile1 = registry.findQueryProfile("profile1");
         assertEquals("5", profile1.get("hits"));
     }

--- a/container-search/src/test/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistryTest.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/compiled/CompiledQueryProfileRegistryTest.java
@@ -4,6 +4,8 @@ package com.yahoo.search.query.profile.compiled;
 import com.yahoo.search.query.profile.config.QueryProfilesConfig;
 import org.junit.Test;
 
+import java.util.concurrent.Executors;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -21,7 +23,7 @@ public class CompiledQueryProfileRegistryTest {
                                                         .value("5")))
                 .build();
 
-        var registry = new CompiledQueryProfileRegistry(config);
+        var registry = new CompiledQueryProfileRegistry(config, Executors.newCachedThreadPool());
         var profile1 = registry.findQueryProfile("profile1");
         assertEquals("5", profile1.get("hits"));
     }


### PR DESCRIPTION
@bratseth PR