### PR TITLE
Don't create ConstArrayRef of empty node vector

### DIFF
--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
@@ -79,7 +79,9 @@ struct BTreeBucketDatabase::ReplicaValueTraits {
         return Entry::createInvalid();
     }
     static uint64_t wrap_and_store_value(DataStoreType& store, const Entry& entry) noexcept {
-        auto replicas_ref = store.add(entry.getBucketInfo().getRawNodes());
+        const auto& raw_nodes = entry.getBucketInfo().getRawNodes();
+        auto replicas_ref = store.add(raw_nodes.empty() ? ConstArrayRef<BucketCopy>()
+                                                        : ConstArrayRef<BucketCopy>(raw_nodes));
         return value_from(entry.getBucketInfo().getLastGarbageCollectionTime(), replicas_ref);
     }
     static void remove_by_wrapped_value(DataStoreType& store, uint64_t value) noexcept {


### PR DESCRIPTION
@geirst please review

`ConstArrayRef` ctor takes ref of 0th vector element, which is undefined
if the vector is empty. As such, this is a general `ConstArrayRef` issue,
but I'm hesitant to add an extra branch to a very frequently called
function, so adding a workaround at this particular callsite instead.
