### PR TITLE
Disallow impossible redundancy

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/NodesSpecification.java
@@ -60,13 +60,17 @@ public class NodesSpecification {
     /** The cloud account to use for nodes in this spec, if any */
     private final Optional<CloudAccount> cloudAccount;
 
+    /* Whether the count attribute was present on the nodes element. */
+    private final boolean hasCountAttribute;
+
     private NodesSpecification(ClusterResources min,
                                ClusterResources max,
                                boolean dedicated, Version version,
                                boolean required, boolean canFail, boolean exclusive,
                                Optional<DockerImage> dockerImageRepo,
                                Optional<String> combinedId,
-                               Optional<CloudAccount> cloudAccount) {
+                               Optional<CloudAccount> cloudAccount,
+                               boolean hasCountAttribute) {
         if (max.smallerThan(min))
             throw new IllegalArgumentException("Min resources must be larger or equal to max resources, but " +
                                                max + " is smaller than " + min);
@@ -89,6 +93,7 @@ public class NodesSpecification {
         this.dockerImageRepo = dockerImageRepo;
         this.combinedId = combinedId;
         this.cloudAccount = cloudAccount;
+        this.hasCountAttribute = hasCountAttribute;
     }
 
     private static NodesSpecification create(boolean dedicated, boolean canFail, Version version,
@@ -97,6 +102,7 @@ public class NodesSpecification {
         var resolvedElement = resolveElement(nodesElement);
         var combinedId = findCombinedId(nodesElement, resolvedElement);
         var resources = toResources(resolvedElement);
+        boolean hasCountAttribute = resolvedElement.stringAttribute("count") != null;
         return new NodesSpecification(resources.getFirst(),
                                       resources.getSecond(),
                                       dedicated,
@@ -106,7 +112,8 @@ public class NodesSpecification {
                                       resolvedElement.booleanAttribute("exclusive", false),
                                       dockerImageToUse(resolvedElement, dockerImageRepo),
                                       combinedId,
-                                      cloudAccount);
+                                      cloudAccount,
+                                      hasCountAttribute);
     }
 
     private static Pair<ClusterResources, ClusterResources> toResources(ModelElement nodesElement) {
@@ -180,7 +187,8 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       Optional.empty(),
-                                      context.getDeployState().getProperties().cloudAccount());
+                                      context.getDeployState().getProperties().cloudAccount(),
+                                      false);
     }
 
     /** Returns a requirement from <code>count</code> dedicated nodes in one group */
@@ -194,7 +202,8 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       Optional.empty(),
-                                      context.getDeployState().getProperties().cloudAccount());
+                                      context.getDeployState().getProperties().cloudAccount(),
+                                      false);
     }
 
     /**
@@ -219,7 +228,8 @@ public class NodesSpecification {
                                       false,
                                       context.getDeployState().getWantedDockerImageRepo(),
                                       Optional.empty(),
-                                      context.getDeployState().getProperties().cloudAccount());
+                                      context.getDeployState().getProperties().cloudAccount(),
+                                      false);
     }
 
     public ClusterResources minResources() { return min; }
@@ -237,6 +247,11 @@ public class NodesSpecification {
      * and increases cost.
      */
     public boolean isExclusive() { return exclusive; }
