### PR TITLE
Depend on jsr305 directly, will not be provided from container-dev

### DIFF
--- a/node-admin/pom.xml
+++ b/node-admin/pom.xml
@@ -56,25 +56,25 @@
 
         <!-- Compile -->
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>orchestrator-restapi</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <scope>compile</scope>
             <exclusions>
                 <exclusion>
                     <!-- Must use the one provided by Jdisc to prevent two instances of slf4j classes. -->


### PR DESCRIPTION
.. in Vespa 8

(This is javax.annotation.concurrent etc.)
