### PR TITLE
make soft doom factor atomic

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -128,8 +128,7 @@ Matcher::getStats()
 {
     std::lock_guard<std::mutex> guard(_statsLock);
     MatchingStats stats = std::move(_stats);
-    _stats = MatchingStats();
-    _stats.softDoomFactor(stats.softDoomFactor());
+    _stats = MatchingStats(stats.softDoomFactor());
     return stats;
 }
 


### PR DESCRIPTION
also avoid actual value race by not assigning it to the initial value
for a (very) short time each time stats are sampled.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@toregge please review