### PR TITLE
Handle previous config being null when setting new config [run-systemtest]

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
@@ -199,8 +199,7 @@ public abstract class ConfigSubscription<T extends ConfigInstance> {
     }
 
     void setConfigAndGeneration(Long generation, boolean applyOnRestart, T config, PayloadChecksums payloadChecksums) {
-        ConfigState<T> prev = this.config.get();
-        T previousConfig = prev.getConfig();
+        T previousConfig = this.config.get().getConfig();
         boolean configChanged = ! Objects.equals(previousConfig, config);
         if (previousConfig != null && configChanged) {
             SnippetGenerator generator = new SnippetGenerator();

--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
@@ -200,13 +200,14 @@ public abstract class ConfigSubscription<T extends ConfigInstance> {
 
     void setConfigAndGeneration(Long generation, boolean applyOnRestart, T config, PayloadChecksums payloadChecksums) {
         ConfigState<T> prev = this.config.get();
-        boolean configChanged = !Objects.equals(prev.getConfig(), config);
-        if (configChanged) {
+        T previousConfig = prev.getConfig();
+        boolean configChanged = ! Objects.equals(previousConfig, config);
+        if (previousConfig != null && configChanged) {
             SnippetGenerator generator = new SnippetGenerator();
             int sizeHint = 500;
             log.log(Level.WARNING, "Config has changed unexpectedly for " + key + ", generation " + generation +
-                                   ", config in state :" + generator.makeSnippet(prev.getConfig().toString(), sizeHint) + ", new config: " +
-                                   generator.makeSnippet(config.toString(), sizeHint));
+                    ", config in state :" + generator.makeSnippet(previousConfig.toString(), sizeHint) + ", new config: " +
+                    generator.makeSnippet(config.toString(), sizeHint));
         }
         this.config.set(new ConfigState<>(true, generation, applyOnRestart, configChanged, config, payloadChecksums));
     }


### PR DESCRIPTION
Handle previous config being null (i.e. not configured before when checking
for unexpected change in config).