### PR TITLE
Don't provide Jetty bundles from 'container' artifact

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -103,9 +103,6 @@
                                         <include>org.apache.felix:org.apache.felix.main:[${felix.version}]:jar:provided</include>
                                         <include>org.bouncycastle:bcpkix-jdk15on:[${bouncycastle.version}]:jar:provided</include>
                                         <include>org.bouncycastle:bcprov-jdk15on:[${bouncycastle.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-http:[${jetty.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-io:[${jetty.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-util:[${jetty.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:log4j-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:slf4j-api:[${slf4j.version}]:jar:provided</include>
@@ -233,16 +230,19 @@
                                         <include>org.eclipse.jetty.http2:http2-common:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty.http2:http2-hpack:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty.http2:http2-server:[${jetty.version}]:jar:test</include>
-                                        <include>org.eclipse.jetty:jetty-alpn-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-java-server:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-alpn-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-client:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-continuation:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-http:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-io:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-jmx:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-security:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-server:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlet:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-servlets:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty:jetty-util-ajax:[${jetty.version}]:jar:test</include>
+                                        <include>org.eclipse.jetty:jetty-util:[${jetty.version}]:jar:test</include>
                                         <include>org.hamcrest:hamcrest-core:1.3:jar:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:2.1.8:jar:test</include>
                                         <include>org.json:json:20090211:jar:test</include>

--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -293,6 +293,13 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <!-- TODO Remove when Jetty is embedded inside container-core -->
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <scope>test</scope>
+      <version>${jetty.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/configserver-flags/pom.xml
+++ b/configserver-flags/pom.xml
@@ -68,6 +68,13 @@
 
         <!-- test -->
         <dependency>
+            <!-- TODO Remove when Jetty is embedded inside container-core -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>defaults</artifactId>
             <version>${project.version}</version>

--- a/configserver/pom.xml
+++ b/configserver/pom.xml
@@ -279,6 +279,13 @@
       <artifactId>http-utils</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <!-- TODO Remove dependency on Jetty once no longer required for multi-part response parsing -->
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <version>${jetty.version}</version>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
   <build>

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
@@ -80,6 +80,7 @@ public class ApplicationApiHandler extends SessionHandler {
                 .orElse(false);
         if (multipartRequest) {
             try {
+                // TODO Remove direct dependency on Jetty for parsing multi-part response (add helper in container-core)
                 MultiPartFormInputStream multiPartFormInputStream = new MultiPartFormInputStream(request.getData(), request.getHeader(CONTENT_TYPE), /* config */null, /* contextTmpDir */null);
                 Map<String, Part> parts = multiPartFormInputStream.getParts().stream()
                         .collect(Collectors.toMap(Part::getName, p -> p));

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -88,9 +88,6 @@
                                         <include>org.apache.felix:org.apache.felix.main:[${felix.version}]:jar:provided</include>
                                         <include>org.bouncycastle:bcpkix-jdk15on:[${bouncycastle.version}]:jar:provided</include>
                                         <include>org.bouncycastle:bcprov-jdk15on:[${bouncycastle.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-http:[${jetty.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-io:[${jetty.version}]:jar:provided</include>
-                                        <include>org.eclipse.jetty:jetty-util:[${jetty.version}]:jar:provided</include>
                                         <include>org.slf4j:jcl-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:log4j-over-slf4j:[${slf4j.version}]:jar:provided</include>
                                         <include>org.slf4j:slf4j-api:[${slf4j.version}]:jar:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -170,21 +170,6 @@
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-http</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-io</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jcl-over-slf4j</artifactId>
                 <version>${slf4j.version}</version>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -156,6 +156,13 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- TODO Remove when Jetty is embedded inside container-core -->
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <scope>test</scope>
+      <version>${jetty.version}</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/flags/pom.xml
+++ b/flags/pom.xml
@@ -93,6 +93,13 @@
             <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- TODO Remove when Jetty is embedded inside container-core -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+            <version>${jetty.version}</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/metrics-proxy/pom.xml
+++ b/metrics-proxy/pom.xml
@@ -143,9 +143,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- TODO Remove when Jetty is embedded inside container-core -->
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http</artifactId>
       <scope>test</scope>
+      <version>${jetty.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/provided-dependencies/pom.xml
+++ b/provided-dependencies/pom.xml
@@ -31,14 +31,6 @@
       <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-http</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>config-lib</artifactId>
       <version>${project.version}</version>

--- a/routing-generator/pom.xml
+++ b/routing-generator/pom.xml
@@ -34,6 +34,13 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <!-- TODO Remove when Jetty is embedded inside container-core -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+            <version>${jetty.version}</version>
+        </dependency>
 
         <!-- provided -->
         <dependency>

--- a/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/DefaultIdentityDocumentClient.java
+++ b/vespa-athenz/src/main/java/com/yahoo/vespa/athenz/identityprovider/client/DefaultIdentityDocumentClient.java
@@ -16,7 +16,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.eclipse.jetty.http.HttpStatus;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -80,7 +79,8 @@ public class DefaultIdentityDocumentClient implements IdentityDocumentClient {
                     .build();
             try (CloseableHttpResponse response = client.execute(request)) {
                 String responseContent = EntityUtils.toString(response.getEntity());
-                if (HttpStatus.isSuccess(response.getStatusLine().getStatusCode())) {
+                int statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode >= 200 && statusCode <= 299) {
                     SignedIdentityDocumentEntity entity = objectMapper.readValue(responseContent, SignedIdentityDocumentEntity.class);
                     return EntityBindingsMapper.toSignedIdentityDocument(entity);
                 } else {
@@ -88,7 +88,7 @@ public class DefaultIdentityDocumentClient implements IdentityDocumentClient {
                             String.format(
                                     "Failed to retrieve identity document for host %s: %d - %s",
                                     host,
-                                    response.getStatusLine().getStatusCode(),
+                                    statusCode,
                                     responseContent));
                 }
             }

--- a/vespa-hadoop/pom.xml
+++ b/vespa-hadoop/pom.xml
@@ -21,6 +21,17 @@
         <pig.version>0.14.0</pig.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Force newer version of jetty-util (to match Jetty version of jdisc) -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Hadoop dependencies -->
         <dependency>

--- a/vespa-osgi-testrunner/pom.xml
+++ b/vespa-osgi-testrunner/pom.xml
@@ -22,6 +22,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <!-- TODO Remove when Jetty is embedded inside container-core -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <scope>test</scope>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>hosted-api</artifactId>
             <version>${project.version}</version>

--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -33,6 +33,19 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>container-core</artifactId>
+            <scope>compile</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <!-- TODO Remove when Jetty is embedded inside container-core -->
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <!-- TODO: remove dependency on container-dev, and instead depend directly on what this module needs! -->
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>container-dev</artifactId>


### PR DESCRIPTION
Add dependency on 'jetty-http' with scope test instead of adding false dependencies with 'container-test'.

Next step is to embedded the core Jetty artifacts inside container-core + create wrapper for multipart-parsing.