### PR TITLE
Register JacksonJsonProvider explicitly.

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.serviceview;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
@@ -41,6 +42,7 @@ public class StateRequestHandler extends RestApiRequestHandler<StateRequestHandl
             .newBuilder()
             .property(ClientProperties.CONNECT_TIMEOUT, 10000)
             .property(ClientProperties.READ_TIMEOUT, 10000)
+            .register(JacksonJsonProvider.class)
             .register((ClientRequestFilter) ctx -> ctx.getHeaders().put(HttpHeaders.USER_AGENT, List.of(USER_AGENT)))
             .build();
 


### PR DESCRIPTION
For some reason required when using the embedded jersey client
and jersey-media-json-jackson is no longer installed in jdisc.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
