### PR TITLE
Failed and breakfixed hosts are always noop in CMRs

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/VcmrMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/VcmrMaintainer.java
@@ -214,6 +214,10 @@ public class VcmrMaintainer extends ControllerMaintainer {
             return hostAction.withState(State.PENDING_RETIREMENT);
         }
 
+        if (isFailed(node)) {
+            return hostAction.withState(State.NONE);
+        }
+
         return hostAction;
     }
 
@@ -258,6 +262,11 @@ public class VcmrMaintainer extends ControllerMaintainer {
     private boolean isOutOfSync(Node node, HostAction action) {
         return action.getState() == State.RETIRED && node.state() != Node.State.parked ||
                 action.getState() == State.RETIRING && !node.wantToRetire();
+    }
+
+    private boolean isFailed(Node node) {
+        return node.state() == Node.State.failed ||
+                node.state() == Node.State.breakfixed;
     }
 
     private Map<ZoneId, List<Node>> nodesByZone() {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
