### PR TITLE
Avoid the 'jdisc/' prefix used for logging during startup of configse…

### DIFF
--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -161,7 +161,7 @@ rm -f $cfpfile
 vespa-run-as-vespa-user sh -c "printenv > $cfpfile"
 fixddir $bundlecachedir
 
-vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
+vespa-run-as-vespa-user vespa-runserver -s ${VESPA_SERVICE_NAME} -r 30 -p $pidfile -- \
 	java \
 	-Xms128m -Xmx2048m \
 	-XX:+PreserveFramePointer \
@@ -190,9 +190,9 @@ vespa-run-as-vespa-user vespa-runserver -s configserver -r 30 -p $pidfile -- \
 	-Djdisc.export.packages= \
 	-Djdisc.cache.path=$bundlecachedir \
 	-Djdisc.bundle.path=${VESPA_HOME}/lib/jars \
-	-Djdisc.logger.enabled=true \
+	-Djdisc.logger.enabled=false \
 	-Djdisc.logger.level=ALL \
-	-Djdisc.logger.tag=jdisc/configserver \
+	-Djdisc.logger.tag=${VESPA_SERVICE_NAME} \
 	-Dfile.encoding=UTF-8 \
 	-Dzookeeper_log_file_prefix=${ZOOKEEPER_LOG_FILE_PREFIX} \
 	-cp "$CP" \


### PR DESCRIPTION
…rver.

Disable logging during startup of jdisc. No reason for doing this different than any other container.

@hakonhall or @hmusum or @bjorncs or @gjoranv 