### PR TITLE
Suppress attribute context lock order reversal warnings.

### DIFF
--- a/tsan-suppressions.txt
+++ b/tsan-suppressions.txt
@@ -5,3 +5,7 @@
 
 deadlock:storage::MergeThrottler::onFlush
 
+deadlock:search::AttributeContext::getAttribute
+deadlock:search::AttributeContext::getAttributeStableEnum
+deadlock:proton::ImportedAttributesContext::getAttribute
+deadlock:proton::ImportedAttributesContext::getAttributeStableEnum


### PR DESCRIPTION
@geirst : please review
