### PR TITLE
Revert "Set archiveUrl for controllers"

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdater.java
@@ -29,8 +29,8 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
     private final NodeRepository nodeRepository;
     private final CuratorArchiveBucketDb archiveBucketDb;
 
-    public ArchiveUriUpdater(Controller controller, Duration interval) {
-        super(controller, interval);
+    public ArchiveUriUpdater(Controller controller, Duration duration) {
+        super(controller, duration);
         this.applications = controller.applications();
         this.nodeRepository = controller.serviceRegistry().configServer().nodeRepository();
         this.archiveBucketDb = controller.archiveBucketDb();
@@ -39,10 +39,6 @@ public class ArchiveUriUpdater extends ControllerMaintainer {
     @Override
     protected double maintain() {
         Map<ZoneId, Set<TenantName>> tenantsByZone = new HashMap<>();
-
-        tenantsByZone.put(controller().zoneRegistry().systemZone().getVirtualId(),
-                          new HashSet<>(INFRASTRUCTURE_TENANTS));
-
         for (var application : applications.asList()) {
             for (var instance : application.instances().values()) {
                 for (var deployment : instance.deployments().values()) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ArchiveUriUpdaterTest.java
@@ -43,9 +43,6 @@ public class ArchiveUriUpdaterTest {
         // Initially we should not set any archive URIs as the archive service does not return any
         updater.maintain();
         assertArchiveUris(Map.of(), zone);
-        // but the controller zone is always present
-        assertArchiveUris(Map.of(TenantName.from("hosted-vespa"), "s3://bucketName/hosted-vespa/"),
-                          ZoneId.from("prod", "controller"));
 
         // Archive service now has URI for tenant1, but tenant1 is not deployed in zone
         setBucketNameInService(Map.of(tenant1, "uri-1"), zone);


### PR DESCRIPTION
Reverts vespa-engine/vespa#21053

Fails with

```
java.util.NoSuchElementException: There is no zone 'prod.controller' in system 'PublicCd'
        at com.yahoo.vespa.hosted.zone.config.HostedZoneRegistry.lambda$get$0(HostedZoneRegistry.java:78)
        at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1220)
        at com.yahoo.vespa.hosted.zone.config.HostedZoneRegistry.get(HostedZoneRegistry.java:77)
        at com.yahoo.vespa.hosted.clients.aws.S3ArchiveService.createArchiveBucketFor(S3ArchiveService.java:115)
```

since HostedZoneRegistry.get() only returns non-system zones.