### PR TITLE
Revert "Wire in mallopt(in param, int value) interface in vespamalloc and ver…"

### DIFF
--- a/vespamalloc/src/tests/stacktrace/stacktrace.cpp
+++ b/vespamalloc/src/tests/stacktrace/stacktrace.cpp
@@ -1,5 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <cstdlib>
+#include <cstdio>
 #include <pthread.h>
 #include <dlfcn.h>
 #include <cassert>

--- a/vespamalloc/src/vespamalloc/malloc/malloc.h
+++ b/vespamalloc/src/vespamalloc/malloc/malloc.h
@@ -25,7 +25,6 @@ public:
     }
     size_t getMaxNumThreads() const override { return _threadList.getMaxNumThreads(); }
 
-    int mallopt(int param, int value);
     void *malloc(size_t sz);
     void *malloc(size_t sz, std::align_val_t);
     void *realloc(void *oldPtr, size_t sz);
@@ -150,11 +149,6 @@ void MemoryManager<MemBlockPtrT, ThreadListT>::info(FILE * os, size_t level)
 }
 
 template <typename MemBlockPtrT, typename ThreadListT>
-int MemoryManager<MemBlockPtrT, ThreadListT>::mallopt(int param, int value) {
-    return _threadList.getCurrent().mallopt(param, value);
-}
-
-template <typename MemBlockPtrT, typename ThreadListT>
 void * MemoryManager<MemBlockPtrT, ThreadListT>::malloc(size_t sz)
 {
     MemBlockPtrT mem;
@@ -211,7 +205,7 @@ void MemoryManager<MemBlockPtrT, ThreadListT>::freeSC(void *ptr, SizeClassT sc)
 template <typename MemBlockPtrT, typename ThreadListT>
 void * MemoryManager<MemBlockPtrT, ThreadListT>::realloc(void *oldPtr, size_t sz)
 {
-    void *ptr(nullptr);
+    void *ptr(NULL);
     if (oldPtr) {
         MemBlockPtrT mem(oldPtr);
         mem.readjustAlignment(_segment);

--- a/vespamalloc/src/vespamalloc/malloc/overload.h
+++ b/vespamalloc/src/vespamalloc/malloc/overload.h
@@ -4,7 +4,7 @@
 #include <dlfcn.h>
 #include <errno.h>
 #include <new>
-#include <cstdlib>
+#include <stdlib.h>
 #include <malloc.h>
 
 class CreateAllocator
@@ -139,11 +139,6 @@ struct mallinfo mallinfo() __THROW {
     return info;
 }
 #endif
-
-int mallopt(int param, int value) throw() __attribute((visibility("default")));
-int mallopt(int param, int value) throw() {
-    return vespamalloc::createAllocator()->mallopt(param, value);
-}
 
 void * malloc(size_t sz) __attribute((visibility("default")));
 void * malloc(size_t sz) {

--- a/vespamalloc/src/vespamalloc/malloc/threadpool.h
+++ b/vespamalloc/src/vespamalloc/malloc/threadpool.h
@@ -19,7 +19,6 @@ public:
     void setPool(AllocPool & pool) {
         _allocPool = & pool;
     }
-    int mallopt(int param, int value);
     void malloc(size_t sz, MemBlockPtrT & mem);
     void free(MemBlockPtrT mem, SizeClassT sc);
 
@@ -66,7 +65,6 @@ private:
     static constexpr bool alwaysReuse(SizeClassT sc) { return sc > ALWAYS_REUSE_SC_LIMIT; }
 
     AllocPool   * _allocPool;
-    ssize_t       _mmapLimit;
     AllocFree     _memList[NUM_SIZE_CLASSES];
     ThreadStatT   _stat[NUM_SIZE_CLASSES];
     uint32_t      _threadId;

--- a/vespamalloc/src/vespamalloc/malloc/threadpool.hpp
+++ b/vespamalloc/src/vespamalloc/malloc/threadpool.hpp
@@ -2,7 +2,6 @@
 #pragma once
 
 #include <vespamalloc/malloc/threadpool.h>
-#include <malloc.h>
 
 namespace vespamalloc {
 
@@ -86,7 +85,6 @@ mallocHelper(size_t exactSize,
 template <typename MemBlockPtrT, typename ThreadStatT >
 ThreadPoolT<MemBlockPtrT, ThreadStatT>::ThreadPoolT() :
     _allocPool(nullptr),
-    _mmapLimit(-1),
     _threadId(0),
     _osThreadId(0)
 {
@@ -94,15 +92,6 @@ ThreadPoolT<MemBlockPtrT, ThreadStatT>::ThreadPoolT() :
 
 template <typename MemBlockPtrT, typename ThreadStatT >
 ThreadPoolT<MemBlockPtrT, ThreadStatT>::~ThreadPoolT() = default;
-
-template <typename MemBlockPtrT, typename ThreadStatT >
-int ThreadPoolT<MemBlockPtrT, ThreadStatT>::mallopt(int param, int value) {
-    if (param == M_MMAP_THRESHOLD) {
-        _mmapLimit = value;
-        return 1;
-    }
-    return 0;
-}
 
 template <typename MemBlockPtrT, typename ThreadStatT >
 void ThreadPoolT<MemBlockPtrT, ThreadStatT>::malloc(size_t sz, MemBlockPtrT & mem)


### PR DESCRIPTION
Reverts vespa-engine/vespa#21118

```
00:07:15 [ 18%] Building CXX object vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/new_test.cpp.o
00:07:15 cd /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1 && /usr/bin/ccache /opt/rh/gcc-toolset-11/root/usr/bin/c++ -DPARANOID_LEVEL=0 -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/configdefinitions/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/fastos/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespalib/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespalog/src -I/sd/workspace/src/git.vzbuilders.com/vespa/vespa/defaults/src -isystem /opt/vespa-deps/include -g -O3 -fno-omit-frame-pointer -Winline -Wuninitialized -Werror -Wall -W -Wchar-subscripts -Wcomment -Wformat -Wparentheses -Wreturn-type -Wswitch -Wtrigraphs -Wunused -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fPIC  -DXXH_INLINE_ALL -DBOOST_DISABLE_ASSERTS -march=sandybridge -mtune=skylake  -Wnoexcept -Wsuggest-override -Wnon-virtual-dtor -Wformat-security -std=c++2a -fdiagnostics-color=auto  -fvisibility-inlines-hidden  -fvisibility=hidden -MD -MT vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/new_test.cpp.o -MF CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/new_test.cpp.o.d -o CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/new_test.cpp.o -c /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp
00:07:15 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp: In member function ‘virtual void {anonymous}::TestKitHook99::Test::test_entry_point()’:
00:07:15 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:100:10: error: ‘function’ is not a member of ‘std’
00:07:15   100 |     std::function<void*(void*,size_t,size_t)> call_reallocarray = [](void *ptr, size_t nmemb, size_t size) noexcept { return reallocarray(ptr, nmemb, size); };
00:07:15       |          ^~~~~~~~
00:07:15 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:6:1: note: ‘std::function’ is defined in header ‘<functional>’; did you forget to ‘#include <functional>’?
00:07:15     5 | #include <dlfcn.h>
00:07:15   +++ |+#include <functional>
00:07:15     6 | 
00:07:15 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:100:19: error: expected primary-expression before ‘void’
00:07:15   100 |     std::function<void*(void*,size_t,size_t)> call_reallocarray = [](void *ptr, size_t nmemb, size_t size) noexcept { return reallocarray(ptr, nmemb, size); };
00:07:15       |                   ^~~~
00:07:15 /sd/workspace/src/git.vzbuilders.com/vespa/vespa/vespamalloc/src/tests/test1/new_test.cpp:108:18: error: ‘call_reallocarray’ was not declared in this scope; did you mean ‘reallocarray’?
00:07:15   108 |     void *arr2 = call_reallocarray(arr, 800, 5);
00:07:15       |                  ^~~~~~~~~~~~~~~~~
00:07:15       |                  reallocarray
00:07:15 make[3]: *** [vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/build.make:76: vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/new_test.cpp.o] Error 1
00:07:15 make[3]: Leaving directory '/sd/workspace/src/git.vzbuilders.com/vespa/vespa'
00:07:15 make[2]: *** [CMakeFiles/Makefile2:112708: vespamalloc/src/tests/test1/CMakeFiles/vespamalloc_new_test_with_vespamalloc_app_object.dir/all] Error 2
00:07:15 make[2]: *** Waiting for unfinished jobs....
``` 