### PR TITLE
Don't consider retiring or failing hosts as valid replacement candidates

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityChecker.java
@@ -187,6 +187,8 @@ public class CapacityChecker {
         var resourceMap = new HashMap<>(availableResources);
         List<Node> validAllocationTargets = allHosts.stream()
                                                     .filter(h -> !hostsToRemove.contains(h))
+                                                    .filter(host -> !host.status().wantToRetire() &&
+                                                            !host.status().wantToFail())
                                                     .collect(Collectors.toList());
         if (validAllocationTargets.size() == 0)
             return Optional.of(HostRemovalFailure.none());


### PR DESCRIPTION
Avoids situations where CMR automation triggers retirement of more hosts than allowed

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
