### PR TITLE
Make zone flag global

### DIFF
--- a/client/go/cmd/config_test.go
+++ b/client/go/cmd/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 	assertConfigCommand(t, "", "config", "set", "application", "t1.a1.i1")
 	assertConfigCommand(t, "application = t1.a1.i1\n", "config", "get", "application")
 
-	assertConfigCommand(t, "api-key-file = /tmp/private.key\napplication = t1.a1.i1\ncolor = auto\ninstance = <unset>\nquiet = false\ntarget = https://127.0.0.1\nwait = 0\n", "config", "get")
+	assertConfigCommand(t, "api-key-file = /tmp/private.key\napplication = t1.a1.i1\ncolor = auto\ninstance = <unset>\nquiet = false\ntarget = https://127.0.0.1\nwait = 0\nzone = <unset>\n", "config", "get")
 
 	assertConfigCommand(t, "", "config", "set", "wait", "60")
 	assertConfigCommandErr(t, "Error: wait option must be an integer >= 0, got \"foo\"\n", "config", "set", "wait", "foo")

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -70,10 +70,10 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 			}
 			if opts.IsCloud() {
 				log.Printf("\nUse %s for deployment status, or follow this deployment at", color.CyanString("vespa status"))
-				log.Print(color.CyanString(fmt.Sprintf("%s/tenant/%s/application/%s/dev/instance/%s/job/%s-%s/run/%d",
+				log.Print(color.CyanString(fmt.Sprintf("%s/tenant/%s/application/%s/%s/instance/%s/job/%s-%s/run/%d",
 					opts.Target.Deployment().System.ConsoleURL,
-					opts.Target.Deployment().Application.Tenant, opts.Target.Deployment().Application.Application, opts.Target.Deployment().Application.Instance,
-					opts.Target.Deployment().Zone.Environment, opts.Target.Deployment().Zone.Region,
+					opts.Target.Deployment().Application.Tenant, opts.Target.Deployment().Application.Application, opts.Target.Deployment().Zone.Environment,
+					opts.Target.Deployment().Application.Instance, opts.Target.Deployment().Zone.Environment, opts.Target.Deployment().Zone.Region,
 					result.ID)))
 			}
 			return waitForQueryService(cli, result.ID)

--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -17,7 +17,6 @@ import (
 
 func newDeployCmd(cli *CLI) *cobra.Command {
 	var (
-		zoneArg     string
 		logLevelArg string
 	)
 	cmd := &cobra.Command{
@@ -46,7 +45,7 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 			if err != nil {
 				return err
 			}
-			target, err := cli.target(targetOptions{zone: zoneArg, logLevel: logLevelArg})
+			target, err := cli.target(targetOptions{logLevel: logLevelArg})
 			if err != nil {
 				return err
 			}
@@ -79,8 +78,7 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 			return waitForQueryService(cli, result.ID)
 		},
 	}
-	cmd.PersistentFlags().StringVarP(&zoneArg, "zone", "z", "", "The zone to use for deployment. This defaults to a dev zone")
-	cmd.PersistentFlags().StringVarP(&logLevelArg, "log-level", "l", "error", `Log level for Vespa logs. Must be "error", "warning", "info" or "debug"`)
+	cmd.Flags().StringVarP(&logLevelArg, "log-level", "l", "error", `Log level for Vespa logs. Must be "error", "warning", "info" or "debug"`)
 	return cmd
 }
 

--- a/client/go/cmd/prod.go
+++ b/client/go/cmd/prod.go
@@ -406,6 +406,6 @@ func verifyTest(cli *CLI, testsParent string, suite string, required bool) error
 		}
 		return nil
 	}
-	_, _, err = runTests(cli, "", testDirectory, true)
+	_, _, err = runTests(cli, testDirectory, true)
 	return err
 }

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -28,6 +28,7 @@ import (
 const (
 	applicationFlag = "application"
 	instanceFlag    = "instance"
+	zoneFlag        = "zone"
 	targetFlag      = "target"
 	waitFlag        = "wait"
 	colorFlag       = "color"
@@ -60,6 +61,7 @@ type Flags struct {
 	target      string
 	application string
 	instance    string
+	zone        string
 	waitSecs    int
 	color       string
 	quiet       bool
@@ -76,8 +78,6 @@ type ErrCLI struct {
 }
 
 type targetOptions struct {
-	// zone declares the zone use when using this target. If empty, a default zone for the system is chosen.
-	zone string
 	// logLevel sets the log level to use for this target. If empty, it defaults to "info".
 	logLevel string
 	// noCertificate declares that no client certificate should be required when using this target.
@@ -154,6 +154,7 @@ func (c *CLI) loadConfig() error {
 	bindings.bindFlag(targetFlag, c.cmd)
 	bindings.bindFlag(applicationFlag, c.cmd)
 	bindings.bindFlag(instanceFlag, c.cmd)
+	bindings.bindFlag(zoneFlag, c.cmd)
 	bindings.bindFlag(waitFlag, c.cmd)
 	bindings.bindFlag(colorFlag, c.cmd)
 	bindings.bindFlag(quietFlag, c.cmd)
@@ -201,6 +202,7 @@ func (c *CLI) configureFlags() {
 	c.cmd.PersistentFlags().StringVarP(&flags.target, targetFlag, "t", "local", "The name or URL of the recipient of this command")
 	c.cmd.PersistentFlags().StringVarP(&flags.application, applicationFlag, "a", "", "The application to manage")
 	c.cmd.PersistentFlags().StringVarP(&flags.instance, instanceFlag, "i", "", "The instance of the application to manage")
+	c.cmd.PersistentFlags().StringVarP(&flags.zone, zoneFlag, "z", "", "The zone to use. This defaults to a dev zone")
 	c.cmd.PersistentFlags().IntVarP(&flags.waitSecs, waitFlag, "w", 0, "Number of seconds to wait for a service to become ready")
 	c.cmd.PersistentFlags().StringVarP(&flags.color, colorFlag, "c", "auto", "Whether to use colors in output.")
 	c.cmd.PersistentFlags().BoolVarP(&flags.quiet, quietFlag, "q", false, "Quiet mode. Only errors will be printed")
@@ -318,7 +320,7 @@ func (c *CLI) createCloudTarget(targetType string, opts targetOptions) (vespa.Ta
 	if err != nil {
 		return nil, err
 	}
-	deployment, err := c.config.deploymentIn(opts.zone, system)
+	deployment, err := c.config.deploymentIn(c.flags.zone, system)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Most commands need to know about the custom zone, if one is used. For historical
reasons however, `-z` was only available in `vespa deploy`. Other commands
therefore used the default zone.

@ean