### PR TITLE
Remove jersey media bundles 2 [run-systemtest]

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -50,7 +50,6 @@
         <javax.validation-api.version>1.1.0.Final</javax.validation-api.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
         <jersey2.version>2.25</jersey2.version>
-        <mimepull.version>1.9.6</mimepull.version>
     </properties>
 
     <build>
@@ -123,13 +122,9 @@
                                         <include>org.glassfish.jersey.core:jersey-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-common:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-server:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.ext:jersey-entity-filtering:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.ext:jersey-proxy-client:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.media:jersey-media-json-jackson:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.media:jersey-media-multipart:[${jersey2.version}]:jar:provided</include>
                                         <include>org.javassist:javassist:[${javassist.version}]:jar:provided</include>
                                         <include>org.json:json:[${org.json.version}]:jar:provided</include>
-                                        <include>org.jvnet.mimepull:mimepull:[${mimepull.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:log4j-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:slf4j-api:[${slf4j.version}]:jar:provided</include>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -211,6 +211,22 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Conflicts with javax.activation:javax.activation-api:1.2.0, which is "exported" via jdisc_core. -->
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Conflicts with javax.xml.bind:jaxb-api:2.3, which is "exported" via jdisc_core.-->
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -194,6 +194,18 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- Do not remove, as long as this is provided by jdisc and configserver uses jersey-client -->
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Do not remove, as long as this is provided by jdisc and configserver uses jersey-client -->
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>provided</scope>
@@ -245,6 +257,17 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
+      <exclusions>
+        <!-- Prevent embedding deps provided by jdisc  -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <!-- Not needed by configserver, but by controller. Also pulls in mimepull. -->

--- a/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/serviceview/StateRequestHandler.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.serviceview;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
@@ -41,6 +42,7 @@ public class StateRequestHandler extends RestApiRequestHandler<StateRequestHandl
             .newBuilder()
             .property(ClientProperties.CONNECT_TIMEOUT, 10000)
             .property(ClientProperties.READ_TIMEOUT, 10000)
+            .register(JacksonJsonProvider.class)
             .register((ClientRequestFilter) ctx -> ctx.getHeaders().put(HttpHeaders.USER_AGENT, List.of(USER_AGENT)))
             .build();
 

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -106,13 +106,9 @@
                                         <include>org.glassfish.jersey.core:jersey-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-common:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-server:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.ext:jersey-entity-filtering:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.ext:jersey-proxy-client:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.media:jersey-media-json-jackson:[${jersey2.version}]:jar:provided</include>
-                                        <include>org.glassfish.jersey.media:jersey-media-multipart:[${jersey2.version}]:jar:provided</include>
                                         <include>org.javassist:javassist:[${javassist.version}]:jar:provided</include>
                                         <include>org.json:json:[${org.json.version}]:jar:provided</include>
-                                        <include>org.jvnet.mimepull:mimepull:[${mimepull.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:log4j-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:slf4j-api:[${slf4j.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -298,9 +298,10 @@
                 <version>${org.json.version}</version>
             </dependency>
             <dependency>
+                <!-- TODO Vespa 8: remove! No longer installed in jdisc -->
                 <groupId>org.jvnet.mimepull</groupId>
                 <artifactId>mimepull</artifactId>
-                <version>${mimepull.version}</version>
+                <version>1.9.6</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -431,7 +432,6 @@
         <javax.validation-api.version>1.1.0.Final</javax.validation-api.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
         <jersey2.version>2.25</jersey2.version>
-        <mimepull.version>1.9.6</mimepull.version>
 
         <!-- Not a dependency. Only included to allow the versions-maven-plugin to check for updates of itself  -->
         <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -252,11 +252,7 @@
                 javax.ws.rs-api-${javax.ws.rs-api.version}.jar,
                 jersey-client-${jersey2.version}.jar,
                 jersey-common-${jersey2.version}.jar,
-                jersey-entity-filtering-${jersey2.version}.jar, <!-- needed by jersey-media-json-jackson -->
                 jersey-guava-${jersey2.version}.jar,
-                jersey-media-json-jackson-${jersey2.version}.jar,
-                jersey-media-multipart-${jersey2.version}.jar,
-                mimepull-${mimepull.version}.jar, <!-- needed by media-multipart -->
                 jersey-server-${jersey2.version}.jar,
                 jersey-proxy-client-${jersey2.version}.jar,
                 osgi-resource-locator-1.0.1.jar,

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -899,7 +899,6 @@ fi
 %{_prefix}/lib/jars/alpn-*.jar
 %{_prefix}/lib/jars/http2-*.jar
 %{_prefix}/lib/jars/jetty-*.jar
-%{_prefix}/lib/jars/mimepull-*.jar
 %{_prefix}/lib/jars/model-evaluation-jar-with-dependencies.jar
 %{_prefix}/lib/jars/model-integration-jar-with-dependencies.jar
 %{_prefix}/lib/jars/org.apache.aries.spifly.dynamic.bundle-*.jar

--- a/vespa_jersey2/pom.xml
+++ b/vespa_jersey2/pom.xml
@@ -20,26 +20,6 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <exclusions>
-        <exclusion>
-          <!-- Conflicts with javax.activation:javax.activation-api:1.2.0, which is "exported" via jdisc_core. -->
-          <groupId>jakarta.activation</groupId>
-          <artifactId>jakarta.activation-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <!-- Conflicts with javax.xml.bind:jaxb-api:2.3, which is "exported" via jdisc_core.-->
-          <groupId>jakarta.xml.bind</groupId>
-          <artifactId>jakarta.xml.bind-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-multipart</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.glassfish.jersey.ext</groupId>
       <artifactId>jersey-proxy-client</artifactId>
     </dependency>
@@ -57,9 +37,7 @@
     </dependency>
 
     <dependency>
-      <!-- Previously pulled in by jersey-container-servlet-core. Contains packages imported by
-      jersey-entity-filtering, which is used by jersey-media-json-jackson, which is used by hosted Vespa
-      framework bundles, July 2021. -->
+      <!-- TODO Vespa 8: Remove, contains packages imported by only one user app (March 2022) -->
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
       <exclusions>
@@ -75,6 +53,24 @@
       Contains packages imported by hosted user applications, July 2021. -->
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <!-- TODO: try to remove! Previously pulled in by jersey-media-json-jackson. -->
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Conflicts with javax.activation:javax.activation-api:1.2.0, which is "exported" via jdisc_core. -->
+          <groupId>jakarta.activation</groupId>
+          <artifactId>jakarta.activation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Conflicts with javax.xml.bind:jaxb-api:2.3, which is "exported" via jdisc_core.-->
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Must be merged with 8456 in internal repo.

There were two problems with the previous attempt:
- jackson-core deps were embedded in the configserver bundle
- The JacksonJsonProvider must now be explicitly registered in the client config (not sure why)
