### PR TITLE
- Use the typesafe vespalib::count_ms() to correcly count ms.

### DIFF
--- a/fnet/src/tests/scheduling/schedule.cpp
+++ b/fnet/src/tests/scheduling/schedule.cpp
@@ -46,7 +46,7 @@ public:
     if (b < a)
       return false;
 
-    if ((b - a) > (3 * FNET_Scheduler::tick_ms.count()))
+    if ((b - a) > (3 * vespalib::count_ms(FNET_Scheduler::tick_ms)))
       return false;
 
     return true;

--- a/fnet/src/vespa/fnet/scheduler.cpp
+++ b/fnet/src/vespa/fnet/scheduler.cpp
@@ -8,6 +8,7 @@
 #include <vespa/log/log.h>
 LOG_SETUP(".fnet.scheduler");
 
+const vespalib::duration FNET_Scheduler::tick_ms = vespalib::from_s(10*1.0/vespalib::getVespaTimerHz());
 
 FNET_Scheduler::FNET_Scheduler(vespalib::steady_time *sampler)
     : _cond(),
@@ -65,7 +66,7 @@ FNET_Scheduler::Schedule(FNET_Task *task, double seconds)
 {
     constexpr double ONE_MONTH_S = 3600 * 24 * 30;
     seconds = std::min(seconds, ONE_MONTH_S);
-    uint32_t ticks = 2 + (uint32_t) std::ceil(seconds * (1000.0 / tick_ms.count()));
+    uint32_t ticks = 2 + (uint32_t) std::ceil(seconds * (1000.0 / vespalib::count_ms(tick_ms)));
 
     std::lock_guard<std::mutex> guard(_lock);
     if (!task->_killed) {

--- a/fnet/src/vespa/fnet/scheduler.h
+++ b/fnet/src/vespa/fnet/scheduler.h
@@ -20,7 +20,7 @@ class FNET_Scheduler
 {
 public:
     using clock = vespalib::steady_clock;
-    static constexpr auto tick_ms = 10ms;
+    static const vespalib::duration tick_ms;
 
     enum scheduler_constants {
         NUM_SLOTS   = 4096,


### PR DESCRIPTION
- Choose tick based on VESPA_TIMER_HZ/10. VESPA_TIMER_HZ has a default of 1000hz.

@havardpe PR