### PR TITLE
Gracefully flush pending Slobrok task on content node RPC teardown [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/storageserver/communicationmanager.cpp
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.cpp
@@ -6,6 +6,7 @@
 #include <vespa/messagebus/emptyreply.h>
 #include <vespa/messagebus/network/rpcnetworkparams.h>
 #include <vespa/messagebus/rpcmessagebus.h>
+#include <vespa/slobrok/sbmirror.h>
 #include <vespa/storage/common/bucket_resolver.h>
 #include <vespa/storage/common/nodestateupdater.h>
 #include <vespa/storage/config/config-stor-server.h>
@@ -804,6 +805,13 @@ void CommunicationManager::updateMessagebusProtocol(const std::shared_ptr<const 
 
 void CommunicationManager::updateBucketSpacesConfig(const BucketspacesConfig& config) {
     _docApiConverter.setBucketResolver(ConfigurableBucketResolver::from_config(config));
+}
+
+bool
+CommunicationManager::address_visible_in_slobrok(const api::StorageMessageAddress& addr) const noexcept
+{
+    assert(_storage_api_rpc_service);
+    return _storage_api_rpc_service->address_visible_in_slobrok_uncached(addr);
 }
 
 } // storage

--- a/storage/src/vespa/storage/storageserver/communicationmanager.h
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.h
@@ -164,6 +164,10 @@ public:
     void updateBucketSpacesConfig(const BucketspacesConfig&);
 
     const CommunicationManagerMetrics& metrics() const noexcept { return _metrics; }
+
+    // Intended primarily for unit tests that fire up multiple nodes and must wait until all
+    // nodes are cross-visible in Slobrok before progressing.
+    [[nodiscard]] bool address_visible_in_slobrok(const api::StorageMessageAddress& addr) const noexcept;
 };
 
 } // storage

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
@@ -110,7 +110,12 @@ void SharedRpcResources::shutdown() {
     assert(!_shutdown);
     if (listen_port() > 0) {
         _slobrok_register->unregisterName(_handle);
+        // Give slobrok some time to dispatch unregister RPC
+        while (_slobrok_register->busy()) {
+            std::this_thread::sleep_for(10ms);
+        }
     }
+    _slobrok_register.reset(); // Implicitly kill any pending slobrok tasks prior to shutting down transport layer
     _transport->ShutDown(true);
     // FIXME need to reset to break weak_ptrs? But ShutDown should already sync pending resolves...!
     _shutdown = true;

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.cpp
@@ -394,6 +394,15 @@ bool StorageApiRpcService::target_supports_direct_rpc(
     return _direct_rpc_supported.load(std::memory_order_relaxed);
 }
 
+bool
+StorageApiRpcService::address_visible_in_slobrok_uncached(
+        const api::StorageMessageAddress& addr) const noexcept
+{
+    auto sb_id = CachingRpcTargetResolver::address_to_slobrok_id(addr);
+    auto specs = _rpc_resources.slobrok_mirror().lookup(sb_id);
+    return !specs.empty();
+}
+
 
 /*
  * Major TODOs:

--- a/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
+++ b/storage/src/vespa/storage/storageserver/rpc/storage_api_rpc_service.h
@@ -56,6 +56,8 @@ public:
     ~StorageApiRpcService() override;
 
     [[nodiscard]] bool target_supports_direct_rpc(const api::StorageMessageAddress& addr) const noexcept;
+    // Bypasses resolver cache and returns whether local Slobrok mirror has at least 1 spec for the given address.
+    [[nodiscard]] bool address_visible_in_slobrok_uncached(const api::StorageMessageAddress& addr) const noexcept;
 
     void RPC_rpc_v1_send(FRT_RPCRequest* req);
     void encode_rpc_v1_response(FRT_RPCRequest& request, api::StorageReply& reply);


### PR DESCRIPTION
@geirst please review

Avoids race between transport connection destruction in one FNET thread
and processing unregistration task in another FNET thread.

