### PR TITLE
Keep using same memory allocator when resizing rcu vector.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.cpp
@@ -49,7 +49,7 @@ SingleValueEnumAttributeBase::remap_enum_store_refs(const EnumIndexRemapper& rem
 {
     // update _enumIndices with new EnumIndex values after enum store has been compacted.
     v.logEnumStoreEvent("reenumerate", "reserved");
-    vespalib::Array<EnumIndex> new_indexes;
+    auto new_indexes = _enumIndices.create_replacement_vector();
     new_indexes.reserve(_enumIndices.capacity());
     v.logEnumStoreEvent("reenumerate", "start");
     auto& filter = remapper.get_entry_ref_filter();

--- a/vespalib/src/vespa/vespalib/util/rcuvector.h
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.h
@@ -122,6 +122,7 @@ public:
     void reset();
     void shrink(size_t newSize) __attribute__((noinline));
     void replaceVector(ArrayType replacement);
+    ArrayType create_replacement_vector() const { return _data.create(); }
 };
 
 template <typename T>

--- a/vespalib/src/vespa/vespalib/util/rcuvector.hpp
+++ b/vespalib/src/vespa/vespalib/util/rcuvector.hpp
@@ -42,7 +42,7 @@ template <typename T>
 void
 RcuVectorBase<T>::reset() {
     // Assumes no readers at this moment
-    ArrayType().swap(_data);
+    _data.reset();
     _data.reserve(16);
 }
 
@@ -52,7 +52,7 @@ RcuVectorBase<T>::~RcuVectorBase() = default;
 template <typename T>
 void
 RcuVectorBase<T>::expand(size_t newCapacity) {
-    ArrayType tmpData;
+    auto tmpData = create_replacement_vector();
     tmpData.reserve(newCapacity);
     for (const T & v : _data) {
         tmpData.push_back_fast(v);
@@ -91,7 +91,7 @@ RcuVectorBase<T>::shrink(size_t newSize)
         return;
     }
     if (!_data.try_unreserve(wantedCapacity)) {
-        ArrayType tmpData;
+        auto tmpData = create_replacement_vector();
         tmpData.reserve(wantedCapacity);
         tmpData.resize(newSize);
         for (uint32_t i = 0; i < newSize; ++i) {


### PR DESCRIPTION
@geirst : please review
@baldersheim : FYI
