### PR TITLE
Revert "Avoid Serializable interface and use typed Comparable<T> MERGEOK"

### DIFF
--- a/document/abi-spec.json
+++ b/document/abi-spec.json
@@ -145,7 +145,9 @@
   },
   "com.yahoo.document.CompressionConfig": {
     "superClass": "java.lang.Object",
-    "interfaces": [],
+    "interfaces": [
+      "java.io.Serializable"
+    ],
     "attributes": [
       "public"
     ],
@@ -166,6 +168,7 @@
   "com.yahoo.document.DataType": {
     "superClass": "com.yahoo.vespa.objects.Identifiable",
     "interfaces": [
+      "java.io.Serializable",
       "java.lang.Comparable"
     ],
     "attributes": [
@@ -228,7 +231,9 @@
   },
   "com.yahoo.document.DataTypeName": {
     "superClass": "java.lang.Object",
-    "interfaces": [],
+    "interfaces": [
+      "java.io.Serializable"
+    ],
     "attributes": [
       "public",
       "final"
@@ -329,7 +334,9 @@
   },
   "com.yahoo.document.DocumentId": {
     "superClass": "com.yahoo.vespa.objects.Identifiable",
-    "interfaces": [],
+    "interfaces": [
+      "java.io.Serializable"
+    ],
     "attributes": [
       "public"
     ],
@@ -636,7 +643,8 @@
     "superClass": "com.yahoo.vespa.objects.FieldBase",
     "interfaces": [
       "com.yahoo.document.fieldset.FieldSet",
-      "java.lang.Comparable"
+      "java.lang.Comparable",
+      "java.io.Serializable"
     ],
     "attributes": [
       "public"
@@ -647,7 +655,7 @@
       "public void <init>(java.lang.String, com.yahoo.document.DataType, com.yahoo.document.DocumentType)",
       "public void <init>(java.lang.String, com.yahoo.document.DataType)",
       "public void <init>(java.lang.String, com.yahoo.document.Field)",
-      "public int compareTo(com.yahoo.document.Field)",
+      "public int compareTo(java.lang.Object)",
       "protected int calculateIdV7(com.yahoo.document.DocumentType)",
       "public void setId(int, com.yahoo.document.DocumentType)",
       "public final com.yahoo.document.DataType getDataType()",
@@ -659,8 +667,7 @@
       "public java.lang.String toString()",
       "public boolean contains(com.yahoo.document.fieldset.FieldSet)",
       "public com.yahoo.document.fieldset.FieldSet clone()",
-      "public bridge synthetic java.lang.Object clone()",
-      "public bridge synthetic int compareTo(java.lang.Object)"
+      "public bridge synthetic java.lang.Object clone()"
     ],
     "fields": [
       "protected com.yahoo.document.DataType dataType",

--- a/document/src/main/java/com/yahoo/document/CompressionConfig.java
+++ b/document/src/main/java/com/yahoo/document/CompressionConfig.java
@@ -3,8 +3,9 @@ package com.yahoo.document;
 
 import com.yahoo.compress.CompressionType;
 
+import java.io.Serializable;
 
-public class CompressionConfig {
+public class CompressionConfig implements Serializable {
 
     public CompressionConfig(CompressionType type,
                              int level,

--- a/document/src/main/java/com/yahoo/document/DataType.java
+++ b/document/src/main/java/com/yahoo/document/DataType.java
@@ -20,6 +20,7 @@ import com.yahoo.vespa.objects.Identifiable;
 import com.yahoo.vespa.objects.Ids;
 import com.yahoo.vespa.objects.ObjectVisitor;
 
+import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedList;
@@ -31,7 +32,7 @@ import java.util.List;
  *
  * @author bratseth
  */
-public abstract class DataType extends Identifiable implements Comparable<DataType> {
+public abstract class DataType extends Identifiable implements Serializable, Comparable<DataType> {
 
     // The global class identifier shared with C++.
     public static int classId = registerClass(Ids.document + 50, DataType.class);
@@ -279,7 +280,7 @@ public abstract class DataType extends Identifiable implements Comparable<DataTy
      */
     public FieldPath buildFieldPath(String fieldPathString) {
         if (fieldPathString.length() > 0) {
-            throw new IllegalArgumentException("Datatype " + this +
+            throw new IllegalArgumentException("Datatype " + toString() +
                                                " does not support further recursive structure: " + fieldPathString);
         }
         return new FieldPath();
@@ -317,7 +318,7 @@ public abstract class DataType extends Identifiable implements Comparable<DataTy
 
     @Override
     public int compareTo(DataType dataType) {
-        return Integer.compare(dataTypeId, dataType.dataTypeId);
+        return Integer.valueOf(dataTypeId).compareTo(dataType.dataTypeId);
     }
 
     /** Returns whether this is a multivalue type, i.e either a CollectionDataType or a MapDataType */

--- a/document/src/main/java/com/yahoo/document/DataTypeName.java
+++ b/document/src/main/java/com/yahoo/document/DataTypeName.java
@@ -4,12 +4,14 @@ package com.yahoo.document;
 import com.yahoo.text.Utf8Array;
 import com.yahoo.text.Utf8String;
 
+import java.io.Serializable;
+
 /**
  * A full document type name. The name is case sensitive. This is a <i>value object</i>.
  *
  * @author bratseth
  */
-public final class DataTypeName {
+public final class DataTypeName implements Serializable {
 
     private final Utf8String name;
 

--- a/document/src/main/java/com/yahoo/document/DocumentId.java
+++ b/document/src/main/java/com/yahoo/document/DocumentId.java
@@ -10,12 +10,13 @@ import com.yahoo.vespa.objects.Deserializer;
 import com.yahoo.vespa.objects.Identifiable;
 import com.yahoo.vespa.objects.Serializer;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * The id of a document
  */
-public class DocumentId extends Identifiable {
+public class DocumentId extends Identifiable implements Serializable {
 
     private IdString id;
     private GlobalId globalId = null;

--- a/document/src/main/java/com/yahoo/document/Field.java
+++ b/document/src/main/java/com/yahoo/document/Field.java
@@ -7,6 +7,8 @@ import com.yahoo.document.fieldset.FieldSet;
 import com.yahoo.document.fieldset.NoFields;
 import com.yahoo.vespa.objects.FieldBase;
 
+import java.io.Serializable;
+
 /**
  * A name and type. Fields are contained in document types to describe their fields,
  * but is also used to represent name/type pairs which are not part of document types.
@@ -14,7 +16,7 @@ import com.yahoo.vespa.objects.FieldBase;
  * @author Thomas Gundersen
  * @author bratseth
  */
-public class Field extends FieldBase implements FieldSet, Comparable<Field> {
+public class Field extends FieldBase implements FieldSet, Comparable, Serializable {
 
     protected DataType dataType;
     protected int fieldId;
@@ -72,8 +74,8 @@ public class Field extends FieldBase implements FieldSet, Comparable<Field> {
         this(name, field.dataType, null);
     }
 
-    public int compareTo(Field o) {
-        return fieldId - o.fieldId;
+    public int compareTo(Object o) {
+        return fieldId - ((Field) o).fieldId;
     }
 
     /**

--- a/document/src/main/java/com/yahoo/document/GlobalId.java
+++ b/document/src/main/java/com/yahoo/document/GlobalId.java
@@ -16,7 +16,7 @@ import java.util.Arrays;
  *
  * @author Simon Thoresen Hult
  */
-public class GlobalId implements Comparable<GlobalId> {
+public class GlobalId implements Comparable {
 
     /**
      * The number of bytes in a global id. This must match the C++ constant in "document/base/globalid.h".
@@ -119,8 +119,9 @@ public class GlobalId implements Comparable<GlobalId> {
         return Arrays.equals(raw, rhs.raw);
     }
 
-    @Override
-    public int compareTo(GlobalId other) {
+    public int compareTo(Object o) {
+        GlobalId other = (GlobalId) o;
+
         for (int i=0 ; i<LENGTH; i++) {
             int thisByte = 0xF & (int) raw[i];
             int otherByte = 0xF & (int) other.raw[i];


### PR DESCRIPTION
Reverts vespa-engine/vespa#23010

00:12:20 [ERROR] Failed to execute goal com.yahoo.vespa:abi-check-plugin:8.0.752:abicheck (default) on project document: ABI spec mismatch. To update run 'mvn package -Dabicheck.writeSpec' -> [Help 1]