### PR TITLE
Prepare for logging in jdisc core [run-systemtest]

### DIFF
--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -128,22 +128,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespajlib</artifactId>
-      <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>vespalog</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.hdrhistogram</groupId>
       <artifactId>HdrHistogram</artifactId>
     </dependency>
@@ -223,6 +207,12 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>hosted-zone-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>jdisc_core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
@@ -235,13 +225,25 @@
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>yolean</artifactId>
+      <artifactId>vespajlib</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>vespalog</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>hosted-zone-api</artifactId>
+      <artifactId>yolean</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -19,11 +19,6 @@
     <!-- COMPILE scope -->
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
-      <artifactId>annotations</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-documentapi</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -167,6 +162,12 @@
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <classifier>no_aop</classifier>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
+++ b/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
@@ -27,6 +27,8 @@ public class OsgiImpl implements Osgi {
     // The initial bundles are never scheduled for uninstall
     private final List<Bundle> initialBundles;
 
+    private final Bundle systemBundle;
+
     // An initial bundle that is not the framework, and can hence be used to look up current bundles
     private final Bundle alwaysCurrentBundle;
 
@@ -37,6 +39,7 @@ public class OsgiImpl implements Osgi {
         if (initialBundles.isEmpty())
             throw new IllegalStateException("No initial bundles!");
 
+        systemBundle = getSystemBundle(initialBundles);
         alwaysCurrentBundle = firstNonFrameworkBundle(initialBundles);
         if (alwaysCurrentBundle == null)
             throw new IllegalStateException("The initial bundles only contained the framework bundle!");
@@ -59,19 +62,30 @@ public class OsgiImpl implements Osgi {
         if (bundle != null) {
             return resolveFromBundle(spec, bundle);
         } else {
-            return resolveFromClassPath(spec);
+            return resolveFromThisBundleOrSystemBundle(spec);
         }
     }
 
+    /**
+     * Tries to resolve the given class from this class' bundle classloader.
+     * If unsuccessful, resolves the class from .
+     */
     @SuppressWarnings("unchecked")
-    private static Class<Object> resolveFromClassPath(BundleInstantiationSpecification spec) {
+    private Class<Object> resolveFromThisBundleOrSystemBundle(BundleInstantiationSpecification spec) {
+        log.fine(() -> "Resolving class from container-disc: " + spec.classId.getName());
         try {
             return (Class<Object>) Class.forName(spec.classId.getName());
         } catch (ClassNotFoundException e) {
-            throw new IllegalArgumentException("Could not create a component with id '" + spec.classId.getName() +
-                    "'. Tried to load class directly, since no bundle was found for spec: " + spec.bundle +
-                    ". If a bundle with the same name is installed, there is a either a version mismatch" +
-                    " or the installed bundle's version contains a qualifier string.");
+            log.fine(() -> "Resolving class from the system bundle (jdisc core): " + spec.classId.getName());
+            try {
+                return (Class<Object>) systemBundle.loadClass(spec.classId.getName());
+            } catch (ClassNotFoundException e2) {
+                throw new IllegalArgumentException(
+                        "Could not create a component with id '" + spec.classId.getName() +
+                                "'. Tried to load class directly, since no bundle was found for spec: " + spec.bundle +
+                                ". If a bundle with the same name is installed, there is a either a version mismatch" +
+                                " or the installed bundle's version contains a qualifier string.");
+            }
         }
     }
 
@@ -155,6 +169,14 @@ public class OsgiImpl implements Osgi {
     @Override
     public boolean hasFelixFramework() {
         return jdiscOsgi.isFelixFramework();
+    }
+
+    private static Bundle getSystemBundle(List<Bundle> bundles ) {
+        for (Bundle b : bundles) {
+            if (b instanceof Framework)
+                return b;
+        }
+        throw new IllegalStateException("No system bundle in " + bundles);
     }
 
     private static Bundle firstNonFrameworkBundle(List<Bundle> bundles) {

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -105,15 +105,23 @@
         </exclusion>
       </exclusions>
     </dependency>
+      <dependency>
+          <groupId>com.yahoo.vespa</groupId>
+          <artifactId>defaults</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+      </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespalog</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -46,7 +46,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+      <dependency>
+          <groupId>com.yahoo.vespa</groupId>
+          <artifactId>annotations</artifactId>
+          <version>${project.version}</version>
+          <scope>provided</scope>
+      </dependency>
+      <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-lib</artifactId>
       <version>${project.version}</version>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -255,6 +255,7 @@
                                 <argument>${project.build.directory}/dependency/annotations.jar</argument>
                                 <argument>${project.build.directory}/dependency/config-lib.jar</argument>
                                 <argument>${project.build.directory}/dependency/defaults.jar</argument>
+                                <argument>${project.build.directory}/dependency/vespajlib.jar</argument>
                                 <argument>${project.build.directory}/dependency/vespalog.jar</argument>
                                 <argument>${project.build.directory}/dependency/yolean.jar</argument>
                                 <argument>${project.build.directory}/dependency/jaxb-api.jar</argument>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -66,7 +66,6 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>defaults</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -171,7 +170,11 @@
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>annotations</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>vespalog</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
     <build>
@@ -249,7 +252,10 @@
                                 <argument>${project.build.directory}/dependency/slf4j-jdk14.jar</argument>
                                 <argument>${project.build.directory}/dependency/jcl-over-slf4j.jar</argument>
                                 <argument>${project.build.directory}/dependency/log4j-over-slf4j.jar</argument>
+                                <argument>${project.build.directory}/dependency/annotations.jar</argument>
                                 <argument>${project.build.directory}/dependency/config-lib.jar</argument>
+                                <argument>${project.build.directory}/dependency/defaults.jar</argument>
+                                <argument>${project.build.directory}/dependency/vespalog.jar</argument>
                                 <argument>${project.build.directory}/dependency/yolean.jar</argument>
                                 <argument>${project.build.directory}/dependency/jaxb-api.jar</argument>
                                 <argument>${project.build.directory}/dependency/jaxb-core.jar</argument>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -285,6 +285,19 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>

--- a/jdisc_core/src/test/java/com/yahoo/jdisc/core/ExportPackagesIT.java
+++ b/jdisc_core/src/test/java/com/yahoo/jdisc/core/ExportPackagesIT.java
@@ -1,0 +1,42 @@
+package com.yahoo.jdisc.core;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.Properties;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for {@link ExportPackages}.
+ *
+ * @author gjoranv
+ */
+public class ExportPackagesIT {
+
+    @Rule
+    public TemporaryFolder tempFolder= new TemporaryFolder();
+
+    @Test
+    public void export_packages_are_added_from_dependency_jars() throws Exception {
+        File file = tempFolder.newFile(ExportPackages.PROPERTIES_FILE);
+
+        ExportPackages.main(new String[] { file.getAbsolutePath(), "target/dependency/guice-no_aop.jar" });
+        assertTrue(file.exists());
+        Properties props = new Properties();
+        String exportPackages;
+        try (FileReader reader = new FileReader(file)) {
+            props.load(reader);
+            exportPackages = props.getProperty(ExportPackages.EXPORT_PACKAGES);
+        }
+        assertNotNull(exportPackages);
+
+        assertTrue(exportPackages.contains("com.google.inject"));
+
+    }
+
+}

--- a/logserver/pom.xml
+++ b/logserver/pom.xml
@@ -17,6 +17,11 @@
     <!-- compile scope -->
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
+      <artifactId>defaults</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -108,6 +108,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>
                     <version>${maven-install-plugin.version}</version>
                     <configuration>
@@ -953,6 +958,7 @@
         <maven-dependency-plugin.version>3.3.0</maven-dependency-plugin.version> <!-- NOTE: When upgrading, also update explicit versions in tenant base poms! -->
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M6</maven-failsafe-plugin.version>
         <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>

--- a/standalone-container/pom.xml
+++ b/standalone-container/pom.xml
@@ -92,7 +92,6 @@
             container-disc-jar-with-dependencies.jar,
             model-evaluation-jar-with-dependencies.jar,
             model-integration-jar-with-dependencies.jar,
-            vespajlib.jar
           </discPreInstallBundle>
         </configuration>
       </plugin>

--- a/vespalog/pom.xml
+++ b/vespalog/pom.xml
@@ -22,16 +22,19 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>vespajlib</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>defaults</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.yahoo.vespa</groupId>


### PR DESCRIPTION
Export vespajlib and vespalog packages from jdisc_core instead of container-disc.

Clean up vespajlib instances (was embedded in both jdisc_core, container-disc, and deployed separately to standalone containers)

Allow the DI framework to resolve component classes from the system bundle (jdisc_core).

The actual log setup will be done in a separate PR.