### PR TITLE
Add more detailed visit failure metrics.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -855,6 +855,17 @@ public class VespaMetricSet {
         metrics.add(new Metric("vds.distributor.visitor.sum.latency.average")); // TODO: Remove in Vespa 8
         metrics.add(new Metric("vds.distributor.visitor.sum.ok.rate"));
         metrics.add(new Metric("vds.distributor.visitor.sum.failures.total.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.notready.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.notconnected.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.wrongdistributor.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.safe_time_not_reached.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.storagefailure.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.timeout.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.busy.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.inconsistent_bucket.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.notfound.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.concurrent_mutations.rate"));
+        metrics.add(new Metric("vds.distributor.visitor.sum.failures.test_and_set_failed.rate"));
 
         metrics.add(new Metric("vds.distributor.docsstored.average"));
         metrics.add(new Metric("vds.distributor.bytesstored.average"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -864,8 +864,6 @@ public class VespaMetricSet {
         metrics.add(new Metric("vds.distributor.visitor.sum.failures.busy.rate"));
         metrics.add(new Metric("vds.distributor.visitor.sum.failures.inconsistent_bucket.rate"));
         metrics.add(new Metric("vds.distributor.visitor.sum.failures.notfound.rate"));
-        metrics.add(new Metric("vds.distributor.visitor.sum.failures.concurrent_mutations.rate"));
-        metrics.add(new Metric("vds.distributor.visitor.sum.failures.test_and_set_failed.rate"));
 
         metrics.add(new Metric("vds.distributor.docsstored.average"));
         metrics.add(new Metric("vds.distributor.bytesstored.average"));


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@vekterli Please review.

Note: 
Some of the added metrics might not be relevant for visit operations, but are still output from the distributors. We should likely remove those from the PR before merging.