### PR TITLE
Introduce new metrics for container threadpool

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -160,6 +160,7 @@ public class VespaMetricSet {
             addMetric(metrics, "jdisc.thread_pool.active_threads", suffixes);
 
             addMetric(metrics, "jdisc.http.jetty.threadpool.thread.max", suffixes);
+            addMetric(metrics, "jdisc.http.jetty.threadpool.thread.min", suffixes);
             addMetric(metrics, "jdisc.http.jetty.threadpool.thread.reserved", suffixes);
             addMetric(metrics, "jdisc.http.jetty.threadpool.thread.busy", suffixes);
             addMetric(metrics, "jdisc.http.jetty.threadpool.thread.total", suffixes);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -158,6 +158,12 @@ public class VespaMetricSet {
             addMetric(metrics, "jdisc.thread_pool.size", suffixes);
             addMetric(metrics, "jdisc.thread_pool.max_allowed_size", suffixes);
             addMetric(metrics, "jdisc.thread_pool.active_threads", suffixes);
+
+            addMetric(metrics, "jdisc.http.jetty.threadpool.thread.max", suffixes);
+            addMetric(metrics, "jdisc.http.jetty.threadpool.thread.reserved", suffixes);
+            addMetric(metrics, "jdisc.http.jetty.threadpool.thread.busy", suffixes);
+            addMetric(metrics, "jdisc.http.jetty.threadpool.thread.total", suffixes);
+            addMetric(metrics, "jdisc.http.jetty.threadpool.queue.size", suffixes);
         }
 
         metrics.add(new Metric("httpapi_latency.max"));
@@ -226,12 +232,6 @@ public class VespaMetricSet {
         metrics.add(new Metric("jdisc.http.ssl.handshake.failure.unknown.rate"));
 
         metrics.add(new Metric("jdisc.http.handler.unhandled_exceptions.rate"));
-
-        addMetric(metrics, "jdisc.http.jetty.threadpool.thread.max", List.of("last"));
-        addMetric(metrics, "jdisc.http.jetty.threadpool.thread.reserved", List.of("last"));
-        addMetric(metrics, "jdisc.http.jetty.threadpool.thread.busy", List.of("sum", "count", "min", "max"));
-        addMetric(metrics, "jdisc.http.jetty.threadpool.thread.total", List.of("sum", "count", "min", "max"));
-        addMetric(metrics, "jdisc.http.jetty.threadpool.queue.size", List.of("sum", "count", "min", "max"));
 
         addMetric(metrics, "jdisc.http.filtering.request.handled", List.of("rate"));
         addMetric(metrics, "jdisc.http.filtering.request.unhandled", List.of("rate"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -154,6 +154,10 @@ public class VespaMetricSet {
             addMetric(metrics, "jdisc.thread_pool.unhandled_exceptions", suffixes);
             addMetric(metrics, "jdisc.thread_pool.work_queue.capacity", suffixes);
             addMetric(metrics, "jdisc.thread_pool.work_queue.size", suffixes);
+            addMetric(metrics, "jdisc.thread_pool.rejected_tasks", suffixes);
+            addMetric(metrics, "jdisc.thread_pool.size", suffixes);
+            addMetric(metrics, "jdisc.thread_pool.max_allowed_size", suffixes);
+            addMetric(metrics, "jdisc.thread_pool.active_threads", suffixes);
         }
 
         metrics.add(new Metric("httpapi_latency.max"));

--- a/container-core/src/main/java/com/yahoo/container/handler/threadpool/ThreadPoolMetric.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/threadpool/ThreadPoolMetric.java
@@ -22,9 +22,23 @@ class ThreadPoolMetric {
         this.defaultContext = metric.createContext(Map.of(THREAD_POOL_NAME_DIMENSION, threadPoolName));
     }
 
-    void reportRejectRequest() { metric.add("serverRejectedRequests", 1L, defaultContext); }
-    void reportThreadPoolSize(long size) { metric.set("serverThreadPoolSize", size, defaultContext); }
-    void reportActiveThreads(long threads) { metric.set("serverActiveThreads", threads, defaultContext); }
+    void reportRejectRequest() {
+        metric.add("serverRejectedRequests", 1L, defaultContext);
+        metric.add("jdisc.thread_pool.rejected_tasks", 1L, defaultContext);
+    }
+
+    void reportThreadPoolSize(long size) {
+        metric.set("serverThreadPoolSize", size, defaultContext);
+        metric.set("jdisc.thread_pool.size", size, defaultContext);
+    }
+
+    void reportMaxAllowedThreadPoolSize(long size) { metric.set("jdisc.thread_pool.max_allowed_size", size, defaultContext); }
+
+    void reportActiveThreads(long threads) {
+        metric.set("serverActiveThreads", threads, defaultContext);
+        metric.set("jdisc.thread_pool.active_threads", threads, defaultContext);
+    }
+
     void reportWorkQueueCapacity(long capacity) { metric.set("jdisc.thread_pool.work_queue.capacity", capacity, defaultContext); }
     void reportWorkQueueSize(long size) { metric.set("jdisc.thread_pool.work_queue.size", size, defaultContext); }
     void reportUnhandledException(Throwable t) {

--- a/container-core/src/test/java/com/yahoo/container/handler/threadpool/ContainerThreadPoolImplTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/threadpool/ContainerThreadPoolImplTest.java
@@ -79,8 +79,9 @@ public class ContainerThreadPoolImplTest {
         ThreadPoolExecutor executor = createPool(metrics, 3, 1200);
         assertEquals(3, executor.getMaximumPoolSize());
         assertEquals(1200, executor.getQueue().remainingCapacity());
-        assertEquals(4, metrics.innvocations().size());
+        assertEquals(7, metrics.innvocations().size());
         assertEquals(3L, metrics.innvocations().get("serverThreadPoolSize").val);
+        assertEquals(3L, metrics.innvocations().get("jdisc.thread_pool.max_allowed_size").val);
         assertEquals(0L, metrics.innvocations().get("serverActiveThreads").val);
         assertEquals(1200L, metrics.innvocations().get("jdisc.thread_pool.work_queue.capacity").val);
         assertEquals(0L, metrics.innvocations().get("jdisc.thread_pool.work_queue.size").val);
@@ -91,8 +92,9 @@ public class ContainerThreadPoolImplTest {
         ThreadPoolExecutor executor = createPool(metrics, 0, 0);
         assertEquals(CPUS*4, executor.getMaximumPoolSize());
         assertEquals(0, executor.getQueue().remainingCapacity());
-        assertEquals(4, metrics.innvocations().size());
+        assertEquals(7, metrics.innvocations().size());
         assertEquals(64L, metrics.innvocations().get("serverThreadPoolSize").val);
+        assertEquals(64L, metrics.innvocations().get("jdisc.thread_pool.max_allowed_size").val);
         assertEquals(0L, metrics.innvocations().get("serverActiveThreads").val);
         assertEquals(64L, metrics.innvocations().get("jdisc.thread_pool.work_queue.capacity").val);
         assertEquals(0L, metrics.innvocations().get("jdisc.thread_pool.work_queue.size").val);


### PR DESCRIPTION
Add the new metrics to improve observability of container threadpools.
These will be included in the updated container tuning docs.