### PR TITLE
Use atomic _compactLidSpaceGeneration in search::AttributeVector.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -528,7 +528,7 @@ AttributeVector::compactLidSpace(uint32_t wantedLidLimit) {
     }
     commit();
     _committedDocIdLimit.store(wantedLidLimit, std::memory_order_release);
-    _compactLidSpaceGeneration = _genHandler.getCurrentGeneration();
+    _compactLidSpaceGeneration.store(_genHandler.getCurrentGeneration(), std::memory_order_relaxed);
     incGeneration();
 }
 
@@ -536,7 +536,7 @@ AttributeVector::compactLidSpace(uint32_t wantedLidLimit) {
 bool
 AttributeVector::canShrinkLidSpace() const {
     return wantShrinkLidSpace() &&
-        _compactLidSpaceGeneration < getFirstUsedGeneration();
+        _compactLidSpaceGeneration.load(std::memory_order_relaxed) < getFirstUsedGeneration();
 }
 
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -501,7 +501,7 @@ private:
     std::atomic<uint32_t>                 _committedDocIdLimit; // docid limit for search
     uint32_t                              _uncommittedDocIdLimit; // based on queued changes
     uint64_t                              _createSerialNum;
-    uint64_t                              _compactLidSpaceGeneration;
+    std::atomic<uint64_t>                 _compactLidSpaceGeneration;
     bool                                  _hasEnum;
     bool                                  _loaded;
     bool                                  _isUpdateableInMemoryOnly;


### PR DESCRIPTION
@havardpe : please review
