### PR TITLE
Initial foundations for C++ mTLS peer authz role constraints [run-systemtest]

### DIFF
--- a/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
+++ b/vespalib/src/tests/net/tls/policy_checking_certificate_verifier/policy_checking_certificate_verifier_test.cpp
@@ -124,7 +124,12 @@ PeerCredentials creds_with_cn(vespalib::stringref cn) {
 
 bool verify(AuthorizedPeers authorized_peers, const PeerCredentials& peer_creds) {
     auto verifier = create_verify_callback_from(std::move(authorized_peers));
-    return verifier->verify(peer_creds);
+    return verifier->verify(peer_creds).success();
+}
+
+AssumedRoles verify_roles(AuthorizedPeers authorized_peers, const PeerCredentials& peer_creds) {
+    auto verifier = create_verify_callback_from(std::move(authorized_peers));
+    return verifier->verify(peer_creds).steal_assumed_roles();
 }
 
 TEST("Default-constructed AuthorizedPeers does not allow all authenticated peers") {
@@ -135,6 +140,16 @@ TEST("Specially constructed set of policies allows all authenticated peers") {
     auto allow_all = AuthorizedPeers::allow_all_authenticated();
     EXPECT_TRUE(allow_all.allows_all_authenticated());
     EXPECT_TRUE(verify(allow_all, creds_with_dns_sans({{"anything.goes"}})));
+}
+
+TEST("specially constructed set of policies returns wildcard role set") {
+    auto allow_all = AuthorizedPeers::allow_all_authenticated();
+    EXPECT_EQUAL(verify_roles(allow_all, creds_with_dns_sans({{"anything.goes"}})), AssumedRoles::make_wildcard_role());
+}
+
+TEST("policy without explicit role set implicitly returns wildcard role set") {
+    auto authorized = authorized_peers({policy_with({required_san_dns("yolo.swag")})});
+    EXPECT_EQUAL(verify_roles(authorized, creds_with_dns_sans({{"yolo.swag"}})), AssumedRoles::make_wildcard_role());
 }
 
 TEST("Non-empty policies do not allow all authenticated peers") {
@@ -231,10 +246,11 @@ struct MultiPolicyMatchFixture {
 };
 
 MultiPolicyMatchFixture::MultiPolicyMatchFixture()
-    : authorized(authorized_peers({policy_with({required_san_dns("hello.world")}),
-                                   policy_with({required_san_dns("foo.bar")}),
-                                   policy_with({required_san_dns("zoid.berg")}),
-                                   policy_with({required_san_uri("zoid://be.rg/")})}))
+    : authorized(authorized_peers({policy_with({required_san_dns("hello.world")},   assumed_roles({"r1"})),
+                                   policy_with({required_san_dns("foo.bar")},       assumed_roles({"r2"})),
+                                   policy_with({required_san_dns("zoid.berg")},     assumed_roles({"r2", "r3"})),
+                                   policy_with({required_san_dns("secret.sauce")},  AssumedRoles::make_wildcard_role()),
+                                   policy_with({required_san_uri("zoid://be.rg/")}, assumed_roles({"r4"}))}))
 {}
 
 MultiPolicyMatchFixture::~MultiPolicyMatchFixture() = default;
@@ -246,12 +262,32 @@ TEST_F("peer verifies if it matches at least 1 policy of multiple", MultiPolicyM
     EXPECT_TRUE(verify(f.authorized, creds_with_uri_sans({{"zoid://be.rg/"}})));
 }
 
+TEST_F("role set is returned for single matched policy", MultiPolicyMatchFixture) {
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"hello.world"}})),   assumed_roles({"r1"}));
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"foo.bar"}})),       assumed_roles({"r2"}));
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"zoid.berg"}})),     assumed_roles({"r2", "r3"}));
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"secret.sauce"}})),  AssumedRoles::make_wildcard_role());
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_uri_sans({{"zoid://be.rg/"}})), assumed_roles({"r4"}));
+}
+
 TEST_F("peer verifies if it matches multiple policies", MultiPolicyMatchFixture) {
     EXPECT_TRUE(verify(f.authorized, creds_with_dns_sans({{"hello.world"}, {"zoid.berg"}})));
 }
 
