### PR TITLE
Correct path

### DIFF
--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -106,7 +106,7 @@ func printPublicKey(system vespa.System, apiKeyFile, tenant string) error {
 	log.Printf("\nThis is your public key:\n%s", color.GreenString(string(pemPublicKey)))
 	log.Printf("Its fingerprint is:\n%s\n", color.CyanString(fingerprint))
 	log.Print("\nTo use this key in Vespa Cloud click 'Add custom key' at")
-	log.Printf(color.CyanString("%s/tenant/%s/keys"), system.ConsoleURL, tenant)
+	log.Printf(color.CyanString("%s/tenant/%s/account/keys"), system.ConsoleURL, tenant)
 	log.Print("and paste the entire public key including the BEGIN and END lines.")
 	return nil
 }


### PR DESCRIPTION
````
To use this key in Vespa Cloud click 'Add custom key' at
https://console.vespa-cloud.com/tenant/mytenant/keys
and paste the entire public key including the BEGIN and END lines.
````

I am redirected to https://console.vespa-cloud.com/tenant/mytenant/account/keys in the console, might as well use the correct path to start with. I have not run any tests, might need update