### PR TITLE
Applications are not allowed to override the 'accesslog' element

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -424,7 +424,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         if (cluster.isHostedVespa() && !accessLogElements.isEmpty()) {
             log.logApplicationPackage(
-                    Level.WARNING, "The element 'accesslog' is not overridable in hosted Vespa");
+                    Level.WARNING, "Applications are not allowed to override the 'accesslog' element");
         } else {
             for (Element accessLog : accessLogElements) {
                 AccessLogBuilder.buildIfNotDisabled(deployState, cluster, accessLog).ifPresent(cluster::addComponent);

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -1124,7 +1124,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         createModel(root, deployState, null, DomBuilderTest.parse(containerService));
         assertFalse(logger.msgs.isEmpty());
         assertEquals(Level.WARNING, logger.msgs.get(0).getFirst());
-        assertEquals("The element 'accesslog' is not overridable in hosted Vespa",
+        assertEquals("Applications are not allowed to override the 'accesslog' element",
                 logger.msgs.get(0).getSecond());
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
