### PR TITLE
Since many services that are invoked regularly are interested in the …

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/executorthreadingservice.cpp
@@ -13,6 +13,7 @@ using vespalib::CpuUsage;
 using vespalib::SequencedTaskExecutor;
 using vespalib::SingleExecutor;
 using vespalib::SyncableThreadExecutor;
+using vespalib::steady_time;
 using OptimizeFor = vespalib::Executor::OptimizeFor;
 using SharedFieldWriterExecutor = proton::ThreadingServiceConfig::SharedFieldWriterExecutor;
 
@@ -72,8 +73,8 @@ ExecutorThreadingService::ExecutorThreadingService(vespalib::Executor & sharedEx
       _invokeRegistrations()
 {
     if (cfg.optimize() == vespalib::Executor::OptimizeFor::THROUGHPUT && invokerService) {
-        _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_indexExecutor.get()](){ executor->wakeup();}));
-        _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_summaryExecutor.get()](){ executor->wakeup();}));
+        _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_indexExecutor.get()](steady_time){ executor->wakeup();}));
+        _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_summaryExecutor.get()](steady_time){ executor->wakeup();}));
     }
     if (_shared_field_writer == SharedFieldWriterExecutor::INDEX) {
         _field_writer = SequencedTaskExecutor::create(CpuUsage::wrap(field_writer_executor, CpuUsage::Category::WRITE),
@@ -82,7 +83,7 @@ ExecutorThreadingService::ExecutorThreadingService(vespalib::Executor & sharedEx
                                                               cfg.indexingThreads(), cfg.defaultTaskLimit(),
                                                               cfg.is_task_limit_hard(), cfg.optimize(), cfg.kindOfwatermark());
         if (cfg.optimize() == vespalib::Executor::OptimizeFor::THROUGHPUT && invokerService) {
-            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_attributeFieldWriter.get()](){ executor->wakeup();}));
+            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_attributeFieldWriter.get()](steady_time){ executor->wakeup();}));
         }
         _index_field_inverter_ptr = _field_writer.get();
         _index_field_writer_ptr = _field_writer.get();
@@ -93,7 +94,7 @@ ExecutorThreadingService::ExecutorThreadingService(vespalib::Executor & sharedEx
                                                       cfg.indexingThreads() * 3, cfg.defaultTaskLimit(),
                                                       cfg.is_task_limit_hard(), cfg.optimize(), cfg.kindOfwatermark());
         if (cfg.optimize() == vespalib::Executor::OptimizeFor::THROUGHPUT && invokerService) {
-            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_field_writer.get()](){ executor->wakeup();}));
+            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_field_writer.get()](steady_time){ executor->wakeup();}));
         }
         _index_field_inverter_ptr = _field_writer.get();
         _index_field_writer_ptr = _field_writer.get();
@@ -112,7 +113,7 @@ ExecutorThreadingService::ExecutorThreadingService(vespalib::Executor & sharedEx
                                                               cfg.indexingThreads(), cfg.defaultTaskLimit(),
                                                               cfg.is_task_limit_hard(), cfg.optimize(), cfg.kindOfwatermark());
         if (cfg.optimize() == vespalib::Executor::OptimizeFor::THROUGHPUT && invokerService) {
-            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_attributeFieldWriter.get()](){ executor->wakeup();}));
+            _invokeRegistrations.push_back(invokerService->registerInvoke([executor=_attributeFieldWriter.get()](steady_time){ executor->wakeup();}));
         }
         _index_field_inverter_ptr = _indexFieldInverter.get();
         _index_field_writer_ptr = _indexFieldWriter.get();

--- a/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/shared_threading_service.cpp
@@ -3,13 +3,11 @@
 #include "shared_threading_service.h"
 #include <vespa/vespalib/util/blockingthreadstackexecutor.h>
 #include <vespa/vespalib/util/cpu_usage.h>
-#include <vespa/vespalib/util/isequencedtaskexecutor.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
-#include <vespa/fnet/transport.h>
-#include <vespa/fastos/thread.h>
 
 using vespalib::CpuUsage;
+using vespalib::steady_time;
 
 VESPA_THREAD_STACK_TAG(proton_field_writer_executor)
 VESPA_THREAD_STACK_TAG(proton_shared_executor)
