### PR TITLE
Only treat the last 2 path segments as repository in DockerImage

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionPrepareHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -291,7 +292,7 @@ public class SessionPrepareHandlerTest extends SessionHandlerTest {
     @Test
     public void test_docker_image_repository() {
         long sessionId = createSession(applicationId());
-        String dockerImageRepository = "foo.bar.com:4443/baz";
+        String dockerImageRepository = "foo.bar.com:4443/baz/qux";
         request(HttpRequest.Method.PUT, sessionId, Map.of("dockerImageRepository", dockerImageRepository,
                                                           "applicationName", applicationId().application().value()));
         applicationRepository.activate(tenantRepository.getTenant(tenant), sessionId, timeoutBudget, false);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -135,7 +135,7 @@ public class RealNodeRepositoryTest {
                 hostname,
                 new NodeAttributes()
                         .withRestartGeneration(1)
-                        .withDockerImage(DockerImage.fromString("registry.example.com/image-1:6.2.3")));
+                        .withDockerImage(DockerImage.fromString("registry.example.com/repo/image-1:6.2.3")));
     }
 
     @Test

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/container/image/ContainerImageDownloaderTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/container/image/ContainerImageDownloaderTest.java
@@ -21,7 +21,7 @@ public class ContainerImageDownloaderTest {
         ContainerEngineMock podman = new ContainerEngineMock().asyncImageDownload(true);
         ContainerImageDownloader downloader = new ContainerImageDownloader(podman);
         TaskContext context = new TestTaskContext();
-        DockerImage image = DockerImage.fromString("registry.example.com/vespa:7.42");
+        DockerImage image = DockerImage.fromString("registry.example.com/repo/vespa:7.42");
 
         assertFalse("Download started", downloader.get(context, image, RegistryCredentials.none));
         assertFalse("Download pending", downloader.get(context, image, RegistryCredentials.none));

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/ContainerFailTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/ContainerFailTest.java
@@ -23,7 +23,7 @@ public class ContainerFailTest {
 
     @Test
     public void test() {
-        DockerImage dockerImage = DockerImage.fromString("registry.example.com/dockerImage");
+        DockerImage dockerImage = DockerImage.fromString("registry.example.com/repo/image");
         try (ContainerTester tester = new ContainerTester(List.of(dockerImage))) {
             ContainerName containerName = new ContainerName("host1");
             String hostname = "host1.test.yahoo.com";

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/MultiContainerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/MultiContainerTest.java
@@ -21,8 +21,8 @@ public class MultiContainerTest {
 
     @Test
     public void test() {
-        DockerImage image1 = DockerImage.fromString("registry.example.com/image1");
-        DockerImage image2 = DockerImage.fromString("registry.example.com/image2");
+        DockerImage image1 = DockerImage.fromString("registry.example.com/repo/image1");
+        DockerImage image2 = DockerImage.fromString("registry.example.com/repo/image2");
         try (ContainerTester tester = new ContainerTester(List.of(image1, image2))) {
             addAndWaitForNode(tester, "host1.test.yahoo.com", image1);
             NodeSpec nodeSpec2 = addAndWaitForNode(tester, "host2.test.yahoo.com", image2);

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/RebootTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/RebootTest.java
@@ -23,7 +23,7 @@ import static org.mockito.ArgumentMatchers.eq;
 public class RebootTest {
 
     private final String hostname = "host1.test.yahoo.com";
-    private final DockerImage dockerImage = DockerImage.fromString("registry.example.com/dockerImage");
+    private final DockerImage dockerImage = DockerImage.fromString("registry.example.com/repo/image");
 
     @Test
     public void test() {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/RestartTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/integration/RestartTest.java
@@ -22,7 +22,7 @@ public class RestartTest {
 
     @Test
     public void test() {
-        DockerImage dockerImage = DockerImage.fromString("registry.example.com/dockerImage:1.2.3");
+        DockerImage dockerImage = DockerImage.fromString("registry.example.com/repo/image:1.2.3");
         try (ContainerTester tester = new ContainerTester(List.of(dockerImage))) {
             String hostname = "host1.test.yahoo.com";
             NodeSpec nodeSpec = NodeSpec.Builder.testSpec(hostname).wantedDockerImage(dockerImage).build();

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImplTest.java
@@ -64,7 +64,7 @@ public class NodeAgentImplTest {
     private static final String hostName = "host1.test.yahoo.com";
 
     private final NodeAgentContextSupplier contextSupplier = mock(NodeAgentContextSupplier.class);
-    private final DockerImage dockerImage = DockerImage.fromString("registry.example.com/dockerImage");
+    private final DockerImage dockerImage = DockerImage.fromString("registry.example.com/repo/image");
     private final ContainerOperations containerOperations = mock(ContainerOperations.class);
     private final NodeRepository nodeRepository = mock(NodeRepository.class);
     private final Orchestrator orchestrator = mock(Orchestrator.class);
@@ -193,7 +193,7 @@ public class NodeAgentImplTest {
 
     @Test
     public void containerIsNotStoppedIfNewImageMustBePulled() {
-        final DockerImage newDockerImage = DockerImage.fromString("registry.example.com/new-image");
+        final DockerImage newDockerImage = DockerImage.fromString("registry.example.com/repo/new-image");
         final NodeSpec node = nodeBuilder(NodeState.active)
                 .wantedDockerImage(newDockerImage).currentDockerImage(dockerImage)
                 .wantedVespaVersion(vespaVersion).currentVespaVersion(vespaVersion)


### PR DESCRIPTION
Images in GCP are on format `[host-and-port]/[project]/[artifact-registry]/[docker-image-name]:[tag]` while images in Yahoo/AWS are `[host-and-port]/[docker-image-name]:[tag]`. All our image names consist of 2 path segments, e.g. `vespa/vespa-tenant-cloud`.