### PR TITLE
Initialize transitive ctor dependencies before use

### DIFF
--- a/slobrok/src/vespa/slobrok/server/sbenv.cpp
+++ b/slobrok/src/vespa/slobrok/server/sbenv.cpp
@@ -105,15 +105,16 @@ SBEnv::SBEnv(const ConfigShim &shim)
       _shuttingDown(false),
       _partnerList(),
       _me(createSpec(_configShim.portNumber())),
-      _rpcHooks(*this),
-      _remotechecktask(std::make_unique<RemoteCheck>(getSupervisor()->GetScheduler(), _exchanger)),
-      _health(),
-      _metrics(_rpcHooks, *_transport),
-      _components(),
       _localRpcMonitorMap(getScheduler(),
                           [this] (MappingMonitorOwner &owner) {
                               return std::make_unique<RpcMappingMonitor>(*_supervisor, owner);
                           }),
+      _globalVisibleHistory(),
+      _rpcHooks(*this), // Transitively references _localRpcMonitorMap and _globalVisibleHistory
+      _remotechecktask(std::make_unique<RemoteCheck>(getSupervisor()->GetScheduler(), _exchanger)),
+      _health(),
+      _metrics(_rpcHooks, *_transport),
+      _components(),
       _exchanger(*this)
 {
     srandom(time(nullptr) ^ getpid());

--- a/slobrok/src/vespa/slobrok/server/sbenv.h
+++ b/slobrok/src/vespa/slobrok/server/sbenv.h
@@ -50,14 +50,14 @@ private:
 
     std::vector<std::string>                   _partnerList;
     std::string                                _me;
+    LocalRpcMonitorMap                         _localRpcMonitorMap;
+    ServiceMapHistory                          _globalVisibleHistory;
     RPCHooks                                   _rpcHooks;
     std::unique_ptr<RemoteCheck>               _remotechecktask;
     vespalib::SimpleHealthProducer             _health;
     MetricsProducer                            _metrics;
     vespalib::SimpleComponentConfigProducer    _components;
-    LocalRpcMonitorMap                         _localRpcMonitorMap;
     UnionServiceMap                            _consensusMap;
-    ServiceMapHistory                          _globalVisibleHistory;
 
     ExchangeManager                            _exchanger;
 


### PR DESCRIPTION
@arnej27959 please review. Maybe there are some sneaky hidden dependencies here that I'm not aware of.

Ensure that `SBEnv` fields that are accessed by `RPCHooks` ctor are
initialized before the `RPCHooks` field itself is created.
