### PR TITLE
Reduce default resource limit for disk from 80% to 75%.

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -93,7 +93,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bjorncs", "tokle"}) default List<String> allowedAthenzProxyIdentities() { return List.of(); }
         @ModelFeatureFlag(owners = {"vekterli"}) default int maxActivationInhibitedOutOfSyncGroups() { return 0; }
         @ModelFeatureFlag(owners = {"hmusum"}) default String jvmOmitStackTraceInFastThrowOption(ClusterSpec.Type type) { return ""; }
-        @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitDisk() { return 0.8; }
+        @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitDisk() { return 0.75; }
         @ModelFeatureFlag(owners = {"hmusum"}) default double resourceLimitMemory() { return 0.8; }
         @ModelFeatureFlag(owners = {"geirst", "vekterli"}) default double minNodeRatioPerGroup() { return 0.0; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean forwardIssuesAsErrors() { return true; }

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -58,7 +58,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private int maxMergeQueueSize = 100;
     private boolean allowDisableMtls = true;
     private List<X509Certificate> operatorCertificates = Collections.emptyList();
-    private double resourceLimitDisk = 0.8;
+    private double resourceLimitDisk = 0.75;
     private double resourceLimitMemory = 0.8;
     private double minNodeRatioPerGroup = 0.0;
     private boolean containerDumpHeapOnShutdownTimeout = false;

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -66,7 +66,7 @@ public class ClusterResourceLimitsTest {
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7));
         assertLimits(0.4, 0.8, 0.7, 0.9,
                 new Fixture().ctrlDisk(0.4));
-        assertLimits(0.8, 0.7, 0.9, 0.85,
+        assertLimits(0.75, 0.7, 0.875, 0.85,
                 new Fixture().ctrlMemory(0.7));
     }
 
@@ -76,7 +76,7 @@ public class ClusterResourceLimitsTest {
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7).nodeDisk(0.9).nodeMemory(0.95));
         assertLimits(0.4, 0.8, 0.95, 0.9,
                 new Fixture().ctrlDisk(0.4).nodeDisk(0.95));
-        assertLimits(0.8, 0.7, 0.9, 0.95,
+        assertLimits(0.75, 0.7, 0.875, 0.95,
                 new Fixture().ctrlMemory(0.7).nodeMemory(0.95));
     }
 
@@ -86,9 +86,9 @@ public class ClusterResourceLimitsTest {
                 new Fixture().nodeDisk(0.9).nodeMemory(0.95));
         assertLimits(0.89, 0.8, 0.9, 0.9,
                 new Fixture().nodeDisk(0.9));
-        assertLimits(0.8, 0.94, 0.9, 0.95,
+        assertLimits(0.75, 0.94, 0.875, 0.95,
                 new Fixture().nodeMemory(0.95));
-        assertLimits(0.8, 0.0, 0.9, 0.005,
+        assertLimits(0.75, 0.0, 0.875, 0.005,
                 new Fixture().nodeMemory(0.005));
     }
 
@@ -102,7 +102,7 @@ public class ClusterResourceLimitsTest {
 
     @Test
     public void default_resource_limits_when_feed_block_is_enabled_in_distributor() {
-        assertLimits(0.8, 0.8, 0.9, 0.9,
+        assertLimits(0.75, 0.8, 0.875, 0.9,
                 new Fixture(true));
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
@@ -118,7 +118,7 @@ public class ContentSchemaClusterTest {
 
     @Test
     public void requireThatOnlyMemoryLimitCanBeSet() throws Exception {
-        assertProtonResourceLimits(0.9, 0.77,
+        assertProtonResourceLimits(0.875, 0.77,
                 new ContentClusterBuilder().protonMemoryLimit(0.77).getXml());
     }
 
@@ -138,8 +138,8 @@ public class ContentSchemaClusterTest {
     @Test
     public void default_resource_limits_with_feed_block_in_distributor() throws Exception {
         var cluster = createCluster(new ContentClusterBuilder().getXml());
-        assertProtonResourceLimits(0.9, 0.9, cluster);
-        assertClusterControllerResourceLimits(0.8, 0.8, cluster);
+        assertProtonResourceLimits(0.875, 0.9, cluster);
+        assertClusterControllerResourceLimits(0.75, 0.8, cluster);
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -104,14 +104,14 @@ public class FleetControllerClusterTest {
 
     @Test
     public void default_cluster_feed_block_limits_are_set() {
-        assertLimits(0.8, 0.8, getConfigForBasicCluster());
+        assertLimits(0.75, 0.8, getConfigForBasicCluster());
     }
 
     @Test
     public void resource_limits_can_be_set_in_tuning() {
         assertLimits(0.6, 0.7, getConfigForResourceLimitsTuning(0.6, 0.7));
         assertLimits(0.6, 0.8, getConfigForResourceLimitsTuning(0.6, null));
-        assertLimits(0.8, 0.7, getConfigForResourceLimitsTuning(null, 0.7));
+        assertLimits(0.75, 0.7, getConfigForResourceLimitsTuning(null, 0.7));
     }
 
     private static final double DELTA = 0.00001;

--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -177,15 +177,15 @@ public class PermanentFlags {
             APPLICATION_ID);
 
     public static final UnboundDoubleFlag RESOURCE_LIMIT_DISK = defineDoubleFlag(
-            "resource-limit-disk", 0.8,
-            "Resource limit (between 0.0 and 1.0) for disk used by cluster controller for when to block feed",
+            "resource-limit-disk", 0.75,
+            "Resource limit (between 0.0 and 1.0) for disk usage on content nodes, used by cluster controller for when to block feed",
             "Takes effect on next deployment",
             APPLICATION_ID
     );
 
     public static final UnboundDoubleFlag RESOURCE_LIMIT_MEMORY = defineDoubleFlag(
             "resource-limit-memory", 0.8,
-            "Resource limit (between 0.0 and 1.0) for memory used by cluster controller for when to block feed",
+            "Resource limit (between 0.0 and 1.0) for memory usage on content nodes, used by cluster controller for when to block feed",
             "Takes effect on next deployment",
             APPLICATION_ID
     );


### PR DESCRIPTION
After the changes in https://github.com/vespa-engine/vespa/pull/20818,
the transient disk used as part of index fusion is no longer reported to the cluster controller.
Transient disk usage should be covered by the resource headroom on content nodes,
instead of leading to feed blocked due to natural fluctuations.
We must therefore adjust the limit slightly down, to ensure the content nodes have enough headroom.

@baldersheim please review
@hmusum FYI