### PR TITLE
inherit directly

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/parser/ConvertSchemaCollection.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/parser/ConvertSchemaCollection.java
@@ -33,7 +33,9 @@ import com.yahoo.vespa.documentmodel.DocumentSummary;
 import com.yahoo.vespa.documentmodel.SummaryField;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -122,6 +124,8 @@ public class ConvertSchemaCollection {
         typeConverter.convert(true);
     }
 
+    private Map<String, SDDocumentType> convertedDocuments = new LinkedHashMap();
+
     public List<Schema> convertToSchemas() {
         typeConverter = new ConvertParsedTypes(orderedInput, docMan);
         typeConverter.convert(false);
@@ -150,7 +154,9 @@ public class ConvertSchemaCollection {
     {
         SDDocumentType document = new SDDocumentType(parsed.name());
         for (String inherit : parsed.getInherited()) {
-            document.inherit(new DataTypeName(inherit));
+            var parent = convertedDocuments.get(inherit);
+            assert(parent != null);
+            document.inherit(parent);
         }
         for (var struct : parsed.getStructs()) {
             var structProxy = fieldConverter.convertStructDeclaration(schema, struct);
@@ -165,6 +171,7 @@ public class ConvertSchemaCollection {
                 document.setFieldId(sdf, field.idOverride());
             }
         }
+        convertedDocuments.put(parsed.name(), document);
         schema.addDocument(document);
     }
 

--- a/config-model/src/main/java/com/yahoo/searchdefinition/parser/IntermediateCollection.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/parser/IntermediateCollection.java
@@ -12,7 +12,7 @@ import com.yahoo.yolean.Exceptions;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +27,7 @@ public class IntermediateCollection {
     private final DeployLogger deployLogger;
     private final ModelContext.Properties modelProperties;
 
-    private Map<String, ParsedSchema> parsedSchemas = new HashMap<>();
+    private Map<String, ParsedSchema> parsedSchemas = new LinkedHashMap<>();
 
     IntermediateCollection() {
         this.deployLogger = new BaseDeployLogger();


### PR DESCRIPTION
* instead of indirect (temporary) inherit from name, inherit
  the already-converted document directly.
* keep schema order.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth or @baldersheim please review
