### PR TITLE
Avoid the 'jdisc/' prefix used for logging during startup of standalo…

### DIFF
--- a/standalone-container/src/main/sh/standalone-container.sh
+++ b/standalone-container/src/main/sh/standalone-container.sh
@@ -187,9 +187,9 @@ StartCommand() {
         -Djdisc.export.packages= \
         -Djdisc.cache.path="$bundlecachedir" \
         -Djdisc.bundle.path="$VESPA_HOME/lib/jars" \
-        -Djdisc.logger.enabled=true \
+        -Djdisc.logger.enabled=false \
         -Djdisc.logger.level=ALL \
-        -Djdisc.logger.tag="jdisc/$service" \
+        -Djdisc.logger.tag="$service" \
         -Dfile.encoding=UTF-8 \
         -cp "$CP" \
         "${jvm_arguments[@]}" \


### PR DESCRIPTION
…ne-container.

Disable logging during startup of jdisc. No reason for doing this different than any other container.

@hakonhall PR