### PR TITLE
Tune criterion for when jobs need to re-run, and some other fixes

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
@@ -819,24 +819,28 @@ public class DeploymentStatus {
                                           .orElse(false))
                         return job.lastCompleted().flatMap(Run::end);
 
-                    return (dependent.equals(job()) ? job.lastTriggered().filter(run -> run.status() == RunStatus.success).stream()
-                                                    : RunList.from(job).status(RunStatus.success).asList().stream())
-                            .filter(run ->    change.platform().map(run.versions().targetPlatform()::equals).orElse(true)
-                                           && change.application().map(run.versions().targetApplication()::equals).orElse(true))
-                            .map(Run::end)
-                            .flatMap(Optional::stream)
-                            .min(naturalOrder());
+                    Optional<Instant> end = Optional.empty();
+                    for (Run run : job.runs().descendingMap().values()) {
+                        if (run.versions().targetsMatch(change)) {
+                            if (run.status() == RunStatus.success) end = run.end();
+                        }
+                        else if (dependent.equals(job())) // If strict completion, consider only last time this change was deployed.
+                            break;
+                    }
+                    return end;
                 }
             };
         }
 
         private static JobStepStatus ofProductionTest(DeclaredTest step, List<StepStatus> dependencies,
-                                                      DeploymentStatus status, InstanceName instance, JobType testType, JobType prodType) {
+                                                      DeploymentStatus status, InstanceName instance,
+                                                      JobType testType, JobType prodType) {
             JobStatus job = status.instanceJobs(instance).get(testType);
+            JobId prodId = new JobId(status.application().id().instance(instance), prodType);
+
             return new JobStepStatus(StepType.test, step, dependencies, job, status) {
                 @Override
                 Optional<Instant> readyAt(Change change, Optional<JobId> dependent) {
-                    JobId prodId = new JobId(status.application().id().instance(instance()), prodType);
                     Optional<Instant> readyAt = super.readyAt(change, dependent);
                     Optional<Instant> deployedAt = status.jobSteps().get(prodId).completedAt(change, Optional.of(prodId));
                     if (readyAt.isEmpty() || deployedAt.isEmpty()) return Optional.empty();
@@ -845,20 +849,12 @@ public class DeploymentStatus {
 
                 @Override
                 Optional<Instant> completedAt(Change change, Optional<JobId> dependent) {
-                    Versions versions = Versions.from(change, status.application, status.deploymentFor(job.id()), status.systemVersion);
-                    return dependent.equals(job()) ? job.lastSuccess()
-                                                        .filter(run -> versions.targetsMatch(run.versions()))
-                                                        .filter(run -> ! status.jobs()
-                                                                               .instance(instance)
-                                                                               .type(prodType)
-                                                                               .lastCompleted().endedNoLaterThan(run.start())
-                                                                               .isEmpty())
-                                                        .map(run -> run.end().get())
-                                                   : RunList.from(job)
-                                                            .matching(run -> versions.targetsMatch(run.versions()))
-                                                            .status(RunStatus.success)
-                                                            .first()
-                                                            .map(run -> run.end().get());
+                    Optional<Instant> deployedAt = status.jobSteps().get(prodId).completedAt(change, Optional.of(prodId));
+                    return (dependent.equals(job()) ? job.lastTriggered().filter(run -> deployedAt.map(at -> ! run.start().isBefore(at)).orElse(false)).stream()
+                                                    : job.runs().values().stream())
+                            .filter(run -> run.status() == RunStatus.success)
+                            .filter(run -> run.versions().targetsMatch(change))
+                            .flatMap(run -> run.end().stream()).findFirst();
                 }
             };
         }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentStatus.java
@@ -335,7 +335,6 @@ public class DeploymentStatus {
             }
             List<Job> toRun = new ArrayList<>();
             List<Change> changes = deployingCompatibilityChange ? List.of(change) : changes(job, step, change);
-            if (changes.isEmpty()) return;
             for (Change partial : changes) {
                 Job jobToRun = new Job(job.type(),
                                        Versions.from(partial, application, existingPlatform, existingApplication, systemVersion),

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -174,10 +174,8 @@ public class DeploymentTrigger {
 
         var prodJobs = new ArrayList<Job>();
         var testJobs = new ArrayList<Job>();
-        for (Job job : readyJobs) {
-            if (job.jobType.isTest()) testJobs.add(job);
-            else prodJobs.add(job);
-        }
+        for (Job job : readyJobs)
+            (job.jobType().isProduction() ? prodJobs : testJobs).add(job);
 
         // Flat list of prod jobs, grouped by application id, retaining the step order
         List<Job> sortedProdJobs = prodJobs.stream()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Versions.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Versions.java
@@ -75,6 +75,12 @@ public class Versions {
                targetApplication.equals(versions.targetApplication());
     }
 
+    /** Returns wheter this change could result in the given target versions. */
+    public boolean targetsMatch(Change change) {
+        return    change.platform().map(targetPlatform::equals).orElse(true)
+               && change.application().map(targetApplication::equals).orElse(true);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -285,7 +285,7 @@ class JobControllerApiHandlerHelper {
             if (stepStatus.type() == DeploymentStatus.StepType.instance) {
                 Cursor deployingObject = stepObject.setObject("deploying");
                 if ( ! change.isEmpty()) {
-                    change.platform().ifPresent(version -> deployingObject.setString("platform", version.toString()));
+                    change.platform().ifPresent(version -> deployingObject.setString("platform", version.toFullString()));
                     change.application().ifPresent(version -> toSlime(deployingObject.setObject("application"), version));
                 }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTester.java
@@ -146,7 +146,7 @@ public class DeploymentTester {
         int triggered;
         int triggeredTotal = 0;
         do {
-            triggered = (int)deploymentTrigger().triggerReadyJobs();
+            triggered = (int) deploymentTrigger().triggerReadyJobs();
             triggeredTotal += triggered;
         } while (triggered > 0);
         return triggeredTotal;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTriggerTest.java
@@ -1109,8 +1109,10 @@ public class DeploymentTriggerTest {
         assertEquals(Change.empty(), alpha.instance().change());
         assertEquals(Change.of(version1), beta.instance().change());
 
+        tester.outstandingChangeDeployer().run();
         beta.triggerJobs();
         tester.runner().run();
+        tester.outstandingChangeDeployer().run();
         beta.triggerJobs();
         tester.outstandingChangeDeployer().run();
         beta.assertRunning(productionUsEast3);
@@ -1134,6 +1136,11 @@ public class DeploymentTriggerTest {
 
         beta.assertRunning(productionUsEast3);
         beta.assertNotRunning(testUsEast3);
+
+        beta.runJob(productionUsEast3)
+            .runJob(testUsEast3);
+
+        assertEquals(Change.empty(), beta.instance().change());
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/playground/deployment.xml
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/playground/deployment.xml
@@ -31,7 +31,7 @@
         </prod>
     </instance>
     <instance id='prod25'>
-        <upgrade rollout="simultaneous" revision-change="when-failing" revision-target="next" />
+        <upgrade rollout="simultaneous" revision-change="when-clear" revision-target="next" />
         <prod>
             <parallel>
                 <steps>
@@ -52,6 +52,17 @@
     <instance id='prod100'>
         <upgrade rollout="simultaneous" revision-change="when-clear" revision-target="next" />
         <prod>
+            <steps>
+                <parallel>
+                    <steps>
+                        <region>eu-west-1</region>
+                        <test>eu-west-1</test>
+                    </steps>
+                    <steps>
+                        <region>ap-northeast-1</region>
+                        <test>ap-northeast-1</test>
+                    </steps>
+                </parallel>
             <parallel>
                 <steps>
                     <region>us-east-3</region>
@@ -66,6 +77,7 @@
                     <test>us-west-1</test>
                 </steps>
             </parallel>
+            </steps>
         </prod>
     </instance>
 </deployment>


### PR DESCRIPTION
@mpolden please review and merge. 

This fixes an issue where a fully deployed application change would become "deploying" again, when an upgrade was triggered for the instance, because the production job "completedAt" was too strict. 