### PR TITLE
Add more strict validation for node counts

### DIFF
--- a/client/go/vespa/xml/config.go
+++ b/client/go/vespa/xml/config.go
@@ -189,26 +189,32 @@ func ParseResources(s string) (Resources, error) {
 // ParseNodeCount parses a node count range from string s.
 func ParseNodeCount(s string) (int, int, error) {
 	parseErr := fmt.Errorf("invalid node count: %q", s)
+	min, max := 0, 0
 	n, err := strconv.Atoi(s)
 	if err == nil {
-		return n, n, nil
-	}
-	if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+		min = n
+		max = n
+	} else if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
 		parts := strings.Split(s[1:len(s)-1], ",")
 		if len(parts) != 2 {
 			return 0, 0, parseErr
 		}
-		min, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+		min, err = strconv.Atoi(strings.TrimSpace(parts[0]))
 		if err != nil {
 			return 0, 0, parseErr
 		}
-		max, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		max, err = strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return 0, 0, parseErr
 		}
-		return min, max, nil
+	} else {
+		return 0, 0, parseErr
 	}
-	return 0, 0, parseErr
+
+	if min <= 0 || min > max {
+		return 0, 0, parseErr
+	}
+	return min, max, nil
 }
 
 // IsProdRegion returns whether string s is a valid production region.

--- a/client/go/vespa/xml/config_test.go
+++ b/client/go/vespa/xml/config_test.go
@@ -258,6 +258,10 @@ func TestParseNodeCount(t *testing.T) {
 
 	assertNodeCount(t, "foo", 0, 0, true)
 	assertNodeCount(t, "[foo,bar]", 0, 0, true)
+
+	assertNodeCount(t, "0", 0, 0, true)
+	assertNodeCount(t, "-1", 0, 0, true)
+	assertNodeCount(t, "[2, 1]", 0, 0, true)
 }
 
 func assertReplace(t *testing.T, input, want, parentElement, element string, data interface{}) {


### PR DESCRIPTION
Disallow count values that are zero, negative and ranges where max is less than
min.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
