### PR TITLE
move functions to more appropriate classes

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/feedoperation/lidvectorcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/feedoperation/lidvectorcontext.cpp
@@ -2,6 +2,7 @@
 
 #include "lidvectorcontext.h"
 #include <vespa/searchlib/common/bitvector.h>
+#include <vespa/searchlib/common/allocatedbitvector.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <cassert>
 
@@ -9,6 +10,7 @@
 LOG_SETUP(".proton.feedoperation.lidvectorcontext");
 
 using search::BitVector;
+using search::AllocatedBitVector;
 
 namespace proton {
 
@@ -73,7 +75,7 @@ LidVectorContext::deserialize(vespalib::nbostream &is)
     LOG(debug, "deserialize: format = %d", format);
     // Use of bitvector when > 1/32 of docs
     if (format == BITVECTOR) {
-        BitVector::UP bitVector = BitVector::create(_docIdLimit);
+        auto bitVector = std::make_unique<AllocatedBitVector>(_docIdLimit);
         is >> *bitVector;
         uint32_t sz(bitVector->size());
         assert(sz == _docIdLimit);

--- a/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
+++ b/searchlib/src/tests/docstore/document_store_visitor/document_store_visitor_test.cpp
@@ -5,7 +5,7 @@
 #include <vespa/searchlib/docstore/logdocumentstore.h>
 #include <vespa/vespalib/stllike/cache_stats.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/common/bitvector.h>
+#include <vespa/searchlib/common/allocatedbitvector.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
@@ -95,7 +95,7 @@ public:
     uint32_t _visitCount;
     uint32_t _visitRmCount;
     uint32_t _docIdLimit;
-    BitVector::UP _valid;
+    std::unique_ptr<AllocatedBitVector> _valid;
     bool _before;
 
     MyVisitorBase(DocumentTypeRepo &repo, uint32_t docIdLimit, bool before);
@@ -106,7 +106,7 @@ MyVisitorBase::MyVisitorBase(DocumentTypeRepo &repo, uint32_t docIdLimit, bool b
       _visitCount(0u),
       _visitRmCount(0u),
       _docIdLimit(docIdLimit),
-      _valid(BitVector::create(docIdLimit)),
+      _valid(std::make_unique<AllocatedBitVector>(docIdLimit)),
       _before(before)
 {
 }
@@ -216,7 +216,7 @@ struct Fixture
     std::unique_ptr<LogDocumentStore> _store;
     uint64_t _syncToken;
     uint32_t _docIdLimit;
-    BitVector::UP _valid;
+    std::unique_ptr<AllocatedBitVector> _valid;
 
     Fixture();
     ~Fixture();
@@ -246,7 +246,7 @@ Fixture::Fixture()
       _store(),
       _syncToken(0u),
       _docIdLimit(0u),
-      _valid(BitVector::create(0u))
+      _valid(std::make_unique<AllocatedBitVector>(0u))
 {
     rmdir();
     mkdir();

--- a/searchlib/src/vespa/searchlib/attribute/flagattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/flagattribute.h
@@ -3,6 +3,7 @@
 
 #include "multinumericattribute.h"
 #include "multi_numeric_search_context.h"
+#include <vespa/searchlib/common/growablebitvector.h>
 
 namespace search {
 
@@ -34,10 +35,10 @@ private:
     void removeOldGenerations(vespalib::GenerationHandler::generation_t firstUsed) override;
     uint32_t getOffset(int8_t value) const { return value + 128; }
 
-    vespalib::GenerationHolder               _bitVectorHolder;
-    std::vector<std::shared_ptr<BitVector> > _bitVectorStore;
-    std::vector<BitVector *>                 _bitVectors;
-    uint32_t                                 _bitVectorSize;
+    vespalib::GenerationHolder                       _bitVectorHolder;
+    std::vector<std::shared_ptr<GrowableBitVector> > _bitVectorStore;
+    std::vector<BitVector *>                         _bitVectors;
+    uint32_t                                         _bitVectorSize;
 };
 
 typedef FlagAttributeT<FlagBaseImpl> FlagAttribute;

--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
@@ -6,10 +6,6 @@
 
 namespace search {
 
-using vespalib::GenerationHeldBase;
-using vespalib::GenerationHeldAlloc;
-using vespalib::GenerationHolder;
-
 namespace {
 
 size_t computeCapacity(size_t capacity, size_t allocatedBytes) {
@@ -129,32 +125,6 @@ AllocatedBitVector::operator=(const BitVector & rhs)
     assert(testBit(size()));
 
     return *this;
-}
-
-GenerationHeldBase::UP
-AllocatedBitVector::grow(Index newSize, Index newCapacity)
-{
-    assert(newCapacity >= newSize);
-    GenerationHeldBase::UP ret;
-    if (newCapacity != capacity()) {
-        AllocatedBitVector tbv(newSize, newCapacity, _alloc.get(), size(), &_alloc);
-        if (newSize > size()) {
-            tbv.clearBitAndMaintainCount(size());  // Clear old guard bit.
-        }
-        ret = std::make_unique<GenerationHeldAlloc<Alloc>>(_alloc);
-        swap(tbv);
-    } else {
-        if (newSize > size()) {
-            Range clearRange(size(), newSize);
-            setSize(newSize);
-            clearIntervalNoInvalidation(clearRange);
-        } else {
-            clearIntervalNoInvalidation(Range(newSize, size()));
-            setSize(newSize);
-            updateCount();
-        }
-    }
-    return ret;
 }
 
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
@@ -6,6 +6,7 @@
 
 namespace search {
 
+class GrowableBitVector;
 class BitVectorTest;
 
 /**
@@ -39,7 +40,7 @@ public:
 
     AllocatedBitVector(const BitVector &other);
     AllocatedBitVector(const AllocatedBitVector &other);
-    virtual ~AllocatedBitVector();
+    ~AllocatedBitVector() override;
     AllocatedBitVector &operator=(const AllocatedBitVector &other);
     AllocatedBitVector &operator=(const BitVector &other);
 
@@ -57,9 +58,7 @@ public:
      *
      * @param newLength the new length of the bit vector (in bits)
      */
-    void resize(Index newLength) override;
-
-    GenerationHeldBase::UP grow(Index newLength, Index newCapacity) override;
+    void resize(Index newLength);
 
 protected:
     Index          _capacityBits;
@@ -67,6 +66,7 @@ protected:
 
 private:
     friend class BitVectorTest;
+    friend class GrowableBitVector;
     void swap(AllocatedBitVector & rhs) {
         std::swap(_capacityBits, rhs._capacityBits);
         _alloc.swap(rhs._alloc);

--- a/searchlib/src/vespa/searchlib/common/bitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/bitvector.cpp
@@ -2,7 +2,6 @@
 
 #include "bitvector.h"
 #include "allocatedbitvector.h"
-#include "growablebitvector.h"
 #include "partialbitvector.h"
 #include <vespa/searchlib/util/file_settings.h>
 #include <vespa/vespalib/hwaccelrated/iaccelrated.h>
@@ -299,18 +298,6 @@ BitVector::hasTrueBitsInternal() const
 }
 
 //////////////////////////////////////////////////////////////////////
-// Set new length. Destruction of content
-//////////////////////////////////////////////////////////////////////
-void
-BitVector::resize(Index)
-{
-    LOG_ABORT("should not be reached");
-}
-GenerationHeldBase::UP
-BitVector::grow(Index, Index )
-{
-    LOG_ABORT("should not be reached");
-}
 
 size_t
 BitVector::getFileBytes(Index bits)
@@ -383,12 +370,6 @@ BitVector::create(const BitVector & rhs)
     return std::make_unique<AllocatedBitVector>(rhs);
 }
 
-BitVector::UP
-BitVector::create(Index numberOfElements, Index newCapacity, GenerationHolder &generationHolder)
-{
-    return std::make_unique<GrowableBitVector>(numberOfElements, newCapacity, generationHolder);
-}
-
 MMappedBitVector::MMappedBitVector(Index numberOfElements, FastOS_FileInterface &file,
                                    int64_t offset, Index doccount) :
     BitVector()
@@ -425,7 +406,7 @@ operator<<(nbostream &out, const BitVector &bv)
 
 
 nbostream &
-operator>>(nbostream &in, BitVector &bv)
+operator>>(nbostream &in, AllocatedBitVector &bv)
 {
     uint64_t size;
     uint64_t cachedHits;

--- a/searchlib/src/vespa/searchlib/common/bitvector.h
+++ b/searchlib/src/vespa/searchlib/common/bitvector.h
@@ -18,6 +18,7 @@ class FastOS_FileInterface;
 namespace search {
 
 class PartialBitVector;
+class AllocatedBitVector;
 
 class BitVector : protected BitWord
 {
@@ -253,11 +254,6 @@ public:
         return getFileBytes(size());
     }
 
-    virtual void resize(Index newLength);
-
-    virtual GenerationHeldBase::UP grow(Index newLength, Index newCapacity);
-    GenerationHeldBase::UP grow(Index newLength) { return grow(newLength, newLength); }
-
     /**
      * This will create the appropriate vector.
      *
@@ -271,7 +267,6 @@ public:
     static UP create(const BitVector & org, Index start, Index end);
     static UP create(Index numberOfElements);
     static UP create(const BitVector & rhs);
-    static UP create(Index newSize, Index newCapacity, GenerationHolder &generationHolder);
 protected:
     using Alloc = vespalib::alloc::Alloc;
     VESPA_DLL_LOCAL BitVector(void * buf, Index start, Index end);
@@ -384,14 +379,14 @@ protected:
     friend vespalib::nbostream &
     operator<<(vespalib::nbostream &out, const BitVector &bv);
     friend vespalib::nbostream &
-    operator>>(vespalib::nbostream &in, BitVector &bv);
+    operator>>(vespalib::nbostream &in, AllocatedBitVector &bv);
 };
 
 vespalib::nbostream &
 operator<<(vespalib::nbostream &out, const BitVector &bv);
 
 vespalib::nbostream &
-operator>>(vespalib::nbostream &in, BitVector &bv);
+operator>>(vespalib::nbostream &in, AllocatedBitVector &bv);
 
 template <typename T>
 void BitVector::andNotWithT(T it) {

--- a/searchlib/src/vespa/searchlib/common/growablebitvector.h
+++ b/searchlib/src/vespa/searchlib/common/growablebitvector.h
@@ -16,6 +16,8 @@ public:
     bool shrink(Index newCapacity);
     bool extend(Index newCapacity);
 private:
+    GenerationHeldBase::UP grow(Index newLength, Index newCapacity);
+
     VESPA_DLL_LOCAL bool hold(GenerationHeldBase::UP v);
     GenerationHolder &_generationHolder;
 };


### PR DESCRIPTION
preparing to make GrowableBitVector an atomic switch between
bitvectors rather than a bitvector itself (to avoid overwriting its
own state while being visible to other threads).

only allocated bitvectors can be resized (non-shared), only growable bitvectors can be grown (shared)
@toregge @baldersheim please review