### PR TITLE
Rename search::NumericAttribute::Equal to search::attribute::NumericMatcher.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -79,6 +79,8 @@ vespa_add_library(searchlib_attribute OBJECT
     multivalueattributesaverutils.cpp
     not_implemented_attribute.cpp
     numericbase.cpp
+    numeric_matcher.cpp
+    numeric_range_matcher.cpp
     posting_list_merger.cpp
     postingchange.cpp
     postinglistattribute.cpp

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.h
@@ -5,6 +5,7 @@
 #include "integerbase.h"
 #include "floatbase.h"
 #include "multivalueattribute.h"
+#include "numeric_range_matcher.h"
 #include "search_context.h"
 #include <limits>
 
@@ -60,7 +61,7 @@ public:
     /*
      * Specialization of SearchContext for weighted set type
      */
-    class SetSearchContext final : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class SetSearchContext final : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     private:
         const MultiValueNumericAttribute<B, M> & _toBeSearched;
@@ -108,7 +109,7 @@ public:
     /*
      * Specialization of SearchContext for array type
      */
-    class ArraySearchContext : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class ArraySearchContext : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     private:
         const MultiValueNumericAttribute<B, M> & _toBeSearched;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattribute.hpp
@@ -192,7 +192,7 @@ bool MultiValueNumericAttribute<B, M>::SetSearchContext::valid() const { return 
 
 template <typename B, typename M>
 MultiValueNumericAttribute<B, M>::SetSearchContext::SetSearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched) :
-    NumericAttribute::Range<T>(*qTerm),
+    attribute::NumericRangeMatcher<T>(*qTerm),
     attribute::SearchContext(toBeSearched),
     _toBeSearched(static_cast<const MultiValueNumericAttribute<B, M> &>(toBeSearched))
 { }
@@ -224,7 +224,7 @@ bool MultiValueNumericAttribute<B, M>::ArraySearchContext::valid() const { retur
 
 template <typename B, typename M>
 MultiValueNumericAttribute<B, M>::ArraySearchContext::ArraySearchContext(QueryTermSimple::UP qTerm, const NumericAttribute & toBeSearched) :
-    NumericAttribute::Range<T>(*qTerm),
+    attribute::NumericRangeMatcher<T>(*qTerm),
     attribute::SearchContext(toBeSearched),
     _toBeSearched(static_cast<const MultiValueNumericAttribute<B, M> &>(toBeSearched))
 { }

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.h
@@ -4,6 +4,7 @@
 
 #include "multienumattribute.h"
 #include "numericbase.h"
+#include "numeric_range_matcher.h"
 #include "primitivereader.h"
 #include "search_context.h"
 
@@ -42,7 +43,7 @@ protected:
     /*
      * Specialization of SearchContext for weighted set type
      */
-    class SetSearchContext : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class SetSearchContext : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     protected:
         const MultiValueNumericEnumAttribute<B, M> & _toBeSearched;
@@ -95,7 +96,7 @@ protected:
     /*
      * Specialization of SearchContext for array type
      */
-    class ArraySearchContext : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class ArraySearchContext : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     protected:
         const MultiValueNumericEnumAttribute<B, M> & _toBeSearched;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericenumattribute.hpp
@@ -138,7 +138,7 @@ MultiValueNumericEnumAttribute<B, M>::getSearch(QueryTermSimple::UP qTerm,
 
 template <typename B, typename M>
 MultiValueNumericEnumAttribute<B, M>::SetSearchContext::SetSearchContext(QueryTermSimpleUP qTerm, const NumericAttribute & toBeSearched) :
-    NumericAttribute::Range<T>(*qTerm),
+    attribute::NumericRangeMatcher<T>(*qTerm),
     SearchContext(toBeSearched),
     _toBeSearched(static_cast<const MultiValueNumericEnumAttribute<B, M> &>(toBeSearched))
 { }
@@ -186,7 +186,7 @@ MultiValueNumericEnumAttribute<B, M>::ArraySearchContext::createFilterIterator(f
 
 template <typename B, typename M>
 MultiValueNumericEnumAttribute<B, M>::ArraySearchContext::ArraySearchContext(QueryTermSimpleUP qTerm, const NumericAttribute & toBeSearched) :
-    NumericAttribute::Range<T>(*qTerm),
+    attribute::NumericRangeMatcher<T>(*qTerm),
     SearchContext(toBeSearched),
     _toBeSearched(static_cast<const MultiValueNumericEnumAttribute<B, M> &>(toBeSearched))
 { }

--- a/searchlib/src/vespa/searchlib/attribute/numeric_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_matcher.cpp
@@ -1,0 +1,14 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "numeric_matcher.hpp"
+
+namespace search::attribute {
+
+template class NumericMatcher<int8_t>;
+template class NumericMatcher<int16_t>;
+template class NumericMatcher<int32_t>;
+template class NumericMatcher<int64_t>;
+template class NumericMatcher<float>;
+template class NumericMatcher<double>;
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/numeric_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_matcher.h
@@ -8,6 +8,10 @@ namespace search { class QueryTermSimple; }
 
 namespace search::attribute {
 
+/*
+ * Class used to determine if an attribute vector value is a match for
+ * the query value.
+ */
 template<typename T>
 class NumericMatcher
 {

--- a/searchlib/src/vespa/searchlib/attribute/numeric_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_matcher.h
@@ -1,0 +1,26 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchcommon/common/range.h>
+
+namespace search { class QueryTermSimple; }
+
+namespace search::attribute {
+
+template<typename T>
+class NumericMatcher
+{
+private:
+    T _value;
+    bool _valid;
+protected:
+    NumericMatcher(const QueryTermSimple& queryTerm, bool avoidUndefinedInRange);
+    bool isValid() const { return _valid; }
+    bool match(T v) const { return v == _value; }
+    Int64Range getRange() const {
+        return Int64Range(static_cast<int64_t>(_value));
+    }
+};
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/numeric_matcher.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_matcher.hpp
@@ -1,0 +1,21 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "numeric_matcher.h"
+#include <vespa/searchlib/query/query_term_simple.h>
+
+namespace search::attribute {
+
+template<typename T>
+NumericMatcher<T>::NumericMatcher(const QueryTermSimple& queryTerm, bool avoidUndefinedInRange)
+    : _value(0),
+      _valid(false)
+{
+    (void) avoidUndefinedInRange;
+    QueryTermSimple::RangeResult<T> res = queryTerm.getRange<T>();
+    _valid = res.valid && res.isEqual() && !res.adjusted;
+    _value = res.high;
+}
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.cpp
@@ -1,0 +1,15 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+
+#include "numeric_range_matcher.hpp"
+
+namespace search::attribute {
+
+template class NumericRangeMatcher<int8_t>;
+template class NumericRangeMatcher<int16_t>;
+template class NumericRangeMatcher<int32_t>;
+template class NumericRangeMatcher<int64_t>;
+template class NumericRangeMatcher<float>;
+template class NumericRangeMatcher<double>;
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.h
@@ -1,0 +1,59 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchcommon/common/range.h>
+#include <cstddef>
+
+namespace search { class QueryTermSimple; }
+
+namespace search::attribute {
+
+template<typename T>
+class NumericRangeMatcher
+{
+protected:
+    T _low;
+    T _high;
+private:
+    bool _valid;
+    int _limit;
+    size_t _max_per_group;
+protected:
+    NumericRangeMatcher(const QueryTermSimple& queryTerm, bool avoidUndefinedInRange=false);
+    Int64Range getRange() const {
+        return Int64Range(static_cast<int64_t>(_low), static_cast<int64_t>(_high));
+    }
+    bool isValid() const { return _valid; }
+    bool match(T v) const { return (_low <= v) && (v <= _high); }
+    int getRangeLimit() const { return _limit; }
+    size_t getMaxPerGroup() const { return _max_per_group; }
+
+    template <typename BaseType>
+    search::Range<BaseType>
+    cappedRange(bool isFloat)
+    {
+        BaseType low = static_cast<BaseType>(_low);
+        BaseType high = static_cast<BaseType>(_high);
+
+        BaseType numMin = std::numeric_limits<BaseType>::min();
+        BaseType numMax = std::numeric_limits<BaseType>::max();
+
+        if (isFloat) {
+            if (_low <= (-numMax)) {
+                low = -numMax;
+            }
+        } else {
+            if (_low <= (numMin)) {
+                low = numMin + 1; // we must avoid the undefined value
+            }
+        }
+
+        if (_high >= (numMax)) {
+            high = numMax;
+        }
+        return search::Range<BaseType>(low, high);
+    }
+};
+
+}

--- a/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.h
@@ -9,6 +9,10 @@ namespace search { class QueryTermSimple; }
 
 namespace search::attribute {
 
+/*
+ * Class used to determine if an attribute vector value is a match for
+ * the query range.
+ */
 template<typename T>
 class NumericRangeMatcher
 {

--- a/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/numeric_range_matcher.hpp
@@ -2,24 +2,13 @@
 
 #pragma once
 
-#include "numericbase.h"
+#include "numeric_range_matcher.h"
 #include <vespa/searchlib/query/query_term_simple.h>
 
-namespace search {
+namespace search::attribute {
 
 template<typename T>
-NumericAttribute::Equal<T>::Equal(const QueryTermSimple &queryTerm, bool avoidUndefinedInRange)
-    : _value(0),
-      _valid(false)
-{
-    (void) avoidUndefinedInRange;
-    QueryTermSimple::RangeResult<T> res = queryTerm.getRange<T>();
-    _valid = res.valid && res.isEqual() && !res.adjusted;
-    _value = res.high;
-}
-
-template<typename T>
-NumericAttribute::Range<T>::Range(const QueryTermSimple & queryTerm, bool avoidUndefinedInRange)
+NumericRangeMatcher<T>::NumericRangeMatcher(const QueryTermSimple& queryTerm, bool avoidUndefinedInRange)
     : _low(0),
       _high(0),
       _valid(false)

--- a/searchlib/src/vespa/searchlib/attribute/numericbase.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/numericbase.cpp
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 
-#include "numericbase.hpp"
+#include "numericbase.h"
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.attribute.numericbase");
@@ -30,19 +30,5 @@ NumericAttribute::load_posting_lists_and_update_enum_store(enumstore::Enumerated
 {
     LOG_ABORT("Should not be reached");
 }
-
-template class NumericAttribute::Range<int8_t>;
-template class NumericAttribute::Range<int16_t>;
-template class NumericAttribute::Range<int32_t>;
-template class NumericAttribute::Range<int64_t>;
-template class NumericAttribute::Range<float>;
-template class NumericAttribute::Range<double>;
-
-template class NumericAttribute::Equal<int8_t>;
-template class NumericAttribute::Equal<int16_t>;
-template class NumericAttribute::Equal<int32_t>;
-template class NumericAttribute::Equal<int64_t>;
-template class NumericAttribute::Equal<float>;
-template class NumericAttribute::Equal<double>;
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/numericbase.h
+++ b/searchlib/src/vespa/searchlib/attribute/numericbase.h
@@ -25,68 +25,6 @@ protected:
     virtual void load_posting_lists_and_update_enum_store(enumstore::EnumeratedPostingsLoader& loader);
     bool onAddDoc(DocId) override { return true; }
 
-    template<typename T>
-    class Equal
-    {
-    private:
-        T _value;
-        bool _valid;
-    protected:
-        Equal(const QueryTermSimple &queryTerm, bool avoidUndefinedInRange);
-        bool isValid() const { return _valid; }
-        bool match(T v) const { return v == _value; }
-        Int64Range getRange() const {
-            return Int64Range(static_cast<int64_t>(_value));
-        }
-    };
-
-    template<typename T>
-    class Range
-    {
-    protected:
-        T _low;
-        T _high;
-    private:
-        bool _valid;
-        int _limit;
-        size_t _max_per_group;
-    protected:
-        Range(const QueryTermSimple & queryTerm, bool avoidUndefinedInRange=false);
-        Int64Range getRange() const {
-            return Int64Range(static_cast<int64_t>(_low), static_cast<int64_t>(_high));
-        }
-        bool isValid() const { return _valid; }
-        bool match(T v) const { return (_low <= v) && (v <= _high); }
-        int getRangeLimit() const { return _limit; }
-        size_t getMaxPerGroup() const { return _max_per_group; }
-
-        template <typename BaseType>
-        search::Range<BaseType>
-        cappedRange(bool isFloat)
-        {
-            BaseType low = static_cast<BaseType>(_low);
-            BaseType high = static_cast<BaseType>(_high);
-
-            BaseType numMin = std::numeric_limits<BaseType>::min();
-            BaseType numMax = std::numeric_limits<BaseType>::max();
-
-            if (isFloat) {
-                if (_low <= (-numMax)) {
-                    low = -numMax;
-                }
-            } else {
-                if (_low <= (numMin)) {
-                    low = numMin + 1; // we must avoid the undefined value
-                }
-            }
-
-            if (_high >= (numMax)) {
-                high = numMax;
-            }
-            return search::Range<BaseType>(low, high);
-        }
-
-    };
 public:
     DECLARE_IDENTIFIABLE_ABSTRACT(NumericAttribute);
 };

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericattribute.hpp
@@ -4,6 +4,8 @@
 #include "attributeiterators.hpp"
 #include "attributevector.hpp"
 #include "load_utils.h"
+#include "numeric_matcher.h"
+#include "numeric_range_matcher.h"
 #include "primitivereader.h"
 #include "singlenumericattribute.h"
 #include "singlenumericattributesaver.h"
@@ -158,9 +160,9 @@ SingleValueNumericAttribute<B>::getSearch(QueryTermSimple::UP qTerm,
     (void) params;
     QueryTermSimple::RangeResult<T> res = qTerm->getRange<T>();
     if (res.isEqual()) {
-        return std::make_unique<SingleSearchContext<NumericAttribute::Equal<T>>>(std::move(qTerm), *this);
+        return std::make_unique<SingleSearchContext<attribute::NumericMatcher<T>>>(std::move(qTerm), *this);
     } else {
-        return std::make_unique<SingleSearchContext<NumericAttribute::Range<T>>>(std::move(qTerm), *this);
+        return std::make_unique<SingleSearchContext<attribute::NumericRangeMatcher<T>>>(std::move(qTerm), *this);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.h
@@ -4,6 +4,7 @@
 
 #include "singleenumattribute.h"
 #include "numericbase.h"
+#include "numeric_range_matcher.h"
 #include "search_context.h"
 #include <map>
 
@@ -49,7 +50,7 @@ protected:
     /*
      * Specialization of SearchContext
      */
-    class SingleSearchContext : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class SingleSearchContext : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     protected:
         const SingleValueNumericEnumAttribute<B> & _toBeSearched;

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericenumattribute.hpp
@@ -174,7 +174,7 @@ SingleValueNumericEnumAttribute<B>::SingleSearchContext::valid() const
 
 template <typename B>
 SingleValueNumericEnumAttribute<B>::SingleSearchContext::SingleSearchContext(QueryTermSimpleUP qTerm, const NumericAttribute & toBeSearched) :
-    NumericAttribute::Range<T>(*qTerm, true),
+    attribute::NumericRangeMatcher<T>(*qTerm, true),
     attribute::SearchContext(toBeSearched),
     _toBeSearched(static_cast<const SingleValueNumericEnumAttribute<B> &>(toBeSearched))
 { }

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.cpp
@@ -213,7 +213,7 @@ bool SingleValueSmallNumericAttribute::SingleSearchContext::valid() const { retu
 
 SingleValueSmallNumericAttribute::SingleSearchContext::SingleSearchContext(std::unique_ptr<QueryTermSimple> qTerm,
                                                                            const SingleValueSmallNumericAttribute & toBeSearched)
-    : NumericAttribute::Range<T>(*qTerm),
+    : attribute::NumericRangeMatcher<T>(*qTerm),
       SearchContext(toBeSearched), _wordData(&toBeSearched._wordData.acquire_elem_ref(0)),
       _valueMask(toBeSearched._valueMask),
       _valueShiftShift(toBeSearched._valueShiftShift),

--- a/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlesmallnumericattribute.h
@@ -4,6 +4,7 @@
 
 #include "integerbase.h"
 #include "floatbase.h"
+#include "numeric_range_matcher.h"
 #include "search_context.h"
 #include <vespa/vespalib/util/atomic.h>
 #include <vespa/vespalib/util/rcuvector.h>
@@ -60,7 +61,7 @@ public:
     /*
      * Specialization of SearchContext
      */
-    class SingleSearchContext : public NumericAttribute::Range<T>, public attribute::SearchContext
+    class SingleSearchContext : public attribute::NumericRangeMatcher<T>, public attribute::SearchContext
     {
     private:
         const Word *_wordData;


### PR DESCRIPTION
Rename search::NumericAttribute::Range to search::attribute::NumericRangeMatcher.

@geirst : please review
@baldersheim : FYI

