### PR TITLE
Give content nodes more headroom when deriving resource limit for disk.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterResourceLimits.java
@@ -91,8 +91,8 @@ public class ClusterResourceLimits {
             deriveClusterControllerLimit(ctrlBuilder.getDiskLimit(), nodeBuilder.getDiskLimit(), ctrlBuilder::setDiskLimit);
             deriveClusterControllerLimit(ctrlBuilder.getMemoryLimit(), nodeBuilder.getMemoryLimit(), ctrlBuilder::setMemoryLimit);
 
-            deriveContentNodeLimit(nodeBuilder.getDiskLimit(), ctrlBuilder.getDiskLimit(), nodeBuilder::setDiskLimit);
-            deriveContentNodeLimit(nodeBuilder.getMemoryLimit(), ctrlBuilder.getMemoryLimit(), nodeBuilder::setMemoryLimit);
+            deriveContentNodeLimit(nodeBuilder.getDiskLimit(), ctrlBuilder.getDiskLimit(), 0.6, nodeBuilder::setDiskLimit);
+            deriveContentNodeLimit(nodeBuilder.getMemoryLimit(), ctrlBuilder.getMemoryLimit(), 0.5, nodeBuilder::setMemoryLimit);
         }
 
         private void considerSettingDefaultClusterControllerLimit(Optional<Double> clusterControllerLimit,
@@ -117,15 +117,16 @@ public class ClusterResourceLimits {
 
         private void deriveContentNodeLimit(Optional<Double> contentNodeLimit,
                                             Optional<Double> clusterControllerLimit,
+                                            double scaleFactor,
                                             Consumer<Double> setter) {
             if (contentNodeLimit.isEmpty()) {
                 clusterControllerLimit.ifPresent(limit ->
-                        setter.accept(calcContentNodeLimit(limit)));
+                        setter.accept(calcContentNodeLimit(limit, scaleFactor)));
             }
         }
 
-        private double calcContentNodeLimit(double clusterControllerLimit) {
-            return clusterControllerLimit + ((1.0 - clusterControllerLimit) / 2);
+        private double calcContentNodeLimit(double clusterControllerLimit, double scaleFactor) {
+            return clusterControllerLimit + ((1.0 - clusterControllerLimit) * scaleFactor);
         }
 
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ClusterResourceLimitsTest.java
@@ -62,11 +62,11 @@ public class ClusterResourceLimitsTest {
 
     @Test
     public void content_node_limits_are_derived_from_cluster_controller_limits_if_not_set() {
-        assertLimits(0.4, 0.7, 0.7, 0.85,
+        assertLimits(0.4, 0.7, 0.76, 0.85,
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7));
-        assertLimits(0.4, 0.8, 0.7, 0.9,
+        assertLimits(0.4, 0.8, 0.76, 0.9,
                 new Fixture().ctrlDisk(0.4));
-        assertLimits(0.75, 0.7, 0.875, 0.85,
+        assertLimits(0.75, 0.7, 0.9, 0.85,
                 new Fixture().ctrlMemory(0.7));
     }
 
@@ -76,7 +76,7 @@ public class ClusterResourceLimitsTest {
                 new Fixture().ctrlDisk(0.4).ctrlMemory(0.7).nodeDisk(0.9).nodeMemory(0.95));
         assertLimits(0.4, 0.8, 0.95, 0.9,
                 new Fixture().ctrlDisk(0.4).nodeDisk(0.95));
-        assertLimits(0.75, 0.7, 0.875, 0.95,
+        assertLimits(0.75, 0.7, 0.9, 0.95,
                 new Fixture().ctrlMemory(0.7).nodeMemory(0.95));
     }
 
@@ -86,15 +86,15 @@ public class ClusterResourceLimitsTest {
                 new Fixture().nodeDisk(0.9).nodeMemory(0.95));
         assertLimits(0.89, 0.8, 0.9, 0.9,
                 new Fixture().nodeDisk(0.9));
-        assertLimits(0.75, 0.94, 0.875, 0.95,
+        assertLimits(0.75, 0.94, 0.9, 0.95,
                 new Fixture().nodeMemory(0.95));
-        assertLimits(0.75, 0.0, 0.875, 0.005,
+        assertLimits(0.75, 0.0, 0.9, 0.005,
                 new Fixture().nodeMemory(0.005));
     }
 
     @Test
     public void limits_are_derived_from_the_other_if_not_set() {
-        assertLimits(0.6, 0.94, 0.8, 0.95,
+        assertLimits(0.6, 0.94, 0.84, 0.95,
                 new Fixture().ctrlDisk(0.6).nodeMemory(0.95));
         assertLimits(0.89, 0.7, 0.9, 0.85,
                 new Fixture().ctrlMemory(0.7).nodeDisk(0.9));
@@ -102,7 +102,7 @@ public class ClusterResourceLimitsTest {
 
     @Test
     public void default_resource_limits_when_feed_block_is_enabled_in_distributor() {
-        assertLimits(0.75, 0.8, 0.875, 0.9,
+        assertLimits(0.75, 0.8, 0.9, 0.9,
                 new Fixture(true));
     }
 
@@ -125,7 +125,7 @@ public class ClusterResourceLimitsTest {
 
         // Verify that limits from feature flags are used
         assertLimits(0.85, 0.90, limits.getClusterControllerLimits());
-        assertLimits(0.925, 0.95, limits.getContentNodeLimits());
+        assertLimits(0.94, 0.95, limits.getContentNodeLimits());
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentSchemaClusterTest.java
@@ -118,7 +118,7 @@ public class ContentSchemaClusterTest {
 
     @Test
     public void requireThatOnlyMemoryLimitCanBeSet() throws Exception {
-        assertProtonResourceLimits(0.875, 0.77,
+        assertProtonResourceLimits(0.9, 0.77,
                 new ContentClusterBuilder().protonMemoryLimit(0.77).getXml());
     }
 
@@ -131,14 +131,14 @@ public class ContentSchemaClusterTest {
     @Test
     public void resource_limits_are_derived_from_the_other_if_not_specified() throws Exception {
         var cluster = createCluster(new ContentClusterBuilder().clusterControllerDiskLimit(0.5).protonMemoryLimit(0.95).getXml());
-        assertProtonResourceLimits(0.75, 0.95, cluster);
+        assertProtonResourceLimits(0.8, 0.95, cluster);
         assertClusterControllerResourceLimits(0.5, 0.94, cluster);
     }
 
     @Test
     public void default_resource_limits_with_feed_block_in_distributor() throws Exception {
         var cluster = createCluster(new ContentClusterBuilder().getXml());
-        assertProtonResourceLimits(0.875, 0.9, cluster);
+        assertProtonResourceLimits(0.9, 0.9, cluster);
         assertClusterControllerResourceLimits(0.75, 0.8, cluster);
     }
 


### PR DESCRIPTION
This ensures content nodes can handle larger spikes in transient disk usage during disk index fusion.
This is a follow up from https://github.com/vespa-engine/vespa/pull/21179.

@baldersheim please review