### PR TITLE
If threads are configured explicit to a positive number, obey it.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -313,7 +313,7 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     _protonDiskLayout = std::make_unique<ProtonDiskLayout>(protonConfig.basedir, protonConfig.tlsspec);
     vespalib::chdir(protonConfig.basedir);
     vespalib::alloc::MmapFileAllocatorFactory::instance().setup(protonConfig.basedir + "/swapdirs");
-    _tls->start();
+    _tls->start(hwInfo.cpu().cores());
     _flushEngine = std::make_unique<FlushEngine>(std::make_shared<flushengine::TlsStatsFactory>(_tls->getTransLogServer()),
                                                  strategy, flush.maxconcurrent, vespalib::from_s(flush.idleinterval));
     _metricsEngine->addExternalMetrics(_summaryEngine->getMetrics());

--- a/searchlib/src/vespa/searchlib/config/translogserver.def
+++ b/searchlib/src/vespa/searchlib/config/translogserver.def
@@ -18,7 +18,7 @@ basedir string default="tmp" restart
 usefsync bool default=true
 
 ##Number of threads available for visiting/subscription.
-maxthreads int default=4 restart
+maxthreads int default=0 restart
 
 ##Default crc method used
 crcmethod enum {ccitt_crc32, xxh64} default=xxh64

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.h
@@ -32,7 +32,7 @@ public:
 
     TransLogServer::SP getTransLogServer() const;
 
-    void start();
+    void start(uint32_t num_cores);
 };
 
 }


### PR DESCRIPTION
If not scale it with num_cores/8 capped i the range [1, 4].
Let default configured value be 0 (unset) instead of 4.

@geirst PR