### PR TITLE
Deprecate load types from Java APIs [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/Clients.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/Clients.java
@@ -13,6 +13,7 @@ import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
  *
  * @author Gunnar Gauslaa Bergem
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class Clients extends ConfigModel {
 
     private static final long serialVersionUID = 1L;

--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
@@ -19,10 +19,10 @@ public class DocumentAccessProvider implements Provider<VespaDocumentAccess> {
     private final VespaDocumentAccess access;
 
     @Inject
-    public DocumentAccessProvider(DocumentmanagerConfig documentmanagerConfig, LoadTypeConfig loadTypeConfig,
+    public DocumentAccessProvider(DocumentmanagerConfig documentmanagerConfig,
                                   MessagebusConfig messagebusConfig, DocumentProtocolPoliciesConfig policiesConfig,
                                   DistributionConfig distributionConfig) {
-        this.access = new VespaDocumentAccess(documentmanagerConfig, loadTypeConfig, System.getProperty("config.id"),
+        this.access = new VespaDocumentAccess(documentmanagerConfig, System.getProperty("config.id"),
                                               messagebusConfig, policiesConfig, distributionConfig);
     }
 

--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
@@ -43,13 +43,12 @@ public class VespaDocumentAccess extends DocumentAccess {
     private boolean shutDown = false;
 
     VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig,
-                        LoadTypeConfig loadTypeConfig,
                         String slobroksConfigId,
                         MessagebusConfig messagebusConfig,
                         DocumentProtocolPoliciesConfig policiesConfig,
                         DistributionConfig distributionConfig) {
         super(new DocumentAccessParams().setDocumentmanagerConfig(documentmanagerConfig));
-        this.parameters = new MessageBusParams(new LoadTypeSet(loadTypeConfig))
+        this.parameters = new MessageBusParams()
                 .setDocumentProtocolPoliciesConfig(policiesConfig, distributionConfig);
         this.parameters.setDocumentmanagerConfig(documentmanagerConfig);
         this.parameters.getRPCNetworkParams().setSlobrokConfigId(slobroksConfigId);

--- a/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/SessionCache.java
+++ b/container-messagebus/src/main/java/com/yahoo/container/jdisc/messagebus/SessionCache.java
@@ -69,14 +69,18 @@ public final class SessionCache extends AbstractComponent {
     @Inject
     public SessionCache(NetworkMultiplexerProvider nets, ContainerMbusConfig containerMbusConfig,
                         DocumentTypeManager documentTypeManager,
-                        LoadTypeConfig loadTypeConfig, MessagebusConfig messagebusConfig,
+                        MessagebusConfig messagebusConfig,
                         DocumentProtocolPoliciesConfig policiesConfig,
                         DistributionConfig distributionConfig) {
         this(nets::net, containerMbusConfig, documentTypeManager,
-             loadTypeConfig, messagebusConfig, policiesConfig, distributionConfig);
+             null/*TODO: Remove on Vespa 8*/, messagebusConfig, policiesConfig, distributionConfig);
 
     }
 
+    /**
+     * @deprecated load types are deprecated. Use constructor without LoadTypeSet instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public SessionCache(Supplier<NetworkMultiplexer> net, ContainerMbusConfig containerMbusConfig,
                         DocumentTypeManager documentTypeManager,
                         LoadTypeConfig loadTypeConfig, MessagebusConfig messagebusConfig,
@@ -86,7 +90,6 @@ public final class SessionCache extends AbstractComponent {
              containerMbusConfig,
              messagebusConfig,
              new DocumentProtocol(documentTypeManager,
-                                  new LoadTypeSet(loadTypeConfig),
                                   policiesConfig,
                                   distributionConfig));
     }

--- a/container-messagebus/src/test/java/com/yahoo/container/jdisc/messagebus/MbusClientProviderTest.java
+++ b/container-messagebus/src/test/java/com/yahoo/container/jdisc/messagebus/MbusClientProviderTest.java
@@ -36,6 +36,7 @@ public class MbusClientProviderTest {
         testClient(new SessionConfig(builder));
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private void testClient(SessionConfig config) {
         SessionCache cache = new SessionCache(() -> NetworkMultiplexer.dedicated(new NullNetwork()),
                                               new ContainerMbusConfig.Builder().build(),

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsStreamingSearcher.java
@@ -90,6 +90,7 @@ public class VdsStreamingSearcher extends VespaBackEndSearcher {
         }
 
         @Override
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public LoadTypeSet getLoadTypeSet() {
             return ((MessageBusDocumentAccess) access.delegate()).getParams().getLoadTypes();
         }

--- a/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
+++ b/container-search/src/main/java/com/yahoo/vespa/streamingvisitors/VdsVisitor.java
@@ -76,6 +76,12 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
 
     public interface VisitorSessionFactory {
         VisitorSession createVisitorSession(VisitorParameters params) throws ParseException;
+
+        /**
+         * @deprecated load types are deprecated
+         */
+        @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         LoadTypeSet getLoadTypeSet();
     }
 
@@ -119,6 +125,7 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         return query.properties().getString(streamingSelection);
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private void setVisitorParameters(String searchCluster, Route route, String documentType) {
         params.setDocumentSelection(createSelectionString(documentType, createQuerySelectionString()));
         params.setTimeoutMs(query.getTimeout()); // Per bucket visitor timeout
@@ -134,6 +141,7 @@ class VdsVisitor extends VisitorDataHandler implements Visitor {
         params.visitInconsistentBuckets(true);
         params.setPriority(DocumentProtocol.Priority.VERY_HIGH);
 
+        // TODO remove on Vespa 8
         if (query.properties().getString(streamingLoadtype) != null) {
             LoadType loadType = visitorSessionFactory.getLoadTypeSet().getNameMap().get(query.properties().getString(streamingLoadtype));
             if (loadType != null) {

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/VdsVisitorTestCase.java
@@ -31,8 +31,9 @@ import static org.junit.Assert.*;
 /**
  * @author <a href="mailto:ulf@yahoo-inc.com">Ulf Carlin</a>
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class VdsVisitorTestCase {
-    private LoadTypeSet loadTypeSet = new LoadTypeSet();
+    private LoadTypeSet loadTypeSet = new LoadTypeSet(); // TODO remove on Vespa 8
 
     public VdsVisitorTestCase() {
         loadTypeSet.addLoadType(1, "low", DocumentProtocol.Priority.LOW_1);
@@ -489,7 +490,7 @@ public class VdsVisitorTestCase {
 
     private static class MockVisitorSessionFactory implements VdsVisitor.VisitorSessionFactory {
         private VisitorParameters params;
-        private LoadTypeSet loadTypeSet;
+        private LoadTypeSet loadTypeSet; // TODO remove on Vespa 8
         private boolean timeoutQuery = false;
         private boolean failQuery = false;
 
@@ -504,6 +505,7 @@ public class VdsVisitorTestCase {
         }
 
         @Override
+        // TODO: Remove on Vespa 8
         public LoadTypeSet getLoadTypeSet() {
             return loadTypeSet;
         }

--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MessageFactory.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MessageFactory.java
@@ -21,12 +21,13 @@ import java.util.logging.Logger;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 class MessageFactory {
 
     private final static Logger log = Logger.getLogger(MessageFactory.class.getName());
     private final Message requestMsg;
-    private final LoadType loadType;
-    private final DocumentProtocol.Priority priority;
+    private final LoadType loadType; // TODO: Remove on Vespa 8
+    private final DocumentProtocol.Priority priority; // TODO: Remove on Vespa 8
 
     @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public MessageFactory(DocumentMessage requestMsg) {

--- a/documentapi/abi-spec.json
+++ b/documentapi/abi-spec.json
@@ -1844,6 +1844,7 @@
       "public static com.yahoo.documentapi.messagebus.protocol.DocumentProtocol$Priority getPriorityByName(java.lang.String)",
       "public void <init>(com.yahoo.document.DocumentTypeManager)",
       "public void <init>(com.yahoo.document.DocumentTypeManager, java.lang.String)",
+      "public void <init>(com.yahoo.document.DocumentTypeManager, com.yahoo.documentapi.messagebus.protocol.DocumentProtocolPoliciesConfig, com.yahoo.vespa.config.content.DistributionConfig)",
       "public void <init>(com.yahoo.document.DocumentTypeManager, com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet, com.yahoo.documentapi.messagebus.protocol.DocumentProtocolPoliciesConfig, com.yahoo.vespa.config.content.DistributionConfig)",
       "public void <init>(com.yahoo.document.DocumentTypeManager, java.lang.String, com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet)",
       "public com.yahoo.documentapi.messagebus.protocol.DocumentProtocol putRoutingPolicyFactory(java.lang.String, com.yahoo.documentapi.messagebus.protocol.RoutingPolicyFactory)",
@@ -3123,7 +3124,8 @@
     ],
     "methods": [
       "public abstract boolean encode(com.yahoo.messagebus.Routable, com.yahoo.document.serialization.DocumentSerializer)",
-      "public abstract com.yahoo.messagebus.Routable decode(com.yahoo.document.serialization.DocumentDeserializer, com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet)"
+      "public abstract com.yahoo.messagebus.Routable decode(com.yahoo.document.serialization.DocumentDeserializer, com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet)",
+      "public com.yahoo.messagebus.Routable decode(com.yahoo.document.serialization.DocumentDeserializer)"
     ],
     "fields": []
   },

--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
@@ -20,6 +20,7 @@ import java.util.TreeMap;
  *
  * @author Håkon Humberset
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class VisitorParameters extends Parameters {
 
     private String documentSelection;
@@ -47,7 +48,7 @@ public class VisitorParameters extends Parameters {
     private int maxBucketsPerVisitor = 1;
     private boolean dynamicallyIncreaseMaxBucketsPerVisitor = false;
     private float dynamicMaxBucketsIncreaseFactor = 2;
-    private LoadType loadType = LoadType.DEFAULT;
+    private LoadType loadType = LoadType.DEFAULT; // TODO: Remove on Vespa 8
     private DocumentProtocol.Priority priority = null;
     private int traceLevel = 0;
     private ThrottlePolicy throttlePolicy = null;
@@ -332,10 +333,18 @@ public class VisitorParameters extends Parameters {
         throttlePolicy = policy;
     }
 
+    /**
+     * @deprecated load types are deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public void setLoadType(LoadType loadType) {
         this.loadType = loadType;
     }
 
+    /**
+     * @deprecated load types are deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public LoadType getLoadType() {
         return loadType;
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusDocumentAccess.java
@@ -53,6 +53,7 @@ public class MessageBusDocumentAccess extends DocumentAccess {
      *
      * @param params All parameters for construction.
      */
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public MessageBusDocumentAccess(MessageBusParams params) {
         super(params);
         this.params = params;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusParams.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/MessageBusParams.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author Einar M R Rosenvinge
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class MessageBusParams extends DocumentAccessParams {
 
     private String routingConfigId = null;
@@ -26,12 +27,16 @@ public class MessageBusParams extends DocumentAccessParams {
     private RPCNetworkParams rpcNetworkParams = new RPCNetworkParams();
     private com.yahoo.messagebus.MessageBusParams mbusParams = new com.yahoo.messagebus.MessageBusParams();
     private SourceSessionParams sourceSessionParams = new SourceSessionParams();
-    private LoadTypeSet loadTypes;
+    private LoadTypeSet loadTypes; // TODO remove on Vespa 8
 
     public MessageBusParams() {
         this(new LoadTypeSet());
     }
 
+    /**
+     * @deprecated load types are deprecated. Use default constructor instead
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public MessageBusParams(LoadTypeSet loadTypes) {
         this.loadTypes = loadTypes;
     }
@@ -39,7 +44,9 @@ public class MessageBusParams extends DocumentAccessParams {
     /**
      *
      * @return Returns the set of load types accepted by this Vespa installation
+     * @deprecated load types are deprecated
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public LoadTypeSet getLoadTypes() {
         return loadTypes;
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/loadtypes/LoadType.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/loadtypes/LoadType.java
@@ -4,8 +4,10 @@ package com.yahoo.documentapi.messagebus.loadtypes;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 
 /**
+ * @deprecated load types are deprecated
  * @author thomasg
  */
+@Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
 public class LoadType {
     private int id;
     private String name;

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/loadtypes/LoadTypeSet.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/loadtypes/LoadTypeSet.java
@@ -20,8 +20,14 @@ import java.util.TreeMap;
  *
  * For testing, you may want to use the empty constructor and add
  * load types yourself with addType().
+ *
+ * @deprecated load types are deprecated
  */
+@Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class LoadTypeSet {
+
+    public static final LoadTypeSet EMPTY = new LoadTypeSet();
 
     class DualMap {
         Map<String, LoadType> nameMap = new TreeMap<String, LoadType>();

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentMessage.java
@@ -9,10 +9,11 @@ import com.yahoo.text.Utf8String;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public abstract class DocumentMessage extends Message {
 
     private DocumentProtocol.Priority priority = DocumentProtocol.Priority.NORMAL_3;
-    private LoadType loadType = LoadType.DEFAULT;
+    private LoadType loadType = LoadType.DEFAULT; // TODO: Remove on Vespa 8
 
     /**
      * Constructs a new message with no content.
@@ -65,10 +66,20 @@ public abstract class DocumentMessage extends Message {
         this.priority = priority;
     }
 
+    /**
+     * @deprecated load types are deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public LoadType getLoadType() {
         return loadType;
     }
 
+    /**
+     * @deprecated load types are deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void setLoadType(LoadType loadType) {
         if (loadType != null) {
             this.loadType = loadType;
@@ -79,7 +90,7 @@ public abstract class DocumentMessage extends Message {
 
     @Override
     public int getApproxSize() {
-        return 4 + 1; // type + priority
+        return 4 + 1; // type + priority // TODO update on Vespa 8 to not include deprecated fields
     }
 
     @Override

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/DocumentProtocol.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
  *
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class DocumentProtocol implements Protocol {
 
     private static final Logger log = Logger.getLogger(DocumentProtocol.class.getName());
@@ -246,12 +247,27 @@ public class DocumentProtocol implements Protocol {
         this(docMan, configId, new LoadTypeSet());
     }
 
+    public DocumentProtocol(DocumentTypeManager documentTypeManager,
+                            DocumentProtocolPoliciesConfig policiesConfig,
+                            DistributionConfig distributionConfig) {
+        this(requireNonNull(documentTypeManager), null, new LoadTypeSet(),
+             requireNonNull(policiesConfig), requireNonNull(distributionConfig));
+    }
+
+    /**
+     * @deprecated load types are deprecated. Use constructor without LoadTypeSet instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public DocumentProtocol(DocumentTypeManager documentTypeManager, LoadTypeSet loadTypes,
                             DocumentProtocolPoliciesConfig policiesConfig, DistributionConfig distributionConfig) {
         this(requireNonNull(documentTypeManager), null, requireNonNull(loadTypes),
-        requireNonNull(policiesConfig), requireNonNull(distributionConfig));
+             requireNonNull(policiesConfig), requireNonNull(distributionConfig));
     }
 
+    /**
+     * @deprecated load types are deprecated. Use constructor without LoadTypeSet instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public DocumentProtocol(DocumentTypeManager docMan, String configId, LoadTypeSet set) {
         this(docMan, configId == null ? "client" : configId, set, null, null);
     }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories60.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories60.java
@@ -6,22 +6,17 @@ import com.yahoo.document.Document;
 import com.yahoo.document.DocumentId;
 import com.yahoo.document.DocumentPut;
 import com.yahoo.document.DocumentUpdate;
-import com.yahoo.document.FixedBucketSpaces;
 import com.yahoo.document.TestAndSetCondition;
 import com.yahoo.document.serialization.DocumentDeserializer;
 import com.yahoo.document.serialization.DocumentSerializer;
-import com.yahoo.document.serialization.DocumentSerializerFactory;
 import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
-import java.util.logging.Level;
 import com.yahoo.messagebus.Routable;
 import com.yahoo.vdslib.DocumentSummary;
 import com.yahoo.vdslib.SearchResult;
 import com.yahoo.vdslib.VisitorStatistics;
 import com.yahoo.vespa.objects.Deserializer;
-import com.yahoo.vespa.objects.Serializer;
 
 import java.util.Map;
-import java.util.logging.Logger;
 
 import static com.yahoo.documentapi.messagebus.protocol.AbstractRoutableFactory.decodeString;
 import static com.yahoo.documentapi.messagebus.protocol.AbstractRoutableFactory.encodeString;
@@ -86,7 +81,7 @@ public abstract class RoutableFactories60 {
             DocumentMessage msg = doDecode(in);
             if (msg != null) {
                 msg.setPriority(DocumentProtocol.getPriority(pri));
-                msg.setLoadType(loadTypes.getIdMap().get(loadType));
+                msg.setLoadType(loadTypes.getIdMap().get(loadType)); // TODO: ignore on Vespa 8
             }
             return msg;
         }
@@ -136,6 +131,7 @@ public abstract class RoutableFactories60 {
             return doEncode(reply, out);
         }
 
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public Routable decode(DocumentDeserializer in, LoadTypeSet loadTypes) {
             byte pri = in.getByte(null);
             DocumentReply reply = doDecode(in);

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactory.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactory.java
@@ -22,7 +22,7 @@ public interface RoutableFactory {
 
     /**
      * <p>This method encodes the content of the given routable into a byte buffer that can later be decoded using the
-     * {@link #decode(DocumentDeserializer, com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet)} method.</p> <p>Return false to signal failure.</p>
+     * {@link #decode(DocumentDeserializer)} method.</p> <p>Return false to signal failure.</p>
      * <p>This method is NOT exception safe.</p>
      *
      * @param obj The routable to encode.
@@ -38,7 +38,15 @@ public interface RoutableFactory {
      * @param in        The buffer to read from.
      * @param loadTypes The LoadTypeSet to inject into the Routable.
      * @return The decoded routable.
+     * @deprecated load types are deprecated. Use method without LoadTypeSet instead
      */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     Routable decode(DocumentDeserializer in, LoadTypeSet loadTypes);
+
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
+    default Routable decode(DocumentDeserializer in) {
+        return decode(in, LoadTypeSet.EMPTY);
+    }
 
 }

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
@@ -28,13 +28,21 @@ import java.util.logging.Logger;
  *
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 final class RoutableRepository {
 
     private static final Logger log = Logger.getLogger(RoutableRepository.class.getName());
     private final CopyOnWriteHashMap<Integer, VersionMap> factoryTypes = new CopyOnWriteHashMap<>();
     private final CopyOnWriteHashMap<CacheKey, RoutableFactory> cache = new CopyOnWriteHashMap<>();
-    private LoadTypeSet loadTypes;
+    private LoadTypeSet loadTypes; // TODO remove on Vespa 8
 
+    public RoutableRepository() {}
+
+    /**
+     * @deprecated load types are deprecated. Use default constructor instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public RoutableRepository(LoadTypeSet set) {
         loadTypes = set;
     }

--- a/documentapi/src/test/java/com/yahoo/documentapi/VisitorParametersTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/VisitorParametersTestCase.java
@@ -7,7 +7,9 @@ import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class VisitorParametersTestCase {
+    // TODO: Remove on Vespa 8
     private LoadType loadType = new LoadType(3, "samnmax", DocumentProtocol.Priority.HIGH_3);
 
     @SuppressWarnings("removal")// TODO: Vespa 8: remove
@@ -21,12 +23,12 @@ public class VisitorParametersTestCase {
         params.setLibraryParameter("groovy", "dudes");
         params.setLibraryParameter("ninja", "turtles");
         params.setMaxBucketsPerVisitor(55);
-        params.setPriority(DocumentProtocol.Priority.HIGHEST);
+        params.setPriority(DocumentProtocol.Priority.HIGHEST); // TODO: Remove on Vespa 8
         params.setRoute("extraterrestrial/highway");
         params.setTimeoutMs(1337);
         params.setMaxPending(111);
         params.setFieldSet(AllFields.NAME);
-        params.setLoadType(loadType);
+        params.setLoadType(loadType); // TODO: Remove on Vespa 8
         params.setVisitRemoves(true);
         params.setVisitInconsistentBuckets(true);
         params.setTraceLevel(9);

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/loadtypes/test/LoadTypesTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/loadtypes/test/LoadTypesTestCase.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertEquals;
 /**
  * @author thomasg
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
+// TODO Vespa 8: remove test case once load types are gone
 public class LoadTypesTestCase {
 
     @Test

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/Messages60TestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/Messages60TestCase.java
@@ -143,6 +143,7 @@ public class Messages60TestCase extends MessagesTestBase {
         private static final String BUCKET_SPACE = "beartato";
 
         @Override
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public void run() {
             GetBucketListMessage msg = new GetBucketListMessage(new BucketId(16, 123));
             msg.setBucketSpace(BUCKET_SPACE);
@@ -151,7 +152,7 @@ public class Messages60TestCase extends MessagesTestBase {
             for (Language lang : LANGUAGES) {
                 msg = (GetBucketListMessage)deserialize("GetBucketListMessage", DocumentProtocol.MESSAGE_GETBUCKETLIST, lang);
                 assertEquals(new BucketId(16, 123), msg.getBucketId());
-                assertEquals("default", msg.getLoadType().getName());
+                assertEquals("default", msg.getLoadType().getName()); // TODO: Remove on Vespa 8
                 assertEquals(BUCKET_SPACE, msg.getBucketSpace());
             }
         }
@@ -162,9 +163,10 @@ public class Messages60TestCase extends MessagesTestBase {
         private static final String BUCKET_SPACE = "andrei";
 
         @Override
+        @SuppressWarnings("removal") // TODO: Remove on Vespa 8
         public void run() {
             StatBucketMessage msg = new StatBucketMessage(new BucketId(16, 123), "id.user=123");
-            msg.setLoadType(null);
+            msg.setLoadType(null); // TODO: Remove on Vespa 8
             msg.setBucketSpace(BUCKET_SPACE);
             assertEquals(BASE_MESSAGE_LENGTH + 27 + serializedLength(BUCKET_SPACE), serialize("StatBucketMessage", msg));
 
@@ -172,7 +174,7 @@ public class Messages60TestCase extends MessagesTestBase {
                 msg = (StatBucketMessage)deserialize("StatBucketMessage", DocumentProtocol.MESSAGE_STATBUCKET, lang);
                 assertEquals(new BucketId(16, 123), msg.getBucketId());
                 assertEquals("id.user=123", msg.getDocumentSelection());
-                assertEquals("default", msg.getLoadType().getName());
+                assertEquals("default", msg.getLoadType().getName()); // TODO: Remove on Vespa 8
                 assertEquals(BUCKET_SPACE, msg.getBucketSpace());
             }
         }

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/MessagesTestBase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/protocol/test/MessagesTestBase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.*;
 /**
  * @author Simon Thoresen Hult
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public abstract class MessagesTestBase {
 
     protected enum Language {
@@ -28,7 +29,7 @@ public abstract class MessagesTestBase {
     protected static final Set<Language> LANGUAGES = EnumSet.allOf(Language.class);
 
     protected final DocumentTypeManager docMan = new DocumentTypeManager();
-    protected final LoadTypeSet loadTypes = new LoadTypeSet();
+    protected final LoadTypeSet loadTypes = new LoadTypeSet(); // TODO remove on Vespa 8
     protected final DocumentProtocol protocol = new DocumentProtocol(docMan, null, loadTypes);
 
     public MessagesTestBase() {

--- a/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/MessageBusVisitorSessionTestCase.java
+++ b/documentapi/src/test/java/com/yahoo/documentapi/messagebus/test/MessageBusVisitorSessionTestCase.java
@@ -697,6 +697,7 @@ public class MessageBusVisitorSessionTestCase {
     }
 
     @Test
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     public void testMessageParameters() {
         MockSender sender = new MockSender();
         MockReceiver receiver = new MockReceiver();
@@ -716,7 +717,7 @@ public class MessageBusVisitorSessionTestCase {
         params.setTimeoutMs(1337);
         params.setMaxPending(111);
         params.setFieldSet(DocIdOnly.NAME);
-        params.setLoadType(new LoadType(3, "samnmax", DocumentProtocol.Priority.HIGH_3));
+        params.setLoadType(new LoadType(3, "samnmax", DocumentProtocol.Priority.HIGH_3)); // TODO: Remove on Vespa 8
         params.setVisitRemoves(true);
         params.setVisitInconsistentBuckets(true);
         params.setTraceLevel(9);

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/MessageBusSessionFactory.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/MessageBusSessionFactory.java
@@ -18,7 +18,8 @@ public class MessageBusSessionFactory implements SessionFactory {
     public MessageBusSessionFactory(MessagePropertyProcessor processor) {
         this(processor, null, null);
     }
-    
+
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private MessageBusSessionFactory(MessagePropertyProcessor processor,
                                     DocumentmanagerConfig documentmanagerConfig,
                                     SlobroksConfig slobroksConfig) {

--- a/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
+++ b/vespaclient-core/src/main/java/com/yahoo/feedapi/MessagePropertyProcessor.java
@@ -33,10 +33,18 @@ public class MessagePropertyProcessor implements ConfigSubscriber.SingleSubscrib
     private String defaultDocprocChain = null;
     private boolean defaultAbortOnDocumentError = true;
     private boolean defaultAbortOnSendError = true;
-    private final LoadTypeSet loadTypes;
+    private final LoadTypeSet loadTypes; // TODO remove on Vespa 8
     private boolean configChanged = false;
 
+    public MessagePropertyProcessor(FeederConfig config) {
+        loadTypes = new LoadTypeSet();
+        configure(config);
+    }
 
+    /**
+     * @deprecated load types are deprecated. Use constructor without LoadTypeConfig instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public MessagePropertyProcessor(FeederConfig config, LoadTypeConfig loadTypeCfg) {
         loadTypes = new LoadTypeSet();
         configure(config, loadTypeCfg);
@@ -127,11 +135,19 @@ public class MessagePropertyProcessor implements ConfigSubscriber.SingleSubscrib
         return feederOptions;
     }
 
+    /**
+     * @deprecated load types are deprecated. configure without LoadTypeConfig instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public synchronized void configure(FeederConfig config, LoadTypeConfig loadTypeConfig) {
         loadTypes.configure(loadTypeConfig);
         configure(config);
     }
 
+    /**
+     * @deprecated load types are deprecated
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     LoadTypeSet getLoadTypes() {
         return loadTypes;
     }
@@ -175,7 +191,7 @@ public class MessagePropertyProcessor implements ConfigSubscriber.SingleSubscrib
         private boolean abortOnDocumentError;
         private boolean abortOnFeedError;
         private boolean createIfNonExistent;
-        private LoadType loadType;
+        private LoadType loadType; // TODO remove on Vespa 8
         private int traceLevel;
 
         PropertySetter(Route route, long timeout, long totalTimeout, DocumentProtocol.Priority priority, LoadType loadType,

--- a/vespaclient-java/src/main/java/com/yahoo/dummyreceiver/DummyReceiver.java
+++ b/vespaclient-java/src/main/java/com/yahoo/dummyreceiver/DummyReceiver.java
@@ -4,7 +4,6 @@ package com.yahoo.dummyreceiver;
 import com.yahoo.concurrent.DaemonThreadFactory;
 import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 import com.yahoo.documentapi.messagebus.MessageBusParams;
-import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.RemoveDocumentMessage;
 import com.yahoo.documentapi.messagebus.protocol.UpdateDocumentMessage;
@@ -68,7 +67,7 @@ public class DummyReceiver implements MessageHandler {
     }
 
     private void init() {
-        MessageBusParams params = new MessageBusParams(new LoadTypeSet());
+        MessageBusParams params = new MessageBusParams();
         params.setRPCNetworkParams(new RPCNetworkParams().setIdentity(new Identity(name)));
         params.setDocumentManagerConfigId("client");
         params.getMessageBusParams().setMaxPendingCount(0);

--- a/vespaclient-java/src/main/java/com/yahoo/vespafeeder/Arguments.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespafeeder/Arguments.java
@@ -153,7 +153,7 @@ public class Arguments {
             }
         }
 
-        propertyProcessor = new MessagePropertyProcessor(getFeederConfig(), new LoadTypeConfig(new LoadTypeConfig.Builder()));
+        propertyProcessor = new MessagePropertyProcessor(getFeederConfig());
     }
 
     private String getParam(List<String> args, String arg) throws IllegalArgumentException {

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
@@ -27,16 +27,30 @@ import java.util.Map;
  *
  * @author bjorncs
  */
+@SuppressWarnings("removal") // TODO: Remove on Vespa 8
 public class DocumentRetriever {
 
     private final ClusterList clusterList;
     private final DocumentAccessFactory documentAccessFactory;
     private final ClientParameters params;
-    private final LoadTypeSet loadTypeSet;
+    private final LoadTypeSet loadTypeSet; // TODO remove on Vespa 8
 
     private MessageBusSyncSession session;
     private MessageBusDocumentAccess documentAccess;
 
+    public DocumentRetriever(ClusterList clusterList,
+                             DocumentAccessFactory documentAccessFactory,
+                             ClientParameters params) {
+        this.clusterList = clusterList;
+        this.documentAccessFactory = documentAccessFactory;
+        this.loadTypeSet = new LoadTypeSet(); // TODO remove on Vespa 8
+        this.params = params;
+    }
+
+    /**
+     * @deprecated load types are deprecated. Use constructor without LoadTypeSet instead.
+     */
+    @Deprecated(forRemoval = true) // TODO: Remove on Vespa 8
     public DocumentRetriever(ClusterList clusterList,
                              DocumentAccessFactory documentAccessFactory,
                              LoadTypeSet loadTypeSet,

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/Main.java
@@ -38,11 +38,12 @@ public class Main {
         Runtime.getRuntime().addShutdownHook(new Thread(documentRetriever::shutdown));
     }
 
+    @SuppressWarnings("removal") // TODO: Remove on Vespa 8
     private static DocumentRetriever createDocumentRetriever(ClientParameters params) {
         return new DocumentRetriever(
                 new ClusterList("client"),
                 new DocumentAccessFactory(),
-                new LoadTypeSet(params.configId),
+                new LoadTypeSet(params.configId), // TODO: Remove on Vespa 8
                 params
         );
     }

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -10,7 +10,6 @@ import com.yahoo.documentapi.VisitorParameters;
 import com.yahoo.documentapi.VisitorSession;
 import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 import com.yahoo.documentapi.messagebus.MessageBusParams;
-import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
 import com.yahoo.log.LogSetup;
 import com.yahoo.messagebus.StaticThrottlePolicy;
@@ -36,7 +35,7 @@ import java.util.stream.Collectors;
 public class VdsVisit {
 
     private VdsVisitParameters params;
-    private MessageBusParams mbparams = new MessageBusParams(new LoadTypeSet());
+    private MessageBusParams mbparams = new MessageBusParams();
     private VisitorSession session;
 
     private final VisitorSessionAccessorFactory sessionAccessorFactory;

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisitTarget.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisitTarget.java
@@ -8,7 +8,6 @@ import com.yahoo.documentapi.VisitorDestinationParameters;
 import com.yahoo.documentapi.VisitorDestinationSession;
 import com.yahoo.documentapi.messagebus.MessageBusDocumentAccess;
 import com.yahoo.documentapi.messagebus.MessageBusParams;
-import com.yahoo.documentapi.messagebus.loadtypes.LoadTypeSet;
 import java.util.logging.Level;
 import com.yahoo.log.LogSetup;
 import com.yahoo.messagebus.network.Identity;
@@ -209,7 +208,7 @@ public class VdsVisitTarget {
     public void run() throws Exception {
         initShutdownHook();
         log.log(Level.FINE, "Starting VdsVisitTarget");
-        MessageBusParams mbusParams = new MessageBusParams(new LoadTypeSet());
+        MessageBusParams mbusParams = new MessageBusParams();
         mbusParams.getRPCNetworkParams().setIdentity(new Identity(slobrokAddress));
 
         if (port > 0) {

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
@@ -129,7 +129,6 @@ public class DocumentRetrieverTest {
         return new DocumentRetriever(
                 clusterList,
                 mockedFactory,
-                new LoadTypeSet(),
                 params);
     }
 
@@ -145,7 +144,7 @@ public class DocumentRetrieverTest {
 
         when(mockedSession.syncSend(any())).thenReturn(createDocumentReply(DOC_ID_1));
 
-        LoadTypeSet loadTypeSet = new LoadTypeSet();
+        LoadTypeSet loadTypeSet = new LoadTypeSet(); // TODO remove on Vespa 8
         loadTypeSet.addLoadType(1, "loadtype", DocumentProtocol.Priority.HIGH_1);
         DocumentRetriever documentRetriever = new DocumentRetriever(
                 new ClusterList(),


### PR DESCRIPTION
@jonmv please review. Load type tentacles reached further than I first thought 🦑
@gjoranv FYI

Load types have not been used in practice for years, and supporting
them in backend metrics etc. has long since been lacking. Prepare for
removing these on Vespa 8.

Most callsites are unchanged, aside from presumed safe changes such
as constructors used by dependency injection. Have added new overloads
without load types where these did not already exist to allow for
an orderly transition.
