### PR TITLE
Jonmv/require parent geq compile version

### DIFF
--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/ApplicationMojo.java
@@ -70,7 +70,7 @@ public class ApplicationMojo extends AbstractMojo {
 
         boolean hasVespaParent = false;
         Artifact parentArtifact = current.getParentArtifact();
-        if (parentArtifact != null && parentArtifact.getGroupId().startsWith("com.yahoo.vespa")) {
+        if (parentArtifact != null && (parentArtifact.getGroupId().startsWith("com.yahoo.vespa.") || parentArtifact.getGroupId().startsWith("ai.vespa."))) {
             hasVespaParent = true;
             Version parentVersion = Version.from(parentArtifact.getVersion());
             if (parentVersion.compareTo(compileVersion) < 0)

--- a/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/Version.java
+++ b/vespa-application-maven-plugin/src/main/java/com/yahoo/container/plugin/mojo/Version.java
@@ -1,0 +1,80 @@
+package com.yahoo.container.plugin.mojo;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+import static java.lang.Integer.min;
+import static java.lang.Integer.parseInt;
+
+/**
+ * @author jonmv
+ */
+public class Version implements Comparable<Version> {
+
+    private static final Comparator<Version> comparator = Comparator.comparingInt(Version::major)
+                                                                    .thenComparing(Version::isSnapshot)
+                                                                    .thenComparing(Version::minor)
+                                                                    .thenComparing(Version::micro);
+
+    private final int major;
+    private final int minor;
+    private final int micro;
+    private final boolean snapshot;
+
+    private Version(int major, int minor, int micro, boolean snapshot) {
+        if (major < 0 || minor < 0 || micro < 0) throw new IllegalArgumentException("version numbers must all be non-negative");
+        this.major = major;
+        this.minor = minor;
+        this.micro = micro;
+        this.snapshot = snapshot;
+    }
+
+    public static Version of(int major, int minor, int micro) {
+        return new Version(major, minor, micro, false);
+    }
+
+    public static Version ofSnapshot(int major) {
+        return new Version(major, 0, 0, true);
+    }
+
+    public static Version from(String version) {
+        if (version.endsWith("-SNAPSHOT")) {
+            String[] parts = version.split("-");
+            if (parts.length != 2) throw new IllegalArgumentException("snapshot version must only specify major, e.g., \"1-SNAPSHOT\"");
+            return ofSnapshot(parseInt(parts[0]));
+        }
+        String[] parts = version.split("\\.");
+        if (parts.length != 3) throw new IllegalArgumentException("release versions must specify major, minor and micro, separated by '.', e.g., \"1.2.0\"");
+        return of(parseInt(parts[0]), parseInt(parts[1]), parseInt(parts[2]));
+    }
+
+    public int major() { return major; }
+    public int minor() { return minor; }
+    public int micro() { return micro; }
+    public boolean isSnapshot() { return snapshot; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Version version = (Version) o;
+        return major == version.major && minor == version.minor && micro == version.micro && snapshot == version.snapshot;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, micro, snapshot);
+    }
+
+    /** Snapshots sort last within their major, and sorting is on major, then minor, then micro otherwise. */
+    @Override
+    public int compareTo(Version other) {
+        return comparator.compare(this, other);
+    }
+
+    @Override
+    public String toString() {
+        return isSnapshot() ? major + "-SNAPSHOT" : major + "." + minor + "." + micro;
+    }
+
+}

--- a/vespa-application-maven-plugin/src/test/java/com/yahoo/container/plugin/mojo/VersionTest.java
+++ b/vespa-application-maven-plugin/src/test/java/com/yahoo/container/plugin/mojo/VersionTest.java
@@ -1,0 +1,31 @@
+package com.yahoo.container.plugin.mojo;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author jonmv
+ */
+public class VersionTest {
+
+    @Test
+    public void test() {
+        assertEquals("1.2.0", Version.from("1.2.0").toString());
+        assertEquals("3-SNAPSHOT", Version.from("3-SNAPSHOT").toString());
+
+        List<Version> versions = List.of(Version.of(1, 2, 3),
+                                         Version.of(1, 2, 4),
+                                         Version.of(1, 3, 2),
+                                         Version.ofSnapshot(1),
+                                         Version.of(2, 1, 0));
+
+        for (int i = 0; i < versions.size(); i++)
+            for (int j = 0; j < versions.size(); j++)
+                assertEquals(versions.get(i) + " should be less than " + versions.get(j),
+                             Integer.compare(i, j), versions.get(i).compareTo(versions.get(j)));
+    }
+
+}


### PR DESCRIPTION
@gjoranv please review.

Only throw if the parent project is a hosted Vespa parent.
Use parentArtifact, which is defined even when parent project cannot be generated. 
Fallback to the version of the plugin itself for what the "vespaversion" is, for those without a vespa parent. 