### PR TITLE
Extend Horizon feature flag expiry

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -223,7 +223,7 @@ public class Flags {
 
     public static final UnboundBooleanFlag ENABLED_HORIZON_DASHBOARD = defineFeatureFlag(
             "enabled-horizon-dashboard", false,
-            List.of("olaa"), "2021-09-13", "2022-02-01",
+            List.of("olaa"), "2021-09-13", "2022-04-01",
             "Enable Horizon dashboard",
             "Takes effect immediately",
             TENANT_ID, CONSOLE_USER_EMAIL


### PR DESCRIPTION
We can consider removing the flag. Let's extend expiry for now, so expiry check succeeds