### PR TITLE
Increase cluster-controller memory

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -328,7 +328,7 @@ public class ContentCluster extends AbstractConfigProducer<AbstractConfigProduce
             }
         }
 
-        public static final NodeResources clusterControllerResources = new NodeResources(0.25, 1, 10, 0.3, DiskSpeed.any, StorageType.any);
+        public static final NodeResources clusterControllerResources = new NodeResources(0.25, 1.14, 10, 0.3, DiskSpeed.any, StorageType.any);
 
         private ClusterControllerContainerCluster getDedicatedSharedControllers(ModelElement contentElement,
                                                                                 Admin admin,


### PR DESCRIPTION
Increase cc memory to fit 7 nodes on 8Gb containers
with 0.95Gb real memory each.
