### PR TITLE
Add note about verifying that the new vespa-cli version works

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -31,6 +31,9 @@ all: test checkfmt install
 
 # Bump the version of the vespa-cli formula and create a pull request to Homebrew repository.
 #
+# When the homebrew PR has been merged, verify that the prebuilt bottles are
+# available for install by running `brew update && brew install vespa-cli`.
+#
 # Example:
 #
 # $ git checkout vX.Y.Z

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -31,8 +31,9 @@ all: test checkfmt install
 
 # Bump the version of the vespa-cli formula and create a pull request to Homebrew repository.
 #
-# When the homebrew PR has been merged, verify that the prebuilt bottles are
-# available for install by running `brew update && brew install vespa-cli`.
+# Homebrew's automated BrewTestBot must do the merge for the bottles to be published. When
+# the PR has been merged check that the merge was done by their bot, and that installing
+# the new version works by running: `brew update && brew install vespa-cli`.
 #
 # Example:
 #


### PR DESCRIPTION
We had an instance where the brew bottles from the PR was not uploaded and made
available when bumping the version.  Their BrewTestBot should merge an approved
PR, when it does it will trigger a bottle upload to make the new version
available for install.

See PRs for details:
https://github.com/Homebrew/homebrew-core/pull/96173
https://github.com/Homebrew/homebrew-core/pull/96229

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

FYI @kkraune 