### PR TITLE
Double slash breaks rpmbuild on RHEL 7 / CentOS 7.

### DIFF
--- a/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
+++ b/searchcorespi/src/vespa/searchcorespi/index/indexmaintainer.cpp
@@ -9,7 +9,7 @@
 #include "indexreadutilities.h"
 #include "indexwriteutilities.h"
 #include "index_disk_dir.h"
-#include <vespa/document/fieldvalue//document.h>
+#include <vespa/document/fieldvalue/document.h>
 #include <vespa/searchcorespi/flush/lambdaflushtask.h>
 #include <vespa/searchlib/common/i_flush_token.h>
 #include <vespa/searchlib/index/schemautil.h>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
