### PR TITLE
handle index names with > 2 dot-separated "words"

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/StructuredParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/StructuredParser.java
@@ -160,8 +160,8 @@ abstract class StructuredParser extends AbstractParser {
                 firstWord.add(tokens.next());
             }
 
-            if (tokens.currentIsNoIgnore(DOT)) {
-                tokens.skip();
+            while (tokens.currentIsNoIgnore(DOT)) {
+                secondWord.add(tokens.next());
                 if (tokens.currentIsNoIgnore(WORD) || tokens.currentIsNoIgnore(NUMBER)) {
                     secondWord.add(tokens.next());
                 } else {
@@ -177,11 +177,7 @@ abstract class StructuredParser extends AbstractParser {
             if ( ! tokens.skipNoIgnore(COLON))
                 return null;
 
-            if (secondWord.size() == 0) {
-                item = concatenate(firstWord);
-            } else {
-                item = concatenate(firstWord) + "." + concatenate(secondWord);
-            }
+            item = concatenate(firstWord) + concatenate(secondWord);
 
             item = indexFacts.getCanonicName(item);
 
@@ -395,7 +391,7 @@ abstract class StructuredParser extends AbstractParser {
             if ( ! tokens.currentIs(NUMBER)) return null;
 
             item = new IntItem(">" + (negative ? "-" : "") + tokens.next() + decimalPart(), true);
-            item.setOrigin(new Substring(initial.substring.start, tokens.currentNoIgnore().substring.start, 
+            item.setOrigin(new Substring(initial.substring.start, tokens.currentNoIgnore().substring.start,
                                          initial.getSubstring().getSuperstring())); // XXX: Unsafe end?
             return item;
         } finally {


### PR DESCRIPTION
* this is necessary when searching in map of struct, where
  the index will be "field.value.subfield" -> 3 "words".

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@bratseth please review
