### PR TITLE
Improve restart messages

### DIFF
--- a/configdefinitions/src/vespa/slobroks.def
+++ b/configdefinitions/src/vespa/slobroks.def
@@ -1,8 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 namespace=cloud.config
 
-### All params must be flagged as 'restart' because this config is manually
-### retrieved by ConfiguredApplication.start to init the rpc server
+### Changes to this config requires restart
 
 ## The connectionspec for a slobrok is used for connecting to it using
 ## the FNET Remote Tools framework.  It is normally on the form

--- a/container-core/src/main/resources/configdefinitions/container.qr.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr.def
@@ -1,8 +1,8 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 namespace=container
 
-### All params must be flagged as 'restart' because this config is manually
-### retrieved by ConfiguredApplication.start to init the rpc server
+### Changes to this config requires restart because it is used to initialize
+### connection to the config system
 
 ## filedistributor rpc configuration
 filedistributor.configid reference default="" restart


### PR DESCRIPTION
These messages are emitted to users on deployment, and in that context it is confusing to see "must be marked as restart".