### PR TITLE
Use a common FNET_Transport owned by Proton in both SceduledExecutor …

### DIFF
--- a/config/src/vespa/config/file_acquirer/file_acquirer.cpp
+++ b/config/src/vespa/config/file_acquirer/file_acquirer.cpp
@@ -13,14 +13,10 @@ LOG_SETUP(".config.file_acquirer");
 
 namespace config {
 
-RpcFileAcquirer::RpcFileAcquirer(const vespalib::string &spec)
-    : _threadPool(std::make_unique<FastOS_ThreadPool>(60_Ki)),
-      _transport(std::make_unique<FNET_Transport>()),
-      _orb(std::make_unique<FRT_Supervisor>(_transport.get())),
+RpcFileAcquirer::RpcFileAcquirer(FNET_Transport & transport, const vespalib::string &spec)
+    : _orb(std::make_unique<FRT_Supervisor>(&transport)),
       _spec(spec)
-{
-    _transport->Start(_threadPool.get());
-}
+{ }
 
 vespalib::string
 RpcFileAcquirer::wait_for(const vespalib::string &file_ref, double timeout_s)
@@ -42,9 +38,6 @@ RpcFileAcquirer::wait_for(const vespalib::string &file_ref, double timeout_s)
     return path;
 }
 
-RpcFileAcquirer::~RpcFileAcquirer()
-{
-    _transport->ShutDown(true);
-}
+RpcFileAcquirer::~RpcFileAcquirer() = default;
 
 } // namespace config

--- a/config/src/vespa/config/file_acquirer/file_acquirer.h
+++ b/config/src/vespa/config/file_acquirer/file_acquirer.h
@@ -6,7 +6,6 @@
 
 class FRT_Supervisor;
 class FNET_Transport;
