### PR TITLE
Application version JSON serialization

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1190,7 +1190,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
                                                  request.getUri()).toString());
 
         DeploymentStatus status = controller.jobController().deploymentStatus(application);
-        application.latestVersion().ifPresent(version -> toSlime(version, object.setObject("latestVersion")));
+        application.latestVersion().ifPresent(version -> JobControllerApiHandlerHelper.toSlime(object.setObject("latestVersion"), version));
 
         application.projectId().ifPresent(id -> object.setLong("projectId", id));
 
@@ -1450,7 +1450,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
         change.platform().ifPresent(version -> object.setString("version", version.toString()));
         change.application()
               .filter(version -> !version.isUnknown())
-              .ifPresent(version -> toSlime(version, object.setObject("revision")));
+              .ifPresent(version -> JobControllerApiHandlerHelper.toSlime(object.setObject("revision"), version));
     }
 
     private void toSlime(Endpoint endpoint, Cursor object) {
@@ -2500,7 +2500,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
         object.setLong("id", run.id().number());
         object.setString("version", run.versions().targetPlatform().toFullString());
         if ( ! run.versions().targetApplication().isUnknown())
-            toSlime(run.versions().targetApplication(), object.setObject("revision"));
+            JobControllerApiHandlerHelper.toSlime(object.setObject("revision"), run.versions().targetApplication());
         object.setString("reason", "unknown reason");
         object.setLong("at", run.end().orElse(run.start()).toEpochMilli());
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1314,7 +1314,6 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
                                                  request.getUri()).toString());
 
         application.latestVersion().ifPresent(version -> {
-            sourceRevisionToSlime(version.source(), object.setObject("source"));
             version.sourceUrl().ifPresent(url -> object.setString("sourceUrl", url));
             version.commit().ifPresent(commit -> object.setString("commit", commit));
         });
@@ -1503,7 +1502,6 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
                   .ifPresent(deploymentTimeToLive -> response.setLong("expiryTimeEpochMs", lastDeploymentStart.plus(deploymentTimeToLive).toEpochMilli()));
 
         application.projectId().ifPresent(i -> response.setString("screwdriverId", String.valueOf(i)));
