### PR TITLE
signal while holding lock

### DIFF
--- a/staging_vespalib/src/tests/sequencedtaskexecutor/adaptive_sequenced_executor_test.cpp
+++ b/staging_vespalib/src/tests/sequencedtaskexecutor/adaptive_sequenced_executor_test.cpp
@@ -51,8 +51,8 @@ public:
                 ++_fail;
             }
             ++_done;
+            _cv.notify_all();
         }
-        _cv.notify_all();
     }
 
     void


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Not exactly sure why this becomes a problem with the adaptive version and not the normal version. However, not holding the lock while signalling will in general require more magic to be safe. Also, it is not even faster to do so, which means we should just stop doing it altogether.

@vekterli please review