### PR TITLE
relative std::this_thread::sleep_for is more efficient than absolute …

### DIFF
--- a/config/src/vespa/config/subscription/configsubscriptionset.cpp
+++ b/config/src/vespa/config/subscription/configsubscriptionset.cpp
@@ -18,7 +18,7 @@ using vespalib::steady_time;
 namespace config {
 
 ConfigSubscriptionSet::ConfigSubscriptionSet(std::shared_ptr<IConfigContext> context)
-    : _maxNapTime(vespalib::adjustTimeoutByDetectedHz(10ms)),
+    : _maxNapTime(vespalib::adjustTimeoutByDetectedHz(20ms)),
       _context(std::move(context)),
       _mgr(_context->getManagerInstance()),
       _currentGeneration(-1),
@@ -82,7 +82,7 @@ ConfigSubscriptionSet::acquireSnapshot(duration timeout, bool ignoreChange)
         lastGeneration = generation;
         now = steady_clock::now();
         if (!inSync && (now < deadline)) {
-            std::this_thread::sleep_until(std::min(now + _maxNapTime, deadline));
+            std::this_thread::sleep_for(std::min(_maxNapTime, deadline - now));
         } else {
             break;
         }

--- a/vespalib/src/vespa/vespalib/util/invokeserviceimpl.cpp
+++ b/vespalib/src/vespa/vespalib/util/invokeserviceimpl.cpp
@@ -64,8 +64,7 @@ void
 InvokeServiceImpl::runLoop() {
     bool done = false;
     while ( ! done ) {
-        const steady_time now = steady_clock::now();
-        _now.store(now, std::memory_order_relaxed);
+        _now.store(steady_clock::now(), std::memory_order_relaxed);
         {
             std::lock_guard guard(_lock);
             for (auto & func: _toInvoke) {
@@ -74,7 +73,7 @@ InvokeServiceImpl::runLoop() {
             done = _closed;
         }
         if ( ! done) {
-            std::this_thread::sleep_until(now + _naptime);
+            std::this_thread::sleep_for(_naptime);
         }
     }
 


### PR DESCRIPTION
…std::this_thread::sleep_until. This is the opposite of std::condition_variable::wait_until/wait_for.

@vekterli PR