### PR TITLE
Choose node resources with a matching host flavor when exclusive

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Limits.java
@@ -63,7 +63,7 @@ public class Limits {
     public Limits fullySpecified(ClusterSpec clusterSpec, NodeRepository nodeRepository, ApplicationId applicationId) {
         if (this.isEmpty()) throw new IllegalStateException("Unspecified limits can not be made fully specified");
 
-        var defaultResources = new CapacityPolicies(nodeRepository).defaultNodeResources(clusterSpec, applicationId);
+        var defaultResources = new CapacityPolicies(nodeRepository).defaultNodeResources(clusterSpec, applicationId, clusterSpec.isExclusive());
         var specifiedMin = min.nodeResources().isUnspecified() ? min.with(defaultResources) : min;
         var specifiedMax = max.nodeResources().isUnspecified() ? max.with(defaultResources) : max;
         return new Limits(specifiedMin, specifiedMax);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -239,7 +239,7 @@ public class AutoscalingTest {
         ClusterSpec cluster1 = tester.clusterSpec(ClusterSpec.Type.container, "cluster1");
 
         NodeResources defaultResources =
-                new CapacityPolicies(tester.nodeRepository()).defaultNodeResources(cluster1, application1);
+                new CapacityPolicies(tester.nodeRepository()).defaultNodeResources(cluster1, application1, false);
 
         // deploy
         tester.deploy(application1, cluster1, Capacity.from(min, max));


### PR DESCRIPTION
When using a custom cloud account (always exclusive) we cannot choose a too
small flavor because there may not be any matching host flavor. This currently
works in our own zones because there is always a shared host that can be used
for admin nodes (feature flag is set in all zones) and there is no way to set
exclusivity requirement for those clusters.

@freva