### PR TITLE
Hosted: Do not use clusterId as part of filename for ConnectionLog

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConnectionLogComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConnectionLogComponent.java
@@ -10,21 +10,26 @@ public class ConnectionLogComponent extends SimpleComponent implements Connectio
 
     private final String logDirectoryName;
     private final String clusterName;
+    private final boolean isHostedVespa;
 
     public ConnectionLogComponent(ContainerCluster<?> cluster, Class<? extends ConnectionLog> cls, String logDirectoryName) {
-        this(cls, logDirectoryName, cluster.getName());
+        this(cls, logDirectoryName, cluster.getName(), cluster.isHostedVespa());
     }
 
-    public ConnectionLogComponent(Class<? extends ConnectionLog> cls, String logDirectoryName, String clusterName) {
+    public ConnectionLogComponent(Class<? extends ConnectionLog> cls, String logDirectoryName, String clusterName, boolean isHostedVespa) {
         super(cls.getName());
         this.logDirectoryName = logDirectoryName;
         this.clusterName = clusterName;
+        this.isHostedVespa = isHostedVespa;
     }
 
     @Override
     public void getConfig(ConnectionLogConfig.Builder builder) {
         builder.cluster(clusterName);
         builder.logDirectoryName(logDirectoryName);
+        if (isHostedVespa) {
+            builder.useClusterIdInFileName(false);
+        }
         builder.queueSize(-1);
     }
 }

--- a/container-core/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/logging/ConnectionLogHandler.java
@@ -9,13 +9,15 @@ class ConnectionLogHandler {
     private final LogFileHandler<ConnectionLogEntry> logFileHandler;
 
     public ConnectionLogHandler(String logDirectoryName, int bufferSize, String clusterName,
-                                int queueSize, LogWriter<ConnectionLogEntry> logWriter) {
+                                int queueSize, LogWriter<ConnectionLogEntry> logWriter, boolean useClusterIdInFileName) {
         logFileHandler = new LogFileHandler<>(
                 LogFileHandler.Compression.ZSTD,
                 bufferSize,
-                String.format("logs/vespa/%s/ConnectionLog.%s.%s", logDirectoryName, clusterName, "%Y%m%d%H%M%S"),
+                useClusterIdInFileName ? String.format("logs/vespa/%s/ConnectionLog.%s.%s", logDirectoryName, clusterName, "%Y%m%d%H%M%S") :
+                                          String.format("logs/vespa/%s/ConnectionLog.%s", logDirectoryName, "%Y%m%d%H%M%S"),
                 "0 60 ...",
-                String.format("ConnectionLog.%s", clusterName),
+                useClusterIdInFileName ? String.format("ConnectionLog.%s", clusterName) :
+                                          "ConnectionLog.",
                 queueSize,
                 "connection-logger",
                 logWriter);

--- a/container-core/src/main/java/com/yahoo/container/logging/FileConnectionLog.java
+++ b/container-core/src/main/java/com/yahoo/container/logging/FileConnectionLog.java
@@ -15,7 +15,7 @@ public class FileConnectionLog extends AbstractComponent implements ConnectionLo
     @Inject
     public FileConnectionLog(ConnectionLogConfig config) {
         logHandler = new ConnectionLogHandler(config.logDirectoryName(), config.bufferSize(), config.cluster(),
-                queueSize(config), new JsonConnectionLogWriter());
+                queueSize(config), new JsonConnectionLogWriter(), config.useClusterIdInFileName());
     }
 
     private static int queueSize(ConnectionLogConfig config) {

--- a/container-core/src/main/resources/configdefinitions/container.logging.connection-log.def
+++ b/container-core/src/main/resources/configdefinitions/container.logging.connection-log.def
@@ -12,3 +12,6 @@ queueSize int default=10000
 
 # Buffer size for the output stream has a default of 256k
 bufferSize int default=262144
+
+# In hosted Vespa we do not use the clusterId in file names for application containers
+useClusterIdInFileName bool default=true


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
