### PR TITLE
Build for 17

### DIFF
--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/AnnotationCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/AnnotationCollector.java
@@ -13,7 +13,7 @@ public class AnnotationCollector extends ClassVisitor {
   private final Set<String> annotations = new HashSet<>();
 
   public AnnotationCollector() {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
   }
 
   @Override

--- a/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
+++ b/abi-check-plugin/src/main/java/com/yahoo/abicheck/collector/PublicSignatureCollector.java
@@ -27,7 +27,7 @@ public class PublicSignatureCollector extends ClassVisitor {
   private Set<String> currentFields;
 
   public PublicSignatureCollector() {
-    super(Opcodes.ASM7);
+    super(Opcodes.ASM9);
   }
 
   private static boolean testBit(long access, long mask) {

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/Analyze.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/Analyze.java
@@ -65,7 +65,7 @@ public class Analyze {
     }
 
     static AnnotationVisitor visitAnnotationDefault(ImportCollector collector) {
-        return new AnnotationVisitor(Opcodes.ASM7) {
+        return new AnnotationVisitor(Opcodes.ASM9) {
             @Override
             public void visit(String name, Object value) {
             }

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeClassVisitor.java
@@ -32,7 +32,7 @@ class AnalyzeClassVisitor extends ClassVisitor implements ImportCollector {
     private final Optional<ArtifactVersion> defaultExportPackageVersion;
 
     AnalyzeClassVisitor(ArtifactVersion defaultExportPackageVersion) {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
         this.defaultExportPackageVersion = Optional.ofNullable(defaultExportPackageVersion);
     }
 
@@ -103,7 +103,7 @@ class AnalyzeClassVisitor extends ClassVisitor implements ImportCollector {
     }
 
     private AnnotationVisitor visitExportPackage() {
-        return new AnnotationVisitor(Opcodes.ASM7) {
+        return new AnnotationVisitor(Opcodes.ASM9) {
             private int major = defaultExportPackageVersion.map(ArtifactVersion::getMajorVersion)
                     .orElse(defaultVersionValue("major"));
             private int minor = defaultExportPackageVersion.map(ArtifactVersion::getMinorVersion)

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeFieldVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeFieldVisitor.java
@@ -19,7 +19,7 @@ public class AnalyzeFieldVisitor extends FieldVisitor implements ImportCollector
     private final Set<String> imports = new HashSet<>();
 
     public AnalyzeFieldVisitor(AnalyzeClassVisitor analyzeClassVisitor) {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
         this.analyzeClassVisitor = analyzeClassVisitor;
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeMethodVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeMethodVisitor.java
@@ -26,7 +26,7 @@ class AnalyzeMethodVisitor extends MethodVisitor implements ImportCollector {
     private final AnalyzeClassVisitor analyzeClassVisitor;
 
     AnalyzeMethodVisitor(AnalyzeClassVisitor analyzeClassVisitor) {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
         this.analyzeClassVisitor = analyzeClassVisitor;
     }
 

--- a/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeSignatureVisitor.java
+++ b/bundle-plugin/src/main/java/com/yahoo/container/plugin/classanalysis/AnalyzeSignatureVisitor.java
@@ -18,7 +18,7 @@ class AnalyzeSignatureVisitor extends SignatureVisitor implements ImportCollecto
     private final Set<String> imports = new HashSet<>();
 
     AnalyzeSignatureVisitor(AnalyzeClassVisitor analyzeClassVisitor) {
-        super(Opcodes.ASM7);
+        super(Opcodes.ASM9);
         this.analyzeClassVisitor = analyzeClassVisitor;
     }
 

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogHandler.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/OsgiLogHandler.java
@@ -130,7 +130,7 @@ class OsgiLogHandler extends Handler {
             case SOURCE_METHOD_NAME:
                 return record.getSourceMethodName();
             case THREAD_ID:
-                return record.getThreadID();
+                return record.getLongThreadID();
             case THROWN:
                 return record.getThrown();
             default:

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/core/OsgiLogHandlerTestCase.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/core/OsgiLogHandlerTestCase.java
@@ -86,7 +86,7 @@ public class OsgiLogHandlerTestCase {
         record.setSequenceNumber(69);
         record.setSourceClassName("sourceClassName");
         record.setSourceMethodName("sourceMethodName");
-        record.setThreadID(69);
+        record.setLongThreadID(69L);
         Throwable thrown = new Throwable();
         record.setThrown(thrown);
         log.log(record);
@@ -116,7 +116,7 @@ public class OsgiLogHandlerTestCase {
         assertEquals(69L, ref.getProperty("SEQUENCE_NUMBER"));
         assertEquals("sourceClassName", ref.getProperty("SOURCE_CLASS_NAME"));
         assertEquals("sourceMethodName", ref.getProperty("SOURCE_METHOD_NAME"));
-        assertEquals(69, ref.getProperty("THREAD_ID"));
+        assertEquals(69L, ref.getProperty("THREAD_ID"));
         assertSame(thrown, ref.getProperty("THROWN"));
         assertNull(ref.getProperty("unknown"));
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -75,7 +75,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <release>11</release>
+                        <release>17</release>
                         <showWarnings>true</showWarnings>
                         <optimize>true</optimize>
                         <showDeprecation>false</showDeprecation>

--- a/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/LogSetupTestCase.java
@@ -61,7 +61,7 @@ public class LogSetupTestCase {
                 + hostname
                 + "\t"
                 + pid
-                + "/" + zookeeperLogRecord.getThreadID() + "\t-\t.org.apache.zookeeper.server.NIOServerCnxn"
+                + "/" + zookeeperLogRecord.getLongThreadID() + "\t-\t.org.apache.zookeeper.server.NIOServerCnxn"
                 + "\twarning\tzookeeper log record";
 
         zookeeperLogRecordError = new LogRecord(Level.SEVERE, "zookeeper error");

--- a/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaFormatterTestCase.java
@@ -41,7 +41,7 @@ public class VespaFormatterTestCase {
 
         testRecord1 = new LogRecord(Level.INFO, "this is a test");
         testRecord1.setInstant(Instant.ofEpochMilli(1098709021843L));
-        testRecord1.setThreadID(123);
+        testRecord1.setLongThreadID(123L);
 
         expected1 = "1098709021.843000\t"
             + hostname + "\t"
@@ -64,7 +64,7 @@ public class VespaFormatterTestCase {
 
         testRecord2 = new LogRecord(Level.INFO, "this is a test");
         testRecord2.setInstant(Instant.ofEpochMilli(1098709021843L));
-        testRecord2.setThreadID(123);
+        testRecord2.setLongThreadID(123L);
         testRecord2.setLoggerName("org.foo");
 
         expected3 = "1098709021.843000\t"
@@ -110,7 +110,7 @@ public class VespaFormatterTestCase {
 
         LogRecord testRecord = new LogRecord(Level.INFO, "this {1} is {0} test");
         testRecord.setInstant(Instant.ofEpochMilli(1098709021843L));
-        testRecord.setThreadID(123);
+        testRecord.setLongThreadID(123L);
         testRecord.setLoggerName("org.foo");
         Object[] params = { "a small", "message" };
         testRecord.setParameters(params);

--- a/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
+++ b/vespalog/src/test/java/com/yahoo/log/VespaLogHandlerTestCase.java
@@ -60,7 +60,7 @@ public class VespaLogHandlerTestCase {
             + "\t"
 	    + pid
             + "/"
-            + record1.getThreadID()
+            + record1.getLongThreadID()
             + "\tmy-test-config-id\tTST\tinfo\tThis is a test";
 
         record2 = new LogRecord(Level.FINE, "This is a test too");
@@ -70,7 +70,7 @@ public class VespaLogHandlerTestCase {
             + hostname
             + "\t"
 	    + pid
-            + "/" + record2.getThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test\tdebug\tThis is a test too";
+            + "/" + record2.getLongThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test\tdebug\tThis is a test too";
 
         record3 = new LogRecord(Level.WARNING, "another test");
         record3.setLoggerName("com.yahoo.log.test");
@@ -79,7 +79,7 @@ public class VespaLogHandlerTestCase {
             + hostname
             + "\t"
 	    + pid
-            + "/" + record3.getThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test"
+            + "/" + record3.getLongThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test"
             + "\twarning\tanother test";
 
         record4 = new LogRecord(Level.WARNING, "unicode \u00E6\u00F8\u00E5 test \u7881 unicode");
@@ -89,7 +89,7 @@ public class VespaLogHandlerTestCase {
             + hostname
             + "\t"
 	    + pid
-            + "/" + record4.getThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test"
+            + "/" + record4.getLongThreadID() + "\tmy-test-config-id\tTST.com.yahoo.log.test"
             + "\twarning\tunicode \u00E6\u00F8\u00E5 test \u7881 unicode";
     }
 


### PR DESCRIPTION
NOTE: this is for 8 only

Build, unit test and javadoc should work for 17 now, verified in docker centos-stream8. However, a couple of unit tests fail consistently both on master+jdk11 and 8+17.

 Build command:
```
mvn clean install -T 1C -Dtest='!ConfigServerRestExecutorImplTest,!CertificateAuthorityApiTest' -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false
```
