### PR TITLE
Don't support user config under document

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/UserConfigBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/UserConfigBuilder.java
@@ -15,17 +15,13 @@ import java.util.logging.Logger;
 
 /**
  * @author Ulf Lilleengen
- * @since 5.1
  */
 public class UserConfigBuilder {
 
     public static final Logger log = Logger.getLogger(UserConfigBuilder.class.getPackage().toString());
 
     public static UserConfigRepo build(Element producerSpec, ConfigDefinitionStore configDefinitionStore, DeployLogger deployLogger) {
-        final Map<ConfigDefinitionKey, ConfigPayloadBuilder> builderMap = new LinkedHashMap<>();
-        if (producerSpec == null) {
-            log.log(Level.FINEST, "In getUserConfigs. producerSpec is null");
-        }
+        Map<ConfigDefinitionKey, ConfigPayloadBuilder> builderMap = new LinkedHashMap<>();
         log.log(Level.FINE, () -> "getUserConfigs for " + producerSpec);
         for (Element configE : XML.getChildren(producerSpec, "config")) {
             buildElement(configE, builderMap, configDefinitionStore, deployLogger);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -243,9 +243,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
                 throw new IllegalArgumentException("Schema '" + schemaDefinitionXMLHandler.getName() + "' referenced in " +
                                                    this + " does not exist");
 
-            // TODO: remove explicit building of user configs when the complete content model is built using builders.
             sc.add(new SearchCluster.SchemaInfo(schema,
-                                                UserConfigBuilder.build(e.getXml(), deployState, deployState.getDeployLogger()),
                                                 deployState.rankProfileRegistry()));
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -191,8 +191,6 @@ public class IndexedSearchCluster extends SearchCluster
                                                                                 deployState.getQueryProfiles().getRegistry(),
                                                                                 deployState.getImportedModels(),
                                                                                 deployState.getExecutor()));
-            // TODO: remove explicit adding of user configs when the complete content model is built using builders.
-            db.mergeUserConfigs(spec.userConfigs());
             documentDbs.add(db);
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
@@ -198,21 +198,18 @@ public abstract class SearchCluster extends AbstractConfigProducer<SearchCluster
     public static final class SchemaInfo {
 
         private final Schema schema;
-        private final UserConfigRepo userConfigRepo;
 
         // Info about profiles needed in memory after build.
         // The rank profile registry itself is not kept around due to its size.
         private final Map<String, RankProfileInfo> rankProfiles;
 
-        public SchemaInfo(Schema schema, UserConfigRepo userConfigRepo, RankProfileRegistry rankProfileRegistry) {
+        public SchemaInfo(Schema schema, RankProfileRegistry rankProfileRegistry) {
             this.schema = schema;
-            this.userConfigRepo = userConfigRepo;
             this.rankProfiles = Collections.unmodifiableMap(toRankProfiles(rankProfileRegistry.rankProfilesOf(schema)));
         }
 
         public String name() { return schema.getName(); }
         public Schema fullSchema() { return schema; }
-        public UserConfigRepo userConfigs() { return userConfigRepo; }
         public Map<String, RankProfileInfo> rankProfiles() { return rankProfiles; }
 
         private Map<String, RankProfileInfo> toRankProfiles(Collection<RankProfile> rankProfiles) {

--- a/config-model/src/main/resources/schema/content.rnc
+++ b/config-model/src/main/resources/schema/content.rnc
@@ -191,7 +191,6 @@ Documents = element documents {
     DocumentProcessing? &
 
     element document {
-        GenericConfig* &
         attribute type { xsd:string } &
         attribute selection { xsd:string }? &
         attribute mode { string "index" | string "streaming" | string "store-only" } &

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
@@ -9,9 +9,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.text.StringUtilities;
-import com.yahoo.vespa.config.ConfigDefinitionKey;
-import com.yahoo.vespa.config.ConfigPayloadBuilder;
-import com.yahoo.vespa.config.GenericConfig;
 import com.yahoo.vespa.config.search.core.ProtonConfig;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
@@ -707,25 +704,6 @@ public class ContentBuilderTest extends DomBuilderTest {
         assertTrue(cfg.contains("summary.cache.compression.level 8"));
         assertTrue(cfg.contains("summary.cache.compression.type LZ4"));
         assertTrue(cfg.contains("summary.read.io DIRECTIO"));
-    }
-
-    @Test
-    public void requireThatUserConfigCanBeSpecifiedForASearchDefinition() {
-        String services =  getConfigOverrideServices(
-                "<node hostalias='mockhost' distribution-key='0'/>",
-                "  <config name='mynamespace.myconfig'>" +
-                "    <myfield>myvalue</myfield>" +
-                "  </config>"
-        );
-
-        VespaModel m = new VespaModelCreatorWithMockPkg(createAppWithMusic(getHosts(), services)).create();
-        String configId = "clu/search/cluster.clu/music";
-        {
-            GenericConfig.GenericConfigBuilder builder = 
-                    new GenericConfig.GenericConfigBuilder(new ConfigDefinitionKey("myconfig", "mynamespace"), new ConfigPayloadBuilder());
-            m.getConfig(builder, configId);
-            assertEquals(builder.getPayload().getSlime().get().field("myfield").asString(), "myvalue");
-        }
     }
 
     @Test


### PR DESCRIPTION
I want to remove support for user config under <document> to enable some other simplification.
I've never heard of anyone using that, it's not explicitly documented, and it doesn't make much sense to me.