### PR TITLE
Do an explicit sync of domain part when rotating tls file.

### DIFF
--- a/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
+++ b/searchlib/src/vespa/searchlib/transactionlog/domain.cpp
@@ -298,6 +298,7 @@ DomainPart::SP
 Domain::optionallyRotateFile(SerialNum serialNum) {
     DomainPart::SP dp = getActivePart();
     if (dp->byteSize() > _config.getPartSizeLimit()) {
+        dp->sync();
         dp->close();
         dp = std::make_shared<DomainPart>(_name, dir(), serialNum, _fileHeaderContext, false);
         {


### PR DESCRIPTION
@geirst or @toregge PR
Necessary to complete #21491