### PR TITLE
use "void" instead of returning unused null

### DIFF
--- a/config-model/src/main/javacc/SDParser.jj
+++ b/config-model/src/main/javacc/SDParser.jj
@@ -433,9 +433,8 @@ Schema rootSchema() :
  * trailing newline tokens.
  *
  * @param schema the schema object to modify.
- * @return Null.
  */
-Object rootSchemaItem(Schema schema) : { }
+void rootSchemaItem(Schema schema) : { }
 {
     ( document(schema)
       | rawAsBase64(schema)
@@ -451,7 +450,6 @@ Object rootSchemaItem(Schema schema) : { }
       | fieldSet(schema)
       | importField(schema)
       | onnxModel(schema) )
-    { return null; }
 }
 
 /**
@@ -472,12 +470,10 @@ Schema rootDocument() :
  * Consumes a single item from within a root document node.
  *
  * @param schema the schema object to modify.
- * @return Null.
  */
-Object rootDocumentItem(Schema schema) : { }
+void rootDocumentItem(Schema schema) : { }
 {
     ( namedDocument(schema) )
-    { return null; }
 }
 
 /**
@@ -533,9 +529,8 @@ void namedDocument(Schema schema) :
  *
  * @param document the document type to modify.
  * @param schema   the schema object to add content to
- * @return Null.
  */
-Object documentBody(SDDocumentType document, Schema schema) :
+void documentBody(SDDocumentType document, Schema schema) :
 {
 }
 {
@@ -545,7 +540,6 @@ Object documentBody(SDDocumentType document, Schema schema) :
       | bodycfg(document)
       | structInside(document, schema)
       | field(document, schema) )
-    { return null; }
 }
 
 void rawAsBase64(Schema schema) :
