### PR TITLE
Expire by time of deployment if no job start time is found

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -7,7 +7,6 @@ import com.yahoo.component.VersionCompatibility;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.transaction.Mutex;
-import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.hosted.controller.Application;
 import com.yahoo.vespa.hosted.controller.ApplicationController;
 import com.yahoo.vespa.hosted.controller.Controller;
@@ -254,6 +253,14 @@ public class JobController {
                        .filter(run -> ! run.isRedeployment())
                        .map(Run::start)
                        .collect(toUnmodifiableList());
+    }
+
+    /** Returns when given deployment last started deploying, falling back to time of deployment if it cannot be determined from job runs */
+    public Instant lastDeploymentStart(ApplicationId instanceId, Deployment deployment) {
+        return jobStarts(new JobId(instanceId, JobType.from(controller.system(),
+                                                            deployment.zone()).get())).stream()
+                                                                                      .findFirst()
+                                                                                      .orElseGet(deployment::at);
     }
 
     /** Returns an immutable map of all known runs for the given application and job type. */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirer.java
@@ -61,9 +61,8 @@ public class DeploymentExpirer extends ControllerMaintainer {
                                        .map(type -> new JobId(instance, type));
         if (jobId.isEmpty()) return false;
 
-        return controller().jobController().jobStarts(jobId.get()).stream().findFirst()
-                           .map(start -> start.plus(ttl.get()).isBefore(controller().clock().instant()))
-                           .orElse(false);
+        return controller().jobController().lastDeploymentStart(instance, deployment)
+                           .plus(ttl.get()).isBefore(controller().clock().instant());
     }
 
 }


### PR DESCRIPTION
I assume this happens because a deployment with many retries will eventually
evict all non-redeploying jobs from history and thus no starting job will be
found.

@jonmv