### PR TITLE
Exclude META-INF files and module-info.class from uber jars.

### DIFF
--- a/application-preprocessor/pom.xml
+++ b/application-preprocessor/pom.xml
@@ -77,12 +77,10 @@
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
-                            <!-- Don't include signature files from bouncycastle in uber jar.  -->
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -93,12 +93,10 @@
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
           <filters>
             <filter>
-              <!-- Don't include signature files from bouncycastle in uber jar.  -->
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/**</exclude>
+                <exclude>module-info.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/document/pom.xml
+++ b/document/pom.xml
@@ -83,12 +83,10 @@
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
-                            <!-- Don't include signature files from bouncycastle in uber jar.  -->
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/filedistribution/pom.xml
+++ b/filedistribution/pom.xml
@@ -104,12 +104,10 @@
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
-                            <!-- Don't include signature files from bouncycastle in uber jar.  -->
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/indexinglanguage/pom.xml
+++ b/indexinglanguage/pom.xml
@@ -67,12 +67,10 @@
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
           <filters>
             <filter>
-              <!-- Don't include signature files from bouncycastle in uber jar.  -->
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/**</exclude>
+                <exclude>module-info.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/logserver/pom.xml
+++ b/logserver/pom.xml
@@ -65,12 +65,10 @@
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
           <filters>
             <filter>
-              <!-- Don't include signature files from bouncycastle in uber jar.  -->
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/**</exclude>
+                <exclude>module-info.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/messagebus/pom.xml
+++ b/messagebus/pom.xml
@@ -69,12 +69,10 @@
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
           <filters>
             <filter>
-              <!-- Don't include signature files from bouncycastle in uber jar.  -->
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
+                <exclude>META-INF/**</exclude>
+                <exclude>module-info.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/security-tools/pom.xml
+++ b/security-tools/pom.xml
@@ -51,13 +51,10 @@
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
           <filters>
             <filter>
-              <!-- Don't include signature files from bouncycastle in uber jar.  -->
               <artifact>*:*</artifact>
               <excludes>
-                <exclude>META-INF/*.SF</exclude>
-                <exclude>META-INF/*.DSA</exclude>
-                <exclude>META-INF/*.RSA</exclude>
-                <exclude>META-INF/versions/*/module-info.class</exclude>
+                <exclude>META-INF/**</exclude>
+                <exclude>module-info.class</exclude>
               </excludes>
             </filter>
           </filters>

--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -191,9 +191,8 @@
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/**</exclude>
+                                        <exclude>module-info.class</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -172,12 +172,10 @@
               <outputFile>target/${project.artifactId}-jar-with-dependencies.jar</outputFile>
               <filters>
                 <filter>
-                  <!-- Don't include signature files in uber jar (most likely from bouncycastle).  -->
                   <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/**</exclude>
+                    <exclude>module-info.class</exclude>
                   </excludes>
                 </filter>
               </filters>

--- a/vespa_feed_perf/pom.xml
+++ b/vespa_feed_perf/pom.xml
@@ -64,12 +64,10 @@
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
-                            <!-- Don't include signature files from bouncycastle in uber jar.  -->
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>

--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -77,12 +77,10 @@
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
                     <filters>
                         <filter>
-                            <!-- Don't include signature files in uber jar (most likely from bouncycastle).  -->
                             <artifact>*:*</artifact>
                             <excludes>
-                                <exclude>META-INF/*.SF</exclude>
-                                <exclude>META-INF/*.DSA</exclude>
-                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/**</exclude>
+                                <exclude>module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>


### PR DESCRIPTION
- Generate countless warnings for duplicates and breaking encapsulation.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
