### PR TITLE
Make attribute Status fields relaxed atomic

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/status.cpp
+++ b/searchcommon/src/vespa/searchcommon/attribute/status.cpp
@@ -1,6 +1,10 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "status.h"
+#include <vespa/vespalib/util/atomic.h>
+
+using namespace vespalib::atomic;
+
 namespace search::attribute {
 
 Status::Status()
@@ -21,15 +25,15 @@ Status::Status()
 }
 
 Status::Status(const Status& rhs)
-    : _numDocs(rhs._numDocs),
-      _numValues(rhs._numValues),
-      _numUniqueValues(rhs._numUniqueValues),
-      _allocated(rhs._allocated),
-      _used(rhs._used),
-      _dead(rhs._dead),
-      _unused(rhs._unused),
-      _onHold(rhs._onHold),
-      _onHoldMax(rhs._onHoldMax),
+    : _numDocs(load_relaxed(rhs._numDocs)),
+      _numValues(load_relaxed(rhs._numValues)),
+      _numUniqueValues(load_relaxed(rhs._numUniqueValues)),
+      _allocated(load_relaxed(rhs._allocated)),
+      _used(load_relaxed(rhs._used)),
+      _dead(load_relaxed(rhs._dead)),
+      _unused(load_relaxed(rhs._unused)),
+      _onHold(load_relaxed(rhs._onHold)),
+      _onHoldMax(load_relaxed(rhs._onHoldMax)),
       _lastSyncToken(rhs.getLastSyncToken()),
       _updates(rhs._updates),
       _nonIdempotentUpdates(rhs._nonIdempotentUpdates),
@@ -40,15 +44,15 @@ Status::Status(const Status& rhs)
 Status&
 Status::operator=(const Status& rhs)
 {
-    _numDocs = rhs._numDocs;
-    _numValues = rhs._numValues;
-    _numUniqueValues = rhs._numUniqueValues;
-    _allocated = rhs._allocated;
-    _used = rhs._used;
-    _dead = rhs._dead;
-    _unused = rhs._unused;
-    _onHold = rhs._onHold;
-    _onHoldMax = rhs._onHoldMax;
+    store_relaxed(_numDocs,         load_relaxed(rhs._numDocs));
+    store_relaxed(_numValues,       load_relaxed(rhs._numValues));
+    store_relaxed(_numUniqueValues, load_relaxed(rhs._numUniqueValues));
+    store_relaxed(_allocated,       load_relaxed(rhs._allocated));
+    store_relaxed(_used,            load_relaxed(rhs._used));
+    store_relaxed(_dead,            load_relaxed(rhs._dead));
+    store_relaxed(_unused,          load_relaxed(rhs._unused));
+    store_relaxed(_onHold,          load_relaxed(rhs._onHold));
+    store_relaxed(_onHoldMax,       load_relaxed(rhs._onHoldMax));
     setLastSyncToken(rhs.getLastSyncToken());
     _updates = rhs._updates;
     _nonIdempotentUpdates = rhs._nonIdempotentUpdates;
@@ -69,14 +73,14 @@ void
 Status::updateStatistics(uint64_t numValues, uint64_t numUniqueValue, uint64_t allocated,
                          uint64_t used, uint64_t dead, uint64_t onHold)
 {
-    _numValues       = numValues;
-    _numUniqueValues = numUniqueValue;
-    _allocated       = allocated;
-    _used            = used;
-    _dead            = dead;
-    _unused          = allocated - used;
-    _onHold          = onHold;
-    _onHoldMax       = std::max(_onHoldMax, onHold);
+    store_relaxed(_numValues,       numValues);
+    store_relaxed(_numUniqueValues, numUniqueValue);
+    store_relaxed(_allocated,       allocated);
+    store_relaxed(_used,            used);
+    store_relaxed(_dead,            dead);
+    store_relaxed(_unused,          allocated - used);
+    store_relaxed(_onHold,          onHold);
+    store_relaxed(_onHoldMax,       std::max(load_relaxed(_onHoldMax), onHold));
 }
 
 }

