### PR TITLE
Logging is not signal safe (implicit allocs), so don't do it inside the signal handler

### DIFF
--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -65,7 +65,6 @@ public:
     ~StorageApp() override;
 
     void handleSignal(int signal) {
-        LOG(info, "Got signal %d", signal);
         _lastSignal = signal;
         _signalCond.notify_one();
     }


### PR DESCRIPTION
@baldersheim please review