### PR TITLE
Ensure we match the service name exactly

### DIFF
--- a/container-core/src/main/sh/find-pid
+++ b/container-core/src/main/sh/find-pid
@@ -87,7 +87,7 @@ if [ -f "$pid_file" ]; then
   parent_pid=$(cat "$pid_file")
   pid=$(pgrep --parent $parent_pid)
 else
-  status=$(vespa-sentinel-cmd list 2>/dev/null | grep --perl-regexp "($service state=|id=\"$service\")")
+  status=$(vespa-sentinel-cmd list 2>/dev/null | grep --perl-regexp "(^$service state=|id=\"$service\")")
   if [ -z "${status}" ]; then
     echo "No service with name or config id '${service}'" >&2
     exit 1


### PR DESCRIPTION
Services 'container' and 'metrisproxy-container' would both match for
"container". Which one was chosen would depend on the order they were returned
from the sentinel.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
