### PR TITLE
Hosted: Stop using clusterName as part of log files for application containers

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -11,6 +11,8 @@ import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.AccessLogComponent.AccessLogType;
 import com.yahoo.vespa.model.container.component.AccessLogComponent.CompressionType;
 
+import java.util.Optional;
+
 /**
  * Container that should be running on same host as the logserver. Sets up a handler for getting logs from logserver.
  * Only in use in hosted Vespa.
@@ -21,7 +23,7 @@ public class LogserverContainer extends Container {
         super(parent, "" + 0, 0, deployState);
         LogserverContainerCluster cluster = (LogserverContainerCluster) parent;
         addComponent(new AccessLogComponent(
-                cluster, AccessLogType.jsonAccessLog, CompressionType.GZIP, cluster.getName(), true));
+                cluster, AccessLogType.jsonAccessLog, CompressionType.GZIP, Optional.of(cluster.getName()), true));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -25,6 +25,7 @@ import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.xml.ContainerModelBuilder;
 import com.yahoo.vespa.model.container.PlatformBundles;
 
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -66,7 +67,7 @@ public class ClusterControllerContainer extends Container implements
                    CLUSTERCONTROLLER_BUNDLE);
         addComponent(new AccessLogComponent(containerCluster().orElse(null), AccessLogComponent.AccessLogType.jsonAccessLog,
                                             AccessLogComponent.CompressionType.GZIP,
-                                            "controller",
+                                            Optional.of("controller"),
                                             deployState.isHosted()));
 
         // TODO: Why are bundles added here instead of in the cluster?

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -60,7 +60,7 @@ public class MetricsProxyContainer extends Container implements
         addNodeSpecificComponents();
         addComponent(new AccessLogComponent(containerCluster().orElse(null), AccessLogComponent.AccessLogType.jsonAccessLog,
                 AccessLogComponent.CompressionType.ZSTD,
-                "metrics-proxy",
+                Optional.of("metrics-proxy"),
                 deployState.isHosted()));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -550,7 +550,9 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public void addDefaultSearchAccessLog() {
         var compressionType = isHostedVespa ? AccessLogComponent.CompressionType.ZSTD : AccessLogComponent.CompressionType.GZIP;
-        addComponent(new AccessLogComponent(this, AccessLogComponent.AccessLogType.jsonAccessLog, compressionType, getName(), isHostedVespa));
+        // In hosted Vespa with one application container per node we do not use the container name to distinguish log files
+        Optional<String> clusterName = isHostedVespa ? Optional.empty() : Optional.of(getName());
+        addComponent(new AccessLogComponent(this, AccessLogComponent.AccessLogType.jsonAccessLog, compressionType, clusterName, isHostedVespa));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
@@ -6,6 +6,7 @@ import com.yahoo.container.core.AccessLogConfig.FileHandler.CompressionFormat;
 import com.yahoo.container.logging.JSONAccessLog;
 import com.yahoo.container.logging.VespaAccessLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.model.VespaVersion;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 
@@ -36,8 +37,10 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
         // In hosted Vespa we do not use the clusterName when setting up application ContainerCluster logging
         this(logType,
                 compressionType,
-                clusterName.isEmpty() ? String.format("logs/vespa/qrs/%s.%s", capitalize(logType.name()), "%Y%m%d%H%M%S") :
-                                        String.format("logs/vespa/qrs/%s.%s.%s", capitalize(logType.name()), clusterName.get(), "%Y%m%d%H%M%S"),
+                clusterName.isEmpty() ? String.format("logs/vespa/access/%s.%s", capitalize(logType.name()), "%Y%m%d%H%M%S") :
+                                        // TODO: Clean up after Vespa 8
+                                        VespaVersion.major == 7 ? String.format("logs/vespa/qrs/%s.%s.%s", capitalize(logType.name()), clusterName.get(), "%Y%m%d%H%M%S") :
+                                                                  String.format("logs/vespa/access/%s.%s.%s", capitalize(logType.name()), clusterName.get(), "%Y%m%d%H%M%S"),
                 null,
                 null,
                 isHostedVespa,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/AccessLogComponent.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * @author Tony Vaagenes
@@ -30,12 +31,19 @@ public final class AccessLogComponent extends SimpleComponent implements AccessL
     private final int queueSize;
     private final Integer bufferSize;
 
-    public AccessLogComponent(ContainerCluster<?> cluster, AccessLogType logType, CompressionType compressionType, String clusterName, boolean isHostedVespa)
+    public AccessLogComponent(ContainerCluster<?> cluster, AccessLogType logType, CompressionType compressionType, Optional<String> clusterName, boolean isHostedVespa)
     {
-        this(logType, compressionType,
-                String.format("logs/vespa/qrs/%s.%s.%s", capitalize(logType.name()), clusterName, "%Y%m%d%H%M%S"),
-                null, null, isHostedVespa,
-                capitalize(logType.name()) + "." + clusterName, -1,
+        // In hosted Vespa we do not use the clusterName when setting up application ContainerCluster logging
+        this(logType,
+                compressionType,
+                clusterName.isEmpty() ? String.format("logs/vespa/qrs/%s.%s", capitalize(logType.name()), "%Y%m%d%H%M%S") :
+                                        String.format("logs/vespa/qrs/%s.%s.%s", capitalize(logType.name()), clusterName.get(), "%Y%m%d%H%M%S"),
+                null,
+                null,
+                isHostedVespa,
+                clusterName.isEmpty() ? capitalize(logType.name()) :
+                                        capitalize(logType.name()) + "." + clusterName.get(),
+                -1,
                 ((cluster instanceof ApplicationContainerCluster) ? 4*1024*1024 : null));
     }
 


### PR DESCRIPTION
…ontainers

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
