### PR TITLE
Embed most Jetty artifacts in container-disc  [run-systemtest]

### DIFF
--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/mojo/GenerateOsgiManifestMojo.java
@@ -111,6 +111,10 @@ public class GenerateOsgiManifestMojo extends AbstractGenerateOsgiManifestMojo {
     }
 
     private void addAdditionalManifestProperties(Map<String, String> manifestContent) {
+        if (isContainerDiscArtifact(project.getArtifact())) {
+            addIfNotEmpty(manifestContent, "Provide-Capability",
+                          "osgi.serviceloader;osgi.serviceloader=\"org.eclipse.jetty.io.ssl.ALPNProcessor$Server\"");
+        }
         addIfNotEmpty(manifestContent, "Bundle-Activator", bundleActivator);
         addIfNotEmpty(manifestContent, "X-JDisc-Privileged-Activator", jdiscPrivilegedActivator);
         addIfNotEmpty(manifestContent, "Main-Class", mainClass);

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>jdisc_jetty</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>linguistics</artifactId>
       <version>${project.version}</version>
       <exclusions>
@@ -224,12 +229,6 @@
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>jdisc_core</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>jdisc_jetty</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -81,6 +81,10 @@
       <version>${project.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.yahoo.vespa</groupId>
+          <artifactId>jdisc_jetty</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>commons-lang</groupId>
           <artifactId>commons-lang</artifactId>
         </exclusion>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -135,16 +135,29 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>jdisc_jetty</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- TODO Vespa 8: remove if these artifacts are embedded in the container-disc bundle. -->
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-http</artifactId>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
+          <groupId>org.eclipse.jetty</groupId>
+          <artifactId>jetty-io</artifactId>
+          <scope>provided</scope>
+      </dependency>
+      <!-- end TODO Vespa 8: remove -->
+
     <!-- end WARNING -->
 
     <!-- ensure that transitive Jackson dependencies are not included in compile scope -->
@@ -206,34 +219,11 @@
 
                <!-- Jetty -->
                 <!-- TODO Vespa 8: embed these in container-core/disc, saving a lot of dep management. -->
-                <!--               Check if those listed in container-dep-versions are not used by hosted apps! -->
-                alpn-api-${jetty-alpn.version}.jar,
-                http2-server-${jetty.version}.jar,
-                http2-common-${jetty.version}.jar,
-                http2-hpack-${jetty.version}.jar,
-                jetty-alpn-java-server-${jetty.version}.jar,
-                jetty-alpn-server-${jetty.version}.jar,
-                jetty-continuation-${jetty.version}.jar,
+                <!--               Check if artifacts are used by hosted apps before moving them up to parent/pom.xml -->
                 jetty-http-${jetty.version}.jar,
                 jetty-io-${jetty.version}.jar,
-                jetty-jmx-${jetty.version}.jar,
-                jetty-security-${jetty.version}.jar,
-                jetty-server-${jetty.version}.jar,
-                jetty-servlet-${jetty.version}.jar,
-                jetty-servlets-${jetty.version}.jar,
                 jetty-util-${jetty.version}.jar,
-                jetty-util-ajax-${jetty.version}.jar,
                 javax.servlet-api-3.1.0.jar,
-
-                <!-- Spifly (required for OSGi service loader used by Jetty)  -->
-                <!-- TODO: embed these in container-core/disc, not used across bundles -->
-                org.apache.aries.spifly.dynamic.bundle-${spifly.version}.jar,
-                asm-${asm.version}.jar,
-                asm-analysis-${asm.version}.jar,
-                asm-commons-${asm.version}.jar,
-                asm-tree-${asm.version}.jar,
-                asm-util-${asm.version}.jar,
-                <!-- Spifly end -->
 
                 <!-- Jersey 2 + Jackson 2 -->
                 aopalliance-repackaged-${hk2.version}.jar,


### PR DESCRIPTION
.. instead of deploying as bundles.

- None of the affected artifacts are exposed from the 'container'
  artifact.

FYI: @hmusum, @aressem (heads up in case of factory breakage, although I expect none)
