### PR TITLE
Use bitvector iterator if attribute term is not used by ranking

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -89,8 +89,6 @@ protected:
         return (numHits > 1000) &&
             (calculateFilteringCost() < calculatePostingListCost(numHits));
     }
-
-public:
 };
 
 


### PR DESCRIPTION
(i.e. unpack not needed).

@geirst : please review
@baldersheim : FYI
