### PR TITLE
Maven shade plugin config

### DIFF
--- a/application-preprocessor/pom.xml
+++ b/application-preprocessor/pom.xml
@@ -75,6 +75,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -48,6 +48,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
         <executions>
           <execution>

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -91,6 +91,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
         <executions>
           <execution>

--- a/document/pom.xml
+++ b/document/pom.xml
@@ -77,26 +77,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <configuration>
-                    <finalName>${project.artifactId}-jar-with-dependencies</finalName>
-                    <transformers>
-                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                            <mainClass>com.yahoo.document.foo</mainClass>
-                        </transformer>
-                    </transformers>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.helger.maven</groupId>
                 <artifactId>ph-javacc-maven-plugin</artifactId>
             </plugin>

--- a/filedistribution/pom.xml
+++ b/filedistribution/pom.xml
@@ -102,6 +102,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>

--- a/indexinglanguage/pom.xml
+++ b/indexinglanguage/pom.xml
@@ -60,30 +60,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <configuration>
-          <finalName>${project.artifactId}-jar-with-dependencies</finalName>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-javacc-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-install-plugin</artifactId>
-        <configuration>
-          <updateReleaseInfo>true</updateReleaseInfo>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/logserver/pom.xml
+++ b/logserver/pom.xml
@@ -63,6 +63,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
           <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>com.yahoo.logserver.Server</mainClass>

--- a/messagebus/pom.xml
+++ b/messagebus/pom.xml
@@ -67,6 +67,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
         <executions>
           <execution>

--- a/security-tools/pom.xml
+++ b/security-tools/pom.xml
@@ -49,6 +49,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <configuration>
           <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+          <createDependencyReducedPom>false</createDependencyReducedPom>
         </configuration>
         <executions>
           <execution>

--- a/vespa-http-client/pom.xml
+++ b/vespa-http-client/pom.xml
@@ -169,7 +169,8 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <outputFile>target/${project.artifactId}-jar-with-dependencies.jar</outputFile>
+              <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>com.yahoo.vespa.http.client.runner.Runner</mainClass>

--- a/vespa_feed_perf/pom.xml
+++ b/vespa_feed_perf/pom.xml
@@ -62,6 +62,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                     <transformers>
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                             <mainClass>com.yahoo.vespa.feed.perf.SimpleFeeder</mainClass>

--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -75,6 +75,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <finalName>${project.artifactId}-jar-with-dependencies</finalName>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The shade plugin changes behaviour for 3.3.0, see 
[MSHADE-321](https://issues.apache.org/jira/browse/MSHADE-321) Always respect 'createDependencyReducedPom' flag

FYI: @baldersheim, @geirst. For removing the fat jar in document + indexinglanguage. They seem unused to me.
