### PR TITLE
Use timeout when getting locks with NodePatcher

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -69,6 +69,7 @@ public class CuratorDatabaseClient {
     private static final Path firmwareCheckPath = root.append("firmwareCheck");
     private static final Path archiveUrisPath = root.append("archiveUris");
 
+    // TODO: Explain reasoning behind timeout value (why its it as high as 10 minutes?)
     private static final Duration defaultLockTimeout = Duration.ofMinutes(10);
 
     private final NodeSerializer nodeSerializer;
@@ -319,7 +320,12 @@ public class CuratorDatabaseClient {
 
     /** Acquires the single cluster-global, reentrant lock for all non-active nodes */
     public Lock lockInactive() {
-        return db.lock(lockPath.append("unallocatedLock"), defaultLockTimeout);
+        return lockInactive(defaultLockTimeout);
+    }
+
+    /** Acquires the single cluster-global, reentrant lock for all non-active nodes */
+    public Lock lockInactive(Duration timeout) {
+        return db.lock(lockPath.append("unallocatedLock"), timeout);
     }
 
     /** Acquires the single cluster-global, reentrant lock for active nodes of this application */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -29,6 +29,7 @@ import com.yahoo.yolean.Exceptions;
 
 import java.io.InputStream;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -86,7 +87,7 @@ public class NodePatcher {
         Map<String, Inspector> recursiveFields = Maps.filterKeys(fields, RECURSIVE_FIELDS::contains);
 
         // Patch
-        NodeMutex nodeMutex = nodeRepository.nodes().lockAndGetRequired(hostname);
+        NodeMutex nodeMutex = nodeRepository.nodes().lockAndGetRequired(hostname, Duration.ofSeconds(10)); // timeout should match the one used by clients
         patch(nodeMutex, regularFields, root, false);
         patchIpConfig(hostname, ipConfigFields);
         if (nodeMutex.node().type().isHost()) {


### PR DESCRIPTION
Client has a timeout of 10 seconds, using a much larger timeout
(as is the default) might lead to lots of requests waiting for the
lock
