### PR TITLE
Use correct certificate/key when generating curl command in hosted

### DIFF
--- a/client/go/cmd/curl.go
+++ b/client/go/cmd/curl.go
@@ -42,11 +42,11 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 		if err != nil {
 			return err
 		}
-		app, err := getApplication()
+		target, err := getTarget()
 		if err != nil {
 			return err
 		}
-		service, err := getService(curlService, 0, "")
+		service, err := target.Service(curlService, 0, 0, "")
 		if err != nil {
 			return err
 		}
@@ -58,26 +58,14 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 		}
 		switch curlService {
 		case vespa.DeployService:
-			t, err := getTarget()
-			if err != nil {
-				return err
-			}
-			if t.Type() == vespa.TargetCloud {
-				if err := addCloudAuth0Authentication(t.Deployment().System, cfg, c); err != nil {
+			if target.Type() == vespa.TargetCloud {
+				if err := addCloudAuth0Authentication(target.Deployment().System, cfg, c); err != nil {
 					return err
 				}
 			}
 		case vespa.DocumentService, vespa.QueryService:
-			privateKeyFile, err := cfg.PrivateKeyPath(app)
-			if err != nil {
-				return err
-			}
-			certificateFile, err := cfg.CertificatePath(app)
-			if err != nil {
-				return err
-			}
-			c.PrivateKey = privateKeyFile
-			c.Certificate = certificateFile
+			c.PrivateKey = service.TLSOptions.PrivateKeyFile
+			c.Certificate = service.TLSOptions.CertificateFile
 		default:
 			return fmt.Errorf("service not found: %s", curlService)
 		}

--- a/client/go/cmd/curl_test.go
+++ b/client/go/cmd/curl_test.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,14 +14,27 @@ import (
 func TestCurl(t *testing.T) {
 	homeDir := filepath.Join(t.TempDir(), ".vespa")
 	httpClient := &mock.HTTPClient{}
-	out, _ := execute(command{homeDir: homeDir, args: []string{"curl", "-n", "-a", "t1.a1.i1", "--", "-v", "--data-urlencode", "arg=with space", "/search"}}, t, httpClient)
+	_, outErr := execute(command{args: []string{"config", "set", "application", "t1.a1.i1"}, homeDir: homeDir}, t, nil)
+	assert.Equal(t, "", outErr)
+	_, outErr = execute(command{args: []string{"config", "set", "target", "cloud"}, homeDir: homeDir}, t, nil)
+	assert.Equal(t, "", outErr)
+	_, outErr = execute(command{args: []string{"auth", "api-key"}, homeDir: homeDir}, t, nil)
+	assert.Equal(t, "", outErr)
+	_, outErr = execute(command{args: []string{"auth", "cert", "--no-add"}, homeDir: homeDir}, t, nil)
+	assert.Equal(t, "", outErr)
+
+	os.Setenv("VESPA_CLI_ENDPOINTS", "{\"endpoints\":[{\"cluster\":\"container\",\"url\":\"http://127.0.0.1:8080\"}]}")
+	out, _ := execute(command{homeDir: homeDir, args: []string{"curl", "-n", "--", "-v", "--data-urlencode", "arg=with space", "/search"}}, t, httpClient)
 
 	expected := fmt.Sprintf("curl --key %s --cert %s -v --data-urlencode 'arg=with space' http://127.0.0.1:8080/search\n",
 		filepath.Join(homeDir, "t1.a1.i1", "data-plane-private-key.pem"),
 		filepath.Join(homeDir, "t1.a1.i1", "data-plane-public-cert.pem"))
 	assert.Equal(t, expected, out)
 
-	out, _ = execute(command{homeDir: homeDir, args: []string{"curl", "-a", "t1.a1.i1", "-s", "deploy", "-n", "/application/v4/tenant/foo"}}, t, httpClient)
+	_, outErr = execute(command{args: []string{"config", "set", "target", "local"}, homeDir: homeDir}, t, nil)
+	assert.Equal(t, "", outErr)
+	out, outErr = execute(command{homeDir: homeDir, args: []string{"curl", "-a", "t1.a1.i1", "-s", "deploy", "-n", "/application/v4/tenant/foo"}}, t, httpClient)
+	assert.Equal(t, "", outErr)
 	expected = "curl http://127.0.0.1:19071/application/v4/tenant/foo\n"
 	assert.Equal(t, expected, out)
 }


### PR DESCRIPTION
Technically you also need to include a role token in the `Authorization` header,
but there is no gentle way of exposing that. The token also expires so I think
we'll leave that as a manual step for now.

@ean