### PR TITLE
Adjust attribute-address-space resource limits.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ResourceLimits.java
@@ -31,13 +31,12 @@ public class ResourceLimits implements FleetcontrollerConfig.Producer, ProtonCon
 
     @Override
     public void getConfig(FleetcontrollerConfig.Builder builder) {
-        // TODO: Choose other defaults when this is default enabled.
         // Note: The resource categories must match the ones used in host info reporting
         // between content nodes and cluster controller:
         // storage/src/vespa/storage/persistence/filestorage/service_layer_host_info_reporter.cpp
         builder.cluster_feed_block_limit.put("memory", memoryLimit.orElse(0.8));
-        builder.cluster_feed_block_limit.put("disk", diskLimit.orElse(0.8));
-        builder.cluster_feed_block_limit.put("attribute-address-space", 0.89);
+        builder.cluster_feed_block_limit.put("disk", diskLimit.orElse(0.75));
+        builder.cluster_feed_block_limit.put("attribute-address-space", 0.9);
     }
 
     @Override

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/FleetControllerClusterTest.java
@@ -121,7 +121,7 @@ public class FleetControllerClusterTest {
         assertEquals(3, limits.size());
         assertEquals(expDisk, limits.get("disk"), DELTA);
         assertEquals(expMemory, limits.get("memory"), DELTA);
-        assertEquals(0.89, limits.get("attribute-address-space"), DELTA);
+        assertEquals(0.9, limits.get("attribute-address-space"), DELTA);
     }
 
     private FleetcontrollerConfig getConfigForResourceLimitsTuning(Double diskLimit, Double memoryLimit) {

--- a/searchcore/src/vespa/searchcore/config/proton.def
+++ b/searchcore/src/vespa/searchcore/config/proton.def
@@ -446,7 +446,7 @@ initialize.threads int default = 0
 
 ## Portion of max address space used in components in attribute vectors
 ## before put and update operations in feed is blocked.
-writefilter.attribute.address_space_limit double default = 0.9
+writefilter.attribute.address_space_limit double default = 0.92
 
 ## Portion of physical memory that can be resident memory in anonymous mapping
 ## by the proton process before put and update portion of feed is blocked.


### PR DESCRIPTION
Feed blocked is now always decided in the cluster controller,
and the new limit of 90% matches what was used in proton previously.

@baldersheim please review