### PR TITLE
Avoid ref of nullptr in nbostream::extend() when existing buffer is empty

### DIFF
--- a/vespalib/src/vespa/vespalib/objects/nbostream.cpp
+++ b/vespalib/src/vespa/vespalib/objects/nbostream.cpp
@@ -128,17 +128,17 @@ void nbostream::compact()
 
 void nbostream::extend(size_t extraSize)
 {
-    if (&_wbuf[0] != _rbuf.c_str()) {
+    if (_wbuf.data() != _rbuf.c_str()) {
         _wbuf.resize(roundUp2inN(_rbuf.size() + extraSize));
         compact();
-        _rbuf = ConstBufferRef(&_wbuf[0], _wbuf.capacity());
+        _rbuf = ConstBufferRef(_wbuf.data(), _wbuf.capacity());
     }
     if (_rp != 0) {
         compact();
     }
     if (space() < extraSize) {
         _wbuf.resize(roundUp2inN(_wbuf.size() + extraSize));
-        _rbuf = ConstBufferRef(&_wbuf[0], _wbuf.capacity());
+        _rbuf = ConstBufferRef(_wbuf.data(), _wbuf.capacity());
     }
 }
 

--- a/vespalib/src/vespa/vespalib/util/array.h
+++ b/vespalib/src/vespa/vespalib/util/array.h
@@ -137,6 +137,8 @@ public:
     }
     void reset();
     bool empty() const                      { return _sz == 0; }
+    T * data() noexcept                     { return static_cast<T *>(_array.get()); }
+    const T * data() const noexcept         { return static_cast<const T *>(_array.get()); }
     T & operator [] (size_t i)              { return *array(i); }
     const T & operator [] (size_t i) const  { return *array(i); }
     bool operator == (const Array & rhs) const;


### PR DESCRIPTION
@baldersheim please review

Add `Array::data()` utility function to get raw buffer pointer instead of
going via `operator[]` which always takes a ref; the latter is not well
defined if the underlying buffer is `nullptr`.
