### PR TITLE
- Avoid using shared_ptr for simpe AllocConfig and ThreadingServiceCo…

### DIFF
--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -149,8 +149,8 @@ public:
                         schema,
                         std::make_shared<DocumentDBMaintenanceConfig>(),
                         search::LogDocumentStore::Config(),
-                        std::make_shared<const ThreadingServiceConfig>(ThreadingServiceConfig::make()),
-                        std::make_shared<const AllocConfig>(),
+                        ThreadingServiceConfig::make(),
+                        AllocConfig::makeDefault(),
                         "client",
                         docTypeName.getName());
     }

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -24,6 +24,7 @@
 #include <vespa/searchcore/proton/server/minimal_document_retriever.h>
 #include <vespa/searchcore/proton/server/reconfig_params.h>
 #include <vespa/searchcore/proton/server/searchabledocsubdb.h>
+#include <vespa/searchcore/proton/server/documentdbconfigmanager.h>
 #include <vespa/searchcore/proton/test/test.h>
 #include <vespa/searchcore/proton/test/thread_utils.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>

--- a/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
@@ -12,6 +12,7 @@
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/searchcore/proton/server/bootstrapconfig.h>
 #include <vespa/searchcore/proton/server/fileconfigmanager.h>
+#include <vespa/searchcore/proton/server/documentdbconfigmanager.h>
 #include <vespa/searchcore/proton/test/documentdb_config_builder.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -106,8 +106,8 @@ struct DBConfigFixture {
              buildSchema(),
              std::make_shared<DocumentDBMaintenanceConfig>(),
              search::LogDocumentStore::Config(),
-             std::make_shared<const ThreadingServiceConfig>(ThreadingServiceConfig::make()),
-             std::make_shared<const AllocConfig>(),
+             ThreadingServiceConfig::make(),
+             AllocConfig::makeDefault(),
              configId,
              docTypeName);
     }

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -202,8 +202,8 @@ std::shared_ptr<DocumentDBConfig> make_document_db_config(std::shared_ptr<Docume
             schema,
             std::make_shared<proton::DocumentDBMaintenanceConfig>(),
             search::LogDocumentStore::Config(),
-            std::make_shared<const proton::ThreadingServiceConfig>(proton::ThreadingServiceConfig::make()),
-            std::make_shared<const proton::AllocConfig>(),
+            proton::ThreadingServiceConfig::make(),
+            proton::AllocConfig::makeDefault(),
             "client",
             doc_type_name.getName());
 }

--- a/searchcore/src/vespa/searchcore/proton/common/alloc_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/alloc_config.cpp
@@ -17,11 +17,6 @@ AllocConfig::AllocConfig(const AllocStrategy& alloc_strategy,
 {
 }
 
-AllocConfig::AllocConfig()
-    : AllocConfig(AllocStrategy(), 1, 1)
-{
-}
-
 AllocConfig::~AllocConfig() = default;
 
 bool

--- a/searchcore/src/vespa/searchcore/proton/common/alloc_config.h
+++ b/searchcore/src/vespa/searchcore/proton/common/alloc_config.h
@@ -21,7 +21,6 @@ class AllocConfig
 
 public:
     AllocConfig(const AllocStrategy& alloc_strategy, uint32_t redundancy, uint32_t searchable_copies);
-    AllocConfig();
     ~AllocConfig();
 
     bool operator==(const AllocConfig &rhs) const noexcept;
@@ -29,6 +28,7 @@ public:
         return !operator==(rhs);
     }
     AllocStrategy make_alloc_strategy(SubDbType sub_db_type) const;
+    static AllocConfig makeDefault() { return AllocConfig(AllocStrategy(), 1, 1); }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
@@ -2,15 +2,17 @@
 
 #pragma once
 
-#include "documentdbconfig.h"
 #include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/config/config-proton.h>
 #include <vespa/document/config/config-documenttypes.h>
+#include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/config/retriever/configsnapshot.h>
 #include <vespa/fileacquirer/config-filedistributorrpc.h>
 
 namespace vespa::config::content::core::internal { class InternalBucketspacesType; }
