### PR TITLE
Set CI=true when compiling the go code to make sure that GOPROXY is e…

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -595,8 +595,7 @@ mvn --batch-mode -e -N io.takari:maven:wrapper -Dmaven=3.6.3
        .
 
 make %{_smp_mflags}
-go env
-VERSION=%{version} make -C client/go install-all
+VERSION=%{version} CI=true make -C client/go install-all
 %endif
 
 %install


### PR DESCRIPTION
…qually set on Copr for both CentOS 7 and CentOS Stream 8.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

I have manually verified that this works on both CentOS 7 and CentOS Stream by trigging builds with this change on Copr.