### PR TITLE
Set archiveUrl for controllers

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
@@ -29,8 +29,8 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
     private final NodeRepository nodeRepository;
     private final CuratorArchiveBucketDb archiveBucketDb;
 
-    public ArchiveUriUpdater(Controller controller, Duration duration) {
-        super(controller, duration);
+    public ArchiveUriUpdater(Controller controller, Duration interval) {
+        super(controller, interval);
         this.applications = controller.applications();
         this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.archiveBucketDb = controller.archiveBucketDb();
@@ -39,6 +39,10 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
     @Override
     protected double maintain() {
         Map<ZoneId, Set<TenantName>> tenantsByZone = new HashMap<>();
+
+        tenantsByZone.put(controller().zoneRegistry().systemZone().getVirtualId(),
+                          new HashSet<>(INFRASTRUCTURE_TENANTS));
+
         for (var application : applications.asList()) {
             for (var instance : application.instances().values()) {
                 for (var deployment : instance.deployments().values()) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdaterTest.java
@@ -43,6 +43,9 @@ public class ArchiveUriUpdaterTest {
         // Initially we should not set any archive URIs as the archive service does not return any
         updater.maintain();
         assertArchiveUris(Map.of(), zone);
+        // but the controller zone is always present
+        assertArchiveUris(Map.of(TenantName.from("hosted-vespa"), "s3://bucketName/hosted-vespa/"),
+                          ZoneId.from("prod", "controller"));
 
         // Archive service now has URI for tenant1, but tenant1 is not deployed in zone
         setBucketNameInService(Map.of(tenant1, "uri-1"), zone);


### PR DESCRIPTION
Make the ArchiveUriUpdater set the archiveUrl for the controllers and controller hosts.  This will then automatically trigger creation of s3 buckets, and archiving of controller and controller host logs.