-class FastOS_ThreadPool;
 
 namespace config {
 
@@ -26,12 +25,10 @@ struct FileAcquirer {
 class RpcFileAcquirer : public FileAcquirer
 {
 private:
-    std::unique_ptr<FastOS_ThreadPool> _threadPool;
-    std::unique_ptr<FNET_Transport> _transport;
-    std::unique_ptr<FRT_Supervisor> _orb;
-    vespalib::string _spec;
+    std::unique_ptr<FRT_Supervisor>   _orb;
+    vespalib::string                  _spec;
 public:
-    RpcFileAcquirer(const vespalib::string &spec);
+    RpcFileAcquirer(FNET_Transport & transport, const vespalib::string &spec);
     vespalib::string wait_for(const vespalib::string &file_ref, double timeout_s) override;
     ~RpcFileAcquirer() override;
 };

--- a/fnet/src/vespa/fnet/transport.cpp
+++ b/fnet/src/vespa/fnet/transport.cpp
@@ -6,8 +6,11 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/rendezvous.h>
-#include <chrono>
+#include <vespa/vespalib/util/backtrace.h>
 #include <xxhash.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".fnet.transport");
 
 namespace {
 
@@ -130,6 +133,8 @@ FNET_Transport::FNET_Transport(const TransportConfig &cfg)
       _threads(),
       _config(cfg.config())
 {
+    // TODO Temporary logging to track down overspend
+    LOG(debug, "FNET_Transport threads=%d from :%s", cfg.num_threads(), vespalib::getStackTrace(0).c_str());
     assert(cfg.num_threads() >= 1);
     for (size_t i = 0; i < cfg.num_threads(); ++i) {
         _threads.emplace_back(std::make_unique<FNET_TransportThread>(*this));

--- a/searchcore/src/apps/tests/CMakeLists.txt
+++ b/searchcore/src/apps/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_persistenceconformance_test_app TEST
     SOURCES
     persistenceconformance_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_initializer
     searchcore_reprocessing

--- a/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
+++ b/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
@@ -387,6 +387,7 @@ public:
           _server(_transport, _bopts.tlsName, _bopts.listenPort, _bopts.tlsDir, _fileHeader),
           _client(vespalib::make_string("tcp/localhost:%d", _bopts.listenPort))
     {
+        _transport.Start(&_threadPool);
     }
     ~BaseUtility() override {
         _transport.ShutDown(true);

--- a/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
+++ b/searchcore/src/apps/vespa-transactionlog-inspect/vespa-transactionlog-inspect.cpp
@@ -8,12 +8,14 @@
 #include <vespa/vespalib/util/programoptions.h>
 #include <vespa/vespalib/util/xmlstream.h>
 #include <vespa/vespalib/util/time.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/document/config/config-documenttypes.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/document/update/documentupdate.h>
 #include <vespa/config/helper/configgetter.hpp>
+#include <vespa/fnet/transport.h>
 #include <vespa/fastos/app.h>
 #include <iostream>
 #include <thread>
@@ -324,7 +326,7 @@ public:
  */
 struct Utility
 {
-    virtual ~Utility() {}
+    virtual ~Utility() = default;
     typedef std::unique_ptr<Utility> UP;
     virtual int run() = 0;
 };
@@ -371,6 +373,8 @@ class BaseUtility : public Utility
 protected:
     const BaseOptions     &_bopts;
     DummyFileHeaderContext _fileHeader;
+    FastOS_ThreadPool      _threadPool;
+    FNET_Transport         _transport;
     TransLogServer         _server;
     client::TransLogClient _client;
 
@@ -378,9 +382,14 @@ public:
     BaseUtility(const BaseOptions &bopts)
         : _bopts(bopts),
           _fileHeader(),
-          _server(_bopts.tlsName, _bopts.listenPort, _bopts.tlsDir, _fileHeader),
+          _threadPool(64_Ki),
+          _transport(),
+          _server(_transport, _bopts.tlsName, _bopts.listenPort, _bopts.tlsDir, _fileHeader),
           _client(vespalib::make_string("tcp/localhost:%d", _bopts.listenPort))
     {
+    }
+    ~BaseUtility() override {
+        _transport.ShutDown(true);
     }
     virtual int run() override = 0;
 };

--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -176,10 +176,10 @@ class DBContext : public DummyDBOwner
 {
 public:
     DirMaker _dmk;
-    DummyFileHeaderContext _fileHeaderContext;
-    TransLogServer _tls;
+    DummyFileHeaderContext        _fileHeaderContext;
     vespalib::ThreadStackExecutor _summaryExecutor;
-    MockSharedThreadingService _shared_service;
+    MockSharedThreadingService    _shared_service;
+    TransLogServer                _tls;
     storage::spi::dummy::DummyBucketExecutor _bucketExecutor;
     bool _mkdirOk;
     matching::QueryLimiter _queryLimiter;
@@ -198,9 +198,9 @@ public:
     DBContext(const std::shared_ptr<const DocumentTypeRepo> &repo, const char *docTypeName)
         : _dmk(docTypeName),
           _fileHeaderContext(),
-          _tls("tmp", 9013, ".", _fileHeaderContext),
           _summaryExecutor(8, 128_Ki),
           _shared_service(_summaryExecutor, _summaryExecutor),
+          _tls(_shared_service.transport(), "tmp", 9013, ".", _fileHeaderContext),
           _bucketExecutor(2),
           _mkdirOk(FastOS_File::MakeDirectory("tmpdb")),
           _queryLimiter(),
@@ -223,7 +223,7 @@ public:
                                                    std::make_shared<BucketspacesConfig>(),
                                                    _tuneFileDocumentDB, _hwInfo);
         _configMgr.forwardConfig(b);
-        _configMgr.nextGeneration(0ms);
+        _configMgr.nextGeneration(_shared_service.transport(), 0ms);
         if (! FastOS_File::MakeDirectory((std::string("tmpdb/") + docTypeName).c_str())) {
             LOG_ABORT("should not be reached");
         }

--- a/searchcore/src/tests/proton/documentdb/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentdb/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_documentdb_test_app TEST
     SOURCES
     documentdb_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_initializer
     searchcore_reprocessing

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_document_subdbs_test_app TEST
     SOURCES
     document_subdbs_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_initializer
     searchcore_reprocessing

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -25,6 +25,7 @@
 #include <vespa/searchcore/proton/server/reconfig_params.h>
 #include <vespa/searchcore/proton/matching/querylimiter.h>
 #include <vespa/searchcore/proton/test/test.h>
+#include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchcore/proton/test/thread_utils.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
 #include <vespa/searchlib/index/docbuilder.h>
@@ -36,8 +37,6 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/config/subscription/sourcespec.h>
-#include <vespa/fastos/thread.h>
-#include <vespa/fnet/transport.h>
 
 using namespace cloud::config::filedistribution;
 using namespace document;
@@ -289,8 +288,7 @@ struct MyConfigSnapshot
 template <typename Traits>
 struct FixtureBase
 {
-    FastOS_ThreadPool        _threadPool;
-    FNET_Transport           _transport;
+    TransportMgr             _transport;
     ThreadStackExecutor      _summaryExecutor;
     ExecutorThreadingService _writeService;
     typename Traits::Config  _cfg;
@@ -303,8 +301,7 @@ struct FixtureBase
     typename Traits::SubDB   _subDb;
     IFeedView::SP            _tmpFeedView;
     FixtureBase()
-        : _threadPool(64_Ki),
-          _transport(),
+        : _transport(),
           _summaryExecutor(1, 64_Ki),
           _writeService(_summaryExecutor),
           _cfg(),
@@ -312,18 +309,16 @@ struct FixtureBase
           _bucketDBHandler(*_bucketDB),
           _ctx(_writeService, _bucketDB, _bucketDBHandler),
           _baseSchema(),
-          _snapshot(std::make_unique<MyConfigSnapshot>(_transport, _baseSchema, Traits::ConfigDir::dir())),
+          _snapshot(std::make_unique<MyConfigSnapshot>(_transport.transport(), _baseSchema, Traits::ConfigDir::dir())),
           _baseDir(BASE_DIR + "/" + SUB_NAME, BASE_DIR),
           _subDb(_cfg._cfg, _ctx._ctx),
           _tmpFeedView()
     {
-        _transport.Start(&_threadPool);
         init();
     }
     ~FixtureBase() {
         _writeService.master().execute(makeLambdaTask([this]() { _subDb.close(); }));
         _writeService.shutdown();
-        _transport.ShutDown(true);
     }
     void setBucketStateCalculator(const std::shared_ptr<IBucketStateCalculator> & calc) {
         vespalib::Gate gate;
@@ -354,7 +349,7 @@ struct FixtureBase
         runInMasterAndSync([&]() { performReconfig(serialNum, reconfigSchema, reconfigConfigDir); });
     }
     void performReconfig(SerialNum serialNum, const Schema &reconfigSchema, const vespalib::string &reconfigConfigDir) {
-        auto newCfg = std::make_unique<MyConfigSnapshot>(_transport, reconfigSchema, reconfigConfigDir);
+        auto newCfg = std::make_unique<MyConfigSnapshot>(_transport.transport(), reconfigSchema, reconfigConfigDir);
         DocumentDBConfig::ComparisonResult cmpResult;
         cmpResult.attributesChanged = true;
         cmpResult.documenttypesChanged = true;

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -36,6 +36,8 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/config/subscription/sourcespec.h>
+#include <vespa/fastos/thread.h>
+#include <vespa/fnet/transport.h>
 
 using namespace cloud::config::filedistribution;
 using namespace document;
@@ -261,7 +263,7 @@ struct MyConfigSnapshot
     DocBuilder _builder;
     DocumentDBConfig::SP _cfg;
     BootstrapConfig::SP  _bootstrap;
-    MyConfigSnapshot(const Schema &schema, const vespalib::string &cfgDir)
+    MyConfigSnapshot(FNET_Transport & transport, const Schema &schema, const vespalib::string &cfgDir)
         : _schema(schema),
           _builder(_schema),
           _cfg(),
@@ -279,7 +281,7 @@ struct MyConfigSnapshot
         ::config::DirSpec spec(cfgDir);
         DocumentDBConfigHelper mgr(spec, "searchdocument");
         mgr.forwardConfig(_bootstrap);
-        mgr.nextGeneration(1ms);
+        mgr.nextGeneration(transport, 1ms);
         _cfg = mgr.getConfig();
     }
 };
@@ -287,35 +289,41 @@ struct MyConfigSnapshot
 template <typename Traits>
 struct FixtureBase
 {
-    ThreadStackExecutor _summaryExecutor;
+    FastOS_ThreadPool        _threadPool;
+    FNET_Transport           _transport;
+    ThreadStackExecutor      _summaryExecutor;
     ExecutorThreadingService _writeService;
-    typename Traits::Config _cfg;
+    typename Traits::Config  _cfg;
     std::shared_ptr<bucketdb::BucketDBOwner> _bucketDB;
-    BucketDBHandler _bucketDBHandler;
+    BucketDBHandler          _bucketDBHandler;
     typename Traits::Context _ctx;
-    typename Traits::Schema _baseSchema;
-    MyConfigSnapshot::UP _snapshot;
-    DirectoryHandler _baseDir;
-    typename Traits::SubDB _subDb;
-    IFeedView::SP _tmpFeedView;
+    typename Traits::Schema  _baseSchema;
+    MyConfigSnapshot::UP     _snapshot;
+    DirectoryHandler         _baseDir;
+    typename Traits::SubDB   _subDb;
+    IFeedView::SP            _tmpFeedView;
     FixtureBase()
-        : _summaryExecutor(1, 64_Ki),
+        : _threadPool(64_Ki),
+          _transport(),
+          _summaryExecutor(1, 64_Ki),
           _writeService(_summaryExecutor),
           _cfg(),
           _bucketDB(std::make_shared<bucketdb::BucketDBOwner>()),
           _bucketDBHandler(*_bucketDB),
           _ctx(_writeService, _bucketDB, _bucketDBHandler),
           _baseSchema(),
-          _snapshot(std::make_unique<MyConfigSnapshot>(_baseSchema, Traits::ConfigDir::dir())),
+          _snapshot(std::make_unique<MyConfigSnapshot>(_transport, _baseSchema, Traits::ConfigDir::dir())),
           _baseDir(BASE_DIR + "/" + SUB_NAME, BASE_DIR),
           _subDb(_cfg._cfg, _ctx._ctx),
           _tmpFeedView()
     {
+        _transport.Start(&_threadPool);
         init();
     }
     ~FixtureBase() {
         _writeService.master().execute(makeLambdaTask([this]() { _subDb.close(); }));
         _writeService.shutdown();
+        _transport.ShutDown(true);
     }
     void setBucketStateCalculator(const std::shared_ptr<IBucketStateCalculator> & calc) {
         vespalib::Gate gate;
@@ -346,7 +354,7 @@ struct FixtureBase
         runInMasterAndSync([&]() { performReconfig(serialNum, reconfigSchema, reconfigConfigDir); });
     }
     void performReconfig(SerialNum serialNum, const Schema &reconfigSchema, const vespalib::string &reconfigConfigDir) {
-        auto newCfg = std::make_unique<MyConfigSnapshot>(reconfigSchema, reconfigConfigDir);
+        auto newCfg = std::make_unique<MyConfigSnapshot>(_transport, reconfigSchema, reconfigConfigDir);
         DocumentDBConfig::ComparisonResult cmpResult;
         cmpResult.attributesChanged = true;
         cmpResult.documenttypesChanged = true;

--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -149,7 +149,7 @@ Fixture::Fixture(bool file_config)
       _bucketExecutor(2),
       _db(),
       _fileHeaderContext(),
-      _tls("tmp", 9014, ".", _fileHeaderContext),
+      _tls(_shared_service.transport(), "tmp", 9014, ".", _fileHeaderContext),
       _queryLimiter(),
       _clock()
 {
@@ -165,7 +165,7 @@ Fixture::Fixture(bool file_config)
                               std::make_shared<BucketspacesConfig>(),
                               tuneFileDocumentDB, HwInfo());
     mgr.forwardConfig(b);
-    mgr.nextGeneration(0ms);
+    mgr.nextGeneration(_shared_service.transport(), 0ms);
     _db = DocumentDB::create(".", mgr.getConfig(), "tcp/localhost:9014", _queryLimiter, _clock, DocTypeName("typea"),
                              makeBucketSpace(),
                              *b->getProtonConfigSP(), _myDBOwner, _shared_service, _bucketExecutor, _tls, _dummy,
@@ -183,7 +183,7 @@ std::unique_ptr<ConfigStore>
 Fixture::make_config_store()
 {
     if (_file_config) {
-        return std::make_unique<FileConfigManager>("config", "", "typea");
+        return std::make_unique<FileConfigManager>(_shared_service.transport(), "config", "", "typea");
     } else {
         return std::make_unique<MemoryConfigStore>();
     }

--- a/searchcore/src/tests/proton/proton_config_fetcher/CMakeLists.txt
+++ b/searchcore/src/tests/proton/proton_config_fetcher/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_proton_config_fetcher_test_app TEST
     SOURCES
     proton_config_fetcher_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_fconfig
 )

--- a/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
+++ b/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
@@ -9,6 +9,7 @@
 #include <vespa/searchcore/proton/common/alloc_config.h>
 #include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/subdbtype.h>
+#include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchcore/config/config-ranking-constants.h>
 #include <vespa/searchcore/config/config-ranking-expressions.h>
 #include <vespa/searchcore/config/config-onnx-models.h>
@@ -19,7 +20,6 @@
 #include <vespa/vespalib/util/varholder.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/testkit/testapp.h>
-#include <vespa/fnet/transport.h>
 #include <vespa/config/common/configcontext.h>
 #include <vespa/config-bucketspaces.h>
 #include <vespa/config-attributes.h>
@@ -65,8 +65,7 @@ struct DoctypeFixture {
 
 struct ConfigTestFixture {
     const std::string configId;
-    FastOS_ThreadPool threadPool;
-    FNET_Transport transport;
+    TransportMgr transport;
     ProtonConfigBuilder protonBuilder;
     DocumenttypesConfigBuilder documenttypesBuilder;
     FiledistributorrpcConfigBuilder filedistBuilder;
@@ -78,7 +77,6 @@ struct ConfigTestFixture {
 
     ConfigTestFixture(const std::string & id)
         : configId(id),
-          threadPool(64_Ki),
           protonBuilder(),
           documenttypesBuilder(),
           filedistBuilder(),
@@ -88,7 +86,6 @@ struct ConfigTestFixture {
           context(std::make_shared<ConfigContext>(set)),
           idcounter(-1)
     {
-        transport.Start(& threadPool);
         set.addBuilder(configId, &protonBuilder);
         set.addBuilder(configId, &documenttypesBuilder);
         set.addBuilder(configId, &filedistBuilder);
@@ -96,9 +93,7 @@ struct ConfigTestFixture {
         addDocType("_alwaysthere_");
     }
 
-    ~ConfigTestFixture() {
-        transport.ShutDown(true);
-    }
+    ~ConfigTestFixture() = default;
 
     DoctypeFixture *addDocType(const std::string &name, bool isGlobal = false) {
         DocumenttypesConfigBuilder::Documenttype dt;
@@ -259,7 +254,7 @@ getDocumentDBConfig(ConfigTestFixture &f, DocumentDBConfigManager &mgr, const Hw
 {
     ConfigRetriever retriever(mgr.createConfigKeySet(), f.context);
     mgr.forwardConfig(f.getBootstrapConfig(1, hwInfo));
-    mgr.update(f.transport, retriever.getBootstrapConfigs()); // Cheating, but we only need the configs
+    mgr.update(f.transport.transport(), retriever.getBootstrapConfigs()); // Cheating, but we only need the configs
     return mgr.getConfig();
 }
 
@@ -310,8 +305,8 @@ TEST_FF("require that documentdb config manager builds schema with imported attr
 TEST_FFF("require that proton config fetcher follows changes to bootstrap",
          ConfigTestFixture("search"),
          ProtonConfigOwner(),
-         ProtonConfigFetcher(f1.transport, ConfigUri(f1.configId, f1.context), f2, 60s)) {
-    f3.start(f1.threadPool);
+         ProtonConfigFetcher(f1.transport.transport(), ConfigUri(f1.configId, f1.context), f2, 60s)) {
+    f3.start(f1.transport.threadPool());
     ASSERT_TRUE(f2._configured);
     ASSERT_TRUE(f1.configEqual(f2.getBootstrapConfig()));
     f2._configured = false;
@@ -325,8 +320,8 @@ TEST_FFF("require that proton config fetcher follows changes to bootstrap",
 TEST_FFF("require that proton config fetcher follows changes to doctypes",
          ConfigTestFixture("search"),
          ProtonConfigOwner(),
-         ProtonConfigFetcher(f1.transport, ConfigUri(f1.configId, f1.context), f2, 60s)) {
-    f3.start(f1.threadPool);
+         ProtonConfigFetcher(f1.transport.transport(), ConfigUri(f1.configId, f1.context), f2, 60s)) {
+    f3.start(f1.transport.threadPool());
 
     f2._configured = false;
     f1.addDocType("typea");
@@ -345,8 +340,8 @@ TEST_FFF("require that proton config fetcher follows changes to doctypes",
 TEST_FFF("require that proton config fetcher reconfigures dbowners",
          ConfigTestFixture("search"),
          ProtonConfigOwner(),
-         ProtonConfigFetcher(f1.transport, ConfigUri(f1.configId, f1.context), f2, 60s)) {
-    f3.start(f1.threadPool);
+         ProtonConfigFetcher(f1.transport.transport(), ConfigUri(f1.configId, f1.context), f2, 60s)) {
+    f3.start(f1.transport.threadPool());
     ASSERT_FALSE(f2.getDocumentDBConfig("typea"));
 
     // Add db and verify that config for db is provided

--- a/searchcore/src/tests/proton/proton_disk_layout/CMakeLists.txt
+++ b/searchcore/src/tests/proton/proton_disk_layout/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_proton_disk_layout_test_app TEST
     SOURCES
     proton_disk_layout_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_fconfig
 )

--- a/searchcore/src/tests/proton/proton_disk_layout/proton_disk_layout_test.cpp
+++ b/searchcore/src/tests/proton/proton_disk_layout/proton_disk_layout_test.cpp
@@ -2,6 +2,7 @@
 
 #include <vespa/searchcore/proton/server/proton_disk_layout.h>
 #include <vespa/searchcore/proton/common/doctypename.h>
+#include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/searchlib/transactionlog/translogclient.h>
@@ -9,14 +10,13 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/vespalib/util/size_literals.h>
-#include <vespa/fnet/transport.h>
 
 using search::index::DummyFileHeaderContext;
 using search::transactionlog::client::TransLogClient;
 using search::transactionlog::TransLogServer;
 using proton::DocTypeName;
 using proton::ProtonDiskLayout;
+using proton::TransportMgr;
 
 static constexpr unsigned int tlsPort = 9018;
 
@@ -31,8 +31,7 @@ struct FixtureBase
 
 struct DiskLayoutFixture {
     DummyFileHeaderContext  _fileHeaderContext;
-    FastOS_ThreadPool       _threadPool;
-    FNET_Transport          _transport;
+    TransportMgr            _transport;
     TransLogServer          _tls;
     vespalib::string        _tlsSpec;
     ProtonDiskLayout        _diskLayout;
@@ -95,18 +94,14 @@ struct DiskLayoutFixture {
 
 DiskLayoutFixture::DiskLayoutFixture()
     : _fileHeaderContext(),
-      _threadPool(64_Ki),
       _transport(),
-      _tls(_transport, "tls", tlsPort, baseDir, _fileHeaderContext),
+      _tls(_transport.transport(), "tls", tlsPort, baseDir, _fileHeaderContext),
       _tlsSpec(vespalib::make_string("tcp/localhost:%u", tlsPort)),
       _diskLayout(baseDir, _tlsSpec)
 {
-    _transport.Start(&_threadPool);
 }
 
-DiskLayoutFixture::~DiskLayoutFixture() {
-    _transport.ShutDown(true);
-}
+DiskLayoutFixture::~DiskLayoutFixture() = default;
 
 struct Fixture : public FixtureBase, public DiskLayoutFixture
 {

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_disk_mem_usage_sampler_test_app TEST
     SOURCES
     disk_mem_usage_sampler_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     GTest::GTest
 )

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -3,8 +3,10 @@
 #include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/i_transient_resource_usage_provider.h>
 #include <vespa/searchcore/proton/server/disk_mem_usage_sampler.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/fnet/transport.h>
+#include <vespa/fastos/thread.h>
 #include <vespa/vespalib/gtest/gtest.h>
-#include <chrono>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -38,16 +40,23 @@ public:
 };
 
 struct DiskMemUsageSamplerTest : public ::testing::Test {
-    DiskMemUsageSampler sampler;
-    DiskMemUsageSamplerTest():
-        sampler(".",
-                DiskMemUsageSampler::Config(0.8, 0.8,
-                                            50ms, make_hw_info()))
+    FastOS_ThreadPool threadPool;
+    FNET_Transport transport;
+    std::unique_ptr<DiskMemUsageSampler> sampler;
+    DiskMemUsageSamplerTest()
+        : threadPool(64_Ki),
+          transport(),
+          sampler(std::make_unique<DiskMemUsageSampler>(transport, ".", DiskMemUsageSampler::Config(0.8, 0.8, 50ms, make_hw_info())))
     {
-        sampler.add_transient_usage_provider(std::make_shared<MyProvider>(50, 200));
-        sampler.add_transient_usage_provider(std::make_shared<MyProvider>(100, 150));
+        transport.Start(&threadPool);
+        sampler->add_transient_usage_provider(std::make_shared<MyProvider>(50, 200));
+        sampler->add_transient_usage_provider(std::make_shared<MyProvider>(100, 150));
     }
-    const DiskMemUsageFilter& filter() const { return sampler.writeFilter(); }
+    ~DiskMemUsageSamplerTest() {
+        sampler.reset();
+        transport.ShutDown(true);
+    }
+    const DiskMemUsageFilter& filter() const { return sampler->writeFilter(); }
 };
 
 TEST_F(DiskMemUsageSamplerTest, resource_usage_is_sampled)

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -3,9 +3,7 @@
 #include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/i_transient_resource_usage_provider.h>
 #include <vespa/searchcore/proton/server/disk_mem_usage_sampler.h>
-#include <vespa/vespalib/util/size_literals.h>
-#include <vespa/fnet/transport.h>
-#include <vespa/fastos/thread.h>
+#include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <thread>
 
@@ -40,21 +38,17 @@ public:
 };
 
 struct DiskMemUsageSamplerTest : public ::testing::Test {
-    FastOS_ThreadPool threadPool;
-    FNET_Transport transport;
+    TransportMgr transport;
     std::unique_ptr<DiskMemUsageSampler> sampler;
     DiskMemUsageSamplerTest()
-        : threadPool(64_Ki),
-          transport(),
-          sampler(std::make_unique<DiskMemUsageSampler>(transport, ".", DiskMemUsageSampler::Config(0.8, 0.8, 50ms, make_hw_info())))
+        : transport(),
+          sampler(std::make_unique<DiskMemUsageSampler>(transport.transport(), ".", DiskMemUsageSampler::Config(0.8, 0.8, 50ms, make_hw_info())))
     {
-        transport.Start(&threadPool);
         sampler->add_transient_usage_provider(std::make_shared<MyProvider>(50, 200));
         sampler->add_transient_usage_provider(std::make_shared<MyProvider>(100, 150));
     }
     ~DiskMemUsageSamplerTest() {
         sampler.reset();
-        transport.ShutDown(true);
     }
     const DiskMemUsageFilter& filter() const { return sampler->writeFilter(); }
 };

--- a/searchcore/src/tests/proton/server/shared_threading_service/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/shared_threading_service/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_executable(searchcore_shared_threading_service_test_app TEST
     SOURCES
     shared_threading_service_test.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     GTest::GTest
 )

--- a/searchcore/src/tests/proton/server/shared_threading_service/shared_threading_service_test.cpp
+++ b/searchcore/src/tests/proton/server/shared_threading_service/shared_threading_service_test.cpp
@@ -3,11 +3,9 @@
 #include <vespa/searchcore/config/config-proton.h>
 #include <vespa/searchcore/proton/server/shared_threading_service.h>
 #include <vespa/searchcore/proton/server/shared_threading_service_config.h>
+#include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/vespalib/util/isequencedtaskexecutor.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
-#include <vespa/vespalib/util/size_literals.h>
-#include <vespa/fnet/transport.h>
-#include <vespa/fastos/thread.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace proton;
@@ -50,22 +48,16 @@ TEST(SharedThreadingServiceConfigTest, shared_threads_are_derived_from_cpu_cores
 
 class SharedThreadingServiceTest : public ::testing::Test {
 public:
-    FastOS_ThreadPool threadPool;
-    FNET_Transport transport;
+    TransportMgr transport;
     std::unique_ptr<SharedThreadingService> service;
     SharedThreadingServiceTest()
-        : threadPool(64_Ki),
-          transport(),
+        : transport(),
           service()
-    {
-        transport.Start(&threadPool);
-    }
-    ~SharedThreadingServiceTest() {
-        transport.ShutDown(true);
-    }
+    { }
+    ~SharedThreadingServiceTest() = default;
     void setup(double concurrency, uint32_t cpu_cores) {
         service = std::make_unique<SharedThreadingService>(
-                SharedThreadingServiceConfig::make(make_proton_config(concurrency), HwInfo::Cpu(cpu_cores)), transport);
+                SharedThreadingServiceConfig::make(make_proton_config(concurrency), HwInfo::Cpu(cpu_cores)), transport.transport());
     }
     SequencedTaskExecutor* field_writer() {
         return dynamic_cast<SequencedTaskExecutor*>(service->field_writer());

--- a/searchcore/src/vespa/searchcore/bmcluster/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/bmcluster/CMakeLists.txt
@@ -32,6 +32,7 @@ vespa_add_library(searchcore_bmcluster STATIC
     storage_api_rpc_bm_feed_handler.cpp
     storage_reply_error_checker.cpp
     DEPENDS
+    searchcore_test
     searchcore_server
     searchcore_initializer
     searchcore_reprocessing

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -5,6 +5,8 @@
 #include <vespa/vespalib/util/time.h>
 #include "disk_mem_usage_filter.h"
 
+class FNET_Transport;
+
 namespace vespalib { class ScheduledExecutor; }
 
 namespace proton {
@@ -51,7 +53,8 @@ public:
         }
     };
 
-    DiskMemUsageSampler(const std::string &path_in,
+    DiskMemUsageSampler(FNET_Transport & transport,
+                        const std::string &path_in,
                         const Config &config);
 
     ~DiskMemUsageSampler();

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -15,7 +15,6 @@
 #include "replay_throttling_policy.h"
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/metrics/updatehook.h>
-#include <vespa/searchcore/proton/attribute/attribute_config_inspector.h>
 #include <vespa/searchcore/proton/attribute/attribute_writer.h>
 #include <vespa/searchcore/proton/attribute/i_attribute_usage_listener.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
@@ -220,7 +219,7 @@ DocumentDB::DocumentDB(const vespalib::string &baseDir,
       _feedHandler(std::make_unique<FeedHandler>(_writeService, tlsSpec, docTypeName, *this, _writeFilter, *this, tlsWriterFactory)),
       _subDBs(*this, *this, *_feedHandler, _docTypeName, _writeService, shared_service.warmup(), fileHeaderContext,
               metricsWireService, getMetrics(), queryLimiter, clock, _configMutex, _baseDir, hwInfo),
-      _maintenanceController(_writeService.master(), shared_service.shared(), _refCount, _docTypeName),
+      _maintenanceController(shared_service.transport(), _writeService.master(), shared_service.shared(), _refCount, _docTypeName),
       _jobTrackers(),
       _calc(),
       _metricsUpdater(_subDBs, _writeService, _jobTrackers, *_sessionManager, _writeFilter, *_feedHandler)

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -272,18 +272,19 @@ build_alloc_config(const ProtonConfig& proton_config, const vespalib::string& do
          distribution_config.redundancy, distribution_config.searchablecopies);
 }
 
-vespalib::string resolve_file(config::RpcFileAcquirer &fileAcquirer, vespalib::TimeBox &timeBox,
-                              const vespalib::string &desc, const vespalib::string &fileref)
+vespalib::string
+resolve_file(config::RpcFileAcquirer &fileAcquirer, vespalib::TimeBox &timeBox,
+             const vespalib::string &desc, const vespalib::string &fileref)
 {
     vespalib::string filePath;
-    LOG(info, "Waiting for file acquirer (%s, ref='%s')", desc.c_str(), fileref.c_str());
+    LOG(debug, "Waiting for file acquirer (%s, ref='%s')", desc.c_str(), fileref.c_str());
     while (timeBox.hasTimeLeft() && (filePath == "")) {
         filePath = fileAcquirer.wait_for(fileref, timeBox.timeLeft());
         if (filePath == "") {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(100ms);
         }
     }
-    LOG(info, "Got file path from file acquirer: '%s' (%s, ref='%s')", filePath.c_str(), desc.c_str(), fileref.c_str());
+    LOG(debug, "Got file path from file acquirer: '%s' (%s, ref='%s')", filePath.c_str(), desc.c_str(), fileref.c_str());
     if (filePath == "") {
         throw config::ConfigTimeoutException(fmt("could not get file path from file acquirer for %s (ref=%s)",
                                                  desc.c_str(), fileref.c_str()));
@@ -294,7 +295,7 @@ vespalib::string resolve_file(config::RpcFileAcquirer &fileAcquirer, vespalib::T
 }
 
 void
-DocumentDBConfigManager::update(const ConfigSnapshot &snapshot)
+DocumentDBConfigManager::update(FNET_Transport & transport, const ConfigSnapshot &snapshot)
 {
     using RankProfilesConfigSP = DocumentDBConfig::RankProfilesConfigSP;
     using RankingConstantsConfigSP = std::shared_ptr<vespa::config::search::core::RankingConstantsConfig>;
@@ -355,7 +356,7 @@ DocumentDBConfigManager::update(const ConfigSnapshot &snapshot)
         const vespalib::string &spec = _bootstrapConfig->getFiledistributorrpcConfig().connectionspec;
         RankingConstants::Vector constants;
         if (spec != "") {
-            config::RpcFileAcquirer fileAcquirer(spec);
+            config::RpcFileAcquirer fileAcquirer(transport, spec);
             vespalib::TimeBox timeBox(5*60, 5);
             for (const RankingConstantsConfig::Constant &rc : newRankingConstantsConfig->constant) {
                 auto desc = fmt("name='%s', type='%s'", rc.name.c_str(), rc.type.c_str());
@@ -371,7 +372,7 @@ DocumentDBConfigManager::update(const ConfigSnapshot &snapshot)
         const vespalib::string &spec = _bootstrapConfig->getFiledistributorrpcConfig().connectionspec;
         RankingExpressions expressions;
         if (spec != "") {
-            config::RpcFileAcquirer fileAcquirer(spec);
+            config::RpcFileAcquirer fileAcquirer(transport, spec);
             vespalib::TimeBox timeBox(5*60, 5);
             for (const RankingExpressionsConfig::Expression &rc : newRankingExpressionsConfig->expression) {
                 auto desc = fmt("name='%s'", rc.name.c_str());
@@ -387,7 +388,7 @@ DocumentDBConfigManager::update(const ConfigSnapshot &snapshot)
         const vespalib::string &spec = _bootstrapConfig->getFiledistributorrpcConfig().connectionspec;
         OnnxModels::Vector models;
         if (spec != "") {
-            config::RpcFileAcquirer fileAcquirer(spec);
+            config::RpcFileAcquirer fileAcquirer(transport, spec);
             vespalib::TimeBox timeBox(5*60, 5);
             for (const OnnxModelsConfig::Model &rc : newOnnxModelsConfig->model) {
                 auto desc = fmt("name='%s'", rc.name.c_str());
@@ -496,12 +497,12 @@ DocumentDBConfigHelper::DocumentDBConfigHelper(const DirSpec &spec, const vespal
 DocumentDBConfigHelper::~DocumentDBConfigHelper() = default;
 
 bool
-DocumentDBConfigHelper::nextGeneration(std::chrono::milliseconds timeoutInMillis)
+DocumentDBConfigHelper::nextGeneration(FNET_Transport & transport, vespalib::duration timeout)
 {
-    ConfigSnapshot snapshot(_retriever->getBootstrapConfigs(timeoutInMillis));
+    ConfigSnapshot snapshot(_retriever->getBootstrapConfigs(timeout));
     if (snapshot.empty())
         return false;
-    _mgr.update(snapshot);
+    _mgr.update(transport, snapshot);
     return true;
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.h
@@ -5,6 +5,8 @@
 #include "documentdbconfig.h"
 #include <mutex>
 
+class FNET_Transport;
+
 namespace config {
     class ConfigRetriever;
     class DirSpec;
@@ -38,7 +40,7 @@ private:
 public:
     DocumentDBConfigManager(const vespalib::string &configId, const vespalib::string &docTypeName);
     ~DocumentDBConfigManager();
-    void update(const config::ConfigSnapshot & snapshot);
+    void update(FNET_Transport & transport, const config::ConfigSnapshot & snapshot);
 
     DocumentDBConfig::SP getConfig() const;
 
@@ -56,7 +58,7 @@ public:
     DocumentDBConfigHelper(const config::DirSpec &spec, const vespalib::string &docTypeName);
     ~DocumentDBConfigHelper();
 
-    bool nextGeneration(std::chrono::milliseconds timeoutInMillis);
+    bool nextGeneration(FNET_Transport & transport, vespalib::duration timeout);
     DocumentDBConfig::SP getConfig() const;
     void forwardConfig(const std::shared_ptr<BootstrapConfig> & config);
 private:

--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
@@ -207,10 +207,12 @@ getFileList(const vespalib::string &snapDir)
 
 }
 
-FileConfigManager::FileConfigManager(const vespalib::string &baseDir,
+FileConfigManager::FileConfigManager(FNET_Transport & transport,
+                                     const vespalib::string &baseDir,
                                      const vespalib::string &configId,
                                      const vespalib::string &docTypeName)
-    : _baseDir(baseDir),
+    : _transport(transport),
+      _baseDir(baseDir),
       _configId(configId),
       _docTypeName(docTypeName),
       _info(baseDir),
@@ -358,7 +360,7 @@ FileConfigManager::loadConfig(const DocumentDBConfig &currentSnapshot, search::S
                                                        bucketspaces,currentSnapshot.getTuneFileDocumentDBSP(),
                                                        sampler.hwInfo());
     dbc.forwardConfig(bootstrap);
-    dbc.nextGeneration(0ms);
+    dbc.nextGeneration(_transport, 0ms);
 
     loadedSnapshot = dbc.getConfig();
     loadedSnapshot->setConfigId(_configId);

--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.h
@@ -11,11 +11,12 @@ namespace proton {
 
 class FileConfigManager : public ConfigStore {
 private:
-    vespalib::string      _baseDir;
-    vespalib::string      _configId;
-    vespalib::string      _docTypeName;
-    search::IndexMetaInfo _info;
-    ProtonConfigSP        _protonConfig;
+    FNET_Transport        & _transport;
+    vespalib::string        _baseDir;
+    vespalib::string        _configId;
+    vespalib::string        _docTypeName;
+    search::IndexMetaInfo   _info;
+    ProtonConfigSP          _protonConfig;
 
 public:
     /**
@@ -24,9 +25,8 @@ public:
      * @param baseDir the directory in which config snapshots are saved and loaded.
      * @param configId the configId that was used to subscribe to config that is later handled by this manager.
      */
-    FileConfigManager(const vespalib::string &baseDir,
-                      const vespalib::string &configId,
-                      const vespalib::string &docTypeName);
+    FileConfigManager(FNET_Transport & transport, const vespalib::string &baseDir,
+                      const vespalib::string &configId, const vespalib::string &docTypeName);
 
     ~FileConfigManager() override;
 

--- a/searchcore/src/vespa/searchcore/proton/server/i_shared_threading_service.h
+++ b/searchcore/src/vespa/searchcore/proton/server/i_shared_threading_service.h
@@ -1,6 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+class FNET_Transport;
+
 namespace vespalib {
 class ISequencedTaskExecutor;
 class ThreadExecutor;
@@ -14,7 +16,7 @@ namespace proton {
  */
 class ISharedThreadingService {
 public:
-    virtual ~ISharedThreadingService() {}
+    virtual ~ISharedThreadingService() = default;
 
     /**
      * Returns the executor used for warmup (e.g. index warmup).
@@ -44,6 +46,11 @@ public:
      * Returns an InvokeService intended for regular wakeup calls.
      */
     virtual vespalib::InvokeService & invokeService() = 0;
+
+    /**
+     * Returns a shared transport object that can be utilized by multiple services.
+     */
+    virtual FNET_Transport & transport() = 0;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchcorespi/index/i_thread_service.h>
 #include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/vespalib/util/scheduledexecutor.h>
+#include <vespa/fastos/thread.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -39,7 +40,8 @@ isRunnable(const MaintenanceJobRunner & job, const Executor * master) {
 
 }
 
-MaintenanceController::MaintenanceController(ISyncableThreadService& masterThread,
+MaintenanceController::MaintenanceController(FNET_Transport & transport,
+                                             ISyncableThreadService& masterThread,
                                              vespalib::Executor& shared_executor,
                                              MonitoredRefCount& refCount,
                                              const DocTypeName& docTypeName)
@@ -49,7 +51,7 @@ MaintenanceController::MaintenanceController(ISyncableThreadService& masterThrea
       _readySubDB(),
       _remSubDB(),
       _notReadySubDB(),
-      _periodicTimer(),
+      _periodicTimer(std::make_unique<vespalib::ScheduledExecutor>(transport)),
       _config(),
       _state(State::INITIALIZING),
       _docTypeName(docTypeName),
@@ -93,7 +95,7 @@ MaintenanceController::killJobs()
     // Called by master write thread
     assert(_masterThread.isCurrentThread());
     LOG(debug, "killJobs(): threadId=%zu", (size_t)FastOS_Thread::GetCurrentThreadId());
-    _periodicTimer.reset();
+    _periodicTimer->reset();
     // No need to take _jobsLock as modification of _jobs also happens in master write thread.
     for (auto &job : _jobs) {
         job->stop(); // Make sure no more tasks are added to the executor
@@ -172,7 +174,7 @@ MaintenanceController::restart()
     if (!getStarted() || getStopping() || !_readySubDB.valid()) {
         return;
     }
-    _periodicTimer = std::make_unique<vespalib::ScheduledExecutor>();
+    _periodicTimer->reset();
 
     addJobsToPeriodicTimer();
 }

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
@@ -42,7 +42,7 @@ public:
     using UP = std::unique_ptr<MaintenanceController>;
     enum class State {INITIALIZING, STARTED, PAUSED, STOPPING};
 
-    MaintenanceController(ISyncableThreadService& masterThread, vespalib::Executor& shared_executor,
+    MaintenanceController(FNET_Transport & transport, ISyncableThreadService& masterThread, vespalib::Executor& shared_executor,
                           vespalib::MonitoredRefCount& refCount, const DocTypeName& docTypeName);
 
     ~MaintenanceController();

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -82,6 +82,8 @@ private:
     };
 
     vespalib::CpuUtil                      _cpu_util;
+    std::unique_ptr<FastOS_ThreadPool>     _threadPool;
+    std::unique_ptr<FNET_Transport>        _transport;
     const config::ConfigUri                _configUri;
     mutable std::shared_mutex              _mutex;
     std::unique_ptr<metrics::UpdateHook>   _metricsHook;
@@ -110,7 +112,6 @@ private:
     vespalib::eval::CompileCache::ExecutorBinding::UP _compile_cache_executor_binding;
     matching::QueryLimiter          _queryLimiter;
     vespalib::Clock                 _clock;
-    FastOS_ThreadPool               _threadPool;
     uint32_t                        _distributionKey;
     bool                            _isInitializing;
     bool                            _abortInit;
@@ -146,7 +147,7 @@ public:
 
     Proton(const config::ConfigUri & configUri,
            const vespalib::string &progName,
-           std::chrono::milliseconds subscribeTimeout);
+           vespalib::duration subscribeTimeout);
     ~Proton() override;
 
     /**
@@ -182,7 +183,7 @@ public:
                   const std::shared_ptr<DocumentDBConfig> &documentDBConfig, InitializeThreads initializeThreads);
 
     metrics::MetricManager & getMetricManager();
-    FastOS_ThreadPool & getThreadPool() { return _threadPool; }
+    FastOS_ThreadPool & getThreadPool() { return *_threadPool; }
 
     bool triggerFlush();
     bool prepareRestart();

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
@@ -26,7 +26,7 @@ class ProtonConfigFetcher : public FastOS_Runnable
 public:
     using BootstrapConfigSP = std::shared_ptr<BootstrapConfig>;
 
-    ProtonConfigFetcher(const config::ConfigUri & configUri, IProtonConfigurer &owner, std::chrono::milliseconds subscribeTimeout);
+    ProtonConfigFetcher(FNET_Transport & transport, const config::ConfigUri & configUri, IProtonConfigurer &owner, vespalib::duration subscribeTimeout);
     ~ProtonConfigFetcher() override;
     /**
      * Get the current config generation.
@@ -36,7 +36,7 @@ public:
     /**
      * Start config fetcher, callbacks may come from now on.
      */
-    void start();
+    void start(FastOS_ThreadPool & threadPool);
 
     /**
      * Shutdown config fetcher, ensuring that no more callbacks arrive
@@ -47,20 +47,19 @@ public:
 
 private:
     typedef std::map<DocTypeName, DocumentDBConfigManager::SP> DBManagerMap;
-    using Clock = std::chrono::steady_clock;
-    using TimePoint = std::chrono::time_point<Clock>;
-    using OldDocumentTypeRepo = std::pair<TimePoint, std::shared_ptr<const document::DocumentTypeRepo>>;
-
-    BootstrapConfigManager  _bootstrapConfigManager;
-    config::ConfigRetriever _retriever;
-    IProtonConfigurer     & _owner;
-
-    mutable std::mutex _mutex; // Protects maps
+    using OldDocumentTypeRepo = std::pair<vespalib::steady_time, std::shared_ptr<const document::DocumentTypeRepo>>;
     using lock_guard = std::lock_guard<std::mutex>;
-    DBManagerMap _dbManagerMap;
 
-    FastOS_ThreadPool _threadPool;
-    std::deque<OldDocumentTypeRepo> _oldDocumentTypeRepos;
+
+    FNET_Transport          & _transport;
+    BootstrapConfigManager    _bootstrapConfigManager;
+    config::ConfigRetriever   _retriever;
+    IProtonConfigurer       & _owner;
+
+    mutable std::mutex        _mutex; // Protects maps
+    DBManagerMap              _dbManagerMap;
+
+    std::deque<OldDocumentTypeRepo>                   _oldDocumentTypeRepos;
     std::shared_ptr<const document::DocumentTypeRepo> _currentDocumentTypeRepo;
 
     void fetchConfigs();

--- a/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.cpp
@@ -6,6 +6,8 @@
 #include <vespa/vespalib/util/isequencedtaskexecutor.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include <vespa/fnet/transport.h>
+#include <vespa/fastos/thread.h>
 
 using vespalib::CpuUsage;
 
@@ -17,8 +19,10 @@ namespace proton {
 
 using SharedFieldWriterExecutor = ThreadingServiceConfig::ProtonConfig::Feeding::SharedFieldWriterExecutor;
 
-SharedThreadingService::SharedThreadingService(const SharedThreadingServiceConfig& cfg)
-    : _warmup(cfg.warmup_threads(), 128_Ki, CpuUsage::wrap(proton_warmup_executor, CpuUsage::Category::COMPACT)),
+SharedThreadingService::SharedThreadingService(const SharedThreadingServiceConfig& cfg, FNET_Transport & transport)
+    :
+      _transport(transport),
+      _warmup(cfg.warmup_threads(), 128_Ki, CpuUsage::wrap(proton_warmup_executor, CpuUsage::Category::COMPACT)),
       _shared(std::make_shared<vespalib::BlockingThreadStackExecutor>(cfg.shared_threads(), 128_Ki,
                                                                       cfg.shared_task_limit(), proton_shared_executor)),
       _field_writer(),

--- a/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.h
+++ b/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.h
@@ -16,15 +16,16 @@ namespace proton {
 class SharedThreadingService : public ISharedThreadingService {
 private:
     using Registration = std::unique_ptr<vespalib::IDestructorCallback>;
-    vespalib::ThreadStackExecutor _warmup;
+    FNET_Transport                                  & _transport;
+    vespalib::ThreadStackExecutor                     _warmup;
     std::shared_ptr<vespalib::SyncableThreadExecutor> _shared;
     std::unique_ptr<vespalib::ISequencedTaskExecutor> _field_writer;
-    vespalib::InvokeServiceImpl _invokeService;
-    std::vector<Registration>   _invokeRegistrations;
+    vespalib::InvokeServiceImpl                       _invokeService;
+    std::vector<Registration>                         _invokeRegistrations;
 
 public:
-    SharedThreadingService(const SharedThreadingServiceConfig& cfg);
-    ~SharedThreadingService();
+    SharedThreadingService(const SharedThreadingServiceConfig& cfg, FNET_Transport & transport);
+    ~SharedThreadingService() override;
 
     std::shared_ptr<vespalib::Executor> shared_raw() { return _shared; }
     void sync_all_executors();
@@ -33,6 +34,7 @@ public:
     vespalib::ThreadExecutor& shared() override { return *_shared; }
     vespalib::ISequencedTaskExecutor* field_writer() override { return _field_writer.get(); }
     vespalib::InvokeService & invokeService() override { return _invokeService; }
+    FNET_Transport & transport() override { return _transport; }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
@@ -7,8 +7,10 @@ vespa_add_library(searchcore_test STATIC
     clusterstatehandler.cpp
     documentdb_config_builder.cpp
     dummy_feed_view.cpp
+    mock_shared_threading_service.cpp
     userdocumentsbuilder.cpp
     threading_service_observer.cpp
+    transport_helper.cpp
     DEPENDS
     searchcore_fconfig
 )

--- a/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.cpp
@@ -1,0 +1,17 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "mock_shared_threading_service.h"
+
+namespace proton {
+
+MockSharedThreadingService::MockSharedThreadingService(ThreadExecutor& warmup_in, ThreadExecutor& shared_in)
+    : _warmup(warmup_in),
+      _shared(shared_in),
+      _invokeService(10ms),
+      _transportMgr()
+{
+}
+
+MockSharedThreadingService::~MockSharedThreadingService() = default;
+
+}

--- a/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.h
@@ -3,26 +3,39 @@
 
 #include <vespa/searchcore/proton/server/i_shared_threading_service.h>
 #include <vespa/vespalib/util/invokeserviceimpl.h>
+#include <vespa/fnet/transport.h>
+#include <vespa/fastos/thread.h>
+#include <vespa/vespalib/util/size_literals.h>
 
 namespace proton {
 
 class MockSharedThreadingService : public ISharedThreadingService {
 private:
-    vespalib::ThreadExecutor& _warmup;
-    vespalib::ThreadExecutor& _shared;
+    vespalib::ThreadExecutor  & _warmup;
+    vespalib::ThreadExecutor  & _shared;
     vespalib::InvokeServiceImpl _invokeService;
+    FastOS_ThreadPool           _threadPool;
+    FNET_Transport              _transport;
 
 public:
     MockSharedThreadingService(vespalib::ThreadExecutor& warmup_in,
                                vespalib::ThreadExecutor& shared_in)
         : _warmup(warmup_in),
           _shared(shared_in),
-          _invokeService(10ms)
-    {}
+          _invokeService(10ms),
+          _threadPool(64_Ki),
+          _transport()
+    {
+        _transport.Start(&_threadPool);
+    }
+    ~MockSharedThreadingService() {
+        _transport.ShutDown(true);
+    }
     vespalib::ThreadExecutor& warmup() override { return _warmup; }
     vespalib::ThreadExecutor& shared() override { return _shared; }
     vespalib::ISequencedTaskExecutor* field_writer() override { return nullptr; }
     vespalib::InvokeService & invokeService() override { return _invokeService; }
+    FNET_Transport & transport() override { return _transport; }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_shared_threading_service.h
@@ -1,41 +1,29 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "transport_helper.h"
 #include <vespa/searchcore/proton/server/i_shared_threading_service.h>
 #include <vespa/vespalib/util/invokeserviceimpl.h>
-#include <vespa/fnet/transport.h>
-#include <vespa/fastos/thread.h>
-#include <vespa/vespalib/util/size_literals.h>
 
 namespace proton {
 
 class MockSharedThreadingService : public ISharedThreadingService {
 private:
-    vespalib::ThreadExecutor  & _warmup;
-    vespalib::ThreadExecutor  & _shared;
-    vespalib::InvokeServiceImpl _invokeService;
-    FastOS_ThreadPool           _threadPool;
-    FNET_Transport              _transport;
+    using ThreadExecutor = vespalib::ThreadExecutor;
+    ThreadExecutor              & _warmup;
+    ThreadExecutor              & _shared;
+    vespalib::InvokeServiceImpl   _invokeService;
+    TransportMgr                  _transportMgr;
 
 public:
-    MockSharedThreadingService(vespalib::ThreadExecutor& warmup_in,
-                               vespalib::ThreadExecutor& shared_in)
-        : _warmup(warmup_in),
-          _shared(shared_in),
-          _invokeService(10ms),
-          _threadPool(64_Ki),
-          _transport()
-    {
-        _transport.Start(&_threadPool);
-    }
-    ~MockSharedThreadingService() {
-        _transport.ShutDown(true);
-    }
-    vespalib::ThreadExecutor& warmup() override { return _warmup; }
-    vespalib::ThreadExecutor& shared() override { return _shared; }
+    MockSharedThreadingService(ThreadExecutor& warmup_in,
+                               ThreadExecutor& shared_in);
+    ~MockSharedThreadingService() override;
+    ThreadExecutor& warmup() override { return _warmup; }
+    ThreadExecutor& shared() override { return _shared; }
     vespalib::ISequencedTaskExecutor* field_writer() override { return nullptr; }
     vespalib::InvokeService & invokeService() override { return _invokeService; }
-    FNET_Transport & transport() override { return _transport; }
+    FNET_Transport & transport() override { return _transportMgr.transport(); }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/test/transport_helper.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/transport_helper.cpp
@@ -1,0 +1,21 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "transport_helper.h"
+#include <vespa/fnet/transport.h>
+#include <vespa/fastos/thread.h>
+#include <vespa/vespalib/util/size_literals.h>
+
+namespace proton {
+
+TransportMgr::TransportMgr()
+    : _threadPool(std::make_unique<FastOS_ThreadPool>(64_Ki)),
+      _transport(std::make_unique<FNET_Transport>())
+{
+    _transport->Start(_threadPool.get());
+}
+
+TransportMgr::~TransportMgr() {
+    _transport->ShutDown(true);
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/test/transport_helper.h
+++ b/searchcore/src/vespa/searchcore/proton/test/transport_helper.h
@@ -1,0 +1,26 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <memory>
+
+class FastOS_ThreadPool;
+class FNET_Transport;
+
+namespace proton {
+
+/**
+ * Helper class contain a FNET_Transport object for use in tests.
+ **/
+class TransportMgr {
+private:
+    std::unique_ptr<FastOS_ThreadPool> _threadPool;
+    std::unique_ptr<FNET_Transport>    _transport;
+
+public:
+    TransportMgr();
+    ~TransportMgr();
+    FNET_Transport & transport() { return *_transport; }
+    FastOS_ThreadPool & threadPool() { return *_threadPool; }
+};
+
+}

--- a/searchlib/src/tests/transactionlogstress/translogstress.cpp
+++ b/searchlib/src/tests/transactionlogstress/translogstress.cpp
@@ -4,8 +4,10 @@
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/searchlib/transactionlog/translogclient.h>
 #include <vespa/vespalib/util/rand48.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/searchlib/util/runnable.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
+#include <vespa/fnet/transport.h>
 #include <vespa/fastos/app.h>
 #include <iostream>
 #include <sstream>
@@ -698,12 +700,12 @@ TransLogStress::Main()
     }
 
     // start transaction log server
+    FastOS_ThreadPool threadPool(256_Ki);
+    FNET_Transport transport;
     DummyFileHeaderContext fileHeaderContext;
-    TransLogServer tls("server", 17897, ".", fileHeaderContext, DomainConfig().setPartSizeLimit(_cfg.domainPartSize));
+    TransLogServer tls(transport, "server", 17897, ".", fileHeaderContext, DomainConfig().setPartSizeLimit(_cfg.domainPartSize));
     TransLogClient client(tlsSpec);
     client.create(domain);
-
-    FastOS_ThreadPool threadPool(256000);
 
     BufferGenerator bufferGenerator(_cfg.minStrLen, _cfg.maxStrLen);
     bufferGenerator.setSeed(_cfg.baseSeed);

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.cpp
@@ -81,19 +81,19 @@ VESPA_THREAD_STACK_TAG(tls_executor);
 
 }
 
-TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+TransLogServer::TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                                const FileHeaderContext &fileHeaderContext)
-    : TransLogServer(name, listenPort, baseDir, fileHeaderContext,
+    : TransLogServer(transport, name, listenPort, baseDir, fileHeaderContext,
                      DomainConfig().setEncoding(Encoding(Encoding::xxh64, Encoding::Compression::zstd))
                                         .setPartSizeLimit(0x10000000).setChunkSizeLimit(0x40000))
 {}
 
-TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+TransLogServer::TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                                const FileHeaderContext &fileHeaderContext, const DomainConfig &  cfg)
-    : TransLogServer(name, listenPort, baseDir, fileHeaderContext, cfg, 4)
+    : TransLogServer(transport, name, listenPort, baseDir, fileHeaderContext, cfg, 4)
 {}
 
-TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+TransLogServer::TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                                const FileHeaderContext &fileHeaderContext, const DomainConfig & cfg, size_t maxThreads)
     : FRT_Invokable(),
       _name(name),
@@ -101,8 +101,7 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
       _domainConfig(cfg),
       _executor(maxThreads, 128_Ki, CpuUsage::wrap(tls_executor, CpuUsage::Category::WRITE)),
       _threadPool(std::make_unique<FastOS_ThreadPool>(120_Ki)),
-      _transport(std::make_unique<FNET_Transport>()),
-      _supervisor(std::make_unique<FRT_Supervisor>(_transport.get())),
+      _supervisor(std::make_unique<FRT_Supervisor>(&transport)),
       _domains(),
       _reqQ(),
       _fileHeaderContext(fileHeaderContext),
@@ -130,7 +129,6 @@ TransLogServer::TransLogServer(const vespalib::string &name, int listenPort, con
             bool listenOk(false);
             for (int i(600); !listenOk && i; i--) {
                 if (_supervisor->Listen(listenSpec)) {
-                    _transport->Start(_threadPool.get());
                     listenOk = true;
                 } else {
                     LOG(warning, "Failed listening at port %s trying for %d seconds more.", listenSpec, i);
@@ -157,7 +155,6 @@ TransLogServer::~TransLogServer()
     _executor.sync();
     _executor.shutdown();
     _executor.sync();
-    _transport->ShutDown(true);
 }
 
 bool

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserver.h
@@ -24,11 +24,11 @@ public:
     friend class TransLogServerExplorer;
     using SP = std::shared_ptr<TransLogServer>;
     using DomainSP = std::shared_ptr<Domain>;
-    TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+    TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                    const common::FileHeaderContext &fileHeaderContext, const DomainConfig & cfg, size_t maxThreads);
-    TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+    TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                    const common::FileHeaderContext &fileHeaderContext, const DomainConfig & cfg);
-    TransLogServer(const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
+    TransLogServer(FNET_Transport & transport, const vespalib::string &name, int listenPort, const vespalib::string &baseDir,
                    const common::FileHeaderContext &fileHeaderContext);
     ~TransLogServer() override;
     DomainStats getDomainStats() const;
@@ -85,7 +85,6 @@ private:
     DomainConfig                        _domainConfig;
     vespalib::ThreadStackExecutor       _executor;
     std::unique_ptr<FastOS_ThreadPool>  _threadPool;
-    std::unique_ptr<FNET_Transport>     _transport;
     std::unique_ptr<FRT_Supervisor>     _supervisor;
     DomainList                          _domains;
     mutable std::shared_mutex           _domainMutex;;          // Protects _domains

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.cpp
@@ -89,13 +89,13 @@ derive_num_threads(uint32_t configured_cores, uint32_t actual_cores) {
 }
 
 void
-TransLogServerApp::start(uint32_t num_cores)
+TransLogServerApp::start(FNET_Transport & transport, uint32_t num_cores)
 {
     std::lock_guard<std::mutex> guard(_lock);
     auto c = _tlsConfig.get();
     DomainConfig domainConfig = getDomainConfig(*c);
     logReconfig(*c, domainConfig);
-   _tls = std::make_shared<TransLogServer>(c->servername, c->listenport, c->basedir, _fileHeaderContext,
+   _tls = std::make_shared<TransLogServer>(transport, c->servername, c->listenport, c->basedir, _fileHeaderContext,
                                             domainConfig, derive_num_threads(c->maxthreads, num_cores));
 }
 

--- a/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.h
+++ b/searchlib/src/vespa/searchlib/transactionlog/translogserverapp.h
@@ -32,7 +32,7 @@ public:
 
     TransLogServer::SP getTransLogServer() const;
 
-    void start(uint32_t num_cores);
+    void start(FNET_Transport & transport, uint32_t num_cores);
 };
 
 }

--- a/staging_vespalib/src/tests/timer/timer_test.cpp
+++ b/staging_vespalib/src/tests/timer/timer_test.cpp
@@ -2,18 +2,15 @@
 
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/scheduledexecutor.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/fnet/transport.h>
+#include <vespa/fastos/thread.h>
 
 using namespace vespalib;
 using vespalib::Executor;
 typedef Executor::Task Task;
 
-class Test : public TestApp
-{
-public:
-    int Main() override;
-    void testScheduling();
-    void testReset();
-};
+namespace {
 
 class TestTask : public Task {
 private:
@@ -23,35 +20,36 @@ public:
     void run() override { _latch.countDown(); }
 };
 
-int
-Test::Main()
-{
-    TEST_INIT("timer_test");
-    testScheduling();
-    testReset();
-    TEST_DONE();
 }
 
-void Test::testScheduling()
-{
+TEST("testScheduling") {
     vespalib::CountDownLatch latch1(3);
     vespalib::CountDownLatch latch2(2);
-    ScheduledExecutor timer;
+    FastOS_ThreadPool threadPool(64_Ki);
+    FNET_Transport transport;
+    transport.Start(&threadPool);
+    ScheduledExecutor timer(transport);
     timer.scheduleAtFixedRate(std::make_unique<TestTask>(latch1), 100ms, 200ms);
     timer.scheduleAtFixedRate(std::make_unique<TestTask>(latch2), 500ms, 500ms);
     EXPECT_TRUE(latch1.await(60s));
     EXPECT_TRUE(latch2.await(60s));
+    timer.reset();
+    transport.ShutDown(true);
 }
 
-void Test::testReset()
-{
+TEST("testReset") {
     vespalib::CountDownLatch latch1(2);
-    ScheduledExecutor timer;
+    FastOS_ThreadPool threadPool(64_Ki);
+    FNET_Transport transport;
+    transport.Start(&threadPool);
+    ScheduledExecutor timer(transport);
     timer.scheduleAtFixedRate(std::make_unique<TestTask>(latch1), 2s, 3s);
     timer.reset();
     EXPECT_TRUE(!latch1.await(3s));
     timer.scheduleAtFixedRate(std::make_unique<TestTask>(latch1), 200ms, 300ms);
     EXPECT_TRUE(latch1.await(60s));
+    timer.reset();
+    transport.ShutDown(true);
 }
 
-TEST_APPHOOK(Test)
+TEST_MAIN() { TEST_RUN_ALL(); }

--- a/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
+++ b/staging_vespalib/src/vespa/vespalib/util/scheduledexecutor.h
@@ -3,7 +3,6 @@
 
 #include <vespa/vespalib/util/executor.h>
 #include <vespa/vespalib/util/time.h>
-#include <vespa/fastos/thread.h>
 #include <vector>
 
 class FNET_Transport;
@@ -20,10 +19,8 @@ class TimerTask;
 class ScheduledExecutor
 {
 private:
-    typedef std::unique_ptr<TimerTask> TimerTaskPtr;
-    typedef std::vector<TimerTaskPtr> TaskList;
-    FastOS_ThreadPool _threadPool;
-    std::unique_ptr<FNET_Transport> _transport;
+    using TaskList = std::vector<std::unique_ptr<TimerTask>>;
+    FNET_Transport & _transport;
     std::mutex _lock;
     TaskList   _taskList;
 
@@ -31,7 +28,7 @@ public:
     /**
      * Create a new timer, capable of scheduling tasks at fixed intervals.
      */
-    ScheduledExecutor();
+    ScheduledExecutor(FNET_Transport & transport);
 
     /**
      * Destroys this timer, finishing the current task executing and then
@@ -46,7 +43,7 @@ public:
      * @param delay The delay to wait before first execution.
      * @param interval The interval in seconds.
      */
-    void scheduleAtFixedRate(vespalib::Executor::Task::UP task, duration delay, duration interval);
+    void scheduleAtFixedRate(std::unique_ptr<Executor::Task> task, duration delay, duration interval);
 
     /**
      * Reset timer, clearing the list of task to execute.


### PR DESCRIPTION
…and TransactionLogServer.

This reduces the number of Transport object by 1 per document type and netto 1 in Proton.
Each of them contains 2 threads.

In addition it uses a common Transport for the RpcFileAcquirer objects used during config fetching.
This prevents creating 3 temporary Transport objects on every reconfig.

@geirst @geirst PR
@havard @vekterli FYI