### PR TITLE
Revert "Remove jersey proxy client [run-systemtest]"

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -122,6 +122,7 @@
                                         <include>org.glassfish.jersey.core:jersey-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-common:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-server:[${jersey2.version}]:jar:provided</include>
+                                        <include>org.glassfish.jersey.ext:jersey-proxy-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.javassist:javassist:[${javassist.version}]:jar:provided</include>
                                         <include>org.json:json:[${org.json.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -106,6 +106,7 @@
                                         <include>org.glassfish.jersey.core:jersey-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-common:[${jersey2.version}]:jar:provided</include>
                                         <include>org.glassfish.jersey.core:jersey-server:[${jersey2.version}]:jar:provided</include>
+                                        <include>org.glassfish.jersey.ext:jersey-proxy-client:[${jersey2.version}]:jar:provided</include>
                                         <include>org.javassist:javassist:[${javassist.version}]:jar:provided</include>
                                         <include>org.json:json:[${org.json.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -29,7 +29,7 @@
     </scm>
 
     <dependencyManagement>
-        <!-- TODO Vespa 8: remove all artifacts that are no longer installed in jdisc.
+        <!-- TODO Vespa 8: remove all artifacts to parent that are no longer installed in jdisc.
                            Those used in configserver/controller must be moved to parent/pom.xml  -->
         <dependencies>
             <dependency>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -254,6 +254,7 @@
                 jersey-common-${jersey2.version}.jar,
                 jersey-guava-${jersey2.version}.jar,
                 jersey-server-${jersey2.version}.jar,
+                jersey-proxy-client-${jersey2.version}.jar,
                 osgi-resource-locator-1.0.1.jar,
                 validation-api-1.1.0.Final.jar
                 <!-- jersey2 end -->

--- a/vespa_jersey2/pom.xml
+++ b/vespa_jersey2/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>javax.ws.rs-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-proxy-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
     </dependency>


### PR DESCRIPTION
Reverts vespa-engine/vespa#21885

component builds fail across the board.  For main component build, node-admin fails in a Phaser IllegalStateException. Not sure about this.  But the ylinux7 build failed with the following, suggesting this PR is at fault.

```
21:09:13 [ERROR]   EPayNotificationHandlerTest.<init>:36 » NoClassDefFound org/glassfish/jersey/c...
```