### PR TITLE
Specify operator access in PathGroup

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/role/PathGroup.java
@@ -238,11 +238,11 @@ enum PathGroup {
     horizonProxy("/horizon/v1/{*}"),
 
     /** Paths used to list and request access to tenant resources */
-    accessRequests(Matcher.tenant, "/application/v4/tenant/{tenant}/access/request/{*}"),
+    accessRequests(Matcher.tenant, "/application/v4/tenant/{tenant}/access/request/operator"),
 
     /** Paths used to approve requests to access tenant resources */
-    accessRequestApproval(Matcher.tenant, "/application/v4/tenant/{tenant}/access/approve/{*}",
-            "/application/v4/tenant/{tenant}/access/managed/{*}");
+    accessRequestApproval(Matcher.tenant, "/application/v4/tenant/{tenant}/access/approve/operator",
+            "/application/v4/tenant/{tenant}/access/managed/operator");
 
     final List<String> pathSpecs;
     final List<Matcher> matchers;


### PR DESCRIPTION
Was wildcard in case we wanted to add more access types later - let's just extend path group whenever necessary instead

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
