### PR TITLE
Don't attempt to execute document moves from a cancelled bucket mover [run-systemtest]

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.cpp
@@ -79,6 +79,7 @@ BucketMover::BucketMover(const BucketId &bucket, const MaintenanceDocumentSubDB 
       _started(0),
       _completed(0),
       _needReschedule(false),
+      _cancelled(false),
       _allScheduled(false),
       _lastGidValid(false),
       _lastGid()
@@ -138,6 +139,7 @@ BucketMover::moveDocuments(std::vector<GuardedMoveOp> moveOps, IDestructorCallba
 
 void
 BucketMover::cancel() {
+    _cancelled = true;
     setAllScheduled();
     _needReschedule.store(true, std::memory_order_relaxed);
 }

--- a/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentbucketmover.h
@@ -123,6 +123,7 @@ public:
 
     const document::BucketId &getBucket() const { return _bucket; }
     void cancel();
+    [[nodiscard]] bool cancelled() const noexcept { return _cancelled; }
     void setAllScheduled() { _allScheduled = true; }
     /// Signals all documents have been scheduled for move
     bool allScheduled() const { return _allScheduled; }
@@ -147,6 +148,7 @@ private:
     std::atomic<uint32_t>           _started;
     std::atomic<uint32_t>           _completed;
     std::atomic<bool>               _needReschedule;
+    bool                            _cancelled;
     bool                            _allScheduled; // All moves started, or operation has been cancelled
     bool                            _lastGidValid;
     document::GlobalId              _lastGid;


### PR DESCRIPTION
@baldersheim @toregge please review

This prevents the following race condition where the bucket mover logic
fails to notify the content layer that the bucket sub DB status has changed
for a particular bucket:

1. Bucket state is changed over SPI, a mover is created and registered and
   a `BucketTask` is scheduled onto the persistence queues to actually do the
   document reads and finalize the move.
2. Before the bucket task is executed, bucket state is changed again over
   the SPI. A new mover is created, the old one is cancelled (tagging
   mover as not consistent) and another `BucketTask` is scheduled onto
   the persistence queues. Note: the old task still remains.
3. Old bucket task is executed and performs the actual document moving
   despite being cancelled. No notification is done towards the content
   layer since the mover was tagged as not being consistent.
4. New bucket task is executed and tries to move the same document set
   as the old mover. Since the documents are no longer present in the
   source document DB, the moves fail. This tags the mover as inconsistent
   and no notification is done. Bucket is automatically rechecked, but
   since all docs are already moved away there is nothing more to do
   and no subsequent mover is created. This means the "should notify?"
   edge is not triggered and the content layer remains blissfully unaware
   of any sub DB changes.

This commit simply changes cancellation to actually inhibit document moves
from taking place. This lets the preempting mover successfully complete its
moves, thus triggering the notify-edge as expected.