+
+    /** Returns whether the count attribute was present on the {@code <nodes>} element. */
+    public boolean hasCountAttribute() {
+        return hasCountAttribute;
+    }
 
     public Map<HostResource, ClusterMembership> provision(HostSystem hostSystem,
                                                           ClusterSpec.Type clusterType,
@@ -451,5 +466,4 @@ public class NodesSpecification {
         return "specification of " + (dedicated ? "dedicated " : "") +
                (min.equals(max) ? min : "min " + min + " max " + max);
     }
-
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Environment;
 import com.yahoo.vespa.config.content.StorDistributionConfig;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.HostSystem;
@@ -203,9 +204,8 @@ public class StorageGroup {
         }
 
         public StorageGroup buildRootGroup(DeployState deployState, RedundancyBuilder redundancyBuilder, ContentCluster owner) {
-            Optional<Integer> maxRedundancy = Optional.empty();
             if (owner.isHosted())
-                maxRedundancy = validateRedundancyAndGroups();
+                validateRedundancyAndGroups(deployState.zone().environment());
 
             Optional<ModelElement> group = Optional.ofNullable(clusterElement.child("group"));
             Optional<ModelElement> nodes = getNodes(clusterElement);
@@ -222,8 +222,7 @@ public class StorageGroup {
                                         : groupBuilder.buildNonHosted(deployState, owner, Optional.empty());
 
             Redundancy redundancy = redundancyBuilder.build(owner.getName(), owner.isHosted(), storageGroup.subgroups.size(),
-                                                            storageGroup.getNumberOfLeafGroups(), storageGroup.countNodes(false),
-                                                            maxRedundancy);
+                                                            storageGroup.getNumberOfLeafGroups(), storageGroup.countNodes(false));
             owner.setRedundancy(redundancy);
             if (storageGroup.partitions.isEmpty() && (redundancy.groups() > 1)) {
                 storageGroup.partitions = Optional.of(computePartitions(redundancy.finalRedundancy(), redundancy.groups()));
@@ -231,27 +230,24 @@ public class StorageGroup {
             return storageGroup;
         }
 
-        private Optional<Integer> validateRedundancyAndGroups() {
+        private void validateRedundancyAndGroups(Environment environment) {
             var redundancyElement = clusterElement.child("redundancy");
-            if (redundancyElement == null) return Optional.empty();
+            if (redundancyElement == null) return;
             long redundancy = redundancyElement.asLong();
 
             var nodesElement = clusterElement.child("nodes");
-            if (nodesElement == null) return Optional.empty();
+            if (nodesElement == null) return;
             var nodesSpec = NodesSpecification.from(nodesElement, context);
+
+            // Allow dev deployment of self-hosted app (w/o count attribute): absent count => 1 node
+            if (!nodesSpec.hasCountAttribute() && environment == Environment.dev) return;
 
             int minNodesPerGroup = (int)Math.ceil((double)nodesSpec.minResources().nodes() / nodesSpec.minResources().groups());
 
-            if (minNodesPerGroup < redundancy) { // TODO: Fail on this on Vespa 8, and simplify? But see ModelProvisioningTest.testThatStandaloneSyntaxWorksOnHostedManuallyDeployed
-                context.getDeployLogger()
-                       .logApplicationPackage(Level.WARNING,
-                                              "Cluster '" + clusterElement.stringAttribute("id") + "' " +
-                                              "specifies redundancy " + redundancy + " but cannot be higher than " +
-                                              "the minimum nodes per group, which is " + minNodesPerGroup);
-                return Optional.of(minNodesPerGroup);
-            }
-            else {
-                return Optional.empty();
+            if (minNodesPerGroup < redundancy) {
+                throw new IllegalArgumentException("Cluster '" + clusterElement.stringAttribute("id") + "' " +
+                                                   "specifies redundancy " + redundancy + ", but it cannot be higher than " +
+                                                   "the minimum nodes per group, which is " + minNodesPerGroup);
             }
         }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/RedundancyBuilder.java
@@ -5,8 +5,6 @@ import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.IndexedHierarchicDistributionValidator;
 import com.yahoo.vespa.model.content.Redundancy;
 
-import java.util.Optional;
-
 /**
  * Builds redundancy config for a content cluster.
  */
@@ -39,13 +37,7 @@ public class RedundancyBuilder {
             }
         }
     }
-    public Redundancy build(String clusterName, boolean isHosted, int subGroups, int leafGroups,  int totalNodes,
-                            Optional<Integer> maxRedundancy) {
-        if (maxRedundancy.isPresent()) {
-            initialRedundancy = Math.min(initialRedundancy, maxRedundancy.get());
-            finalRedundancy = Math.min(finalRedundancy, maxRedundancy.get());
-            readyCopies = Math.min(readyCopies, maxRedundancy.get());
-        }
+    public Redundancy build(String clusterName, boolean isHosted, int subGroups, int leafGroups,  int totalNodes) {
         if (isHosted) {
             return new Redundancy(initialRedundancy, finalRedundancy, readyCopies, leafGroups, totalNodes);
         } else {

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -1107,16 +1107,13 @@ public class ModelProvisioningTest {
         int numberOfHosts = 3;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false, "node-1-3-50-03");
-        assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
-
-        ContentCluster cluster = model.getContentClusters().get("bar");
-        assertEquals(2, cluster.redundancy().effectiveInitialRedundancy());
-        assertEquals(2, cluster.redundancy().effectiveFinalRedundancy());
-        assertEquals(2, cluster.redundancy().effectiveReadyCopies());
-        assertEquals("1|*", cluster.getRootGroup().getPartitions().get());
-        assertEquals(0, cluster.getRootGroup().getNodes().size());
-        assertEquals(2, cluster.getRootGroup().getSubgroups().size());
+        try {
+            VespaModel model = tester.createModel(services, false, "node-1-3-50-03");
+            fail("Expected exception");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals("Cluster 'bar' specifies redundancy 2, but it cannot be higher than the minimum nodes per group, which is 1", Exceptions.toMessageString(e));
+        }
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/VespaModelTester.java
@@ -192,14 +192,19 @@ public class VespaModelTester {
         VespaModelCreatorWithMockPkg modelCreatorWithMockPkg = new VespaModelCreatorWithMockPkg(hosts, services, generateSchemas("type1"));
         ApplicationPackage appPkg = modelCreatorWithMockPkg.appPkg;
 
-        provisioner = hosted ?        new ProvisionerAdapter(new InMemoryProvisioner(hostsByResources,
-                                                                                     failOnOutOfCapacity,
-                                                                                     useMaxResources,
-                                                                                     alwaysReturnOneNode,
-                                                                                     false,
-                                                                                     startIndexForClusters,
-                                                                                     retiredHostNames)) :
-                                      new SingleNodeProvisioner();
+        if (hosted) {
+            InMemoryProvisioner provisioner = new InMemoryProvisioner(hostsByResources,
+                                                                      failOnOutOfCapacity,
+                                                                      useMaxResources,
+                                                                      alwaysReturnOneNode,
+                                                                      false,
+                                                                      startIndexForClusters,
+                                                                      retiredHostNames);
+            provisioner.setEnvironment(zone.environment());
+            this.provisioner = new ProvisionerAdapter(provisioner);
+        } else {
+            provisioner = new SingleNodeProvisioner();
+        }
 
         TestProperties properties = new TestProperties()
                 .setMultitenant(hosted) // Note: system tests are multitenant but not hosted

--- a/configserver/src/test/apps/hosted-no-write-access-control/services.xml
+++ b/configserver/src/test/apps/hosted-no-write-access-control/services.xml
@@ -15,7 +15,7 @@
   </container>
 
   <content id="music" version="1.0">
-    <redundancy>2</redundancy>
+    <redundancy>1</redundancy>
     <documents>
       <document type="music" mode="index" />
     </documents>

--- a/configserver/src/test/apps/hosted-no-write-access-control/services.xml
+++ b/configserver/src/test/apps/hosted-no-write-access-control/services.xml
@@ -15,11 +15,11 @@
   </container>
 
   <content id="music" version="1.0">
-    <redundancy>1</redundancy>
+    <redundancy>2</redundancy>
     <documents>
       <document type="music" mode="index" />
     </documents>
-    <nodes count="2" groups="2"/>
+    <nodes count="4" groups="2"/>
   </content>
 
 </services>

--- a/configserver/src/test/apps/hosted/services.xml
+++ b/configserver/src/test/apps/hosted/services.xml
@@ -18,11 +18,11 @@
   </container>
 
   <content id="music" version="1.0">
-    <redundancy>1</redundancy>
+    <redundancy>2</redundancy>
     <documents>
       <document type="music" mode="index" />
     </documents>
-    <nodes count="2" groups="2"/>
+    <nodes count="4" groups="2"/>
   </content>
 
 </services>

--- a/configserver/src/test/apps/hosted/services.xml
+++ b/configserver/src/test/apps/hosted/services.xml
@@ -18,7 +18,7 @@
   </container>
 
   <content id="music" version="1.0">
-    <redundancy>2</redundancy>
+    <redundancy>1</redundancy>
     <documents>
       <document type="music" mode="index" />
     </documents>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ConfigServerBootstrapTest.java
@@ -66,7 +66,7 @@ public class ConfigServerBootstrapTest {
     @Test
     public void testBootstrap() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        InMemoryProvisioner provisioner = new InMemoryProvisioner(7, false);
+        InMemoryProvisioner provisioner = new InMemoryProvisioner(9, false);
         DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory())
                                                                        .configserverConfig(configserverConfig)
                                                                        .hostProvisioner(provisioner).build();
@@ -104,7 +104,7 @@ public class ConfigServerBootstrapTest {
     @Test
     public void testBootstrapWithVipStatusFile() throws Exception {
         ConfigserverConfig configserverConfig = createConfigserverConfig(temporaryFolder);
-        InMemoryProvisioner provisioner = new InMemoryProvisioner(7, false);
+        InMemoryProvisioner provisioner = new InMemoryProvisioner(9, false);
         DeployTester tester = new DeployTester.Builder(temporaryFolder).modelFactory(createHostedModelFactory())
                 .configserverConfig(configserverConfig).hostProvisioner(provisioner).build();
         tester.deployApp("src/test/apps/hosted/");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -173,7 +173,7 @@ public class DeployTester {
     }
 
     private static HostProvisioner createProvisioner() {
-        return new InMemoryProvisioner(7, false);
+        return new InMemoryProvisioner(9, false);
     }
 
     private static class FailingModelFactory implements ModelFactory {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -165,7 +165,7 @@ public class HostedDeployTest {
                                                                        .hostedConfigserverConfig(Zone.defaultZone())
                                                                        .build();
         tester.deployApp("src/test/apps/hosted/", "6.2.0");
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
     }
 
     /**
@@ -174,7 +174,7 @@ public class HostedDeployTest {
      */
     @Test
     public void testCreateOnlyNeededModelVersions() {
-        List<Host> hosts = createHosts(7, "6.0.0", "6.1.0", null, "6.1.0"); // Use a host without a version as well.
+        List<Host> hosts = createHosts(9, "6.0.0", "6.1.0", null, "6.1.0"); // Use a host without a version as well.
 
         CountingModelFactory factory600 = createHostedModelFactory(Version.fromString("6.0.0"));
         CountingModelFactory factory610 = createHostedModelFactory(Version.fromString("6.1.0"));
@@ -188,7 +188,7 @@ public class HostedDeployTest {
         DeployTester tester = createTester(hosts, modelFactories, prodZone);
         // Deploy with version that does not exist on hosts, the model for this version should also be created
         tester.deployApp("src/test/apps/hosted/", "7.0.0");
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
 
         // Check >0 not ==0 as the session watcher thread is running and will redeploy models in the background
         assertTrue(factory600.creationCount() > 0);
@@ -205,7 +205,7 @@ public class HostedDeployTest {
      */
     @Test
     public void testCreateOnlyNeededModelVersionsNewNodes() {
-        List<Host> hosts = createHosts(7, (String) null);
+        List<Host> hosts = createHosts(9, (String) null);
 
         CountingModelFactory factory600 = createHostedModelFactory(Version.fromString("6.0.0"));
         CountingModelFactory factory610 = createHostedModelFactory(Version.fromString("6.1.0"));
@@ -216,7 +216,7 @@ public class HostedDeployTest {
         DeployTester tester = createTester(hosts, modelFactories, prodZone);
         // Deploy with version that does not exist on hosts, the model for this version should also be created
         tester.deployApp("src/test/apps/hosted/", "7.0.0");
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
 
         // Check >0 not ==0 as the session watcher thread is running and will redeploy models in the background
         assertTrue(factory700.creationCount() > 0);
@@ -229,7 +229,7 @@ public class HostedDeployTest {
      */
     @Test
     public void testCreateNeededModelVersionsForManuallyDeployedApps() {
-        List<Host> hosts = createHosts(5, "7.0.0");
+        List<Host> hosts = createHosts(7, "7.0.0");
 
         CountingModelFactory factory700 = createHostedModelFactory(Version.fromString("7.0.0"), devZone);
         CountingModelFactory factory710 = createHostedModelFactory(Version.fromString("7.1.0"), devZone);
@@ -239,7 +239,7 @@ public class HostedDeployTest {
         DeployTester tester = createTester(hosts, modelFactories, devZone);
         // Deploy with version that does not exist on hosts, the model for this version should also be created
         tester.deployApp("src/test/apps/hosted/", "7.2.0");
-        assertEquals(5, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
 
         // Check >0 not ==0 as the session watcher thread is running and will redeploy models in the background
         // Nodes are on 7.0.0 (should be created), no nodes on 7.1.0 (should not be created), 7.2.0 should always be created
@@ -254,7 +254,7 @@ public class HostedDeployTest {
      */
     @Test
     public void testCreateModelVersionsForManuallyDeployedAppsWhenCreatingFailsForOneVersion() {
-        List<Host> hosts = createHosts(5, "7.0.0");
+        List<Host> hosts = createHosts(7, "7.0.0");
 
         ModelFactory factory700 = createFailingModelFactory(Version.fromString("7.0.0"));
         CountingModelFactory factory720 = createHostedModelFactory(Version.fromString("7.2.0"), devZone);
@@ -264,7 +264,7 @@ public class HostedDeployTest {
         // Deploy with version that does not exist on hosts, the model for this version should be created even
         // if creating 7.0.0 fails
         tester.deployApp("src/test/apps/hosted/", "7.2.0");
-        assertEquals(5, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
 
         // Check >0 not ==0 as the session watcher thread is running and will redeploy models in the background
         assertTrue("Newest model for latest major version is always included", factory720.creationCount() > 0);
@@ -299,7 +299,7 @@ public class HostedDeployTest {
         String oldestVersion = oldestMajorVersion + ".0.0";
         String newestOnOldMajorVersion = oldestMajorVersion + ".1.0";
         String newestOnNewMajorVersion = newestMajorVersion + ".2.0";
-        List<Host> hosts = createHosts(7, oldestVersion, newestOnNewMajorVersion);
+        List<Host> hosts = createHosts(9, oldestVersion, newestOnNewMajorVersion);
 
         CountingModelFactory factory1 = createHostedModelFactory(Version.fromString(oldestVersion));
         CountingModelFactory factory2 = createHostedModelFactory(Version.fromString(newestOnOldMajorVersion));
@@ -308,7 +308,7 @@ public class HostedDeployTest {
 
         DeployTester tester = createTester(hosts, modelFactories, prodZone);
         tester.deployApp("src/test/apps/hosted/", oldestVersion);
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
 
         // Check >0 not ==0 as the session watcher thread is running and will redeploy models in the background
         assertTrue(factory1.creationCount() > 0);
@@ -350,7 +350,7 @@ public class HostedDeployTest {
     @Test
     public void testAccessControlIsOnlyCheckedWhenNoProdDeploymentExists() {
         // Provisioner does not reuse hosts, so need twice as many hosts as app requires
-        List<Host> hosts = createHosts(14, "6.0.0");
+        List<Host> hosts = createHosts(18, "6.0.0");
 
         List<ModelFactory> modelFactories = List.of(createHostedModelFactory(Version.fromString("6.0.0")),
                                                     createHostedModelFactory(Version.fromString("6.1.0")),
@@ -360,12 +360,12 @@ public class HostedDeployTest {
         ApplicationId applicationId = tester.applicationId();
         // Deploy with oldest version
         tester.deployApp("src/test/apps/hosted/", "6.0.0");
-        assertEquals(7, tester.getAllocatedHostsOf(applicationId).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(applicationId).getHosts().size());
 
         // Deploy with version that does not exist on hosts and with app package that has no write access control,
         // validation of access control should not be done, since the app is already deployed in prod
         tester.deployApp("src/test/apps/hosted-no-write-access-control", "6.1.0");
-        assertEquals(7, tester.getAllocatedHostsOf(applicationId).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(applicationId).getHosts().size());
     }
 
     @Test
@@ -408,7 +408,7 @@ public class HostedDeployTest {
 
     @Test
     public void testThatConfigChangeActionsAreCollectedFromAllModels() {
-        List<Host> hosts = createHosts(7, "6.1.0", "6.2.0");
+        List<Host> hosts = createHosts(9, "6.1.0", "6.2.0");
         List<ServiceInfo> services = List.of(
                 new ServiceInfo("serviceName", "serviceType", null, new HashMap<>(), "configId", "hostName"));
 
@@ -421,12 +421,12 @@ public class HostedDeployTest {
         DeployTester tester = createTester(hosts, modelFactories, prodZone);
         tester.deployApp("src/test/apps/hosted/", "6.2.0");
 
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
     }
 
     @Test
     public void testThatAllowedConfigChangeActionsAreActedUpon() {
-        List<Host> hosts = createHosts(7, "6.1.0");
+        List<Host> hosts = createHosts(9, "6.1.0");
         List<ServiceInfo> services = List.of(
                 new ServiceInfo("serviceName", "serviceType", null, Map.of("clustername", "cluster"), "configId", "hostName"));
 
@@ -447,7 +447,7 @@ public class HostedDeployTest {
                 .build();
         PrepareResult prepareResult = tester.deployApp("src/test/apps/hosted/", "6.1.0");
 
-        assertEquals(7, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
+        assertEquals(9, tester.getAllocatedHostsOf(tester.applicationId()).getHosts().size());
         assertTrue(prepareResult.configChangeActions().getRestartActions().isEmpty()); // Handled by deployment.
         assertEquals(Optional.of(ApplicationReindexing.empty()
                                                       .withPending("cluster", "music", prepareResult.sessionId())),

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/MaintainerTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/MaintainerTester.java
@@ -31,7 +31,7 @@ class MaintainerTester {
 
     MaintainerTester(Clock clock, TemporaryFolder temporaryFolder) throws IOException {
         this.curator = new MockCurator();
-        InMemoryProvisioner hostProvisioner = new InMemoryProvisioner(7, false);
+        InMemoryProvisioner hostProvisioner = new InMemoryProvisioner(9, false);
         Provisioner provisioner = new MockProvisioner().hostProvisioner(hostProvisioner);
         ConfigserverConfig configserverConfig = new ConfigserverConfig.Builder()
                 .hostedVespa(true)


### PR DESCRIPTION
But allow it for hosted deployment in dev if the count attribute of the nodes element is absent, to support deployment of self-hosted apps to dev.
