### PR TITLE
Allow proxying /state/v1/metrics via with service name + hostname

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server;
 
-import com.yahoo.net.DomainName;
 import com.google.inject.Inject;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
@@ -30,6 +29,7 @@ import com.yahoo.container.jdisc.secretstore.SecretStore;
 import com.yahoo.docproc.jdisc.metric.NullMetric;
 import com.yahoo.io.IOUtils;
 import com.yahoo.jdisc.Metric;
+import com.yahoo.net.DomainName;
 import com.yahoo.path.Path;
 import com.yahoo.restapi.HttpURL;
 import com.yahoo.slime.Slime;
@@ -559,24 +559,8 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         }
     }
 
-    public HttpResponse serviceStatusPage(ApplicationId applicationId, String hostName, String serviceName, HttpURL.Path pathSuffix) {
-        // WARNING: pathSuffix may be given by the external user. Make sure no security issues arise...
-        // We should be OK here, because at most, pathSuffix may change the parent path, but cannot otherwise
-        // change the hostname and port. Exposing other paths on the cluster controller should be fine.
-        // TODO: It would be nice to have a simple check to verify pathSuffix doesn't contain /../ components.
-        HttpURL.Path pathPrefix = HttpURL.Path.empty();
-        switch (serviceName) {
-            case "container-clustercontroller":
-                pathPrefix = pathPrefix.append("clustercontroller-status").append("v1");
-                break;
-            case "distributor":
-            case "storagenode":
-                break;
-            default:
-                throw new NotFoundException("No status page for service: " + serviceName);
-        }
-
-        return httpProxy.get(getApplication(applicationId), hostName, serviceName, pathPrefix.append(pathSuffix));
+    public HttpResponse proxyServiceHostnameRequest(ApplicationId applicationId, String hostName, String serviceName, HttpURL.Path path) {
+        return httpProxy.get(getApplication(applicationId), hostName, serviceName, path);
     }
 
     public Map<String, ClusterReindexing> getClusterReindexingStatus(ApplicationId applicationId) {

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/application/HttpProxy.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/application/HttpProxy.java
@@ -6,11 +6,6 @@ import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.PortInfo;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.container.jdisc.HttpResponse;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.logging.Level;
-
 import com.yahoo.net.DomainName;
 import com.yahoo.restapi.HttpURL;
 import com.yahoo.restapi.HttpURL.Path;
@@ -22,10 +17,9 @@ import com.yahoo.vespa.config.server.http.NotFoundException;
 import com.yahoo.vespa.config.server.http.SimpleHttpFetcher;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class HttpProxy {
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/SimpleHttpFetcher.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/SimpleHttpFetcher.java
@@ -8,16 +8,13 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.util.Timeout;
-
-import java.util.logging.Level;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class SimpleHttpFetcher implements HttpFetcher {
@@ -40,16 +37,12 @@ public class SimpleHttpFetcher implements HttpFetcher {
                 return new StaticResponse(
                         response.getCode(),
                         entity.getContentType(),
-                        EntityUtils.toString(entity));
+                        entity.getContent().readAllBytes());
             }
         } catch (SocketTimeoutException e) {
             String message = "Timed out after " + params.readTimeoutMs + " ms reading response from " + url;
             logger.log(Level.WARNING, message, e);
             throw new RequestTimeoutException(message);
-        } catch (ParseException e) {
-            String message = "Parse error in response from " + url;
-            logger.log(Level.WARNING, message, e);
-            throw new InternalServerException(message);
         } catch (IOException e) {
             String message = "Failed to get response from " + url;
             logger.log(Level.WARNING, message, e);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/StaticResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/StaticResponse.java
@@ -3,33 +3,27 @@ package com.yahoo.vespa.config.server.http;
 
 import com.yahoo.container.jdisc.HttpResponse;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 public class StaticResponse extends HttpResponse {
     private final String contentType;
-    private final InputStream body;
+    private final byte[] body;
 
-    /**
-     * @param body    Ownership is passed to StaticResponse (is responsible for closing it)
-     */
-    public StaticResponse(int status, String contentType, InputStream body) {
+    public StaticResponse(int status, String contentType, byte[] body) {
         super(status);
         this.contentType = contentType;
         this.body = body;
     }
 
     public StaticResponse(int status, String contentType, String body) {
-        this(status, contentType, new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+        this(status, contentType, body.getBytes(StandardCharsets.UTF_8));
     }
 
     @Override
     public void render(OutputStream outputStream) throws IOException {
-        body.transferTo(outputStream);
-        body.close();
+        outputStream.write(body);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
-import com.yahoo.net.DomainName;
 import com.google.inject.Inject;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ApplicationFile;
@@ -15,6 +14,7 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.io.IOUtils;
 import com.yahoo.jdisc.Response;
+import com.yahoo.net.DomainName;
 import com.yahoo.restapi.ErrorResponse;
 import com.yahoo.restapi.HttpURL;
 import com.yahoo.restapi.MessageResponse;
@@ -86,6 +86,7 @@ public class ApplicationHandler extends HttpHandler {
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/metrics/proton")) return protonMetrics(applicationId(path));
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/reindexing")) return getReindexingStatus(applicationId(path));
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/service/{service}/{hostname}/status/{*}")) return serviceStatusPage(applicationId(path), path.get("service"), path.get("hostname"), path.getRest());
+        if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/service/{service}/{hostname}/state/v1/metrics")) return serviceStateV1metrics(applicationId(path), path.get("service"), path.get("hostname"));
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/serviceconverge")) return listServiceConverge(applicationId(path), request);
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/serviceconverge/{hostAndPort}")) return checkServiceConverge(applicationId(path), path.get("hostAndPort"), request);
         if (path.matches("/application/v2/tenant/{tenant}/application/{application}/environment/{ignore}/region/{ignore}/instance/{instance}/suspended")) return isSuspended(applicationId(path));
@@ -134,7 +135,22 @@ public class ApplicationHandler extends HttpHandler {
     }
 
     private HttpResponse serviceStatusPage(ApplicationId applicationId, String service, String hostname, HttpURL.Path pathSuffix) {
-        return applicationRepository.serviceStatusPage(applicationId, hostname, service, pathSuffix);
+        HttpURL.Path pathPrefix = HttpURL.Path.empty();
+        switch (service) {
+            case "container-clustercontroller":
+                pathPrefix = pathPrefix.append("clustercontroller-status").append("v1");
+                break;
+            case "distributor":
+            case "storagenode":
+                break;
+            default:
+                throw new com.yahoo.vespa.config.server.NotFoundException("No status page for service: " + service);
+        }
+        return applicationRepository.proxyServiceHostnameRequest(applicationId, hostname, service, pathPrefix.append(pathSuffix));
+    }
+
+    private HttpResponse serviceStateV1metrics(ApplicationId applicationId, String service, String hostname) {
+        return applicationRepository.proxyServiceHostnameRequest(applicationId, hostname, service, HttpURL.Path.parse("/state/v1/metrics"));
     }
 
     private HttpResponse content(ApplicationId applicationId, HttpURL.Path contentPath, HttpRequest request) {

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
@@ -56,7 +56,8 @@ public interface ConfigServer {
 
     Map<?,?> getServiceApiResponse(DeploymentId deployment, String serviceName, Path restPath);
 
-    String getServiceStatusPage(DeploymentId deployment, String serviceName, DomainName node, Path subPath);
+    /** Returns a proxied response from a given path running on a given service and node */
+    ProxyResponse getServiceNodePage(DeploymentId deployment, String serviceName, DomainName node, Path subPath);
 
     /**
      * Gets the Vespa logs of the given deployment.

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.controller.restapi.application;
 
 import ai.vespa.hosted.api.Signatures;
-import ai.vespa.validation.Validation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
@@ -70,9 +69,6 @@ import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.RunId;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.SourceRevision;
 import com.yahoo.vespa.hosted.controller.api.integration.noderepository.RestartFilter;
-import com.yahoo.vespa.hosted.controller.api.integration.resource.MeteringData;
-import com.yahoo.vespa.hosted.controller.api.integration.resource.ResourceAllocation;
-import com.yahoo.vespa.hosted.controller.api.integration.resource.ResourceSnapshot;
 import com.yahoo.vespa.hosted.controller.api.integration.secrets.TenantSecretStore;
 import com.yahoo.vespa.hosted.controller.api.integration.user.User;
 import com.yahoo.vespa.hosted.controller.api.role.Role;
@@ -158,7 +154,6 @@ import java.util.logging.Level;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static ai.vespa.validation.Validation.requireAtLeast;
 import static com.yahoo.jdisc.Response.Status.BAD_REQUEST;
 import static com.yahoo.jdisc.Response.Status.CONFLICT;
 import static com.yahoo.yolean.Exceptions.uncheck;
@@ -275,6 +270,7 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/service")) return services(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/service/{service}/state/v1/{*}")) return service(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), path.get("service"), path.getRest(), request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/service/{service}/{host}/status/{*}")) return status(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), path.get("service"), path.get("host"), path.getRest(), request);
+        if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/service/{service}/{host}/state/v1/metrics")) return status(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), path.get("service"), path.get("host"), path.getRest(), request);
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/nodes")) return nodes(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"));
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/clusters")) return clusters(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"));
         if (path.matches("/application/v4/tenant/{tenant}/application/{application}/instance/{instance}/environment/{environment}/region/{region}/content/{*}")) return content(path.get("tenant"), path.get("application"), path.get("instance"), path.get("environment"), path.get("region"), path.getRest(), request);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -534,8 +534,8 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     }
 
     @Override
-    public String getServiceStatusPage(DeploymentId deployment, String serviceName, DomainName node, Path subPath) {
-        return "<h1>OK</h1>";
+    public ProxyResponse getServiceNodePage(DeploymentId deployment, String serviceName, DomainName node, Path subPath) {
+        return new ProxyResponse("<h1>OK</h1>".getBytes(StandardCharsets.UTF_8), "text/html", 200);
     }
 
     @Override


### PR DESCRIPTION
Allows getting `/state/v1/metrics` for a given hostname + service via `/application/v2` instead of the service + identifier via `/serviceview/v1`.

Must be merged with internal PR.