### PR TITLE
Deprecate DocumentAPI methods using explicit operation priority [run-systemtest]

### DIFF
--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MessageFactory.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MessageFactory.java
@@ -28,23 +28,25 @@ class MessageFactory {
     private final LoadType loadType;
     private final DocumentProtocol.Priority priority;
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public MessageFactory(DocumentMessage requestMsg) {
         this.requestMsg = requestMsg;
         loadType = requestMsg.getLoadType();
-        priority = requestMsg.getPriority();
+        priority = requestMsg.getPriority(); // TODO: Remove on Vespa 8
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public DocumentMessage fromDocumentOperation(Processing processing, DocumentOperation documentOperation) {
         DocumentMessage message = newMessage(documentOperation);
         message.setLoadType(loadType);
-        message.setPriority(priority);
+        message.setPriority(priority); // TODO: Remove on Vespa 8
         message.setRoute(requestMsg.getRoute());
         message.setTimeReceivedNow();
         message.setTimeRemaining(requestMsg.getTimeRemainingNow());
         message.getTrace().setLevel(requestMsg.getTrace().getLevel());
         log.log(Level.FINE, () -> "Created '" + message.getClass().getName() +
                                   "', route = '" + message.getRoute() +
-                                  "', priority = '" + message.getPriority().name() +
+                                  "', priority = '" + message.getPriority().name() + // TODO: Remove on Vespa 8
                                   "', load type = '" + message.getLoadType() +
                                   "', trace level = '" + message.getTrace().getLevel() +
                                   "', time remaining = '" + message.getTimeRemaining() + "'.");

--- a/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
+++ b/docproc/src/test/java/com/yahoo/docproc/jdisc/DocumentProcessingHandlerTestBase.java
@@ -135,9 +135,10 @@ public abstract class DocumentProcessingHandlerTestBase {
 
     protected abstract DocumentType getType();
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean sendMessage(String destinationChainName, DocumentMessage msg) {
         msg.setRoute(Route.parse("test/chain." + destinationChainName + " " + remoteServer.connectionSpec()));
-        msg.setPriority(DocumentProtocol.Priority.HIGH_1);
+        msg.setPriority(DocumentProtocol.Priority.HIGH_1); // TODO: Remove on Vespa 8
         msg.setLoadType(LoadType.DEFAULT);
         msg.getTrace().setLevel(9);
         msg.setTimeRemaining(60 * 1000);

--- a/documentapi/src/main/java/com/yahoo/documentapi/AsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/AsyncSession.java
@@ -47,7 +47,10 @@ public interface AsyncSession extends Session {
      * @param document the Document to put
      * @param priority the priority with which to send the operation
      * @return the synchronous result of this operation
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default Result put(Document document, DocumentProtocol.Priority priority) {
         return put(new DocumentPut(document), parameters().withPriority(priority));
     }
@@ -78,7 +81,10 @@ public interface AsyncSession extends Session {
      * @param documentPut the DocumentPut to perform
      * @param priority the priority with which to send the operation
      * @return the synchronous result of this operation
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default Result put(DocumentPut documentPut, DocumentProtocol.Priority priority) {
         return put(documentPut, parameters().withPriority(priority));
     }
@@ -125,9 +131,9 @@ public interface AsyncSession extends Session {
      * @param priority The priority with which to perform this operation.
      * @return the synchronous result of this operation
      * @throws UnsupportedOperationException if this access implementation does not support retrieving
-     * @deprecated the 'headersonly' flag has no effect
+     * @deprecated The 'headersonly' flag has no effect. Specifying explicit operation priority is deprecated
      */
-    @Deprecated // TODO: Remove on Vespa 8
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     default Result get(DocumentId id, boolean headersOnly, DocumentProtocol.Priority priority) {
         return get(id);
     }
@@ -144,7 +150,10 @@ public interface AsyncSession extends Session {
      * @param priority The priority with which to perform this operation.
      * @return the synchronous result of this operation
      * @throws UnsupportedOperationException if this access implementation does not support retrieving
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default Result get(DocumentId id, DocumentProtocol.Priority priority) {
         return get(id, parameters().withPriority(priority));
     }
@@ -193,7 +202,10 @@ public interface AsyncSession extends Session {
      * @param priority The priority with which to perform this operation.
      * @return the synchronous result of this operation
      * @throws UnsupportedOperationException if this access implementation does not support removal
+     * @deprecated specifying explicit operation priority is deprecated. Use methods without priority parameter.
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default Result remove(DocumentId id, DocumentProtocol.Priority priority) {
         return remove(id, parameters().withPriority(priority));
     }
@@ -258,7 +270,10 @@ public interface AsyncSession extends Session {
      * @param priority The priority with which to perform this operation.
      * @return the synchronous result of this operation
      * @throws UnsupportedOperationException if this access implementation does not support update
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default Result update(DocumentUpdate update, DocumentProtocol.Priority priority) {
         return update(update, parameters().withPriority(priority));
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/DocumentOperationParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/DocumentOperationParameters.java
@@ -42,7 +42,10 @@ public class DocumentOperationParameters {
         return empty;
     }
 
-    /** Sets the priority with which to perform an operation. */
+    /** Sets the priority with which to perform an operation.
+     * @deprecated specifying explicit operation priority is deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public DocumentOperationParameters withPriority(DocumentProtocol.Priority priority) {
         return new DocumentOperationParameters(requireNonNull(priority), fieldSet, route, traceLevel, deadline, responseHandler);
     }
@@ -80,6 +83,10 @@ public class DocumentOperationParameters {
         return new DocumentOperationParameters(priority, fieldSet, route, traceLevel, deadline, requireNonNull(responseHandler));
     }
 
+    /**
+     * @deprecated explicit operation priority is deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public Optional<DocumentProtocol.Priority> priority() { return Optional.ofNullable(priority); }
     public Optional<String> fieldSet() { return Optional.ofNullable(fieldSet); }
     public Optional<String> route() { return Optional.ofNullable(route); }

--- a/documentapi/src/main/java/com/yahoo/documentapi/SyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/SyncSession.java
@@ -35,7 +35,10 @@ public interface SyncSession extends Session {
      *
      * @param documentPut the DocumentPut operation
      * @param priority the priority with which to perform this operation
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     default void put(DocumentPut documentPut, DocumentProtocol.Priority priority) {
         put(documentPut, parameters().withPriority(priority));
     }
@@ -67,7 +70,10 @@ public interface SyncSession extends Session {
      * @param priority the priority with which to perform this operation
      * @return the document with this id, or null if there is none
      * @throws UnsupportedOperationException thrown if this does not support retrieving
+     * @deprecated specifying explicit operation priority is deprecated. Set fieldSet via
+     *             {@link #get(DocumentId, DocumentOperationParameters, Duration)} instead.
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     default Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority priority) {
         return get(id, fieldSet, priority, null);
     }
@@ -93,7 +99,9 @@ public interface SyncSession extends Session {
      * @return the known document having this id, or null if there is no document having this id
      * @throws UnsupportedOperationException thrown if this access does not support retrieving
      * @throws DocumentAccessException on any messagebus error, including timeout ({@link com.yahoo.messagebus.ErrorCode#TIMEOUT})
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority priority, Duration timeout);
 
     /**
@@ -106,7 +114,7 @@ public interface SyncSession extends Session {
      * @throws UnsupportedOperationException thrown if this access does not support retrieving
      * @throws DocumentAccessException on any messagebus error, including timeout ({@link com.yahoo.messagebus.ErrorCode#TIMEOUT})
      */
-    default Document get(DocumentId id, DocumentOperationParameters parameters,  Duration timeout) {
+    default Document get(DocumentId id, DocumentOperationParameters parameters, Duration timeout) {
         return get(id, timeout);
     }
 
@@ -125,7 +133,9 @@ public interface SyncSession extends Session {
      * @param priority the priority with which to perform this operation
      * @return true if the document with this id was removed, false otherwise.
      * @throws UnsupportedOperationException thrown if this access does not support removal
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     boolean remove(DocumentRemove documentRemove, DocumentProtocol.Priority priority);
 
     /**
@@ -162,7 +172,9 @@ public interface SyncSession extends Session {
      * @throws DocumentAccessException on update error, including but not limited to: 1. timeouts,
      * 2. the document exists but the {@link DocumentUpdate#setCondition(TestAndSetCondition) condition}
      * is not met.
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     boolean update(DocumentUpdate update, DocumentProtocol.Priority priority);
 
     /**

--- a/documentapi/src/main/java/com/yahoo/documentapi/local/LocalSyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/local/LocalSyncSession.java
@@ -33,6 +33,8 @@ public class LocalSyncSession implements SyncSession {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void put(DocumentPut documentPut, DocumentProtocol.Priority priority) {
         access.documents.put(documentPut.getId(), documentPut.getDocument());
     }
@@ -43,6 +45,8 @@ public class LocalSyncSession implements SyncSession {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority priority, Duration timeout) {
         return access.documents.get(id);
     }
@@ -57,6 +61,8 @@ public class LocalSyncSession implements SyncSession {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean remove(DocumentRemove documentRemove, DocumentProtocol.Priority priority) {
         return remove(documentRemove);
     }
@@ -72,6 +78,8 @@ public class LocalSyncSession implements SyncSession {
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean update(DocumentUpdate update, DocumentProtocol.Priority pri) {
         Document document = access.documents.get(update.getId());
         if (document == null) {

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusAsyncSession.java
@@ -7,7 +7,6 @@ import com.yahoo.document.DocumentPut;
 import com.yahoo.document.DocumentRemove;
 import com.yahoo.document.DocumentUpdate;
 import com.yahoo.document.fieldset.AllFields;
-import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.documentapi.AsyncParameters;
 import com.yahoo.documentapi.AsyncSession;
 import com.yahoo.documentapi.DocumentIdResponse;
@@ -109,6 +108,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Result put(DocumentPut documentPut, DocumentOperationParameters parameters) {
         PutDocumentMessage msg = new PutDocumentMessage(documentPut);
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_3));
@@ -121,12 +121,14 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
     }
 
     @Override
-    @Deprecated // TODO: Remove on Vespa 8
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Result get(DocumentId id, boolean headersOnly, DocumentProtocol.Priority pri) {
         return get(id, pri);
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Result get(DocumentId id, DocumentOperationParameters parameters) {
         // TODO Vespa 8: change to DocumentOnly.NAME
         GetDocumentMessage msg = new GetDocumentMessage(id, parameters.fieldSet().orElse(AllFields.NAME));
@@ -140,6 +142,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Result remove(DocumentRemove remove, DocumentOperationParameters parameters) {
         RemoveDocumentMessage msg = new RemoveDocumentMessage(remove);
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_2));
@@ -152,6 +155,7 @@ public class MessageBusAsyncSession implements MessageBusSession, AsyncSession {
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Result update(DocumentUpdate update, DocumentOperationParameters parameters) {
         UpdateDocumentMessage msg = new UpdateDocumentMessage(update);
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_2));

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusSyncSession.java
@@ -127,11 +127,14 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void put(DocumentPut documentPut, DocumentProtocol.Priority priority) {
         put(documentPut, parameters().withPriority(priority));
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void put(DocumentPut documentPut, DocumentOperationParameters parameters) {
         PutDocumentMessage msg = new PutDocumentMessage(documentPut);
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_3));
@@ -147,11 +150,14 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Document get(DocumentId id, String fieldSet, DocumentProtocol.Priority pri, Duration timeout) {
         return get(id, parameters().withFieldSet(fieldSet).withPriority(pri), timeout);
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public Document get(DocumentId id, DocumentOperationParameters parameters, Duration timeout) {
         // TODO Vespa 8: change to DocumentOnly.NAME
         GetDocumentMessage msg = new GetDocumentMessage(id, parameters.fieldSet().orElse(AllFields.NAME));
@@ -178,11 +184,14 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean remove(DocumentRemove documentRemove, DocumentProtocol.Priority pri) {
         return remove(documentRemove, parameters().withPriority(pri));
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean remove(DocumentRemove documentRemove, DocumentOperationParameters parameters) {
         RemoveDocumentMessage msg = new RemoveDocumentMessage(documentRemove.getId());
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_2));
@@ -203,11 +212,14 @@ public class MessageBusSyncSession implements MessageBusSession, SyncSession, Re
     }
 
     @Override
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean update(DocumentUpdate update, DocumentProtocol.Priority pri) {
         return update(update, parameters().withPriority(pri));
     }
 
     @Override
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public boolean update(DocumentUpdate update, DocumentOperationParameters parameters) {
         UpdateDocumentMessage msg = new UpdateDocumentMessage(update);
         msg.setPriority(parameters.priority().orElse(DocumentProtocol.Priority.NORMAL_2));

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusVisitorSession.java
@@ -638,6 +638,7 @@ public class MessageBusVisitorSession implements VisitorSession {
             return sb.toString();
         }
 
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         private CreateVisitorMessage createMessage(VisitorIterator.BucketProgress bucket) {
             CreateVisitorMessage msg = new CreateVisitorMessage(
                     params.getVisitorLibrary(),
@@ -660,7 +661,7 @@ public class MessageBusVisitorSession implements VisitorSession {
             msg.setRoute(params.getRoute());
             msg.setMaxBucketsPerVisitor(params.getMaxBucketsPerVisitor());
             msg.setLoadType(params.getLoadType());
-            msg.setPriority(params.getPriority());
+            msg.setPriority(params.getPriority()); // TODO: remove on Vespa 8
 
             msg.setRetryEnabled(false);
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentMessage.java
@@ -49,14 +49,18 @@ public abstract class DocumentMessage extends Message {
      * document protocol.
      *
      * @return The priority.
+     * @deprecated explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public DocumentProtocol.Priority getPriority() { return priority; }
 
     /**
      * Sets the priority tag for this message.
      *
      * @param priority The priority to set.
+     * @deprecated specifying explicit operation priority is deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public void setPriority(DocumentProtocol.Priority priority) {
         this.priority = priority;
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories60.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories60.java
@@ -66,6 +66,7 @@ public abstract class RoutableFactories60 {
          */
         protected abstract DocumentMessage doDecode(DocumentDeserializer deserializer);
 
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public boolean encode(Routable obj, DocumentSerializer out) {
             if (!(obj instanceof DocumentMessage)) {
                 throw new AssertionError(
@@ -73,13 +74,14 @@ public abstract class RoutableFactories60 {
                         "routable type " + obj.getType() + "(" + obj.getClass().getName() + ").");
             }
             DocumentMessage msg = (DocumentMessage)obj;
-            out.putByte(null, (byte)(msg.getPriority().getValue()));
+            out.putByte(null, (byte)(msg.getPriority().getValue())); // TODO: encode default value on Vespa 8
             out.putInt(null, msg.getLoadType().getId());
             return doEncode(msg, out);
         }
 
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public Routable decode(DocumentDeserializer in, LoadTypeSet loadTypes) {
-            byte pri = in.getByte(null);
+            byte pri = in.getByte(null); // TODO: ignore on Vespa 8
             int loadType = in.getInt(null);
             DocumentMessage msg = doDecode(in);
             if (msg != null) {

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/MessageBusVisitorSessionTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/MessageBusVisitorSessionTestCase.java
@@ -452,6 +452,7 @@ public class MessageBusVisitorSessionTestCase {
         return params;
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private String createVisitorToString(CreateVisitorMessage msg) {
         StringBuilder sb = new StringBuilder();
         sb.append("CreateVisitorMessage(buckets=[\n");
@@ -501,7 +502,7 @@ public class MessageBusVisitorSessionTestCase {
         if (msg.getLoadType() != LoadType.DEFAULT) {
             sb.append("load type=").append(msg.getLoadType().getName()).append("\n");
         }
-        if (msg.getPriority() != DocumentProtocol.Priority.NORMAL_3) {
+        if (msg.getPriority() != DocumentProtocol.Priority.NORMAL_3) { // TODO: remove on Vespa 8
             sb.append("priority=").append(msg.getPriority()).append("\n");
         }
         if (!"DumpVisitor".equals(msg.getLibraryName())) {

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ClientFeederV3.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/vespa/http/server/ClientFeederV3.java
@@ -240,6 +240,7 @@ class ClientFeederV3 {
         return message;
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private void setMessageParameters(DocumentOperationMessageV3 msg, FeederSettings settings) {
         msg.getMessage().setContext(new ReplyContext(msg.getOperationId(), feedReplies));
         if (settings.traceLevel != null) {
@@ -249,7 +250,7 @@ class ClientFeederV3 {
             try {
                 DocumentProtocol.Priority priority = DocumentProtocol.Priority.valueOf(settings.priority);
                 if (msg.getMessage() instanceof DocumentMessage) {
-                    ((DocumentMessage) msg.getMessage()).setPriority(priority);
+                    ((DocumentMessage) msg.getMessage()).setPriority(priority); // TODO: Remove on Vespa 8
                 }
             }
             catch (IllegalArgumentException i) {

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
@@ -141,9 +141,10 @@ public class DocumentRetriever {
         return messageBusParams;
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private Message createDocumentRequest(String docid, LoadType loadType) {
         GetDocumentMessage msg = new GetDocumentMessage(new DocumentId(docid), params.fieldSet);
-        msg.setPriority(params.priority);
+        msg.setPriority(params.priority); // TODO: Remove on Vespa 8
         msg.setRetryEnabled(!params.noRetry);
 
         if (loadType != null) {

--- a/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespafeeder/VespaFeederTestCase.java
@@ -152,13 +152,14 @@ public class VespaFeederTestCase {
     }
 
     @Test
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void feedFile() throws Exception {
         FeedFixture f = new FeedFixture();
         Arguments arguments = new Arguments("--file src/test/files/myfeed.xml --priority LOW_1".split(" "), f.sessionFactory);
         new VespaFeeder(arguments, f.typeManager).parseFiles(System.in, f.printStream);
 
         assertEquals(3, f.sessionFactory.messages.size());
-        assertEquals(DocumentProtocol.Priority.LOW_1, ((PutDocumentMessage)f.sessionFactory.messages.get(0)).getPriority());
+        assertEquals(DocumentProtocol.Priority.LOW_1, ((PutDocumentMessage)f.sessionFactory.messages.get(0)).getPriority()); // TODO: Remove on Vespa 8
         assertEquals("id:test:news::foo", ((PutDocumentMessage) f.sessionFactory.messages.get(0)).getDocumentPut().getDocument().getId().toString());
         DocumentUpdate update = ((UpdateDocumentMessage) f.sessionFactory.messages.get(1)).getDocumentUpdate();
         assertEquals("id:test:news::foo", update.getId().toString());
@@ -175,9 +176,10 @@ public class VespaFeederTestCase {
         assertJsonFeedState(feedFixture);
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     protected void assertJsonFeedState(FeedFixture feedFixture) {
         assertEquals(3, feedFixture.sessionFactory.messages.size());
-        assertEquals(DocumentProtocol.Priority.LOW_1, ((PutDocumentMessage)feedFixture.sessionFactory.messages.get(0)).getPriority());
+        assertEquals(DocumentProtocol.Priority.LOW_1, ((PutDocumentMessage)feedFixture.sessionFactory.messages.get(0)).getPriority()); // TODO: Remove on Vespa 8
         assertEquals("id:test:news::foo", ((PutDocumentMessage) feedFixture.sessionFactory.messages.get(0)).getDocumentPut().getDocument().getId().toString());
         DocumentUpdate update = ((UpdateDocumentMessage) feedFixture.sessionFactory.messages.get(1)).getDocumentUpdate();
         assertEquals("id:test:news::foo", update.getId().toString());

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
@@ -134,6 +134,7 @@ public class DocumentRetrieverTest {
     }
 
     @Test
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void testSendSingleMessage() throws DocumentRetrieverException {
         ClientParameters params = createParameters()
                 .setDocumentIds(asIterator(DOC_ID_1))
@@ -156,7 +157,7 @@ public class DocumentRetrieverTest {
         verify(mockedSession, times(1)).syncSend(argThat((ArgumentMatcher<GetDocumentMessage>) o ->
                 o.getPriority().equals(DocumentProtocol.Priority.HIGH_1) &&
                 !o.getRetryEnabled() &&
-                o.getLoadType().equals(new LoadType(1, "loadtype", DocumentProtocol.Priority.HIGH_1))));
+                o.getLoadType().equals(new LoadType(1, "loadtype", DocumentProtocol.Priority.HIGH_1)))); // TODO: Remove on Vespa 8
         assertContainsDocument(DOC_ID_1);
     }
 


### PR DESCRIPTION
@bratseth please review
@gjoranv FYI

This is functionality that made more sense when we had spinning drives
and no async write scheduling in the backend. Going away on Vespa 8.

