### PR TITLE
Don't require overriding max() if using predef as grouping expression

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
@@ -16,6 +16,7 @@ import com.yahoo.searchlib.aggregation.Grouping;
 import com.yahoo.searchlib.aggregation.GroupingLevel;
 import com.yahoo.searchlib.aggregation.HitsAggregationResult;
 import com.yahoo.searchlib.expression.ExpressionNode;
+import com.yahoo.searchlib.expression.RangeBucketPreDefFunctionNode;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -430,6 +431,10 @@ class RequestBuilder {
 
     private int validateSummaryMax(GroupingLevel lvl) {
         int max = transform.getMax(lvl.getGroupPrototype().getTag());
+        if (lvl.getExpression() instanceof RangeBucketPreDefFunctionNode) {
+            int maxBuckets = ((RangeBucketPreDefFunctionNode) lvl.getExpression()).getBucketList().size() + 1; // +1 for "null" bucket
+            if (maxBuckets < max || max <= 0) max = maxBuckets;
+        }
         if (max <= 0) throw new IllegalInputException(
                 "Cannot return unbounded number of groups when 'grouping.globalMaxGroups' is enabled. " +
                         "Either restrict group count with max() or disable 'grouping.globalMaxGroups'. " +

--- a/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/vespa/RequestBuilder.java
@@ -412,7 +412,7 @@ class RequestBuilder {
         for (Grouping grp : requestList) {
             int levelMultiplier = 1;
             for (GroupingLevel lvl : grp.getLevels()) {
-                totalGroupsAndSummaries += (levelMultiplier *= validateSummaryMax(lvl));
+                totalGroupsAndSummaries += (levelMultiplier *= validateGroupMax(lvl));
                 var hars = hitsAggregationResult(lvl);
                 for (HitsAggregationResult har : hars) {
                     totalGroupsAndSummaries += (levelMultiplier * validateSummaryMax(har));
@@ -429,7 +429,7 @@ class RequestBuilder {
         this.totalGroupsAndSummaries = totalGroupsAndSummaries;
     }
 
-    private int validateSummaryMax(GroupingLevel lvl) {
+    private int validateGroupMax(GroupingLevel lvl) {
         int max = transform.getMax(lvl.getGroupPrototype().getTag());
         if (lvl.getExpression() instanceof RangeBucketPreDefFunctionNode) {
             int maxBuckets = ((RangeBucketPreDefFunctionNode) lvl.getExpression()).getBucketList().size() + 1; // +1 for "null" bucket

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/RequestBuilderTestCase.java
@@ -780,6 +780,7 @@ public class RequestBuilderTestCase {
                 "all(" +
                         "   all(group(a) max(3) each(output(count()) max(5) each(output(summary())))) " +
                         "   all(group(b) max(3) each(output(count()) max(5) each(output(summary())))))");
+        assertTotalGroupsAndSummaries(3, "all(group(predefined(a,bucket(1,3),bucket(6,9))) each(output(count())))");
     }
 
     @Test

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/BoolResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/BoolResultNodeVector.java
@@ -24,6 +24,8 @@ public class BoolResultNodeVector extends ResultNodeVector {
         return add((BoolResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected int onGetClassId() {
         return classId;

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatBucketResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatBucketResultNodeVector.java
@@ -35,6 +35,8 @@ public class FloatBucketResultNodeVector extends ResultNodeVector {
         return add((FloatBucketResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ArrayList<FloatBucketResultNode> getVector() {
         return vector;
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/FloatResultNodeVector.java
@@ -31,6 +31,8 @@ public class FloatResultNodeVector extends ResultNodeVector {
         return this;
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ResultNodeVector add(ResultNode r) {
         return add((FloatResultNode)r);
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/Int16ResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/Int16ResultNodeVector.java
@@ -34,6 +34,8 @@ public class Int16ResultNodeVector extends ResultNodeVector {
         return add((Int16ResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected int onGetClassId() {
         return classId;

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/Int32ResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/Int32ResultNodeVector.java
@@ -35,6 +35,8 @@ public class Int32ResultNodeVector extends ResultNodeVector {
         return add((Int32ResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected int onGetClassId() {
         return classId;

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/Int8ResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/Int8ResultNodeVector.java
@@ -35,6 +35,8 @@ public class Int8ResultNodeVector extends ResultNodeVector {
         return add((Int8ResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected int onGetClassId() {
         return classId;

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/IntegerBucketResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/IntegerBucketResultNodeVector.java
@@ -40,6 +40,8 @@ public class IntegerBucketResultNodeVector extends ResultNodeVector {
         return add((IntegerBucketResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected void onSerialize(Serializer buf) {
         super.onSerialize(buf);

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/IntegerResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/IntegerResultNodeVector.java
@@ -35,6 +35,8 @@ public class IntegerResultNodeVector extends ResultNodeVector {
         return add((IntegerResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     @Override
     protected int onGetClassId() {
         return classId;

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/RawBucketResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/RawBucketResultNodeVector.java
@@ -31,6 +31,8 @@ public class RawBucketResultNodeVector extends ResultNodeVector {
         return add((RawBucketResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ArrayList<RawBucketResultNode> getVector() {
         return vector;
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/RawResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/RawResultNodeVector.java
@@ -35,6 +35,8 @@ public class RawResultNodeVector extends ResultNodeVector {
         return add((RawResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ArrayList<RawResultNode> getVector() {
         return vector;
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/ResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/ResultNodeVector.java
@@ -42,4 +42,6 @@ public abstract class ResultNodeVector extends ResultNode {
     }
 
     public abstract ResultNodeVector add(ResultNode r);
+
+    public abstract int size();
 }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/StringBucketResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/StringBucketResultNodeVector.java
@@ -35,6 +35,8 @@ public class StringBucketResultNodeVector extends ResultNodeVector {
         return add((StringBucketResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ArrayList<StringBucketResultNode> getVector() {
         return vector;
     }

--- a/searchlib/src/main/java/com/yahoo/searchlib/expression/StringResultNodeVector.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/expression/StringResultNodeVector.java
@@ -35,6 +35,8 @@ public class StringResultNodeVector extends ResultNodeVector {
         return add((StringResultNode)r);
     }
 
+    @Override public int size() { return vector.size(); }
+
     public ArrayList<StringResultNode> getVector() {
         return vector;
     }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
