### PR TITLE
Messagebus only requires slobrok as a client, not the full server.

### DIFF
--- a/documentapi/CMakeLists.txt
+++ b/documentapi/CMakeLists.txt
@@ -9,7 +9,6 @@ vespa_define_module(
     document
     slobrok
     messagebus
-    metrics
     configdefinitions
     vdslib
 

--- a/messagebus/CMakeLists.txt
+++ b/messagebus/CMakeLists.txt
@@ -6,7 +6,7 @@ vespa_define_module(
     config_cloudconfig
     vespalib
     fnet
-    slobrok_slobrokserver
+    slobrok
 
     LIBS
     src/vespa/messagebus


### PR DESCRIPTION
@vekterli PR