### PR TITLE
Revert "Jersey no longer needed for configserver without /serviceview…

### DIFF
--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -241,6 +241,52 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Jersey, needed by serviceview  -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <scope>provided</scope>  <!-- TODO: Vespa 8: Set to compile if we get rid of the javax.ws.rs-api bundle -->
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-server</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-jaxb</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.ext</groupId>
+      <artifactId>jersey-proxy-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <exclusions>
+        <!-- Prevent embedding deps provided by jdisc  -->
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <!-- Not needed by configserver, but by controller. Also pulls in mimepull. -->
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-multipart</artifactId>
+    </dependency>
+    <!-- Jersey END -->
+
   </dependencies>
   <build>
     <plugins>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -241,7 +241,7 @@
       <version>${project.version}</version>
     </dependency>
 
-    <!-- Jersey, needed by serviceview  -->
+    <!-- Jersey, needed by orchestrator  -->
     <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
…/v1/"

This reverts commit e593f6bf57a63b71e0e078466104fc110a60d267.

@freva or anyone else, please review and merge.