@@ -972,9 +966,8 @@ void structField(FieldOperationContainer field, Schema schema, SDDocumentType do
  * @param field    the field being built
  * @param schema   the schema object to add content to
  * @param document the owning document, or null if this is a search field
- * @return Null
  */
-String fieldBody(SDField field, Schema schema, SDDocumentType document) : { }
+void fieldBody(SDField field, Schema schema, SDDocumentType document) : { }
 {
     ( alias(field) |
       attribute(field) |
@@ -998,7 +991,6 @@ String fieldBody(SDField field, Schema schema, SDDocumentType document) : { }
       summaryTo(field) |
       weight(field) |
       weightedset(field) )
-    { return null; }
 }
 
 /**
@@ -1008,9 +1000,8 @@ String fieldBody(SDField field, Schema schema, SDDocumentType document) : { }
  * @param field    the field being built
  * @param schema   the schema object to add content to
  * @param document the owning document, or null if this is a schema field
- * @return Null
  */
-String structFieldBody(FieldOperationContainer field, Schema schema, SDDocumentType document) : { }
+void structFieldBody(FieldOperationContainer field, Schema schema, SDDocumentType document) : { }
 {
     ( summaryInField(field) |
       indexing(field) |
@@ -1019,19 +1010,16 @@ String structFieldBody(FieldOperationContainer field, Schema schema, SDDocumentT
       queryCommand(field) |
       structField(field, schema, document) |
       summaryTo(field) )
-    { return null; }
 }
 
 /**
  * This rule consumes an indexing block of a field element.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object indexing(FieldOperationContainer field) : { }
+void indexing(FieldOperationContainer field) : { }
 {
     ( <INDEXING> ( (<COLON> indexingOperation(field, false)) | indexingOperation(field, true) ) )
-    { return null; }
 }
 
 /**
@@ -1090,9 +1078,8 @@ void weight(FieldOperationContainer field) :
  * This rule consumes a weighted set statement of a field element.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object weightedset(FieldOperationContainer field) :
+void weightedset(FieldOperationContainer field) :
 {
     WeightedSetOperation op = new WeightedSetOperation();
 }
@@ -1101,7 +1088,6 @@ Object weightedset(FieldOperationContainer field) :
                     | (lbrace() (weightedsetBody(op) (<NL>)*)* <RBRACE>) )
     {
         field.addOperation(op);
-        return null;
     }
 }
 
@@ -1109,15 +1095,11 @@ Object weightedset(FieldOperationContainer field) :
  * This rule consumes one body item of a weighted set block.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object weightedsetBody(WeightedSetOperation field) : { }
+void weightedsetBody(WeightedSetOperation field) : { }
 {
     ( <CREATEIFNONEXISTENT> { field.setCreateIfNonExistent(true); }
       | <REMOVEIFZERO>      { field.setRemoveIfZero(true); } )
-    {
-        return null;
-    }
 }
 
 /**
@@ -1144,9 +1126,8 @@ void rankType(FieldOperationContainer field) :
  * This rule consumes an attribute statement of a field element.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object attribute(FieldOperationContainer field) :
+void attribute(FieldOperationContainer field) :
 {
     String name = field.getName();
 }
@@ -1159,11 +1140,10 @@ Object attribute(FieldOperationContainer field) :
            | (lbrace() (attributeSetting(field, op, name) (<NL>)*)* <RBRACE>) )
     {
         field.addOperation(op);
-        return null;
     }
 }
 
-Object sorting(FieldOperationContainer field, String name) :
+void sorting(FieldOperationContainer field, String name) :
 {
     SortingOperation op = new SortingOperation(name);
 }
@@ -1173,11 +1153,10 @@ Object sorting(FieldOperationContainer field, String name) :
            | (lbrace() (sortingSetting(op, name) (<NL>)*)* <RBRACE>) )
     {
         field.addOperation(op);
-        return null;
     }
 }
 
-Object sortingSetting(SortingOperation sorting, String attributeName) :
+void sortingSetting(SortingOperation sorting, String attributeName) :
 {
     String locale;
 }
@@ -1199,7 +1178,6 @@ Object sortingSetting(SortingOperation sorting, String attributeName) :
                            )
       | <LOCALE> <COLON> locale = identifierWithDash() { sorting.setLocale(locale); }
     )
-    { return null; }
 }
 
 /**
@@ -1207,9 +1185,8 @@ Object sortingSetting(SortingOperation sorting, String attributeName) :
  *
  * @param field The field to modify.
  * @param attributeName The name of the attribute to change.
- * @return Null.
  */
-Object attributeSetting(FieldOperationContainer field, AttributeOperation attribute, String attributeName) :
+void attributeSetting(FieldOperationContainer field, AttributeOperation attribute, String attributeName) :
 {
     String str;
 }
@@ -1231,16 +1208,14 @@ Object attributeSetting(FieldOperationContainer field, AttributeOperation attrib
       | attributeTensorType(attribute)
       | <DISTANCEMETRIC> <COLON> str = identifierWithDash() { attribute.setDistanceMetric(str); }
     )
-    { return null; }
 }
 
 /**
  * This rule consumes a tensor type statement for an attribute element.
  *
  * @param attribute The attribute to modify.
- * @return Null.
  */
-Object attributeTensorType(AttributeOperation attribute) :
+void attributeTensorType(AttributeOperation attribute) :
 {
     TensorType tensorType;
 }
@@ -1250,16 +1225,14 @@ Object attributeTensorType(AttributeOperation attribute) :
         // TODO: Remove on Vespa 8
         deployLogger.logApplicationPackage(Level.WARNING, "In field '" + attribute.getName() + "': Specifying tensor type on the attribute is deprecated and has no effect.");
     }
-    { return null; }
 }
 
 /**
  * This rule consumes a summary statement defined inside a document-summary block.
  *
  * @param document The document summary to modify.
- * @return Null.
  */
