### PR TITLE
Explicitly precompute GlobalId for reference values to avoid lazy init race

### DIFF
--- a/document/src/vespa/document/base/documentid.cpp
+++ b/document/src/vespa/document/base/documentid.cpp
@@ -59,8 +59,9 @@ DocumentId::calculateGlobalId() const
     IdString::LocationType location(_id.getLocation());
     memcpy(key, &location, 4);
 
-    _globalId.first = true;
+    // FIXME this lazy init mechanic does not satisfy const thread safety
     _globalId.second.set(key);
+    _globalId.first = true;
 }
 
 std::ostream &

--- a/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
+++ b/document/src/vespa/document/fieldvalue/referencefieldvalue.cpp
@@ -75,6 +75,8 @@ void ReferenceFieldValue::setDeserializedDocumentId(const DocumentId& id) {
     assert(_dataType != nullptr);
     requireIdOfMatchingType(id, _dataType->getTargetType());
     _documentId = id;
+    // Pre-cache GID to ensure it's not attempted lazily initialized later in a racing manner.
+    (void) _documentId.getGlobalId();
     _altered = false;
 }
 


### PR DESCRIPTION
@baldersheim please review

This is a workaround for `DocumentId::getGlobalId()`'s lazy GID computation
currently not being thread safe in a `const` context.

The following race was previously possible:
 * Attribute writer thread calls `DocumentId::getGlobalId` when applying
   the reference value update to a reference attribute. Writes GID and flag.
 * Shared executor thread calls `DocumentId::operator=` with the same ID
   instance as the rhs argument when applying the reference value update
   to the doc store. Causes a read race with the above write.

