### PR TITLE
Revert "Set correct user on container crash path"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
@@ -9,7 +9,6 @@ import com.yahoo.vespa.hosted.node.admin.nodeadmin.ConvergenceException;
 import com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentContext;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
-import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixUser;
 import com.yahoo.vespa.hosted.node.admin.task.util.fs.ContainerPath;
 import com.yahoo.vespa.hosted.node.admin.task.util.process.Terminal;
 
@@ -85,14 +84,8 @@ public class CoredumpHandler {
 
 
     public void converge(NodeAgentContext context, Supplier<Map<String, Object>> nodeAttributesSupplier, boolean throwIfCoreBeingWritten) {
-        ContainerPath containerCrashPath = context.paths().of(crashPatchInContainer, context.users().vespa());
+        ContainerPath containerCrashPath = context.paths().of(crashPatchInContainer);
         ContainerPath containerProcessingPath = containerCrashPath.resolve(PROCESSING_DIRECTORY_NAME);
-
-        // TODO (freva): Remove after 7.584
-        UnixUser vespaUser = context.users().vespa();
-        UnixPath processingPath = new UnixPath(containerProcessingPath);
-        if (processingPath.getOwnerId() != vespaUser.uid()) processingPath.setOwnerId(vespaUser.uid());
-        if (processingPath.getGroupId() != vespaUser.gid()) processingPath.setGroupId(vespaUser.gid());
 
         updateMetrics(context, containerCrashPath);
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#22490
Broke publiccd
```
[2022-05-06 10:41:40.048] ERROR   : node-admin       Container.com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl
	ctl1: Unhandled exception, ignoring
	exception=
	java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /data/vespa/storage/ctl1/opt/vespa/var/crash/processing
```