### PR TITLE
In order to properly detach supervisor from the transport, do an asyn…

### DIFF
--- a/fnet/src/vespa/fnet/frt/supervisor.cpp
+++ b/fnet/src/vespa/fnet/frt/supervisor.cpp
@@ -27,8 +27,9 @@ FRT_Supervisor::FRT_Supervisor(FNET_Transport *transport)
 FRT_Supervisor::~FRT_Supervisor()
 {
     if (_connector != nullptr) {
-        _connector->SubRef();
+        _connector->Owner()->Close(_connector, /* needref */ false);
     }
+    _transport->sync();
 }
 
 FNET_Scheduler *

--- a/fnet/src/vespa/fnet/transport_thread.cpp
+++ b/fnet/src/vespa/fnet/transport_thread.cpp
@@ -302,8 +302,7 @@ FNET_TransportThread::Add(FNET_IOComponent *comp, bool needRef)
     if (needRef) {
         comp->AddRef();
     }
-    PostEvent(&FNET_ControlPacket::IOCAdd,
-              FNET_Context(comp));
+    PostEvent(&FNET_ControlPacket::IOCAdd, FNET_Context(comp));
 }
 
 
@@ -313,8 +312,7 @@ FNET_TransportThread::EnableWrite(FNET_IOComponent *comp, bool needRef)
     if (needRef) {
         comp->AddRef();
     }
-    PostEvent(&FNET_ControlPacket::IOCEnableWrite,
-              FNET_Context(comp));
+    PostEvent(&FNET_ControlPacket::IOCEnableWrite, FNET_Context(comp));
 }
 
 void
@@ -323,8 +321,7 @@ FNET_TransportThread::handshake_act(FNET_IOComponent *comp, bool needRef)
     if (needRef) {
         comp->AddRef();
     }
-    PostEvent(&FNET_ControlPacket::IOCHandshakeACT,
-              FNET_Context(comp));
+    PostEvent(&FNET_ControlPacket::IOCHandshakeACT, FNET_Context(comp));
 }
 
 void
@@ -333,8 +330,7 @@ FNET_TransportThread::Close(FNET_IOComponent *comp, bool needRef)
     if (needRef) {
         comp->AddRef();
     }
-    PostEvent(&FNET_ControlPacket::IOCClose,
-              FNET_Context(comp));
+    PostEvent(&FNET_ControlPacket::IOCClose, FNET_Context(comp));
 }
 
 


### PR DESCRIPTION
…c close and proper sync of trasnport threads.

@havardpe PR
Must go in after #21350 