### PR TITLE
Make reconfiguring dynamic vs unlimited throttling not require restarting [run-systemtest]

### DIFF
--- a/configdefinitions/src/vespa/stor-filestor.def
+++ b/configdefinitions/src/vespa/stor-filestor.def
@@ -80,7 +80,7 @@ resource_usage_reporter_noise_level double default=0.001
 ##  - DYNAMIC uses DynamicThrottlePolicy under the hood and will block if the window
 ##    is full (if a blocking throttler API call is invoked).
 ##
-async_operation_throttler.type enum { UNLIMITED, DYNAMIC } default=UNLIMITED restart
+async_operation_throttler.type enum { UNLIMITED, DYNAMIC } default=UNLIMITED
 ## Internal throttler tuning parameters that only apply when type == DYNAMIC:
 async_operation_throttler.window_size_increment int default=20
 async_operation_throttler.window_size_decrement_factor double default=1.2
@@ -104,7 +104,7 @@ async_operation_throttler.throttle_individual_merge_feed_ops bool default=true
 ##    is full (if a blocking throttler API call is invoked).
 ##
 ## TODO deprecate in favor of the async_operation_throttler struct instead.
-async_operation_throttler_type enum { UNLIMITED, DYNAMIC } default=UNLIMITED restart
+async_operation_throttler_type enum { UNLIMITED, DYNAMIC } default=UNLIMITED
 
 ## Specifies the extent the throttling window is increased by when the async throttle
 ## policy has decided that more concurrent operations are desirable. Also affects the

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandler.h
@@ -276,6 +276,10 @@ public:
 
     virtual vespalib::SharedOperationThrottler& operation_throttler() const noexcept = 0;
 
+    virtual void reconfigure_dynamic_throttler(const vespalib::SharedOperationThrottler::DynamicThrottleParams& params) = 0;
+
+    virtual void use_dynamic_operation_throttling(bool use_dynamic) noexcept = 0;
+
     virtual void set_throttle_apply_bucket_diff_ops(bool throttle_apply_bucket_diff) noexcept = 0;
 };
 

--- a/storage/src/vespa/storage/persistence/mergehandler.cpp
+++ b/storage/src/vespa/storage/persistence/mergehandler.cpp
@@ -32,7 +32,6 @@ MergeHandler::MergeHandler(PersistenceUtil& env, spi::PersistenceProvider& spi,
       _cluster_context(cluster_context),
       _env(env),
       _spi(spi),
-      _operation_throttler(_env._fileStorHandler.operation_throttler()),
       _monitored_ref_count(std::make_unique<MonitoredRefCount>()),
       _maxChunkSize(maxChunkSize),
       _commonMergeChainOptimalizationMinimumSize(commonMergeChainOptimalizationMinimumSize),
@@ -515,7 +514,7 @@ MergeHandler::applyDiffEntry(std::shared_ptr<ApplyBucketDiffState> async_results
                              spi::Context& context,
                              const document::DocumentTypeRepo& repo) const
 {
-    auto throttle_token = throttle_merge_feed_ops() ? _operation_throttler.blocking_acquire_one()
+    auto throttle_token = throttle_merge_feed_ops() ? _env._fileStorHandler.operation_throttler().blocking_acquire_one()
                                                     : vespalib::SharedOperationThrottler::Token();
     spi::Timestamp timestamp(e._entry._timestamp);
     if (!(e._entry._flags & (DELETED | DELETED_IN_PLACE))) {

--- a/storage/src/vespa/storage/persistence/mergehandler.h
+++ b/storage/src/vespa/storage/persistence/mergehandler.h
@@ -24,7 +24,6 @@
 
 namespace vespalib {
 class ISequencedTaskExecutor;
-class SharedOperationThrottler;
 }
 
 namespace storage {
@@ -96,7 +95,6 @@ private:
     const ClusterContext &_cluster_context;
     PersistenceUtil          &_env;
     spi::PersistenceProvider &_spi;
-    vespalib::SharedOperationThrottler& _operation_throttler;
     std::unique_ptr<vespalib::MonitoredRefCount> _monitored_ref_count;
     const uint32_t            _maxChunkSize;
     const uint32_t            _commonMergeChainOptimalizationMinimumSize;


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

Instead of having one abstract throttler created from bootstrap config,
explicitly create one dynamic and one unlimited throttler and allow for
atomically switching between the two based on received config.

The `MergeHandler` component will now always fetch the current throttler
from the `FileStorHandler` instead of caching it at construction time.

This commit removes the `restart` annotation on the existing throttler
type config enums.
