### PR TITLE
Don't set deprecated fields when aggregating visitor statistics

### DIFF
--- a/documentapi/src/tests/messages/messages60test.cpp
+++ b/documentapi/src/tests/messages/messages60test.cpp
@@ -382,8 +382,8 @@ Messages60Test::testCreateVisitorReply()
             EXPECT_EQUAL(ref.getVisitorStatistics().getBytesVisited(), (uint64_t)1024000);
             EXPECT_EQUAL(ref.getVisitorStatistics().getDocumentsReturned(), (uint64_t)123);
             EXPECT_EQUAL(ref.getVisitorStatistics().getBytesReturned(), (uint64_t)512000);
-            EXPECT_EQUAL(ref.getVisitorStatistics().getSecondPassDocumentsReturned(), (uint64_t)456);
-            EXPECT_EQUAL(ref.getVisitorStatistics().getSecondPassBytesReturned(), (uint64_t)789100);
+            EXPECT_EQUAL(ref.getVisitorStatistics().getSecondPassDocumentsReturned(), (uint64_t)456); // TODO remove on Vespa 8
+            EXPECT_EQUAL(ref.getVisitorStatistics().getSecondPassBytesReturned(), (uint64_t)789100); // TODO remove on Vespa 8
         }
     }
     return true;

--- a/documentapi/src/vespa/documentapi/messagebus/routablefactories60.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/routablefactories60.cpp
@@ -170,6 +170,7 @@ RoutableFactories60::CreateVisitorReplyFactory::doDecode(document::ByteBuffer &b
     vs.setBytesVisited(decodeLong(buf));
     vs.setDocumentsReturned(decodeLong(buf));
     vs.setBytesReturned(decodeLong(buf));
+    // TODO remove second pass concept on Vespa 8
     vs.setSecondPassDocumentsReturned(decodeLong(buf));
     vs.setSecondPassBytesReturned(decodeLong(buf));
     reply->setVisitorStatistics(vs);
@@ -187,6 +188,7 @@ RoutableFactories60::CreateVisitorReplyFactory::doEncode(const DocumentReply &ob
     buf.putLong(reply.getVisitorStatistics().getBytesVisited());
     buf.putLong(reply.getVisitorStatistics().getDocumentsReturned());
     buf.putLong(reply.getVisitorStatistics().getBytesReturned());
+    // TODO remove second pass concept on Vespa 8
     buf.putLong(reply.getVisitorStatistics().getSecondPassDocumentsReturned());
     buf.putLong(reply.getVisitorStatistics().getSecondPassBytesReturned());
     return true;

--- a/storage/src/vespa/storage/visiting/visitor.cpp
+++ b/storage/src/vespa/storage/visiting/visitor.cpp
@@ -24,35 +24,23 @@ using document::BucketSpace;
 namespace storage {
 
 Visitor::HitCounter::HitCounter()
-    : _firstPassHits(0),
-      _firstPassBytes(0),
-      _secondPassHits(0),
-      _secondPassBytes(0)
+    : _doc_hits(0),
+      _doc_bytes(0)
 {
 }
 
 void
 Visitor::HitCounter::addHit(const document::DocumentId& , uint32_t size)
 {
-    bool firstPass = false;
-
-    if (firstPass) {
-        _firstPassHits++;
-        _firstPassBytes += size;
-    } else {
-        _secondPassHits++;
-        _secondPassBytes += size;
-    }
-
+    _doc_hits++;
+    _doc_bytes += size;
 }
 
 void
-Visitor::HitCounter::updateVisitorStatistics(vdslib::VisitorStatistics& statistics)
+Visitor::HitCounter::updateVisitorStatistics(vdslib::VisitorStatistics& statistics) const
 {
-    statistics.setDocumentsReturned(statistics.getDocumentsReturned() + _firstPassHits);
-    statistics.setBytesReturned(statistics.getBytesReturned() + _firstPassBytes);
-    statistics.setSecondPassDocumentsReturned(statistics.getSecondPassDocumentsReturned() + _secondPassHits);
-    statistics.setSecondPassBytesReturned(statistics.getSecondPassBytesReturned() + _secondPassBytes);
+    statistics.setDocumentsReturned(statistics.getDocumentsReturned() + _doc_hits);
+    statistics.setBytesReturned(statistics.getBytesReturned() + _doc_bytes);
 }
 
 Visitor::VisitorTarget::MessageMeta::MessageMeta(

--- a/storage/src/vespa/storage/visiting/visitor.h
+++ b/storage/src/vespa/storage/visiting/visitor.h
@@ -89,24 +89,11 @@ public:
     class HitCounter {
     public:
         HitCounter();
-
         void addHit(const document::DocumentId& hit, uint32_t size);
-
-        void updateVisitorStatistics(vdslib::VisitorStatistics& statistics);
-
-        uint32_t getFirstPassHits() const { return _firstPassHits; }
-
-        uint64_t getFirstPassBytes() const { return _firstPassBytes; }
-
-        uint32_t getSecondPassHits() const { return _secondPassHits; }
-
-        uint64_t getSecondPassBytes() const { return _secondPassBytes; }
-
+        void updateVisitorStatistics(vdslib::VisitorStatistics& statistics) const;
     private:
-        uint32_t _firstPassHits;
-        uint64_t _firstPassBytes;
-        uint32_t _secondPassHits;
-        uint64_t _secondPassBytes;
+        uint32_t _doc_hits;
+        uint64_t _doc_bytes;
     };
 
     enum VisitorState

--- a/storageapi/src/vespa/storageapi/mbusprot/protocolserialization5_0.cpp
+++ b/storageapi/src/vespa/storageapi/mbusprot/protocolserialization5_0.cpp
@@ -538,6 +538,7 @@ ProtocolSerialization5_0::onEncode(GBBuf& buf, const api::CreateVisitorReply& ms
     buf.putLong(msg.getVisitorStatistics().getBytesVisited());
     buf.putLong(msg.getVisitorStatistics().getDocumentsReturned());
     buf.putLong(msg.getVisitorStatistics().getBytesReturned());
+    // TODO remove second pass concept on Vespa 8
     buf.putLong(msg.getVisitorStatistics().getSecondPassDocumentsReturned());
     buf.putLong(msg.getVisitorStatistics().getSecondPassBytesReturned());
 }
@@ -554,6 +555,7 @@ ProtocolSerialization5_0::onDecodeCreateVisitorReply(const SCmd& cmd, BBuf& buf)
     vs.setBytesVisited(SH::getLong(buf));
     vs.setDocumentsReturned(SH::getLong(buf));
     vs.setBytesReturned(SH::getLong(buf));
+    // TODO remove second pass concept on Vespa 8
     vs.setSecondPassDocumentsReturned(SH::getLong(buf));
     vs.setSecondPassBytesReturned(SH::getLong(buf));
     msg->setVisitorStatistics(vs);

--- a/storageapi/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
+++ b/storageapi/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
@@ -1240,8 +1240,8 @@ void ProtocolSerialization7::onEncode(GBBuf& buf, const api::CreateVisitorReply&
         proto_stats->set_bytes_visited(stats.getBytesVisited());
         proto_stats->set_documents_returned(stats.getDocumentsReturned());
         proto_stats->set_bytes_returned(stats.getBytesReturned());
-        proto_stats->set_second_pass_documents_returned(stats.getSecondPassDocumentsReturned());
-        proto_stats->set_second_pass_bytes_returned(stats.getSecondPassBytesReturned());
+        proto_stats->set_second_pass_documents_returned(stats.getSecondPassDocumentsReturned()); // TODO remove on Vespa 8
+        proto_stats->set_second_pass_bytes_returned(stats.getSecondPassBytesReturned()); // TODO remove on Vespa 8
     });
 }
 
@@ -1287,8 +1287,8 @@ api::StorageReply::UP ProtocolSerialization7::onDecodeCreateVisitorReply(const S
         vs.setBytesVisited(proto_stats.bytes_visited());
         vs.setDocumentsReturned(proto_stats.documents_returned());
         vs.setBytesReturned(proto_stats.bytes_returned());
-        vs.setSecondPassDocumentsReturned(proto_stats.second_pass_documents_returned());
-        vs.setSecondPassBytesReturned(proto_stats.second_pass_bytes_returned());
+        vs.setSecondPassDocumentsReturned(proto_stats.second_pass_documents_returned()); // TODO remove on Vespa 8
+        vs.setSecondPassBytesReturned(proto_stats.second_pass_bytes_returned()); // TODO remove on Vespa 8
         reply->setVisitorStatistics(vs);
         return reply;
     });

--- a/vdslib/src/vespa/vdslib/container/visitorstatistics.h
+++ b/vdslib/src/vespa/vdslib/container/visitorstatistics.h
@@ -40,8 +40,8 @@ private:
     uint64_t _bytesVisited;
     uint64_t _documentsReturned;
     uint64_t _bytesReturned;
-    uint64_t _secondPassDocumentsReturned;
-    uint64_t _secondPassBytesReturned;
+    uint64_t _secondPassDocumentsReturned; // TODO remove on Vespa 8
+    uint64_t _secondPassBytesReturned; // TODO remove on Vespa 8
 };
 
 }


### PR DESCRIPTION
@baldersheim please review

The 1st/2nd pass functionality has been deprecated for a long time,
but unfortunately the documents/bytes visited stats have been wired
to be returned as part of 2nd phase statistics instead of the regular
higher-level fields. This commit changes this, but the serialization
will still have to remain in place until Vespa 8.
