### PR TITLE
Make MatchEngine node state polling atomic

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
@@ -177,14 +177,14 @@ MatchEngine::performSearch(search::engine::SearchRequest::Source req)
 }
 
 bool MatchEngine::isOnline() const {
-    return _nodeUp;
+    return _nodeUp.load(std::memory_order_relaxed);
 }
 
 
 void
 MatchEngine::setNodeUp(bool nodeUp)
 {
-    _nodeUp = nodeUp;
+    _nodeUp.store(nodeUp, std::memory_order_relaxed);
 }
 
 void
@@ -192,7 +192,7 @@ MatchEngine::setNodeMaintenance(bool nodeMaintenance)
 {
     _nodeMaintenance = nodeMaintenance;
     if (nodeMaintenance) {
-        _nodeUp = false;
+        _nodeUp.store(false, std::memory_order_relaxed);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.h
@@ -25,7 +25,7 @@ private:
     HandlerMap<ISearchHandler>         _handlers;
     vespalib::ThreadStackExecutor      _executor;
     vespalib::SimpleThreadBundle::Pool _threadBundlePool;
-    bool                               _nodeUp;
+    std::atomic<bool>                  _nodeUp;
     bool                               _nodeMaintenance;
 
 public:


### PR DESCRIPTION
State is polled across threads, so access must be well-defined.
