### PR TITLE
Remove most use of vespalib::rmdir in vespalib. Deprecate vespalib::mkdir.

### DIFF
--- a/vespalib/src/tests/assert/assert_test.cpp
+++ b/vespalib/src/tests/assert/assert_test.cpp
@@ -3,18 +3,18 @@
 #include <vespa/vespalib/process/process.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/assert.h>
-#include <vespa/vespalib/io/fileutil.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <vespa/defaults.h>
+#include <filesystem>
 
 using namespace vespalib;
 
 TEST("that it borks the first time.") {
     std::string assertName;
     const char * assertDir = "var/db/vespa/tmp";
-    vespalib::rmdir("var", true);
-    ASSERT_TRUE(vespalib::mkdir(assertDir, true));
+    std::filesystem::remove_all(std::filesystem::path("var"));
+    ASSERT_TRUE(std::filesystem::create_directories(std::filesystem::path(assertDir)));
     {
         Process proc("ulimit -c 0 && exec env VESPA_HOME=./ ./vespalib_asserter_app myassert 10000");
         ASSERT_EQUAL(proc.join() & 0x7f, 6);
@@ -30,7 +30,7 @@ TEST("that it borks the first time.") {
         ASSERT_EQUAL(proc.join() & 0x7f, 6);
     }
     ASSERT_EQUAL(0, unlink(assertName.c_str()));
-    ASSERT_TRUE(vespalib::rmdir("var", true));
+    ASSERT_LESS(0u, std::filesystem::remove_all(std::filesystem::path("var")));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/tests/util/mmap_file_allocator_factory/mmap_file_allocator_factory_test.cpp
+++ b/vespalib/src/tests/util/mmap_file_allocator_factory/mmap_file_allocator_factory_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/vespalib/util/mmap_file_allocator.h>
 #include <vespa/vespalib/util/memory_allocator.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <filesystem>
 
 using vespalib::alloc::MemoryAllocator;
 using vespalib::alloc::MmapFileAllocator;
@@ -43,7 +44,7 @@ TEST(MmapFileAllocatorFactoryTest, nonempty_dir_gives_allocator)
     allocator1.reset();
     EXPECT_FALSE(isDirectory(allocator1_dir));
     MmapFileAllocatorFactory::instance().setup("");
-    rmdir(basedir, true);
+    std::filesystem::remove_all(std::filesystem::path(basedir));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/io/fileutil.h
+++ b/vespalib/src/vespa/vespalib/io/fileutil.h
@@ -223,6 +223,9 @@ extern vespalib::string getCurrentDirectory();
  * @throw IoException If we failed create the directory.
  *
  * @return True if it did not exist, false if it did.
+ *
+ * This function is deprecated. Use std::filesystem::create_directory or std::filesystem::create_directories
+ * instead.
  */
 extern bool mkdir(const vespalib::string & directory, bool recursive = true);
 

--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <sys/mman.h>
 #include <cassert>
+#include <filesystem>
 
 namespace vespalib::alloc {
 
@@ -16,7 +17,7 @@ MmapFileAllocator::MmapFileAllocator(const vespalib::string& dir_name)
       _allocations(),
       _freelist()
 {
-    mkdir(_dir_name, true);
+    std::filesystem::create_directories(std::filesystem::path(_dir_name));
     _file.open(O_RDWR | O_CREAT | O_TRUNC, false);
 }
 
@@ -25,7 +26,7 @@ MmapFileAllocator::~MmapFileAllocator()
     assert(_allocations.empty());
     _file.close();
     _file.unlink();
-    rmdir(_dir_name, true);
+    std::filesystem::remove_all(std::filesystem::path(_dir_name));
 }
 
 uint64_t

--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator_factory.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator_factory.cpp
@@ -2,8 +2,8 @@
 
 #include "mmap_file_allocator_factory.h"
 #include "mmap_file_allocator.h"
-#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <filesystem>
 
 namespace vespalib::alloc {
 
@@ -23,7 +23,7 @@ MmapFileAllocatorFactory::setup(const vespalib::string& dir_name)
     _dir_name = dir_name;
     _generation = 0;
     if (!_dir_name.empty()) {
-        rmdir(_dir_name, true);
+        std::filesystem::remove_all(std::filesystem::path(_dir_name));
     }
 }
 


### PR DESCRIPTION
@geirst : please review
