### PR TITLE
Increase minimum number of Jetty threads [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/JettyHttpServer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/JettyHttpServer.java
@@ -87,7 +87,7 @@ public class JettyHttpServer extends SimpleComponent implements ServerConfig.Pro
         if (cluster instanceof ApplicationContainerCluster) {
             builder.minWorkerThreads(-1).maxWorkerThreads(-1);
         } else {
-            builder.minWorkerThreads(5).maxWorkerThreads(5);
+            builder.minWorkerThreads(6).maxWorkerThreads(6);
         }
     }
 


### PR DESCRIPTION
Ref. https://github.com/vespa-engine/vespa/pull/21095
(Error message when having too few threads is misleading, need 6 threads, not 5)