### PR TITLE
Remove explicit maven-dependency-analyzer dependency

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,14 +92,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${maven-dependency-plugin.version}</version>
-                    <dependencies>
-                      <!-- TODO: remove when upgrading to 3.1.2 -->
-                      <dependency>
-                        <groupId>org.apache.maven.shared</groupId>
-                        <artifactId>maven-dependency-analyzer</artifactId>
-                        <version>1.11.1</version>
-                      </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
- We are now using  maven-dependency-plugin:3.2.0

