### PR TITLE
Stop using deprecated ioutil functions

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -8,8 +8,7 @@ ifeq ($(VERSION),)
 	VERSION = $(DEVEL_VERSION)
 endif
 
-BIN ?= $(CURDIR)/bin
-SHARE ?= $(CURDIR)/share
+PREFIX ?= $(CURDIR)
 DIST ?= $(CURDIR)/dist
 
 GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/build.Version=$(VERSION)"
@@ -110,17 +109,16 @@ ifdef CI
 endif
 
 install: ci
-	env GOBIN=$(BIN) go install $(GO_FLAGS) ./...
+	env GOBIN=$(PREFIX)/bin go install $(GO_FLAGS) ./...
 
 manpages: install
-	mkdir -p $(SHARE)/man/man1
-	$(BIN)/vespa man $(SHARE)/man/man1
+	mkdir -p $(PREFIX)/share/man/man1
+	$(PREFIX)/bin/vespa man $(PREFIX)/share/man/man1
 
 clean:
 	rm -rf $(DIST)
-	rm -f $(BIN)/vespa $(SHARE)/man/man1/vespa.1 $(SHARE)/man/man1/vespa-*.1
-	rmdir -p $(BIN) &> /dev/null || true
-	rmdir -p $(SHARE)/man/man1 &> /dev/null || true
+	rm -f $(PREFIX)/bin/vespa $(PREFIX)/share/man/man1/vespa.1 $(PREFIX)/share/man/man1/vespa-*.1
+	rmdir -p $(PREFIX)/bin $(PREFIX)/share/man/man1 &> /dev/null || true
 
 test: ci
 	go test ./...

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -16,13 +16,6 @@ GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/build.Version=$
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 DIST_TARGETS := dist-mac dist-mac-arm64 dist-linux dist-linux-arm64 dist-win32 dist-win64
 
-GOPROXY_OVERRIDE :=
-ifndef GOPROXY
-ifeq ($(shell go env GOPROXY),direct)
-GOPROXY_OVERRIDE := GOPROXY=https://proxy.golang.org,direct
-endif
-endif
-
 all: test checkfmt install
 
 #
@@ -83,7 +76,7 @@ dist-win64: GOOS=windows
 dist-win64: GOARCH=amd64
 
 $(DIST_TARGETS): DIST_NAME=vespa-cli_$(VERSION)_$(GOOS)_$(GOARCH)
-$(DIST_TARGETS): dist-version manpages
+$(DIST_TARGETS): dist-version ci manpages
 $(DIST_TARGETS):
 	mkdir -p $(DIST)/$(DIST_NAME)/bin
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) $(GOPROXY_OVERRIDE) go build -o $(DIST)/$(DIST_NAME)/bin $(GO_FLAGS) ./...
@@ -109,11 +102,15 @@ install-all: all manpages
 # Development targets
 #
 
-install:
+ci:
 ifdef CI
+# Ensure that CI systems use a proxy for downloading dependencies
+	go env -w GOPROXY="https://proxy.golang.org,direct"
 	go env
 endif
-	env GOBIN=$(BIN) $(GOPROXY_OVERRIDE) go install $(GO_FLAGS) ./...
+
+install: ci
+	env GOBIN=$(BIN) go install $(GO_FLAGS) ./...
 
 manpages: install
 	mkdir -p $(SHARE)/man/man1
@@ -125,8 +122,8 @@ clean:
 	rmdir -p $(BIN) &> /dev/null || true
 	rmdir -p $(SHARE)/man/man1 &> /dev/null || true
 
-test:
-	env $(GOPROXY_OVERRIDE) go test ./...
+test: ci
+	go test ./...
 
 checkfmt:
 	@bash -c "diff --line-format='%L' <(echo -n) <(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }

