### PR TITLE
Remove TODO on changing toString to YQL format

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -317,9 +317,6 @@ public abstract class Item implements Cloneable {
      * ([itemName] [body])
      * </pre>
      * where the body may recursively be other items.
-     *
-     * <p>
-     * TODO (Vespa 8?): Output YQL
      */
     @Override
     public String toString() {

--- a/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
+++ b/document/src/main/java/com/yahoo/document/select/rule/DocumentTypeNode.java
@@ -13,7 +13,7 @@ import com.yahoo.document.select.Context;
 import com.yahoo.document.select.Visitor;
 
 /**
- * A document type node which returns the document type if exactly the type sopecified or false otherwise:
+ * A document type node which returns the document type if exactly the type specified or false otherwise:
  * For using the exact document type as a condition.
  *
  * @author bratseth


### PR DESCRIPTION
It would be nice but it breaks 842 tests for us,
and probably a lot for applications too, so it is just
not worth the effort.
