### PR TITLE
Skip tests if onnxruntime unavailable, part 2

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/StatelessOnnxEvaluationTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/StatelessOnnxEvaluationTest.java
@@ -63,6 +63,7 @@ public class StatelessOnnxEvaluationTest {
 
     @Test
     public void testStatelessOnnxModelEvaluation() throws IOException {
+        assumeTrue(OnnxEvaluator.isRuntimeAvailable());
         Path appDir = Path.fromString("src/test/cfg/application/onnx");
         Path storedAppDir = appDir.append("copy");
         try {


### PR DESCRIPTION
This change was accidentally left out of https://github.com/vespa-engine/vespa/pull/21135