+
+namespace document { class DocumentTypeRepo; }
 
 namespace proton {
 
@@ -25,7 +27,7 @@ public:
     using FiledistributorrpcConfig = const cloud::config::filedistribution::FiledistributorrpcConfig;
     using FiledistributorrpcConfigSP = std::shared_ptr<FiledistributorrpcConfig>;
 
-    typedef DocumentDBConfig::DocumenttypesConfigSP DocumenttypesConfigSP;
+    using DocumenttypesConfigSP = std::shared_ptr<DocumenttypesConfig>;
     using BucketspacesConfig = const vespa::config::content::core::internal::InternalBucketspacesType;
     using BucketspacesConfigSP = std::shared_ptr<BucketspacesConfig>;
 

--- a/searchcore/src/vespa/searchcore/proton/server/configstore.h
+++ b/searchcore/src/vespa/searchcore/proton/server/configstore.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "documentdbconfig.h"
 #include "feedconfigstore.h"
 #include <vespa/searchcommon/common/schema.h>
 
@@ -10,6 +9,8 @@ namespace vespa::config::search::core::internal {
     class InternalProtonType;
 }
 namespace proton {
+
+class DocumentDBConfig;
 
 struct ConfigStore : FeedConfigStore {
     typedef std::unique_ptr<ConfigStore> UP;
@@ -25,7 +26,7 @@ struct ConfigStore : FeedConfigStore {
      *                       resulting config snapshot.
      */
     virtual void loadConfig(const DocumentDBConfig &currentSnapshot, SerialNum serialNum,
-                            DocumentDBConfig::SP &loadedSnapshot) = 0;
+                            std::shared_ptr<DocumentDBConfig> &loadedSnapshot) = 0;
     virtual void saveConfig(const DocumentDBConfig &snapshot, SerialNum serialNum) = 0;
 
     virtual void removeInvalid() = 0;

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -449,7 +449,7 @@ DocumentDB::applyConfig(DocumentDBConfig::SP configSnapshot, SerialNum serialNum
         return;
     }
 
-    ConfigComparisonResult cmpres;
+    DocumentDBConfig::ComparisonResult cmpres;
     Schema::SP oldSchema;
     int64_t generation = configSnapshot->getGeneration();
     {

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfig.h
@@ -3,15 +3,18 @@
 #pragma once
 
 #include "document_db_maintenance_config.h"
-#include <vespa/document/config/documenttypes_config_fwd.h>
-#include <vespa/searchlib/common/tunefileinfo.h>
-#include <vespa/searchcommon/common/schema.h>
+#include "threading_service_config.h"
+#include <vespa/searchcore/proton/common/alloc_config.h>
 #include <vespa/searchcore/proton/matching/ranking_constants.h>
 #include <vespa/searchcore/proton/matching/ranking_expressions.h>
 #include <vespa/searchcore/proton/matching/onnx_models.h>
+#include <vespa/searchlib/common/tunefileinfo.h>
+#include <vespa/searchlib/docstore/logdocumentstore.h>
+#include <vespa/searchcommon/common/schema.h>
+#include <vespa/document/config/documenttypes_config_fwd.h>
+
 #include <vespa/config/retriever/configkeyset.h>
 #include <vespa/config/retriever/configsnapshot.h>
-#include <vespa/searchlib/docstore/logdocumentstore.h>
 
 namespace vespa::config::search::internal {
     class InternalSummaryType;
@@ -29,9 +32,6 @@ namespace document {
 }
 
 namespace proton {
-
-class ThreadingServiceConfig;
-class AllocConfig;
 
 class DocumentDBConfig
 {
@@ -57,7 +57,6 @@ public:
         bool storeChanged;
         bool visibilityDelayChanged;
         bool flushChanged;
-        bool threading_service_config_changed;
         bool alloc_config_changed;
 
         ComparisonResult();
@@ -92,7 +91,6 @@ public:
             }
             return *this;
         }
-        ComparisonResult &set_threading_service_config_changed(bool val) { threading_service_config_changed = val; return *this; }
         ComparisonResult &set_alloc_config_changed(bool val) { alloc_config_changed = val; return *this; }
     };
 
@@ -137,8 +135,8 @@ private:
     search::index::Schema::SP        _schema;
     MaintenanceConfigSP              _maintenance;
     search::LogDocumentStore::Config _storeConfig;
-    std::shared_ptr<const ThreadingServiceConfig> _threading_service_config;
-    std::shared_ptr<const AllocConfig> _alloc_config;
+    const ThreadingServiceConfig     _threading_service_config;
+    const AllocConfig                _alloc_config;
     SP                               _orig;
     bool                             _delayedAttributeAspects;
 
@@ -146,18 +144,18 @@ private:
     template <typename T>
     bool equals(const T * lhs, const T * rhs) const
     {
-        if (lhs == NULL) {
-            return rhs == NULL;
+        if (lhs == nullptr) {
+            return rhs == nullptr;
         }
-        return rhs != NULL && *lhs == *rhs;
+        return rhs != nullptr && *lhs == *rhs;
     }
     template <typename T, typename Func>
     bool equals(const T *lhs, const T *rhs, Func isEqual) const
     {
-        if (lhs == NULL) {
-            return rhs == NULL;
+        if (lhs == nullptr) {
+            return rhs == nullptr;
         }
-        return rhs != NULL && isEqual(*lhs, *rhs);
+        return rhs != nullptr && isEqual(*lhs, *rhs);
     }
 public:
     DocumentDBConfig(int64_t generation,
@@ -177,8 +175,8 @@ public:
                      const search::index::Schema::SP &schema,
                      const DocumentDBMaintenanceConfig::SP &maintenance,
                      const search::LogDocumentStore::Config & storeConfig,
-                     std::shared_ptr<const ThreadingServiceConfig> threading_service_config,
-                     std::shared_ptr<const AllocConfig> alloc_config,
+                     const ThreadingServiceConfig & threading_service_config,
+                     const AllocConfig & alloc_config,
                      const vespalib::string &configId,
                      const vespalib::string &docTypeName) noexcept;
 
@@ -220,10 +218,8 @@ public:
     const MaintenanceConfigSP &getMaintenanceConfigSP() const { return _maintenance; }
     const search::TuneFileDocumentDB::SP &getTuneFileDocumentDBSP() const { return _tuneFileDocumentDB; }
     bool getDelayedAttributeAspects() const { return _delayedAttributeAspects; }
-    const ThreadingServiceConfig& get_threading_service_config() const { return *_threading_service_config; }
-    const std::shared_ptr<const ThreadingServiceConfig>& get_threading_service_config_shared_ptr() const { return _threading_service_config; }
-    const AllocConfig& get_alloc_config() const { return *_alloc_config; }
-    const std::shared_ptr<const AllocConfig>& get_alloc_config_shared_ptr() const { return _alloc_config; }
+    const ThreadingServiceConfig& get_threading_service_config() const { return _threading_service_config; }
+    const AllocConfig& get_alloc_config() const { return _alloc_config; }
 
     bool operator==(const DocumentDBConfig &rhs) const;
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigscout.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigscout.cpp
@@ -1,20 +1,19 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "documentdbconfigscout.h"
+#include "documentdbconfig.h"
 #include <vespa/searchcore/proton/attribute/attributesconfigscout.h>
 
 using vespa::config::search::AttributesConfig;
 
 namespace proton {
 
-
-DocumentDBConfig::SP
-DocumentDBConfigScout::scout(const DocumentDBConfig::SP &config,
+std::shared_ptr<DocumentDBConfig>
+DocumentDBConfigScout::scout(const std::shared_ptr<DocumentDBConfig> &config,
                              const DocumentDBConfig &liveConfig)
 {
     AttributesConfigScout acScout(liveConfig.getAttributesConfig());
-    std::shared_ptr<AttributesConfig>
-        ac(acScout.adjust(config->getAttributesConfig()));
+    std::shared_ptr<AttributesConfig> ac(acScout.adjust(config->getAttributesConfig()));
     if (*ac == config->getAttributesConfig())
         return config; // no change
     return config->newFromAttributesConfig(ac);

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigscout.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigscout.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include "documentdbconfig.h"
+#include <memory>
 
-namespace proton
-{
+namespace proton {
+
+class DocumentDBConfig;
 
 /**
  * Class to create adjusted document db config that minimizes the number of
@@ -16,9 +17,8 @@ namespace proton
 class DocumentDBConfigScout
 {
 public:
-    static DocumentDBConfig::SP
-    scout(const DocumentDBConfig::SP &config,
-          const DocumentDBConfig &liveConfig);
+    static std::shared_ptr<DocumentDBConfig>
+    scout(const std::shared_ptr<DocumentDBConfig> &config, const DocumentDBConfig &liveConfig);
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb_configurer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb_configurer.cpp
@@ -2,6 +2,7 @@
 
 #include "fast_access_doc_subdb_configurer.h"
 #include "i_attribute_writer_factory.h"
+#include "documentdbconfig.h"
 #include <vespa/searchcore/proton/attribute/attribute_writer.h>
 #include <vespa/searchcore/proton/common/document_type_inspector.h>
 #include <vespa/searchcore/proton/common/indexschema_inspector.h>

--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.cpp
@@ -2,6 +2,7 @@
 
 #include "fileconfigmanager.h"
 #include "bootstrapconfig.h"
+#include "documentdbconfigmanager.h"
 #include <vespa/searchcore/proton/common/hw_info_sampler.h>
 #include <vespa/config/print/fileconfigwriter.h>
 #include <vespa/config-bucketspaces.h>
@@ -17,6 +18,7 @@
 #include <vespa/config-summary.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>
 #include <vespa/config/helper/configgetter.hpp>
+#include <vespa/fastos/file.h>
 #include <sstream>
 #include <cassert>
 #include <fcntl.h>

--- a/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fileconfigmanager.h
@@ -2,10 +2,11 @@
 #pragma once
 
 #include "configstore.h"
-#include "documentdbconfigmanager.h"
 #include <vespa/searchlib/common/indexmetainfo.h>
 #include <vespa/searchlib/common/serialnum.h>
 #include <vespa/vespalib/objects/nbostream.h>
+
+class FNET_Transport;
 
 namespace proton {
 
@@ -47,7 +48,7 @@ public:
      *                       resulting config snapshot.
      */
     void loadConfig(const DocumentDBConfig &currentSnapshot, SerialNum serialNum,
-                    DocumentDBConfig::SP &loadedSnapshot) override;
+                    std::shared_ptr<DocumentDBConfig> &loadedSnapshot) override;
 
     void removeInvalid() override;
     void prune(SerialNum serialNum) override;

--- a/searchcore/src/vespa/searchcore/proton/server/memoryconfigstore.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/memoryconfigstore.cpp
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "memoryconfigstore.h"
+#include "documentdbconfig.h"
 #include <cassert>
 
 #include <vespa/log/log.h>
@@ -38,12 +39,12 @@ void
 MemoryConfigStore::saveConfig(const DocumentDBConfig &config,
                               SerialNum serial)
 {
-    _maps->configs[serial].reset(new DocumentDBConfig(config));
+    _maps->configs[serial] = std::make_shared<DocumentDBConfig>(config);
     _maps->_valid.insert(serial);
 }
 void
 MemoryConfigStore::loadConfig(const DocumentDBConfig &, SerialNum serial,
-                              DocumentDBConfig::SP &loaded_config)
+                              std::shared_ptr<DocumentDBConfig> &loaded_config)
 {
     assert(hasValidSerial(serial));
     loaded_config = _maps->configs[serial];
@@ -88,7 +89,7 @@ MemoryConfigStores::getConfigStore(const std::string &type) {
     if (!_config_maps[type].get()) {
         _config_maps[type].reset(new ConfigMaps);
     }
-    return ConfigStore::UP(new MemoryConfigStore(_config_maps[type]));
+    return std::make_unique<MemoryConfigStore>(_config_maps[type]);
 }
 
 }  // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/memoryconfigstore.h
+++ b/searchcore/src/vespa/searchcore/proton/server/memoryconfigstore.h
@@ -3,15 +3,15 @@
 #pragma once
 
 #include "configstore.h"
-#include "documentdbconfig.h"
 #include <vespa/searchcommon/common/schema.h>
 #include <map>
+#include <set>
 
 namespace proton {
 
 struct ConfigMaps {
     typedef std::shared_ptr<ConfigMaps> SP;
-    std::map<search::SerialNum, DocumentDBConfig::SP> configs;
+    std::map<search::SerialNum, std::shared_ptr<DocumentDBConfig>> configs;
     std::set<search::SerialNum> _valid;
     ~ConfigMaps();
 };
@@ -32,7 +32,7 @@ public:
     bool hasValidSerial(SerialNum serial) const override;
     SerialNum getPrevValidSerial(SerialNum serial) const override;
     void saveConfig(const DocumentDBConfig &config, SerialNum serial) override;
-    void loadConfig(const DocumentDBConfig &, SerialNum serial, DocumentDBConfig::SP &loaded_config) override;
+    void loadConfig(const DocumentDBConfig &, SerialNum serial, std::shared_ptr<DocumentDBConfig> &loaded_config) override;
     void removeInvalid() override;
     void prune(SerialNum serial) override;
     void serializeConfig(SerialNum, vespalib::nbostream &) override;

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -15,6 +15,7 @@
 #include "resource_usage_explorer.h"
 #include "searchhandlerproxy.h"
 #include "simpleflush.h"
+#include "documentdbconfig.h"
 
 #include <vespa/document/base/exceptions.h>
 #include <vespa/document/datatype/documenttype.h>
@@ -46,6 +47,7 @@
 #include <vespa/vespalib/util/random.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
+#include <vespa/fastos/file.h>
 #ifdef __linux__
 #include <malloc.h>
 #endif
@@ -398,7 +400,7 @@ Proton::addDocumentDB(const DocTypeName &docTypeName,
                       document::BucketSpace bucketSpace,
                       const vespalib::string &configId,
                       const BootstrapConfig::SP &bootstrapConfig,
-                      const DocumentDBConfig::SP &documentDBConfig,
+                      const std::shared_ptr<DocumentDBConfig> &documentDBConfig,
                       InitializeThreads initializeThreads)
 {
     try {
@@ -586,7 +588,7 @@ DocumentDB::SP
 Proton::addDocumentDB(const document::DocumentType &docType,
                       document::BucketSpace bucketSpace,
                       const BootstrapConfig::SP &bootstrapConfig,
-                      const DocumentDBConfig::SP &documentDBConfig,
+                      const std::shared_ptr<DocumentDBConfig> &documentDBConfig,
                       InitializeThreads initializeThreads)
 {
     const ProtonConfig &config(bootstrapConfig->getProtonConfig());

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.cpp
@@ -4,6 +4,7 @@
 #include "bootstrapconfig.h"
 #include "proton_config_snapshot.h"
 #include "i_proton_configurer.h"
+#include "documentdbconfigmanager.h"
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <thread>

--- a/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton_config_fetcher.h
@@ -3,18 +3,21 @@
 #pragma once
 
 #include "bootstrapconfigmanager.h"
-#include "documentdbconfigmanager.h"
 #include "i_document_db_config_owner.h"
 #include <vespa/fastos/thread.h>
 #include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/config/retriever/configretriever.h>
 #include <vespa/config/subscription/configuri.h>
+#include <deque>
+
+class FNET_Transport;
 
 namespace document { class DocumentTypeRepo; }
 
 namespace proton {
 
 class BootstrapConfig;
+class DocumentDBConfigManager;
 class IProtonConfigurer;
 
 /**
@@ -46,7 +49,7 @@ public:
     void Run(FastOS_ThreadInterface * thread, void *arg) override;
 
 private:
-    typedef std::map<DocTypeName, DocumentDBConfigManager::SP> DBManagerMap;
+    typedef std::map<DocTypeName, std::shared_ptr<DocumentDBConfigManager>> DBManagerMap;
     using OldDocumentTypeRepo = std::pair<vespalib::steady_time, std::shared_ptr<const document::DocumentTypeRepo>>;
     using lock_guard = std::lock_guard<std::mutex>;
 

--- a/searchcore/src/vespa/searchcore/proton/server/rpc_hooks.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/rpc_hooks.cpp
@@ -4,6 +4,7 @@
 #include "proton.h"
 #include <vespa/searchcore/proton/matchengine/matchengine.h>
 #include <vespa/vespalib/util/lambdatask.h>
+#include <vespa/vespalib/util/compressionconfig.h>
 #include <vespa/fnet/frt/supervisor.h>
 #include <vespa/fnet/transport.h>
 

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.cpp
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "reconfig_params.h"
 #include "searchable_doc_subdb_configurer.h"
+#include "reconfig_params.h"
 #include <vespa/searchcore/proton/matching/matcher.h>
 #include <vespa/searchcore/proton/attribute/attribute_writer.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include "documentdbconfigmanager.h"
 #include "isummaryadapter.h"
 #include "matchers.h"
 #include "matchview.h"
@@ -23,6 +22,10 @@
 #include <vespa/vespalib/util/varholder.h>
 #include <vespa/searchcore/proton/reference/i_document_db_reference_resolver.h>
 
+namespace proton::matching {
+    class RankingExpressions;
+    class OnnxModels;
+}
 namespace proton {
 
 struct IDocumentDBReferenceResolver;

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.h
@@ -7,6 +7,7 @@
 #include "searchview.h"
 #include "summaryadapter.h"
 #include "igetserialnum.h"
+#include "document_db_flush_config.h"
 #include <vespa/eval/eval/value_cache/constant_tensor_loader.h>
 #include <vespa/eval/eval/value_cache/constant_value_cache.h>
 #include <vespa/searchcore/proton/attribute/attributemanager.h>

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include "documentdbconfig.h"
 #include "idocumentsubdb.h"
 #include "storeonlyfeedview.h"
 #include "summaryadapter.h"
@@ -21,6 +20,7 @@
 namespace proton {
 
 class AllocStrategy;
+class DocumentDBConfig;
 struct DocumentDBTaggedMetrics;
 class DocumentMetaStoreInitializerResult;
 class FeedHandler;

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.cpp
@@ -48,15 +48,15 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(int64_t generation,
       _schema(schema),
       _maintenance(std::make_shared<DocumentDBMaintenanceConfig>()),
       _store(),
-      _threading_service_config(std::make_shared<const ThreadingServiceConfig>(ThreadingServiceConfig::make())),
-      _alloc_config(std::make_shared<const AllocConfig>()),
+      _threading_service_config(ThreadingServiceConfig::make()),
+      _alloc_config(AllocConfig::makeDefault()),
       _configId(configId),
       _docTypeName(docTypeName)
 { }
 
 
 DocumentDBConfigBuilder::DocumentDBConfigBuilder(const DocumentDBConfig &cfg)
-     : _generation(cfg.getGeneration()),
+    : _generation(cfg.getGeneration()),
       _rankProfiles(cfg.getRankProfilesConfigSP()),
       _rankingConstants(cfg.getRankingConstantsSP()),
       _rankingExpressions(cfg.getRankingExpressionsSP()),
@@ -73,13 +73,13 @@ DocumentDBConfigBuilder::DocumentDBConfigBuilder(const DocumentDBConfig &cfg)
       _schema(cfg.getSchemaSP()),
       _maintenance(cfg.getMaintenanceConfigSP()),
       _store(cfg.getStoreConfig()),
-      _threading_service_config(cfg.get_threading_service_config_shared_ptr()),
-      _alloc_config(cfg.get_alloc_config_shared_ptr()),
+      _threading_service_config(cfg.get_threading_service_config()),
+      _alloc_config(cfg.get_alloc_config()),
       _configId(cfg.getConfigId()),
       _docTypeName(cfg.getDocTypeName())
 {}
 
-DocumentDBConfigBuilder::~DocumentDBConfigBuilder() {}
+DocumentDBConfigBuilder::~DocumentDBConfigBuilder() = default;
 
 DocumentDBConfig::SP
 DocumentDBConfigBuilder::build()

--- a/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
+++ b/searchcore/src/vespa/searchcore/proton/test/documentdb_config_builder.h
@@ -28,8 +28,8 @@ private:
     search::index::Schema::SP _schema;
     DocumentDBConfig::MaintenanceConfigSP _maintenance;
     search::LogDocumentStore::Config _store;
-    std::shared_ptr<const ThreadingServiceConfig> _threading_service_config;
-    std::shared_ptr<const AllocConfig> _alloc_config;
+    const ThreadingServiceConfig _threading_service_config;
+    const AllocConfig _alloc_config;
     vespalib::string _configId;
     vespalib::string _docTypeName;
 


### PR DESCRIPTION
…nfig.

- Reduce exposure of DocumentDBConfig and DocumentDBConfigManager classes.

@toregge or @geirst PR