### PR TITLE
fix tsan warnings related to match phase limiting

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.h
@@ -32,8 +32,8 @@ public:
                      DiversityCutoffStrategy diversityCutoffStrategy);
     ~AttributeLimiter();
     search::queryeval::SearchIterator::UP create_search(size_t want_hits, size_t max_group_size, bool strictSearch);
-    bool was_used() const { return ((!_match_datas.empty()) || (_blueprint.get() != nullptr)); }
-    ssize_t getEstimatedHits() const { return _estimatedHits; }
+    bool was_used() const;
+    ssize_t getEstimatedHits() const;
     static DiversityCutoffStrategy toDiversityCutoffStrategy(vespalib::stringref strategy);
 private:
     const vespalib::string & toString(DiversityCutoffStrategy strategy);
@@ -45,7 +45,7 @@ private:
     std::mutex                                 _lock;
     std::vector<search::fef::MatchData::UP>    _match_datas;
     search::queryeval::Blueprint::UP           _blueprint;
-    ssize_t                                    _estimatedHits;
+    std::atomic<ssize_t>                       _estimatedHits;
     double                                     _diversityCutoffFactor;
     DiversityCutoffStrategy                    _diversityCutoffStrategy;
 };


### PR DESCRIPTION
This fixes the tsan warnings. The consequences of 'wrong' would
probably be incorrect coverage result or similar. However, the fact
that the race warning indicates that we read the was_used/estimate
BEFORE writing them could indicate that not all threads agree on
whether we want to limit the search or not (they should). Not sure if
this is a real issue or how serious it is.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@baldersheim please review
@vekterli FYI