### PR TITLE
Remove test that invokes undefined pthread behavior

### DIFF
--- a/vespalib/src/tests/signalhandler/signalhandler_test.cpp
+++ b/vespalib/src/tests/signalhandler/signalhandler_test.cpp
@@ -53,17 +53,6 @@ TEST(SignalHandlerTest, can_dump_stack_of_another_thread)
     t.join();
 }
 
-TEST(SignalHandlerTest, dumping_stack_of_an_ex_thread_does_not_crash)
-{
-    std::thread t([]() noexcept {
-        // Do a lot of nothing at all.
-    });
-    auto tid = t.native_handle();
-    t.join();
-    auto trace = SignalHandler::get_cross_thread_stack_trace(tid);
-    EXPECT_EQ(trace, "(pthread_kill() failed; could not get backtrace)");
-}
-
 TEST(SignalHandlerTest, can_get_stack_trace_of_own_thread)
 {
     auto trace = my_totally_tubular_and_groovy_function();

--- a/vespalib/src/vespa/vespalib/util/signalhandler.h
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.h
@@ -131,7 +131,8 @@ public:
     /**
      * Get the stack trace of the current point of execution of the thread referenced
      * by `thread_id`. This may be the same ID as the calling thread, in which case
-     * the current call stack is returned.
+     * the current call stack is returned. The pthread_t ID must be valid; invoking
+     * this function without a valid ID is undefined behavior.
      *
      * Returned format is the same as that of vespalib::getStackTrace().
      *


### PR DESCRIPTION
@toregge please review
@havardpe FYI

It is not well-defined to call a pthread function with a thread that
is no longer valid. Remove test and add a precondition comment to
the function that IDs must be valid.