+TEST_F("union role set is returned if multiple policies match", MultiPolicyMatchFixture) {
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"hello.world"}, {"foo.bar"}, {"zoid.berg"}})),
+                 assumed_roles({"r1", "r2", "r3"}));
+    // Wildcard role is tracked as a distinct role string
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"hello.world"}, {"foo.bar"}, {"secret.sauce"}})),
+                 assumed_roles({"r1", "r2", "*"}));
+}
+
 TEST_F("peer must match at least 1 of multiple policies", MultiPolicyMatchFixture) {
     EXPECT_FALSE(verify(f.authorized, creds_with_dns_sans({{"does.not.exist"}})));
+}
+
+TEST_F("empty role set is returned if no policies match", MultiPolicyMatchFixture) {
+    EXPECT_EQUAL(verify_roles(f.authorized, creds_with_dns_sans({{"does.not.exist"}})), AssumedRoles::make_empty());
 }
 
 TEST("CN requirement without glob pattern is matched as exact string") {

--- a/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(vespalib_vespalib_net_tls OBJECT
     SOURCES
+    assumed_roles.cpp
     authorization_mode.cpp
+    authorization_result.cpp
     auto_reloading_tls_crypto_engine.cpp
     crypto_codec.cpp
     crypto_codec_adapter.cpp

--- a/vespalib/src/vespa/vespalib/net/tls/assumed_roles.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/assumed_roles.cpp
@@ -1,0 +1,95 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "assumed_roles.h"
+#include <vespa/vespalib/stllike/asciistream.h>
+#include <algorithm>
+#include <ostream>
+
+namespace vespalib::net::tls {
+
+const string AssumedRoles::WildcardRole("*");
+
+AssumedRoles::AssumedRoles() = default;
+
+AssumedRoles::AssumedRoles(RoleSet assumed_roles)
+    : _assumed_roles(std::move(assumed_roles))
+{}
+
+AssumedRoles::AssumedRoles(const AssumedRoles&) = default;
+AssumedRoles& AssumedRoles::operator=(const AssumedRoles&) = default;
+AssumedRoles::AssumedRoles(AssumedRoles&&) noexcept = default;
+AssumedRoles& AssumedRoles::operator=(AssumedRoles&&) noexcept = default;
+AssumedRoles::~AssumedRoles() = default;
+
+bool AssumedRoles::can_assume_role(const string& role) const noexcept {
+    return (_assumed_roles.contains(role) || _assumed_roles.contains(WildcardRole));
+}
+
+std::vector<string> AssumedRoles::ordered_roles() const {
+    std::vector<string> roles;
+    for (const auto& r : _assumed_roles) {
+        roles.emplace_back(r);
+    }
+    std::sort(roles.begin(), roles.end());
+    return roles;
+}
+
+bool AssumedRoles::operator==(const AssumedRoles& rhs) const noexcept {
+    return (_assumed_roles == rhs._assumed_roles);
+}
+
+void AssumedRoles::print(asciistream& os) const {
+    os << "AssumedRoles(roles: [";
+    auto roles = ordered_roles();
+    for (size_t i = 0; i < roles.size(); ++i) {
+        if (i > 0) {
+            os << ", ";
+        }
+        os << roles[i];
+    }
+    os << "])";
+}
+
+asciistream& operator<<(asciistream& os, const AssumedRoles& res) {
+    res.print(os);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const AssumedRoles& res) {
+    os << to_string(res);
+    return os;
+}
+
+string to_string(const AssumedRoles& res) {
+    asciistream os;
+    os << res;
+    return os.str();
+}
+
+AssumedRoles AssumedRoles::make_for_roles(RoleSet assumed_roles) {
+    return AssumedRoles(std::move(assumed_roles));
+}
+
+AssumedRoles AssumedRoles::make_wildcard_role() {
+    return AssumedRoles(RoleSet({WildcardRole}));
+}
+
+AssumedRoles AssumedRoles::make_empty() {
+    return {};
+}
+
+AssumedRolesBuilder::AssumedRolesBuilder() = default;
+AssumedRolesBuilder::~AssumedRolesBuilder() = default;
+
+void AssumedRolesBuilder::add_union(const AssumedRoles& roles) {
+    // TODO fix hash_set iterator range insert()
+    for (const auto& role : roles.unordered_roles()) {
+        _wip_roles.insert(role);
+    }
+}
+
+AssumedRoles AssumedRolesBuilder::build_with_move() {
+    return AssumedRoles::make_for_roles(std::move(_wip_roles));
+}
+
+}
+

--- a/vespalib/src/vespa/vespalib/net/tls/assumed_roles.h
+++ b/vespalib/src/vespa/vespalib/net/tls/assumed_roles.h
@@ -1,0 +1,80 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/stllike/string.h>
+#include <vector>
+#include <iosfwd>
+
+namespace vespalib { class asciistream; }
+
+namespace vespalib::net::tls {
+
+/**
+ * Encapsulates a set of roles that requests over a particular authenticated
+ * connection can assume, based on the authorization rules it matched during mTLS
+ * handshaking.
+ *
+ * If at least one role is a wildcard ('*') role, the connection can assume _any_
+ * possible role. This is the default when no role constraints are specified in
+ * the TLS configuration file (legacy behavior). However, a default-constructed
+ * AssumedRoles instance does not allow any roles to be assumed.
+ */
+class AssumedRoles {
+public:
+    using RoleSet = hash_set<string>;
+private:
+    RoleSet _assumed_roles;
+
+    static const string WildcardRole;
+
+    explicit AssumedRoles(RoleSet assumed_roles);
+public:
+    AssumedRoles();
+    AssumedRoles(const AssumedRoles&);
+    AssumedRoles& operator=(const AssumedRoles&);
+    AssumedRoles(AssumedRoles&&) noexcept;
+    AssumedRoles& operator=(AssumedRoles&&) noexcept;
+    ~AssumedRoles();
+
+    [[nodiscard]] bool empty() const noexcept {
+        return _assumed_roles.empty();
+    }
+
+    /**
+     * Returns true iff `role` is present in the role set OR the role set contains
+     * the special wildcard role.
+     */
+    [[nodiscard]] bool can_assume_role(const string& role) const noexcept;
+
+    [[nodiscard]] const RoleSet& unordered_roles() const noexcept {
+        return _assumed_roles;
+    }
+
+    [[nodiscard]] std::vector<string> ordered_roles() const;
+
+    bool operator==(const AssumedRoles& rhs) const noexcept;
+
+    void print(asciistream& os) const;
+
+    static AssumedRoles make_for_roles(RoleSet assumed_roles);
+    static AssumedRoles make_wildcard_role(); // Allows assuming _all_ possible roles
+    static AssumedRoles make_empty(); // Matches _no_ possible roles
+};
+
+asciistream& operator<<(asciistream&, const AssumedRoles&);
+std::ostream& operator<<(std::ostream&, const AssumedRoles&);
+string to_string(const AssumedRoles&);
+
+class AssumedRolesBuilder {
+    AssumedRoles::RoleSet _wip_roles;
+public:
+    AssumedRolesBuilder();
+    ~AssumedRolesBuilder();
+
+    void add_union(const AssumedRoles& roles);
+    [[nodiscard]] bool empty() const noexcept { return _wip_roles.empty(); }
+    [[nodiscard]] AssumedRoles build_with_move();
+};
+
+}

--- a/vespalib/src/vespa/vespalib/net/tls/authorization_result.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/authorization_result.cpp
@@ -1,0 +1,62 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "authorization_result.h"
+#include <vespa/vespalib/stllike/asciistream.h>
+#include <ostream>
+
+namespace vespalib::net::tls {
+
+AuthorizationResult::AuthorizationResult() = default;
+
+AuthorizationResult::AuthorizationResult(AssumedRoles assumed_roles)
+    : _assumed_roles(std::move(assumed_roles))
+{}
+
+AuthorizationResult::AuthorizationResult(const AuthorizationResult&) = default;
+AuthorizationResult& AuthorizationResult::operator=(const AuthorizationResult&) = default;
+AuthorizationResult::AuthorizationResult(AuthorizationResult&&) noexcept = default;
+AuthorizationResult& AuthorizationResult::operator=(AuthorizationResult&&) noexcept = default;
+AuthorizationResult::~AuthorizationResult() = default;
+
+void AuthorizationResult::print(asciistream& os) const {
+    os << "AuthorizationResult(";
+    if (!success()) {
+        os << "NOT AUTHORIZED";
+    } else {
+        os << _assumed_roles;
+    }
+    os << ')';
+}
+
+AuthorizationResult
+AuthorizationResult::make_authorized_for_roles(AssumedRoles assumed_roles) {
+    return AuthorizationResult(std::move(assumed_roles));
+}
+
+AuthorizationResult
+AuthorizationResult::make_authorized_for_all_roles() {
+    return AuthorizationResult(AssumedRoles::make_wildcard_role());
+}
+
+AuthorizationResult
+AuthorizationResult::make_not_authorized() {
+    return {};
+}
+
+asciistream& operator<<(asciistream& os, const AuthorizationResult& res) {
+    res.print(os);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const AuthorizationResult& res) {
+    os << to_string(res);
+    return os;
+}
+
+string to_string(const AuthorizationResult& res) {
+    asciistream os;
+    os << res;
+    return os.str();
+}
+
+}

--- a/vespalib/src/vespa/vespalib/net/tls/authorization_result.h
+++ b/vespalib/src/vespa/vespalib/net/tls/authorization_result.h
@@ -1,0 +1,55 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "assumed_roles.h"
+#include <vespa/vespalib/stllike/string.h>
+#include <iosfwd>
+
+namespace vespalib { class asciistream; }
+
+namespace vespalib::net::tls {
+
+/**
+ * The result of evaluating configured mTLS authorization rules against the
+ * credentials presented by a successfully authenticated peer certificate.
+ *
+ * This result contains the union set of all roles specified by the matching
+ * authorization rules. If no rules matched, the set will be empty. The role
+ * set will also be empty for a default-constructed instance.
+ */
+class AuthorizationResult {
+    AssumedRoles _assumed_roles;
+
+    explicit AuthorizationResult(AssumedRoles assumed_roles);
+public:
+    AuthorizationResult();
+    AuthorizationResult(const AuthorizationResult&);
+    AuthorizationResult& operator=(const AuthorizationResult&);
+    AuthorizationResult(AuthorizationResult&&) noexcept;
+    AuthorizationResult& operator=(AuthorizationResult&&) noexcept;
+    ~AuthorizationResult();
+
+    // Returns true iff at least one assumed role has been granted.
+    [[nodiscard]] bool success() const noexcept {
+        return !_assumed_roles.empty();
+    }
+
+    [[nodiscard]] const AssumedRoles& assumed_roles() const noexcept {
+        return _assumed_roles;
+    }
+    [[nodiscard]] AssumedRoles steal_assumed_roles() noexcept {
+        return std::move(_assumed_roles);
+    }
+
+    void print(asciistream& os) const;
+
+    static AuthorizationResult make_authorized_for_roles(AssumedRoles assumed_roles);
+    static AuthorizationResult make_authorized_for_all_roles();
+    static AuthorizationResult make_not_authorized();
+};
+
+asciistream& operator<<(asciistream&, const AuthorizationResult&);
+std::ostream& operator<<(std::ostream&, const AuthorizationResult&);
+string to_string(const AuthorizationResult&);
+
+}

--- a/vespalib/src/vespa/vespalib/net/tls/certificate_verification_callback.h
+++ b/vespalib/src/vespa/vespalib/net/tls/certificate_verification_callback.h
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "authorization_result.h"
 #include "peer_credentials.h"
 
 namespace vespalib::net::tls {
@@ -13,15 +14,15 @@ struct CertificateVerificationCallback {
     virtual ~CertificateVerificationCallback() = default;
     // Return true iff the peer credentials pass verification, false otherwise.
     // Must be thread safe.
-    virtual bool verify(const PeerCredentials& peer_creds) const = 0;
+    [[nodiscard]] virtual AuthorizationResult verify(const PeerCredentials& peer_creds) const = 0;
 };
 
 // Simplest possible certificate verification callback which accepts the certificate
 // iff all its pre-verification by OpenSSL has passed. This means its chain is valid
 // and it is signed by a trusted CA.
 struct AcceptAllPreVerifiedCertificates : CertificateVerificationCallback {
-    bool verify([[maybe_unused]] const PeerCredentials& peer_creds) const override {
-        return true; // yolo
+    AuthorizationResult verify([[maybe_unused]] const PeerCredentials& peer_creds) const override {
+        return AuthorizationResult::make_authorized_for_all_roles(); // yolo
     }
 };
 

--- a/vespalib/src/vespa/vespalib/net/tls/crypto_codec.h
+++ b/vespalib/src/vespa/vespalib/net/tls/crypto_codec.h
@@ -53,6 +53,8 @@ struct DecodeResult {
 };
 
 struct TlsContext;
+class PeerCredentials;
+class AssumedRoles;
 
 // TODO move to different namespace, not dependent on TLS?
 
@@ -174,6 +176,18 @@ public:
      *               possible to encode at least 1 frame.
      */
     virtual EncodeResult half_close(char* ciphertext, size_t ciphertext_size) noexcept = 0;
+
+    /**
+     * Credentials of the _remote peer_ as observed during certificate exchange. E.g.
+     * if this is a client codec, peer_credentials() returns the _server_ credentials
+     * and vice versa.
+     */
+    [[nodiscard]] virtual const PeerCredentials& peer_credentials() const noexcept = 0;
+
+    /**
+     * Union set of all assumed roles in the peer policy rules that fully matched the peer's credentials.
+     */
+    [[nodiscard]] virtual const AssumedRoles& assumed_roles() const noexcept = 0;
 
     /*
      * Creates an implementation defined CryptoCodec that provides at least TLSv1.2

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
@@ -451,14 +451,14 @@ int OpenSslTlsContextImpl::verify_cb_wrapper(int preverified_ok, ::X509_STORE_CT
     auto* self = static_cast<OpenSslTlsContextImpl*>(SSL_CTX_get_app_data(ssl_ctx));
     LOG_ASSERT(self != nullptr);
 
-    if (self->verify_trusted_certificate(store_ctx, codec_impl->peer_address())) {
+    if (self->verify_trusted_certificate(store_ctx, *codec_impl)) {
         return 1;
     }
     ConnectionStatistics::get(SSL_in_accept_init(ssl) != 0).inc_invalid_peer_credentials();
     return 0;
 }
 
-bool OpenSslTlsContextImpl::verify_trusted_certificate(::X509_STORE_CTX* store_ctx, const SocketAddress& peer_address) {
+bool OpenSslTlsContextImpl::verify_trusted_certificate(::X509_STORE_CTX* store_ctx, OpenSslCryptoCodecImpl& codec_impl) {
     const auto authz_mode = authorization_mode();
     // TODO consider if we want to fill in peer credentials even if authorization is disabled
     if (authz_mode == AuthorizationMode::Disable) {
@@ -477,18 +477,22 @@ bool OpenSslTlsContextImpl::verify_trusted_certificate(::X509_STORE_CTX* store_c
         return false;
     }
     try {
-        const bool verified_by_cb = _cert_verify_callback->verify(creds);
-        if (!verified_by_cb) {
+        auto authz_result = _cert_verify_callback->verify(creds);
+        if (!authz_result.success()) {
             // Buffer warnings on peer IP address to avoid log flooding.
-            LOGBT(warning, peer_address.ip_address(),
+            LOGBT(warning, codec_impl.peer_address().ip_address(),
                   "Certificate verification of peer '%s' failed with %s",
-                  peer_address.spec().c_str(), to_string(creds).c_str());
+                  codec_impl.peer_address().spec().c_str(), to_string(creds).c_str());
             return (authz_mode != AuthorizationMode::Enforce);
         }
+        // Store away credentials and role set for later use by requests that arrive over this connection.
+        // TODO encapsulate as const shared_ptr to immutable object to better facilitate sharing?
+        codec_impl.set_peer_credentials(std::move(creds));
+        codec_impl.set_assumed_roles(authz_result.steal_assumed_roles());
     } catch (std::exception& e) {
-        LOGBT(error, peer_address.ip_address(),
+        LOGBT(error, codec_impl.peer_address().ip_address(),
               "Got exception during certificate verification callback for peer '%s': %s",
-              peer_address.spec().c_str(), e.what());
+              codec_impl.peer_address().spec().c_str(), e.what());
         return false;
     } // we don't expect any non-std::exception derived exceptions, so let them terminate the process.
     return true;

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.h
@@ -12,6 +12,8 @@
 
 namespace vespalib::net::tls::impl {
 
+class OpenSslCryptoCodecImpl;
+
 class OpenSslTlsContextImpl : public TlsContext {
     crypto::SslCtxPtr _ctx;
     AuthorizationMode _authorization_mode;
@@ -47,7 +49,7 @@ private:
     void set_ssl_ctx_self_reference();
     void set_accepted_cipher_suites(const std::vector<vespalib::string>& ciphers);
 
-    bool verify_trusted_certificate(::X509_STORE_CTX* store_ctx, const SocketAddress& peer_address);
+    bool verify_trusted_certificate(::X509_STORE_CTX* store_ctx, OpenSslCryptoCodecImpl& codec_impl);
 
     static int verify_cb_wrapper(int preverified_ok, ::X509_STORE_CTX* store_ctx);
 };

--- a/vespalib/src/vespa/vespalib/net/tls/peer_credentials.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_credentials.cpp
@@ -2,12 +2,15 @@
 
 #include "peer_credentials.h"
 #include <vespa/vespalib/stllike/asciistream.h>
-#include <iostream>
-#include <sstream>
+#include <ostream>
 
 namespace vespalib::net::tls {
 
 PeerCredentials::PeerCredentials() = default;
+PeerCredentials::PeerCredentials(const PeerCredentials&) = default;
+PeerCredentials& PeerCredentials::operator=(const PeerCredentials&) = default;
+PeerCredentials::PeerCredentials(PeerCredentials&&) noexcept = default;
+PeerCredentials& PeerCredentials::operator=(PeerCredentials&&) noexcept = default;
 PeerCredentials::~PeerCredentials() = default;
 
 std::ostream& operator<<(std::ostream& os, const PeerCredentials& creds) {
@@ -15,17 +18,40 @@ std::ostream& operator<<(std::ostream& os, const PeerCredentials& creds) {
     return os;
 }
 
-vespalib::string to_string(const PeerCredentials& creds) {
-    vespalib::asciistream os;
-    os << "PeerCredentials(CN '" << creds.common_name
-       << "', DNS SANs [";
-    for (size_t i = 0; i < creds.dns_sans.size(); ++i) {
+namespace {
+void emit_comma_separated_string_list(asciistream& os, stringref title,
+                                      const std::vector<string>& strings, bool prefix_comma)
+{
+    if (prefix_comma) {
+        os << ", ";
+    }
+    os << title << " [";
+    for (size_t i = 0; i < strings.size(); ++i) {
         if (i != 0) {
             os << ", ";
         }
-        os << '\'' << creds.dns_sans[i] << '\'';
+        os << '\'' << strings[i] << '\'';
     }
-    os << "])";
+    os << ']';
+}
+}
+
+vespalib::string to_string(const PeerCredentials& creds) {
+    asciistream os;
+    os << "PeerCredentials(";
+    bool emit_comma = false;
+    if (!creds.common_name.empty()) {
+        os << "CN '" << creds.common_name << "'";
+        emit_comma = true;
+    }
+    if (!creds.dns_sans.empty()) {
+        emit_comma_separated_string_list(os, "DNS SANs", creds.dns_sans, emit_comma);
+        emit_comma = true;
+    }
+    if (!creds.uri_sans.empty()) {
+        emit_comma_separated_string_list(os, "URI SANs", creds.uri_sans, emit_comma);
+    }
+    os << ')';
     return os.str();
 }
 

--- a/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
@@ -18,6 +18,10 @@ struct PeerCredentials {
     std::vector<vespalib::string> uri_sans;
 
     PeerCredentials();
+    PeerCredentials(const PeerCredentials&);
+    PeerCredentials& operator=(const PeerCredentials&);
+    PeerCredentials(PeerCredentials&&) noexcept;
+    PeerCredentials& operator=(PeerCredentials&&) noexcept;
     ~PeerCredentials();
 };
 

--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.cpp
@@ -119,6 +119,21 @@ RequiredPeerCredential::RequiredPeerCredential(Field field, vespalib::string mus
 
 RequiredPeerCredential::~RequiredPeerCredential() = default;
 
+PeerPolicy::PeerPolicy() = default;
+
+PeerPolicy::PeerPolicy(std::vector<RequiredPeerCredential> required_peer_credentials)
+    : _required_peer_credentials(std::move(required_peer_credentials)),
+      _assumed_roles(AssumedRoles::make_wildcard_role())
+{}
+
+PeerPolicy::PeerPolicy(std::vector<RequiredPeerCredential> required_peer_credentials,
+                       AssumedRoles assumed_roles)
+    : _required_peer_credentials(std::move(required_peer_credentials)),
+      _assumed_roles(std::move(assumed_roles))
+{}
+
+PeerPolicy::~PeerPolicy() = default;
+
 namespace {
 template <typename Collection>
 void print_joined(std::ostream& os, const Collection& coll, const char* sep) {

--- a/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_policies.h
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "assumed_roles.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <memory>
 #include <vector>
@@ -49,17 +50,26 @@ public:
 class PeerPolicy {
     // _All_ credentials must match for the policy itself to match.
     std::vector<RequiredPeerCredential> _required_peer_credentials;
+    AssumedRoles                        _assumed_roles;
 public:
-    PeerPolicy() = default;
-    explicit PeerPolicy(std::vector<RequiredPeerCredential> required_peer_credentials_)
-        : _required_peer_credentials(std::move(required_peer_credentials_))
-    {}
+    PeerPolicy();
+    // This policy is created with a wildcard role set, i.e. full access.
+    explicit PeerPolicy(std::vector<RequiredPeerCredential> required_peer_credentials);
 
-    bool operator==(const PeerPolicy& rhs) const {
-        return (_required_peer_credentials == rhs._required_peer_credentials);
+    PeerPolicy(std::vector<RequiredPeerCredential> required_peer_credentials,
+               AssumedRoles assumed_roles);
+
+    ~PeerPolicy();
+
+    bool operator==(const PeerPolicy& rhs) const noexcept {
+        return ((_required_peer_credentials == rhs._required_peer_credentials) &&
+                (_assumed_roles == rhs._assumed_roles));
     }
-    const std::vector<RequiredPeerCredential>& required_peer_credentials() const noexcept {
+    [[nodiscard]] const std::vector<RequiredPeerCredential>& required_peer_credentials() const noexcept {
         return _required_peer_credentials;
+    }
+    [[nodiscard]] const AssumedRoles& assumed_roles() const noexcept {
+        return _assumed_roles;
     }
 };
 

--- a/vespalib/src/vespa/vespalib/test/peer_policy_utils.cpp
+++ b/vespalib/src/vespa/vespalib/test/peer_policy_utils.cpp
@@ -16,8 +16,21 @@ RequiredPeerCredential required_san_uri(vespalib::stringref pattern) {
     return {RequiredPeerCredential::Field::SAN_URI, pattern};
 }
 
+AssumedRoles assumed_roles(const std::vector<string>& roles) {
+    // TODO fix hash_set iterator range ctor to make this a one-liner
+    AssumedRoles::RoleSet role_set;
+    for (const auto& role : roles) {
+        role_set.insert(role);
+    }
+    return AssumedRoles::make_for_roles(std::move(role_set));
+}
+
 PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds) {
     return PeerPolicy(std::move(creds));
+}
+
+PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds, AssumedRoles roles) {
+    return {std::move(creds), std::move(roles)};
 }
 
 AuthorizedPeers authorized_peers(std::vector<PeerPolicy> peer_policies) {

--- a/vespalib/src/vespa/vespalib/test/peer_policy_utils.h
+++ b/vespalib/src/vespa/vespalib/test/peer_policy_utils.h
@@ -8,7 +8,9 @@ namespace vespalib::net::tls {
 RequiredPeerCredential required_cn(vespalib::stringref pattern);
 RequiredPeerCredential required_san_dns(vespalib::stringref pattern);
 RequiredPeerCredential required_san_uri(vespalib::stringref pattern);
+AssumedRoles assumed_roles(const std::vector<string>& roles);
 PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds);
+PeerPolicy policy_with(std::vector<RequiredPeerCredential> creds, AssumedRoles roles);
 AuthorizedPeers authorized_peers(std::vector<PeerPolicy> peer_policies);
 
 }


### PR DESCRIPTION
@havardpe and @bjorncs please review

Exposes the following information via the OpenSSL-backed `CryptoCodec`:

 * Credentials retrieved from authenticated peer certificate.
 * Union set of assumed roles from all peer authorization rules that
   matched the peer certificate.

Note that this does not add parsing of any mTLS config file role fields,
nor any FNET/FRT wiring required for RPC requests to be associated with
a particular peer authz context. Syntax and semantics etc still pending.