-Object summaryInDocument(DocumentSummary document) :
+void summaryInDocument(DocumentSummary document) :
 {
     String name;
     DataType type;
@@ -1282,7 +1255,6 @@ Object summaryInDocument(DocumentSummary document) :
         }
         op.applyToSummary(summary);
         document.add(summary);
-        return null;
     }
 }
 
@@ -1290,9 +1262,8 @@ Object summaryInDocument(DocumentSummary document) :
  * The rule consumes a summary statement defined inside a field.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object summaryInField(FieldOperationContainer field) :
+void summaryInField(FieldOperationContainer field) :
 {
     SummaryInFieldOperation summary;
 }
@@ -1301,7 +1272,6 @@ Object summaryInField(FieldOperationContainer field) :
                   | summary = summaryInFieldLong(field)) )
     {
         field.addOperation(summary);
-        return null;
     }
 }
 
@@ -1354,30 +1324,26 @@ SummaryInFieldOperation summaryInFieldLong(FieldOperationContainer field) :
  * This rule consumes an item of a summary field block.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object summaryItem(SummaryInFieldLongOperation field) : { }
+void summaryItem(SummaryInFieldLongOperation field) : { }
 {
     ( summaryTransform(field)
       | summaryBolding(field)
       | summarySourceList(field)
       | summaryDestinationList(field)
       | summaryProperties(field) )
-    { return null; }
 }
 
 /**
  * This rule consumes a transform statement for a summary field element.
  *
  * @param field            The field to modify.
- * @return Null.
  */
-Object summaryTransform(SummaryInFieldOperation field) : { }
+void summaryTransform(SummaryInFieldOperation field) : { }
 {
     ( <DYNAMIC>             { field.setTransform(SummaryTransform.DYNAMICTEASER); }
      | <MATCHEDELEMENTSONLY> { field.setTransform(SummaryTransform.MATCHED_ELEMENTS_FILTER); }
      | (<FULL> | <STATIC>) { field.setTransform(SummaryTransform.NONE); } )
-    { return null; }
 }
 
 /**
@@ -1603,15 +1569,13 @@ FieldOperationContainer match(FieldOperationContainer field) : { }
  * This rule consumes a single match item for a match block.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object matchItem(FieldOperationContainer field) : { }
+void matchItem(FieldOperationContainer field) : { }
 {
     ( matchType(field) | exactTerminator(field) | gramSize(field) | matchSize(field) )
-    { return null; }
 }
 
-Object matchType(FieldOperationContainer container) :
+void matchType(FieldOperationContainer container) :
 {
     MatchOperation matchOp = new MatchOperation();
 }
@@ -1628,7 +1592,6 @@ Object matchType(FieldOperationContainer container) :
       | <SUFFIX>    { matchOp.setMatchingAlgorithm(Matching.Algorithm.SUFFIX); } )
     {
         container.addOperation(matchOp);
-        return null;
     }
 }
 
@@ -1674,9 +1637,8 @@ void matchSize(FieldOperationContainer container) :
  * Consumes a rank statement of a field element.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object rank(FieldOperationContainer field) :
+void rank(FieldOperationContainer field) :
 {
     RankOperation op = new RankOperation();
 }
@@ -1685,7 +1647,6 @@ Object rank(FieldOperationContainer field) :
              | (lbrace() (rankSetting(op) (<NL>)*)* <RBRACE>) )
     {
         field.addOperation(op);
-        return null;
     }
 }
 
@@ -1693,14 +1654,12 @@ Object rank(FieldOperationContainer field) :
  * Consumes a single rank setting of a rank statement.
  *
  * @param field The field to modify.
- * @return Null.
  */
-Object rankSetting(RankOperation field) : { }
+void rankSetting(RankOperation field) : { }
 {
     ( <LITERAL>   { field.setLiteral(true); }
       | <NORMAL>  { field.setNormal(true); }
       | <FILTER>  { field.setFilter(true); } )
-    { return null; }
 }
 
 /**
@@ -1738,9 +1697,8 @@ void indexingRewrite(FieldOperationContainer field) : { }
  * Consumes a document-summary block from within a schema block.
  *
  * @param schema the schema object to add content to
- * @return Null
  */
