### PR TITLE
Only shutdown non-null configurer

### DIFF
--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -434,7 +434,9 @@ public final class ConfiguredApplication implements Application {
     @Override
     public void destroy() {
         log.info("Destroy: Shutting down container now");
-        configurer.shutdown();
+        if (configurer != null) {
+            configurer.shutdown();
+        }
         slobrokConfigSubscriber.ifPresent(SlobrokConfigSubscriber::shutdown);
         Container.get().shutdown();
         unregisterInSlobrok();


### PR DESCRIPTION
Happens if `app.start()` throws before `configurer` is assigned in
https://github.com/vespa-engine/vespa/blob/master/jdisc_core/src/main/java/com/yahoo/jdisc/core/ApplicationLoader.java#L149-L162

@bjorncs