### PR TITLE
use atomics for disk footprint to avoid tsan warnings.

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/filechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/filechunk.h
@@ -115,7 +115,7 @@ public:
     virtual ssize_t read(uint32_t lid, SubChunkId chunk, vespalib::DataBuffer & buffer) const;
     virtual void read(LidInfoWithLidV::const_iterator begin, size_t count, IBufferVisitor & visitor) const;
     void remove(uint32_t lid, uint32_t size);
-    virtual size_t getDiskFootprint() const { return _diskFootprint; }
+    virtual size_t getDiskFootprint() const { return _diskFootprint.load(std::memory_order_relaxed); }
     virtual size_t getMemoryFootprint() const;
     virtual size_t getMemoryMetaFootprint() const;
     virtual vespalib::MemoryUsage getMemoryUsage() const;
@@ -210,13 +210,13 @@ private:
     const bool             _skipCrcOnRead;
     size_t                 _erasedCount;
     size_t                 _erasedBytes;
-    size_t                 _diskFootprint;
+    std::atomic<size_t>    _diskFootprint;
     size_t                 _sumNumBuckets;
     size_t                 _numChunksWithBuckets;
     size_t                 _numUniqueBuckets;
     File                   _file;
 protected:
-    void setDiskFootprint(size_t sz) { _diskFootprint = sz; }
+    void setDiskFootprint(size_t sz) { _diskFootprint.store(sz, std::memory_order_relaxed); }
     static size_t adjustSize(size_t sz);
 
     class ChunkInfo

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -607,8 +607,8 @@ WriteableFileChunk::getDiskFootprint(const unique_lock & guard) const
 {
     assert(guard.mutex() == &_lock && guard.owns_lock());
     return frozen()
-           ? FileChunk::getDiskFootprint()
-           : _currentDiskFootprint + FileChunk::getDiskFootprint();
+        ? FileChunk::getDiskFootprint()
+        : _currentDiskFootprint.load(std::memory_order_relaxed) + FileChunk::getDiskFootprint();
 }
 
 size_t
@@ -859,7 +859,7 @@ WriteableFileChunk::needFlushPendingChunks(const unique_lock & guard, uint64_t s
 
 void
 WriteableFileChunk::updateCurrentDiskFootprint() {
-    _currentDiskFootprint = _idxFileSize + _dataFile.getSize();
+    _currentDiskFootprint.store(_idxFileSize + _dataFile.getSize(), std::memory_order_relaxed);
 }
 
 /*

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -121,7 +121,7 @@ private:
     uint64_t          _pendingIdx;
     uint64_t          _pendingDat;
     uint64_t          _idxFileSize;
-    uint64_t          _currentDiskFootprint;
+    std::atomic<uint64_t> _currentDiskFootprint;
     uint32_t          _nextChunkId;
     Chunk::UP         _active;
     size_t            _alignment;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli please review
@baldersheim FYI

The disk footprint of a writeable chunk is written while holding locks A and B, and read while holding lock C. As long as only a single actor can write it this might be ok, @baldersheim please have a quick look.