### PR TITLE
Just use default allocator unless there is anything special.

### DIFF
--- a/fastlib/src/vespa/fastlib/io/bufferedfile.cpp
+++ b/fastlib/src/vespa/fastlib/io/bufferedfile.cpp
@@ -375,7 +375,7 @@ size_t computeBufLen(size_t buflen)
 Fast_BufferedFile::Fast_BufferedFile(FastOS_FileInterface *file, size_t bufferSize) :
     FastOS_FileInterface(),
     _fileleft(static_cast<uint64_t>(-1)),
-    _buf(vespalib::alloc::Alloc::allocMMap(computeBufLen(bufferSize))),
+    _buf(vespalib::alloc::Alloc::alloc(computeBufLen(bufferSize))),
     _bufi(nullptr),
     _bufe(nullptr),
     _filepos(0),


### PR DESCRIPTION
@toregge PR