### PR TITLE
Doc type manager as injectable component [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -23,11 +23,11 @@ public class DocprocChains extends Chains<DocprocChain> {
         addComponent(docprocHandler);
     }
 
-    private void addComponent(Component component) {
-        if (!(getParent() instanceof ContainerCluster)) {
+    private void addComponent(Component<?, ?> component) {
+        if (!(getParent() instanceof ContainerCluster<?>)) {
             return;
         }
-        ((ContainerCluster) getParent()).addComponent(component);
+        ((ContainerCluster<?>) getParent()).addComponent(component);
     }
 
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -7,6 +7,7 @@ import com.yahoo.container.jdisc.config.SessionConfig;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.component.chain.Chains;
 import com.yahoo.vespa.model.container.component.chain.ProcessingHandler;
@@ -21,6 +22,7 @@ public class DocprocChains extends Chains<DocprocChain> {
         super(parent, subId);
         docprocHandler = new ProcessingHandler<>(this, "com.yahoo.docproc.jdisc.DocumentProcessingHandler");
         addComponent(docprocHandler);
+        addComponent(new SimpleComponent("com.yahoo.document.DocumentTypeManager"));
     }
 
     private void addComponent(Component<?, ?> component) {

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/DocumentProcessingHandler.java
@@ -102,7 +102,7 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
                                      ComponentRegistry<AbstractConcreteDocumentFactory> docFactoryRegistry,
                                      ChainsConfig chainsConfig,
                                      SchemamappingConfig mappingConfig,
-                                     DocumentmanagerConfig docManConfig,
+                                     DocumentTypeManager documentTypeManager,
                                      DocprocConfig docprocConfig,
                                      ContainerDocumentConfig containerDocConfig,
                                      Metric metric) {
@@ -110,7 +110,7 @@ public class DocumentProcessingHandler extends AbstractRequestHandler {
              documentProcessorComponentRegistry, docFactoryRegistry,
                 new DocumentProcessingHandlerParameters()
                      .setMaxNumThreads(docprocConfig.numthreads())
-                     .setDocumentTypeManager(new DocumentTypeManager(docManConfig))
+                     .setDocumentTypeManager(documentTypeManager)
                      .setChainsModel(buildFromConfig(chainsConfig)).setSchemaMap(configureMapping(mappingConfig))
                      .setMetric(metric)
                      .setContainerDocumentConfig(containerDocConfig));


### PR DESCRIPTION
I didn't expect it to be this simple, so let's see what factory says. There used to be self-subscribing of config that made this difficult, but that was probably removed some time back. 