### PR TITLE
Don't verify zipped tests for now

### DIFF
--- a/client/go/cmd/prod.go
+++ b/client/go/cmd/prod.go
@@ -146,7 +146,10 @@ $ vespa prod submit`,
 				"See https://cloud.vespa.ai/en/getting-to-production")
 			return
 		}
-		verifyTests(pkg.TestPath, target)
+		// TODO: Always verify tests. Do it before packaging, when running Maven from this CLI.
+		if ! pkg.IsZip() {
+			verifyTests(pkg.TestPath, target)
+		}
 		isCI := os.Getenv("CI") != ""
 		if !isCI {
 			fmt.Fprintln(stderr, color.Yellow("Warning:"), "We recommend doing this only from a CD job")

--- a/client/go/cmd/prod.go
+++ b/client/go/cmd/prod.go
@@ -147,7 +147,7 @@ $ vespa prod submit`,
 			return
 		}
 		// TODO: Always verify tests. Do it before packaging, when running Maven from this CLI.
-		if ! pkg.IsZip() {
+		if !pkg.IsZip() {
 			verifyTests(pkg.TestPath, target)
 		}
 		isCI := os.Getenv("CI") != ""


### PR DESCRIPTION
@hakonhall or @mpolden please review and merge.

This code path currently fails when the tests are in a zip, because it assumes that isn't a zip ... 🤦 
We either need to unpack the zip, and verify any tests in it, or verify prior to zipping. 