### PR TITLE
Correctly set scope override for some jupiter deps

### DIFF
--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -234,13 +234,14 @@
                             <!-- override default test bundle scope translation which translates 'test' to 'compile' -->
                             <!-- note: ordering affects how overrides are evaluated! -->
                             <testBundleScopeOverrides>
-                                ${extraTestBundleScopeOverrides},
-                                com.yahoo.vespa:application:test,
-                                com.yahoo.vespa:container-test:runtime,
-                                org.junit.jupiter:junit-jupiter-api:provided,
+                                ${extraTestBundleScopeOverrides},                                
                                 org.opentest4j:opentest4j:test,
+                                org.junit.platform:junit-platform-commons:test,
+                                org.junit.jupiter:junit-jupiter-api:provided,
                                 org.junit.jupiter:junit-jupiter-engine:test,
                                 org.junit.vintage:junit-vintage-engine:test,
+                                com.yahoo.vespa:application:test,
+                                com.yahoo.vespa:container-test:runtime,
                                 com.yahoo.vespa:vespa-feed-client:runtime, <!-- prevent effective compile scope of vespa-feed-client in test bundle -->
                                 com.yahoo.vespa:vespa-feed-client-api:provided,
                                 com.yahoo.vespa:tenant-cd-api:provided


### PR DESCRIPTION
@gjoranv or @hakonhall please review and merge. 
@bjorncs FYI (opentest4j was placed below junit-jupiter-api, which contained it, so that entry was just ignored.)

We generate import-package statements for packages exported from junit-jupiter-api, even when when these are used only from inside that bundle. 
Setting the scope of the re-exported dependencies (that's what they are) to test (instead of provided) gets rid of these false imports.
