### PR TITLE
Early return from asciistream file read if file is empty

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
@@ -628,6 +628,9 @@ asciistream::createFromFile(stringref fileName)
         if (sz < 0) {
             throw IoException("Failed getting size of  file " + fileName + " : Error=" + file.getLastErrorString(), IoException::UNSPECIFIED, VESPA_STRLOC);
         }
+        if (sz == 0) {
+            return is;
+        }
         alloc::Alloc buf = alloc::Alloc::alloc(sz);
         ssize_t actual = file.Read(buf.get(), sz);
         if (actual != sz) {


### PR DESCRIPTION
@baldersheim please review

Avoids a transitive `vespalib::string` append with `nullptr` buffer and
zero length, which in turn ends up passing `nullptr` to `memmove`, which
is undefined.
