### PR TITLE
Deprecate config.subscription

### DIFF
--- a/application/src/test/java/com/yahoo/application/TestDocProc.java
+++ b/application/src/test/java/com/yahoo/application/TestDocProc.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.application;
 
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.docproc.DocumentProcessor;
 import com.yahoo.docproc.Processing;
 import com.yahoo.document.config.DocumentmanagerConfig;
@@ -12,7 +11,6 @@ import com.yahoo.document.config.DocumentmanagerConfig;
 public class TestDocProc extends DocumentProcessor {
 
     public TestDocProc(DocumentmanagerConfig config) {
-        new ConfigSubscriber().subscribe(DocumentmanagerConfig.class, "client");
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducer.java
@@ -234,6 +234,7 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
         return didApply;
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private void applyUserConfig(ConfigInstance.Builder builder, ConfigPayloadBuilder payloadBuilder) {
         ConfigInstance.Builder override;
         if (builder instanceof GenericConfig.GenericConfigBuilder) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/derived/AttributeFields.java
@@ -179,6 +179,7 @@ public class AttributeFields extends Derived implements AttributesConfig.Produce
         return "attributes";
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private Map<String, AttributesConfig.Attribute.Builder> toMap(List<AttributesConfig.Attribute.Builder> ls) {
         Map<String, AttributesConfig.Attribute.Builder> ret = new LinkedHashMap<>();
         for (AttributesConfig.Attribute.Builder builder : ls) {

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/RpcConfigSourceClient.java
@@ -45,6 +45,7 @@ class RpcConfigSourceClient implements ConfigSourceClient, Runnable {
     private final Supervisor supervisor = new Supervisor(new Transport("config-source-client"));
 
     private final ResponseHandler responseHandler;
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private final ConfigSourceSet configSourceSet;
     private final Object subscribersLock = new Object();
     private final Map<ConfigCacheKey, Subscriber> subscribers = new ConcurrentHashMap<>();
@@ -59,6 +60,7 @@ class RpcConfigSourceClient implements ConfigSourceClient, Runnable {
             Executors.newScheduledThreadPool(1, new DaemonThreadFactory("delayed responses"));
     private final ScheduledFuture<?> delayedResponsesFuture;
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     RpcConfigSourceClient(ResponseHandler responseHandler, ConfigSourceSet configSourceSet) {
         this.responseHandler = responseHandler;
         this.configSourceSet = configSourceSet;

--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
@@ -26,6 +26,7 @@ public class FileDistributionAndUrlDownload {
     private final ScheduledExecutorService cleanupExecutor =
             new ScheduledThreadPoolExecutor(1, new DaemonThreadFactory("file references and downloads cleanup"));
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     public FileDistributionAndUrlDownload(Supervisor supervisor, ConfigSourceSet source) {
         fileDistributionRpcServer = new FileDistributionRpcServer(supervisor, createDownloader(supervisor, source));
         urlDownloadRpcServer = new UrlDownloadRpcServer(supervisor);
@@ -44,6 +45,7 @@ public class FileDistributionAndUrlDownload {
         }
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private FileDownloader createDownloader(Supervisor supervisor, ConfigSourceSet source) {
         return new FileDownloader(new FileDistributionConnectionPool(source, supervisor),
                                   supervisor,

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ConfigProxyRpcServerTest.java
@@ -256,6 +256,7 @@ public class ConfigProxyRpcServerTest {
         assertEquals("success", req.returnValues().get(0).asString());
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private static ProxyServer createTestServer(ConfigSourceSet source) {
         return new ProxyServer(null, source, new RpcConfigSourceClient(new ResponseHandler(), source));
     }
@@ -264,6 +265,7 @@ public class ConfigProxyRpcServerTest {
 
         private static final Spec SPEC = new Spec(0);
 
+        @SuppressWarnings("removal") // TODO Vespa 8: remove
         private final ProxyServer proxyServer = createTestServer(new ConfigSourceSet(configSourceAddress));
         private final Supervisor supervisor = new Supervisor(new Transport());
         private final ConfigProxyRpcServer rpcServer = new ConfigProxyRpcServer(proxyServer, supervisor, SPEC);

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockConfigSource.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/MockConfigSource.java
@@ -15,6 +15,7 @@ import java.util.Set;
  *
  * @author hmusum
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 class MockConfigSource extends ConfigSourceSet {
     private final HashMap<ConfigKey<?>, RawConfig> backing = new HashMap<>();
 

--- a/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
+++ b/config-proxy/src/test/java/com/yahoo/vespa/config/proxy/ProxyServerTest.java
@@ -222,6 +222,7 @@ public class ProxyServerTest {
         assertEquals(ProxyServer.DEFAULT_PROXY_CONFIG_SOURCES, properties.configSources[0]);
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private static ProxyServer createTestServer(ConfigSourceSet source, ConfigSourceClient configSourceClient) {
         return new ProxyServer(null, source, configSourceClient);
     }

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -186,6 +186,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <!-- TODO Vespa 8: remove configuration.
+             Included to allow 'removal' warnings for classes in its own module -->
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all,-serial,-try,-processing,-removal</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
+++ b/config/src/main/java/com/yahoo/config/subscription/CfgConfigPayloadBuilder.java
@@ -17,7 +17,9 @@ import static java.util.logging.Level.FINEST;
  * Deserializes config payload (cfg format) to a ConfigPayload.
  *
  * @author hmusum
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class CfgConfigPayloadBuilder {
     private static final java.util.logging.Logger log = java.util.logging.Logger.getLogger(CfgConfigPayloadBuilder.class.getName());
 

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigDebug.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigDebug.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.INFO;
 
 // Debug class that provides useful helper routines
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigDebug {
     public static void logDebug(Logger logger, long timestamp, ConfigKey<?> key, String logmessage) {
         if (key.getConfigId().matches(".*container.?\\d+.*") || key.getConfigId().matches(".*doc.api.*")) {

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigGetter.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigGetter.java
@@ -34,7 +34,10 @@ public class ConfigGetter<T extends ConfigInstance> {
      *
      * @param source a {@link ConfigSource}
      * @param clazz  a config class
+     *
+     * @deprecated Config should always be injected via the component class constructor. For unit tests, use config builders.
      */
+    @Deprecated(forRemoval = true, since = "7")
     public ConfigGetter(ConfigSource source, Class<T> clazz) {
         this.clazz = clazz;
         this.source = source;
@@ -74,7 +77,10 @@ public class ConfigGetter<T extends ConfigInstance> {
      * @param configId a config id to use when getting the config
      * @param source   a {@link ConfigSource}
      * @return an instance of a config class
+     *
+     * @deprecated Config should always be injected via the component class constructor. For unit tests, use config builders.
      */
+    @Deprecated(forRemoval = true, since = "7")
     public static <T extends ConfigInstance> T getConfig(Class<T> c, String configId, ConfigSource source) {
         ConfigGetter<T> getter = new ConfigGetter<>(source, c);
         return getter.getConfig(configId);

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigHandle.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigHandle.java
@@ -10,7 +10,9 @@ import com.yahoo.config.subscription.impl.ConfigSubscription;
  *
  * @param <T> the type of the config
  * @author vegardh
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigHandle<T extends ConfigInstance> {
 
     private final ConfigSubscription<T> sub;

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigInstanceSerializer.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigInstanceSerializer.java
@@ -9,7 +9,9 @@ import com.yahoo.slime.Slime;
  * Implements a config instance serializer, serializing a config instance to a slime object.
  *
  * @author Ulf Lilleengen
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigInstanceSerializer implements Serializer {
     private final Slime slime;
     private final Cursor root;

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigInstanceUtil.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigInstanceUtil.java
@@ -14,7 +14,9 @@ import com.yahoo.vespa.config.*;
 
 /**
  * @author gjoranv
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigInstanceUtil {
 
     /**

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigInterruptedException.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigInterruptedException.java
@@ -4,8 +4,10 @@ package com.yahoo.config.subscription;
 /**
  * This exception is thrown when any blocking call within the Config API is interrupted.
  * @author Ulf Lilleengen
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
 @SuppressWarnings("serial")
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigInterruptedException extends RuntimeException {
     public ConfigInterruptedException(Throwable cause) {
         super(cause);

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
@@ -11,7 +11,9 @@ import com.yahoo.vespa.config.ConfigKey;
  * Config source as a programmatically built set of {@link com.yahoo.config.ConfigInstance}s
  *
  * @author Vegard Havdal
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigSet implements ConfigSource {
     private final Map<ConfigKey<?>, ConfigInstance.Builder> configs = new ConcurrentHashMap<>();
 

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSource.java
@@ -5,7 +5,9 @@ package com.yahoo.config.subscription;
  * A type of source of config
  *
  * @author Vegard Havdal
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public interface ConfigSource {
 
 }

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
@@ -18,7 +18,9 @@ import static java.util.logging.Level.INFO;
  * upper/lower-casing and whitespaces.
  *
  * @author gjoranv
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigSourceSet implements ConfigSource {
 
     private static final Logger log = Logger.getLogger(ConfigSourceSet.class.getName());

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -28,7 +28,9 @@ import static java.util.stream.Collectors.toList;
  * {@link ConfigHandle} which {@link #subscribe(Class, String)} returned.
  *
  * @author Vegard Havdal
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigSubscriber implements AutoCloseable {
 
     private static final Logger log = Logger.getLogger(ConfigSubscriber.class.getName());

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigURI.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigURI.java
@@ -10,7 +10,9 @@ import com.yahoo.config.subscription.impl.JRTConfigRequester;
  * object to simplify parameter passing.
  *
  * @author Ulf Lilleengen
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class ConfigURI {
 
     private String configId;

--- a/config/src/main/java/com/yahoo/config/subscription/DirSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/DirSource.java
@@ -6,8 +6,9 @@ import java.io.File;
 /**
  * Source specifying config from a local directory
  * @author Vegard Havdal
- *
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class DirSource implements ConfigSource {
     private final File dir;
 

--- a/config/src/main/java/com/yahoo/config/subscription/FileSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/FileSource.java
@@ -7,7 +7,9 @@ import java.io.File;
  * Source specifying config from one local file
  *
  * @author Vegard Havdal
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class FileSource implements ConfigSource {
 
     private final File file;

--- a/config/src/main/java/com/yahoo/config/subscription/JarSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/JarSource.java
@@ -6,8 +6,9 @@ import java.util.jar.JarFile;
 /**
  * Source specifying config as a jar file entry
  * @author Vegard Havdal
- *
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class JarSource implements ConfigSource {
     private final String path;
     private final JarFile jarFile;

--- a/config/src/main/java/com/yahoo/config/subscription/RawSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/RawSource.java
@@ -5,7 +5,9 @@ package com.yahoo.config.subscription;
  * Source specifying raw config, where payload is given programmatically
  *
  * @author Vegard Havdal
+ * @deprecated  Will be removed in Vespa 8. Only for internal use.
  */
+@Deprecated(forRemoval = true, since = "7")
 public class RawSource implements ConfigSource {
 
     public final String payload;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileServer.java
@@ -223,6 +223,7 @@ public class FileServer {
     }
 
     private static ConnectionPool createConnectionPool(List<String> configServers, Supervisor supervisor) {
+        @SuppressWarnings("removal") // TODO Vespa 8: remove
         ConfigSourceSet configSourceSet = new ConfigSourceSet(configServers);
         if (configServers.size() == 0) return FileDownloader.emptyConnectionPool();
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -96,6 +96,7 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
                                                        File downloadDirectory,
                                                        Supervisor supervisor) {
         List<String> otherConfigServersInCluster = getOtherConfigServersInCluster(configserverConfig);
+        @SuppressWarnings("removal") // TODO Vespa 8: remove
         ConfigSourceSet configSourceSet = new ConfigSourceSet(otherConfigServersInCluster);
 
         ConnectionPool connectionPool = (otherConfigServersInCluster.isEmpty())

--- a/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/testutil/HandlersConfigurerTestWrapper.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Executors;
 */
 public class HandlersConfigurerTestWrapper {
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private final ConfigSourceSet configSources =
             new ConfigSourceSet(this.getClass().getSimpleName() + ": " + new Random().nextLong());
     private final HandlersConfigurerDi configurer;

--- a/container-core/src/main/java/com/yahoo/container/di/CloudSubscriber.java
+++ b/container-core/src/main/java/com/yahoo/container/di/CloudSubscriber.java
@@ -21,6 +21,7 @@ import static java.util.logging.Level.FINE;
  * @author Tony Vaagenes
  * @author ollivir
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class CloudSubscriber  implements Subscriber {
     private static final Logger log = Logger.getLogger(CloudSubscriber.class.getName());
 

--- a/container-core/src/main/java/com/yahoo/container/di/CloudSubscriberFactory.java
+++ b/container-core/src/main/java/com/yahoo/container/di/CloudSubscriberFactory.java
@@ -20,6 +20,7 @@ import java.util.WeakHashMap;
  * @author Tony Vaagenes
  * @author ollivir
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class CloudSubscriberFactory implements SubscriberFactory {
 
     private final ConfigSource configSource;

--- a/container-core/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-core/src/main/java/com/yahoo/container/di/Container.java
@@ -217,6 +217,7 @@ public class Container {
         }
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private void invalidateGeneration(long generation, Throwable cause) {
         leastGeneration = Math.max(retriever.getComponentsGeneration(), retriever.getBootstrapGeneration()) + 1;
         if (!(cause instanceof InterruptedException) && !(cause instanceof ConfigInterruptedException)) {

--- a/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
+++ b/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
@@ -16,6 +16,7 @@ import java.util.Random;
  * @author gjoranv
  * @author ollivir
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class DirConfigSource {
     private final TemporaryFolder tempFolder = createTemporaryFolder();
     public final ConfigSource configSource;

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -285,6 +285,7 @@ public final class ConfiguredApplication implements Application {
         return builder;
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private void startReconfigurerThread() {
         reconfigurerThread = new Thread(() -> {
             while ( ! Thread.interrupted()) {

--- a/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileConfigurer.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileConfigurer.java
@@ -19,6 +19,7 @@ import java.util.Set;
 /**
  * @author bratseth
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class QueryProfileConfigurer implements ConfigSubscriber.SingleSubscriber<QueryProfilesConfig> {
 
     private final ConfigSubscriber subscriber = new ConfigSubscriber();

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/QuotingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/QuotingSearcherTestCase.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Steinar Knutsen
  */
-@SuppressWarnings("deprecation")
 public class QuotingSearcherTestCase {
 
     public static QuotingSearcher createQuotingSearcher(String configId) {

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateNearestNeighborTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateNearestNeighborTestCase.java
@@ -2,6 +2,7 @@
 package com.yahoo.search.searchers;
 
 import com.yahoo.config.subscription.ConfigGetter;
+import com.yahoo.config.subscription.FileSource;
 import com.yahoo.config.subscription.RawSource;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
@@ -18,7 +19,11 @@ import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.config.search.AttributesConfig;
 
+import com.yahoo.vespa.config.search.RankProfilesConfig;
 import org.junit.Test;
+
+import java.io.File;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -32,8 +37,8 @@ public class ValidateNearestNeighborTestCase {
     public ValidateNearestNeighborTestCase() {
         searcher = new ValidateNearestNeighborSearcher(
                 ConfigGetter.getConfig(AttributesConfig.class,
-                                       "raw:",
-                                       new RawSource("attribute[5]\n" +
+                                       "raw:" +
+                                                     "attribute[5]\n" +
                                                      "attribute[0].name                simple\n" +
                                                      "attribute[0].datatype            INT32\n" +
                                                      "attribute[1].name                dvector\n" +
@@ -57,7 +62,7 @@ public class ValidateNearestNeighborTestCase {
                                                      "attribute[7].name                threetypes\n" +
                                                      "attribute[7].datatype            TENSOR\n" +
                                                      "attribute[7].tensortype          tensor(x{})\n"
-        )));
+        ));
     }
 
     private static TensorType tt_dense_dvector_42 = TensorType.fromSpec("tensor(x[42])");

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/ValidateMatchPhaseSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/ValidateMatchPhaseSearcherTestCase.java
@@ -27,8 +27,8 @@ public class ValidateMatchPhaseSearcherTestCase {
     public ValidateMatchPhaseSearcherTestCase() {
         searcher = new ValidateMatchPhaseSearcher(
                 ConfigGetter.getConfig(AttributesConfig.class,
-                                       "raw:",
-                                       new RawSource("attribute[4]\n" +
+                                       "raw:" +
+                                                     "attribute[4]\n" +
                                                      "attribute[0].name                ok\n" +
                                                      "attribute[0].datatype            INT32\n" +
                                                      "attribute[0].collectiontype      SINGLE\n" +
@@ -45,7 +45,7 @@ public class ValidateMatchPhaseSearcherTestCase {
                                                      "attribute[3].datatype            INT32\n" +
                                                      "attribute[3].collectiontype      ARRAY\n" +
                                                      "attribute[3].fastsearch          true"
-        )));
+        ));
     }
 
     private static String getErrorMatch(String attribute) {

--- a/docproc/src/main/java/com/yahoo/docproc/proxy/SchemaMap.java
+++ b/docproc/src/main/java/com/yahoo/docproc/proxy/SchemaMap.java
@@ -16,6 +16,7 @@ import java.util.Map.Entry;
  * 
  * @author vegardh
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class SchemaMap implements ConfigSubscriber.SingleSubscriber<SchemamappingConfig> {
 
     /** Map key. Doctype can be null, not the others. */

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManager.java
@@ -3,7 +3,6 @@ package com.yahoo.document;
 
 import com.google.inject.Inject;
 import com.yahoo.config.subscription.ConfigSubscriber;
-import com.yahoo.document.annotation.AnnotationReferenceDataType;
 import com.yahoo.document.annotation.AnnotationType;
 import com.yahoo.document.annotation.AnnotationTypeRegistry;
 import com.yahoo.document.annotation.AnnotationTypes;
@@ -14,7 +13,14 @@ import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.tensor.TensorType;
 
 import java.lang.reflect.Modifier;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -33,6 +39,8 @@ import java.util.logging.Logger;
 public class DocumentTypeManager {
 
     private final static Logger log = Logger.getLogger(DocumentTypeManager.class.getName());
+
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private ConfigSubscriber subscriber;
 
     // *Configured data types* (not built-in/primitive) indexed by their id

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
@@ -24,6 +24,7 @@ import com.yahoo.tensor.TensorType;
  *
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSubscriber<DocumentmanagerConfig> {
 
     private final static Logger log = Logger.getLogger(DocumentTypeManagerConfigurer.class.getName());

--- a/documentapi/src/main/java/com/yahoo/documentapi/DocumentAccess.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/DocumentAccess.java
@@ -47,6 +47,7 @@ import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 public abstract class DocumentAccess {
 
     private final DocumentTypeManager documentTypeManager;
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private final ConfigSubscriber documentTypeConfigSubscriber;
 
     /**

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentRouteSelectorPolicy.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentRouteSelectorPolicy.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
  *
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class DocumentRouteSelectorPolicy
         implements DocumentProtocolRoutingPolicy, ConfigSubscriber.SingleSubscriber<DocumentrouteselectorpolicyConfig> {
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/MessageTypePolicy.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/MessageTypePolicy.java
@@ -15,6 +15,7 @@ import static java.util.stream.Collectors.toUnmodifiableMap;
 /**
  * @author baldersheim
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class MessageTypePolicy implements DocumentProtocolRoutingPolicy, ConfigSubscriber.SingleSubscriber<MessagetyperouteselectorpolicyConfig> {
 
     private final AtomicReference<Map<Integer, Route>> configRef = new AtomicReference<>();

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -37,8 +37,11 @@ class FileAcquirerImpl implements FileAcquirer {
     private static final Logger log = Logger.getLogger(FileAcquirerImpl.class.getName());
 
     private final Supervisor supervisor = new Supervisor(new Transport("fileaquirer"));
+
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private final ConfigSubscriber configSubscriber;
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private class Connection implements ConfigSubscriber.SingleSubscriber<FiledistributorrpcConfig> {
         private final Lock targetLock = new ReentrantLock();
         private Target target;
@@ -122,6 +125,7 @@ class FileAcquirerImpl implements FileAcquirer {
         }
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     public FileAcquirerImpl(String configId) {
         configSubscriber = new ConfigSubscriber();
         configSubscriber.subscribe(connection, FiledistributorrpcConfig.class, configId);

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDistributionConnectionPool.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDistributionConnectionPool.java
@@ -22,6 +22,7 @@ import java.util.List;
  */
 public class FileDistributionConnectionPool extends JRTConnectionPool {
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     public FileDistributionConnectionPool(ConfigSourceSet sourceSet, Supervisor supervisor) {
         super(sourceSet, supervisor);
     }

--- a/messagebus/src/main/java/com/yahoo/messagebus/ConfigAgent.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/ConfigAgent.java
@@ -14,6 +14,7 @@ import com.yahoo.messagebus.routing.RoutingTableSpec;
  *
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class ConfigAgent implements ConfigSubscriber.SingleSubscriber<MessagebusConfig>{
 
     private final ConfigURI configURI;

--- a/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/SlobrokConfigSubscriber.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/network/rpc/SlobrokConfigSubscriber.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
  *
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class SlobrokConfigSubscriber implements ConfigSubscriber.SingleSubscriber<SlobroksConfig>{
 
     private static final Logger log = Logger.getLogger(SlobrokConfigSubscriber.class.getName());

--- a/messagebus/src/test/java/com/yahoo/messagebus/ConfigAgentTestCase.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/ConfigAgentTestCase.java
@@ -22,6 +22,7 @@ public class ConfigAgentTestCase {
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     @Test
     public void testRoutingConfig() throws InterruptedException {
         LocalHandler handler = new LocalHandler();

--- a/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelsEvaluatorTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelsEvaluatorTest.java
@@ -28,10 +28,11 @@ import static org.junit.Assert.assertTrue;
 public class ModelsEvaluatorTest {
 
     private static final double delta = 0.00000000001;
+    private static final String CONFIG_DIR = "src/test/resources/config/rankexpression/";
 
     @Test
     public void testEvaluationDependingFunctionTakingArguments() {
-        ModelsEvaluator models = createModels("src/test/resources/config/rankexpression/");
+        ModelsEvaluator models = createModels();
         FunctionEvaluator function = models.evaluatorOf("macros", "secondphase");
         function.bind("match", 3);
         function.bind("rankBoost", 5);
@@ -41,7 +42,7 @@ public class ModelsEvaluatorTest {
     /** Tests a function defined as 4 * (var1 + var2) */
     @Test
     public void testSettingMissingValue() {
-        ModelsEvaluator models = createModels("src/test/resources/config/rankexpression/");
+        ModelsEvaluator models = createModels();
 
         {
             FunctionEvaluator function = models.evaluatorOf("macros", "secondphase");
@@ -127,18 +128,18 @@ public class ModelsEvaluatorTest {
     // TODO: Test argument-less function
     // TODO: Test with nested functions
 
-    private ModelsEvaluator createModels(String path) {
-        Path configDir = Path.fromString(path);
-        RankProfilesConfig config = new ConfigGetter<>(new FileSource(configDir.append("rank-profiles.cfg").toFile()),
-                                                       RankProfilesConfig.class).getConfig("");
-        RankingConstantsConfig constantsConfig = new ConfigGetter<>(new FileSource(configDir.append("ranking-constants.cfg").toFile()),
-                                                                    RankingConstantsConfig.class).getConfig("");
-        RankingExpressionsConfig expressionsConfig = new ConfigGetter<>(new FileSource(configDir.append("ranking-expressions.cfg").toFile()),
-                                                                        RankingExpressionsConfig.class).getConfig("");
-        OnnxModelsConfig onnxModelsConfig = new ConfigGetter<>(new FileSource(configDir.append("onnx-models.cfg").toFile()),
-                                                               OnnxModelsConfig.class).getConfig("");
-        return new ModelsEvaluator(new RankProfilesConfigImporterWithMockedConstants(Path.fromString(path).append("constants"), MockFileAcquirer.returnFile(null)),
+    private ModelsEvaluator createModels() {
+        RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
+        RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));
+        RankingExpressionsConfig expressionsConfig = ConfigGetter.getConfig(RankingExpressionsConfig.class, fileConfigId("ranking-expressions.cfg"));
+        OnnxModelsConfig onnxModelsConfig = ConfigGetter.getConfig(OnnxModelsConfig.class, fileConfigId("onnx-models.cfg"));
+
+        return new ModelsEvaluator(new RankProfilesConfigImporterWithMockedConstants(Path.fromString(CONFIG_DIR).append("constants"), MockFileAcquirer.returnFile(null)),
                 config, constantsConfig, expressionsConfig, onnxModelsConfig);
+    }
+
+    private static String fileConfigId(String filename) {
+        return "file:" + CONFIG_DIR + filename;
     }
 
 }

--- a/model-evaluation/src/test/java/ai/vespa/models/evaluation/OnnxEvaluatorTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/evaluation/OnnxEvaluatorTest.java
@@ -26,10 +26,11 @@ import static org.junit.Assert.assertTrue;
 public class OnnxEvaluatorTest {
 
     private static final double delta = 0.00000000001;
+    private static final String CONFIG_DIR = "src/test/resources/config/onnx/";
 
     @Test
     public void testOnnxEvaluation() {
-        ModelsEvaluator models = createModels("src/test/resources/config/onnx/");
+        ModelsEvaluator models = createModels();
 
         assertTrue(models.models().containsKey("add_mul"));
         assertTrue(models.models().containsKey("one_layer"));
@@ -49,24 +50,23 @@ public class OnnxEvaluatorTest {
         assertEquals(function.evaluate(), Tensor.from("tensor<float>(d0[2],d1[1]):[0.63931,0.67574]"));
     }
 
-    private ModelsEvaluator createModels(String path) {
-        Path configDir = Path.fromString(path);
-        RankProfilesConfig config = new ConfigGetter<>(new FileSource(configDir.append("rank-profiles.cfg").toFile()),
-                                                       RankProfilesConfig.class).getConfig("");
-        RankingConstantsConfig constantsConfig = new ConfigGetter<>(new FileSource(configDir.append("ranking-constants.cfg").toFile()),
-                                                                    RankingConstantsConfig.class).getConfig("");
-        RankingExpressionsConfig expressionsConfig = new ConfigGetter<>(new FileSource(configDir.append("ranking-expressions.cfg").toFile()),
-                                                                        RankingExpressionsConfig.class).getConfig("");
-        OnnxModelsConfig onnxModelsConfig = new ConfigGetter<>(new FileSource(configDir.append("onnx-models.cfg").toFile()),
-                                                               OnnxModelsConfig.class).getConfig("");
+    private ModelsEvaluator createModels() {
+        RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
+        RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));
+        RankingExpressionsConfig expressionsConfig = ConfigGetter.getConfig(RankingExpressionsConfig.class, fileConfigId("ranking-expressions.cfg"));
+        OnnxModelsConfig onnxModelsConfig = ConfigGetter.getConfig(OnnxModelsConfig.class, fileConfigId("onnx-models.cfg"));
 
         Map<String, File> fileMap = new HashMap<>();
         for (OnnxModelsConfig.Model onnxModel : onnxModelsConfig.model()) {
-            fileMap.put(onnxModel.fileref().value(), new File(path + onnxModel.fileref().value()));
+            fileMap.put(onnxModel.fileref().value(), new File(CONFIG_DIR + onnxModel.fileref().value()));
         }
         FileAcquirer fileAcquirer = MockFileAcquirer.returnFiles(fileMap);
 
         return new ModelsEvaluator(config, constantsConfig, expressionsConfig, onnxModelsConfig, fileAcquirer);
+    }
+
+    private static String fileConfigId(String filename) {
+        return "file:" + CONFIG_DIR + filename;
     }
 
 }

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
@@ -57,6 +57,7 @@ public class StandaloneSubscriberFactory implements SubscriberFactory {
             return ret;
         }
 
+        @SuppressWarnings("removal") // TODO Vespa 8: remove
         @Override
         public long waitNextGeneration(boolean isInitializing) {
             generation++;

--- a/vdslib/src/main/java/com/yahoo/vdslib/distribution/Distribution.java
+++ b/vdslib/src/main/java/com/yahoo/vdslib/distribution/Distribution.java
@@ -39,6 +39,7 @@ public class Distribution {
         private final boolean distributorAutoOwnershipTransferOnWholeGroupDown;
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     private ConfigSubscriber configSub;
     private final AtomicReference<Config> config = new AtomicReference<>(new Config(null, 1, false));
 
@@ -60,6 +61,7 @@ public class Distribution {
         return p;
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     // NOTE: keep in sync with the below
     private ConfigSubscriber.SingleSubscriber<StorDistributionConfig> configSubscriber = config -> {
         try {
@@ -146,6 +148,7 @@ public class Distribution {
         }
     }
 
+    @SuppressWarnings("removal") // TODO Vespa 8: remove
     public Distribution(String configId) {
         try {
             configSub = new ConfigSubscriber();

--- a/vdslib/src/test/java/com/yahoo/vdslib/distribution/DistributionTestFactory.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/distribution/DistributionTestFactory.java
@@ -4,8 +4,6 @@ package com.yahoo.vdslib.distribution;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.document.BucketId;
 import com.yahoo.vdslib.state.ClusterState;
-import com.yahoo.vdslib.state.Node;
-import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
 import org.codehaus.jettison.json.JSONArray;
@@ -16,8 +14,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
+
+// TODO: Use config builder instead of ConfigGetter to create test config.
 public class DistributionTestFactory extends CrossPlatformTestFactory {
 
     private static final String testDirectory = "src/tests/distribution/testdata";

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
@@ -20,6 +20,7 @@ import java.util.logging.Logger;
  * Utility class for assigning properties to messages, either from implicit
  * config values or from explicit values in requests.
  */
+@SuppressWarnings("removal") // TODO Vespa 8: remove
 public class MessagePropertyProcessor implements ConfigSubscriber.SingleSubscriber<FeederConfig> {
 
     private static final Logger log = Logger.getLogger(MessagePropertyProcessor.class.getName());


### PR DESCRIPTION
This PR keeps the parts of ConfigGetter that does not rely on other types in the package.
