### PR TITLE
Name matching query properties using camelCase as done elsewhere.

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -106,10 +106,10 @@ public class QueryProperties extends Properties {
             }
             else if (key.size() == 3 && key.get(1).equals(Ranking.MATCHING)) {
                 Matching matching = ranking.getMatching();
-                if (key.last().equals(Matching.TERMWISELIMIT)) return matching.getTermwiseLimit();
-                if (key.last().equals(Matching.NUMTHREADSPERSEARCH)) return matching.getNumThreadsPerSearch();
-                if (key.last().equals(Matching.NUMSEARCHPARTITIIONS)) return matching.getNumSearchPartitions();
-                if (key.last().equals(Matching.MINHITSPERTHREAD)) return matching.getMinHitsPerThread();
+                if (equalsWithLowerCaseAlias(key.last(), Matching.TERMWISELIMIT)) return matching.getTermwiseLimit();
+                if (equalsWithLowerCaseAlias(key.last(), Matching.NUMTHREADSPERSEARCH)) return matching.getNumThreadsPerSearch();
+                if (equalsWithLowerCaseAlias(key.last(), Matching.NUMSEARCHPARTITIIONS)) return matching.getNumSearchPartitions();
+                if (equalsWithLowerCaseAlias(key.last(), Matching.MINHITSPERTHREAD)) return matching.getMinHitsPerThread();
 
             }
             else if (key.size() > 2) {
@@ -250,13 +250,13 @@ public class QueryProperties extends Properties {
                 }
                 else if (key.size() == 3 && key.get(1).equals(Ranking.MATCHING)) {
                     Matching matching = ranking.getMatching();
-                    if (key.last().equals(Matching.TERMWISELIMIT))
+                    if (equalsWithLowerCaseAlias(key.last(), Matching.TERMWISELIMIT))
                         matching.setTermwiselimit(asDouble(value, 1.0));
-                    else if (key.last().equals(Matching.NUMTHREADSPERSEARCH))
+                    else if (equalsWithLowerCaseAlias(key.last(), Matching.NUMTHREADSPERSEARCH))
                         matching.setNumThreadsPerSearch(asInteger(value, 1));
-                    else if (key.last().equals(Matching.NUMSEARCHPARTITIIONS))
+                    else if (equalsWithLowerCaseAlias(key.last(), Matching.NUMSEARCHPARTITIIONS))
                         matching.setNumSearchPartitions(asInteger(value, 1));
-                    else if (key.last().equals(Matching.MINHITSPERTHREAD))
+                    else if (equalsWithLowerCaseAlias(key.last(), Matching.MINHITSPERTHREAD))
                         matching.setMinHitsPerThread(asInteger(value, 0));
                     else if (key.last().equals(Matching.POST_FILTER_THRESHOLD))
                         matching.setPostFilterThreshold(asDouble(value, 1.0));
@@ -396,6 +396,11 @@ public class QueryProperties extends Properties {
     private void throwIllegalParameter(String key,String namespace) {
         throw new IllegalInputException("'" + key + "' is not a valid property in '" + namespace +
                                         "'. See the query api for valid keys starting by '" + namespace + "'.");
+    }
+
+    private boolean equalsWithLowerCaseAlias(String key, String property) {
+        // The lowercase alias is used to provide backwards compatibility of a query property that was wrongly named in the first place.
+        return key.equals(property) || key.equals(property.toLowerCase());
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
+++ b/container-search/src/main/java/com/yahoo/search/query/ranking/Matching.java
@@ -18,10 +18,10 @@ public class Matching implements Cloneable {
     /** The type representing the property arguments consumed by this */
     private static final QueryProfileType argumentType;
 
-    public static final String TERMWISELIMIT = "termwiselimit";
-    public static final String NUMTHREADSPERSEARCH = "numthreadspersearch";
-    public static final String NUMSEARCHPARTITIIONS = "numsearchpartitions";
-    public static final String MINHITSPERTHREAD = "minhitsperthread";
+    public static final String TERMWISELIMIT = "termwiseLimit";
+    public static final String NUMTHREADSPERSEARCH = "numThreadsPerSearch";
+    public static final String NUMSEARCHPARTITIIONS = "numSearchPartitions";
+    public static final String MINHITSPERTHREAD = "minHitsPerThread";
     public static final String POST_FILTER_THRESHOLD = "postFilterThreshold";
     public static final String APPROXIMATE_THRESHOLD = "approximateThreshold";
 

--- a/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/MatchingTestCase.java
@@ -26,10 +26,10 @@ public class MatchingTestCase {
     @Test
     public void testQueryOverrides() {
         Query query = new Query("?query=test" +
-                "&ranking.matching.termwiselimit=0.7" +
-                "&ranking.matching.numthreadspersearch=17" +
-                "&ranking.matching.numsearchpartitions=13" +
-                "&ranking.matching.minhitsperthread=3" +
+                "&ranking.matching.termwiseLimit=0.7" +
+                "&ranking.matching.numThreadsPerSearch=17" +
+                "&ranking.matching.numSearchPartitions=13" +
+                "&ranking.matching.minHitsPerThread=3" +
                 "&ranking.matching.postFilterThreshold=0.8" +
                 "&ranking.matching.approximateThreshold=0.3");
         assertEquals(Double.valueOf(0.7), query.getRanking().getMatching().getTermwiseLimit());
@@ -46,6 +46,20 @@ public class MatchingTestCase {
         assertEquals("3", query.getRanking().getProperties().get("vespa.matching.minhitsperthread").get(0));
         assertEquals("0.8", query.getRanking().getProperties().get("vespa.matching.global_filter.upper_limit").get(0));
         assertEquals("0.3", query.getRanking().getProperties().get("vespa.matching.global_filter.lower_limit").get(0));
+    }
+
+    @Test
+    public void testBackwardsCompatibleQueryOverrides() {
+        // The lowercase aliases are supported to provide backwards compatibility of the properties that was wrongly named in the first place.
+        Query query = new Query("?query=test" +
+                "&ranking.matching.termwiselimit=0.7" +
+                "&ranking.matching.numthreadspersearch=17" +
+                "&ranking.matching.numsearchpartitions=13" +
+                "&ranking.matching.minhitsperthread=3");
+        assertEquals(Double.valueOf(0.7), query.getRanking().getMatching().getTermwiseLimit());
+        assertEquals(Integer.valueOf(17), query.getRanking().getMatching().getNumThreadsPerSearch());
+        assertEquals(Integer.valueOf(13), query.getRanking().getMatching().getNumSearchPartitions());
+        assertEquals(Integer.valueOf(3), query.getRanking().getMatching().getMinHitsPerThread());
     }
 
     private void verifyException(String key, String value) {


### PR DESCRIPTION
Also provide the lowercase version as alias for backwards compatibility.

@baldersheim please review
@jobergum FYI