### PR TITLE
Let deadlock detector dump stack of potentially deadlocked threads

### DIFF
--- a/fastos/src/vespa/fastos/thread.h
+++ b/fastos/src/vespa/fastos/thread.h
@@ -381,7 +381,7 @@ public:
     /**
      * Returns the id of this thread.
      */
-    virtual FastOS_ThreadId GetThreadId ()=0;
+    virtual FastOS_ThreadId GetThreadId () const noexcept = 0;
 };
 
 

--- a/fastos/src/vespa/fastos/unix_thread.cpp
+++ b/fastos/src/vespa/fastos/unix_thread.cpp
@@ -102,7 +102,7 @@ FastOS_UNIX_Thread::~FastOS_UNIX_Thread()
     }
 }
 
-FastOS_ThreadId FastOS_UNIX_Thread::GetThreadId ()
+FastOS_ThreadId FastOS_UNIX_Thread::GetThreadId () const noexcept
 {
     return _handle;
 }

--- a/fastos/src/vespa/fastos/unix_thread.h
+++ b/fastos/src/vespa/fastos/unix_thread.h
@@ -36,7 +36,7 @@ public:
 
     ~FastOS_UNIX_Thread();
 
-    FastOS_ThreadId GetThreadId () override;
+    FastOS_ThreadId GetThreadId () const noexcept override;
     static bool CompareThreadIds (FastOS_ThreadId a, FastOS_ThreadId b);
     static FastOS_ThreadId GetCurrentThreadId ();
 };

--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -56,6 +56,7 @@ App::setupSignals()
     SIG::PIPE.ignore();
     SIG::INT.hook();
     SIG::TERM.hook();
+    SIG::enable_cross_thread_stack_tracing();
 }
 
 void

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -65,17 +65,17 @@ disable_queue_limits_for_chained_merges bool default=true
 
 ## Whether the deadlock detector should be enabled or not. If disabled, it will
 ## still run, but it will never actually abort the process it is running in.
-enable_dead_lock_detector bool default=false restart
+enable_dead_lock_detector bool default=false
 
 ## Whether to enable deadlock detector warnings in log or not. If enabled,
 ## warnings will be written even if dead lock detecting is not enabled.
-enable_dead_lock_detector_warnings bool default=true restart
+enable_dead_lock_detector_warnings bool default=true
 
 ## Each thread registers how often it will at minimum register ticks (given that
 ## the system is not overloaded. If you are running Vespa on overloaded nodes,
 ## you can use this slack timeout to add to the thread timeouts in order to
 ## allow for more slack before dead lock detector kicks in. The value is in seconds.
-dead_lock_detector_timeout_slack double default=240 restart
+dead_lock_detector_timeout_slack double default=240
 
 ## If set to 0, storage will attempt to auto-detect the number of VDS mount
 ## points to use. If set to a number, force this number. This number only makes

