### PR TITLE
better error messages

### DIFF
--- a/eval/src/apps/analyze_onnx_model/analyze_onnx_model.cpp
+++ b/eval/src/apps/analyze_onnx_model/analyze_onnx_model.cpp
@@ -20,6 +20,10 @@ using vespalib::FilePointer;
 using namespace vespalib::eval;
 using namespace vespalib::eval::test;
 
+struct MyError {
+    vespalib::string msg;
+};
+
 bool read_line(FilePointer &file, vespalib::string &line) {
     char line_buffer[1024];
     char *res = fgets(line_buffer, sizeof(line_buffer), file.fp());
@@ -139,16 +143,50 @@ struct MakeInputType {
     }
 };
 
+vespalib::string make_bound_str(const std::map<vespalib::string,size_t> &bound) {
+    vespalib::string result;
+    if (!bound.empty()) {
+        for (const auto &[name, size]: bound) {
+            if (result.empty()) {
+                result.append(" (");
+            } else {
+                result.append(",");
+            }
+            result.append(fmt("%s=%zu", name.c_str(), size));
+        }
+        result.append(")");
+    }
+    return result;
+}
+
+void bind_input(Onnx::WirePlanner &planner, const Onnx::TensorInfo &input, const ValueType &type) {
+    auto bound = planner.get_bound_sizes(input);
+    if (!planner.bind_input_type(type, input)) {
+        auto bound_str = make_bound_str(bound);
+        throw MyError{fmt("incompatible type for input '%s': %s -> %s%s",
+                          input.name.c_str(), type.to_spec().c_str(), input.type_as_string().c_str(), bound_str.c_str())};
+    }
+}
+
+ValueType make_output(const Onnx::WirePlanner &planner, const Onnx::TensorInfo &output) {
+    auto type = planner.make_output_type(output);
+    if (type.is_error()) {
+        throw MyError{fmt("unable to make compatible type for output '%s': %s -> error",
+                          output.name.c_str(), output.type_as_string().c_str())};
+    }
+    return type;
+}
+
 Onnx::WireInfo make_plan(Options &opts, const Onnx &model) {
     Onnx::WirePlanner planner;
     MakeInputType make_input_type(opts);
     for (const auto &input: model.inputs()) {
         auto type = make_input_type(input);
-        REQUIRE(planner.bind_input_type(type, input));
+        bind_input(planner, input, type);
     }
     planner.prepare_output_types(model);
     for (const auto &output: model.outputs()) {
-        REQUIRE(!planner.make_output_type(output).is_error());
+        make_output(planner, output);
     }
     return planner.get_wire_info(model);
 }
