### PR TITLE
Revert "Cheaper way to get number of children."

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/ResultBuilder.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/ResultBuilder.java
@@ -269,7 +269,7 @@ class ResultBuilder {
         }
 
         private long correctExpressionCountEstimate(long count, int tag) {
-            int actualGroupCount = group.getNumChildren();
+            int actualGroupCount = group.getChildren().size();
             // Use actual group count if estimate differ. If max is present, only use actual group count if less than max.
             // NOTE: If the actual group count is 0, estimate is also 0.
             if (actualGroupCount > 0 && count != actualGroupCount) {
@@ -325,11 +325,10 @@ class ResultBuilder {
 
         void addGroup(com.yahoo.searchlib.aggregation.Group execGroup) {
             GroupBuilder groupBuilder = getOrCreateGroup(execGroup);
-            if (execGroup.getNumChildren() > 0) {
-                List<com.yahoo.searchlib.aggregation.Group> children = execGroup.getChildren();
-                boolean ranked = children.get(0).isRankedByRelevance();
+            if (!execGroup.getChildren().isEmpty()) {
+                boolean ranked = execGroup.getChildren().get(0).isRankedByRelevance();
                 execGroup.sortChildrenByRank();
-                for (com.yahoo.searchlib.aggregation.Group childGroup : children) {
+                for (com.yahoo.searchlib.aggregation.Group childGroup : execGroup.getChildren()) {
                     GroupListBuilder childList = groupBuilder.getOrCreateChildList(childGroup.getTag(), ranked);
                     childList.addGroup(childGroup);
                 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/aggregation/Group.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/aggregation/Group.java
@@ -229,14 +229,9 @@ public class Group extends Identifiable {
         return this;
     }
 
-    /** Returns immutable list of child groups to this. */
+    /** Returns the list of child groups to this. */
     public List<Group> getChildren() {
         return List.copyOf(children);
-    }
-
-    /** Returns number of children groups */
-    public int getNumChildren() {
-        return children.size();
     }
 
     /**


### PR DESCRIPTION
Reverts vespa-engine/vespa#22166

Some system tests started failing, could be that expected output in tests needs to be updated instead of this revert. @baldersheim please review