### PR TITLE
Eliminate gcc compiler warnings when using old version of gtest (< 1.11)

### DIFF
--- a/vespalib/src/tests/btree/btree-stress/btree_stress_test.cpp
+++ b/vespalib/src/tests/btree/btree-stress/btree_stress_test.cpp
@@ -359,6 +359,12 @@ using TestTypes = testing::Types<DirectKeyValueParams, IndirectKeyValueParams>;
 
 VESPA_GTEST_TYPED_TEST_SUITE(BTreeStressTest, TestTypes);
 
+// Disable warnings emitted by gtest generated files when using typed tests
+#pragma GCC diagnostic push
+#ifndef __clang__
+#pragma GCC diagnostic ignored "-Wsuggest-override"
+#endif
+
 TYPED_TEST(BTreeStressTest, basic_lower_bound)
 {
     this->basic_lower_bound();
@@ -378,5 +384,7 @@ TYPED_TEST(BTreeStressTest, multiple_lower_bound_readers_during_updates)
 {
     this->multiple_lower_bound_readers_during_updates();
 }
+
+#pragma GCC diagnostic pop
 
 GTEST_MAIN_RUN_ALL_TESTS()


### PR DESCRIPTION
@baldersheim : please review