@@ -189,7 +227,7 @@ int probe_types() {
     StdOut std_out;
     Slime params;
     if (!JsonFormat::decode(std_in, params)) {
-        return 3;
+        throw MyError{"invalid json"};
     }
     Slime result;
     auto &root = result.setObject();
@@ -199,13 +237,20 @@ int probe_types() {
     for (size_t i = 0; i < model.inputs().size(); ++i) {
         auto spec = params["inputs"][model.inputs()[i].name].asString().make_string();
         auto input_type = ValueType::from_spec(spec);
-        REQUIRE(!input_type.is_error());
-        REQUIRE(planner.bind_input_type(input_type, model.inputs()[i]));
+        if (input_type.is_error()) {
+            if (!params["inputs"][model.inputs()[i].name].valid()) {
+                throw MyError{fmt("missing type for model input '%s'",
+                                  model.inputs()[i].name.c_str())};
+            } else {
+                throw MyError{fmt("invalid type for model input '%s': '%s'",
+                                  model.inputs()[i].name.c_str(), spec.c_str())};
+            }
+        }
+        bind_input(planner, model.inputs()[i], input_type);
     }
     planner.prepare_output_types(model);
     for (const auto &output: model.outputs()) {
-        auto output_type = planner.make_output_type(output);
-        REQUIRE(!output_type.is_error());
+        auto output_type = make_output(planner, output);
         types.setString(output.name, output_type.to_spec());
     }
     write_compact(result, std_out);
@@ -253,6 +298,9 @@ int my_main(int argc, char **argv) {
 int main(int argc, char **argv) {
     try {
         return my_main(argc, argv);
+    } catch (const MyError &err) {
+        fprintf(stderr, "error: %s\n", err.msg.c_str());
+        return 3;
     } catch (const std::exception &ex) {
         fprintf(stderr, "got exception: %s\n", ex.what());
         return 2;

--- a/eval/src/tests/apps/analyze_onnx_model/CMakeLists.txt
+++ b/eval/src/tests/apps/analyze_onnx_model/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(eval_analyze_onnx_model_test_app TEST
     analyze_onnx_model_test.cpp
     DEPENDS
     vespaeval
+    AFTER
+    eval_analyze_onnx_model_app
 )
-vespa_add_test(NAME eval_analyze_onnx_model_test_app COMMAND eval_analyze_onnx_model_test_app
-               DEPENDS eval_analyze_onnx_model_test_app eval_analyze_onnx_model_app)
+vespa_add_test(NAME eval_analyze_onnx_model_test_app COMMAND eval_analyze_onnx_model_test_app)

--- a/eval/src/tests/apps/eval_expr/CMakeLists.txt
+++ b/eval/src/tests/apps/eval_expr/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_executable(eval_eval_expr_test_app TEST
     eval_expr_test.cpp
     DEPENDS
     vespaeval
+    AFTER
+    eval_eval_expr_app
 )
-vespa_add_test(NAME eval_eval_expr_test_app COMMAND eval_eval_expr_test_app
-               DEPENDS eval_eval_expr_test_app eval_eval_expr_app)
+vespa_add_test(NAME eval_eval_expr_test_app COMMAND eval_eval_expr_test_app)

--- a/eval/src/tests/apps/eval_expr/eval_expr_test.cpp
+++ b/eval/src/tests/apps/eval_expr/eval_expr_test.cpp
@@ -56,7 +56,7 @@ Result::~Result() = default;
 
 struct Server : public ServerCmd {
     TimeBomb time_bomb;
-    Server() : ServerCmd(server_cmd, true), time_bomb(60) {}
+    Server() : ServerCmd(server_cmd), time_bomb(60) {}
     Result eval(const vespalib::string &expr, const vespalib::string &name = {}, bool verbose = false) {
         Slime req;
         auto &obj = req.setObject();
@@ -69,6 +69,9 @@ struct Server : public ServerCmd {
         }
         Slime reply = invoke(req);
         return {reply.get()};
+    }
+    ~Server() {
+        EXPECT_EQUAL(shutdown(), 0);
     }
 };
 

--- a/eval/src/vespa/eval/eval/test/test_io.h
+++ b/eval/src/vespa/eval/eval/test/test_io.h
@@ -73,13 +73,24 @@ private:
     ChildIn _child_stdin;
     ChildOut _child_stdout;
     vespalib::string _basename;
-    bool _verbose;
+    bool _closed;
+    bool _exited;
+    int _exit_code;
 
-    void maybe_dump_message(const char *prefix, const Slime &slime);
+    void maybe_close();
+    void maybe_exit();
+
+    void dump_string(const char *prefix, const vespalib::string &str);
+    void dump_message(const char *prefix, const Slime &slime);
+
 public:
-    ServerCmd(vespalib::string cmd, bool verbose);
+    struct capture_stderr_tag{};
+    ServerCmd(vespalib::string cmd);
+    ServerCmd(vespalib::string cmd, capture_stderr_tag);
     ~ServerCmd();
     Slime invoke(const Slime &req);
+    vespalib::string write_then_read_all(const vespalib::string &input);
+    int shutdown();
 };
 
 /**

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.cpp
@@ -382,6 +382,22 @@ Onnx::WirePlanner::bind_input_type(const ValueType &vespa_in, const TensorInfo &
     return true;
 }
 
+std::map<vespalib::string,size_t>
+Onnx::WirePlanner::get_bound_sizes(const TensorInfo &onnx_in) const
+{
+    std::map<vespalib::string,size_t> result;
+    for (const auto &dim: onnx_in.dimensions) {
+        if (dim.is_symbolic()) {
+            auto pos = _symbolic_sizes.find(dim.name);
+            if (pos != _symbolic_sizes.end()) {
+                assert(pos->second != 0);
+                result.emplace(dim.name, pos->second);
+            }
+        }
+    }
+    return result;
+}
+
 void
 Onnx::WirePlanner::prepare_output_types(const Onnx &model)
 {

--- a/eval/src/vespa/eval/onnx/onnx_wrapper.h
+++ b/eval/src/vespa/eval/onnx/onnx_wrapper.h
@@ -94,6 +94,7 @@ public:
         ~WirePlanner();
         static CellType best_cell_type(Onnx::ElementType type);
         bool bind_input_type(const ValueType &vespa_in, const TensorInfo &onnx_in);
+        std::map<vespalib::string,size_t> get_bound_sizes(const TensorInfo &onnx_in) const;
         void prepare_output_types(const Onnx &model);
         ValueType make_output_type(const TensorInfo &onnx_out) const;
         WireInfo get_wire_info(const Onnx &model) const;

--- a/vespalib/src/vespa/vespalib/util/child_process.h
+++ b/vespalib/src/vespa/vespalib/util/child_process.h
@@ -28,6 +28,7 @@ private:
         std::condition_variable _cond;
         std::queue<std::string> _queue;
         std::string             _data;
+        int                     _num_streams;
         bool                    _gotEOF;
         int                     _waitCnt;
         bool                    _readEOF;
@@ -38,7 +39,7 @@ private:
         void updateEOF();
 
     public:
-        Reader();
+        Reader(int num_streams);
         ~Reader() override;
 
         uint32_t read(char *buf, uint32_t len, int msTimeout);
@@ -57,6 +58,7 @@ private:
 public:
     ChildProcess(const ChildProcess &) = delete;
     ChildProcess &operator=(const ChildProcess &) = delete;
+    struct capture_stderr_tag{};
     
     /**
      * @brief Run a child process
@@ -65,6 +67,15 @@ public:
      * @param cmd A shell command line to run
      **/
     explicit ChildProcess(const char *cmd);
+
+    /**
+     * @brief Run a child process
+     *
+     * Starts a process running the given command. stderr is
+     * redirected into stdout.
+     * @param cmd A shell command line to run
+     **/
+    explicit ChildProcess(const char *cmd, capture_stderr_tag);
 
     /** @brief destructor doing cleanup if needed */
     ~ChildProcess();


### PR DESCRIPTION
added support for capturing stderr when you expect stuff to fail in
order to capture all error messages from the child process.

simplify ServerCmd to always be verbose (print stdin/stdout(stderr)
interactions).

improve ServerCmd to enable explicitly checking the child process exit
code.

fixed test dependency on binary for eval expr and analyze model tests.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@lesters please review
