### PR TITLE
remove bitvector swap function

### DIFF
--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
@@ -108,23 +108,4 @@ AllocatedBitVector::resize(Index newLength)
     clear();
 }
 
-AllocatedBitVector &
-AllocatedBitVector::operator=(const AllocatedBitVector & rhs)
-{
-    AllocatedBitVector tmp(rhs);
-    swap(tmp);
-    assert(testBit(size()));
-
-    return *this;
-}
-AllocatedBitVector &
-AllocatedBitVector::operator=(const BitVector & rhs)
-{
-    AllocatedBitVector tmp(rhs);
-    swap(tmp);
-    assert(testBit(size()));
-
-    return *this;
-}
-
 } // namespace search

--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.h
@@ -41,8 +41,6 @@ public:
     AllocatedBitVector(const BitVector &other);
     AllocatedBitVector(const AllocatedBitVector &other);
     ~AllocatedBitVector() override;
-    AllocatedBitVector &operator=(const AllocatedBitVector &other);
-    AllocatedBitVector &operator=(const BitVector &other);
 
     /**
      * Query the size of the bit vector.
@@ -67,14 +65,8 @@ protected:
 private:
     friend class BitVectorTest;
     friend class GrowableBitVector;
-    void swap(AllocatedBitVector & rhs) {
-        std::swap(_capacityBits, rhs._capacityBits);
-        _alloc.swap(rhs._alloc);
-        BitVector::swap(rhs);
-    }
 
     AllocatedBitVector(const BitVector &other, std::pair<Index, Index> size_capacity);
 };
 
 } // namespace search
-

--- a/searchlib/src/vespa/searchlib/common/bitvector.h
+++ b/searchlib/src/vespa/searchlib/common/bitvector.h
@@ -207,17 +207,6 @@ public:
         _numTrueBits.store(invalidCount(), std::memory_order_relaxed);
     }
 
-    void swap(BitVector & rhs) {
-        auto my_words = _words;
-        vespalib::atomic::store_ref_release(_words, rhs._words);
-        vespalib::atomic::store_ref_release(rhs._words, my_words);
-        std::swap(_startOffset, rhs._startOffset);
-        std::swap(_sz, rhs._sz);
-        Index tmp = rhs._numTrueBits;
-        rhs._numTrueBits = _numTrueBits.load(std::memory_order_relaxed);
-        _numTrueBits.store(tmp, std::memory_order_relaxed);
-    }
-
     /**
      * Count bits in partial bitvector [..>.
      *
@@ -393,4 +382,3 @@ void BitVector::andNotWithT(T it) {
 }
 
 } // namespace search
-


### PR DESCRIPTION
Also remove assignment operator for allocated bitvectors since it was
not used.

@toregge please review
@baldersheim FYI
