### PR TITLE
Use a conservative flush strategy before we reach the proton resource…

### DIFF
--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -81,6 +81,10 @@ flush.memory.conservative.memorylimitfactor double default=0.5
 ## In this case this factor is multiplied with 'maxtlssize' to calculate a conservative value to use instead.
 flush.memory.conservative.disklimitfactor double default=0.5
 
+## The factor used to multiply with the resource limits for disk / memory to find the high
+## watermark indicating when to from normal into conservative mode for the flush strategy.
+flush.memory.conservative.highwatermarkfactor double default=0.95
+
 ## The factor used to multiply with the resource limits for disk / memory to find the low
 ## watermark indicating when to go back from conservative to normal mode for the flush strategy.
 flush.memory.conservative.lowwatermarkfactor double default=0.9

--- a/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
@@ -13,9 +13,10 @@ namespace {
 bool
 shouldUseConservativeMode(const ResourceUsageState &resourceState,
                           bool currentlyUseConservativeMode,
+                          double high_watermark_factor,
                           double lowWatermarkFactor)
 {
-    return resourceState.aboveLimit() ||
+    return resourceState.aboveLimit(high_watermark_factor) ||
            (currentlyUseConservativeMode && resourceState.aboveLimit(lowWatermarkFactor));
 }
 
@@ -25,6 +26,7 @@ void
 MemoryFlushConfigUpdater::considerUseConservativeDiskMode(const LockGuard &guard, MemoryFlush::Config &newConfig)
 {
     if (shouldUseConservativeMode(_currState.diskState(), _useConservativeDiskMode,
+                                  _currConfig.conservative.highwatermarkfactor,
                                   _currConfig.conservative.lowwatermarkfactor))
     {
         newConfig.maxGlobalTlsSize = _currConfig.maxtlssize * _currConfig.conservative.disklimitfactor;
@@ -41,6 +43,7 @@ void
 MemoryFlushConfigUpdater::considerUseConservativeMemoryMode(const LockGuard &, MemoryFlush::Config &newConfig)
 {
     if (shouldUseConservativeMode(_currState.memoryState(), _useConservativeMemoryMode,
+                                  _currConfig.conservative.highwatermarkfactor,
                                   _currConfig.conservative.lowwatermarkfactor))
     {
         newConfig.maxGlobalMemory = _currConfig.maxmemory * _currConfig.conservative.memorylimitfactor;


### PR DESCRIPTION
… limits for memory and disk.

This should improve protons ability to have enough headroom to handle transient resource usage
(memory index and disk index fusion) before reaching feed blocked inside proton.

@baldersheim please review