### PR TITLE
Differentiate deployment method when clearing old app versions

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/ApplicationVersion.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/deployment/ApplicationVersion.java
@@ -185,7 +185,7 @@ public class ApplicationVersion implements Comparable<ApplicationVersion> {
         if (buildNumber().isEmpty() || o.buildNumber().isEmpty())
             return Boolean.compare(buildNumber().isPresent(), o.buildNumber.isPresent()); // Unknown version sorts first
 
-        if (deployedDirectly || o.deployedDirectly)
+        if (deployedDirectly != o.deployedDirectly)
             return Boolean.compare( ! deployedDirectly, ! o.deployedDirectly); // Directly deployed versions sort first
 
         return Long.compare(buildNumber().getAsLong(), o.buildNumber().getAsLong());

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializer.java
@@ -229,13 +229,15 @@ public class ApplicationSerializer {
     }
 
     private void versionsToSlime(Application application, Cursor object) {
-        // Add all deployed versions as well
+        // Add all indirectly deployed versions as well
+        // Remove after all apps are updated
         application.instances()
                 .values()
                 .stream()
                 .flatMap(instance -> instance.deployments().values().stream())
                 .map(Deployment::applicationVersion)
                 .forEach(application.versions()::add);
+        application.versions().removeIf(ApplicationVersion::isDeployedDirectly);
 
         application.versions().forEach(version -> toSlime(version, object.addObject()));
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ApplicationSerializerTest.java
@@ -159,9 +159,9 @@ public class ApplicationSerializerTest {
         assertEquals(original.latestVersion().get().sourceUrl(), serialized.latestVersion().get().sourceUrl());
         assertEquals(original.latestVersion().get().commit(), serialized.latestVersion().get().commit());
         assertEquals(original.latestVersion().get().bundleHash(), serialized.latestVersion().get().bundleHash());
-        // Check deployed versions are added
+        // Check indirectly deployed versions are added, directly deployed are removed
         assertEquals(original.versions(), serialized.versions());
-        assertEquals(serialized.versions(), new TreeSet<>(Set.of(applicationVersion1, applicationVersion2)));
+        assertEquals(serialized.versions(), new TreeSet<>(Set.of(applicationVersion2)));
 
 
         assertEquals(original.deploymentSpec().xmlForm(), serialized.deploymentSpec().xmlForm());


### PR DESCRIPTION
Alternatively, we could delete directly deployed versions elsewhere, e.g. in `JobController.deploy`