### PR TITLE
Suppress "removal" warnings for java.lang.SecurityManager

### DIFF
--- a/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtConverterTestCase.java
+++ b/searchlib/src/test/java/com/yahoo/searchlib/gbdt/GbdtConverterTestCase.java
@@ -22,11 +22,13 @@ import static org.junit.Assert.fail;
 public class GbdtConverterTestCase {
 
     @Before
+    @SuppressWarnings("removal")
     public void enableSecurityManager() {
         System.setSecurityManager(new NoExitSecurityManager());
     }
 
     @After
+    @SuppressWarnings("removal")
     public void disableSecurityManager() {
         System.setSecurityManager(null);
     }
@@ -140,6 +142,7 @@ public class GbdtConverterTestCase {
         }
     }
 
+    @SuppressWarnings("removal")
     private static class NoExitSecurityManager extends SecurityManager {
 
         @Override

--- a/vespajlib/src/main/java/com/yahoo/concurrent/ThreadFactoryFactory.java
+++ b/vespajlib/src/main/java/com/yahoo/concurrent/ThreadFactoryFactory.java
@@ -36,6 +36,7 @@ public class ThreadFactoryFactory {
             final String namePrefix;
             final boolean isDaemon;
 
+            @SuppressWarnings("removal")
             Factory(final String name, boolean isDaemon) {
                 this.isDaemon = isDaemon;
                 final SecurityManager s = System.getSecurityManager();

--- a/vespajlib/src/test/java/com/yahoo/io/FatalErrorHandlerTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/io/FatalErrorHandlerTestCase.java
@@ -12,9 +12,10 @@ import org.junit.Test;
 /**
  * Just to remove noise from the coverage report.
  *
- * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
+ * @author Steinar Knutsen
  */
 public class FatalErrorHandlerTestCase {
+    @SuppressWarnings("removal")
     private static final class AvoidExiting extends SecurityManager {
 
         @Override
@@ -31,12 +32,14 @@ public class FatalErrorHandlerTestCase {
     private FatalErrorHandler h;
 
     @Before
+    @SuppressWarnings("removal")
     public void setUp() throws Exception {
         h = new FatalErrorHandler();
         System.setSecurityManager(new AvoidExiting());
     }
 
     @After
+    @SuppressWarnings("removal")
     public void tearDown() throws Exception {
         System.setSecurityManager(null);
     }


### PR DESCRIPTION
The compiler does not complain about unnecessary SuppressWarnings, so we can do this on master.