### PR TITLE
Use port as observed by client when constructing URI

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/filter/util/FilterUtils.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/filter/util/FilterUtils.java
@@ -10,12 +10,14 @@ import com.yahoo.jdisc.handler.ContentChannel;
 import com.yahoo.jdisc.handler.ResponseHandler;
 import com.yahoo.jdisc.http.Cookie;
 import com.yahoo.jdisc.http.filter.DiscFilterRequest;
+import com.yahoo.jdisc.http.server.jetty.RequestUtils;
 
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Helper methods for auth0/okta request filters.
@@ -64,7 +66,10 @@ public class FilterUtils {
 
     public static URI createUriFromRequest(DiscFilterRequest request, String path) {
         try {
-            return new URI(request.getScheme(), null, request.getServerName(), request.getUri().getPort(), path, null, null);
+            // Prefer local port as observed by client over local listen port
+            int port = Optional.ofNullable((Integer)request.getAttribute(RequestUtils.JDICS_REQUEST_PORT))
+                    .orElse(request.getUri().getPort());
+            return new URI(request.getScheme(), null, request.getServerName(), port, path, null, null);
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestFactory.java
@@ -33,6 +33,7 @@ class HttpRequestFactory {
                     new InetSocketAddress(servletRequest.getRemoteAddr(), servletRequest.getRemotePort()),
                     getConnection((Request) servletRequest).getCreatedTimeStamp());
             httpRequest.context().put(RequestUtils.JDISC_REQUEST_X509CERT, getCertChain(servletRequest));
+            httpRequest.context().put(RequestUtils.JDICS_REQUEST_PORT, servletRequest.getLocalPort());
             servletRequest.setAttribute(HttpRequest.class.getName(), httpRequest);
             return httpRequest;
         } catch (Utf8Appendable.NotUtf8Exception e) {

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/RequestUtils.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/RequestUtils.java
@@ -17,6 +17,11 @@ public class RequestUtils {
     public static final String JDISC_RESPONSE_CHAIN = "jdisc.response.chain";
     public static final String SERVLET_REQUEST_X509CERT = "javax.servlet.request.X509Certificate";
 
+    // The local port as reported by servlet spec. This will be influenced by Host header and similar mechanisms.
+    // The request URI uses the local listen port as the URI is used for handler routing/bindings.
+    // Use this attribute for generating URIs that is presented to client.
+    public static final String JDICS_REQUEST_PORT = "jdisc.request.port";
+
     private RequestUtils() {}
 
     public static Connection getConnection(Request request) {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
