### PR TITLE
add fieldsets after inheriting

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedTypes.java
+++ b/config-model/src/main/java/com/yahoo/schema/parser/ConvertParsedTypes.java
@@ -170,10 +170,10 @@ public class ConvertParsedTypes {
             for (var fieldset : schema.getFieldSets()) {
                 fieldSets.put(fieldset.name(), fieldset.getFieldNames());
             }
-            docToFill.addFieldSets(fieldSets);
             for (String inherit : doc.getInherited()) {
                 docToFill.inherit(findDocFromSchemas(inherit));
             }
+            docToFill.addFieldSets(fieldSets);
         }
     }
 

--- a/document/src/vespa/document/repo/documenttyperepo.cpp
+++ b/document/src/vespa/document/repo/documenttyperepo.cpp
@@ -819,13 +819,6 @@ private:
         for (const auto & importD : docT.importedfield) {
             doc_type->add_imported_field_name(importD.name);
         }
-        for (const auto & entry : docT.fieldsets) {
-            DocumentType::FieldSet::Fields fields;
-            for (const auto& f : entry.second.fields) {
-                fields.insert(f);
-            }
-            doc_type->addFieldSet(entry.first, fields);
-        }
         for (const auto & inheritD : docT.inherits) {
             const DataType *dt = _made_types[inheritD.idx];
             const DocumentType * parent = dynamic_cast<const DocumentType *>(dt);
@@ -836,6 +829,13 @@ private:
             } else {
                 doc_type->inherit(*parent);
             }
+        }
+        for (const auto & entry : docT.fieldsets) {
+            DocumentType::FieldSet::Fields fields;
+            for (const auto& f : entry.second.fields) {
+                fields.insert(f);
+            }
+            doc_type->addFieldSet(entry.first, fields);
         }
     }
 


### PR DESCRIPTION
* bad design of DocumentType class (in both Java and C++)
  causes silent failures when this is done in the wrong order.

@baldersheim please review