--- a/client/go/auth/auth0/auth0.go
+++ b/client/go/auth/auth0/auth0.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -287,7 +286,7 @@ func (a *Auth0) persistConfig() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(a.Path, buf, 0600); err != nil {
+	if err := os.WriteFile(a.Path, buf, 0600); err != nil {
 		return err
 	}
 
@@ -334,7 +333,7 @@ func (a *Auth0) initContext() (err error) {
 	}
 
 	var buf []byte
-	if buf, err = ioutil.ReadFile(a.Path); err != nil {
+	if buf, err = os.ReadFile(a.Path); err != nil {
 		return err
 	}
 

--- a/client/go/auth/token.go
+++ b/client/go/auth/token.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -53,7 +53,7 @@ func (t *TokenRetriever) Refresh(ctx context.Context, system string) (TokenRespo
 
 	defer r.Body.Close()
 	if r.StatusCode != http.StatusOK {
-		b, _ := ioutil.ReadAll(r.Body)
+		b, _ := io.ReadAll(r.Body)
 		bodyStr := string(b)
 		return TokenResponse{}, fmt.Errorf("cannot get a new access token from the refresh token: %s", bodyStr)
 	}

--- a/client/go/cmd/api_key.go
+++ b/client/go/cmd/api_key.go
@@ -5,8 +5,8 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -78,7 +78,7 @@ func doApiKey(cli *CLI, overwriteKey bool, args []string) error {
 	if err != nil {
 		return fmt.Errorf("could not create api key: %w", err)
 	}
-	if err := ioutil.WriteFile(apiKeyFile, apiKey, 0600); err == nil {
+	if err := os.WriteFile(apiKeyFile, apiKey, 0600); err == nil {
 		cli.printSuccess("API private key written to ", apiKeyFile)
 		return printPublicKey(system, apiKeyFile, app.Tenant)
 	} else {
@@ -87,7 +87,7 @@ func doApiKey(cli *CLI, overwriteKey bool, args []string) error {
 }
 
 func printPublicKey(system vespa.System, apiKeyFile, tenant string) error {
-	pemKeyData, err := ioutil.ReadFile(apiKeyFile)
+	pemKeyData, err := os.ReadFile(apiKeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to read: %s: %w", apiKeyFile, err)
 	}

--- a/client/go/cmd/clone_list_test.go
+++ b/client/go/cmd/clone_list_test.go
@@ -2,7 +2,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,7 +59,7 @@ func TestListSampleApps(t *testing.T) {
 }
 
 func readTestData(t *testing.T, name string) string {
-	contents, err := ioutil.ReadFile(filepath.Join("testdata", name))
+	contents, err := os.ReadFile(filepath.Join("testdata", name))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -254,7 +253,7 @@ func (c *Config) readAPIKey(tenantName string) ([]byte, error) {
 	if override, ok := c.get(apiKeyFlag); ok {
 		return []byte(override), nil
 	}
-	return ioutil.ReadFile(c.apiKeyPath(tenantName))
+	return os.ReadFile(c.apiKeyPath(tenantName))
 }
 
 // useAPIKey returns true if an API key should be used when authenticating with system.
@@ -282,7 +281,7 @@ func (c *Config) readSessionID(app vespa.ApplicationID) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	b, err := ioutil.ReadFile(sessionPath)
+	b, err := os.ReadFile(sessionPath)
 	if err != nil {
 		return 0, err
 	}
@@ -294,7 +293,7 @@ func (c *Config) writeSessionID(app vespa.ApplicationID, sessionID int64) error 
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(sessionPath, []byte(fmt.Sprintf("%d\n", sessionID)), 0600)
+	return os.WriteFile(sessionPath, []byte(fmt.Sprintf("%d\n", sessionID)), 0600)
 }
 
 func (c *Config) applicationFilePath(app vespa.ApplicationID, name string) (string, error) {

--- a/client/go/cmd/config_test.go
+++ b/client/go/cmd/config_test.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -93,6 +92,6 @@ func TestUseAPIKey(t *testing.T) {
 	_, err := os.Create(filepath.Join(cli.config.homeDir, "t2.api-key.pem"))
 	require.Nil(t, err)
 	assert.True(t, cli.config.useAPIKey(cli, vespa.PublicSystem, "t2"))
-	require.Nil(t, ioutil.WriteFile(filepath.Join(cli.config.homeDir, "auth.json"), []byte(authContent), 0600))
+	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "auth.json"), []byte(authContent), 0600))
 	assert.False(t, cli.config.useAPIKey(cli, vespa.PublicSystem, "t2"))
 }

--- a/client/go/cmd/document.go
+++ b/client/go/cmd/document.go
@@ -7,7 +7,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -179,7 +178,7 @@ func documentService(cli *CLI) (*vespa.Service, error) {
 }
 
 func operationOptions(stderr io.Writer, printCurl bool, timeoutSecs int) vespa.OperationOptions {
-	curlOutput := ioutil.Discard
+	curlOutput := io.Discard
 	if printCurl {
 		curlOutput = stderr
 	}

--- a/client/go/cmd/document_test.go
+++ b/client/go/cmd/document_test.go
@@ -5,7 +5,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"os"
 	"strconv"
 	"testing"
 
@@ -121,7 +121,7 @@ func assertDocumentSend(arguments []string, expectedOperation string, expectedMe
 	assert.Equal(t, "application/json", client.LastRequest.Header.Get("Content-Type"))
 	assert.Equal(t, expectedMethod, client.LastRequest.Method)
 
-	expectedPayload, _ := ioutil.ReadFile(expectedPayloadFile)
+	expectedPayload, _ := os.ReadFile(expectedPayloadFile)
 	assert.Equal(t, string(expectedPayload), util.ReaderToString(client.LastRequest.Body))
 }
 

--- a/client/go/cmd/prod.go
+++ b/client/go/cmd/prod.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -171,7 +170,7 @@ $ vespa prod submit`,
 func writeWithBackup(stdout io.Writer, pkg vespa.ApplicationPackage, filename, contents string) error {
 	dst := filepath.Join(pkg.Path, filename)
 	if util.PathExists(dst) {
-		data, err := ioutil.ReadFile(dst)
+		data, err := os.ReadFile(dst)
 		if err != nil {
 			return err
 		}
@@ -196,7 +195,7 @@ func writeWithBackup(stdout io.Writer, pkg vespa.ApplicationPackage, filename, c
 		}
 	}
 	fmt.Fprintf(stdout, "Writing %s\n", color.GreenString(dst))
-	return ioutil.WriteFile(dst, []byte(contents), 0644)
+	return os.WriteFile(dst, []byte(contents), 0644)
 }
 
 func updateRegions(cli *CLI, stdin *bufio.Reader, deploymentXML xml.Deployment, system vespa.System) (xml.Deployment, error) {

--- a/client/go/cmd/prod_test.go
+++ b/client/go/cmd/prod_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -79,7 +78,7 @@ func TestProdInit(t *testing.T) {
 }
 
 func readFileString(t *testing.T, filename string) string {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +97,7 @@ func createApplication(t *testing.T, pkgDir string, java bool) {
     <region>aws-us-east-1c</region>
   </prod>
 </deployment>`
-	if err := ioutil.WriteFile(filepath.Join(appDir, "deployment.xml"), []byte(deploymentXML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(appDir, "deployment.xml"), []byte(deploymentXML), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,19 +118,19 @@ func createApplication(t *testing.T, pkgDir string, java bool) {
   </content>
 </services>`
 
-	if err := ioutil.WriteFile(filepath.Join(appDir, "services.xml"), []byte(servicesXML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(appDir, "services.xml"), []byte(servicesXML), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	if java {
-		if err := ioutil.WriteFile(filepath.Join(pkgDir, "pom.xml"), []byte(""), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(pkgDir, "pom.xml"), []byte(""), 0644); err != nil {
 			t.Fatal(err)
 		}
 	} else {
 		testsDir := filepath.Join(pkgDir, "src", "test", "application", "tests")
-		testBytes, _ := ioutil.ReadAll(strings.NewReader("{\"steps\":[{}]}"))
+		testBytes, _ := io.ReadAll(strings.NewReader("{\"steps\":[{}]}"))
 		writeTest(filepath.Join(testsDir, "system-test", "test.json"), testBytes, t)
 		writeTest(filepath.Join(testsDir, "staging-setup", "test.json"), testBytes, t)
 		writeTest(filepath.Join(testsDir, "staging-test", "test.json"), testBytes, t)
@@ -142,7 +141,7 @@ func writeTest(path string, content []byte, t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path, content, 0644); err != nil {
+	if err := os.WriteFile(path, content, 0644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -174,7 +173,7 @@ func (c *CLI) configureOutput(cmd *cobra.Command, args []string) error {
 		c.Stderr = colorable.NewColorable(f)
 	}
 	if quiet, _ := c.config.get(quietFlag); quiet == "true" {
-		c.Stdout = ioutil.Discard
+		c.Stdout = io.Discard
 	}
 	log.SetFlags(0) // No timestamps
 	log.SetOutput(c.Stdout)

--- a/client/go/cmd/test.go
+++ b/client/go/cmd/test.go
@@ -9,7 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -75,7 +75,7 @@ func runTests(cli *CLI, zone, rootPath string, dryRun bool) (int, []string, erro
 	if stat, err := os.Stat(rootPath); err != nil {
 		return 0, nil, errHint(err, "See https://docs.vespa.ai/en/reference/testing")
 	} else if stat.IsDir() {
-		tests, err := ioutil.ReadDir(rootPath) // TODO: Use os.ReadDir when >= 1.16 is required.
+		tests, err := os.ReadDir(rootPath)
 		if err != nil {
 			return 0, nil, errHint(err, "See https://docs.vespa.ai/en/reference/testing")
 		}
@@ -118,7 +118,7 @@ func runTests(cli *CLI, zone, rootPath string, dryRun bool) (int, []string, erro
 // Runs the test at the given path, and returns the specified test name if the test fails
 func runTest(testPath string, context testContext) (string, error) {
 	var test test
-	testBytes, err := ioutil.ReadFile(testPath)
+	testBytes, err := os.ReadFile(testPath)
 	if err != nil {
 		return "", errHint(err, "See https://docs.vespa.ai/en/reference/testing")
 	}
@@ -238,7 +238,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 		URL:    requestUrl,
 		Method: method,
 		Header: header,
-		Body:   ioutil.NopCloser(bytes.NewReader(requestBody)),
+		Body:   io.NopCloser(bytes.NewReader(requestBody)),
 	}
 	defer request.Body.Close()
 
@@ -289,7 +289,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 		return "", "", nil
 	}
 
-	responseBodyBytes, err := ioutil.ReadAll(response.Body)
+	responseBodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return "", "", err
 	}
@@ -399,7 +399,7 @@ func getParameters(parametersRaw []byte, testsPath string) (map[string]string, e
 				return nil, err
 			}
 			resolvedParametersPath := filepath.Join(testsPath, parametersPath)
-			parametersRaw, err = ioutil.ReadFile(resolvedParametersPath)
+			parametersRaw, err = os.ReadFile(resolvedParametersPath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to read request parameters at %s: %w", resolvedParametersPath, err)
 			}
@@ -420,7 +420,7 @@ func getBody(bodyRaw []byte, testsPath string) ([]byte, error) {
 			return nil, err
 		}
 		resolvedBodyPath := filepath.Join(testsPath, bodyPath)
-		bodyRaw, err = ioutil.ReadFile(resolvedBodyPath)
+		bodyRaw, err = os.ReadFile(resolvedBodyPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read body file at %s: %w", resolvedBodyPath, err)
 		}

--- a/client/go/cmd/test_test.go
+++ b/client/go/cmd/test_test.go
@@ -5,9 +5,10 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -21,14 +22,14 @@ import (
 
 func TestSuite(t *testing.T) {
 	client := &mock.HTTPClient{}
-	searchResponse, _ := ioutil.ReadFile("testdata/tests/response.json")
+	searchResponse, _ := os.ReadFile("testdata/tests/response.json")
 	client.NextStatus(200)
 	client.NextStatus(200)
 	for i := 0; i < 11; i++ {
 		client.NextResponseString(200, string(searchResponse))
 	}
 
-	expectedBytes, _ := ioutil.ReadFile("testdata/tests/expected-suite.out")
+	expectedBytes, _ := os.ReadFile("testdata/tests/expected-suite.out")
 	cli, stdout, stderr := newTestCLI(t)
 	cli.httpClient = client
 	assert.NotNil(t, cli.Run("test", "testdata/tests/system-test"))
@@ -93,7 +94,7 @@ func TestSuiteWithoutTests(t *testing.T) {
 
 func TestSingleTest(t *testing.T) {
 	client := &mock.HTTPClient{}
-	searchResponse, _ := ioutil.ReadFile("testdata/tests/response.json")
+	searchResponse, _ := os.ReadFile("testdata/tests/response.json")
 	client.NextStatus(200)
 	client.NextStatus(200)
 	client.NextResponseString(200, string(searchResponse))
@@ -101,7 +102,7 @@ func TestSingleTest(t *testing.T) {
 	cli, stdout, stderr := newTestCLI(t)
 	cli.httpClient = client
 
-	expectedBytes, _ := ioutil.ReadFile("testdata/tests/expected.out")
+	expectedBytes, _ := os.ReadFile("testdata/tests/expected.out")
 	assert.Nil(t, cli.Run("test", "testdata/tests/system-test/test.json"))
 	assert.Equal(t, string(expectedBytes), stdout.String())
 	assert.Equal(t, "", stderr.String())
@@ -119,8 +120,8 @@ func TestSingleTestWithCloudAndEndpoints(t *testing.T) {
 	certFile := filepath.Join(certDir, "cert")
 	kp, err := vespa.CreateKeyPair()
 	require.Nil(t, err)
-	require.Nil(t, ioutil.WriteFile(keyFile, kp.PrivateKey, 0600))
-	require.Nil(t, ioutil.WriteFile(certFile, kp.Certificate, 0600))
+	require.Nil(t, os.WriteFile(keyFile, kp.PrivateKey, 0600))
+	require.Nil(t, os.WriteFile(certFile, kp.Certificate, 0600))
 
 	client := &mock.HTTPClient{}
 	cli, stdout, stderr := newTestCLI(
@@ -132,7 +133,7 @@ func TestSingleTestWithCloudAndEndpoints(t *testing.T) {
 	)
 	cli.httpClient = client
 
-	searchResponse, err := ioutil.ReadFile("testdata/tests/response.json")
+	searchResponse, err := os.ReadFile("testdata/tests/response.json")
 	require.Nil(t, err)
 	client.NextStatus(200)
 	client.NextStatus(200)
@@ -140,7 +141,7 @@ func TestSingleTestWithCloudAndEndpoints(t *testing.T) {
 	client.NextResponseString(200, string(searchResponse))
 
 	assert.Nil(t, cli.Run("test", "testdata/tests/system-test/test.json", "-t", "cloud", "-a", "t.a.i"))
-	expectedBytes, err := ioutil.ReadFile("testdata/tests/expected.out")
+	expectedBytes, err := os.ReadFile("testdata/tests/expected.out")
 	require.Nil(t, err)
 	assert.Equal(t, "", stderr.String())
 	assert.Equal(t, string(expectedBytes), stdout.String())
@@ -166,7 +167,7 @@ func createRequest(method string, uri string, body string) *http.Request {
 		URL:    requestUrl,
 		Method: method,
 		Header: nil,
-		Body:   ioutil.NopCloser(strings.NewReader(body)),
+		Body:   io.NopCloser(strings.NewReader(body)),
 	}
 }
 

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/vespa-engine/vespa/client/go
 
-go 1.15
+go 1.16
 
 require (
 	github.com/briandowns/spinner v1.16.0

--- a/client/go/mock/http.go
+++ b/client/go/mock/http.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"bytes"
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -54,7 +54,7 @@ func (c *HTTPClient) Do(request *http.Request, timeout time.Duration) (*http.Res
 	return &http.Response{
 			Status:     "Status " + strconv.Itoa(response.Status),
 			StatusCode: response.Status,
-			Body:       ioutil.NopCloser(bytes.NewBuffer(response.Body)),
+			Body:       io.NopCloser(bytes.NewBuffer(response.Body)),
 			Header:     response.Header,
 		},
 		nil

--- a/client/go/util/io.go
+++ b/client/go/util/io.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -43,7 +42,7 @@ func ReaderToBytes(reader io.Reader) []byte {
 
 // Returns the contents of reader as indented JSON
 func ReaderToJSON(reader io.Reader) string {
-	bodyBytes, _ := ioutil.ReadAll(reader)
+	bodyBytes, _ := io.ReadAll(reader)
 	var prettyJSON bytes.Buffer
 	parseError := json.Indent(&prettyJSON, bodyBytes, "", "    ")
 	if parseError != nil { // Not JSON: Print plainly
@@ -55,7 +54,7 @@ func ReaderToJSON(reader io.Reader) string {
 // AtomicWriteFile atomically writes data to filename.
 func AtomicWriteFile(filename string, data []byte) error {
 	dir := filepath.Dir(filename)
-	tmpFile, err := ioutil.TempFile(dir, "vespa")
+	tmpFile, err := os.CreateTemp(dir, "vespa")
 	if err != nil {
 		return err
 	}

--- a/client/go/vespa/application.go
+++ b/client/go/vespa/application.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -125,7 +124,7 @@ func (ap *ApplicationPackage) zipReader(test bool) (io.ReadCloser, error) {
 		zipFile = ap.TestPath
 	}
 	if !ap.IsZip() {
-		tempZip, err := ioutil.TempFile("", "vespa")
+		tempZip, err := os.CreateTemp("", "vespa")
 		if err != nil {
 			return nil, fmt.Errorf("could not create a temporary zip file for the application package: %w", err)
 		}

--- a/client/go/vespa/crypto.go
+++ b/client/go/vespa/crypto.go
@@ -15,7 +15,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"strings"
@@ -133,7 +132,7 @@ func (rs *RequestSigner) SignRequest(request *http.Request) error {
 		return err
 	}
 	base64Signature := base64.StdEncoding.EncodeToString(signature)
-	request.Body = ioutil.NopCloser(body)
+	request.Body = io.NopCloser(body)
 	if request.Header == nil {
 		request.Header = make(http.Header)
 	}

--- a/client/go/vespa/deploy.go
+++ b/client/go/vespa/deploy.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -235,7 +234,7 @@ func Submit(opts DeploymentOptions) error {
 	request := &http.Request{
 		URL:    u,
 		Method: "POST",
-		Body:   ioutil.NopCloser(&body),
+		Body:   io.NopCloser(&body),
 		Header: make(http.Header),
 	}
 	request.Header.Set("Content-Type", writer.FormDataContentType())
@@ -270,7 +269,7 @@ func uploadApplicationPackage(url *url.URL, opts DeploymentOptions) (PrepareResu
 		URL:    url,
 		Method: "POST",
 		Header: header,
-		Body:   ioutil.NopCloser(zipReader),
+		Body:   io.NopCloser(zipReader),
 	}
 	service, err := opts.Target.Service(DeployService, opts.Timeout, 0, "")
 	if err != nil {
@@ -323,7 +322,7 @@ func checkResponse(req *http.Request, response *http.Response, serviceDescriptio
 
 // Returns the error message in the given JSON, or the entire content if it could not be extracted
 func extractError(reader io.Reader) string {
-	responseData, _ := ioutil.ReadAll(reader)
+	responseData, _ := io.ReadAll(reader)
 	var response map[string]interface{}
 	json.Unmarshal(responseData, &response)
 	if response["error-code"] == "INVALID_APPLICATION_PACKAGE" {

--- a/client/go/vespa/deploy_test.go
+++ b/client/go/vespa/deploy_test.go
@@ -2,7 +2,6 @@
 package vespa
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func writeFile(t *testing.T, name string) {
 	err := os.MkdirAll(filepath.Dir(name), 0755)
 	assert.Nil(t, err)
 	if !strings.HasSuffix(name, string(os.PathSeparator)) {
-		err = ioutil.WriteFile(name, []byte{0}, 0644)
+		err = os.WriteFile(name, []byte{0}, 0644)
 		assert.Nil(t, err)
 	}
 }

--- a/client/go/vespa/document.go
+++ b/client/go/vespa/document.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -64,7 +63,7 @@ func sendOperation(documentId string, jsonFile string, service *Service, operati
 			return util.FailureWithDetail("Could not open file '"+jsonFile+"'", err.Error())
 		}
 		defer fileReader.Close()
-		documentData, err = ioutil.ReadAll(fileReader)
+		documentData, err = io.ReadAll(fileReader)
 		if err != nil {
 			return util.FailureWithDetail("Failed to read '"+jsonFile+"'", err.Error())
 		}
@@ -101,7 +100,7 @@ func sendOperation(documentId string, jsonFile string, service *Service, operati
 		URL:    url,
 		Method: operationToHTTPMethod(operation),
 		Header: header,
-		Body:   ioutil.NopCloser(bytes.NewReader(documentData)),
+		Body:   io.NopCloser(bytes.NewReader(documentData)),
 	}
 	response, err := serviceDo(service, request, jsonFile, options)
 	if err != nil {

--- a/client/go/vespa/target.go
+++ b/client/go/vespa/target.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -164,7 +163,7 @@ func wait(client util.HTTPClient, fn responseFunc, reqFn requestFunc, certificat
 		response, httpErr = client.Do(req, 10*time.Second)
 		if httpErr == nil {
 			statusCode = response.StatusCode
-			body, err := ioutil.ReadAll(response.Body)
+			body, err := io.ReadAll(response.Body)
 			if err != nil {
 				return 0, err
 			}

--- a/client/go/vespa/target_test.go
+++ b/client/go/vespa/target_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -134,7 +133,7 @@ func TestLog(t *testing.T) {
 	vc.deploymentConverged = true
 
 	var buf bytes.Buffer
-	target := createCloudTarget(t, srv.URL, ioutil.Discard)
+	target := createCloudTarget(t, srv.URL, io.Discard)
 	if err := target.PrintLog(LogOptions{Writer: &buf, Level: 3}); err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +147,7 @@ func TestCheckVersion(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(vc.mockVespaHandler))
 	defer srv.Close()
 
-	target := createCloudTarget(t, srv.URL, ioutil.Discard)
+	target := createCloudTarget(t, srv.URL, io.Discard)
 	assert.Nil(t, target.CheckVersion(version.MustParse("8.0.0")))
 	assert.Nil(t, target.CheckVersion(version.MustParse("8.1.0")))
 	assert.NotNil(t, target.CheckVersion(version.MustParse("7.0.0")))


### PR DESCRIPTION
The oldest version we're building with is now Go 1.16.

@ean