### PR TITLE
flip "experimental-sd-parsing" feature flag default

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -119,7 +119,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bjorncs", "baldersheim"}) default boolean enableJdiscPreshutdownCommand() { return true; }
         @ModelFeatureFlag(owners = {"arnej"}) default boolean avoidRenamingSummaryFeatures() { return false; }
         @ModelFeatureFlag(owners = {"bjorncs", "baldersheim"}, removeAfter = "7.569") default boolean mergeGroupingResultInSearchInvoker() { return true; }
-        @ModelFeatureFlag(owners = {"arnej"}) default boolean experimentalSdParsing() { return false; }
+        @ModelFeatureFlag(owners = {"arnej"}) default boolean experimentalSdParsing() { return true; }
         @ModelFeatureFlag(owners = {"hmusum"}, removeAfter = "7.571") default String adminClusterNodeArchitecture() { return adminClusterArchitecture().name(); }
         @ModelFeatureFlag(owners = {"hmusum"}) default Architecture adminClusterArchitecture() { return Architecture.getDefault(); }
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -391,7 +391,7 @@ public class Flags {
             APPLICATION_ID);
 
     public static final UnboundBooleanFlag EXPERIMENTAL_SD_PARSING = defineFeatureFlag(
-            "experimental-sd-parsing", false,
+            "experimental-sd-parsing", true,
             List.of("arnej"), "2022-03-04", "2022-12-31",
             "Parsed schema files via intermediate format",
             "Takes effect at redeployment",


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

if there are no problems this week, we can flip the default for this feature flag for release on monday.
