### PR TITLE
Move setting of node resources to node repo

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -51,7 +51,6 @@ import com.yahoo.vespa.model.content.storagecluster.StorageCluster;
 import com.yahoo.vespa.model.search.IndexedSearchCluster;
 import com.yahoo.vespa.model.search.Tuning;
 import org.w3c.dom.Element;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -62,8 +61,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 
-import static com.yahoo.config.provision.NodeResources.DiskSpeed;
-import static com.yahoo.config.provision.NodeResources.StorageType;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -328,17 +325,14 @@ public class ContentCluster extends AbstractConfigProducer<AbstractConfigProduce
             }
         }
 
-        public static final NodeResources clusterControllerResources = new NodeResources(0.25, 1.14, 10, 0.3, DiskSpeed.any, StorageType.any);
-
         private ClusterControllerContainerCluster getDedicatedSharedControllers(ModelElement contentElement,
                                                                                 Admin admin,
                                                                                 ConfigModelContext context,
                                                                                 DeployState deployState,
                                                                                 String clusterName) {
             if (admin.getClusterControllers() == null) {
-                NodeResources nodeResources = clusterControllerResources.with(deployState.featureFlags().adminClusterArchitecture());
                 NodesSpecification spec = NodesSpecification.requiredFromSharedParents(deployState.zone().environment().isProduction() ? 3 : 1,
-                                                                                       nodeResources,
+                                                                                       NodeResources.unspecified(),
                                                                                        contentElement,
                                                                                        context);
                 Collection<HostResource> hosts = spec.provision(admin.hostSystem(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
@@ -47,7 +47,7 @@ public class AllocationOptimizer {
             limits = Limits.of(new ClusterResources(minimumNodes,    1, NodeResources.unspecified()),
                                new ClusterResources(maximumNodes, maximumNodes, NodeResources.unspecified()));
         else
-            limits = atLeast(minimumNodes, limits).fullySpecified(current.clusterSpec().type(), nodeRepository, clusterModel.application().id());
+            limits = atLeast(minimumNodes, limits).fullySpecified(current.clusterSpec(), nodeRepository, clusterModel.application().id());
         Optional<AllocatableClusterResources> bestAllocation = Optional.empty();
         NodeList hosts = nodeRepository.nodes().list().hosts();
         for (int groups = limits.min().groups(); groups <= limits.max().groups(); groups++) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
@@ -60,10 +60,10 @@ public class Limits {
         return resources;
     }
 
-    public Limits fullySpecified(ClusterSpec.Type type, NodeRepository nodeRepository, ApplicationId applicationId) {
+    public Limits fullySpecified(ClusterSpec clusterSpec, NodeRepository nodeRepository, ApplicationId applicationId) {
         if (this.isEmpty()) throw new IllegalStateException("Unspecified limits can not be made fully specified");
 
-        var defaultResources = new CapacityPolicies(nodeRepository).defaultNodeResources(type, applicationId);
+        var defaultResources = new CapacityPolicies(nodeRepository).defaultNodeResources(clusterSpec, applicationId);
         var specifiedMin = min.nodeResources().isUnspecified() ? min.with(defaultResources) : min;
         var specifiedMax = max.nodeResources().isUnspecified() ? max.with(defaultResources) : max;
         return new Limits(specifiedMin, specifiedMax);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -76,14 +76,17 @@ public class CapacityPolicies {
         return target;
     }
 
-    public NodeResources defaultNodeResources(ClusterSpec.Type clusterType, ApplicationId applicationId) {
-        if (clusterType == ClusterSpec.Type.admin) {
+    public NodeResources defaultNodeResources(ClusterSpec clusterSpec, ApplicationId applicationId) {
+        if (clusterSpec.type() == ClusterSpec.Type.admin) {
             Architecture architecture = Architecture.valueOf(
                     ADMIN_CLUSTER_NODE_ARCHITECTURE.bindTo(flagSource)
                                                    .with(APPLICATION_ID, applicationId.serializedForm())
                                                    .value());
 
-            return zone.getCloud().dynamicProvisioning() && ! sharedHosts.apply(clusterType) ?
+            if (clusterSpec.id().value().equals("cluster-controllers"))
+                 return new NodeResources(0.25, 1.14, 10, 0.3).with(architecture);
+
+            return zone.getCloud().dynamicProvisioning() && ! sharedHosts.apply(clusterSpec.type()) ?
                     new NodeResources(0.5, 4, 50, 0.3).with(architecture) :
                     new NodeResources(0.5, 2, 50, 0.3).with(architecture);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -119,7 +119,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
 
     private NodeResources getNodeResources(ClusterSpec cluster, NodeResources nodeResources, ApplicationId applicationId) {
         return nodeResources.isUnspecified()
-                ? capacityPolicies.defaultNodeResources(cluster.type(), applicationId)
+                ? capacityPolicies.defaultNodeResources(cluster, applicationId)
                 : nodeResources;
     }
 
@@ -180,7 +180,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
     private ClusterResources initialResourcesFrom(Capacity requested, ClusterSpec clusterSpec, ApplicationId applicationId) {
         var initial = requested.minResources();
         if (initial.nodeResources().isUnspecified())
-            initial = initial.with(capacityPolicies.defaultNodeResources(clusterSpec.type(), applicationId));
+            initial = initial.with(capacityPolicies.defaultNodeResources(clusterSpec, applicationId));
         return initial;
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -239,7 +239,7 @@ public class AutoscalingTest {
         ClusterSpec cluster1 = tester.clusterSpec(ClusterSpec.Type.container, "cluster1");
 
         NodeResources defaultResources =
-                new CapacityPolicies(tester.nodeRepository()).defaultNodeResources(cluster1.type(), application1);
+                new CapacityPolicies(tester.nodeRepository()).defaultNodeResources(cluster1, application1);
 
         // deploy
         tester.deploy(application1, cluster1, Capacity.from(min, max));


### PR DESCRIPTION
* Will use the same node resources for all model versions, so no
  need to worry about changing the resources and getting issues
  when changing topology due to retiring of nodes
* Will do resource settings in the same place as for other admin
  clusters