### PR TITLE
Only require restart if advertised resources have been changed

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/NodeResourceChangeValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/NodeResourceChangeValidator.java
@@ -46,7 +46,7 @@ public class NodeResourceChangeValidator implements ChangeValidator {
         return model.allocatedHosts().getHosts().stream().filter(host -> host.membership().isPresent())
                                                          .filter(host -> host.membership().get().cluster().id().equals(clusterId))
                                                          .findFirst()
-                                                         .map(host -> host.realResources());
+                                                         .map(host -> host.advertisedResources());
     }
 
     private List<ConfigChangeAction> createRestartActionsFor(ClusterSpec.Id clusterId, VespaModel model) {


### PR DESCRIPTION
The real memory may depend on the host flavor, so use advertised instead.