### PR TITLE
Support passing keys through environment

### DIFF
--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -15,12 +15,30 @@ import (
 
 var overwriteKey bool
 
+const apiKeyLongDoc = `Create a new user API key for authentication with Vespa Cloud.
+
+The API key will be stored in the Vespa CLI home directory
+(see 'vespa help config'). Other commands will then automatically load the API
+key as necessary.
+
+It's possible to override the API key used through environment variables. This
+can be useful in continuous integration systems.
+
+* VESPA_CLI_API_KEY containing the key directly:
+
+  export VESPA_CLI_API_KEY="my api key"
+
+* VESPA_CLI_API_KEY_FILE containing path to the key:
+
+  export VESPA_CLI_API_KEY_FILE=/path/to/api-key
+
+Note that when overriding API key through environment variables, that key will
+always be used. It's not possible to specify a tenant-specific key.`
+
 func init() {
 	apiKeyCmd.Flags().BoolVarP(&overwriteKey, "force", "f", false, "Force overwrite of existing API key")
 	apiKeyCmd.MarkPersistentFlagRequired(applicationFlag)
 }
-
-var example string
 
 func apiKeyExample() string {
 	if vespa.Auth0AccessTokenEnabled() {
@@ -33,6 +51,7 @@ func apiKeyExample() string {
 var apiKeyCmd = &cobra.Command{
 	Use:               "api-key",
 	Short:             "Create a new user API key for authentication with Vespa Cloud",
+	Long:              apiKeyLongDoc,
 	Example:           apiKeyExample(),
 	DisableAutoGenTag: true,
 	Args:              cobra.ExactArgs(0),
@@ -42,6 +61,7 @@ var apiKeyCmd = &cobra.Command{
 var deprecatedApiKeyCmd = &cobra.Command{
 	Use:               "api-key",
 	Short:             "Create a new user API key for authentication with Vespa Cloud",
+	Long:              apiKeyLongDoc,
 	Example:           apiKeyExample(),
 	DisableAutoGenTag: true,
 	Args:              cobra.ExactArgs(0),

--- a/client/go/cmd/cert.go
+++ b/client/go/cmd/cert.go
@@ -5,14 +5,40 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/vespa-engine/vespa/client/go/util"
 	"github.com/vespa-engine/vespa/client/go/vespa"
-	"os"
-	"path/filepath"
 )
 
 var overwriteCertificate bool
+
+const longDoc = `Create a new private key and self-signed certificate for Vespa Cloud deployment.
+
+The private key and certificate will be stored in the Vespa CLI home directory
+(see 'vespa help config'). Other commands will then automatically load the
+certificate as necessary.
+
+It's possible to override the private key and certificate used through
+environment variables. This can be useful in continuous integration systems.
+
+* VESPA_CLI_DATA_PLANE_CERT and VESPA_CLI_DATA_PLANE_KEY containing the
+  certificate and private key directly:
+
+  export VESPA_CLI_DATA_PLANE_CERT="my cert"
+  export VESPA_CLI_DATA_PLANE_KEY="my private key"
+
+* VESPA_CLI_DATA_PLANE_CERT_FILE and VESPA_CLI_DATA_PLANE_KEY_FILE containing
+  paths to the certificate and private key:
+
+  export VESPA_CLI_DATA_PLANE_CERT_FILE=/path/to/cert
+  export VESPA_CLI_DATA_PLANE_KEY_FILE=/path/to/key
+
+Note that when overriding key pair through environment variables, that key pair
+will always be used for all applications. It's not possible to specify an
+application-specific key.`
 
 func init() {
 	certCmd.Flags().BoolVarP(&overwriteCertificate, "force", "f", false, "Force overwrite of existing certificate and private key")
@@ -30,6 +56,7 @@ func certExample() string {
 var certCmd = &cobra.Command{
 	Use:               "cert",
 	Short:             "Create a new private key and self-signed certificate for Vespa Cloud deployment",
+	Long:              longDoc,
 	Example:           certExample(),
 	DisableAutoGenTag: true,
 	Args:              cobra.MaximumNArgs(1),
@@ -39,6 +66,7 @@ var certCmd = &cobra.Command{
 var deprecatedCertCmd = &cobra.Command{
 	Use:               "cert",
 	Short:             "Create a new private key and self-signed certificate for Vespa Cloud deployment",
+	Long:              longDoc,
 	Example:           "$ vespa cert -a my-tenant.my-app.my-instance",
 	DisableAutoGenTag: true,
 	Args:              cobra.MaximumNArgs(1),

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -181,10 +181,16 @@ func (c *Config) X509KeyPair(app vespa.ApplicationID) (KeyPair, error) {
 }
 
 func (c *Config) APIKeyPath(tenantName string) string {
+	if override, ok := os.LookupEnv("VESPA_CLI_API_KEY_FILE"); ok {
+		return override
+	}
 	return filepath.Join(c.Home, tenantName+".api-key.pem")
 }
 
 func (c *Config) ReadAPIKey(tenantName string) ([]byte, error) {
+	if override, ok := os.LookupEnv("VESPA_CLI_API_KEY"); ok {
+		return []byte(override), nil
+	}
 	return ioutil.ReadFile(c.APIKeyPath(tenantName))
 }
 


### PR DESCRIPTION
With this both the API key and data plane cert/key can be configured through
environment variables.

@hakonhall

FYI @bergum