### PR TITLE
Use vespalib::string in TestAndSetCondition

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/messages/testandsetcondition.h
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/testandsetcondition.h
@@ -2,18 +2,20 @@
 // @author Vegard Sjonfjell
 #pragma once
 
+#include <vespa/vespalib/stllike/string.h>
+
 namespace documentapi {
 
 class TestAndSetCondition {
 private:
-    std::string _selection;
+    vespalib::string _selection;
 
 public:
     TestAndSetCondition()
         : _selection()
     {}
     
-    TestAndSetCondition(vespalib::stringref selection)
+    explicit TestAndSetCondition(vespalib::stringref selection)
         : _selection(selection)
     {}
 
@@ -23,7 +25,7 @@ public:
     TestAndSetCondition(TestAndSetCondition &&) = default;
     TestAndSetCondition & operator=(TestAndSetCondition &&) = default;
 
-    const std::string & getSelection() const { return _selection; }
+    const vespalib::string & getSelection() const { return _selection; }
     bool isPresent() const { return !_selection.empty(); }
 };
 

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -282,7 +282,7 @@ bool put_is_from_reindexing_visitor(const api::PutCommand& cmd) {
 
 // Precondition: put_is_from_reindexing_visitor(cmd) == true
 std::string extract_reindexing_token(const api::PutCommand& cmd) {
-    const std::string& tas_str = cmd.getCondition().getSelection();
+    const auto& tas_str = cmd.getCondition().getSelection();
     auto eq_idx = tas_str.find_first_of('=');
     if (eq_idx != std::string::npos) {
         return tas_str.substr(eq_idx + 1);

--- a/vespalib/src/tests/stllike/string_test.cpp
+++ b/vespalib/src/tests/stllike/string_test.cpp
@@ -489,4 +489,23 @@ TEST("test that empty_string is shared and empty") {
     EXPECT_EQUAL(empty_string(), "");
 }
 
+TEST("starts_with has expected semantics for small_string") {
+    vespalib::string a("foobar");
+    EXPECT_TRUE(a.starts_with(""));
+    EXPECT_TRUE(a.starts_with("foo"));
+    EXPECT_TRUE(a.starts_with("foobar"));
+    EXPECT_FALSE(a.starts_with("foobarf"));
+    EXPECT_FALSE(a.starts_with("oobar"));
+}
+
+TEST("starts_with has expected semantics for stringref") {
+    vespalib::string a("foobar");
+    vespalib::stringref ar(a);
+    EXPECT_TRUE(ar.starts_with(""));
+    EXPECT_TRUE(ar.starts_with("foo"));
+    EXPECT_TRUE(ar.starts_with("foobar"));
+    EXPECT_FALSE(ar.starts_with("foobarf"));
+    EXPECT_FALSE(ar.starts_with("oobar"));
+}
+
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -111,6 +111,7 @@ public:
         }
         return npos;
     }
+
     /**
      * Find the last occurrence of a substring, starting at e and
      * searching in reverse order.
@@ -126,6 +127,17 @@ public:
         int diff(memcmp(_s, s, std::min(sz, size())));
         return (diff != 0) ? diff : (size() - sz);
     }
+
+    /**
+     * Returns true iff input string is a prefix of this string.
+     */
+    [[nodiscard]] bool starts_with(stringref prefix) const noexcept {
+        if (prefix.size() > size()) {
+            return false;
+        }
+        return (memcmp(data(), prefix.data(), prefix.size()) == 0);
+    }
+
     const char & operator [] (size_t i) const { return _s[i]; }
     operator std::string () const { return std::string(_s, _sz); }
     bool operator  <        (const char * s) const noexcept { return compare(s, strlen(s)) < 0; }
@@ -254,6 +266,16 @@ public:
      */
     void pop_back() {
       _resize(size() - 1);
+    }
+
+    /**
+     * Returns true iff input string is a prefix of this string.
+     */
+    [[nodiscard]] bool starts_with(stringref prefix) const noexcept {
+        if (prefix.size() > size()) {
+            return false;
+        }
+        return (memcmp(buffer(), prefix.data(), prefix.size()) == 0);
     }
 
     /**


### PR DESCRIPTION
@baldersheim please review

Avoids some implicit conversions. Add `starts_with` to `vespalib::string`
and `vespalib::stringref` to allow drop-in replacement for Document API code.
