### PR TITLE
Avoid logging error when client exits

### DIFF
--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -66,19 +66,14 @@
       <artifactId>snappy-java</artifactId>
       <scope>compile</scope>
     </dependency>
-
+    <dependency>
+      <!-- Needed by zookeeper, which only has an optional dependency. -->
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <compilerArgs>
-            <arg>-Xlint:all</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/zookeeper-command-line-client/pom.xml
+++ b/zookeeper-command-line-client/pom.xml
@@ -71,6 +71,15 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
            <archive>

--- a/zookeeper-command-line-client/src/main/java/com/yahoo/vespa/zookeeper/cli/Main.java
+++ b/zookeeper-command-line-client/src/main/java/com/yahoo/vespa/zookeeper/cli/Main.java
@@ -3,8 +3,8 @@ package com.yahoo.vespa.zookeeper.cli;
 
 import com.yahoo.vespa.zookeeper.client.ZkClientConfigBuilder;
 import org.apache.zookeeper.ZooKeeperMain;
+import org.apache.zookeeper.util.ServiceUtils;
 import org.slf4j.impl.SimpleLogger;
-
 import java.io.IOException;
 
 /**
@@ -20,6 +20,7 @@ public class Main {
         new ZkClientConfigBuilder()
                 .toConfigProperties()
                 .forEach(System::setProperty);
+        ServiceUtils.setSystemExitProcedure(System::exit);
         ZooKeeperMain.main(args);
     }
 }


### PR DESCRIPTION
Depend on spotbugs  to avoid issue with
edu.umd.cs.findbugs.annotations.SuppressFBWarnings that leads to compiler
warning