### PR TITLE
Let empty entry BufferType sentinel be static instead of global [run-systemtest]

### DIFF
--- a/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.cpp
@@ -21,9 +21,10 @@ void
 DirectTensorStore::TensorBufferType::cleanHold(void* buffer, size_t offset, ElemCount num_elems, CleanContext clean_ctx)
 {
     TensorSP* elem = static_cast<TensorSP*>(buffer) + offset;
+    const auto& empty = empty_entry();
     for (size_t i = 0; i < num_elems; ++i) {
         clean_ctx.extraBytesCleaned((*elem)->get_memory_usage().allocatedBytes());
-        *elem = _emptyEntry;
+        *elem = empty;
         ++elem;
     }
 }

--- a/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/direct_tensor_store.h
@@ -24,7 +24,7 @@ private:
     class TensorBufferType : public vespalib::datastore::BufferType<TensorSP> {
     private:
         using ParentType = BufferType<TensorSP>;
-        using ParentType::_emptyEntry;
+        using ParentType::empty_entry;
         using CleanContext = typename ParentType::CleanContext;
     public:
         TensorBufferType();

--- a/searchlib/src/vespa/searchlib/tensor/streamed_value_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/streamed_value_store.cpp
@@ -166,9 +166,10 @@ void
 StreamedValueStore::TensorBufferType::cleanHold(void* buffer, size_t offset, ElemCount num_elems, CleanContext clean_ctx)
 {
     TensorEntry::SP* elem = static_cast<TensorEntry::SP*>(buffer) + offset;
+    const auto& empty = empty_entry();
     for (size_t i = 0; i < num_elems; ++i) {
         clean_ctx.extraBytesCleaned((*elem)->get_memory_usage().allocatedBytes());
-        *elem = _emptyEntry;
+        *elem = empty;
         ++elem;
     }
 }

--- a/searchlib/src/vespa/searchlib/tensor/streamed_value_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/streamed_value_store.h
@@ -51,7 +51,7 @@ private:
     class TensorBufferType : public vespalib::datastore::BufferType<TensorEntry::SP> {
     private:
         using ParentType = BufferType<TensorEntry::SP>;
-        using ParentType::_emptyEntry;
+        using ParentType::empty_entry;
         using CleanContext = typename ParentType::CleanContext;
     public:
         TensorBufferType() noexcept;

--- a/vespalib/src/vespa/vespalib/btree/btreenodestore.h
+++ b/vespalib/src/vespa/vespalib/btree/btreenodestore.h
@@ -25,7 +25,7 @@ template <typename EntryType>
 class BTreeNodeBufferType : public datastore::BufferType<EntryType, FrozenBtreeNode<EntryType>>
 {
     using ParentType = datastore::BufferType<EntryType, FrozenBtreeNode<EntryType>>;
-    using ParentType::_emptyEntry;
+    using ParentType::empty_entry;
     using ParentType::_arraySize;
     using ElemCount = typename ParentType::ElemCount;
     using CleanContext = typename ParentType::CleanContext;

--- a/vespalib/src/vespa/vespalib/datastore/buffer_type.h
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_type.h
@@ -133,7 +133,7 @@ template <typename EntryType, typename EmptyType = EntryType>
 class BufferType : public BufferTypeBase
 {
 protected:
-    static EntryType _emptyEntry;
+    static const EntryType& empty_entry() noexcept;
 
 public:
     BufferType() noexcept : BufferType(1,1,1) {}

--- a/vespalib/src/vespa/vespalib/datastore/large_array_buffer_type.h
+++ b/vespalib/src/vespa/vespalib/datastore/large_array_buffer_type.h
@@ -20,7 +20,7 @@ class LargeArrayBufferType : public BufferType<Array<EntryT>>
     using AllocSpec = ArrayStoreConfig::AllocSpec;
     using ArrayType = Array<EntryT>;
     using ParentType = BufferType<ArrayType>;
-    using ParentType::_emptyEntry;
+    using ParentType::empty_entry;
     using CleanContext = typename ParentType::CleanContext;
     std::shared_ptr<alloc::MemoryAllocator> _memory_allocator;
 public:

--- a/vespalib/src/vespa/vespalib/datastore/large_array_buffer_type.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/large_array_buffer_type.hpp
@@ -22,9 +22,10 @@ void
 LargeArrayBufferType<EntryT>::cleanHold(void* buffer, size_t offset, ElemCount numElems, CleanContext cleanCtx)
 {
     ArrayType* elem = static_cast<ArrayType*>(buffer) + offset;
+    const auto& empty = empty_entry();
     for (size_t i = 0; i < numElems; ++i) {
         cleanCtx.extraBytesCleaned(sizeof(EntryT) * elem->size());
-        *elem = _emptyEntry;
+        *elem = empty;
         ++elem;
     }
 }


### PR DESCRIPTION
@toregge and @baldersheim please review

Avoids issue where a global `BufferType` with a transitive `Alloc` instance
binds to a null reference allocator since the global allocator instance
has not yet been initialized as part of global constructor invocation.

Manually hoist empty sentinel ref outside of loops since it might not
be obvious to the compiler that the same object is reused over and over.
