### PR TITLE
Clean up 'searchchain' and 'searchchains' syntax in services.xml

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainsBuilder.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom.chains;
 
-import com.yahoo.config.application.Xml;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
@@ -26,16 +25,10 @@ class DomChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends Chai
         extends VespaDomBuilder.DomConfigProducerBuilder<CHAINS> {
 
     private final Collection<ComponentType<COMPONENT>> allowedComponentTypes;
-    private final String appPkgChainsDir;
-    private final Element outerChainsElem;
 
-    protected DomChainsBuilder(Element outerChainsElem,
-                               Collection<ComponentType<COMPONENT>> allowedComponentTypes,
-                               String appPkgChainsDir) {
+    protected DomChainsBuilder(Collection<ComponentType<COMPONENT>> allowedComponentTypes) {
 
-        this.outerChainsElem = outerChainsElem;
         this.allowedComponentTypes = new ArrayList<>(allowedComponentTypes);
-        this.appPkgChainsDir = appPkgChainsDir;
     }
 
     protected abstract CHAINS newChainsInstance(AbstractConfigProducer<?> parent);
@@ -58,12 +51,7 @@ class DomChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends Chai
 
     private List<Element> allChainElements(DeployState deployState, Element chainsElement) {
         List<Element> chainsElements = new ArrayList<>();
-        if (outerChainsElem != null)
-            chainsElements.add(outerChainsElem);
         chainsElements.add(chainsElement);
-
-        if (appPkgChainsDir != null)
-            chainsElements.addAll(Xml.allElemsFromPath(deployState.getApplicationPackage(), appPkgChainsDir));
 
         return chainsElements;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/InheritanceBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/InheritanceBuilder.java
@@ -18,36 +18,20 @@ public class InheritanceBuilder {
 
     public InheritanceBuilder(Element spec) {
         inheritance = new ChainSpecification.Inheritance(
-                // XXX: for this to work, the tagname in the spec must match the tagname inside the 'inherits' elem, e.g. 'searchchain->inherits->searchchain'
-                read(spec, "inherits", spec.getTagName()),
-                read(spec, "excludes", "exclude"));
+                read(spec, "inherits"),
+                read(spec, "excludes"));
     }
 
     public ChainSpecification.Inheritance build() {
         return inheritance;
     }
 
-    private Set<ComponentSpecification> read(Element spec, String attributeName, String elementName) {
+    private Set<ComponentSpecification> read(Element spec, String attributeName) {
         Set<ComponentSpecification> componentSpecifications = new LinkedHashSet<>();
 
         componentSpecifications.addAll(spaceSeparatedComponentSpecificationsFromAttribute(spec, attributeName));
 
-        // TODO: the 'inherits' element is undocumented, and can be removed in an upcoming version of Vespa
-        componentSpecifications.addAll(idRefFromElements(XML.getChild(spec, "inherits"), elementName));
-
-
         return componentSpecifications;
-    }
-
-    private Collection<ComponentSpecification> idRefFromElements(Element spec, String elementName) {
-        Collection<ComponentSpecification> result = new ArrayList<>();
-        if (spec == null)
-            return result;
-
-        for (Element element : XML.getChildren(spec, elementName)) {
-            result.add(XmlHelper.getIdRef(element));
-        }
-        return result;
     }
 
     private Collection<ComponentSpecification> spaceSeparatedComponentSpecificationsFromAttribute(Element spec, String attributeName) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom.chains.docproc;
 
-import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
@@ -20,8 +19,8 @@ import java.util.Map;
  */
 public class DomDocprocChainsBuilder  extends DomChainsBuilder<DocumentProcessor, DocprocChain, DocprocChains> {
     public DomDocprocChainsBuilder(Element outerChainsElem, boolean supportDocprocChainsDir) {
-        super(outerChainsElem, List.of(ComponentType.documentprocessor),
-              supportDocprocChainsDir ? ApplicationPackage.DOCPROCCHAINS_DIR: null);
+        super(List.of(ComponentType.documentprocessor)
+        );
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingBuilder.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.builder.xml.dom.chains.processing;
 
-import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
@@ -21,7 +20,7 @@ import java.util.Map;
 public class DomProcessingBuilder extends DomChainsBuilder<Processor, ProcessingChain, ProcessingChains> {
 
     public DomProcessingBuilder(Element outerChainsElem) {
-        super(outerChainsElem, List.of(ComponentsBuilder.ComponentType.processor), ApplicationPackage.PROCESSORCHAINS_DIR);
+        super(List.of(ComponentsBuilder.ComponentType.processor));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainsBuilder.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
-import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainsBuilder;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChain;
@@ -22,14 +21,8 @@ import java.util.Map;
  */
 public class DomSearchChainsBuilder extends DomChainsBuilder<Searcher<?>, SearchChain, SearchChains> {
 
-    public DomSearchChainsBuilder(Element outerChainsElem, boolean supportSearchChainsDir) {
-        super(outerChainsElem, Arrays.asList(ComponentType.searcher, ComponentType.federation),
-              supportSearchChainsDir ? ApplicationPackage.SEARCHCHAINS_DIR: null);
-    }
-
-    // For unit testing without outer chains
     public DomSearchChainsBuilder() {
-        this(null, false);
+        super(Arrays.asList(ComponentType.searcher, ComponentType.federation));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/SearchChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/SearchChainsBuilder.java
@@ -25,9 +25,8 @@ public class SearchChainsBuilder extends ChainsBuilder<Searcher<?>, SearchChain>
 
     private static final Map<String, Class<? extends DomChainBuilderBase<? extends Searcher<?>, ? extends SearchChain>>>
             chainType2builderClass = Collections.unmodifiableMap(
-            new LinkedHashMap<String, Class<? extends DomChainBuilderBase<? extends Searcher<?>, ? extends SearchChain>>>() {{
+            new LinkedHashMap<>() {{
                 put("chain", DomSearchChainBuilder.class);
-                put("searchchain", DomSearchChainBuilder.class);
                 put("provider", DomProviderBuilder.class);
             }});
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainsBuilder.java
@@ -31,7 +31,7 @@ public class FilterChainsBuilder extends DomChainsBuilder<Filter, Chain<Filter>,
                     HttpBuilder.RESPONSE_CHAIN_TAG_NAME, FilterChainBuilder.class);
 
     public FilterChainsBuilder() {
-        super(null, allowedComponentTypes, null);
+        super(allowedComponentTypes);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -602,7 +602,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private ContainerSearch buildSearch(DeployState deployState, ApplicationContainerCluster containerCluster, Element producerSpec) {
-        SearchChains searchChains = new DomSearchChainsBuilder(null, false)
+        SearchChains searchChains = new DomSearchChainsBuilder()
                                             .build(deployState, containerCluster, producerSpec);
 
         ContainerSearch containerSearch = new ContainerSearch(containerCluster, searchChains, new ContainerSearch.Options());

--- a/config-model/src/main/resources/schema/federation.rnc
+++ b/config-model/src/main/resources/schema/federation.rnc
@@ -2,7 +2,7 @@
 # Schema for federation configuration inside the searchchains section.
 
 GenericSource =
-    GenericSearchChainInQrservers &
+    SearchChainInFederation &
     FederationOptions?
 
 Source =

--- a/config-model/src/main/resources/schema/searchchains-standalone.rnc
+++ b/config-model/src/main/resources/schema/searchchains-standalone.rnc
@@ -1,4 +1,0 @@
-# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-include "common.rnc"
-include "searchchains.rnc"
-start = SearchChains

--- a/config-model/src/main/resources/schema/searchchains.rnc
+++ b/config-model/src/main/resources/schema/searchchains.rnc
@@ -3,40 +3,17 @@
 
 include "federation.rnc"
 
-SearchChains =
-    element searchchains {
-        Searcher* &
-        SearchChainInQrservers* &
-        GenericConfig*
-   }
-
-OuterSearchChains =
-    element searchchains {
-        Searcher* &
-        SearchChainInQrservers*
-   }
-
-SearchChainInQrservers =
-    element searchchain {
-        GenericSearchChainInQrservers
-    } |
-    Provider
-
-GenericSearchChainInQrservers =
+SearchChainInFederation =
     ComponentId &
-    SearchChainInheritanceInQrservers &
+    SearchChainInheritanceInFederation &
     attribute searchers { text }? &
     Searcher* &
     Phase* &
     GenericConfig*
 
-SearchChainInheritanceInQrservers =
+SearchChainInheritanceInFederation =
     attribute inherits { text }? &
-    attribute excludes { text }? &
-    element inherits {
-        element searchchain { ComponentSpec }* &
-        element exclude { ComponentSpec }*
-    }?
+    attribute excludes { text }?
 
 Searcher =
     RegularSearcher |

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
@@ -83,8 +83,8 @@ public class VespaDomBuilderTest {
 
     @Test
     public void testGetElement() {
-        Element e = Xml.getElement(new StringReader("<searchchain><foo>sdf</foo></searchchain>"));
-        assertEquals(e.getTagName(), "searchchain");
+        Element e = Xml.getElement(new StringReader("<chain><foo>sdf</foo></chain>"));
+        assertEquals(e.getTagName(), "chain");
         assertEquals(XML.getChild(e, "foo").getTagName(), "foo");
         assertEquals(XML.getValue(XML.getChild(e, "foo")), "sdf");
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSchemaChainsBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSchemaChainsBuilderTest.java
@@ -43,7 +43,7 @@ public class DomSchemaChainsBuilderTest extends DomBuilderTest {
     private SearchChains searchChains;
 
     private static final Element element = parse(
-            "<searchchains>",
+            "<search>",
             "  <searcher id='searcher:1'/>",
 
             "  <provider id='provider:1' inherits='parentChain1 parentChain2' excludes='ExcludedSearcher1 ExcludedSearcher2'",
@@ -59,15 +59,15 @@ public class DomSchemaChainsBuilderTest extends DomBuilderTest {
 
             "  </provider>",
 
-            "  <searchchain id='default'>",
+            "  <chain id='default'>",
             "    <federation id='federationSearcher'>",
             "      <source id='mysource'>",
             "        <federationoptions optional='false' />",
             "      </source>",
             "    </federation>",
-            "  </searchchain>",
+            "  </chain>",
 
-            "</searchchains>");
+            "</search>");
 
 
     @Before
@@ -78,17 +78,17 @@ public class DomSchemaChainsBuilderTest extends DomBuilderTest {
     @Test
     public void referToFederationAsSearcher() {
         final Element element = parse(
-                "<searchchains>",
+                "<search>",
                 "  <federation id='federationSearcher'>",
                 "    <source id='mysource'>",
                 "      <federationoptions optional='false' />",
                 "    </source>",
                 "  </federation>",
 
-                "  <searchchain id='default'>",
+                "  <chain id='default'>",
                 "    <searcher id='federationSearcher'/>",
-                "  </searchchain>",
-                "</searchchains>");
+                "  </chain>",
+                "</search>");
 
         try {
             MockRoot root = new MockRoot();

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/searchchain/SchemaChainsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/searchchain/SchemaChainsTest.java
@@ -21,15 +21,10 @@ import static org.junit.Assert.assertEquals;
  */
 public class SchemaChainsTest extends SchemaChainsTestBase {
 
-    private ChainsConfig chainsConfig;
     private ClusterConfig clusterConfig;
 
     @Before
     public void subscribe() {
-        ChainsConfig.Builder chainsBuilder = new ChainsConfig.Builder();
-        chainsBuilder = (ChainsConfig.Builder)root.getConfig(chainsBuilder, "searchchains");
-        chainsConfig = new ChainsConfig(chainsBuilder);
-
         ClusterConfig.Builder clusterBuilder = new ClusterConfig.Builder();
         clusterBuilder = (ClusterConfig.Builder)root.getConfig(clusterBuilder, "searchchains/chain/cluster2/component/" + ClusterSearcher.class.getName());
         clusterConfig = new ClusterConfig(clusterBuilder);
@@ -39,7 +34,7 @@ public class SchemaChainsTest extends SchemaChainsTestBase {
     @Override
     Element servicesXml() {
         return parse(
-            "<searchchains>",
+            "<search>",
             "  <searcher id='searcher:1' classId='classId1' />",
 
             "  <provider id='provider:1' inherits='parentChain1 parentChain2' excludes='ExcludedSearcher1 ExcludedSearcher2'",
@@ -67,20 +62,7 @@ public class SchemaChainsTest extends SchemaChainsTestBase {
             "       <queryType>PROGRAMMATIC</queryType>",
             "    </config>",
             "  </provider>",
-
-            "  <searchchain id='default:99'>",
-            "    <federation id='federation:98' provides='provide_federation' before='p1 p2' after='s1 s2'>",
-            "      <source id='source:1'>",
-            "        <federationoptions optional='false' />",
-            "      </source>",
-            "    </federation>",
-            "  </searchchain>",
-
-            "  <searchchain id='parentChain1' />",
-            "  <searchchain id='parentChain2' />",
-            "  <searchchain id='parentChain3' />",
-            "  <searchchain id='parentChain4' />",
-            "</searchchains>");
+            "</search>");
     }
 
     private SearchChains getSearchChains() {


### PR DESCRIPTION
This syntax has been disallowed in the xml schema for a long time, but never cleaned up.