### PR TITLE
Add dependency to javax.annotation-api

### DIFF
--- a/controller-server/pom.xml
+++ b/controller-server/pom.xml
@@ -124,6 +124,14 @@
         <!-- compile -->
 
         <dependency>
+            <!-- TODO Vespa 8: remove dep? -->
+            <!-- Required by Jersey (loaded via javax.ws.rs-api) -->
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>


### PR DESCRIPTION
This is not a permanent solution. When we remove jersey from vespa_jersey2 (Jackson will remain), controller-server must have all necessary jersey deps declared in its own pom. 