### PR TITLE
Support proxying of health checks to connector requiring proxy-protocol [run-systemtest]

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -252,6 +252,7 @@
                                         <include>org.eclipse.jetty.http2:http2-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-java-server:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-client:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-continuation:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-jmx:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-security:[${jetty.version}]:jar:test</include>

--- a/container-core/pom.xml
+++ b/container-core/pom.xml
@@ -287,12 +287,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-      <version>${jetty.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -227,6 +227,7 @@
                 http2-hpack-${jetty.version}.jar,
                 jetty-alpn-java-server-${jetty.version}.jar,
                 jetty-alpn-server-${jetty.version}.jar,
+                jetty-client-${jetty.version}.jar,
                 jetty-continuation-${jetty.version}.jar,
                 jetty-http-${jetty.version}.jar,
                 jetty-io-${jetty.version}.jar,

--- a/jdisc_jetty/pom.xml
+++ b/jdisc_jetty/pom.xml
@@ -29,6 +29,10 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-continuation</artifactId>
     </dependency>
     <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -763,6 +763,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-continuation</artifactId>
                 <version>${jetty.version}</version>
             </dependency>


### PR DESCRIPTION
Use Jetty instead of Apache http client.
Install jetty-client bundle.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
