### PR TITLE
Revert "Warn if config changes without generation changing"

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
@@ -206,9 +206,7 @@ public abstract class ConfigSubscription<T extends ConfigInstance> {
             int sizeHint = 500;
             log.log(Level.WARNING, "Config has changed unexpectedly for " + key + ", generation " + generation +
                     ", config in state :" + generator.makeSnippet(previousConfig.toString(), sizeHint) + ", new config: " +
-                    generator.makeSnippet(config.toString(), sizeHint) +
-                    ". This likely happened because config changed on a previous generation" +
-                    ", look for earlier entry in log with warning about config changing without a change in config generation.");
+                    generator.makeSnippet(config.toString(), sizeHint));
         }
         this.config.set(new ConfigState<>(true, generation, applyOnRestart, configChanged, config, payloadChecksums));
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigRequester.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigRequester.java
@@ -194,7 +194,9 @@ public class JRTConfigRequester implements RequestWaiter {
         failures = 0;
         sub.setLastCallBackOKTS(Instant.now());
         log.log(FINE, () -> "OK response received in handleOkRequest: " + jrtReq);
-        sub.updateConfig(jrtReq);
+        if (jrtReq.hasUpdatedGeneration()) {
+            sub.updateConfig(jrtReq);
+        }
         scheduleNextRequest(jrtReq, sub, calculateSuccessDelay(), calculateSuccessTimeout());
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#22113

Cannot return from `nextConfig()` without a new config, breaks API