### PR TITLE
Use the CentOS Stream 8 image as base for Screwdriver when publishing…

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -183,6 +183,8 @@ jobs:
       - *save-cache
 
   publish-release:
+    image: docker.io/vespaengine/vespa-build-centos-stream8:latest
+
     annotations:
       screwdriver.cd/cpu: 7
       screwdriver.cd/ram: 16


### PR DESCRIPTION
… releases.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
