### PR TITLE
struct/document name collision fails

### DIFF
--- a/config-model/src/test/java/com/yahoo/searchdefinition/StructTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/StructTestCase.java
@@ -6,6 +6,7 @@ import com.yahoo.document.config.DocumenttypesConfig;
 import com.yahoo.document.config.DocumentmanagerConfig;
 import com.yahoo.searchdefinition.derived.Deriver;
 import com.yahoo.searchdefinition.parser.ParseException;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.io.IOException;
 import static org.junit.Assert.fail;
@@ -35,9 +36,12 @@ public class StructTestCase extends AbstractSchemaTestCase {
     }
 
     @Test
+    @Ignore
     public void testStructAndDocumentWithSameNames() {
         try {
             DocumenttypesConfig.Builder dt = Deriver.getDocumentTypesConfig("src/test/examples/structanddocumentwithsamenames.sd");
+            // while the above line may work, the config generated will fail.
+            // See also NameCollisionTestCase.
         } catch (Exception e) {
             fail("Should not have thrown exception " + e);
         }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/derived/NameCollisionTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/derived/NameCollisionTestCase.java
@@ -2,7 +2,12 @@
 
 package com.yahoo.searchdefinition.derived;
 
+import com.yahoo.config.model.deploy.TestProperties;
+import com.yahoo.document.DocumentTypeManager;
+import com.yahoo.searchdefinition.ApplicationBuilder;
+
 import org.junit.Test;
+import static org.junit.Assert.assertThrows;
 
 /**
  * Verifies that a struct in a document type is preferred over another document type
@@ -14,7 +19,21 @@ public class NameCollisionTestCase extends AbstractExportingTestCase {
 
     @Test
     public void testNameCollision() throws Exception {
-        assertCorrectDeriving("namecollision", "collisionstruct", new TestableDeployLogger());
+        var ex = assertThrows(IllegalArgumentException.class, () -> {
+                assertCorrectDeriving("namecollision", "collisionstruct",
+                                      new TestProperties().setExperimentalSdParsing(false),
+                                      new TestableDeployLogger());
+                var docman = DocumentTypeManager.fromFile("temp/namecollision/documentmanager.cfg");
+            });
+        System.err.println("MSG 1: "+ex.getClass()+" -> "+ex.getMessage());
+        var ey = assertThrows(IllegalArgumentException.class, () -> {
+                assertCorrectDeriving("namecollision", "collisionstruct",
+                                      new TestProperties().setExperimentalSdParsing(true),
+                                      new TestableDeployLogger());
+                var docman = DocumentTypeManager.fromFile("temp/namecollision/documentmanager.cfg");
+            });
+        System.err.println("MSG 2: "+ey.getMessage());
+
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/searchdefinition/parser/IntermediateParserTestCase.java
+++ b/config-model/src/test/java/com/yahoo/searchdefinition/parser/IntermediateParserTestCase.java
@@ -251,7 +251,6 @@ public class IntermediateParserTestCase {
         checkFileParses("src/test/examples/stemmingdefault.sd");
         checkFileParses("src/test/examples/stemmingsetting.sd");
         checkFileParses("src/test/examples/strange.sd");
-        checkFileParses("src/test/examples/structanddocumentwithsamenames.sd");
         checkFileParses("src/test/examples/struct.sd");
         checkFileParses("src/test/examples/summaryfieldcollision.sd");
         checkFileParses("src/test/examples/weightedset-summaryto.sd");

--- a/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
+++ b/document/src/main/java/com/yahoo/document/DocumentTypeManagerConfigurer.java
@@ -61,8 +61,13 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
 
     public ConfigSubscriber configure(String configId) {
         ConfigSubscriber subscriber = new ConfigSubscriber();
-        subscriber.subscribe(this, DocumentmanagerConfig.class, configId);
-        return subscriber;
+        try {
+            subscriber.subscribe(this, DocumentmanagerConfig.class, configId);
+            return subscriber;
+        } catch (RuntimeException e) {
+            subscriber.close();
+            throw e;
+        }
     }
 
     /** One-shot configuration; should be called on a newly constructed manager */
@@ -264,7 +269,7 @@ public class DocumentTypeManagerConfigurer implements ConfigSubscriber.SingleSub
                 var old = configMap.put(id, dataTypeConfig);
                 if (old != null) {
                     throw new IllegalArgumentException
-                        ("Multiple configs for id "+id+" first: "+old+" second: "+dataTypeConfig);
+                        ("Multiple configs for id "+id+" first:\n"+old+"\nsecond:\n"+dataTypeConfig);
                 }
             }
         }


### PR DESCRIPTION
* the unit tests claims that this works, and seems to verify that.
  But the generated config isn't valid.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

this is basically the same problem as:
different structs (in unrelated .sd files) can't have the same name.
