### PR TITLE
Remove dependency to javax.annotation-api

### DIFF
--- a/controller-server/pom.xml
+++ b/controller-server/pom.xml
@@ -118,14 +118,6 @@
         <!-- compile -->
 
         <dependency>
-            <!-- TODO Vespa 8: remove dep? -->
-            <!-- Required by Jersey (loaded via javax.ws.rs-api) -->
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>


### PR DESCRIPTION
- Was required by javax.ws.rs-api exceptions that are no longer thrown by this module.


