### PR TITLE
Shutdown reconfiguration thread in a more controlled way [run-systemtest]

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
@@ -145,6 +145,8 @@ public class HandlersConfigurerDi {
 
     public void shutdown() { container.shutdown(currentGraph); }
 
+    public void shutdownConfigRetriever() { container.shutdownConfigRetriever(); }
+
     /** Returns the currently active application configuration generation */
     public long generation() { return currentGraph.generation(); }
 

--- a/container-core/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-core/src/main/java/com/yahoo/container/di/Container.java
@@ -254,14 +254,14 @@ public class Container {
     }
 
     public void shutdown(ComponentGraph graph) {
-        shutdownConfigurer();
+        shutdownConfigRetriever();
         if (graph != null) {
             scheduleGraphForDeconstruction(graph);
             destructor.shutdown();
         }
     }
 
-    void shutdownConfigurer() {
+    public void shutdownConfigRetriever() {
         retriever.shutdown();
     }
 

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -44,7 +44,7 @@ public class ContainerTest extends ContainerTestBase {
         ComponentTakingConfig component = createComponentTakingConfig(getNewComponentGraph(container));
         assertEquals("myString", component.config.stringVal());
 
-        container.shutdownConfigurer();
+        container.shutdownConfigRetriever();
     }
 
     @Test
@@ -66,7 +66,7 @@ public class ContainerTest extends ContainerTestBase {
         ComponentTakingConfig component2 = createComponentTakingConfig(newComponentGraph);
         assertEquals("reconfigured", component2.config.stringVal());
 
-        container.shutdownConfigurer();
+        container.shutdownConfigRetriever();
     }
 
     @Test
@@ -90,7 +90,7 @@ public class ContainerTest extends ContainerTestBase {
         assertNotNull(ComponentGraph.getNode(newGraph, "id1"));
         assertNotNull(ComponentGraph.getNode(newGraph, "id2"));
 
-        container.shutdownConfigurer();
+        container.shutdownConfigRetriever();
     }
 
     //@Test TODO

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -95,8 +95,8 @@ public final class ConfiguredApplication implements Application {
     private final OsgiFramework restrictedOsgiFramework;
     private final Phaser nonTerminatedContainerTracker = new Phaser(1);
     private final Thread reconfigurerThread;
+    private final Thread portWatcher;
     private HandlersConfigurerDi configurer;
-    private Thread portWatcher;
     private QrConfig qrConfig;
 
     private Register slobrokRegistrator = null;
@@ -137,6 +137,7 @@ public final class ConfiguredApplication implements Application {
         this.restrictedOsgiFramework = new DisableOsgiFramework(new RestrictedBundleContext(osgiFramework.bundleContext()));
         this.shutdownDeadline = new ShutdownDeadline(configId);
         this.reconfigurerThread = new Thread(this::doReconfigurationLoop, "configured-application-reconfigurer");
+        this.portWatcher = new Thread(this::watchPortChange, "configured-application-port-watcher");
     }
 
     @Override
@@ -150,7 +151,7 @@ public final class ConfiguredApplication implements Application {
         initializeAndActivateContainer(builder, () -> {});
         reconfigurerThread.setDaemon(true);
         reconfigurerThread.start();
-        portWatcher = new Thread(this::watchPortChange, "configured-application-port-watcher");
+
         portWatcher.setDaemon(true);
         portWatcher.start();
         if (setupRpc()) {

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -148,6 +148,7 @@ public final class ConfiguredApplication implements Application {
         ContainerBuilder builder = createBuilderWithGuiceBindings();
         configurer = createConfigurer(builder.guiceModules().activate());
         initializeAndActivateContainer(builder, () -> {});
+        reconfigurerThread.setDaemon(true);
         reconfigurerThread.start();
         portWatcher = new Thread(this::watchPortChange, "configured-application-port-watcher");
         portWatcher.setDaemon(true);

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -94,14 +94,15 @@ public final class ConfiguredApplication implements Application {
                                       new ComponentRegistry<>());
     private final OsgiFramework restrictedOsgiFramework;
     private final Phaser nonTerminatedContainerTracker = new Phaser(1);
+    private final Thread reconfigurerThread;
     private HandlersConfigurerDi configurer;
-    private Thread reconfigurerThread;
     private Thread portWatcher;
     private QrConfig qrConfig;
 
     private Register slobrokRegistrator = null;
     private Supervisor supervisor = null;
     private Acceptor acceptor = null;
+    private volatile boolean shutdownReconfiguration = false;
 
     static {
         LogSetup.initVespaLogging("Container");
@@ -135,6 +136,7 @@ public final class ConfiguredApplication implements Application {
                 : Optional.empty();
         this.restrictedOsgiFramework = new DisableOsgiFramework(new RestrictedBundleContext(osgiFramework.bundleContext()));
         this.shutdownDeadline = new ShutdownDeadline(configId);
+        this.reconfigurerThread = new Thread(this::doReconfigurationLoop, "configured-application-reconfigurer");
     }
 
     @Override
@@ -146,7 +148,7 @@ public final class ConfiguredApplication implements Application {
         ContainerBuilder builder = createBuilderWithGuiceBindings();
         configurer = createConfigurer(builder.guiceModules().activate());
         initializeAndActivateContainer(builder, () -> {});
-        startReconfigurerThread();
+        reconfigurerThread.start();
         portWatcher = new Thread(this::watchPortChange, "configured-application-port-watcher");
         portWatcher.setDaemon(true);
         portWatcher.start();
@@ -286,30 +288,27 @@ public final class ConfiguredApplication implements Application {
     }
 
     @SuppressWarnings("removal") // TODO Vespa 8: remove
-    private void startReconfigurerThread() {
-        reconfigurerThread = new Thread(() -> {
-            while ( ! Thread.interrupted()) {
-                try {
-                    ContainerBuilder builder = createBuilderWithGuiceBindings();
+    private void doReconfigurationLoop() {
+        while (!shutdownReconfiguration) {
+            try {
+                ContainerBuilder builder = createBuilderWithGuiceBindings();
 
-                    // Block until new config arrives, and it should be applied
-                    Runnable cleanupTask = configurer.waitForNextGraphGeneration(builder.guiceModules().activate(), false);
-                    initializeAndActivateContainer(builder, cleanupTask);
-                } catch (UncheckedInterruptedException | ConfigInterruptedException e) {
-                    break;
-                } catch (Exception | LinkageError e) { // LinkageError: OSGi problems
-                    tryReportFailedComponentGraphConstructionMetric(configurer, e);
-                    log.log(Level.SEVERE,
-                            "Reconfiguration failed, your application package must be fixed, unless this is a " +
-                            "JNI reload issue: " + Exceptions.toMessageString(e), e);
-                } catch (Error e) {
-                    com.yahoo.protect.Process.logAndDie("java.lang.Error on reconfiguration: We are probably in " +
-                                                        "a bad state and will terminate", e);
-                }
+                // Block until new config arrives, and it should be applied
+                Runnable cleanupTask = configurer.waitForNextGraphGeneration(builder.guiceModules().activate(), false);
+                initializeAndActivateContainer(builder, cleanupTask);
+            } catch (UncheckedInterruptedException | ConfigInterruptedException e) {
+                break;
+            } catch (Exception | LinkageError e) { // LinkageError: OSGi problems
+                tryReportFailedComponentGraphConstructionMetric(configurer, e);
+                log.log(Level.SEVERE,
+                        "Reconfiguration failed, your application package must be fixed, unless this is a " +
+                                "JNI reload issue: " + Exceptions.toMessageString(e), e);
+            } catch (Error e) {
+                com.yahoo.protect.Process.logAndDie("java.lang.Error on reconfiguration: We are probably in " +
+                        "a bad state and will terminate", e);
             }
-            log.fine("Shutting down HandlersConfigurerDi");
-        }, "configured-application-reconfigurer");
-        reconfigurerThread.start();
+        }
+        log.fine("Reconfiguration loop exited");
     }
 
     private static void tryReportFailedComponentGraphConstructionMetric(HandlersConfigurerDi configurer, Throwable error) {
@@ -397,7 +396,7 @@ public final class ConfiguredApplication implements Application {
     }
 
     private void stopServersAndAwaitTermination(String logPrefix) {
-        shutdownReconfigurerThread();
+        shutdownReconfigurer();
         log.info(logPrefix + ": Closing servers");
         startAndStopServers(List.of());
         startAndRemoveClients(List.of());
@@ -407,20 +406,24 @@ public final class ConfiguredApplication implements Application {
         log.info(logPrefix + ": Finished");
     }
 
-    // TODO Do more graceful shutdown of reconfigurer thread. The interrupt may leave the container in state where
-    //      graceful shutdown is impossible or may hang.
-    private void shutdownReconfigurerThread() {
+    private void shutdownReconfigurer() {
+        if (!reconfigurerThread.isAlive()) {
+            log.info("Reconfiguration thread shutdown already completed");
+            return;
+        }
+        log.info("Shutting down reconfiguration thread");
+        long start = System.currentTimeMillis();
+        shutdownReconfiguration = true;
+        configurer.shutdownConfigRetriever();
         try {
-            //Workaround for component constructors masking InterruptedException.
-            while (reconfigurerThread != null && reconfigurerThread.isAlive()) {
-                reconfigurerThread.interrupt();
-                long millis = 200;
-                reconfigurerThread.join(millis);
-                reconfigurerThread = null;
-            }
+            reconfigurerThread.join();
+            log.info(String.format(
+                    "Reconfiguration shutdown completed in %.3f seconds", (System.currentTimeMillis() - start) / 1000D));
         } catch (InterruptedException e) {
-            log.info("Interrupted while joining on HandlersConfigurer reconfigure thread.");
-            Thread.currentThread().interrupt();
+            String message = "Interrupted while waiting for reconfiguration shutdown";
+            log.warning(message);
+            log.log(Level.FINE, e.getMessage(), e);
+            throw new UncheckedInterruptedException(message, true);
         }
     }
 


### PR DESCRIPTION
Use interrupts is a horrible mechanism as we cannot control which part of the code receives the signal.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