--- a/searchcommon/src/vespa/searchcommon/attribute/status.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/status.h
@@ -17,22 +17,23 @@ public:
     void updateStatistics(uint64_t numValues, uint64_t numUniqueValue, uint64_t allocated,
                           uint64_t used, uint64_t dead, uint64_t onHold);
 
-    uint64_t getNumDocs()                  const { return _numDocs; }
-    uint64_t getNumValues()                const { return _numValues; }
-    uint64_t getNumUniqueValues()          const { return _numUniqueValues; }
-    uint64_t getAllocated()                const { return _allocated; }
-    uint64_t getUsed()                     const { return _used; }
-    uint64_t getDead()                     const { return _dead; }
-    uint64_t getOnHold()                   const { return _onHold; }
-    uint64_t getOnHoldMax()                const { return _onHoldMax; }
+    uint64_t getNumDocs()                  const { return _numDocs.load(std::memory_order_relaxed); }
+    uint64_t getNumValues()                const { return _numValues.load(std::memory_order_relaxed); }
+    uint64_t getNumUniqueValues()          const { return _numUniqueValues.load(std::memory_order_relaxed); }
+    uint64_t getAllocated()                const { return _allocated.load(std::memory_order_relaxed); }
+    uint64_t getUsed()                     const { return _used.load(std::memory_order_relaxed); }
+    uint64_t getDead()                     const { return _dead.load(std::memory_order_relaxed); }
+    uint64_t getOnHold()                   const { return _onHold.load(std::memory_order_relaxed); }
+    uint64_t getOnHoldMax()                const { return _onHoldMax.load(std::memory_order_relaxed); }
     // This might be accessed from other threads than the writer thread.
     uint64_t getLastSyncToken()            const { return _lastSyncToken.load(std::memory_order_relaxed); }
     uint64_t getUpdateCount()              const { return _updates; }
     uint64_t getNonIdempotentUpdateCount() const { return _nonIdempotentUpdates; }
     uint32_t getBitVectors() const { return _bitVectors; }
 
-    void setNumDocs(uint64_t v)                  { _numDocs = v; }
-    void incNumDocs()                            { ++_numDocs; }
+    void setNumDocs(uint64_t v)                  { _numDocs.store(v, std::memory_order_relaxed); }
+    void incNumDocs()                            { _numDocs.store(_numDocs.load(std::memory_order_relaxed) + 1u,
+                                                                  std::memory_order_relaxed); }
     void setLastSyncToken(uint64_t v)            { _lastSyncToken.store(v, std::memory_order_relaxed); }
     void incUpdates(uint64_t v=1)                { _updates += v; }
     void incNonIdempotentUpdates(uint64_t v = 1) { _nonIdempotentUpdates += v; }
@@ -42,15 +43,15 @@ public:
     static vespalib::string
     createName(vespalib::stringref index, vespalib::stringref attr);
 private:
-    uint64_t _numDocs;
-    uint64_t _numValues;
-    uint64_t _numUniqueValues;
-    uint64_t _allocated;
-    uint64_t _used;
-    uint64_t _dead;
-    uint64_t _unused;
-    uint64_t _onHold;
-    uint64_t _onHoldMax;
+    std::atomic<uint64_t> _numDocs;
+    std::atomic<uint64_t> _numValues;
+    std::atomic<uint64_t> _numUniqueValues;
+    std::atomic<uint64_t> _allocated;
+    std::atomic<uint64_t> _used;
+    std::atomic<uint64_t> _dead;
+    std::atomic<uint64_t> _unused;
+    std::atomic<uint64_t> _onHold;
+    std::atomic<uint64_t> _onHoldMax;
     std::atomic<uint64_t> _lastSyncToken;
     uint64_t _updates;
     uint64_t _nonIdempotentUpdates;


### PR DESCRIPTION
@geirst please review. I only atomic-ified the fields written by `updateStatistics()` since that was what TSan complained about. Let me know if I should do the same for the remaining fields (`_lastSyncToken` was already atomic).

Fields could be written and read from separate threads.

