### PR TITLE
Add lock around visitor queue size read during metric snapshot callback

### DIFF
--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -86,6 +86,7 @@ VisitorManager::create_and_start_manager_thread()
 void
 VisitorManager::updateMetrics(const MetricLockGuard &)
 {
+    std::lock_guard sync(_visitorLock);
     _metrics->queueSize.addValue(_visitorQueue.size());
 }
 


### PR DESCRIPTION
@toregge please review

Mutex should have very little contention in the common case.

