### PR TITLE
Make it possible to configure what aspects of merges should be throttled [run-systemtest]

### DIFF
--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -88,6 +88,11 @@ async_operation_throttler.window_size_backoff double default=0.95
 async_operation_throttler.min_window_size int default=20
 async_operation_throttler.max_window_size int default=-1 # < 0 implies INT_MAX
 async_operation_throttler.resize_rate double default=3.0
+## If true, each put/remove contained within a merge is individually throttled as if it
+## were a put/remove from a client. If false, merges are throttled at a persistence thread
+## level, i.e. per ApplyBucketDiff message, regardless of how many document operations
+## are contained within.
+async_operation_throttler.throttle_individual_merge_feed_ops bool default=true
 
 ## Specify throttling used for async persistence operations. This throttling takes place
 ## before operations are dispatched to Proton and serves as a limiter for how many

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -275,6 +275,8 @@ public:
     virtual ActiveOperationsStats get_active_operations_stats(bool reset_min_max) const = 0;
 
     virtual vespalib::SharedOperationThrottler& operation_throttler() const noexcept = 0;
+
+    virtual void set_throttle_apply_bucket_diff_ops(bool throttle_apply_bucket_diff) noexcept = 0;
 };
 
 } // storage

--- a/storage/src/vespa/storage/persistence/mergehandler.h
+++ b/storage/src/vespa/storage/persistence/mergehandler.h
@@ -81,6 +81,15 @@ public:
     void handleApplyBucketDiffReply(api::ApplyBucketDiffReply&, MessageSender&, MessageTrackerUP) const;
     void drain_async_writes();
 
+    // Thread safe, as it's set during live reconfig from the main filestor manager.
+    void set_throttle_merge_feed_ops(bool throttle) noexcept {
+        _throttle_merge_feed_ops.store(throttle, std::memory_order_relaxed);
+    }
+
+    [[nodiscard]] bool throttle_merge_feed_ops() const noexcept {
+        return _throttle_merge_feed_ops.load(std::memory_order_relaxed);
+    }
+
 private:
     using DocEntryList = std::vector<std::unique_ptr<spi::DocEntry>>;
     const framework::Clock   &_clock;
@@ -92,6 +101,7 @@ private:
     const uint32_t            _maxChunkSize;
     const uint32_t            _commonMergeChainOptimalizationMinimumSize;
     vespalib::ISequencedTaskExecutor& _executor;
+    std::atomic<bool>         _throttle_merge_feed_ops;
 
     MessageTrackerUP handleGetBucketDiffStage2(api::GetBucketDiffCommand&, MessageTrackerUP) const;
     /** Returns a reply if merge is complete */

--- a/storage/src/vespa/storage/persistence/persistencehandler.cpp
+++ b/storage/src/vespa/storage/persistence/persistencehandler.cpp
@@ -181,4 +181,10 @@ PersistenceHandler::processLockedMessage(FileStorHandler::LockedMessage lock) co
     }
 }
 
+void
+PersistenceHandler::set_throttle_merge_feed_ops(bool throttle) noexcept
+{
+    _mergeHandler.set_throttle_merge_feed_ops(throttle);
+}
+
 }

--- a/storage/src/vespa/storage/persistence/persistencehandler.h
+++ b/storage/src/vespa/storage/persistence/persistencehandler.h
@@ -35,6 +35,8 @@ public:
     const AsyncHandler & asyncHandler() const { return _asyncHandler; }
     const SplitJoinHandler & splitjoinHandler() const { return _splitJoinHandler; }
     const SimpleMessageHandler & simpleMessageHandler() const { return _simpleHandler; }
+
+    void set_throttle_merge_feed_ops(bool throttle) noexcept;
 private:
     // Message handling functions
     MessageTracker::UP handleCommandSplitByType(api::StorageCommand&, MessageTracker::UP tracker) const;


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Add live config for choosing whether merges should be throttled
on a per-feed operation (`MergeHandler`) level, or on an `ApplyBucketDiff`
persistence thread level.

This is intended to be a temporary feature while we do experiments, so
some liberties are taken with regards to how holes are punched in the
various abstraction layers.
