### PR TITLE
Revert back to CentOS 7 for open source releasing for now.

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -183,8 +183,6 @@ jobs:
       - *save-cache
 
   publish-release:
-    image: docker.io/vespaengine/vespa-build-centos-stream8:latest
-
     annotations:
       screwdriver.cd/cpu: 7
       screwdriver.cd/ram: 16

--- a/screwdriver/release-java-artifacts.sh
+++ b/screwdriver/release-java-artifacts.sh
@@ -31,10 +31,8 @@ cd $VESPA_DIR
 git checkout $VESPA_REF
 
 mkdir -p $SD_SOURCE_DIR/screwdriver/deploy
-openssl aes-256-cbc -md md5 -pass pass:$GPG_ENCPHRASE -in $SD_SOURCE_DIR/screwdriver/pubring.gpg.enc -out $SD_SOURCE_DIR/screwdriver/deploy/pubring.gpg -d
-openssl aes-256-cbc -md md5 -pass pass:$GPG_ENCPHRASE -in $SD_SOURCE_DIR/screwdriver/secring.gpg.enc -out $SD_SOURCE_DIR/screwdriver/deploy/secring.gpg -d
-export GPG_TTY=$(tty)
-export TERM=xterm
+openssl aes-256-cbc -pass pass:$GPG_ENCPHRASE -in $SD_SOURCE_DIR/screwdriver/pubring.gpg.enc -out $SD_SOURCE_DIR/screwdriver/deploy/pubring.gpg -d
+openssl aes-256-cbc -pass pass:$GPG_ENCPHRASE -in $SD_SOURCE_DIR/screwdriver/secring.gpg.enc -out $SD_SOURCE_DIR/screwdriver/deploy/secring.gpg -d
 
 # Build the Java code with the correct version set
 find . -name "pom.xml" -exec sed -i'' -e "s,<version>.*SNAPSHOT.*</version>,<version>$VESPA_RELEASE</version>," \

--- a/screwdriver/release-rpms.sh
+++ b/screwdriver/release-rpms.sh
@@ -12,7 +12,7 @@ fi
 readonly VESPA_RELEASE="$1"
 readonly VESPA_REF="$2"
 
-VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/epel-7-x86_64 --repoid=vespa -q vespa | tail -1 | cut -d: -f2 | cut -d- -f1)
+VESPA_RPM=$(repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/epel-7-x86_64 --repoid=vespa -q vespa | cut -d: -f2 | cut -d- -f1)
 echo "Latest RPM on Copr: $VESPA_RPM"
 
 if [ "$VESPA_RELEASE" == "$VESPA_RPM" ]; then
@@ -32,7 +32,7 @@ cd vespa
 dist/release-vespa-rpm.sh $VESPA_RELEASE $VESPA_REF
 
 while [ "$VESPA_RELEASE" != "$VESPA_RPM" ]; do
-  VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/epel-7-x86_64 --repoid=vespa -q vespa | tail -1 | cut -d: -f2 | cut -d- -f1)
+  VESPA_RPM=$(repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/epel-7-x86_64 --repoid=vespa -q vespa | cut -d: -f2 | cut -d- -f1)
   echo "RPM: $VESPA_RPM"
   sleep 150
 done


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

There are issues with the gpg packages, nexus plugin and selection of JDK when using the CentOS Stream 8 image. We need to get a release out, so revert this for now.
