### PR TITLE
Add parentheses to apply the cast on the end result instead of the va…

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/component/Deconstructor.java
@@ -108,7 +108,7 @@ public class Deconstructor implements ComponentDeconstructor {
         * Used to randomize restart to avoid simultaneous cluster restarts.
         */
         private Duration getRandomizedShutdownDelay() {
-            long seconds = (long) random.nextDouble() * 60 * 10;
+            long seconds = (long) (random.nextDouble() * 60 * 10);
             return Duration.ofSeconds(seconds);
         }
 


### PR DESCRIPTION
…lue in the range [0.0, 1.0>, which will always be 0.

@bjorncs or @bratseth or @gjoranv PR