### PR TITLE
Revert "Decide default flavours based on requested Vespa version"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
-import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterResources;
@@ -13,14 +12,11 @@ import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 
-import java.util.Map;
-import java.util.TreeMap;
 import java.util.function.Function;
 
 import static com.yahoo.config.provision.NodeResources.Architecture;
 import static com.yahoo.vespa.flags.FetchVector.Dimension.APPLICATION_ID;
 import static com.yahoo.vespa.flags.PermanentFlags.ADMIN_CLUSTER_NODE_ARCHITECTURE;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Defines the policies for assigning cluster capacity in various environments
@@ -87,27 +83,17 @@ public class CapacityPolicies {
                                                    .with(APPLICATION_ID, applicationId.serializedForm())
                                                    .value());
 
-            if (clusterSpec.id().value().equals("cluster-controllers")) {
-                return versioned(clusterSpec, Map.of(new Version("1"), new NodeResources(0.25, 1.14, 10, 0.3)))
-                        .with(architecture);
-            }
+            if (clusterSpec.id().value().equals("cluster-controllers"))
+                 return new NodeResources(0.25, 1.14, 10, 0.3).with(architecture);
 
-            return (zone.getCloud().dynamicProvisioning() && ! sharedHosts.apply(clusterSpec.type())
-                    ? versioned(clusterSpec, Map.of(new Version("1"), new NodeResources(0.5, 4, 50, 0.3)))
-                    : versioned(clusterSpec, Map.of(new Version("1"), new NodeResources(0.5, 2, 50, 0.3))))
-                    .with(architecture);
+            return zone.getCloud().dynamicProvisioning() && ! sharedHosts.apply(clusterSpec.type()) ?
+                    new NodeResources(0.5, 4, 50, 0.3).with(architecture) :
+                    new NodeResources(0.5, 2, 50, 0.3).with(architecture);
         }
 
-        return zone.getCloud().dynamicProvisioning()
-               ? versioned(clusterSpec, Map.of(new Version("1"), new NodeResources(2.0, 8, 50, 0.3)))
-               : versioned(clusterSpec, Map.of(new Version("1"), new NodeResources(1.5, 8, 50, 0.3)));
-    }
-
-    /** Returns the resources for the newest version not newer than that requested in the cluster spec. */
-    static NodeResources versioned(ClusterSpec spec, Map<Version, NodeResources> resources) {
-        return requireNonNull(new TreeMap<>(resources).floorEntry(spec.vespaVersion()),
-                              "no default resources applicable for " + spec + " among: " + resources)
-                .getValue();
+        return zone.getCloud().dynamicProvisioning() ?
+                new NodeResources(2.0, 8, 50, 0.3) :
+                new NodeResources(1.5, 8, 50, 0.3);
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -7,9 +7,6 @@ import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterResources;
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.ClusterSpec.Group;
-import com.yahoo.config.provision.ClusterSpec.Id;
-import com.yahoo.config.provision.ClusterSpec.Type;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
@@ -40,7 +37,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -53,7 +49,6 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1023,22 +1018,6 @@ public class ProvisioningTest {
         SystemState state = prepare(application, 1, 1, 1, 1, nodeResources, tester);
         assertEquals(4, state.allHosts.size());
         tester.activate(application, state.allHosts);
-    }
-
-    @Test
-    public void test_versioned_resources() {
-        ClusterSpec.Builder spec = ClusterSpec.specification(Type.container, Id.from("id")).group(Group.from(0));
-        Map<Version, NodeResources> resources = Map.of(new Version("7"), new NodeResources(2, 2, 2, 2),
-                                                       new Version("8"), new NodeResources(3, 3, 3, 3),
-                                                       new Version("6"), new NodeResources(1, 1, 1, 1));
-
-        assertThrows(NullPointerException.class,
-                     () -> CapacityPolicies.versioned(spec.vespaVersion("5.0").build(), resources));
-        assertEquals(new NodeResources(1, 1, 1, 1), CapacityPolicies.versioned(spec.vespaVersion("6.0").build(), resources));
-        assertEquals(new NodeResources(2, 2, 2, 2), CapacityPolicies.versioned(spec.vespaVersion("7.0").build(), resources));
-        assertEquals(new NodeResources(2, 2, 2, 2), CapacityPolicies.versioned(spec.vespaVersion("7.1").build(), resources));
-        assertEquals(new NodeResources(3, 3, 3, 3), CapacityPolicies.versioned(spec.vespaVersion("8.0").build(), resources));
-        assertEquals(new NodeResources(3, 3, 3, 3), CapacityPolicies.versioned(spec.vespaVersion("9.0").build(), resources));
     }
 
     private SystemState prepare(ApplicationId application, int container0Size, int container1Size, int content0Size,


### PR DESCRIPTION
Reverts vespa-engine/vespa#22501

Fails unit test:

[ERROR] config_server_reprovisioning(com.yahoo.vespa.hosted.provision.maintenance.RetiredExpirerTest)  Time elapsed: 0.008 s  <<< ERROR!
java.lang.NullPointerException: no default resources applicable for admin cluster 'zone-config-servers'  among: {1=[vcpu: 0.5, memory: 2.0 Gb, disk 50.0 Gb, bandwidth: 0.3 Gbps, architecture: x86_64]}
	at java.base/java.util.Objects.requireNonNull(Objects.java:246)
	at com.yahoo.vespa.hosted.provision.provisioning.CapacityPolicies.versioned(CapacityPolicies.java:108)