-Object documentSummary(Schema schema) :
+void documentSummary(Schema schema) :
 {
     String name;
     DocumentSummary summary;
@@ -1758,7 +1716,6 @@ Object documentSummary(Schema schema) :
          )*
       <RBRACE>
       )
-    { return null; }
 }
 
 /**
@@ -1782,12 +1739,10 @@ void inheritsDocumentSummary(DocumentSummary documentSummary, Schema schema) :
  * Consumes a single document-summary item.
  *
  * @param summary The document summary to modify.
- * @return Null.
  */
-Object documentSummaryItem(DocumentSummary summary) : { }
+void documentSummaryItem(DocumentSummary summary) : { }
 {
     summaryInDocument(summary)
-    { return null; }
 }
 
 /**
@@ -1795,9 +1750,8 @@ Object documentSummaryItem(DocumentSummary summary) : { }
  *
  * @param schema the schema object to add content to
  * @param field  the field to modify
- * @return Null
  */
-Object index(Schema schema, FieldOperationContainer field) :
+void index(Schema schema, FieldOperationContainer field) :
 {
     IndexOperation op = new IndexOperation();
     String indexName = (field != null) ? field.getName() : null;
@@ -1821,7 +1775,6 @@ Object index(Schema schema, FieldOperationContainer field) :
         } else {
             field.addOperation(op);
         }
-        return null;
     }
 }
 
@@ -1829,9 +1782,8 @@ Object index(Schema schema, FieldOperationContainer field) :
  * Consumes a single index statement for an index block.
  *
  * @param index The index to modify.
- * @return Null.
  */
-Object indexBody(IndexOperation index) :
+void indexBody(IndexOperation index) :
 {
     String str;
     int arity;
@@ -1849,7 +1801,6 @@ Object indexBody(IndexOperation index) :
       | <ENABLE_BM25>                                                  { index.setEnableBm25(true); }
       | hnswIndex(index)                                               { }
     )
-    { return null; }
 }
 
 void hnswIndex(IndexOperation index) :
@@ -1902,9 +1853,8 @@ void onnxModel(Schema schema) :
  * This rule consumes an onnx-model block.
  *
  * @param onnxModel The onnxModel to modify.
- * @return Null.
  */
-Object onnxModelItem(OnnxModel onnxModel) :
+void onnxModelItem(OnnxModel onnxModel) :
 {
     String path = null;
 }
@@ -1925,9 +1875,6 @@ Object onnxModelItem(OnnxModel onnxModel) :
             onnxModel.addOutputNameMapping(name, as);
         }
     )
-    {
-        return null;
-    }
 }
 
 /**
@@ -2010,9 +1957,8 @@ void rankProfile(Schema schema) :
  * This rule consumes a single statement for a rank-profile block.
  *
  * @param profile The rank profile to modify.
- * @return Null.
  */
-Object rankProfileItem(RankProfile profile) : { }
+void rankProfileItem(RankProfile profile) : { }
 {
     ( fieldRankType(profile)
       | fieldWeight(profile)
@@ -2033,7 +1979,6 @@ Object rankProfileItem(RankProfile profile) : { }
       | constants(profile)
       | matchFeatures(profile)
       | summaryFeatures(profile) )
-    { return null; }
 }
 
 /**
@@ -2203,7 +2148,7 @@ void firstPhase(RankProfile profile) :
     <FIRSTPHASE> lbrace() (firstPhaseItem(profile) (<NL>)*)* <RBRACE>
 }
 
-Object firstPhaseItem(RankProfile profile) :
+void firstPhaseItem(RankProfile profile) :
 {
   String expression;
   int rerankCount;
@@ -2214,7 +2159,6 @@ Object firstPhaseItem(RankProfile profile) :
       | (<KEEPRANKCOUNT> <COLON> rerankCount = integer()) { profile.setKeepRankCount(rerankCount); }
       | (<RANKSCOREDROPLIMIT> <COLON> dropLimit = consumeFloat()) { profile.setRankScoreDropLimit(dropLimit); }
     )
-    { return null; }
 }
 
 /**
@@ -2231,9 +2175,8 @@ void secondPhase(RankProfile profile) : { }
  * Consumes a statement for a second-phase block.
  *
  * @param profile The rank profile to modify.
- * @return Null.
  */