--- a/storage/src/vespa/storage/frameworkimpl/thread/appkiller.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/thread/appkiller.cpp
@@ -9,10 +9,10 @@ LOG_SETUP(".deadlock.killer");
 namespace storage {
 
 void RealAppKiller::kill() {
-    LOG(info, "Aborting the server to dump core, as we're "
-              "most likely deadlocked and want a core file "
-              "to view the stack traces.");
-    LOG_ABORT("should not be reached");
+    LOG(error, "One or more threads have failed internal liveness checks; aborting process. "
+               "A core dump will be generated (if enabled by the kernel). "
+               "Please report this to the Vespa team at https://github.com/vespa-engine/vespa/issues");
+    abort();
 }
 
 } // storage

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -273,7 +273,6 @@ StorageNode::handleLiveConfigUpdate(const InitialGuard & initGuard)
     // we want to handle.
 
     if (_newServerConfig) {
-        bool updated = false;
         StorServerConfigBuilder oldC(*_serverConfig);
         StorServerConfig& newC(*_newServerConfig);
         DIFFERWARN(rootFolder, "Cannot alter root folder of node live");
@@ -282,7 +281,10 @@ StorageNode::handleLiveConfigUpdate(const InitialGuard & initGuard)
         DIFFERWARN(isDistributor, "Cannot alter role of node live");
         _serverConfig = std::make_unique<StorServerConfig>(oldC);
         _newServerConfig.reset();
-        (void)updated;
+        _deadLockDetector->enableWarning(_serverConfig->enableDeadLockDetectorWarnings);
+        _deadLockDetector->enableShutdown(_serverConfig->enableDeadLockDetector);
+        _deadLockDetector->setProcessSlack(vespalib::from_s(_serverConfig->deadLockDetectorTimeoutSlack));
+        _deadLockDetector->setWaitSlack(vespalib::from_s(_serverConfig->deadLockDetectorTimeoutSlack));
     }
     if (_newDistributionConfig) {
         StorDistributionConfigBuilder oldC(*_distributionConfig);

--- a/storage/src/vespa/storageframework/defaultimplementation/thread/threadimpl.cpp
+++ b/storage/src/vespa/storageframework/defaultimplementation/thread/threadimpl.cpp
@@ -4,6 +4,7 @@
 #include "threadpoolimpl.h"
 #include <vespa/storageframework/generic/clock/clock.h>
 #include <vespa/vespalib/util/atomic.h>
+#include <vespa/vespalib/util/signalhandler.h>
 
 #include <vespa/log/bufferedlogger.h>
 LOG_SETUP(".framework.thread.impl");
@@ -76,6 +77,12 @@ void
 ThreadImpl::join()
 {
     _thread.join();
+}
+
+vespalib::string
+ThreadImpl::get_live_thread_stack_trace() const
+{
+    return vespalib::SignalHandler::get_cross_thread_stack_trace(_thread.native_thread_id());
 }
 
 void

--- a/storage/src/vespa/storageframework/defaultimplementation/thread/threadimpl.h
+++ b/storage/src/vespa/storageframework/defaultimplementation/thread/threadimpl.h
@@ -13,7 +13,7 @@ namespace storage::framework::defaultimplementation {
 
 struct ThreadPoolImpl;
 
-class ThreadImpl : public Thread
+class ThreadImpl final : public Thread
 {
     struct BackendThread : public document::Runnable {
         ThreadImpl& _impl;
@@ -61,12 +61,15 @@ public:
     ThreadImpl(ThreadPoolImpl&, Runnable&, vespalib::stringref id, vespalib::duration waitTime,
                vespalib::duration maxProcessTime, int ticksBeforeWait,
                std::optional<vespalib::CpuUsage::Category> cpu_category);
-    ~ThreadImpl();
+    ~ThreadImpl() override;
 
     bool interrupted() const override;
     bool joined() const override;
     void interrupt() override;
     void join() override;
+
+    vespalib::string get_live_thread_stack_trace() const override;
+
     void registerTick(CycleType, vespalib::steady_time) override;
     vespalib::duration getWaitTime() const override {
         return _properties.getWaitTime();
@@ -76,8 +79,8 @@ public:
     }
 
     void setTickData(const ThreadTickData&);
-    ThreadTickData getTickData() const;
-    const ThreadProperties& getProperties() const { return _properties; }
+    ThreadTickData getTickData() const override;
+    const ThreadProperties& getProperties() const override { return _properties; }
 };
 
 }

--- a/storage/src/vespa/storageframework/defaultimplementation/thread/threadpoolimpl.h
+++ b/storage/src/vespa/storageframework/defaultimplementation/thread/threadpoolimpl.h
@@ -9,7 +9,7 @@ namespace storage::framework::defaultimplementation {
 
 class ThreadImpl;
 
-struct ThreadPoolImpl : public ThreadPool
+struct ThreadPoolImpl final : public ThreadPool
 {
     FastOS_ThreadPool          _backendThreadPool;
     std::vector<ThreadImpl*>   _threads;

--- a/storage/src/vespa/storageframework/generic/thread/CMakeLists.txt
+++ b/storage/src/vespa/storageframework/generic/thread/CMakeLists.txt
@@ -2,7 +2,7 @@
 vespa_add_library(storageframework_thread OBJECT
     SOURCES
     thread.cpp
-    threadpool.cpp
+    thread_properties.cpp
     tickingthread.cpp
     DEPENDS
 )

--- a/storage/src/vespa/storageframework/generic/thread/thread.h
+++ b/storage/src/vespa/storageframework/generic/thread/thread.h
@@ -13,9 +13,18 @@
 #pragma once
 
 #include "runnable.h"
+#include "thread_properties.h"
 #include <condition_variable>
 
 namespace storage::framework {
+
+/** Data kept on each thread due to the registerTick functionality. */
+struct ThreadTickData {
+    CycleType _lastTickType;
+    vespalib::steady_time _lastTick;
+    vespalib::duration _maxProcessingTimeSeen;
+    vespalib::duration _maxWaitTimeSeen;
+};
 
 class Thread : public ThreadHandle {
     vespalib::string _id;
@@ -44,6 +53,11 @@ public:
      * called after thread has already finished, it is a noop.
      */
     virtual void join() = 0;
+
+    virtual ThreadTickData getTickData() const = 0;
+    virtual const ThreadProperties& getProperties() const = 0;
+
+    virtual vespalib::string get_live_thread_stack_trace() const = 0;
 
     /**
      * Utility function to interrupt and join a thread, possibly broadcasting

--- a/storage/src/vespa/storageframework/generic/thread/thread_properties.cpp
+++ b/storage/src/vespa/storageframework/generic/thread/thread_properties.cpp
@@ -1,6 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "threadpool.h"
+#include "thread_properties.h"
 
 namespace storage::framework {
 

--- a/storage/src/vespa/storageframework/generic/thread/thread_properties.h
+++ b/storage/src/vespa/storageframework/generic/thread/thread_properties.h
@@ -1,0 +1,49 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/storageframework/generic/clock/time.h>
+#include <cstdint>
+
+namespace storage::framework {
+
+/**
+ * Each thread may have different properties, as to how long they wait between
+ * ticks and how long they're supposed to use processing between ticks. To be
+ * able to specify this per thread, a set of properties can be set by each
+ * thread.
+ */
+class ThreadProperties {
+private:
+    /**
+     * Time this thread should maximum use to process before a tick is
+     * registered. (Including wait time if wait time is not set)
+     */
+    vespalib::duration _maxProcessTime;
+    /**
+     * Time this thread will wait in a non-interrupted wait cycle.
+     * Used in cases where a wait cycle is registered. As long as no other
+     * time consuming stuff is done in a wait cycle, you can just use the
+     * wait time here. The deadlock detector should add a configurable
+     * global time period before flagging deadlock anyways.
+     */
+    vespalib::duration _waitTime;
+    /**
+     * Number of ticks to be done before a wait.
+     */
+    uint32_t _ticksBeforeWait;
+
+public:
+    ThreadProperties(vespalib::duration waitTime,
+                     vespalib::duration maxProcessTime,
+                     int ticksBeforeWait);
+
+    vespalib::duration getMaxProcessTime() const { return _maxProcessTime; }
+    vespalib::duration getWaitTime() const { return _waitTime; }
+    int getTicksBeforeWait() const { return _ticksBeforeWait; }
+
+    vespalib::duration getMaxCycleTime() const {
+        return std::max(_maxProcessTime, _waitTime);
+    }
+};
+
+}

--- a/storage/src/vespa/storageframework/generic/thread/threadpool.h
+++ b/storage/src/vespa/storageframework/generic/thread/threadpool.h
@@ -22,60 +22,10 @@
 
 namespace storage::framework {
 
-/**
- * Each thread may have different properties, as to how long they wait between
- * ticks and how long they're supposed to use processing between ticks. To be
- * able to specify this per thread, a set of properties can be set by each
- * thread.
- */
-class ThreadProperties {
-private:
-    /**
-     * Time this thread should maximum use to process before a tick is
-     * registered. (Including wait time if wait time is not set)
-     */
-    vespalib::duration _maxProcessTime;
-    /**
-     * Time this thread will wait in a non-interrupted wait cycle.
-     * Used in cases where a wait cycle is registered. As long as no other
-     * time consuming stuff is done in a wait cycle, you can just use the
-     * wait time here. The deadlock detector should add a configurable
-     * global time period before flagging deadlock anyways.
-     */
-    vespalib::duration _waitTime;
-    /**
-     * Number of ticks to be done before a wait.
-     */
-    uint32_t _ticksBeforeWait;
-
- public:
-    ThreadProperties(vespalib::duration waitTime,
-                     vespalib::duration maxProcessTime,
-                     int ticksBeforeWait);
-
-    vespalib::duration getMaxProcessTime() const { return _maxProcessTime; }
-    vespalib::duration getWaitTime() const { return _waitTime; }
-    int getTicksBeforeWait() const { return _ticksBeforeWait; }
-
-    vespalib::duration getMaxCycleTime() const {
-      return std::max(_maxProcessTime, _waitTime);
-    }
-};
-
-/** Data kept on each thread due to the registerTick functinality. */
-struct ThreadTickData {
-    CycleType _lastTickType;
-    vespalib::steady_time _lastTick;
-    vespalib::duration _maxProcessingTimeSeen;
-    vespalib::duration _maxWaitTimeSeen;
-};
-
 /** Interface used to access data for the existing threads. */
 struct ThreadVisitor {
     virtual ~ThreadVisitor() = default;
-    virtual void visitThread(const vespalib::string& id,
-                             const ThreadProperties&,
-                             const ThreadTickData&) = 0;
+    virtual void visitThread(const Thread& thread) = 0;
 };
 
 struct ThreadPool {

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -209,6 +209,7 @@ int StorageApp::main(int argc, char **argv)
 
 int main(int argc, char **argv) {
     vespalib::SignalHandler::PIPE.ignore();
+    vespalib::SignalHandler::enable_cross_thread_stack_tracing();
     storage::StorageApp app;
     storage::sigtramp = &app;
     int retval = app.main(argc,argv);

--- a/vespalib/src/vespa/vespalib/util/document_runnable.cpp
+++ b/vespalib/src/vespa/vespalib/util/document_runnable.cpp
@@ -72,6 +72,11 @@ bool Runnable::join() const
     return true;
 }
 
+FastOS_ThreadId Runnable::native_thread_id() const noexcept
+{
+    return GetThread()->GetThreadId();
+}
+
 void Runnable::Run(FastOS_ThreadInterface*, void*)
 {
     {

--- a/vespalib/src/vespa/vespalib/util/document_runnable.h
+++ b/vespalib/src/vespa/vespalib/util/document_runnable.h
@@ -88,6 +88,8 @@ public:
      * Checks if runnable is running or not. (Started is considered running)
      */
     [[nodiscard]] bool running() const noexcept;
+
+    FastOS_ThreadId native_thread_id() const noexcept;
 };
 
 }


### PR DESCRIPTION
@geirst please review
@havardpe @baldersheim FYI

Enable cross-thread stack tracing as part of signal handler init
code in both storage and proton daemons.

Make deadlock detector parameters live configurable. Remove existing
`restart` config definition annotations to reflect this.

Remove dumping of bucket DB locks which hasn't really worked for a
long time now.

