### PR TITLE
deprecate modifying types in-place

### DIFF
--- a/document/src/main/java/com/yahoo/document/CollectionDataType.java
+++ b/document/src/main/java/com/yahoo/document/CollectionDataType.java
@@ -41,8 +41,11 @@ public abstract class CollectionDataType extends DataType {
     protected FieldValue createByReflection(Object arg) { return null; }
 
     /**
-     * Sets the nested type of this CollectionDataType.&nbsp;WARNING! Do not use! Only to be used by config system!
+     * WARNING! Do not use! Only to be used by config system!
+     * Sets the nested type of this CollectionDataType.
+     * @deprecated // TODO Vespa 8 remove
      */
+    @Deprecated(forRemoval = true, since = "7")
     public void setNestedType(DataType nestedType) {
         this.nestedType = nestedType;
     }

--- a/document/src/main/java/com/yahoo/document/MapDataType.java
+++ b/document/src/main/java/com/yahoo/document/MapDataType.java
@@ -21,7 +21,6 @@ public class MapDataType extends DataType {
         super("Map<"+keyType.getName()+","+valueType.getName()+">", id);
         this.keyType=keyType;
         this.valueType = valueType;
-
     }
 
     public MapDataType(DataType keyType, DataType valueType) {
@@ -54,19 +53,24 @@ public class MapDataType extends DataType {
     }
 
     /**
-     * Sets the key type of this MapDataType.&nbsp;WARNING! Do not use! Only to be used by config system!
+     * WARNING! Do not use! Only to be used by config system!
+     * Sets the key type of this MapDataType.
+     * @deprecated // TODO Vespa 8 remove
      */
+    @Deprecated(forRemoval = true, since = "7")
     public void setKeyType(DataType keyType) {
         this.keyType = keyType;
     }
 
     /**
-     * Sets the key type of this MapDataType.&nbsp;WARNING! Do not use! Only to be used by config system!
+     * WARNING! Do not use! Only to be used by config system!
+     * Sets the value type of this MapDataType.
+     * @deprecated // TODO Vespa 8 remove
      */
+    @Deprecated(forRemoval = true, since = "7")
     public void setValueType(DataType valueType) {
         this.valueType = valueType;
     }
-
 
     @Override
     public MapFieldValue createFieldValue() {


### PR DESCRIPTION
* instead of modifying a MapDataType or WeightedSetDataType instance
  in-place, make a new instance as necessary.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
