### PR TITLE
Revert "Add lock around visitor queue size read during metric snapshot callback"

### DIFF
--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -86,7 +86,6 @@ VisitorManager::create_and_start_manager_thread()
 void
 VisitorManager::updateMetrics(const MetricLockGuard &)
 {
-    std::lock_guard sync(_visitorLock);
     _metrics->queueSize.addValue(_visitorQueue.size());
 }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#22414

Unit test storageserver_gtest_runner_app started failing with thread sanitizer warnings about lock order reversal.
