### PR TITLE
Use vespalib::datastore::AtomicEntryRef in search::memoryindex::Posti…

### DIFF
--- a/searchlib/src/vespa/searchlib/memoryindex/feature_store.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/feature_store.cpp
@@ -106,6 +106,16 @@ FeatureStore::addFeatures(uint32_t packedIndex, const DocIdAndFeatures &features
 }
 
 void
+FeatureStore::add_features_guard_bytes()
+{
+    uint32_t len = DECODE_SAFETY;
+    uint32_t pad = RefType::pad(len);
+    auto result = _store.rawAllocator<int8_t>(_typeId).alloc(len + pad);
+    memset(result.data, 0, len + pad);
+    _store.incDead(result.ref, len + pad);
+}
+
+void
 FeatureStore::getFeatures(uint32_t packedIndex, vespalib::datastore::EntryRef ref, DocIdAndFeatures &features)
 {
     setupForField(packedIndex, _d);

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -124,11 +124,7 @@ FieldIndex<interleaved_features>::compactFeatures()
                 // Filter on which buffers to move features from when
                 // performing incremental compaction.
 
-                EntryRef newFeatures = _featureStore.moveFeatures(packedIndex, posting_entry.get_features());
-
-                // Features must be written before reference is updated.
-                std::atomic_thread_fence(std::memory_order_release);
-
+                EntryRef newFeatures = _featureStore.moveFeatures(packedIndex, posting_entry.get_features_relaxed());
                 // Reference the moved data
                 posting_entry.update_features(newFeatures);
             }
@@ -141,11 +137,7 @@ FieldIndex<interleaved_features>::compactFeatures()
                 // Filter on which buffers to move features from when
                 // performing incremental compaction.
 
-                EntryRef newFeatures = _featureStore.moveFeatures(packedIndex, posting_entry.get_features());
-
-                // Features must be written before reference is updated.
-                std::atomic_thread_fence(std::memory_order_release);
-
+                EntryRef newFeatures = _featureStore.moveFeatures(packedIndex, posting_entry.get_features_relaxed());
                 // Reference the moved data
                 posting_entry.update_features(newFeatures);
             }
@@ -184,7 +176,7 @@ FieldIndex<interleaved_features>::dump(search::index::IndexBuilder & indexBuilde
                 const PostingListEntryType &entry(pitr.getData());
                 features.set_num_occs(entry.get_num_occs());
                 features.set_field_length(entry.get_field_length());
-                _featureStore.setupForReadFeatures(entry.get_features(), decoder);
+                _featureStore.setupForReadFeatures(entry.get_features_relaxed(), decoder);
                 decoder.readFeatures(features);
                 indexBuilder.add_document(features);
             }
@@ -197,7 +189,7 @@ FieldIndex<interleaved_features>::dump(search::index::IndexBuilder & indexBuilde
                 const PostingListEntryType &entry(kd->getData());
                 features.set_num_occs(entry.get_num_occs());
                 features.set_field_length(entry.get_field_length());
-                _featureStore.setupForReadFeatures(entry.get_features(), decoder);
+                _featureStore.setupForReadFeatures(entry.get_features_relaxed(), decoder);
                 decoder.readFeatures(features);
                 indexBuilder.add_document(features);
             }

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index_base.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index_base.h
@@ -97,6 +97,8 @@ public:
         return _featureStore.addFeatures(_fieldId, features).first;
     }
 
+    void add_features_guard_bytes() { _featureStore.add_features_guard_bytes(); }
+
     FieldIndexBase(const index::Schema& schema, uint32_t fieldId);
     FieldIndexBase(const index::Schema& schema, uint32_t fieldId, const index::FieldLengthInfo& info);
     ~FieldIndexBase();

--- a/searchlib/src/vespa/searchlib/memoryindex/ordered_field_index_inserter.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/ordered_field_index_inserter.h
@@ -41,6 +41,10 @@ private:
     // Pending changes to posting list for (_word)
     std::vector<uint32_t>    _removes;
     std::vector<PostingListKeyDataType> _adds;
+    using WordEntry = std::tuple<vespalib::stringref, size_t, size_t>;
+    std::vector<WordEntry> _word_entries;
+    size_t _removes_offset;
+    size_t _adds_offset;
 
     static constexpr uint32_t noFieldId = std::numeric_limits<uint32_t>::max();
     static constexpr uint32_t noDocId = std::numeric_limits<uint32_t>::max();

--- a/searchlib/src/vespa/searchlib/memoryindex/posting_list_entry.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/posting_list_entry.h
@@ -2,7 +2,7 @@
 
 # pragma once
 
-#include <vespa/vespalib/datastore/entryref.h>
+#include <vespa/vespalib/datastore/atomic_entry_ref.h>
 
 namespace search::memoryindex {
 
@@ -49,7 +49,7 @@ public:
 template <bool interleaved_features>
 class PostingListEntry : public std::conditional_t<interleaved_features, InterleavedFeatures, NoInterleavedFeatures> {
     using ParentType = std::conditional_t<interleaved_features, InterleavedFeatures, NoInterleavedFeatures>;
-    mutable vespalib::datastore::EntryRef _features; // reference to compressed features
+    mutable vespalib::datastore::AtomicEntryRef _features; // reference to compressed features
 
 public:
     explicit PostingListEntry(vespalib::datastore::EntryRef features, uint16_t num_occs, uint16_t field_length)
@@ -64,14 +64,15 @@ public:
     {
     }
 
-    vespalib::datastore::EntryRef get_features() const { return _features; }
+    vespalib::datastore::EntryRef get_features() const noexcept { return _features.load_acquire(); }
+    vespalib::datastore::EntryRef get_features_relaxed() const noexcept { return _features.load_relaxed(); }
 
     /*
      * Reference moved features (used when compacting FeatureStore).
      * The moved features must have the same content as the original
      * features.
      */
-    void update_features(vespalib::datastore::EntryRef features) const { _features = features; }
+    void update_features(vespalib::datastore::EntryRef features) const { _features.store_release(features); }
 };
 
 template class PostingListEntry<false>;

--- a/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.cpp
+++ b/searchlib/src/vespa/searchlib/test/fakedata/fakememtreeocc.cpp
@@ -263,7 +263,7 @@ FakeMemTreeOccMgr::flush()
         lastWord = wordIdx;
         if (i->getRemove()) {
             if (itr.valid() && itr.getKey() == docId) {
-                uint64_t bits = _featureStore.bitSize(fw->getPackedIndex(), EntryRef(itr.getData().get_features()));
+                uint64_t bits = _featureStore.bitSize(fw->getPackedIndex(), EntryRef(itr.getData().get_features_relaxed()));
                 _featureSizes[wordIdx] -= RefType::align((bits + 7) / 8) * 8;
                 tree.remove(itr);
             }


### PR DESCRIPTION
…ngListEntry.

Add guard bytes to feature store for each memory index commit to avoid
conflict between decoder overrun and addition of new features.

@havardpe : please review

