### PR TITLE
Auto-adjust targetHits for approximate nearest neighbor search when u…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -300,7 +300,7 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
     if (trace) {
         trace->addEvent(5, "Handle global filter in query execution plan");
     }
-    blueprint.set_global_filter(*global_filter);
+    blueprint.set_global_filter(*global_filter, estimated_hit_ratio);
     return true;
 }
 

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -374,7 +374,7 @@ expect_nearest_neighbor_blueprint(const vespalib::string& attribute_tensor_type_
     const auto& nearest = downcast<const NearestNeighborBlueprint>(*result);
     EXPECT_EQ(attribute_tensor_type_spec, nearest.get_attribute_tensor().getTensorType().to_spec());
     EXPECT_EQ(converted_query_tensor, spec_from_value(nearest.get_query_tensor()));
-    EXPECT_EQ(7u, nearest.get_target_num_hits());
+    EXPECT_EQ(7u, nearest.get_target_hits());
 }
 
 TEST(AttributeBlueprintTest, nearest_neighbor_blueprint_is_created_by_attribute_blueprint_factory)

--- a/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/intermediate_blueprints_test.cpp
@@ -72,7 +72,7 @@ TEST("test AndNot Blueprint") {
         EXPECT_EQUAL(true, a.getState().want_global_filter());
         auto empty_global_filter = GlobalFilter::create();
         EXPECT_FALSE(empty_global_filter->has_filter());
-        a.set_global_filter(*empty_global_filter);
+        a.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQUAL(false, got_global_filter(a.getChild(0)));
         EXPECT_EQUAL(true,  got_global_filter(a.getChild(1)));
     }
@@ -147,7 +147,7 @@ TEST("test And Blueprint") {
         a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
         EXPECT_EQUAL(true, a.getState().want_global_filter());
         auto empty_global_filter = GlobalFilter::create();
-        a.set_global_filter(*empty_global_filter);
+        a.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQUAL(false, got_global_filter(a.getChild(0)));
         EXPECT_EQUAL(true,  got_global_filter(a.getChild(1)));
     }
@@ -227,7 +227,7 @@ TEST("test Or Blueprint") {
         o.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
         EXPECT_EQUAL(true, o.getState().want_global_filter());
         auto empty_global_filter = GlobalFilter::create();
-        o.set_global_filter(*empty_global_filter);
+        o.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQUAL(false, got_global_filter(o.getChild(0)));
         EXPECT_EQUAL(true,  got_global_filter(o.getChild(o.childCnt() - 1)));
     }
@@ -382,7 +382,7 @@ TEST("test Rank Blueprint") {
         a.addChild(ap(MyLeafSpec(20).addField(1, 1).want_global_filter().create()));
         EXPECT_EQUAL(true, a.getState().want_global_filter());
         auto empty_global_filter = GlobalFilter::create();
-        a.set_global_filter(*empty_global_filter);
+        a.set_global_filter(*empty_global_filter, 1.0);
         EXPECT_EQUAL(false, got_global_filter(a.getChild(0)));
         EXPECT_EQUAL(true,  got_global_filter(a.getChild(1)));
     }

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -126,7 +126,7 @@ public:
         set_cost_tier(value);
         return *this;
     }
-    void set_global_filter(const GlobalFilter &) override {
+    void set_global_filter(const GlobalFilter &, double) override {
         _got_global_filter = true;
     }
     bool got_global_filter() const { return _got_global_filter; }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -125,7 +125,7 @@ Blueprint::get_replacement()
 }
 
 void
-Blueprint::set_global_filter(const GlobalFilter &)
+Blueprint::set_global_filter(const GlobalFilter &, double)
 {
 }
 
@@ -441,11 +441,11 @@ IntermediateBlueprint::optimize(Blueprint* &self)
 }
 
 void
-IntermediateBlueprint::set_global_filter(const GlobalFilter &global_filter)
+IntermediateBlueprint::set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio)
 {
     for (auto & child : _children) {
         if (child->getState().want_global_filter()) {
-            child->set_global_filter(global_filter);
+            child->set_global_filter(global_filter, estimated_hit_ratio);
         }
     }
 }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -202,7 +202,17 @@ public:
 
     virtual bool supports_termwise_children() const { return false; }
     virtual bool always_needs_unpack() const { return false; }
-    virtual void set_global_filter(const GlobalFilter &global_filter);
+
+    /**
+     * Sets the global filter on the query blueprint tree.
+     *
+     * This function is implemented by leaf blueprints that want the global filter,
+     * signaled by LeafBlueprint::set_want_global_filter().
+     *
+     * @param global_filter The global filter that is calculated once per query if wanted.
+     * @param estimated_hit_ratio The estimated hit ratio of the query (in the range [0.0, 1.0]).
+     */
+    virtual void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio);
 
     virtual const State &getState() const = 0;
     const Blueprint &root() const;
@@ -302,7 +312,7 @@ public:
     void setDocIdLimit(uint32_t limit) override final;
 
     void optimize(Blueprint* &self) override final;
-    void set_global_filter(const GlobalFilter &global_filter) override;
+    void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
 
     IndexList find(const IPredicate & check) const;
     size_t childCnt() const { return _children.size(); }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -21,15 +21,16 @@ namespace search::queryeval {
 class NearestNeighborBlueprint : public ComplexLeafBlueprint {
 public:
     enum class Algorithm {
-        BRUTE_FORCE,
-        BRUTE_FORCE_FALLBACK,
+        EXACT,
+        EXACT_FALLBACK,
         INDEX_TOP_K,
         INDEX_TOP_K_WITH_FILTER
     };
 private:
     const tensor::ITensorAttribute& _attr_tensor;
     std::unique_ptr<vespalib::eval::Value> _query_tensor;
-    uint32_t _target_num_hits;
+    uint32_t _target_hits;
+    uint32_t _adjusted_target_hits;
     bool _approximate;
     uint32_t _explore_additional_hits;
     double _distance_threshold;
@@ -50,7 +51,7 @@ public:
     NearestNeighborBlueprint(const queryeval::FieldSpec& field,
                              const tensor::ITensorAttribute& attr_tensor,
                              std::unique_ptr<vespalib::eval::Value> query_tensor,
-                             uint32_t target_num_hits, bool approximate, uint32_t explore_additional_hits,
+                             uint32_t target_hits, bool approximate, uint32_t explore_additional_hits,
                              double distance_threshold,
                              double global_filter_lower_limit,
                              double global_filter_upper_limit);
@@ -59,8 +60,9 @@ public:
     ~NearestNeighborBlueprint();
     const tensor::ITensorAttribute& get_attribute_tensor() const { return _attr_tensor; }
     const vespalib::eval::Value& get_query_tensor() const { return *_query_tensor; }
-    uint32_t get_target_num_hits() const { return _target_num_hits; }
-    void set_global_filter(const GlobalFilter &global_filter) override;
+    uint32_t get_target_hits() const { return _target_hits; }
+    uint32_t get_adjusted_target_hits() const { return _adjusted_target_hits; }
+    void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _distance_threshold; }
 


### PR DESCRIPTION
…sing post-filtering.

The goal is to expose 'targetHits' hits to first-phase ranking.
Before searching the HNSW index, targetHits is adjusted based on the estimated hit ratio of the query
to compensate for the hits that will be removed in post-filtering.

@baldersheim please review
@jobergum 
