### PR TITLE
Add vespalib utility functions for atomic memory access

### DIFF
--- a/vespalib/src/vespa/vespalib/util/atomic.h
+++ b/vespalib/src/vespa/vespalib/util/atomic.h
@@ -100,7 +100,7 @@ template <typename T>
     static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
 #if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<const T>::is_always_lock_free);
-    return std::atomic_ref<const T>(a).load(std::memory_order_acquire);
+    return std::atomic_ref<const T>(a).load(std::memory_order_seq_cst);
 #else
     // TODO replace with compiler intrinsic
     std::atomic_thread_fence(std::memory_order_seq_cst);

--- a/vespalib/src/vespa/vespalib/util/atomic.h
+++ b/vespalib/src/vespa/vespalib/util/atomic.h
@@ -1,0 +1,155 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <atomic>
+#include <type_traits>
+
+/**
+ * Utility functions for single value atomic memory accesses.
+ *
+ * store/load_ref_* functions can be used to provide well-defined atomic
+ * memory access to memory locations that aren't explicitly wrapped in std::atomic
+ * objects. In this case, all potentially racing loads/stores _must_ be through
+ * atomic utility functions (or atomic_ref).
+ *
+ * Non-ref store/load_* functions are just syntactic sugar to make code using
+ * atomics more readable, but additionally adds sanity checks that all atomics
+ * are always lock-free.
+ */
+
+namespace vespalib::atomic {
+
+//
+// std::atomic_ref<T> helpers
+//
+
+// No atomic_ref on clang on darwin (for now)
+#if defined(__clang__) && defined(__apple_build_version__)
+#  define VESPA_NO_ATOMIC_REF_SUPPORT
+#endif
+
+namespace detail {
+template <typename T> struct is_std_atomic : std::false_type {};
+template <typename T> struct is_std_atomic<std::atomic<T>> : std::true_type {};
+template <typename T> inline constexpr bool is_std_atomic_v = is_std_atomic<T>::value;
+}
+
+// TODO can generalize atomic_ref code once no special casing is needed
+
+template <typename T1, typename T2>
+constexpr void store_ref_relaxed(T1& lhs, T2&& v) noexcept {
+    static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<T1>::is_always_lock_free);
+    std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_relaxed);
+#else
+    // TODO replace with compiler intrinsic
+    lhs = std::forward<T2>(v);
+#endif
+}
+
+template <typename T1, typename T2>
+constexpr void store_ref_release(T1& lhs, T2&& v) noexcept {
+    static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<T1>::is_always_lock_free);
+    std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_release);
+#else
+    // TODO replace with compiler intrinsic
+    lhs = std::forward<T2>(v);
+    std::atomic_thread_fence(std::memory_order_release);
+#endif
+}
+
+template <typename T1, typename T2>
+constexpr void store_ref_seq_cst(T1& lhs, T2&& v) noexcept {
+    static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<T1>::is_always_lock_free);
+    std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_seq_cst);
+#else
+    // TODO replace with compiler intrinsic
+    lhs = std::forward<T2>(v);
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_ref_relaxed(const T& a) noexcept {
+    static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<const T>::is_always_lock_free);
+    return std::atomic_ref<const T>(a).load(std::memory_order_relaxed);
+#else
+    // TODO replace with compiler intrinsic
+    return a;
+#endif
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_ref_acquire(const T& a) noexcept {
+    static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<const T>::is_always_lock_free);
+    return std::atomic_ref<const T>(a).load(std::memory_order_acquire);
+#else
+    // TODO replace with compiler intrinsic
+    std::atomic_thread_fence(std::memory_order_acquire);
+    return a;
+#endif
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_ref_seq_cst(const T& a) noexcept {
+    static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
+#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+    static_assert(std::atomic_ref<const T>::is_always_lock_free);
+    return std::atomic_ref<const T>(a).load(std::memory_order_acquire);
+#else
+    // TODO replace with compiler intrinsic
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+    return a;
+#endif
+}
+
+//
+// std::atomic<T> helpers
+//
+
+template <typename T1, typename T2>
+constexpr void store_relaxed(std::atomic<T1>& lhs, T2&& v) noexcept {
+    static_assert(std::atomic<T1>::is_always_lock_free);
+    lhs.store(std::forward<T2>(v), std::memory_order_relaxed);
+}
+
+template <typename T1, typename T2>
+constexpr void store_release(std::atomic<T1>& lhs, T2&& v) noexcept {
+    static_assert(std::atomic<T1>::is_always_lock_free);
+    lhs.store(std::forward<T2>(v), std::memory_order_release);
+}
+
+template <typename T1, typename T2>
+constexpr void store_seq_cst(std::atomic<T1>& lhs, T2&& v) noexcept {
+    static_assert(std::atomic<T1>::is_always_lock_free);
+    lhs.store(std::forward<T2>(v), std::memory_order_seq_cst);
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_relaxed(const std::atomic<T>& a) noexcept {
+    static_assert(std::atomic<T>::is_always_lock_free);
+    return a.load(std::memory_order_relaxed);
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_acquire(const std::atomic<T>& a) noexcept {
+    static_assert(std::atomic<T>::is_always_lock_free);
+    return a.load(std::memory_order_acquire);
+}
+
+template <typename T>
+[[nodiscard]] constexpr T load_seq_cst(const std::atomic<T>& a) noexcept {
+    static_assert(std::atomic<T>::is_always_lock_free);
+    return a.load(std::memory_order_seq_cst);
+}
+
+} // vespalib::atomic

--- a/vespalib/src/vespa/vespalib/util/atomic.h
+++ b/vespalib/src/vespa/vespalib/util/atomic.h
@@ -3,6 +3,7 @@
 
 #include <atomic>
 #include <type_traits>
+#include <version>
 
 /**
  * Utility functions for single value atomic memory accesses.
@@ -23,11 +24,6 @@ namespace vespalib::atomic {
 // std::atomic_ref<T> helpers
 //
 
-// No atomic_ref on clang on darwin (for now)
-#if defined(__clang__) && defined(__apple_build_version__)
-#  define VESPA_NO_ATOMIC_REF_SUPPORT
-#endif
-
 namespace detail {
 template <typename T> struct is_std_atomic : std::false_type {};
 template <typename T> struct is_std_atomic<std::atomic<T>> : std::true_type {};
@@ -39,7 +35,7 @@ template <typename T> inline constexpr bool is_std_atomic_v = is_std_atomic<T>::
 template <typename T1, typename T2>
 constexpr void store_ref_relaxed(T1& lhs, T2&& v) noexcept {
     static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<T1>::is_always_lock_free);
     std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_relaxed);
 #else
@@ -51,7 +47,7 @@ constexpr void store_ref_relaxed(T1& lhs, T2&& v) noexcept {
 template <typename T1, typename T2>
 constexpr void store_ref_release(T1& lhs, T2&& v) noexcept {
     static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<T1>::is_always_lock_free);
     std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_release);
 #else
@@ -64,7 +60,7 @@ constexpr void store_ref_release(T1& lhs, T2&& v) noexcept {
 template <typename T1, typename T2>
 constexpr void store_ref_seq_cst(T1& lhs, T2&& v) noexcept {
     static_assert(!detail::is_std_atomic_v<T1>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<T1>::is_always_lock_free);
     std::atomic_ref<T1>(lhs).store(std::forward<T2>(v), std::memory_order_seq_cst);
 #else
@@ -77,7 +73,7 @@ constexpr void store_ref_seq_cst(T1& lhs, T2&& v) noexcept {
 template <typename T>
 [[nodiscard]] constexpr T load_ref_relaxed(const T& a) noexcept {
     static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<const T>::is_always_lock_free);
     return std::atomic_ref<const T>(a).load(std::memory_order_relaxed);
 #else
@@ -89,7 +85,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr T load_ref_acquire(const T& a) noexcept {
     static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<const T>::is_always_lock_free);
     return std::atomic_ref<const T>(a).load(std::memory_order_acquire);
 #else
@@ -102,7 +98,7 @@ template <typename T>
 template <typename T>
 [[nodiscard]] constexpr T load_ref_seq_cst(const T& a) noexcept {
     static_assert(!detail::is_std_atomic_v<T>, "atomic ref function invoked with a std::atomic, probably not intended");
-#ifndef VESPA_NO_ATOMIC_REF_SUPPORT
+#if __cpp_lib_atomic_ref
     static_assert(std::atomic_ref<const T>::is_always_lock_free);
     return std::atomic_ref<const T>(a).load(std::memory_order_acquire);
 #else


### PR DESCRIPTION
@havardpe and @toregge please review
@toregge feel free to add Clang on Darwin intrinsics if so desired 🦄 

Adds the following utilities:

* Atomic reference wrapper functions for accessing single memory
  locations as if they were `std::atomic` instances.
* Wrappers for less verbose `std::atomic` loads/stores that also
  sanity-check that accesses are always lock-free.

