### PR TITLE
Implement createFilterSearch() for DirectAttributeBlueprint.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -562,6 +562,13 @@ public:
         return std::make_unique<queryeval::DocumentWeightSearchIterator>(*tfmda[0], _attr, _dict_entry);
     }
 
+    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
+        (void) constraint; // We provide an iterator with exact results, so no need to take constraint into consideration.
+        auto wrapper = std::make_unique<FilterWrapper>(getState().numFields());
+        wrapper->wrap(createLeafSearch(wrapper->tfmda(), strict));
+        return wrapper;
+    }
+
     void visitMembers(vespalib::ObjectVisitor &visitor) const override {
         LeafBlueprint::visitMembers(visitor);
         visit(visitor, "attribute", _attrName);


### PR DESCRIPTION
This ensures that query terms searching a weighted set attribute with fast-search
are included in the global filter used in nearest neighbor search in a hnsw index.

@toregge please review
@jobergum FYI