-        sourceRevisionToSlime(deployment.applicationVersion().source(), response);
 
         var instance = application.instances().get(deploymentId.applicationId().instance());
         if (instance != null) {
@@ -1562,23 +1560,6 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
     private Instant lastDeploymentStart(ApplicationId instanceId, Deployment deployment) {
         return controller.jobController().jobStarts(new JobId(instanceId, JobType.from(controller.system(), deployment.zone()).get()))
                          .stream().findFirst().orElse(deployment.at());
-    }
-
-    private void toSlime(ApplicationVersion applicationVersion, Cursor object) {
-        if ( ! applicationVersion.isUnknown()) {
-            object.setLong("buildNumber", applicationVersion.buildNumber().getAsLong());
-            object.setString("hash", applicationVersion.id());
-            sourceRevisionToSlime(applicationVersion.source(), object.setObject("source"));
-            applicationVersion.sourceUrl().ifPresent(url -> object.setString("sourceUrl", url));
-            applicationVersion.commit().ifPresent(commit -> object.setString("commit", commit));
-        }
-    }
-
-    private void sourceRevisionToSlime(Optional<SourceRevision> revision, Cursor object) {
-        if (revision.isEmpty()) return;
-        object.setString("gitRepository", revision.get().repository());
-        object.setString("gitBranch", revision.get().branch());
-        object.setString("gitCommit", revision.get().commit());
     }
 
     private void toSlime(RotationState state, Cursor object) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -1516,7 +1516,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
                         .map(type -> new JobId(instance.id(), type))
                         .map(status.jobSteps()::get)
                         .ifPresent(stepStatus -> {
-                            JobControllerApiHandlerHelper.applicationVersionToSlime(
+                            JobControllerApiHandlerHelper.toSlime(
                                     response.setObject("applicationVersion"), deployment.applicationVersion());
                             if (!status.jobsToRun().containsKey(stepStatus.job().get()))
                                 response.setString("status", "complete");

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -100,22 +100,6 @@ class JobControllerApiHandlerHelper {
         return new SlimeJsonResponse(slime);
     }
 
-    static void applicationVersionToSlime(Cursor versionObject, ApplicationVersion version) {
-        versionObject.setString("hash", version.id());
-        if (version.isUnknown())
-            return;
-
-        versionObject.setLong("build", version.buildNumber().getAsLong());
-        Cursor sourceObject = versionObject.setObject("source");
-        version.source().ifPresent(source -> {
-            sourceObject.setString("gitRepository", source.repository());
-            sourceObject.setString("gitBranch", source.branch());
-            sourceObject.setString("gitCommit", source.commit());
-        });
-        version.sourceUrl().ifPresent(url -> versionObject.setString("sourceUrl", url));
-        version.commit().ifPresent(commit -> versionObject.setString("commit", commit));
-    }
-
     /**
      * @return Response with logs from a single run
      */
@@ -351,12 +335,12 @@ class JobControllerApiHandlerHelper {
         }
 
         Cursor buildsArray = responseObject.setArray("builds");
-        application.versions().stream().sorted(reverseOrder()).forEach(version -> applicationVersionToSlime(buildsArray.addObject(), version));
+        application.versions().stream().sorted(reverseOrder()).forEach(version -> toSlime(buildsArray.addObject(), version));
 
         return new SlimeJsonResponse(slime);
     }
 
-    private static void toSlime(Cursor versionObject, ApplicationVersion version) {
+    static void toSlime(Cursor versionObject, ApplicationVersion version) {
         version.buildNumber().ifPresent(id -> versionObject.setLong("build", id));
         version.compileVersion().ifPresent(platform -> versionObject.setString("compileVersion", platform.toFullString()));
         version.sourceUrl().ifPresent(url -> versionObject.setString("sourceUrl", url));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/complete-application.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/complete-application.json
@@ -6,12 +6,7 @@
   "validationOverrides": "<validation-overrides>\n    <allow until=\"2016-04-28\" comment=\"Renaming content cluster\">content-cluster-removal</allow>\n    <allow until=\"2016-08-22\" comment=\"Migrating us-east-3 to C-2E\">cluster-size-reduction</allow>\n    <allow until=\"2017-06-30\" comment=\"Test Vespa upgrade tests\">force-automatic-tenant-upgrade-test</allow>\n</validation-overrides>\n",
   "projectId": 102889,
   "deployingField": {
-    "buildNumber": 42,
-    "sourceRevision": {
-      "repositoryField": "git@git.host:user/repo.git",
-      "branchField": "origin/master",
-      "commitField": "234f3e4e77049d0b9538c9e1b356d17eb1dedb6a"
-    }
+    "build": 42
   },
   "outstandingChangeField": false,
   "queryQuality": 100,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2-with-patches.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2-with-patches.json
@@ -3,13 +3,8 @@
   "application": "application2",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant2/application/application2/job/",
   "latestVersion": {
-    "buildNumber": 1,
-    "hash": "1.0.1-commit1",
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "build": 1,
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },
@@ -24,13 +19,8 @@
       "instance": "instance1",
       "deploying": {
         "revision": {
-          "buildNumber": 1,
-          "hash": "1.0.1-commit1",
-          "source": {
-            "gitRepository": "repository1",
-            "gitBranch": "master",
-            "gitCommit": "commit1"
-          },
+          "build": 1,
+          "compileVersion": "6.1.0",
           "sourceUrl": "repository1/tree/commit1",
           "commit": "commit1"
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2.json
@@ -3,13 +3,8 @@
   "application": "application2",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant2/application/application2/job/",
   "latestVersion": {
-    "buildNumber": 1,
-    "hash": "1.0.1-commit1",
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "build": 1,
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },
@@ -23,13 +18,8 @@
       "instance": "instance1",
       "deploying": {
         "revision": {
-          "buildNumber": 1,
-          "hash": "1.0.1-commit1",
-          "source": {
-            "gitRepository": "repository1",
-            "gitBranch": "master",
-            "gitCommit": "commit1"
-          },
+          "build": 1,
+          "compileVersion": "6.1.0",
           "sourceUrl": "repository1/tree/commit1",
           "commit": "commit1"
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-cloud.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-cloud.json
@@ -21,9 +21,6 @@
   "revision": "1.0.1-commit1",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "1000",
-  "gitRepository": "repository1",
-  "gitBranch": "master",
-  "gitCommit": "commit1",
   "applicationVersion": {
     "build": 1,
     "compileVersion": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-cloud.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-cloud.json
@@ -25,13 +25,8 @@
   "gitBranch": "master",
   "gitCommit": "commit1",
   "applicationVersion": {
-    "hash": "1.0.1-commit1",
     "build": 1,
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
@@ -1226,35 +1226,20 @@
   ],
   "builds": [
     {
-      "hash": "1.0.3-commit1",
       "build": 3,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     },
     {
-      "hash": "1.0.2-commit1",
       "build": 2,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     },
     {
-      "hash": "1.0.1-commit1",
       "build": 1,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
@@ -633,46 +633,26 @@
   ],
   "builds": [
     {
-      "hash": "1.0.4-commit1",
       "build": 4,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     },
     {
-      "hash": "1.0.3-commit1",
       "build": 3,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     },
     {
-      "hash": "1.0.2-commit1",
       "build": 2,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     },
     {
-      "hash": "1.0.1-commit1",
       "build": 1,
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
@@ -21,9 +21,6 @@
   "revision": "1.0.1-commit1",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "1000",
-  "gitRepository": "repository1",
-  "gitBranch": "master",
-  "gitCommit": "commit1",
   "applicationVersion": {
     "build": 1,
     "compileVersion": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-with-routing-policy.json
@@ -25,13 +25,8 @@
   "gitBranch": "master",
   "gitCommit": "commit1",
   "applicationVersion": {
-    "hash": "1.0.1-commit1",
     "build": 1,
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
@@ -21,9 +21,6 @@
   "revision": "1.0.1-commit1",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "1000",
-  "gitRepository": "repository1",
-  "gitBranch": "master",
-  "gitCommit": "commit1",
   "applicationVersion": {
     "build": 1,
     "compileVersion": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-without-shared-endpoints.json
@@ -25,13 +25,8 @@
   "gitBranch": "master",
   "gitCommit": "commit1",
   "applicationVersion": {
-    "hash": "1.0.1-commit1",
     "build": 1,
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -50,13 +50,8 @@
     }
   ],
   "applicationVersion": {
-    "hash": "1.0.1-commit1",
     "build": 1,
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment.json
@@ -37,9 +37,6 @@
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "123",
-  "gitRepository": "repository1",
-  "gitBranch": "master",
-  "gitCommit": "commit1",
   "endpointStatus": [
     {
       "endpointId": "default",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-with-routing-policy.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance-with-routing-policy.json
@@ -3,11 +3,6 @@
   "application": "application1",
   "instance": "instance1",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/",
-  "source": {
-    "gitRepository": "repository1",
-    "gitBranch": "master",
-    "gitCommit": "commit1"
-  },
   "sourceUrl": "repository1/tree/commit1",
   "commit": "commit1",
   "projectId": 1000,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance.json
@@ -3,11 +3,6 @@
   "application": "application1",
   "instance": "instance1",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/",
-  "source": {
-    "gitRepository": "repository1",
-    "gitBranch": "master",
-    "gitCommit": "commit1"
-  },
   "sourceUrl": "repository1/tree/commit1",
   "commit": "commit1",
   "projectId": 123,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance.json
@@ -8,13 +8,8 @@
   "projectId": 123,
   "deploying": {
     "revision": {
-      "buildNumber": 1,
-      "hash": "1.0.1-commit1",
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "build": 1,
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance1-recursive.json
@@ -3,11 +3,6 @@
   "application": "application1",
   "instance": "instance1",
   "deployments": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/",
-  "source": {
-    "gitRepository": "repository1",
-    "gitBranch": "master",
-    "gitCommit": "commit1"
-  },
   "sourceUrl": "repository1/tree/commit1",
   "commit": "commit1",
   "projectId": 123,

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance1-recursive.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/instance1-recursive.json
@@ -8,13 +8,8 @@
   "projectId": 123,
   "deploying": {
     "revision": {
-      "buildNumber": 1,
-      "hash": "1.0.1-commit1",
-      "source": {
-        "gitRepository": "repository1",
-        "gitBranch": "master",
-        "gitCommit": "commit1"
-      },
+      "build": 1,
+      "compileVersion": "6.1.0",
       "sourceUrl": "repository1/tree/commit1",
       "commit": "commit1"
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -53,13 +53,8 @@
     }
   ],
   "applicationVersion": {
-    "hash": "1.0.1-commit1",
     "build": 1,
-    "source": {
-      "gitRepository": "repository1",
-      "gitBranch": "master",
-      "gitCommit": "commit1"
-    },
+    "compileVersion": "6.1.0",
     "sourceUrl": "repository1/tree/commit1",
     "commit": "commit1"
   },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/prod-us-central-1.json
@@ -40,9 +40,6 @@
   "revision": "(ignore)",
   "deployTimeEpochMs": "(ignore)",
   "screwdriverId": "123",
-  "gitRepository": "repository1",
-  "gitBranch": "master",
-  "gitCommit": "commit1",
   "endpointStatus": [
     {
       "endpointId": "default",


### PR DESCRIPTION
Wanted to expose `compileVersion` in `builds`, but then I saw that we have 3 ways of serializing `ApplicationVersion`. This PR changes it to 1 way. 

My understand is that we want to get rid of `SourceRevision` in favor of `sourceUrl`, with this PR the only users of `ApplicationVersion::source` are tests and ZK serialization code.

I've verified that `source` object, `hash` and `buildNumber` are not used anywhere except in 1 internal documentation page, which I'll update.