### PR TITLE
Write temporary file to same directory as final file

### DIFF
--- a/client/go/cmd/test_test.go
+++ b/client/go/cmd/test_test.go
@@ -5,9 +5,6 @@
 package cmd
 
 import (
-	"fmt"
-	"github.com/vespa-engine/vespa/client/go/util"
-	"github.com/vespa-engine/vespa/client/go/vespa"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -15,6 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vespa-engine/vespa/client/go/util"
+	"github.com/vespa-engine/vespa/client/go/vespa"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -40,7 +40,6 @@ func TestSuite(t *testing.T) {
 		requests = append(requests, createSearchRequest(baseUrl+"/search/"))
 	}
 	assertRequests(requests, client, t)
-	fmt.Println(outBytes)
 	assert.Equal(t, string(expectedBytes), outBytes)
 	assert.Equal(t, "", errBytes)
 }

--- a/client/go/util/io.go
+++ b/client/go/util/io.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -53,7 +54,8 @@ func ReaderToJSON(reader io.Reader) string {
 
 // AtomicWriteFile atomically writes data to filename.
 func AtomicWriteFile(filename string, data []byte) error {
-	tmpFile, err := ioutil.TempFile("", "vespa")
+	dir := filepath.Dir(filename)
+	tmpFile, err := ioutil.TempFile(dir, "vespa")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Avoids issues where the default temporary directory is on a different
filesystem.

@bratseth