### PR TITLE
Revert "Allow reading API key from default path when Auth0 is not configured"

### DIFF
--- a/client/go/cmd/config.go
+++ b/client/go/cmd/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/vespa-engine/vespa/client/go/auth/auth0"
 	"github.com/vespa-engine/vespa/client/go/config"
+	"github.com/vespa-engine/vespa/client/go/util"
 	"github.com/vespa-engine/vespa/client/go/vespa"
 )
 
@@ -432,21 +433,30 @@ func (c *Config) authConfigPath() string {
 	return filepath.Join(c.homeDir, "auth.json")
 }
 
-func (c *Config) readAPIKey(cli *CLI, system vespa.System, tenantName string) ([]byte, error) {
+func (c *Config) readAPIKey(tenantName string) ([]byte, error) {
 	if override, ok := c.apiKeyFromEnv(); ok {
 		return override, nil
 	}
-	if path, ok := c.apiKeyFileFromEnv(); ok {
-		return os.ReadFile(path)
+	return os.ReadFile(c.apiKeyPath(tenantName))
+}
+
+// useAPIKey returns true if an API key should be used when authenticating with system.
+func (c *Config) useAPIKey(cli *CLI, system vespa.System, tenantName string) bool {
+	if _, ok := c.apiKeyFromEnv(); ok {
+		return true
+	}
+	if _, ok := c.apiKeyFileFromEnv(); ok {
+		return true
 	}
 	if !cli.isCI() {
+		// Fall back to API key, if present and Auth0 has not been configured
 		client, err := auth0.New(c.authConfigPath(), system.Name, system.URL)
-		if err == nil && client.HasCredentials() {
-			return nil, nil // use Auth0
+		if err != nil || !client.HasCredentials() {
+			cli.printWarning("Regular authentication is preferred over API key in a non-CI context", "Authenticate with 'vespa auth login'")
+			return util.PathExists(c.apiKeyPath(tenantName))
 		}
-		cli.printWarning("Authenticating with API key. This is discouraged in non-CI environments", "Authenticate with 'vespa auth login'")
 	}
-	return os.ReadFile(c.apiKeyPath(tenantName))
+	return false
 }
 
 func (c *Config) readSessionID(app vespa.ApplicationID) (int64, error) {

--- a/client/go/cmd/root.go
+++ b/client/go/cmd/root.go
@@ -324,9 +324,11 @@ func (c *CLI) createCloudTarget(targetType string, opts targetOptions) (vespa.Ta
 	)
 	switch targetType {
 	case vespa.TargetCloud:
-		apiKey, err = c.config.readAPIKey(c, system, deployment.Application.Tenant)
-		if err != nil {
-			return nil, err
+		if c.config.useAPIKey(c, system, deployment.Application.Tenant) {
+			apiKey, err = c.config.readAPIKey(deployment.Application.Tenant)
+			if err != nil {
+				return nil, err
+			}
 		}
 		authConfigPath = c.config.authConfigPath()
 		deploymentTLSOptions = vespa.TLSOptions{}


### PR DESCRIPTION
Reverts vespa-engine/vespa#22138

Suspecting that this broke some integration tests.