### PR TITLE
Set commitLogCount for cluster controller to 10

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerCluster.java
@@ -9,7 +9,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.HostSpec;
-import com.yahoo.net.HostName;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.admin.Configserver;
 import com.yahoo.vespa.model.container.Container;
@@ -18,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toUnmodifiableSet;
 
@@ -58,6 +56,10 @@ public class ClusterControllerCluster extends AbstractConfigProducer<ClusterCont
             serverBuilder.retired(container.isRetired());
             builder.server(serverBuilder);
         }
+        // Reindexing progress stores huge (observed 530k) progress tokens
+        // in zookeeper. These temporarily ends up in a 500 elements long commit log in memory.
+        // Reducing the log to 10 for cluster-controller should make this manageable for admin nodes too.
+        builder.commitLogCount(10);
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/ClusterControllerTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/ClusterControllerTestCase.java
@@ -231,6 +231,7 @@ public class ClusterControllerTestCase extends DomBuilderTest {
         assertEquals(id, config.myid());
         Collection<Integer> serverIds = Collections2.transform(config.server(), ZookeeperServerConfig.Server::id);
         assertTrue(serverIds.contains(id));
+        assertEquals(10, config.commitLogCount());
     }
 
     public void assertCuratorConfig(TestRoot root) {

--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -16,10 +16,9 @@ maxClientConnections int default=0
 dataDir string default="var/zookeeper"
 
 clientPort int default=2181
-# TODO(bjorncs): remove setting - no longer in use
-secureClientPort int default=2184
 
 snapshotCount int default=50000
+commitLogCount int default=500
 # Purge interval in hours
 autopurge.purgeInterval int default=1
 autopurge.snapRetainCount int default=15

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -42,6 +42,7 @@ public class Configurator {
         // Need to set this as a system property, otherwise it will be parsed for _every_ packet and an exception will be thrown (and handled)
         System.setProperty("zookeeper.globalOutstandingLimit", "1000");
         System.setProperty("zookeeper.snapshot.compression.method", zookeeperServerConfig.snapshotMethod());
+        System.setProperty("zookeeper.commitLogCount", String.valueOf(zookeeperServerConfig.commitLogCount()));
     }
 
     void writeConfigToDisk() { writeConfigToDisk(VespaTlsConfig.fromSystem()); }


### PR DESCRIPTION
Other zookeeper server system properties are set in Configurator through config, so do that with `zookeeper.commitLogCount` as well. We could add a feature flag for this if needed.