### PR TITLE
Add a application/{app}/prod resource

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -92,6 +92,7 @@ enum PathGroup {
     application(Matcher.tenant,
                 Matcher.application,
                 "/application/v4/tenant/{tenant}/application/{application}",
+                "/application/v4/tenant/{tenant}/application/{application}/prod",
                 "/application/v4/tenant/{tenant}/application/{application}/instance/",
                 "/application/v4/tenant/{tenant}/application/{application}/instance/{ignored}"),
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -410,6 +410,10 @@ public class ApplicationApiTest extends ControllerContainerTest {
                                       .userIdentity(USER_ID),
                               new File("application2-with-patches.json"));
 
+        tester.assertResponse(request("/application/v4/tenant/tenant2/application/application2/prod", GET)
+                        .screwdriverIdentity(SCREWDRIVER_ID),
+                new File("application2-prod.json"));
+
         // PATCH in removal of the application major version override removal
         tester.assertResponse(request("/application/v4/tenant/tenant2/application/application2", PATCH)
                                       .userIdentity(USER_ID)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2-prod.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/application2-prod.json
@@ -1,0 +1,47 @@
+{
+  "tenant": "tenant2",
+  "application": "application2",
+  "deployments": "http://localhost:8080/application/v4/tenant/tenant2/application/application2/job/",
+  "latestVersion": {
+    "buildNumber": 1,
+    "hash": "1.0.1-commit1",
+    "source": {
+      "gitRepository": "repository1",
+      "gitBranch": "master",
+      "gitCommit": "commit1"
+    },
+    "sourceUrl": "repository1/tree/commit1",
+    "commit": "commit1"
+  },
+  "projectId": 1000,
+  "majorVersion": 7,
+  "pemDeployKeys": [
+    "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuKVFA8dXk43kVfYKzkUqhEY2rDT9\nz/4jKSTHwbYR8wdsOSrJGVEUPbS2nguIJ64OJH7gFnxM6sxUVj+Nm2HlXw==\n-----END PUBLIC KEY-----\n"
+  ],
+  "metrics": {
+    "queryServiceQuality": 0.0,
+    "writeServiceQuality": 0.0
+  },
+  "activity": {},
+  "instances": [
+    {
+      "name": "default",
+      "deployments": []
+    },
+    {
+      "name": "instance1",
+      "deployments": [
+        {
+          "name": "prod.us-west-1",
+          "declared": true,
+          "active": null
+        },
+        {
+          "name": "prod.us-east-3",
+          "declared": true,
+          "active": null
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I sketched out this while thinking about issues with disappearing deployments and instances in our application view in the Console. I think the only way out of this is to always show a union of what is currently deployed/registered in ZooKeeper and what is mentioned in `deployment.xml`.

In this draft PR I created a new `/application/{app}/prod` resource that recursively shows all this information. The structure returned is

```yaml
tenant: name
application: application
instances:
  - name: instance-name
    deployments:
      - name: test
         declared: true
         active: null
     - name: prod.aws-us-east-1c
        declared: true
        active:
          <all deployment stuff here>
```

`declared` means the deployment is mentioned in the latest deployment spec. `active` that is non-null means there is a running deployment that we have information about.

@freva and @jonmv - is this a good approach to make sure we don't accidentally hide information about the system state to the user?
     
