### PR TITLE
Copr git >= 2.35.3 requires workaround for source code ownership safe…

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -8,6 +8,7 @@ SPECFILE := $(SPECDIR)/vespa-$(VESPA_VERSION).spec
 
 deps:
 	dnf install -y git rpmdevtools
+	git config --global --add safe.directory $$(realpath $(TOP)/..)
 
 srpm: VESPA_VERSION = $$(git tag --points-at HEAD | grep -oP "\d+\.\d+\.\d+" | sort -V | tail -1)
 srpm: deps


### PR DESCRIPTION
…ty mechanism that we can't control.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
