### PR TITLE
Preserve all node events

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -347,19 +347,24 @@ public final class Node implements Nodelike {
                         allocation, history, type, reports, Optional.empty(), reservedTo, exclusiveToApplicationId, exclusiveToClusterType, switchHostname, trustStoreItems);
     }
 
-    /** Returns a copy of this with a history record saying it was detected to be down at this instant */
+    /** Returns a copy of this with a history record saying it was detected to be down at given instant */
     public Node downAt(Instant instant, Agent agent) {
         return with(history.with(new History.Event(History.Event.Type.down, agent, instant)));
     }
 
-    /** Returns a copy of this with any history record saying it has been detected down removed */
-    public Node up() {
-        return with(history.without(History.Event.Type.down));
+    /** Returns a copy of this with a history record saying it was detected to be up at given instant */
+    public Node upAt(Instant instant, Agent agent) {
+        return with(history.with(new History.Event(History.Event.Type.up, agent, instant)));
     }
 
-    /** Returns whether this node has a record of being down */
+    /** Returns whether this node is down, according to its recorded 'down' and 'up' events */
     public boolean isDown() {
-        return history().event(History.Event.Type.down).isPresent();
+        Optional<Instant> downAt = history().event(History.Event.Type.down).map(History.Event::at);
+        if (downAt.isEmpty()) return false;
+
+        Optional<Instant> upAt = history().event(History.Event.Type.up).map(History.Event::at);
+        if (upAt.isEmpty()) return true;
+        return !downAt.get().isBefore(upAt.get());
     }
 
     /** Returns a copy of this with allocation set as specified. <code>node.state</code> is *not* changed. */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -449,12 +449,15 @@ public final class Node implements Nodelike {
 
     /** Returns a copy of this node with the current OS version set to the given version at the given instant */
     public Node withCurrentOsVersion(Version version, Instant instant) {
-        var newStatus = status.withOsVersion(status.osVersion().withCurrent(Optional.of(version)));
-        var newHistory = history();
-        // Only update history if version has changed
-        if (status.osVersion().current().isEmpty() || !status.osVersion().current().get().equals(version)) {
+        Optional<Version> newVersion = Optional.of(version);
+        if (status.osVersion().current().equals(newVersion)) return this; // No change
+
+        History newHistory = history();
+        // Only update history if version was non-empty and changed to a different version
+        if (status.osVersion().current().isPresent() && !status.osVersion().current().equals(newVersion)) {
             newHistory = history.with(new History.Event(History.Event.Type.osUpgraded, Agent.system, instant));
         }
+        Status newStatus = status.withOsVersion(status.osVersion().withCurrent(newVersion));
         return this.with(newStatus).with(newHistory);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -359,10 +359,10 @@ public final class Node implements Nodelike {
 
     /** Returns whether this node is down, according to its recorded 'down' and 'up' events */
     public boolean isDown() {
-        Optional<Instant> downAt = history().event(History.Event.Type.down).map(History.Event::at);
+        Optional<Instant> downAt = history().lastEvent(History.Event.Type.down).map(History.Event::at);
         if (downAt.isEmpty()) return false;
 
-        Optional<Instant> upAt = history().event(History.Event.Type.up).map(History.Event::at);
+        Optional<Instant> upAt = history().lastEvent(History.Event.Type.up).map(History.Event::at);
         if (upAt.isEmpty()) return true;
         return !downAt.get().isBefore(upAt.get());
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
@@ -107,7 +107,7 @@ public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
         // Scaling event is complete if:
         // - 1. no nodes which was retired by this are still present (which also implies data distribution is complete)
         if (clusterNodes.retired().stream()
-                        .anyMatch(node -> node.history().hasEventAt(History.Event.Type.retired, event.at())))
+                        .anyMatch(node -> node.history().hasLastEventAt(event.at(), History.Event.Type.retired)))
             return cluster;
         // - 2. all nodes have switched to the right config generation (currently only measured on containers)
         for (var nodeTimeseries : nodeRepository().metricsDb().getNodeTimeseries(Duration.between(event.at(), clock().instant()),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
@@ -6,9 +6,9 @@ import com.yahoo.component.Vtag;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.NodeAllocationException;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.NodeAllocationException;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.lang.MutableInteger;
 import com.yahoo.transaction.Mutex;
@@ -164,8 +164,7 @@ public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
         }
 
         return candidatesForRemoval(nodes).stream()
-                .sorted(Comparator.comparing(node -> node.history().events().stream()
-                                                         .map(History.Event::at).min(Comparator.naturalOrder()).orElse(Instant.MIN)))
+                .sorted(Comparator.comparing(node -> node.history().asList().stream().findFirst().map(History.Event::at).orElse(Instant.MIN)))
                 .filter(node -> {
                     if (!sharedHosts.containsKey(node.hostname()) || sharedHosts.size() > minCount) {
                         sharedHosts.remove(node.hostname());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ExpeditedChangeApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ExpeditedChangeApplicationMaintainer.java
@@ -78,11 +78,11 @@ public class ExpeditedChangeApplicationMaintainer extends ApplicationMaintainer 
 
         List<String> reasons = nodes.stream()
                                     .flatMap(node -> node.history()
-                                                            .events()
-                                                            .stream()
-                                                            .filter(event -> expediteChangeBy(event.agent()))
-                                                            .filter(event -> lastDeployTime.get().isBefore(event.at()))
-                                                            .map(event -> event.type() + (event.agent() == Agent.system ? "" : " by " + event.agent())))
+                                                         .asList()
+                                                         .stream()
+                                                         .filter(event -> expediteChangeBy(event.agent()))
+                                                         .filter(event -> lastDeployTime.get().isBefore(event.at()))
+                                                         .map(event -> event.type() + (event.agent() == Agent.system ? "" : " by " + event.agent())))
                                     .sorted()
                                     .distinct()
                                     .collect(Collectors.toList());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/Expirer.java
@@ -57,7 +57,7 @@ public abstract class Expirer extends NodeRepositoryMaintainer {
     }
 
     protected final boolean isExpired(Node node, Duration expiryTime) {
-        return node.history().hasEventBefore(eventType, clock().instant().minus(expiryTime));
+        return node.history().hasLastEventBefore(clock().instant().minus(expiryTime), eventType);
     }
 
     /** Implement this callback to take action to expire these nodes */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
@@ -73,10 +73,10 @@ public class FailedExpirer extends NodeRepositoryMaintainer {
         recycleIf(remainingNodes, node -> node.allocation().isEmpty());
         recycleIf(remainingNodes, node ->
                 !node.allocation().get().membership().cluster().isStateful() &&
-                node.history().hasEventBefore(History.Event.Type.failed, clock().instant().minus(statelessExpiry)));
+                node.history().hasLastEventBefore(clock().instant().minus(statelessExpiry), History.Event.Type.failed));
         recycleIf(remainingNodes, node ->
                 node.allocation().get().membership().cluster().isStateful() &&
-                node.history().hasEventBefore(History.Event.Type.failed, clock().instant().minus(statefulExpiry)));
+                node.history().hasLastEventBefore(clock().instant().minus(statefulExpiry), History.Event.Type.failed));
         return 1.0;
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -20,7 +20,6 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.ClusterId;
-import com.yahoo.vespa.hosted.provision.node.History;
 import com.yahoo.vespa.hosted.provision.persistence.CacheStats;
 import com.yahoo.vespa.service.monitor.ServiceModel;
 import com.yahoo.vespa.service.monitor.ServiceMonitor;
@@ -248,8 +247,8 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
             boolean down = NodeHealthTracker.allDown(services);
             metric.set("nodeFailerBadNode", (down ? 1 : 0), context);
 
-            boolean nodeDownInNodeRepo = node.history().event(History.Event.Type.down).isPresent();
-            metric.set("downInNodeRepo", (nodeDownInNodeRepo ? 1 : 0), context);
+            boolean recordedDown = node.isDown();
+            metric.set("downInNodeRepo", (recordedDown ? 1 : 0), context);
         }
 
         metric.set("numberOfServices", numberOfServices, context);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
@@ -61,7 +61,7 @@ public class NodeHealthTracker extends NodeRepositoryMaintainer {
                 Optional<Instant> lastLocalRequest = hostLivenessTracker.lastRequestFrom(node.hostname());
                 if (lastLocalRequest.isEmpty()) continue;
 
-                if (!node.history().hasEventAfter(History.Event.Type.requested, lastLocalRequest.get())) {
+                if (!node.history().hasLastEventAfter(lastLocalRequest.get(), History.Event.Type.requested)) {
                     History updatedHistory = node.history()
                                                  .with(new History.Event(History.Event.Type.requested, Agent.NodeHealthTracker, lastLocalRequest.get()));
                     nodeRepository().nodes().write(node.with(updatedHistory), lock);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
@@ -96,7 +96,7 @@ public class NodeHealthTracker extends NodeRepositoryMaintainer {
                 if (isDown) {
                     recordAsDown(node.get(), lock);
                 } else {
-                    clearDownRecord(node.get(), lock);
+                    recordAsUp(node.get(), lock);
                 }
             } catch (ApplicationLockException e) {
                 // Fine, carry on with other nodes. We'll try updating this one in the next run
@@ -129,14 +129,14 @@ public class NodeHealthTracker extends NodeRepositoryMaintainer {
 
     /** Record a node as down if not already recorded */
     private void recordAsDown(Node node, Mutex lock) {
-        if (node.history().event(History.Event.Type.down).isPresent()) return; // already down: Don't change down timestamp
+        if (node.isDown()) return; // already down: Don't change down timestamp
         nodeRepository().nodes().write(node.downAt(clock().instant(), Agent.NodeHealthTracker), lock);
     }
 
     /** Clear down record for node, if any */
-    private void clearDownRecord(Node node, Mutex lock) {
-        if (node.history().event(History.Event.Type.down).isEmpty()) return;
-        nodeRepository().nodes().write(node.up(), lock);
+    private void recordAsUp(Node node, Mutex lock) {
+        if (!node.isDown()) return; // already up: Don't change up timestamp
+        nodeRepository().nodes().write(node.upAt(clock().instant(), Agent.NodeHealthTracker), lock);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooter.java
@@ -55,11 +55,11 @@ public class NodeRebooter extends NodeRepositoryMaintainer {
         var rebootEvents = EnumSet.of(History.Event.Type.provisioned, History.Event.Type.rebooted, History.Event.Type.osUpgraded);
         var rebootInterval = Duration.ofDays(rebootIntervalInDays.value());
 
-        Optional<Duration> overdue = node.history().events().stream()
-                .filter(event -> rebootEvents.contains(event.type()))
-                .map(History.Event::at)
-                .max(Comparator.naturalOrder())
-                .map(lastReboot -> Duration.between(lastReboot, clock().instant()).minus(rebootInterval));
+        Optional<Duration> overdue = node.history().asList().stream()
+                                         .filter(event -> rebootEvents.contains(event.type()))
+                                         .map(History.Event::at)
+                                         .max(Comparator.naturalOrder())
+                                         .map(lastReboot -> Duration.between(lastReboot, clock().instant()).minus(rebootInterval));
 
         if (overdue.isEmpty()) // should never happen as all hosts should have provisioned timestamp
             return random.nextDouble() < interval().getSeconds() / (double) rebootInterval.getSeconds();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ProvisionedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ProvisionedExpirer.java
@@ -54,7 +54,7 @@ public class ProvisionedExpirer extends Expirer {
     }
 
     private boolean parkedByProvisionedExpirer(Node node) {
-        return node.history().event(History.Event.Type.parked)
+        return node.history().lastEvent(History.Event.Type.parked)
                 .map(History.Event::agent)
                 .map(Agent.ProvisionedExpirer::equals)
                 .orElse(false);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirer.java
@@ -116,7 +116,7 @@ public class RetiredExpirer extends NodeRepositoryMaintainer {
                 // allowing the removal of any config server.
                 return false;
             }
-        } else if (node.history().hasEventBefore(History.Event.Type.retired, clock().instant().minus(retiredExpiry))) {
+        } else if (node.history().hasLastEventBefore(clock().instant().minus(retiredExpiry), History.Event.Type.retired)) {
             log.warning("Node " + node + " has been retired longer than " + retiredExpiry + ": Allowing removal. This may cause data loss");
             return true;
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -840,7 +840,7 @@ public class Nodes {
         if (agent == Agent.operator) return false;
         if (node.type() == NodeType.tenant && node.status().wantToDeprovision()) return false;
         boolean retirementRequestedByOperator = node.status().wantToRetire() &&
-                                                node.history().event(History.Event.Type.wantToRetire)
+                                                node.history().lastEvent(History.Event.Type.wantToRetire)
                                                     .map(History.Event::agent)
                                                     .map(a -> a == Agent.operator)
                                                     .orElse(false);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -219,7 +219,7 @@ public class NodeSerializer {
     }
 
     private void toSlime(History history, Cursor array) {
-        for (History.Event event : history.events())
+        for (History.Event event : history.asList())
             toSlime(event, array.addObject());
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -197,7 +197,7 @@ class NodesResponse extends SlimeJsonResponse {
     }
 
     private void toSlime(History history, Cursor array) {
-        for (History.Event event : history.events()) {
+        for (History.Event event : history.asList()) {
             Cursor object = array.addObject();
             object.setString("event", event.type().name());
             object.setLong("at", event.at().toEpochMilli());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -185,7 +185,7 @@ public class NodeRepositoryTest {
         tester.clock().advance(Duration.ofSeconds(1));
         tester.addHost("id1", "host1", "default", NodeType.host);
         tester.addHost("id2", "host2", "default", NodeType.host);
-        assertFalse(tester.nodeRepository().nodes().node("host1").get().history().hasEventAfter(History.Event.Type.deprovisioned, testStart));
+        assertFalse(tester.nodeRepository().nodes().node("host1").get().history().hasLastEventAfter(testStart, History.Event.Type.deprovisioned));
 
         // Set host 1 properties and deprovision it
         try (var lock = tester.nodeRepository().nodes().lockAndGetRequired("host1")) {
@@ -208,7 +208,7 @@ public class NodeRepositoryTest {
         Node host1 = tester.nodeRepository().nodes().node("host1").get();
         Node host2 = tester.nodeRepository().nodes().node("host2").get();
         assertEquals(Node.State.deprovisioned, host1.state());
-        assertTrue(host1.history().hasEventAfter(History.Event.Type.deprovisioned, testStart));
+        assertTrue(host1.history().hasLastEventAfter(testStart, History.Event.Type.deprovisioned));
 
         // Adding it again preserves some information from the deprovisioned host and removes it
         tester.addHost("id2", "host1", "default", NodeType.host);
@@ -218,7 +218,7 @@ public class NodeRepositoryTest {
                     tester.nodeRepository().nodes().node("host1", Node.State.deprovisioned).isPresent());
         assertFalse("Not transferred from deprovisioned host", host1.status().wantToRetire());
         assertFalse("Not transferred from deprovisioned host", host1.status().wantToDeprovision());
-        assertTrue("Transferred from deprovisioned host", host1.history().hasEventAfter(History.Event.Type.deprovisioned, testStart));
+        assertTrue("Transferred from deprovisioned host", host1.history().hasLastEventAfter(testStart, History.Event.Type.deprovisioned));
         assertTrue("Transferred from deprovisioned host", host1.status().firmwareVerifiedAt().isPresent());
         assertEquals("Transferred from deprovisioned host", 1, host1.status().failCount());
         assertEquals("Transferred from deprovisioned host", 1, host1.reports().getReports().size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/InactiveAndFailedExpirerTest.java
@@ -78,7 +78,7 @@ public class InactiveAndFailedExpirerTest {
         Node ready = tester.nodeRepository().nodes().setReady(List.of(dirty.asList().get(0)), Agent.system, getClass().getSimpleName()).get(0);
         assertEquals("Allocated history is removed on readying",
                 List.of(History.Event.Type.provisioned, History.Event.Type.readied),
-                ready.history().events().stream().map(History.Event::type).collect(Collectors.toList()));
+                ready.history().asList().stream().map(History.Event::type).collect(Collectors.toList()));
 
         // Dirty times out for the other one
         tester.advanceTime(Duration.ofMinutes(14));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRebooterTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
@@ -60,7 +61,8 @@ public class NodeRebooterTest {
         // OS upgrade counts as reboot, so within 0x-1x there is no reboots
         tester.clock().advance(rebootInterval);
         rebooter.maintain();
-        simulateReboot(nodeRepository);
+        scheduleOsUpgrade(nodeRepository);
+        simulateOsUpgrade(nodeRepository);
         assertReadyHosts(15, nodeRepository, 1L);
 
         // OS upgrade counts as reboot, but within 1x-2x reboots are scheduled again
@@ -109,6 +111,8 @@ public class NodeRebooterTest {
 
     private void makeReadyHosts(int count, ProvisioningTester tester) {
         tester.makeReadyNodes(count, new NodeResources(64, 256, 1000, 10), NodeType.host, 10);
+        // Set initial OS version
+        tester.patchNodes(node -> node.type().isHost(), (node) -> node.with(node.status().withOsVersion(node.status().osVersion().withCurrent(Optional.of(Version.fromString("7.0"))))));
     }
 
     /** Set current reboot generation to the wanted reboot generation whenever it is larger (i.e record a reboot) */
@@ -122,7 +126,7 @@ public class NodeRebooterTest {
 
     /** Schedule OS upgrade for all host nodes */
     private void scheduleOsUpgrade(NodeRepository nodeRepository) {
-        nodeRepository.osVersions().setTarget(NodeType.host, Version.fromString("7.0"), Duration.ZERO, false);
+        nodeRepository.osVersions().setTarget(NodeType.host, Version.fromString("7.1"), Duration.ZERO, false);
     }
 
     /** Simulate completion of an OS upgrade */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/HistoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/HistoryTest.java
@@ -1,0 +1,59 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.node;
+
+import com.yahoo.vespa.hosted.provision.node.History.Event;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mpolden
+ */
+public class HistoryTest {
+
+    @Test
+    public void truncate_events() {
+        assertEquals(0, new History(List.of(), 2).asList().size());
+        assertEquals(1, new History(shuffledEvents(1), 2).asList().size());
+        assertEquals(2, new History(shuffledEvents(2), 2).asList().size());
+
+        History history = new History(shuffledEvents(5), 3);
+        assertEquals(3, history.asList().size());
+        assertEquals("Most recent events are kept",
+                     List.of(2L, 3L, 4L),
+                     history.asList().stream().map(e -> e.at().toEpochMilli()).collect(Collectors.toList()));
+    }
+
+    @Test
+    public void repeating_event_overwrites_existing() {
+        Instant i0 = Instant.ofEpochMilli(1);
+        History history = new History(List.of(new Event(Event.Type.readied, Agent.system, i0)));
+
+        Instant i1 = Instant.ofEpochMilli(2);
+        history = history.with(new Event(Event.Type.reserved, Agent.system, i1));
+        assertEquals(2, history.asList().size());
+
+        Instant i2 = Instant.ofEpochMilli(3);
+        history = history.with(new Event(Event.Type.reserved, Agent.system, i2));
+
+        assertEquals(2, history.asList().size());
+        assertEquals(i2, history.asList().get(1).at());
+    }
+
+    private static List<Event> shuffledEvents(int count) {
+        Instant start = Instant.ofEpochMilli(0);
+        List<Event> events = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            events.add(new Event(Event.Type.values()[i], Agent.system, start.plusMillis(i)));
+        }
+        Collections.shuffle(events);
+        return events;
+    }
+
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/HistoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/node/HistoryTest.java
@@ -30,22 +30,6 @@ public class HistoryTest {
                      history.asList().stream().map(e -> e.at().toEpochMilli()).collect(Collectors.toList()));
     }
 
-    @Test
-    public void repeating_event_overwrites_existing() {
-        Instant i0 = Instant.ofEpochMilli(1);
-        History history = new History(List.of(new Event(Event.Type.readied, Agent.system, i0)));
-
-        Instant i1 = Instant.ofEpochMilli(2);
-        history = history.with(new Event(Event.Type.reserved, Agent.system, i1));
-        assertEquals(2, history.asList().size());
-
-        Instant i2 = Instant.ofEpochMilli(3);
-        history = history.with(new Event(Event.Type.reserved, Agent.system, i2));
-
-        assertEquals(2, history.asList().size());
-        assertEquals(i2, history.asList().get(1).at());
-    }
-
     private static List<Event> shuffledEvents(int count) {
         Instant start = Instant.ofEpochMilli(0);
         List<Event> events = new ArrayList<>();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -71,7 +71,7 @@ public class NodeSerializerTest {
         assertEquals(node.id(), copy.id());
         assertEquals(node.state(), copy.state());
         assertFalse(copy.allocation().isPresent());
-        assertEquals(0, copy.history().events().size());
+        assertEquals(0, copy.history().asList().size());
     }
 
     @Test
@@ -81,14 +81,14 @@ public class NodeSerializerTest {
                                                              DiskSpeed.any, StorageType.any, Architecture.arm64);
 
         clock.advance(Duration.ofMinutes(3));
-        assertEquals(0, node.history().events().size());
+        assertEquals(0, node.history().asList().size());
         node = node.allocate(ApplicationId.from(TenantName.from("myTenant"),
                                                 ApplicationName.from("myApplication"),
                                                 InstanceName.from("myInstance")),
                              ClusterMembership.from("content/myId/0/0/stateful", Vtag.currentVersion, Optional.empty()),
                              requestedResources,
                              clock.instant());
-        assertEquals(1, node.history().events().size());
+        assertEquals(1, node.history().asList().size());
         node = node.withRestart(new Generation(1, 2));
         node = node.withReboot(new Generation(3, 4));
         node = node.with(FlavorConfigBuilder.createDummies("arm64").getFlavorOrThrow("arm64"), Agent.system, clock.instant());
@@ -112,7 +112,7 @@ public class NodeSerializerTest {
         assertEquals(node.allocation().get().membership(), copy.allocation().get().membership());
         assertEquals(node.allocation().get().requestedResources(), copy.allocation().get().requestedResources());
         assertEquals(node.allocation().get().isRemovable(), copy.allocation().get().isRemovable());
-        assertEquals(2, copy.history().events().size());
+        assertEquals(2, copy.history().asList().size());
         assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.reserved).get().at());
         assertEquals(NodeType.tenant, copy.type());
     }
@@ -160,7 +160,7 @@ public class NodeSerializerTest {
         assertEquals(3, node.allocation().get().restartGeneration().wanted());
         assertEquals(4, node.allocation().get().restartGeneration().current());
         assertEquals(Arrays.asList(History.Event.Type.provisioned, History.Event.Type.reserved),
-                node.history().events().stream().map(History.Event::type).collect(Collectors.toList()));
+                node.history().asList().stream().map(History.Event::type).collect(Collectors.toList()));
         assertTrue(node.allocation().get().isRemovable());
         assertEquals(NodeType.tenant, node.type());
     }
@@ -170,18 +170,18 @@ public class NodeSerializerTest {
         Node node = createNode();
 
         clock.advance(Duration.ofMinutes(3));
-        assertEquals(0, node.history().events().size());
+        assertEquals(0, node.history().asList().size());
         node = node.allocate(ApplicationId.from(TenantName.from("myTenant"),
                                                 ApplicationName.from("myApplication"),
                                                 InstanceName.from("myInstance")),
                              ClusterMembership.from("content/myId/0/0/stateful", Vtag.currentVersion, Optional.empty()),
                              node.flavor().resources(),
                              clock.instant());
-        assertEquals(1, node.history().events().size());
+        assertEquals(1, node.history().asList().size());
         clock.advance(Duration.ofMinutes(2));
         node = node.retire(Agent.application, clock.instant());
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
-        assertEquals(2, copy.history().events().size());
+        assertEquals(2, copy.history().asList().size());
         assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.retired).get().at());
         assertEquals(Agent.application,
                      (copy.history().event(History.Event.Type.retired).get()).agent());
@@ -209,13 +209,13 @@ public class NodeSerializerTest {
                 "    \"wantedVespaVersion\": \"6.42.2\"\n" +
                 "  }\n" +
                 "}\n").getBytes());
-        assertEquals(0, node.history().events().size());
+        assertEquals(0, node.history().asList().size());
         assertTrue(node.allocation().isPresent());
         assertEquals("ugccloud-container", node.allocation().get().membership().cluster().id().value());
         assertEquals("container", node.allocation().get().membership().cluster().type().name());
         assertEquals(0, node.allocation().get().membership().cluster().group().get().index());
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
-        assertEquals(0, copy.history().events().size());
+        assertEquals(0, copy.history().asList().size());
     }
 
     @Test
@@ -356,7 +356,7 @@ public class NodeSerializerTest {
                                .withCurrentOsVersion(Version.fromString("7.1"), Instant.ofEpochMilli(456));
         serialized = nodeSerializer.fromJson(State.provisioned, nodeSerializer.toJson(serialized));
         assertEquals(Version.fromString("7.1"), serialized.status().osVersion().current().get());
-        var osUpgradedEvents = serialized.history().events().stream()
+        var osUpgradedEvents = serialized.history().asList().stream()
                                          .filter(event -> event.type() == History.Event.Type.osUpgraded)
                                          .collect(Collectors.toList());
         assertEquals("OS upgraded event is added", 1, osUpgradedEvents.size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -113,7 +113,7 @@ public class NodeSerializerTest {
         assertEquals(node.allocation().get().requestedResources(), copy.allocation().get().requestedResources());
         assertEquals(node.allocation().get().isRemovable(), copy.allocation().get().isRemovable());
         assertEquals(2, copy.history().asList().size());
-        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.reserved).get().at());
+        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().lastEvent(History.Event.Type.reserved).get().at());
         assertEquals(NodeType.tenant, copy.type());
     }
 
@@ -182,9 +182,9 @@ public class NodeSerializerTest {
         node = node.retire(Agent.application, clock.instant());
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
         assertEquals(2, copy.history().asList().size());
-        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().event(History.Event.Type.retired).get().at());
+        assertEquals(clock.instant().truncatedTo(MILLIS), copy.history().lastEvent(History.Event.Type.retired).get().at());
         assertEquals(Agent.application,
-                     (copy.history().event(History.Event.Type.retired).get()).agent());
+                     (copy.history().lastEvent(History.Event.Type.retired).get()).agent());
         assertTrue(copy.allocation().get().membership().retired());
 
         Node removable = copy.with(node.allocation().get().removable(true));
@@ -296,7 +296,7 @@ public class NodeSerializerTest {
         Node copy = nodeSerializer.fromJson(Node.State.provisioned, nodeSerializer.toJson(node));
         assertEquals(1234, copy.flavor().resources().diskGb(), 0);
         assertEquals(node, copy);
-        assertTrue(node.history().event(History.Event.Type.resized).isPresent());
+        assertTrue(node.history().lastEvent(History.Event.Type.resized).isPresent());
     }
 
     @Test
@@ -372,7 +372,7 @@ public class NodeSerializerTest {
         node = node.withFirmwareVerifiedAt(Instant.ofEpochMilli(100));
         node = nodeSerializer.fromJson(State.active, nodeSerializer.toJson(node));
         assertEquals(100, node.status().firmwareVerifiedAt().get().toEpochMilli());
-        assertEquals(Instant.ofEpochMilli(100), node.history().event(History.Event.Type.firmwareVerified).get().at());
+        assertEquals(Instant.ofEpochMilli(100), node.history().lastEvent(History.Event.Type.firmwareVerified).get().at());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializerTest.java
@@ -351,11 +351,11 @@ public class NodeSerializerTest {
         assertFalse(serialized.status().osVersion().current().isPresent());
 
         // Update OS version
-        serialized = serialized.withCurrentOsVersion(Version.fromString("7.1"), Instant.ofEpochMilli(123))
-                               // Another update for same version:
-                               .withCurrentOsVersion(Version.fromString("7.1"), Instant.ofEpochMilli(456));
+        serialized = serialized.withCurrentOsVersion(Version.fromString("7.1"), Instant.ofEpochMilli(42))
+                               .withCurrentOsVersion(Version.fromString("7.2"), Instant.ofEpochMilli(123))
+                               .withCurrentOsVersion(Version.fromString("7.2"), Instant.ofEpochMilli(456));
         serialized = nodeSerializer.fromJson(State.provisioned, nodeSerializer.toJson(serialized));
-        assertEquals(Version.fromString("7.1"), serialized.status().osVersion().current().get());
+        assertEquals(Version.fromString("7.2"), serialized.status().osVersion().current().get());
         var osUpgradedEvents = serialized.history().asList().stream()
                                          .filter(event -> event.type() == History.Event.Type.osUpgraded)
                                          .collect(Collectors.toList());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -880,7 +880,7 @@ public class ProvisioningTest {
         assertTrue("Time of event is updated for all nodes",
                    reserved.stream()
                            .allMatch(n -> n.history()
-                           .event(History.Event.Type.reserved)
+                           .lastEvent(History.Event.Type.reserved)
                            .get().at()
                            .equals(tester.clock().instant().truncatedTo(MILLIS))));
 
@@ -1167,7 +1167,7 @@ public class ProvisioningTest {
 
     /** A predicate that returns whether a node has been retired by the given agent */
     private static Predicate<Node> retiredBy(Agent agent) {
-        return (node) -> node.history().event(History.Event.Type.retired)
+        return (node) -> node.history().lastEvent(History.Event.Type.retired)
                 .filter(e -> e.type() == History.Event.Type.retired)
                 .filter(e -> e.agent() == agent)
                 .isPresent();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -55,11 +55,6 @@
       "event": "activated",
       "at": 123,
       "agent": "application"
-    },
-    {
-      "event": "osUpgraded",
-      "at": 123,
-      "agent": "system"
     }
   ],
   "ipAddresses": [

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/dockerhost1-with-firmware-data.json
@@ -37,6 +37,11 @@
   "wantToRebuild": false,
   "history": [
     {
+      "event": "firmwareVerified",
+      "at": 100,
+      "agent": "system"
+    },
+    {
       "event": "provisioned",
       "at": 123,
       "agent": "system"
@@ -55,11 +60,6 @@
       "event": "activated",
       "at": 123,
       "agent": "application"
-    },
-    {
-      "event": "firmwareVerified",
-      "at": 100,
-      "agent": "system"
     }
   ],
   "ipAddresses": [


### PR DESCRIPTION
Node events are now limited by a total size limit, instead of one per type.

@bratseth