### PR TITLE
Report current docker image & vespa version for coredump

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.node.admin.maintenance;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.yahoo.config.provision.ApplicationId;
-import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
 import com.yahoo.vespa.hosted.node.admin.container.Container;
@@ -183,9 +182,9 @@ public class StorageMaintainer {
         attributes.put("kernel_version", System.getProperty("os.version"));
         attributes.put("cpu_microcode_version", getMicrocodeVersion());
 
-        attributes.put("docker_image", getDockerImage(context, container));
+        container.map(c -> c.image().asString()).ifPresent(image -> attributes.put("docker_image", image));
+        container.flatMap(c -> c.image().tag()).ifPresent(version -> attributes.put("vespa_version", version));
         context.node().parentHostname().ifPresent(parent -> attributes.put("parent_hostname", parent));
-        context.node().currentVespaVersion().ifPresent(version -> attributes.put("vespa_version", version.toFullString()));
         context.node().owner().ifPresent(owner -> {
             attributes.put("tenant", owner.tenant().value());
             attributes.put("application", owner.application().value());
@@ -235,13 +234,5 @@ public class StorageMaintainer {
         }
 
         return results[1].trim();
-    }
-
-    private String getDockerImage(NodeAgentContext context, Optional<Container> container) {
-        return container.map(c -> c.image().asString())
-                .orElse(context.node().currentDockerImage()
-                        .map(DockerImage::asString)
-                        .orElse("<none>")
-                );
     }
 }


### PR DESCRIPTION
Current version in node-repo may be wrong if core is dumped during upgrade. Only report the docker image of the currently running container and use the version from that docker image tag.

Fixes VESPA-23022.