### PR TITLE
add special DocumentOnly fieldset in Java as well

### DIFF
--- a/document/abi-spec.json
+++ b/document/abi-spec.json
@@ -2576,6 +2576,24 @@
       "public static final java.lang.String NAME"
     ]
   },
+  "com.yahoo.document.fieldset.DocumentOnly": {
+    "superClass": "java.lang.Object",
+    "interfaces": [
+      "com.yahoo.document.fieldset.FieldSet"
+    ],
+    "attributes": [
+      "public"
+    ],
+    "methods": [
+      "public void <init>()",
+      "public boolean contains(com.yahoo.document.fieldset.FieldSet)",
+      "public com.yahoo.document.fieldset.FieldSet clone()",
+      "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields": [
+      "public static final java.lang.String NAME"
+    ]
+  },
   "com.yahoo.document.fieldset.FieldCollection": {
     "superClass": "java.util.ArrayList",
     "interfaces": [

--- a/document/src/main/java/com/yahoo/document/fieldset/DocumentOnly.java
+++ b/document/src/main/java/com/yahoo/document/fieldset/DocumentOnly.java
@@ -1,0 +1,18 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.document.fieldset;
+
+/**
+ * @author arnej27959
+ */
+public class DocumentOnly implements FieldSet {
+    public static final String NAME = "[document]";
+    @Override
+    public boolean contains(FieldSet o) {
+        return (o instanceof DocumentOnly || o instanceof DocIdOnly || o instanceof NoFields);
+    }
+
+    @Override
+    public FieldSet clone() {
+        return new DocumentOnly();
+    }
+}

--- a/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
+++ b/document/src/test/java/com/yahoo/document/DocumentTestCaseBase.java
@@ -5,6 +5,8 @@ import com.yahoo.document.datatypes.FloatFieldValue;
 import com.yahoo.document.datatypes.Raw;
 
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -60,6 +62,8 @@ public class DocumentTestCaseBase {
         floatField = testDocType.getField("floatattr");
         stringField = testDocType.getField("stringattr");
         minField = testDocType.getField("Minattr");
+
+        testDocType.addFieldSets(Map.of("[document]", List.of("stringattr", "intattr")));
 
         docMan.registerDocumentType(testDocType);
     }

--- a/document/src/test/java/com/yahoo/document/fieldset/FieldSetTestCase.java
+++ b/document/src/test/java/com/yahoo/document/fieldset/FieldSetTestCase.java
@@ -23,6 +23,7 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
     @Test
     public void testClone() throws Exception {
         assertTrue(new AllFields().clone() instanceof AllFields);
+        assertTrue(new DocumentOnly().clone() instanceof DocumentOnly);
         assertTrue(new NoFields().clone() instanceof NoFields);
         assertTrue(new DocIdOnly().clone() instanceof DocIdOnly);
     }
@@ -32,6 +33,7 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
         FieldSetRepo repo = new FieldSetRepo();
 
         assertTrue(repo.parse(docMan, AllFields.NAME) instanceof AllFields);
+        assertTrue(repo.parse(docMan, DocumentOnly.NAME) instanceof DocumentOnly);
         assertTrue(repo.parse(docMan, NoFields.NAME) instanceof NoFields);
         assertTrue(repo.parse(docMan, DocIdOnly.NAME) instanceof DocIdOnly);
 
@@ -72,20 +74,29 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
         assertTrue(intAttr.contains(new DocIdOnly()));
         assertTrue(intAttr.contains(new NoFields()));
         assertFalse(intAttr.contains(new AllFields()));
+        assertFalse(intAttr.contains(new DocumentOnly()));
 
         assertFalse(new NoFields().contains(intAttr));
         assertFalse(new NoFields().contains(new AllFields()));
         assertFalse(new NoFields().contains(new DocIdOnly()));
+        assertFalse(new NoFields().contains(new DocumentOnly()));
 
         assertTrue(new AllFields().contains(intAttr));
         assertTrue(new AllFields().contains(rawAttr));
         assertTrue(new AllFields().contains(new DocIdOnly()));
+        assertTrue(new AllFields().contains(new DocumentOnly()));
         assertTrue(new AllFields().contains(new NoFields()));
         assertTrue(new AllFields().contains(new AllFields()));
 
         assertTrue(new DocIdOnly().contains(new NoFields()));
         assertTrue(new DocIdOnly().contains(new DocIdOnly()));
+        assertFalse(new DocIdOnly().contains(new DocumentOnly()));
         assertFalse(new DocIdOnly().contains(intAttr));
+
+        assertTrue(new DocumentOnly().contains(new NoFields()));
+        assertTrue(new DocumentOnly().contains(new DocIdOnly()));
+        assertTrue(new DocumentOnly().contains(new DocumentOnly()));
+        assertFalse(new DocumentOnly().contains(intAttr));
 
         assertContains("testdoc:rawattr,intattr", "testdoc:intattr");
         assertNotContains("testdoc:intattr", "testdoc:rawattr,intattr");
@@ -124,6 +135,7 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
         doc.removeFieldValue("rawattr");
 
         assertEquals("floatattr:3.56,stringattr:tjohei,intattr:50,byteattr:30", doCopyFields(doc, AllFields.NAME));
+        assertEquals("stringattr:tjohei,intattr:50", doCopyFields(doc, DocumentOnly.NAME));
         assertEquals("floatattr:3.56,byteattr:30", doCopyFields(doc, "testdoc:floatattr,byteattr"));
     }
 
@@ -140,6 +152,7 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
         doc.removeFieldValue("rawattr");
 
         assertEquals("floatattr:3.56,stringattr:tjohei,intattr:50,byteattr:30", doStripFields(doc, AllFields.NAME));
+        assertEquals("stringattr:tjohei,intattr:50", doStripFields(doc, DocumentOnly.NAME));
         assertEquals("floatattr:3.56,byteattr:30", doStripFields(doc, "testdoc:floatattr,byteattr"));
     }
 
@@ -150,6 +163,7 @@ public class FieldSetTestCase extends DocumentTestCaseBase {
                         AllFields.NAME,
                         NoFields.NAME,
                         DocIdOnly.NAME,
+                        DocumentOnly.NAME,
                         "testdoc:rawattr",
                         "testdoc:rawattr,intattr"
                 };

--- a/document/src/vespa/document/base/testdocrepo.cpp
+++ b/document/src/vespa/document/base/testdocrepo.cpp
@@ -27,6 +27,7 @@ DocumenttypesConfig TestDocRepo::getDefaultConfig() {
     const int mystruct_id = -2092985851;
     const int structarray_id = 759956026;
     config_builder::DocumenttypesConfigBuilderHelper builder;
+    ::config::StringVector documentfields = { "headerval", "hstringval", "title" };
     builder.document(type1_id, "testdoctype1",
                      Struct("testdoctype1.header")
                      .addField("headerval", DataType::T_INT)
@@ -55,7 +56,9 @@ DocumenttypesConfig TestDocRepo::getDefaultConfig() {
                      .addTensorField("sparse_tensor", "tensor(x{})")
                      .addTensorField("sparse_xy_tensor", "tensor(x{},y{})")
                      .addTensorField("sparse_float_tensor", "tensor<float>(x{})")
-                     .addTensorField("dense_tensor", "tensor(x[2])"));
+                     .addTensorField("dense_tensor", "tensor(x[2])"))
+        .doc_type.fieldsets["[document]"].fields.swap(documentfields);
+
     builder.document(type2_id, "testdoctype2",
                      Struct("testdoctype2.header")
                      .addField("onlyinchild", DataType::T_INT),

--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
@@ -4,6 +4,7 @@ package com.yahoo.documentapi;
 import com.yahoo.document.BucketId;
 import com.yahoo.document.FixedBucketSpaces;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadType;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.messagebus.ThrottlePolicy;
@@ -30,6 +31,7 @@ public class VisitorParameters extends Parameters {
     private long fromTimestamp = 0;
     private long toTimestamp = 0;
     boolean visitRemoves = false;
+    // TODO Vespa 8: change to DocumentOnly.NAME;
     private String fieldSet = AllFields.NAME;
     boolean visitInconsistentBuckets = false;
     private ProgressToken resumeToken = null;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -7,6 +7,7 @@ import com.yahoo.document.DocumentPut;
 import com.yahoo.document.DocumentRemove;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.documentapi.AsyncParameters;
 import com.yahoo.documentapi.AsyncSession;
 import com.yahoo.documentapi.DocumentIdResponse;
@@ -127,6 +128,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
 
     @Override
     public Result get(DocumentId id, DocumentOperationParameters parameters) {
+        // TODO Vespa 8: change to DocumentOnly.NAME
         GetDocumentMessage msg = new GetDocumentMessage(id, parameters.fieldSet().orElse(AllFields.NAME));
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_1));
         return send(msg, parameters);

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
@@ -7,6 +7,7 @@ import com.yahoo.document.DocumentPut;
 import com.yahoo.document.DocumentRemove;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.documentapi.AsyncParameters;
 import com.yahoo.documentapi.DocumentAccessException;
 import com.yahoo.documentapi.DocumentOperationParameters;
@@ -152,6 +153,7 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
 
     @Override
     public Document get(DocumentId id, DocumentOperationParameters parameters, Duration timeout) {
+        // TODO Vespa 8: change to DocumentOnly.NAME
         GetDocumentMessage msg = new GetDocumentMessage(id, parameters.fieldSet().orElse(AllFields.NAME));
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_1));
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/CreateVisitorMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/CreateVisitorMessage.java
@@ -4,6 +4,7 @@ package com.yahoo.documentapi.messagebus.protocol;
 import com.yahoo.document.BucketId;
 import com.yahoo.document.FixedBucketSpaces;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -24,6 +25,7 @@ public class CreateVisitorMessage extends DocumentMessage {
     private long fromTime = 0;
     private long toTime = 0;
     private boolean visitRemoves = false;
+    // TODO Vespa 8: change to DocumentOnly.NAME
     private String fieldSet = AllFields.NAME;
     private boolean visitInconsistentBuckets = false;
     private Map<String, byte[]> params = new TreeMap<>();

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetDocumentMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetDocumentMessage.java
@@ -3,6 +3,7 @@ package com.yahoo.documentapi.messagebus.protocol;
 
 import com.yahoo.document.DocumentId;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 
 import java.util.Arrays;
 
@@ -11,6 +12,7 @@ import java.util.Arrays;
  */
 public class GetDocumentMessage extends DocumentMessage {
 
+    // TODO Vespa 8: change to DocumentOnly.NAME
     final static String DEFAULT_FIELD_SET = AllFields.NAME;
     private DocumentId documentId = null;
     private String fieldSet = DEFAULT_FIELD_SET;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -20,6 +20,7 @@ import com.yahoo.document.FixedBucketSpaces;
 import com.yahoo.document.TestAndSetCondition;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.document.fieldset.DocIdOnly;
 import com.yahoo.document.idstring.IdIdString;
 import com.yahoo.document.json.DocumentOperationType;
@@ -379,6 +380,7 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
             StorageCluster destination = resolveCluster(Optional.of(requireProperty(request, DESTINATION_CLUSTER)), clusters);
             VisitorParameters parameters = parseParameters(request, path);
             parameters.setRemoteDataHandler("[Content:cluster=" + destination.name() + "]"); // Bypass indexing.
+            // TODO Vespa 8: change to DocumentOnly.NAME
             parameters.setFieldSet(AllFields.NAME);
             return () -> {
                 visitWithRemote(request, parameters, handler);
@@ -1088,6 +1090,7 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
             throw new IllegalArgumentException("Must set 'cluster' parameter to a valid content cluster id when visiting at a root /document/v1/ level");
 
         VisitorParameters parameters = parseCommonParameters(request, path, cluster);
+        // TODO Vespa 8: change to DocumentOnly.NAME
         parameters.setFieldSet(getProperty(request, FIELD_SET).orElse(path.documentType().map(type -> type + ":[document]").orElse(AllFields.NAME)));
         parameters.setMaxTotalHits(wantedDocumentCount);
         parameters.visitInconsistentBuckets(true);

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespaget;
 
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.document.fieldset.DocIdOnly;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import org.apache.commons.cli.CommandLine;
@@ -67,6 +68,7 @@ public class CommandLineOptions {
                 .longOpt(PRINTIDS_OPTION)
                 .build());
 
+        // TODO Vespa 8: change to DocumentOnly.NAME
         options.addOption(Option.builder("f")
                 .hasArg(true)
                 .desc("Retrieve the specified fields only (see https://docs.vespa.ai/en/documents.html#fieldsets) (default '" + AllFields.NAME + "')")
@@ -181,8 +183,9 @@ public class CommandLineOptions {
 
             if (printIdsOnly) {
                 fieldSet = DocIdOnly.NAME;
-            } else if (fieldSet.isEmpty()) {
-                fieldSet = AllFields.NAME;
+            } else if (fieldSet.isEmpty()) { 
+                // TODO Vespa 8: change to DocumentOnly.NAME
+               fieldSet = AllFields.NAME;
             }
 
             if (!cluster.isEmpty() && !route.isEmpty()) {

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespaget;
 
 import com.yahoo.document.fieldset.AllFields;
+import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.document.fieldset.DocIdOnly;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import org.junit.Rule;
@@ -55,6 +56,7 @@ public class CommandLineOptionsTest {
         assertFalse(params.help);
         assertFalse(params.documentIds.hasNext());
         assertFalse(params.printIdsOnly);
+        // TODO Vespa 8: change to DocumentOnly.NAME
         assertEquals(AllFields.NAME, params.fieldSet);
         assertEquals("default-get", params.route);
         assertTrue(params.cluster.isEmpty());


### PR DESCRIPTION
* should have same behavior in Java and C++
* extend unit tests to verify
* note various places where we want to change the default on Vespa 8 branch

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli please review
@jonmv please review
