### PR TITLE
Add explorer for the hardware information on the content node machine.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -54,6 +54,7 @@ vespa_add_library(searchcore_server STATIC
     forcecommitdonetask.cpp
     health_adapter.cpp
     heart_beat_job.cpp
+    hw_info_explorer.cpp
     idocumentdbowner.cpp
     ifeedview.cpp
     ireplayconfig.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
@@ -1,0 +1,31 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "hw_info_explorer.h"
+#include <vespa/vespalib/data/slime/cursor.h>
+
+namespace proton {
+
+HwInfoExplorer::HwInfoExplorer(const HwInfo& info)
+    : _info(info)
+{
+}
+
+void
+HwInfoExplorer::get_state(const vespalib::slime::Inserter& inserter, bool full) const
+{
+    auto& object = inserter.insertObject();
+    if (full) {
+        auto& disk = object.setObject("disk");
+        disk.setLong("size_bytes", _info.disk().sizeBytes());
+        disk.setBool("slow", _info.disk().slow());
+        disk.setBool("shared", _info.disk().shared());
+
+        auto& memory = object.setObject("memory");
+        memory.setLong("size_bytes", _info.memory().sizeBytes());
+
+        auto& cpu = object.setObject("cpu");
+        cpu.setLong("cores", _info.cpu().cores());
+    }
+}
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.h
@@ -1,0 +1,24 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/net/state_explorer.h>
+
+namespace proton {
+
+/**
+ * Class used to explore the hardware information on the machine on which proton runs.
+ */
+class HwInfoExplorer : public vespalib::StateExplorer
+{
+private:
+    HwInfo _info;
+
+public:
+    HwInfoExplorer(const HwInfo& info);
+
+    virtual void get_state(const vespalib::slime::Inserter& inserter, bool full) const override;
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -85,6 +85,7 @@ private:
     };
 
     vespalib::CpuUtil                      _cpu_util;
+    HwInfo                                 _hw_info;
     FastOS_ThreadPool                    & _threadPool;
     FNET_Transport                       & _transport;
     const config::ConfigUri                _configUri;


### PR DESCRIPTION
This is accessible via state/v1/custom/component/hwinfo on the searchnode (content node).

@toregge please review
@baldersheim @jobergum 