@@ -39,7 +37,7 @@ SharedThreadingService::SharedThreadingService(const SharedThreadingServiceConfi
                                                                 fw_cfg.optimize(),
                                                                 fw_cfg.kindOfwatermark());
         if (fw_cfg.optimize() == vespalib::Executor::OptimizeFor::THROUGHPUT) {
-            _invokeRegistrations.push_back(_invokeService.registerInvoke([executor = _field_writer.get()]() {
+            _invokeRegistrations.push_back(_invokeService.registerInvoke([executor = _field_writer.get()](steady_time) {
                 executor->wakeup();
             }));
         }

--- a/staging_vespalib/src/vespa/vespalib/util/clock.cpp
+++ b/staging_vespalib/src/vespa/vespalib/util/clock.cpp
@@ -15,16 +15,22 @@ Clock::Clock() :
 
 Clock::~Clock() = default;
 
-void Clock::setTime() const
+void
+Clock::setTime() const
 {
-    _timeNS.store(count_ns(steady_clock::now().time_since_epoch()), std::memory_order_relaxed);
+    setTime(steady_clock::now());
+}
+void
+Clock::setTime(steady_time now) const
+{
+    _timeNS.store(count_ns(now.time_since_epoch()), std::memory_order_relaxed);
 }
 
 void
 Clock::start(InvokeService & invoker)
 {
     _running.store(true, std::memory_order_relaxed);
-    _invokeRegistration = invoker.registerInvoke([this]() { setTime(); });
+    _invokeRegistration = invoker.registerInvoke([this](steady_time now) { setTime(now); });
 }
 
 void

--- a/staging_vespalib/src/vespa/vespalib/util/clock.h
+++ b/staging_vespalib/src/vespa/vespalib/util/clock.h
@@ -24,6 +24,7 @@ private:
     std::unique_ptr<IDestructorCallback>      _invokeRegistration;
 
     void setTime() const;
+    VESPA_DLL_LOCAL void setTime(steady_time now) const;
 public:
     Clock();
     ~Clock();

--- a/vespalib/src/vespa/vespalib/util/invokeservice.h
+++ b/vespalib/src/vespa/vespalib/util/invokeservice.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "idestructorcallback.h"
+#include "time.h"
 #include <functional>
 
 namespace vespalib {
@@ -13,8 +14,9 @@ namespace vespalib {
  **/
 class InvokeService {
 public:
+    using InvokeFunc = std::function<void(steady_time)>;
     virtual ~InvokeService() = default;
-    virtual std::unique_ptr<IDestructorCallback> registerInvoke(std::function<void()> func) = 0;
+    virtual std::unique_ptr<IDestructorCallback> registerInvoke(InvokeFunc func) = 0;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/util/invokeserviceimpl.h
+++ b/vespalib/src/vespa/vespalib/util/invokeserviceimpl.h
@@ -14,14 +14,14 @@ namespace vespalib {
  * An invoke service what will invoke the given function with at specified frequency.
  */
 class InvokeServiceImpl : public InvokeService {
-    using VoidFunc = std::function<void()>;
 public:
     InvokeServiceImpl(duration napTime);
     InvokeServiceImpl(const InvokeServiceImpl &) = delete;
     InvokeServiceImpl & operator=(const InvokeServiceImpl &) = delete;
     ~InvokeServiceImpl() override;
-    std::unique_ptr<IDestructorCallback> registerInvoke(VoidFunc func) override;
+    std::unique_ptr<IDestructorCallback> registerInvoke(InvokeFunc func) override;
 private:
+    using IdAndFunc = std::pair<uint64_t, InvokeFunc>;
     class Registration;
     void unregister(uint64_t id);
     void runLoop();
@@ -29,7 +29,7 @@ private:
     std::mutex                     _lock;
     uint64_t                       _currId;
     bool                           _closed;
-    std::vector<std::pair<uint64_t, VoidFunc>> _toInvoke;
+    std::vector<IdAndFunc>         _toInvoke;
     std::unique_ptr<std::thread>   _thread;
 };
 


### PR DESCRIPTION
…time we can provide the steady time at no cost.

All invokcations will be done with the same time.
In addition the ticking will happen at regular intervals as long as the invocations are shorter than the invoke interval.
Currently this saves the clock sampling in vespalib::Clock::setTime, as we now use std::thread::sleep_until() instead of sleep_for() and make an explicit sample in the loop.

@havardpe PR