### PR TITLE
Revert "Add preallocate() to ConcurrentResourcePool"

### DIFF
--- a/yolean/abi-spec.json
+++ b/yolean/abi-spec.json
@@ -202,7 +202,6 @@
     "methods": [
       "public void <init>(com.yahoo.yolean.concurrent.ResourceFactory)",
       "public void <init>(java.util.function.Supplier)",
-      "public void preallocate(int)",
       "public final java.lang.Object alloc()",
       "public final void free(java.lang.Object)",
       "public java.util.Iterator iterator()"

--- a/yolean/src/main/java/com/yahoo/yolean/concurrent/ConcurrentResourcePool.java
+++ b/yolean/src/main/java/com/yahoo/yolean/concurrent/ConcurrentResourcePool.java
@@ -18,20 +18,13 @@ public class ConcurrentResourcePool<T> implements Iterable<T> {
     private final Queue<T> pool = new ConcurrentLinkedQueue<>();
     private final Supplier<T> factory;
 
-    /** @deprecated Use {@link ConcurrentResourcePool(Supplier)} instead */
-    @Deprecated(forRemoval = true, since = "7")
+    // TODO: Deprecate
     public ConcurrentResourcePool(ResourceFactory<T> factory) {
         this.factory = factory.asSupplier();
     }
 
     public ConcurrentResourcePool(Supplier<T> factory) {
         this.factory = factory;
-    }
-
-    public void preallocate(int instances) {
-        for (int i = 0; i < instances; i++) {
-            pool.offer(factory.get());
-        }
     }
 
     /**


### PR DESCRIPTION
Reverts vespa-engine/vespa#22290

Broke factory:
```
19:50:42 [WARNING] COMPILATION WARNING : 
19:50:42 [INFO] -------------------------------------------------------------
19:50:42 [WARNING] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/libyell-linguistics/src/main/java/com/yahoo/language/lib/yell/LanguagePool.java:[21,21] <T>ConcurrentResourcePool(com.yahoo.yolean.concurrent.ResourceFactory<T>) in com.yahoo.yolean.concurrent.ConcurrentResourcePool has been deprecated and marked for removal
19:50:42 [WARNING] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/libyell-linguistics/src/main/java/com/yahoo/language/lib/langdetect/DetectorContextPool.java:[20,21] <T>ConcurrentResourcePool(com.yahoo.yolean.concurrent.ResourceFactory<T>) in com.yahoo.yolean.concurrent.ConcurrentResourcePool has been deprecated and marked for removal
19:50:42 [INFO] 2 warnings 
19:50:42 [INFO] -------------------------------------------------------------
19:50:42 [INFO] -------------------------------------------------------------
19:50:42 [ERROR] COMPILATION ERROR : 
19:50:42 [INFO] -------------------------------------------------------------
19:50:42 [ERROR] /sd/workspace/src/git.vzbuilders.com/vespa/vespa-yahoo/libyell-linguistics/src/main/java/com/yahoo/language/lib/yell/LanguagePool.java: warnings found and -Werror specified
```