### PR TITLE
Simplify shared load balancer service

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
@@ -5,16 +5,10 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.vespa.hosted.provision.Node;
-import com.yahoo.vespa.hosted.provision.NodeList;
-import com.yahoo.vespa.hosted.provision.NodeRepository;
-import com.yahoo.vespa.hosted.provision.node.IP;
 
-import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This implementation of {@link LoadBalancerService} returns the load balancer(s) that exists by default in the shared
@@ -27,28 +21,18 @@ import java.util.stream.Collectors;
  */
 public class SharedLoadBalancerService implements LoadBalancerService {
 
-    private static final Comparator<Node> hostnameComparator = Comparator.comparing(Node::hostname);
-
-    private final NodeRepository nodeRepository;
     private final String vipHostname;
 
-    public SharedLoadBalancerService(NodeRepository nodeRepository, String vipHostname) {
-        this.nodeRepository = Objects.requireNonNull(nodeRepository);
+    public SharedLoadBalancerService(String vipHostname) {
         this.vipHostname = Objects.requireNonNull(vipHostname);
     }
 
     @Override
     public LoadBalancerInstance create(LoadBalancerSpec spec, boolean force) {
-        NodeList proxyNodes = nodeRepository.nodes().list().nodeType(NodeType.proxy).sortedBy(hostnameComparator);
-        if (proxyNodes.isEmpty()) throw new IllegalStateException("No proxy nodes found in node-repository");
-        Set<String> networks = proxyNodes.stream()
-                                         .flatMap(node -> node.ipConfig().primary().stream())
-                                         .map(SharedLoadBalancerService::withPrefixLength)
-                                         .collect(Collectors.toSet());
         return new LoadBalancerInstance(HostName.from(vipHostname),
                                         Optional.empty(),
-                                        Set.of(4080, 4443),
-                                        networks,
+                                        Set.of(4443),
+                                        Set.of(),
                                         spec.reals());
     }
 
@@ -66,13 +50,6 @@ public class SharedLoadBalancerService implements LoadBalancerService {
     public boolean supports(NodeType nodeType, ClusterSpec.Type clusterType) {
         // Shared routing layer only supports routing to tenant nodes
         return nodeType == NodeType.tenant && clusterType.isContainer();
-    }
-
-    private static String withPrefixLength(String address) {
-        if (IP.isV6(address)) {
-            return address + "/128";
-        }
-        return address + "/32";
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -66,7 +66,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         maintainers.add(new ScalingSuggestionsMaintainer(nodeRepository, defaults.scalingSuggestionsInterval, metric));
         maintainers.add(new SwitchRebalancer(nodeRepository, defaults.switchRebalancerInterval, metric, deployer));
 
-        provisionServiceProvider.getLoadBalancerService(nodeRepository)
+        provisionServiceProvider.getLoadBalancerService()
                                 .map(lbService -> new LoadBalancerExpirer(nodeRepository, defaults.loadBalancerExpirerInterval, lbService, metric))
                                 .ifPresent(maintainers::add);
         provisionServiceProvider.getHostProvisioner()

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
@@ -18,7 +18,7 @@ public class EmptyProvisionServiceProvider implements ProvisionServiceProvider {
     private final HostResourcesCalculator hostResourcesCalculator = new IdentityHostResourcesCalculator();
 
     @Override
-    public Optional<LoadBalancerService> getLoadBalancerService(NodeRepository nodeRepository) {
+    public Optional<LoadBalancerService> getLoadBalancerService() {
         return Optional.empty();
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -70,7 +70,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
         this.allocationOptimizer = new AllocationOptimizer(nodeRepository);
         this.capacityPolicies = new CapacityPolicies(nodeRepository);
         this.zone = zone;
-        this.loadBalancerProvisioner = provisionServiceProvider.getLoadBalancerService(nodeRepository)
+        this.loadBalancerProvisioner = provisionServiceProvider.getLoadBalancerService()
                                                                .map(lbService -> new LoadBalancerProvisioner(nodeRepository, lbService));
         this.nodeResourceLimits = new NodeResourceLimits(nodeRepository);
         this.preparer = new Preparer(nodeRepository,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionServiceProvider.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
-import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 
 import java.util.Optional;
@@ -13,7 +12,7 @@ import java.util.Optional;
  */
 public interface ProvisionServiceProvider {
 
-    Optional<LoadBalancerService> getLoadBalancerService(NodeRepository nodeRepository);
+    Optional<LoadBalancerService> getLoadBalancerService();
 
     Optional<HostProvisioner> getHostProvisioner();
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.testutils;
 
 import com.google.inject.Inject;
-import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerService;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancerServiceMock;
 import com.yahoo.vespa.hosted.provision.provisioning.EmptyProvisionServiceProvider;
@@ -38,7 +37,7 @@ public class MockProvisionServiceProvider implements ProvisionServiceProvider {
     }
 
     @Override
-    public Optional<LoadBalancerService> getLoadBalancerService(NodeRepository nodeRepository) {
+    public Optional<LoadBalancerService> getLoadBalancerService() {
         return loadBalancerService;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerServiceTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerServiceTest.java
@@ -4,8 +4,6 @@ package com.yahoo.vespa.hosted.provision.lb;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.NodeType;
-import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
 import org.junit.Test;
 
 import java.util.Optional;
@@ -18,8 +16,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class SharedLoadBalancerServiceTest {
 
-    private final ProvisioningTester tester = new ProvisioningTester.Builder().build();
-    private final SharedLoadBalancerService loadBalancerService = new SharedLoadBalancerService(tester.nodeRepository(), "vip.example.com");
+    private final SharedLoadBalancerService loadBalancerService = new SharedLoadBalancerService("vip.example.com");
     private final ApplicationId applicationId = ApplicationId.from("tenant1", "application1", "default");
     private final ClusterSpec.Id clusterId = ClusterSpec.Id.from("qrs1");
     private final Set<Real> reals = Set.of(
@@ -29,18 +26,12 @@ public class SharedLoadBalancerServiceTest {
 
     @Test
     public void test_create_lb() {
-        tester.makeReadyNodes(2, "default", NodeType.proxy);
         var lb = loadBalancerService.create(new LoadBalancerSpec(applicationId, clusterId, reals), false);
 
         assertEquals(HostName.from("vip.example.com"), lb.hostname());
         assertEquals(Optional.empty(), lb.dnsZone());
-        assertEquals(Set.of("127.0.0.1/32", "127.0.0.2/32", "::1/128", "::2/128"), lb.networks());
-        assertEquals(Set.of(4080, 4443), lb.ports());
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void test_exception_on_missing_proxies() {
-        loadBalancerService.create(new LoadBalancerSpec(applicationId, clusterId, reals), false);
+        assertEquals(Set.of(), lb.networks());
+        assertEquals(Set.of(4443), lb.ports());
     }
 
     @Test


### PR DESCRIPTION
Networks are only used to setup ACL rules from ELBs in AWS, where they can take any IP in a /24 block. In zones with shared load balancers, we know all IPs which requests will come from - it's the proxy nodes. Which are already added to the ACL rules.

Must be merged with internal PR.