### PR TITLE
Stop providing guice.assistedinject, not used by vespa or tenants.

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -86,7 +86,6 @@
                                         <include>com.google.guava:failureaccess:[1.0.1]:jar:provided</include>
                                         <include>com.google.j2objc:j2objc-annotations:[1.1]:jar:provided</include>
 
-                                        <include>com.google.inject.extensions:guice-assistedinject:[${guice.version}]:jar:provided</include>
                                         <include>com.google.inject:guice:[${guice.version}]:jar:provided:no_aop</include>
                                         <include>com.sun.activation:javax.activation:[1.2.0]:jar:provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:[${jaxb.version}]:jar:provided</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -71,7 +71,6 @@
                                         <include>com.google.guava:failureaccess:[1.0.1]:jar:provided</include>
                                         <include>com.google.j2objc:j2objc-annotations:[1.1]:jar:provided</include>
 
-                                        <include>com.google.inject.extensions:guice-assistedinject:[${guice.version}]:jar:provided</include>
                                         <include>com.google.inject:guice:[${guice.version}]:jar:provided:no_aop</include>
                                         <include>com.sun.activation:javax.activation:[1.2.0]:jar:provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:[${jaxb.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -68,11 +68,6 @@
                 <version>${guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.inject.extensions</groupId>
-                <artifactId>guice-assistedinject</artifactId>
-                <version>${guice.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.inject</groupId>
                 <artifactId>guice</artifactId>
                 <version>${guice.version}</version>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -74,18 +74,6 @@
             <classifier>no_aop</classifier> <!-- Non-AOP version required for Java 8 compatibility -->
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-assistedinject</artifactId>
-            <scope>compile</scope>
-            <exclusions>
-                <!-- Depends on AOP version of Guice, which is not Java 8 compatible -->
-                <exclusion>
-                    <groupId>com.google.inject</groupId>
-                    <artifactId>guice</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.framework</artifactId>
             <scope>compile</scope>
@@ -227,7 +215,6 @@
                                 <argument>${exportPackagesFile}</argument>
                                 <argument>__REPLACE_VERSION__${project.build.directory}/dependency/guava.jar</argument>
                                 <argument>${project.build.directory}/dependency/guice-no_aop.jar</argument>
-                                <argument>${project.build.directory}/dependency/guice-assistedinject.jar</argument>
                                 <argument>${project.build.directory}/dependency/org.apache.felix.log.jar</argument>
                                 <argument>${project.build.directory}/dependency/slf4j-api.jar</argument>
                                 <argument>${project.build.directory}/dependency/slf4j-jdk14.jar</argument>

--- a/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
+++ b/jdisc_core_test/test_bundles/cert-k-pkgs/src/main/java/com/yahoo/jdisc/bundle/k/CertificateK.java
@@ -20,7 +20,6 @@ public class CertificateK {
     private final com.google.common.reflect.Reflection reflection = null;
     private final com.google.common.util.concurrent.AbstractIdleService idleService = null;
     private final com.google.inject.AbstractModule module = null;
-    private final com.google.inject.assistedinject.Assisted assisted = null;
     private final com.google.inject.binder.AnnotatedConstantBindingBuilder builder = null;
     private final com.google.inject.matcher.Matchers matchers = null;
     private final com.google.inject.multibindings.MapBinder<String, String> mapBinder = null;


### PR DESCRIPTION
- Artifact: com.google.inject.extensions:guice-assistedinject
- Package that was exported: com.google.inject.assistedinject

