### PR TITLE
Use lock guard on _lock while getting memory meta footprint.

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.cpp
@@ -629,6 +629,7 @@ WriteableFileChunk::getMemoryFootprint() const
 size_t
 WriteableFileChunk::getMemoryMetaFootprint() const
 {
+    std::lock_guard guard(_lock);
     constexpr size_t mySizeWithoutMyParent(sizeof(*this) - sizeof(FileChunk));
     return mySizeWithoutMyParent + FileChunk::getMemoryMetaFootprint();
 }


### PR DESCRIPTION
@havardpe : please review
