### PR TITLE
Trim down search::multivalue::Value and search::multivalue::WeightedValue.

### DIFF
--- a/searchcommon/src/vespa/searchcommon/attribute/multi_value_traits.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/multi_value_traits.h
@@ -1,0 +1,42 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <type_traits>
+
+namespace search::multivalue {
+
+template <typename T> class Value;
+template <typename T> class WeightedValue;
+
+/*
+ * Check for the presence of a weight.
+ */
+template <typename T>
+struct is_WeightedValue;
+
+template <typename T>
+struct is_WeightedValue<Value<T>> : std::false_type {};
+
+template <typename T>
+struct is_WeightedValue<WeightedValue<T>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_WeightedValue_v = is_WeightedValue<T>::value;
+
+/*
+ * Extract inner type.
+ */
+template <typename T>
+struct ValueType;
+
+template <typename T>
+struct ValueType<Value<T>> { using type = T; };
+
+template <typename T>
+struct ValueType<WeightedValue<T>> { using type = T; };
+
+template <typename T>
+using ValueType_t = typename ValueType<T>::type;
+
+}

--- a/searchcommon/src/vespa/searchcommon/attribute/multivalue.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/multivalue.h
@@ -9,7 +9,6 @@ namespace search::multivalue {
 template <typename T>
 class Value {
 public:
-    typedef T ValueType;
     Value() noexcept : _v() {}
     Value(T v) noexcept : _v(v) { }
     Value(T v, int32_t w) noexcept : _v(v) { (void) w; }
@@ -20,13 +19,9 @@ public:
     operator T & ()           { return _v; }
     int32_t weight()    const { return 1; }
     void setWeight(int32_t w) { (void) w; }
-    void incWeight(int32_t w) { (void) w; }
     bool operator ==(const Value<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const Value<T> & rhs) const { return _v < rhs._v; }
     bool operator >(const Value<T> & rhs) const { return _v > rhs._v; }
-    static bool hasWeight() { return false; }
-
-    static constexpr bool _hasWeight = false;
 private:
     T _v;
 };
@@ -34,7 +29,6 @@ private:
 template <typename T>
 class WeightedValue {
 public:
-    typedef T ValueType;
     WeightedValue() noexcept : _v(), _w(1) { }
     WeightedValue(T v, int32_t w) noexcept : _v(v), _w(w) { }
     T value()             const { return _v; }
@@ -44,14 +38,10 @@ public:
     operator T & ()             { return _v; }
     int32_t weight()      const { return _w; }
     void setWeight(int32_t w)   { _w = w; }
-    void incWeight(int32_t w)   { _w += w; }
 
     bool operator==(const WeightedValue<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const WeightedValue<T> & rhs) const { return _v < rhs._v; }
     bool operator >(const WeightedValue<T> & rhs) const { return _v > rhs._v; }
-    static bool hasWeight() { return true; }
-
-    static constexpr bool _hasWeight = true;
 private:
     T       _v;
     int32_t _w;

--- a/searchcommon/src/vespa/searchcommon/attribute/multivalue.h
+++ b/searchcommon/src/vespa/searchcommon/attribute/multivalue.h
@@ -18,7 +18,6 @@ public:
     operator T ()       const { return _v; }
     operator T & ()           { return _v; }
     int32_t weight()    const { return 1; }
-    void setWeight(int32_t w) { (void) w; }
     bool operator ==(const Value<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const Value<T> & rhs) const { return _v < rhs._v; }
     bool operator >(const Value<T> & rhs) const { return _v > rhs._v; }
@@ -37,7 +36,6 @@ public:
     operator T ()         const { return _v; }
     operator T & ()             { return _v; }
     int32_t weight()      const { return _w; }
-    void setWeight(int32_t w)   { _w = w; }
 
     bool operator==(const WeightedValue<T> & rhs) const { return _v == rhs._v; }
     bool operator <(const WeightedValue<T> & rhs) const { return _v < rhs._v; }

--- a/searchlib/src/vespa/searchlib/attribute/flagattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/flagattribute.cpp
@@ -73,7 +73,7 @@ template <typename B>
 bool
 FlagAttributeT<B>::onLoadEnumerated(ReaderBase &attrReader)
 {
-    typedef typename B::WType::ValueType TT;
+    using TT = multivalue::ValueType_t<typename B::WType>;
 
     uint32_t numDocs = attrReader.getNumIdx() - 1;
     uint64_t numValues = attrReader.getNumValues();
@@ -133,7 +133,7 @@ void FlagAttributeT<B>::setNewValues(DocId doc, const std::vector<typename B::WT
 
 template <typename B>
 void
-FlagAttributeT<B>::setNewBVValue(DocId doc, typename B::WType::ValueType value)
+FlagAttributeT<B>::setNewBVValue(DocId doc, multivalue::ValueType_t<typename B::WType> value)
 {
     uint32_t offset = getOffset(value);
     BitVector * bv = _bitVectors[offset];

--- a/searchlib/src/vespa/searchlib/attribute/flagattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/flagattribute.h
@@ -22,7 +22,7 @@ private:
     void setNewValues(DocId doc, const std::vector<typename B::WType> & values) override;
 
 public:
-    void setNewBVValue(DocId doc, typename B::WType::ValueType value);
+    void setNewBVValue(DocId doc, multivalue::ValueType_t<typename B::WType> value);
 
 private:
     bool onAddDoc(DocId doc) override;

--- a/searchlib/src/vespa/searchlib/attribute/load_utils.h
+++ b/searchlib/src/vespa/searchlib/attribute/load_utils.h
@@ -6,6 +6,7 @@
 #include "attributevector.h"
 #include "readerbase.h"
 #include <vespa/vespalib/util/arrayref.h>
+#include <vespa/searchcommon/attribute/multi_value_traits.h>
 
 namespace vespalib::datastore {
 
@@ -46,7 +47,7 @@ template <class MvMapping, class Saver>
 uint32_t
 loadFromEnumeratedMultiValue(MvMapping &mapping,
                              ReaderBase &attrReader,
-                             vespalib::ConstArrayRef<atomic_utils::NonAtomicValue_t<typename MvMapping::MultiValueType::ValueType>> enumValueToValueMap,
+                             vespalib::ConstArrayRef<atomic_utils::NonAtomicValue_t<multivalue::ValueType_t<typename MvMapping::MultiValueType>>> enumValueToValueMap,
                              vespalib::ConstArrayRef<uint32_t> enum_value_remapping,
                              Saver saver) __attribute((noinline));
 

--- a/searchlib/src/vespa/searchlib/attribute/load_utils.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/load_utils.hpp
@@ -11,13 +11,13 @@ template <class MvMapping, class Saver>
 uint32_t
 loadFromEnumeratedMultiValue(MvMapping & mapping,
                              ReaderBase & attrReader,
-                             vespalib::ConstArrayRef<atomic_utils::NonAtomicValue_t<typename MvMapping::MultiValueType::ValueType>> enumValueToValueMap,
+                             vespalib::ConstArrayRef<atomic_utils::NonAtomicValue_t<multivalue::ValueType_t<typename MvMapping::MultiValueType>>> enumValueToValueMap,
                              vespalib::ConstArrayRef<uint32_t> enum_value_remapping,
                              Saver saver)
 {
     mapping.prepareLoadFromMultiValue();
     using MultiValueType = typename MvMapping::MultiValueType;
-    using ValueType = typename MultiValueType::ValueType;
+    using ValueType = multivalue::ValueType_t<MultiValueType>;
     using NonAtomicValueType = atomic_utils::NonAtomicValue_t<ValueType>;
     std::vector<MultiValueType> indices;
     uint32_t numDocs = attrReader.getNumIdx() - 1;
@@ -36,7 +36,7 @@ loadFromEnumeratedMultiValue(MvMapping & mapping,
             if (!enum_value_remapping.empty()) {
                 enumValue = enum_value_remapping[enumValue];
             }
-            int32_t weight = MultiValueType::_hasWeight ? attrReader.getNextWeight() : 1;
+            int32_t weight = multivalue::is_WeightedValue_v<MultiValueType> ? attrReader.getNextWeight() : 1;
             if constexpr (std::is_same_v<ValueType, NonAtomicValueType>) {
                 indices.emplace_back(enumValueToValueMap[enumValue], weight);
             } else {

--- a/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.cpp
@@ -107,7 +107,7 @@ onSave(IAttributeSaveTarget &saveTarget)
 {
     bool compaction_broke_save = false;
     CountWriter countWriter(saveTarget);
-    WeightWriter<MultiValueType::_hasWeight> weightWriter(saveTarget);
+    WeightWriter<multivalue::is_WeightedValue_v<MultiValueType>> weightWriter(saveTarget);
     DatWriter datWriter(saveTarget, _enumSaver.get_enumerator(),
                         [this]() { return compaction_interferred(); });
     _enumSaver.writeUdat(saveTarget);

--- a/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.h
+++ b/searchlib/src/vespa/searchlib/attribute/multienumattributesaver.h
@@ -4,6 +4,7 @@
 
 #include "multivalueattributesaver.h"
 #include "enumattributesaver.h"
+#include <vespa/searchcommon/attribute/multi_value_traits.h>
 
 namespace search {
 
@@ -18,7 +19,7 @@ class MultiValueEnumAttributeSaver : public MultiValueAttributeSaver
 {
     using Parent = MultiValueAttributeSaver;
     using MultiValueType = MultiValueT;
-    using ValueType = typename MultiValueType::ValueType;
+    using ValueType = multivalue::ValueType_t<MultiValueType>;
     using GenerationHandler = vespalib::GenerationHandler;
     using Parent::_frozenIndices;
     using MultiValueMapping = attribute::MultiValueMapping<MultiValueType>;

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattributesaver.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattributesaver.cpp
@@ -31,8 +31,9 @@ public:
     void
     writeValues(vespalib::ConstArrayRef<MultiValueT> values) {
         for (const MultiValueT &valueRef : values) {
-            typename MultiValueT::ValueType value(valueRef);
-            _datWriter->write(&value, sizeof(typename MultiValueT::ValueType));
+            using ValueType = multivalue::ValueType_t<MultiValueT>;
+            ValueType value(valueRef);
+            _datWriter->write(&value, sizeof(ValueType));
         }
     }
 };
@@ -63,7 +64,7 @@ MultiValueNumericAttributeSaver<MultiValueT>::
 onSave(IAttributeSaveTarget &saveTarget)
 {
     CountWriter countWriter(saveTarget);
-    WeightWriter<MultiValueType::_hasWeight> weightWriter(saveTarget);
+    WeightWriter<multivalue::is_WeightedValue_v<MultiValueType>> weightWriter(saveTarget);
     DatWriter datWriter(saveTarget);
 
     for (uint32_t docId = 0; docId < _frozenIndices.size(); ++docId) {

--- a/searchlib/src/vespa/searchlib/attribute/multinumericattributesaver.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericattributesaver.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "multivalueattributesaver.h"
+#include <vespa/searchcommon/attribute/multi_value_traits.h>
 
 namespace search {
 
@@ -17,7 +18,7 @@ class MultiValueNumericAttributeSaver : public MultiValueAttributeSaver
 {
     using Parent = MultiValueAttributeSaver;
     using MultiValueType = MultiValueT;
-    using ValueType = typename MultiValueType::ValueType;
+    using ValueType = multivalue::ValueType_t<MultiValueType>;
     using GenerationHandler = vespalib::GenerationHandler;
     using Parent::_frozenIndices;
     using MultiValueMapping = attribute::MultiValueMapping<MultiValueType>;

--- a/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multivalueattribute.h
@@ -7,6 +7,7 @@
 #include "multi_value_mapping.h"
 #include <vespa/searchcommon/attribute/i_multi_value_attribute.h>
 #include <vespa/searchcommon/attribute/i_multi_value_read_view.h>
+#include <vespa/searchcommon/attribute/multi_value_traits.h>
 
 namespace search {
 
@@ -28,7 +29,7 @@ protected:
 
     using MultiValueType = M;
     using MultiValueMapping = attribute::MultiValueMapping<MultiValueType>;
-    typedef typename MultiValueType::ValueType            ValueType;
+    using ValueType = multivalue::ValueType_t<MultiValueType>;
     typedef std::vector<MultiValueType>                   ValueVector;
     using MultiValueArrayRef = vespalib::ConstArrayRef<MultiValueType>;
     typedef typename ValueVector::iterator                ValueVectorIterator;

--- a/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/dotproductfeature.cpp
@@ -274,9 +274,9 @@ template <typename BaseType>
 void DotProductExecutorBase<BaseType>::execute(uint32_t docId) {
     auto values = getAttributeValues(docId);
     size_t commonRange = std::min(values.size(), _queryVector.size());
-    static_assert(std::is_same<typename AT::ValueType, BaseType>::value);
+    static_assert(std::is_same_v<multivalue::ValueType_t<AT>, BaseType>);
     outputs().set_number(0, _multiplier.dotProduct(
-            &_queryVector[0], reinterpret_cast<const typename AT::ValueType *>(values.data()), commonRange));
+            &_queryVector[0], reinterpret_cast<const multivalue::ValueType_t<AT> *>(values.data()), commonRange));
 }
 
 template <typename A>
@@ -396,7 +396,7 @@ constexpr void sanity_check_reinterpret_cast_compatibility() {
     static_assert(IsNonWeightedType<AttributeValueType>::value);
     static_assert(sizeof(BaseType) == sizeof(AttributeValueType));
     static_assert(sizeof(BaseType) == sizeof(FillerValueType));
-    static_assert(std::is_same<BaseType, typename AttributeValueType::ValueType>::value);
+    static_assert(std::is_same_v<BaseType, multivalue::ValueType_t<AttributeValueType>>);
 }
 
 }


### PR DESCRIPTION
Use traits to check for presence of a weight and to extract inner type.

@geirst : please review
@baldersheim : FYI