-Object secondPhaseItem(RankProfile profile) :
+void secondPhaseItem(RankProfile profile) :
 {
     String expression;
     int rerankCount;
@@ -2242,16 +2185,14 @@ Object secondPhaseItem(RankProfile profile) :
     ( expression = expression()                 { profile.setSecondPhaseRanking(expression); }
       | (<RERANKCOUNT> <COLON> rerankCount = integer()) { profile.setRerankCount(rerankCount); }
     )
-    { return null; }
 }
 
 /**
  * This rule consumes a summary-features block of a rank profile.
  *
  * @param profile The rank profile to modify.
- * @return Null.
  */
-Object summaryFeatures(RankProfile profile) :
+void summaryFeatures(RankProfile profile) :
 {
     String features;
     String inherited = null;
@@ -2269,7 +2210,6 @@ Object summaryFeatures(RankProfile profile) :
     )
     {
         profile.addSummaryFeatures(getFeatureList(features));
-        return null;
     }
 }
 
@@ -2277,9 +2217,8 @@ Object summaryFeatures(RankProfile profile) :
  * This rule consumes a match-features block of a rank profile.
  *
  * @param profile The rank profile to modify.
- * @return Null.
  */
-Object matchFeatures(RankProfile profile) :
+void matchFeatures(RankProfile profile) :
 {
     String features;
 }
@@ -2296,12 +2235,11 @@ Object matchFeatures(RankProfile profile) :
     )
     {
         profile.addMatchFeatures(getFeatureList(features));
-        return null;
     }
 }
 
 /** Consumes a rank-features block of a rank profile */
-Object rankFeatures(RankProfile profile) :
+void rankFeatures(RankProfile profile) :
 {
     String features;
 }
@@ -2311,7 +2249,6 @@ Object rankFeatures(RankProfile profile) :
                                                            token.image.lastIndexOf("}")).trim(); } )
     {
         profile.addRankFeatures(getFeatureList(features));
-        return null;
     }
 }
 
@@ -2505,14 +2442,13 @@ void rankDegradationPosbinSize() :
 /**
  * This rule consumes part of a rank-degradation statement of a rank profile.
  */
-Object rankDegradationItem() :
+void rankDegradationItem() :
 {
 }
 {
     ( rankDegradationBinSize()
       | rankDegradationBinLow()
       | rankDegradationPosbinSize() )
-    { return null; }
 }
 
 /**
@@ -2520,7 +2456,7 @@ Object rankDegradationItem() :
  *
  * @param profile The rank profile to modify.
  */
-Object rankDegradation(RankProfile profile) :
+void rankDegradation(RankProfile profile) :
 {
     double freq;
 }
@@ -2529,9 +2465,6 @@ Object rankDegradation(RankProfile profile) :
     { deployLogger.logApplicationPackage(Level.WARNING, "Specifying 'rank-degradation-frequency' in 'rank-profile' is deprecated and has no effect."); }
       | <RANKDEGRADATION> lbrace() ( rankDegradationItem() (<NL>)*)+ <RBRACE>
     )
-    {
-        return null;
-    }
 }
 
 /**


### PR DESCRIPTION
* lots of old parsing methods declared to return Object
  always returned (unused) null; make them void instead

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
