### PR TITLE
Detect that we are running in docker-on-mac and automatically reduce …

### DIFF
--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -118,10 +118,14 @@ add_valgrind_suppressions_file() {
 }
 
 optionally_reduce_base_frequency() {
-    os_release=`uname -r`
-    if [[ "$os_release" == *linuxkit* ]]; then
-        export VESPA_TIMER_HZ=100
-        : "Running docker on macos. Reducing base frequency from 1000hz to 100hz due to high cost of sampling time. This will reduce timeout accuracy. VESPA_TIMER_HZ=$VESPA_TIMER_HZ"
+    if [ -z "$VESPA_TIMER_HZ" ]; then
+        os_release=`uname -r`
+        if [[ "$os_release" == *linuxkit* ]]; then
+            export VESPA_TIMER_HZ=100
+            : "Running docker on macos. Reducing base frequency from 1000hz to 100hz due to high cost of sampling time. This will reduce timeout accuracy. VESPA_TIMER_HZ=$VESPA_TIMER_HZ"
+        fi
+    else
+        : "VESPA_TIMER_HZ already set to $VESPA_TIMER_HZ. Skipping auto detection."
     fi
 }
 

--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -121,7 +121,7 @@ optionally_reduce_base_frequency() {
     os_release=`uname -r`
     if [[ "$os_release" == *linuxkit* ]]; then
         export VESPA_TIMER_HZ=100
-        echo "Running docker on macos. Reducing base frequency from 1000hz to 100hz due to high cost of sampling time. This will reduce timeout accuracy. VESPA_TIMER_HZ=$VESPA_TIMER_HZ"
+        : "Running docker on macos. Reducing base frequency from 1000hz to 100hz due to high cost of sampling time. This will reduce timeout accuracy. VESPA_TIMER_HZ=$VESPA_TIMER_HZ"
     fi
 }
 

--- a/vespabase/src/common-env.sh
+++ b/vespabase/src/common-env.sh
@@ -117,10 +117,20 @@ add_valgrind_suppressions_file() {
     fi
 }
 
+optionally_reduce_base_frequency() {
+    os_release=`uname -r`
+    if [[ "$os_release" == *linuxkit* ]]; then
+        export VESPA_TIMER_HZ=100
+        echo "Running docker on macos. Reducing base frequency from 1000hz to 100hz due to high cost of sampling time. This will reduce timeout accuracy. VESPA_TIMER_HZ=$VESPA_TIMER_HZ"
+    fi
+}
+
 populate_environment
 
 export LD_LIBRARY_PATH=$VESPA_HOME/lib64
 export MALLOC_ARENA_MAX=1
+
+optionally_reduce_base_frequency
 
 # Prefer newer gdb and pstack
 prepend_path /opt/rh/gcc-toolset-11/root/usr/bin


### PR DESCRIPTION
…timer frequency due to expensive

calls to sample time. This might reduce timeout accuracy from 1ms to 10ms, but that is fine for development.
docker-on-mac will never be supported as production environment.

@arnej27959 and @hmusum PR
@jobergum FYI