### PR TITLE
Support all services types in the curl subcommand

### DIFF
--- a/client/go/cmd/curl.go
+++ b/client/go/cmd/curl.go
@@ -20,7 +20,7 @@ var curlService string
 func init() {
 	rootCmd.AddCommand(curlCmd)
 	curlCmd.Flags().BoolVarP(&curlDryRun, "dry-run", "n", false, "Print the curl command that would be executed")
-	curlCmd.Flags().StringVarP(&curlService, "service", "s", "query", "Which service to query")
+	curlCmd.Flags().StringVarP(&curlService, "service", "s", "query", "Which service to query. Must be \"deploy\", \"document\" or \"query\"")
 }
 
 var curlCmd = &cobra.Command{
@@ -59,21 +59,19 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 		}
 		switch curlService {
 		case "deploy":
-			if !vespa.Auth0AccessTokenEnabled() {
-				return errors.New("accessing control plane using curl subcommand is only supported for Auth0 device flow")
-			}
 			t, err := getTarget()
 			if err != nil {
 				return err
 			}
 			if t.Type() == "cloud" {
+				if !vespa.Auth0AccessTokenEnabled() {
+					return errors.New("accessing control plane using curl subcommand is only supported for Auth0 device flow")
+				}
 				if err := addCloudAuth0Authentication(cfg, c); err != nil {
 					return err
 				}
 			}
-		case "document":
-			fallthrough
-		case "query":
+		case "document", "query":
 			privateKeyFile, err := cfg.PrivateKeyPath(app)
 			if err != nil {
 				return err

--- a/client/go/cmd/curl_test.go
+++ b/client/go/cmd/curl_test.go
@@ -18,4 +18,8 @@ func TestCurl(t *testing.T) {
 		filepath.Join(homeDir, "t1.a1.i1", "data-plane-private-key.pem"),
 		filepath.Join(homeDir, "t1.a1.i1", "data-plane-public-cert.pem"))
 	assert.Equal(t, expected, out)
+
+	out, _ = execute(command{homeDir: homeDir, args: []string{"curl", "-s", "deploy", "-n", "/application/v4/tenant/foo"}}, t, httpClient)
+	expected = "curl https://127.0.0.1:19071/application/v4/tenant/foo\n"
+	assert.Equal(t, expected, out)
 }


### PR DESCRIPTION
Required authentication is chosen based on which service is accessed, and if
you have Auth0 or api-key available.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
