### PR TITLE
process all the summary fields with same name

### DIFF
--- a/config-model/src/main/java/com/yahoo/searchdefinition/ImmutableSchema.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/ImmutableSchema.java
@@ -46,6 +46,6 @@ public interface ImmutableSchema {
     }
     List<ImmutableSDField> allFieldsList();
 
-    Map<String, SummaryField> getSummaryFields(ImmutableSDField field);
+    List<SummaryField> getSummaryFields(ImmutableSDField field);
 
 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/Schema.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/Schema.java
@@ -602,7 +602,9 @@ public class Schema implements ImmutableSchema {
                     for (var already : summaryFields) {
                         if (summaryField == already) wanted = false;
                     }
-                    summaryFields.add(summaryField);
+                    if (wanted) {
+                        summaryFields.add(summaryField);
+                    }
                 }
             }
         }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/Schema.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/Schema.java
@@ -584,21 +584,25 @@ public class Schema implements ImmutableSchema {
     public Map<String, DocumentSummary> getSummariesInThis() { return Collections.unmodifiableMap(summaries); }
 
     /**
-     * Returns all summary fields, of all document summaries, which has the given field as source. If there are
-     * multiple summary fields with the same name, the last one will be used (they should all have the same content, if
-     * this is a valid search definition).The map becomes owned by the receiver.
+     * Returns all summary fields, of all document summaries, which has the given field as source.
+     * The list becomes owned by the receiver.
      *
      * @param field the source field
-     * @return the map of summary fields found
+     * @return the list of summary fields found
      */
     @Override
-    public Map<String, SummaryField> getSummaryFields(ImmutableSDField field) {
-        Map<String, SummaryField> summaryFields = inherited.isPresent() ? requireInherited().getSummaryFields(field)
-                                                                        : new java.util.LinkedHashMap<>();
+    public List<SummaryField> getSummaryFields(ImmutableSDField field) {
+        List<SummaryField> summaryFields = inherited.isPresent()
+            ? requireInherited().getSummaryFields(field)
+            : new java.util.ArrayList<>();
         for (DocumentSummary documentSummary : summaries.values()) {
             for (SummaryField summaryField : documentSummary.getSummaryFields().values()) {
                 if (summaryField.hasSource(field.getName())) {
-                    summaryFields.put(summaryField.getName(), summaryField);
+                    boolean wanted = true;
+                    for (var already : summaryFields) {
+                        if (summaryField == already) wanted = false;
+                    }
+                    summaryFields.add(summaryField);
                 }
             }
         }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/AddAttributeTransformToSummaryOfImportedFields.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/AddAttributeTransformToSummaryOfImportedFields.java
@@ -34,7 +34,7 @@ public class AddAttributeTransformToSummaryOfImportedFields extends Processor {
     }
 
     private Stream<SummaryField> getSummaryFieldsForImportedField(ImmutableSDField importedField) {
-        return schema.getSummaryFields(importedField).values().stream();
+        return schema.getSummaryFields(importedField).stream();
     }
 
     private void setTransform(ImmutableSDField field) {

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/IndexingOutputs.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/IndexingOutputs.java
@@ -42,7 +42,7 @@ public class IndexingOutputs extends Processor {
     }
 
     public void findSummaryTo(Schema schema, SDField field, Set<String> dynamicSummary, Set<String> staticSummary) {
-        Map<String, SummaryField> summaryFields = schema.getSummaryFields(field);
+        var summaryFields = schema.getSummaryFields(field);
         if (summaryFields.isEmpty()) {
             fillSummaryToFromField(field, dynamicSummary, staticSummary);
         } else {
@@ -50,9 +50,9 @@ public class IndexingOutputs extends Processor {
         }
     }
 
-    private void fillSummaryToFromSearch(Schema schema, SDField field, Map<String, SummaryField> summaryFields,
+    private void fillSummaryToFromSearch(Schema schema, SDField field, List<SummaryField> summaryFields,
                                          Set<String> dynamicSummary, Set<String> staticSummary) {
-        for (SummaryField summaryField : summaryFields.values()) {
+        for (SummaryField summaryField : summaryFields) {
             fillSummaryToFromSummaryField(schema, field, summaryField, dynamicSummary, staticSummary);
         }
     }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/PredicateProcessor.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/PredicateProcessor.java
@@ -72,7 +72,7 @@ public class PredicateProcessor extends Processor {
                     if (summary != null) {
                         summary.remove(attribute.getName());
                     }
-                    for (SummaryField summaryField : schema.getSummaryFields(field).values()) {
+                    for (SummaryField summaryField : schema.getSummaryFields(field)) {
                         summaryField.setTransform(SummaryTransform.NONE);
                     }
                 }

--- a/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReferenceFieldsProcessor.java
+++ b/config-model/src/main/java/com/yahoo/searchdefinition/processing/ReferenceFieldsProcessor.java
@@ -58,7 +58,7 @@ public class ReferenceFieldsProcessor extends Processor {
     }
 
     private void clearSummaryTransformOnSummaryFields(SDField field) {
-        schema.getSummaryFields(field).values().forEach(summaryField -> summaryField.setTransform(SummaryTransform.NONE));
+        schema.getSummaryFields(field).forEach(summaryField -> summaryField.setTransform(SummaryTransform.NONE));
     }
 
 }


### PR DESCRIPTION
* we may have multiple instances of the "same" summary field when
  declared in document-summary blocks; ensure we process all of them.
* fixes: https://github.com/vespa-engine/vespa/issues/21733

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bjorncs or @bratseth please review
