### PR TITLE
Configure load balancer with nodes that will become active

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerList.java
@@ -2,6 +2,8 @@
 package com.yahoo.vespa.hosted.provision.lb;
 
 import com.yahoo.collections.AbstractFilteringList;
+import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ClusterSpec;
 
 import java.util.Collection;
 
@@ -19,6 +21,16 @@ public class LoadBalancerList extends AbstractFilteringList<LoadBalancer, LoadBa
     /** Returns the subset of load balancers that are in given state */
     public LoadBalancerList in(LoadBalancer.State state) {
         return matching(lb -> lb.state() == state);
+    }
+
+    /** Returns the subset of load balancers in given cluster */
+    public LoadBalancerList application(ApplicationId application) {
+        return matching(lb -> lb.id().application().equals(application));
+    }
+
+    /** Returns the subset of load balancers in given cluster */
+    public LoadBalancerList cluster(ClusterSpec.Id cluster) {
+        return matching(lb -> lb.id().cluster().equals(cluster));
     }
 
     public static LoadBalancerList copyOf(Collection<LoadBalancer> loadBalancers) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancers.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancers.java
@@ -2,20 +2,9 @@
 package com.yahoo.vespa.hosted.provision.lb;
 
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.NodeType;
-import com.yahoo.vespa.hosted.provision.Node;
-import com.yahoo.vespa.hosted.provision.NodeList;
-import com.yahoo.vespa.hosted.provision.NodeRepository;
-import com.yahoo.vespa.hosted.provision.node.NodeAcl;
 import com.yahoo.vespa.hosted.provision.persistence.CuratorDatabaseClient;
 
-import java.util.Comparator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * The load balancers of this node repo.


### PR DESCRIPTION
Before this we only considered the current nodes (before activate-transaction is
committed), which worked in most cases because prepare does all the necessary
work. However, this is not the case when nodes are removed.

@bratseth