### PR TITLE
Expose current active operation throttler token count

### DIFF
--- a/vespalib/src/tests/shared_operation_throttler/shared_operation_throttler_test.cpp
+++ b/vespalib/src/tests/shared_operation_throttler/shared_operation_throttler_test.cpp
@@ -29,6 +29,8 @@ TEST("unlimited throttler does not throttle") {
     EXPECT_TRUE(token2.valid());
     // Window size should be zero (i.e. unlimited) for unlimited throttler
     EXPECT_EQUAL(throttler->current_window_size(), 0u);
+    // But we still track the active token count
+    EXPECT_EQUAL(throttler->current_active_token_count(), 2u);
 }
 
 TEST_F("dynamic throttler respects initial window size", DynamicThrottleFixture()) {
@@ -38,6 +40,7 @@ TEST_F("dynamic throttler respects initial window size", DynamicThrottleFixture(
     EXPECT_FALSE(token2.valid());
 
     EXPECT_EQUAL(f1._throttler->current_window_size(), 1u);
+    EXPECT_EQUAL(f1._throttler->current_active_token_count(), 1u);
 }
 
 TEST_F("blocking acquire returns immediately if slot available", DynamicThrottleFixture()) {
@@ -87,9 +90,13 @@ TEST_F("token destruction frees up throttle window slot", DynamicThrottleFixture
     {
         auto token = f1._throttler->try_acquire_one();
         EXPECT_TRUE(token.valid());
+        EXPECT_EQUAL(f1._throttler->current_active_token_count(), 1u);
     }
+    EXPECT_EQUAL(f1._throttler->current_active_token_count(), 0u);
+
     auto token = f1._throttler->try_acquire_one();
     EXPECT_TRUE(token.valid());
+    EXPECT_EQUAL(f1._throttler->current_active_token_count(), 1u);
 }
 
 TEST_F("token can be moved and reset", DynamicThrottleFixture()) {

--- a/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
+++ b/vespalib/src/vespa/vespalib/util/shared_operation_throttler.h
@@ -65,7 +65,8 @@ public:
     // May return 0, in which case the window size is unlimited.
     [[nodiscard]] virtual uint32_t current_window_size() const noexcept = 0;
 
-    // Exposed for unit testing only.
+    [[nodiscard]] virtual uint32_t current_active_token_count() const noexcept = 0;
+
     [[nodiscard]] virtual uint32_t waiting_threads() const noexcept = 0;
 
     struct DynamicThrottleParams {


### PR DESCRIPTION
@geirst please review

Allows for inspecting _actual_ operation parallelism vs. the _maximum_
parallelism given by the internal policy window size. Remove the note
stating that waiting thread count is for testing only, as we want to be
able to expose that as well.

Available for both the dynamic and the unlimited implementations, as they
both explicitly track active token counts.
