### PR TITLE
Revert "Change user query default from ALL to WEAKAND on Vespa 8"

### DIFF
--- a/application/src/test/java/com/yahoo/application/ApplicationTest.java
+++ b/application/src/test/java/com/yahoo/application/ApplicationTest.java
@@ -62,7 +62,7 @@ public class ApplicationTest {
                      Application.fromApplicationPackage(new File("src/test/app-packages/withcontent"), Networking.disable)) {
             Result result = application.getJDisc("default").search().process(new ComponentSpecification("default"),
                                                                                  new Query("?query=substring:foobar&timeout=20000"));
-            assertEquals("WEAKAND(100) (AND substring:fo substring:oo substring:ob substring:ba substring:ar)",
+            assertEquals("AND substring:fo substring:oo substring:ob substring:ba substring:ar",
                          result.hits().get("hasQuery").getQuery().getModel().getQueryTree().toString());
         }
     }

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/AllParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/AllParser.java
@@ -55,6 +55,7 @@ public class AllParser extends SimpleParser {
         CompositeItem and = null;
         NotItem not = null; // Store negatives here as we go
         Item current;
+
         // Find all items
         do {
             current = negativeItem();

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/SimpleParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/SimpleParser.java
@@ -51,6 +51,7 @@ abstract class SimpleParser extends StructuredParser {
         Item topLevelItem = null;
         NotItem not = null;
         Item item = null;
+
         do {
             item = positiveItem();
             if (item != null) {

--- a/container-search/src/main/java/com/yahoo/search/query/Model.java
+++ b/container-search/src/main/java/com/yahoo/search/query/Model.java
@@ -86,7 +86,7 @@ public class Model implements Cloneable {
     private Locale locale = null;
     private QueryTree queryTree = null; // The query tree to execute. This is lazily created from the program
     private String defaultIndex = null;
-    private Query.Type type = Query.Type.WEAKAND;
+    private Query.Type type = Query.Type.ALL;
     private Query parent;
     private Set<String> sources = new LinkedHashSet<>();
     private Set<String> restrict = new LinkedHashSet<>();

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -740,7 +740,7 @@ public class YqlParser implements Parser {
         if (allowEmpty && (wordData == null || wordData.isEmpty())) return new NullItem();
 
         String grammar = getAnnotation(ast, USER_INPUT_GRAMMAR, String.class,
-                                       Query.Type.WEAKAND.toString(), "grammar for handling user input");
+                                       Query.Type.ALL.toString(), "grammar for handling user input");
         String defaultIndex = getAnnotation(ast, USER_INPUT_DEFAULT_INDEX,
                                             String.class, "default", "default index for user input terms");
         Language language = decideParsingLanguage(ast, wordData);
@@ -1448,7 +1448,7 @@ public class YqlParser implements Parser {
                                             "setting for whether to use substring match of input data");
         boolean exact = exactMatch != null ? exactMatch : indexFactsSession.getIndex(indexNameExpander.expand(field)).isExact();
         String grammar = getAnnotation(ast, USER_INPUT_GRAMMAR, String.class,
-                                       Query.Type.WEAKAND.toString(), "grammar for handling word input");
+                                       Query.Type.ALL.toString(), "grammar for handling word input");
         Preconditions.checkArgument((prefixMatch ? 1 : 0) +
                                     (substrMatch ? 1 : 0) + (suffixMatch ? 1 : 0) < 2,
                                     "Only one of prefix, substring and suffix can be set.");

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ExactMatchAndDefaultIndexTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ExactMatchAndDefaultIndexTestCase.java
@@ -33,15 +33,15 @@ public class ExactMatchAndDefaultIndexTestCase {
 
         Query q = new Query("?query=" + enc("a/b foo.com") + "&default-index=testexact");
         q.getModel().setExecution(new Execution(Execution.Context.createContextStub(facts)));
-        assertEquals("WEAKAND(100) testexact:a/b testexact:foo.com", q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND testexact:a/b testexact:foo.com", q.getModel().getQueryTree().getRoot().toString());
         q = new Query("?query=" + enc("a/b foo.com"));
-        assertEquals("WEAKAND(100) (AND a b) (AND foo com)", q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND a b foo com", q.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
     public void testDefaultIndexSpecialChars() {
         Query q = new Query("?query=" + enc("dog & cat") + "&default-index=textsearch");
-        assertEquals("WEAKAND(100) textsearch:dog textsearch:cat", q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND textsearch:dog textsearch:cat", q.getModel().getQueryTree().getRoot().toString());
     }
 
     private String enc(String s) {

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/SubstringTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/SubstringTestCase.java
@@ -14,14 +14,14 @@ import java.net.URLEncoder;
 /**
  * Check Substring in conjunction with query tokenization and parsing behaves properly.
  *
- * @author Steinar Knutsen
+ * @author <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 public class SubstringTestCase {
 
     @Test
     public final void testTokenLengthAndLowercasing() {
         Query q = new Query("/?query=\u0130");
-        WordItem root = (WordItem) ((CompositeItem)q.getModel().getQueryTree().getRoot()).getItem(0);
+        WordItem root = (WordItem) q.getModel().getQueryTree().getRoot();
         assertEquals("\u0130", root.getRawWord());
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/IntItemTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/IntItemTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.prelude.query.test;
 
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.IntItem;
-import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.search.Query;
 import org.junit.Test;
 
@@ -19,7 +18,7 @@ public class IntItemTestCase {
         Query q1 = new Query("/?query=123%20456%20789");
         Query q2 = new Query("/?query=123%20456");
 
-        WeakAndItem andItem = (WeakAndItem) q2.getModel().getQueryTree().getRoot();
+        AndItem andItem = (AndItem) q2.getModel().getQueryTree().getRoot();
         var item = new IntItem(789L, "");
         item.setFromQuery(true);
         andItem.addItem(item);

--- a/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/test/QueryCanonicalizerTestCase.java
@@ -104,7 +104,7 @@ public class QueryCanonicalizerTestCase {
         and22.addItem(and31);
         and22.addItem(and32);
         and22.addItem(new WordItem("word"));
-        assertCanonicalized("word", null, new Query("?query=word&type=all"));
+        assertCanonicalized("word", null, new Query("?query=word"));
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/CollapsePhraseSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/CollapsePhraseSearcherTestCase.java
@@ -65,12 +65,12 @@ public class CollapsePhraseSearcherTestCase {
 
     @Test
     public void testNegative1() {
-        assertEquals("WEAKAND(100) \"abc def\"", transformQuery("?query=" + enc("\"abc def\"")));
+        assertEquals("\"abc def\"", transformQuery("?query=" + enc("\"abc def\"")));
     }
 
     @Test
     public void testNegative2() {
-        assertEquals("WEAKAND(100) a \"abc def\" b", transformQuery("?query=" + enc("a \"abc def\" b")));
+        assertEquals("AND a \"abc def\" b", transformQuery("?query=" + enc("a \"abc def\" b")));
     }
 
     private String enc(String s) {

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/LiteralBoostSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/LiteralBoostSearcherTestCase.java
@@ -19,31 +19,31 @@ import static org.junit.Assert.assertEquals;
 /**
  * Tests the complete field match query transformer
  *
- * @author Steinar Knutsen
+ * @author  <a href="mailto:steinar@yahoo-inc.com">Steinar Knutsen</a>
  */
 public class LiteralBoostSearcherTestCase {
 
     @Test
     public void testSimpleQueryWithBoost() {
-        assertEquals("RANK (WEAKAND(100) abc) default_literal:abc",
+        assertEquals("RANK abc default_literal:abc",
                      transformQuery("?query=abc&source=cluster1&restrict=type1"));
     }
 
     @Test
     public void testSimpleQueryNoBoost() {
-        assertEquals("WEAKAND(100) abc",
+        assertEquals("abc",
                 transformQuery("?query=abc&source=cluster1&restrict=type2"));
     }
 
     @Test
     public void testQueryWithExplicitIndex() {
-        assertEquals("RANK (WEAKAND(100) absolute:abc) absolute_literal:abc",
+        assertEquals("RANK absolute:abc absolute_literal:abc",
                 transformQuery("?query=absolute:abc&source=cluster1&restrict=type1"));
     }
 
     @Test
     public void testQueryWithExplicitIndexNoBoost() {
-        assertEquals("WEAKAND(100) absolute:abc",
+        assertEquals("absolute:abc",
                 transformQuery("?query=absolute:abc&source=cluster1&restrict=type2"));
     }
 
@@ -64,7 +64,7 @@ public class LiteralBoostSearcherTestCase {
 
     @Test
     public void testTermindexQuery() {
-        assertEquals("RANK (+(WEAKAND(100) a b d) -c) default_literal:a "+
+        assertEquals("RANK (+(AND a b d) -c) default_literal:a "+
                      "default_literal:b default_literal:d",
                      transformQuery("?query=a b -c d&source=cluster1&restrict=type1"));
     }
@@ -72,7 +72,7 @@ public class LiteralBoostSearcherTestCase {
     @Test
     public void testQueryWithoutBoost() {
         assertEquals("RANK (AND nonexistant a nonexistant b) default_literal:nonexistant default_literal:a default_literal:nonexistant default_literal:b",
-                     transformQuery("?query=nonexistant:a nonexistant:b&source=cluster1&restrict=type1&type=all"));
+                     transformQuery("?query=nonexistant:a nonexistant:b&source=cluster1&restrict=type1"));
     }
 
     private String transformQuery(String rawQuery) {

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NonPhrasingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NonPhrasingSearcherTestCase.java
@@ -28,7 +28,7 @@ public class NonPhrasingSearcherTestCase {
         Query query=new Query("?query=void+aword+kanoo");
 
         new Execution(searcher, Execution.Context.createContextStub()).search(query);
-        assertEquals("WEAKAND(100) void kanoo", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND void kanoo", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NormalizingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/NormalizingSearcherTestCase.java
@@ -41,35 +41,35 @@ public class NormalizingSearcherTestCase {
     public void testNoNormalizingNecssary() {
         Query query = new Query("/search?query=bilen&search=cluster1&restrict=type1");
         createExecution().search(query);
-        assertEquals("WEAKAND(100) bilen", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("bilen", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
     public void testAttributeQuery() {
         Query query = new Query("/search?query=attribute:" + enc("b\u00e9yonc\u00e8 b\u00e9yonc\u00e8") + "&search=cluster1&restrict=type1");
         createExecution().search(query);
-        assertEquals("WEAKAND(100) attribute:b\u00e9yonc\u00e8 beyonce", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND attribute:b\u00e9yonc\u00e8 beyonce", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
     public void testOneTermNormalizing() {
         Query query = new Query("/search?query=b\u00e9yonc\u00e8&search=cluster1&restrict=type1");
         createExecution().search(query);
-        assertEquals("WEAKAND(100) beyonce", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("beyonce", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
     public void testOneTermNoNormalizingDifferentSearchDef() {
         Query query = new Query("/search?query=b\u00e9yonc\u00e8&search=cluster1&restrict=type2");
         createExecution().search(query);
-        assertEquals("WEAKAND(100) béyoncè", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("béyoncè", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
     public void testTwoTermQuery() throws UnsupportedEncodingException {
         Query query = new Query("/search?query=" + enc("b\u00e9yonc\u00e8 beyonc\u00e9") + "&search=cluster1&restrict=type1");
         createExecution().search(query);
-        assertEquals("WEAKAND(100) beyonce beyonce", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND beyonce beyonce", query.getModel().getQueryTree().getRoot().toString());
     }
 
     private String enc(String s) {
@@ -86,7 +86,7 @@ public class NormalizingSearcherTestCase {
         Query query = new Query("/search?query=" + enc("\"b\u00e9yonc\u00e8 beyonc\u00e9\"") + "&search=cluster1&restrict=type1");
         query.setTraceLevel(2);
         createExecution().search(query);
-        assertEquals("WEAKAND(100) \"beyonce beyonce\"", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("\"beyonce beyonce\"", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
@@ -34,7 +34,7 @@ public class StemmingSearcherTestCase {
     @Test
     public void testStemOnlySomeTerms() {
         assertStem("/search?query=Holes in CVS and Subversion nostem:Found",
-                   "WEAKAND(100) hole in cvs and subversion nostem:Found");
+                   "AND hole in cvs and subversion nostem:Found");
     }
 
     @Test
@@ -78,7 +78,7 @@ public class StemmingSearcherTestCase {
 
     @Test
     public void testDontStemPrefixes() {
-        assertStem("/search?query=ist*&language=de", "WEAKAND(100) ist*");
+        assertStem("/search?query=ist*&language=de", "ist*");
     }
 
     @Test
@@ -91,9 +91,9 @@ public class StemmingSearcherTestCase {
     @Test
     public void testNounStemming() {
         assertStem("/search?query=noun:towers noun:tower noun:tow",
-                   "WEAKAND(100) noun:tower noun:tower noun:tow");
+                   "AND noun:tower noun:tower noun:tow");
         assertStem("/search?query=notnoun:towers notnoun:tower notnoun:tow",
-                   "WEAKAND(100) notnoun:tower notnoun:tower notnoun:tow");
+                   "AND notnoun:tower notnoun:tower notnoun:tow");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class StemmingSearcherTestCase {
         Query q = new Query(QueryTestCase.httpEncode("?query=cars"));
         new Execution(new Chain<Searcher>(new StemmingSearcher(linguistics)),
                       Execution.Context.createContextStub(indexFacts, linguistics)).search(q);
-        assertEquals("WEAKAND(100) cars", q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("cars", q.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
@@ -132,11 +132,16 @@ public class StemmingSearcherTestCase {
 
     @Test
     public void testMultipleStemming() {
+        try {
         Query q = new Query(QueryTestCase.httpEncode("/search?language=en&search=four&query=trees \"nouns girls\" flowers \"a verbs a\" girls&default-index=foobar"));
         executeStemming(q);
-        assertEquals("WEAKAND(100) WORD_ALTERNATIVES foobar:[ tree(0.7) trees(1.0) ] "+
+        assertEquals("AND WORD_ALTERNATIVES foobar:[ tree(0.7) trees(1.0) ] "+
                      "foobar:\"noun girl\" WORD_ALTERNATIVES foobar:[ flower(0.7) flowers(1.0) ] "+
                      "foobar:\"a verb a\" WORD_ALTERNATIVES foobar:[ girl(0.7) girls(1.0) ]", q.getModel().getQueryTree().getRoot().toString());
+       } catch (Exception e) {
+           System.err.println("got exception: "+ e);
+           e.printStackTrace();
+       }
     }
 
     private Execution.Context newExecutionContext() {

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/FieldCollapsingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/FieldCollapsingSearcherTestCase.java
@@ -272,7 +272,7 @@ public class FieldCollapsingSearcherTestCase {
         chained.put(messUp, docsource);
 
         // Caveat: Collapse is set to false, because that's what the collapser asks for
-        Query q = new Query("?query=%22test%20collapse%22+b&collapsefield=amid&type=all");
+        Query q = new Query("?query=%22test%20collapse%22+b&collapsefield=amid");
 
         // The searcher turns off collapsing further on in the chain
         q.properties().set("collapse", "0");
@@ -289,7 +289,7 @@ public class FieldCollapsingSearcherTestCase {
         docsource.addResult(q, r);
 
         // Test basic collapsing on mid
-        q = new Query("?query=%22test%20collapse%22&collapsefield=amid&type=all");
+        q = new Query("?query=%22test%20collapse%22&collapsefield=amid");
         r = doSearch(collapse, q, 0, 2, chained);
 
         assertEquals(2, docsource.getQueryCount());

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/AutomataTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/AutomataTestCase.java
@@ -31,14 +31,14 @@ public class AutomataTestCase extends RuleBaseAbstractTestCase {
 
         Query query=new Query("?query=sony+digital+camera");
         ruleBase.analyze(query,0);
-        assertEquals("RANK (WEAKAND(100) sony digital camera) dsp1:sony dsp5:digicamera", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("RANK (AND sony digital camera) dsp1:sony dsp5:digicamera", query.getModel().getQueryTree().getRoot().toString());
 
         query=new Query("?query=sony+digital+camera&rules.reload");
         ruleBase=searcher.getDefaultRuleBase();
         assertTrue(ruleBase.getSource().endsWith(root + "automatarules.sr"));
         assertEquals(root + "semantics.fsa",ruleBase.getAutomataFile());
         ruleBase.analyze(query,0);
-        assertEquals("RANK (WEAKAND(100) sony digital camera) dsp1:sony dsp5:digicamera", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("RANK (AND sony digital camera) dsp1:sony dsp5:digicamera", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/BacktrackingTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/BacktrackingTestCase.java
@@ -51,45 +51,45 @@ public class BacktrackingTestCase {
 
     @Test
     public void testMultilevelBacktrackingLiteralTerms() {
-        assertSemantics("WEAKAND(100) replaced","word1 word2 word5 word8");
+        assertSemantics("replaced","word1 word2 word5 word8");
     }
 
     @Test
     public void testMultilevelBacktrackingWontReorderOthertermsLiteralTerms() {
-        assertSemantics("WEAKAND(100) other1 other2 other3 replaced","other1 other2 other3 word1 word2 word5 word8");
+        assertSemantics("AND other1 other2 other3 replaced","other1 other2 other3 word1 word2 word5 word8");
     }
 
     @Test
     public void testMultilevelBacktrackingWithMulticompoundMatchLiteralTerms() {
-        assertSemantics("WEAKAND(100) other1 other2 other3 replaced","other1 other2 other3 word1 word2 word5-word8");
+        assertSemantics("AND other1 other2 other3 replaced","other1 other2 other3 word1 word2 word5-word8");
     }
 
     @Test
     public void testMultilevelBacktrackingPreservePartialMatchBeforeLiteralTerms() {
-        assertSemantics("WEAKAND(100) word1 word2 word5 replaced","word1 word2 word5 word1 word2 word5 word8");
+        assertSemantics("AND word1 word2 word5 replaced","word1 word2 word5 word1 word2 word5 word8");
     }
 
     @Test
     public void testMultilevelBacktrackingPreservePartialMatchAfterLiteralTerms() {
-        assertSemantics("WEAKAND(100) replaced word1 word2 word5","word1 word2 word5 word8 word1 word2 word5 ");
+        assertSemantics("AND replaced word1 word2 word5","word1 word2 word5 word8 word1 word2 word5 ");
     }
 
     // reference terms ---------------
 
     @Test
     public void testMultilevelBacktrackingReferenceTerms() {
-        assertSemantics("WEAKAND(100) ref:ref1 ref:ref2 ref:ref5 ref:ref8","ref1 ref2 ref5 ref8");
+        assertSemantics("AND ref:ref1 ref:ref2 ref:ref5 ref:ref8","ref1 ref2 ref5 ref8");
     }
 
     @Test
     public void testMultilevelBacktrackingPreservePartialMatchBeforeReferenceTerms() {
-        assertSemantics("WEAKAND(100) ref1 ref2 ref5 ref:ref1 ref:ref2 ref:ref5 ref:ref8",
+        assertSemantics("AND ref1 ref2 ref5 ref:ref1 ref:ref2 ref:ref5 ref:ref8",
                         "ref1 ref2 ref5 ref1 ref2 ref5 ref8");
     }
 
     @Test
     public void testMultilevelBacktrackingPreservePartialMatchAfterReferenceTerms() {
-        assertSemantics("WEAKAND(100) ref:ref1 ref:ref2 ref:ref5 ref:ref8 ref1 ref2 ref5",
+        assertSemantics("AND ref:ref1 ref:ref2 ref:ref5 ref:ref8 ref1 ref2 ref5",
                         "ref1 ref2 ref5 ref8 ref1 ref2 ref5");
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ConfigurationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ConfigurationTestCase.java
@@ -62,63 +62,63 @@ public class ConfigurationTestCase {
 
     @Test
     public void testParent() {
-        assertSemantics("WEAKAND(100) vehiclebrand:audi", "audi cars", "parent");
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa", "alfa bus", "parent");
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", "parent.sr");
-        assertSemantics("WEAKAND(100) vw car",        "vw cars", "parent");
-        assertSemantics("WEAKAND(100) skoda car",     "skoda cars", "parent.sr");
+        assertSemantics("vehiclebrand:audi", "audi cars", "parent");
+        assertSemantics("vehiclebrand:alfa", "alfa bus", "parent");
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", "parent.sr");
+        assertSemantics("AND vw car",        "vw cars", "parent");
+        assertSemantics("AND skoda car",     "skoda cars", "parent.sr");
     }
 
     @Test
     public void testChild1() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "audi cars", "child1.sr");
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa",  "alfa bus", "child1");
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", "child1");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "vw cars", "child1");
-        assertSemantics("WEAKAND(100) skoda car",      "skoda cars", "child1");
+        assertSemantics("vehiclebrand:skoda", "audi cars", "child1.sr");
+        assertSemantics("vehiclebrand:alfa",  "alfa bus", "child1");
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", "child1");
+        assertSemantics("vehiclebrand:skoda", "vw cars", "child1");
+        assertSemantics("AND skoda car",      "skoda cars", "child1");
     }
 
     @Test
     public void testChild2() {
-        assertSemantics("WEAKAND(100) vehiclebrand:audi", "audi cars", "child2");
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa", "alfa bus", "child2.sr");
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", "child2.sr");
-        assertSemantics("WEAKAND(100) vw car", "vw cars", "child2");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "skoda cars", "child2");
+        assertSemantics("vehiclebrand:audi", "audi cars", "child2");
+        assertSemantics("vehiclebrand:alfa", "alfa bus", "child2.sr");
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", "child2.sr");
+        assertSemantics("AND vw car", "vw cars", "child2");
+        assertSemantics("vehiclebrand:skoda", "skoda cars", "child2");
     }
 
     @Test
     public void testGrandchild() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "audi cars", "grandchild.sr");
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa", "alfa bus", "grandchild");
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", "grandchild");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "vw cars", "grandchild");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "skoda cars", "grandchild");
+        assertSemantics("vehiclebrand:skoda", "audi cars", "grandchild.sr");
+        assertSemantics("vehiclebrand:alfa", "alfa bus", "grandchild");
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", "grandchild");
+        assertSemantics("vehiclebrand:skoda", "vw cars", "grandchild");
+        assertSemantics("vehiclebrand:skoda", "skoda cars", "grandchild");
     }
 
     @Test
     public void testSearcher() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "vw cars",   "grandchild");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "vw cars",   "grandchild.sd");
+        assertSemantics("vehiclebrand:skoda", "vw cars",   "grandchild");
+        assertSemantics("vehiclebrand:skoda", "vw cars",   "grandchild.sd");
         try {
-            assertSemantics("WEAKAND(100) vw cars",    "vw cars",   "doesntexist");
+            assertSemantics("AND vw cars",    "vw cars",   "doesntexist");
             fail("No exception on missing rule base");
         }
         catch (RuleBaseException e) {
             // Success
         }
-        assertSemantics("WEAKAND(100) vw cars",       "vw cars",   "grandchild.sd&rules.off");
-        assertSemanticsRulesOff("WEAKAND(100) vw cars",       "vw cars");
+        assertSemantics("AND vw cars",       "vw cars",   "grandchild.sd&rules.off");
+        assertSemanticsRulesOff("AND vw cars",       "vw cars");
 
-        assertSemantics("WEAKAND(100) vw car",        "vw cars",   "child2");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","skoda cars","child2");
+        assertSemantics("AND vw car",        "vw cars",   "child2");
+        assertSemantics("vehiclebrand:skoda","skoda cars","child2");
 
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","audi cars", "child1");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars",   "child1");
-        assertSemantics("WEAKAND(100) skoda car",     "skoda cars","child1");
+        assertSemantics("vehiclebrand:skoda","audi cars", "child1");
+        assertSemantics("vehiclebrand:skoda","vw cars",   "child1");
+        assertSemantics("AND skoda car",     "skoda cars","child1");
 
-        assertSemantics("WEAKAND(100) vw car",        "vw cars",   "parent");
-        assertSemantics("WEAKAND(100) skoda car",     "skoda cars","parent");
+        assertSemantics("AND vw car",        "vw cars",   "parent");
+        assertSemantics("AND skoda car",     "skoda cars","parent");
     }
 
     private Result doSearch(Searcher searcher, Query query, int offset, int hits) {

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/InheritanceTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/InheritanceTestCase.java
@@ -89,38 +89,38 @@ public class InheritanceTestCase {
 
     @Test
     public void testParent()  {
-        assertSemantics("WEAKAND(100) vehiclebrand:audi", "audi cars", parent);
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa", "alfa bus", parent);
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", parent);
-        assertSemantics("WEAKAND(100) vw car",       "vw cars", parent);
-        assertSemantics("WEAKAND(100) skoda car",    "skoda cars", parent);
+        assertSemantics("vehiclebrand:audi", "audi cars", parent);
+        assertSemantics("vehiclebrand:alfa", "alfa bus", parent);
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", parent);
+        assertSemantics("AND vw car",       "vw cars", parent);
+        assertSemantics("AND skoda car",    "skoda cars", parent);
     }
 
     @Test
     public void testChild1() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "audi cars", child1);
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa", "alfa bus", child1);
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv", "bmw motorcycle", child1);
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda", "vw cars", child1);
-        assertSemantics("WEAKAND(100) skoda car",      "skoda cars", child1);
+        assertSemantics("vehiclebrand:skoda", "audi cars", child1);
+        assertSemantics("vehiclebrand:alfa", "alfa bus", child1);
+        assertSemantics("AND vehiclebrand:bmw expensivetv", "bmw motorcycle", child1);
+        assertSemantics("vehiclebrand:skoda", "vw cars", child1);
+        assertSemantics("AND skoda car",      "skoda cars", child1);
     }
 
     @Test
     public void testChild2() {
-        assertSemantics("WEAKAND(100) vehiclebrand:audi","audi cars", child2);
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa","alfa bus", child2);
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv","bmw motorcycle", child2);
-        assertSemantics("WEAKAND(100) vw car","vw cars", child2);
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","skoda cars", child2);
+        assertSemantics("vehiclebrand:audi","audi cars", child2);
+        assertSemantics("vehiclebrand:alfa","alfa bus", child2);
+        assertSemantics("AND vehiclebrand:bmw expensivetv","bmw motorcycle", child2);
+        assertSemantics("AND vw car","vw cars", child2);
+        assertSemantics("vehiclebrand:skoda","skoda cars", child2);
     }
 
     @Test
     public void testGrandchild() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","audi cars", grandchild);
-        assertSemantics("WEAKAND(100) vehiclebrand:alfa","alfa bus", grandchild);
-        assertSemantics("AND (WEAKAND(100) vehiclebrand:bmw) expensivetv","bmw motorcycle", grandchild);
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars", grandchild);
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","skoda cars", grandchild);
+        assertSemantics("vehiclebrand:skoda","audi cars", grandchild);
+        assertSemantics("vehiclebrand:alfa","alfa bus", grandchild);
+        assertSemantics("AND vehiclebrand:bmw expensivetv","bmw motorcycle", grandchild);
+        assertSemantics("vehiclebrand:skoda","vw cars", grandchild);
+        assertSemantics("vehiclebrand:skoda","skoda cars", grandchild);
     }
 
     @Test
@@ -133,28 +133,28 @@ public class InheritanceTestCase {
 
     @Test
     public void testSearcher() {
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars",   "");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars",   "&rules.rulebase=grandchild");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars",   "&rules.rulebase=grandchild.sd");
+        assertSemantics("vehiclebrand:skoda","vw cars",   "");
+        assertSemantics("vehiclebrand:skoda","vw cars",   "&rules.rulebase=grandchild");
+        assertSemantics("vehiclebrand:skoda","vw cars",   "&rules.rulebase=grandchild.sd");
         try {
-            assertSemantics("WEAKAND(100) vw cars",       "vw cars",   "&rules.rulebase=doesntexist");
+            assertSemantics("AND vw cars",       "vw cars",   "&rules.rulebase=doesntexist");
             fail("No exception on missing rule base");
         }
         catch (RuleBaseException e) {
             // Success
         }
-        assertSemantics("WEAKAND(100) vw cars",       "vw cars",   "&rules.rulebase=grandchild.sd&rules.off");
-        assertSemantics("WEAKAND(100) vw cars",       "vw cars",   "&rules.off");
+        assertSemantics("AND vw cars",       "vw cars",   "&rules.rulebase=grandchild.sd&rules.off");
+        assertSemantics("AND vw cars",       "vw cars",   "&rules.off");
 
-        assertSemantics("WEAKAND(100) vw car",        "vw cars",   "&rules.rulebase=child2");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","skoda cars","&rules.rulebase=child2");
+        assertSemantics("AND vw car",        "vw cars",   "&rules.rulebase=child2");
+        assertSemantics("vehiclebrand:skoda","skoda cars","&rules.rulebase=child2");
 
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","audi cars", "&rules.rulebase=child1");
-        assertSemantics("WEAKAND(100) vehiclebrand:skoda","vw cars",   "&rules.rulebase=child1");
-        assertSemantics("WEAKAND(100) skoda car",     "skoda cars","&rules.rulebase=child1");
+        assertSemantics("vehiclebrand:skoda","audi cars", "&rules.rulebase=child1");
+        assertSemantics("vehiclebrand:skoda","vw cars",   "&rules.rulebase=child1");
+        assertSemantics("AND skoda car",     "skoda cars","&rules.rulebase=child1");
 
-        assertSemantics("WEAKAND(100) vw car",        "vw cars",   "&rules.rulebase=parent");
-        assertSemantics("WEAKAND(100) skoda car",     "skoda cars","&rules.rulebase=parent");
+        assertSemantics("AND vw car",        "vw cars",   "&rules.rulebase=parent");
+        assertSemantics("AND skoda car",     "skoda cars","&rules.rulebase=parent");
     }
 
     protected void assertSemantics(String result,String input,String ruleSelection) {

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/Parameter2TestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/Parameter2TestCase.java
@@ -20,7 +20,7 @@ public class Parameter2TestCase extends RuleBaseAbstractTestCase {
     /** Tests parameter production */
     @Test
     public void testParameterProduction() {
-        assertRankParameterSemantics("WEAKAND(100) a","a&ranking=usrank","date",0);
+        assertRankParameterSemantics("a","a&ranking=usrank","date",0);
     }
 
     private void assertRankParameterSemantics(String producedQuery,String inputQuery,

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ParameterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ParameterTestCase.java
@@ -55,12 +55,12 @@ public class ParameterTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     public void testMultipleAlternativeParameterValuesInCondition() {
-        assertInputRankParameterSemantics("WEAKAND(100) one", "foo", "cat");
-        assertInputRankParameterSemantics("WEAKAND(100) one", "foo", "cat0");
-        assertInputRankParameterSemantics("WEAKAND(100) one", "bar", "cat");
-        assertInputRankParameterSemantics("WEAKAND(100) one", "bar", "cat0");
-        assertInputRankParameterSemantics("WEAKAND(100) one one", "foo+bar", "cat0");
-        assertInputRankParameterSemantics("WEAKAND(100) fuki sushi", "fuki+sushi", "cat0");
+        assertInputRankParameterSemantics("one", "foo", "cat");
+        assertInputRankParameterSemantics("one", "foo", "cat0");
+        assertInputRankParameterSemantics("one", "bar", "cat");
+        assertInputRankParameterSemantics("one", "bar", "cat0");
+        assertInputRankParameterSemantics("AND one one", "foo+bar", "cat0");
+        assertInputRankParameterSemantics("AND fuki sushi", "fuki+sushi", "cat0");
     }
 
     private void assertInputRankParameterSemantics(String producedQuery,String inputQuery, String rankParameterValue) {

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ProductionRuleTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ProductionRuleTestCase.java
@@ -52,7 +52,7 @@ public class ProductionRuleTestCase {
         RuleEvaluation e = new Evaluation(query, null).freshRuleEvaluation();
         assertTrue(rule.matches(e));
         rule.produce(e);
-        assertEquals("WEAKAND(100) brand:sony", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND brand:sony", query.getModel().getQueryTree().getRoot().toString());
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/StopwordTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/StopwordTestCase.java
@@ -18,19 +18,19 @@ public class StopwordTestCase extends RuleBaseAbstractTestCase {
 
     @Test
     public void testStopwords() {
-        assertSemantics("WEAKAND(100) mlr:ve mlr:heard mlr:beautiful mlr:world",
+        assertSemantics("AND mlr:ve mlr:heard mlr:beautiful mlr:world",
                         new Query(QueryTestCase.httpEncode("?query=i don't know if you've heard, but it's a beautiful world&default-index=mlr&tracelevel.rules=0")));
     }
 
     /** If the query contains nothing but stopwords, we won't remove them */
     @Test
     public void testOnlyStopwords() {
-        assertSemantics("WEAKAND(100) mlr:the", new Query(QueryTestCase.httpEncode("?query=the the&default-index=mlr&tracelevel.rules=0")));
+        assertSemantics("mlr:the", new Query(QueryTestCase.httpEncode("?query=the the&default-index=mlr&tracelevel.rules=0")));
     }
 
     @Test
     public void testStopwordsInPhrase() {
-        assertSemantics("WEAKAND(100) mlr:\"ve heard\" mlr:beautiful mlr:world",
+        assertSemantics("AND mlr:\"ve heard\" mlr:beautiful mlr:world",
                         new Query(QueryTestCase.httpEncode("?query=\"i don't know if you've heard\", but it's a beautiful world&default-index=mlr&tracelevel.rules=0")));
     }
 

--- a/container-search/src/test/java/com/yahoo/prelude/test/GetRawWordTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/GetRawWordTestCase.java
@@ -17,26 +17,25 @@ public class GetRawWordTestCase {
 
     @Test
     public void testGetRawWord() {
-        Query query = new Query("?query=%C4%B0%C5%9EBANKASI%20GAZ%C4%B0EM%C4%B0R&type=all&searchChain=vespa");
+        Query query = new Query("?query=%C4%B0%C5%9EBANKASI%20GAZ%C4%B0EM%C4%B0R&searchChain=vespa");
         assertEquals("AND \u0130\u015EBANKASI GAZ\u0130EM\u0130R", query.getModel().getQueryTree().toString());
-        AndItem root = (AndItem)query.getModel().getQueryTree().getRoot();
+        AndItem root=(AndItem)query.getModel().getQueryTree().getRoot();
 
         {
-            WordItem word = (WordItem)root.getItem(0);
-            assertEquals("\u0130\u015EBANKASI", word.getRawWord());
-            assertEquals(0, word.getOrigin().start);
-            assertEquals(9, word.getOrigin().end);
+            WordItem word=(WordItem)root.getItem(0);
+            assertEquals("\u0130\u015EBANKASI",word.getRawWord());
+            assertEquals(0,word.getOrigin().start);
+            assertEquals(9,word.getOrigin().end);
         }
 
         {
-            WordItem word = (WordItem)root.getItem(1);
-            assertEquals("GAZ\u0130EM\u0130R", word.getRawWord());
-            assertEquals(10, word.getOrigin().start);
-            assertEquals(18, word.getOrigin().end);
+            WordItem word=(WordItem)root.getItem(1);
+            assertEquals("GAZ\u0130EM\u0130R",word.getRawWord());
+            assertEquals(10,word.getOrigin().start);
+            assertEquals(18,word.getOrigin().end);
         }
 
-        assertEquals("Total string is just these words",18,
-                     ((WordItem)root.getItem(0)).getOrigin().getSuperstring().length());
+        assertEquals("Total string is just these words",18,((WordItem)root.getItem(0)).getOrigin().getSuperstring().length());
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
@@ -71,9 +71,9 @@ public class IndexFactsTestCase {
         // First check default behavior
         IndexFacts indexFacts = createIndexFacts();
         Query q = newQuery("?query=a:b", indexFacts);
-        assertEquals("WEAKAND(100) a:b", q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("a:b",  q.getModel().getQueryTree().getRoot().toString());
         q = newQuery("?query=notarealindex:b", indexFacts);
-        assertEquals("WEAKAND(100) (AND notarealindex b)",  q.getModel().getQueryTree().getRoot().toString());
+        assertEquals("AND notarealindex b",  q.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
@@ -144,7 +144,7 @@ public class IndexFactsTestCase {
         Query query = new Query();
         query.getModel().getSources().add("artist");
         assertTrue(indexFacts.newSession(query).getIndex(indexName).isExact());
-        Query q = newQuery("?query=" + indexName + ":foo...&search=artist&type=all", indexFacts);
+        Query q = newQuery("?query=" + indexName + ":foo...&search=artist", indexFacts);
         assertEquals(indexName + ":foo...", q.getModel().getQueryTree().getRoot().toString());
     }
 
@@ -193,7 +193,7 @@ public class IndexFactsTestCase {
         IndexFacts.Session session = indexFacts.newSession(query);
         assertFalse(session.getIndex("bar").isExact());
         assertTrue(session.getIndex(u_name).isExact());
-        Query q = newQuery("?query=" + u_name + ":foo...&search=foobar&type=all", indexFacts);
+        Query q = newQuery("?query=" + u_name + ":foo...&search=foobar", indexFacts);
         assertEquals(u_name + ":foo...", q.getModel().getQueryTree().getRoot().toString());
     }
 
@@ -302,8 +302,8 @@ public class IndexFactsTestCase {
         IndexFacts.Session session2 = indexFacts.newSession(query2.getModel().getSources(), query2.getModel().getRestrict());
         assertTrue(session1.getIndex("url").isUriIndex());
         assertTrue(session2.getIndex("url").isUriIndex());
-        assertEquals("WEAKAND(100) (AND url:https url:foo url:bar)", query1.getModel().getQueryTree().toString());
-        assertEquals("WEAKAND(100) (AND url:https url:foo url:bar)", query2.getModel().getQueryTree().toString());
+        assertEquals("AND url:https url:foo url:bar", query1.getModel().getQueryTree().toString());
+        assertEquals("AND url:https url:foo url:bar", query2.getModel().getQueryTree().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
@@ -38,8 +38,8 @@ public class QueryTestCase {
 
     @Test
     public void testSimpleQueryParsing () {
-        Query q = newQuery("/search?query=foobar&offset=10&hits=20&type=all");
-        assertEquals("foobar", ((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
+        Query q = newQuery("/search?query=foobar&offset=10&hits=20");
+        assertEquals("foobar",((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
         assertEquals(10, q.getOffset());
         assertEquals(20, q.getHits());
     }
@@ -99,7 +99,7 @@ public class QueryTestCase {
 
     @Test
     public void testUtf8Decoding() {
-        Query q = new Query("/?query=beyonc%C3%A9&type=all");
+        Query q = new Query("/?query=beyonc%C3%A9");
         assertEquals("beyonc\u00e9", ((WordItem) q.getModel().getQueryTree().getRoot()).getWord());
     }
 
@@ -200,7 +200,7 @@ public class QueryTestCase {
     public void testDefaultIndex() {
         Query q = newQuery("?query=hi hello keyword:kanoo " +
                             "default:munkz \"phrases too\"&default-index=def");
-        assertEquals("WEAKAND(100) def:hi def:hello keyword:kanoo " +
+        assertEquals("AND def:hi def:hello keyword:kanoo " +
                      "default:munkz def:\"phrases too\"",
                      q.getModel().getQueryTree().getRoot().toString());
     }
@@ -275,11 +275,11 @@ public class QueryTestCase {
     @Test
     public void testUnicodeNormalization() {
         Linguistics linguistics = new SimpleLinguistics();
-        Query query = newQueryFromEncoded("?query=content:%EF%BC%B3%EF%BC%AF%EF%BC%AE%EF%BC%B9&type=all", Language.ENGLISH,
+        Query query = newQueryFromEncoded("?query=content:%EF%BC%B3%EF%BC%AF%EF%BC%AE%EF%BC%B9", Language.ENGLISH,
                                           linguistics);
-        assertEquals("SONY", ((WordItem) query.getModel().getQueryTree().getRoot()).getWord());
+        assertEquals("SONY",((WordItem) query.getModel().getQueryTree().getRoot()).getWord());
 
-        query = newQueryFromEncoded("?query=foo&filter=+%EF%BC%B3%EF%BC%AF%EF%BC%AE%EF%BC%B9&type=all", Language.ENGLISH,
+        query = newQueryFromEncoded("?query=foo&filter=+%EF%BC%B3%EF%BC%AF%EF%BC%AE%EF%BC%B9", Language.ENGLISH,
                                     linguistics);
         assertEquals("RANK foo |SONY", query.getModel().getQueryTree().getRoot().toString());
 
@@ -332,10 +332,10 @@ public class QueryTestCase {
     @Test
     public void testCopy() {
         Query qs = newQuery("?query=test&rankfeature.something=2");
-        assertEquals("WEAKAND(100) test", qs.getModel().getQueryTree().toString());
+        assertEquals("test", qs.getModel().getQueryTree().toString());
         assertEquals((int)qs.properties().getInteger("rankfeature.something"),2);
         Query qp = new Query(qs);
-        assertEquals("WEAKAND(100) test", qp.getModel().getQueryTree().getRoot().toString());
+        assertEquals("test", qp.getModel().getQueryTree().getRoot().toString());
         assertFalse(qp.getRanking().getFeatures().isEmpty());
         assertEquals(2.0, qp.getRanking().getFeatures().getDouble("something").getAsDouble(), 0.000001);
     }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/rpc/ProtobufSerializationTest.java
@@ -68,7 +68,7 @@ public class ProtobufSerializationTest {
         hit.setGlobalId(new GlobalId(IdString.createIdString("id:ns:type::id")).getRawId());
         var bytes = ProtobufSerialization.serializeDocsumRequest(builder, Collections.singletonList(hit));
 
-        assertEquals(46, bytes.length);
+        assertEquals(41, bytes.length);
     }
 
     private String contentsOf(ByteString property) {

--- a/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTest.java
@@ -167,7 +167,7 @@ public class SearchHandlerTest {
         HttpSearchResponse s = new HttpSearchResponse(200, r, q, new XmlRenderer());
         assertEquals("text/xml", s.getContentType());
         assertNull(s.getCoverage());
-        assertEquals("query 'WEAKAND(100) dummy'", s.getParsedQuery());
+        assertEquals("query 'dummy'", s.getParsedQuery());
         assertEquals(500, s.getTiming().getTimeout());
     }
 

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileIntegrationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileIntegrationTestCase.java
@@ -57,20 +57,20 @@ public class QueryProfileIntegrationTestCase {
         // Tests a profile setting hits and offset
         request = HttpRequest.createTestRequest("search?queryProfile=hitsoffset", Method.GET);
         response = (HttpSearchResponse)searchHandler.handle(request); // Cast to access content directly
-        assertEquals(20, response.getQuery().getHits());
-        assertEquals(80, response.getQuery().getOffset());
+        assertEquals(20,response.getQuery().getHits());
+        assertEquals(80,response.getQuery().getOffset());
 
         // Tests a non-resolved profile request
         request = HttpRequest.createTestRequest("search?queryProfile=none", Method.GET);
         response = (HttpSearchResponse)searchHandler.handle(request); // Cast to access content directly
-        assertNotNull("Got an error", response.getResult().hits().getError());
-        assertEquals("Could not resolve query profile 'none'", response.getResult().hits().getError().getDetailedMessage());
+        assertNotNull("Got an error",response.getResult().hits().getError());
+        assertEquals("Could not resolve query profile 'none'",response.getResult().hits().getError().getDetailedMessage());
 
         // Tests that properties in objects owned by query is handled correctly
         request = HttpRequest.createTestRequest("search?query=word&queryProfile=test", Method.GET);
         response = (HttpSearchResponse)searchHandler.handle(request); // Cast to access content directly
-        assertEquals("index" ,response.getQuery().getModel().getDefaultIndex());
-        assertEquals("WEAKAND(100) index:word", response.getQuery().getModel().getQueryTree().toString());
+        assertEquals("index",response.getQuery().getModel().getDefaultIndex());
+        assertEquals("index:word",response.getQuery().getModel().getQueryTree().toString());
         configurer.shutdown();
     }
 

--- a/container-search/src/test/java/com/yahoo/search/query/profile/test/QueryFromProfileTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/test/QueryFromProfileTestCase.java
@@ -35,7 +35,7 @@ public class QueryFromProfileTestCase {
 
         Query query = new Query(HttpRequest.createTestRequest("?model=querybest", Method.GET), cRegistry.getComponent("topLevel"));
         assertEquals("best", query.properties().get("model.queryString"));
-        assertEquals("WEAKAND(100) best", query.getModel().getQueryTree().toString());
+        assertEquals("best", query.getModel().getQueryTree().toString());
     }
 
     @Test
@@ -58,7 +58,7 @@ public class QueryFromProfileTestCase {
 
         Query query = new Query(HttpRequest.createTestRequest("?query=overrides&model=querybest", Method.GET), cRegistry.getComponent("root"));
         assertEquals("overrides", query.properties().get("model.queryString"));
-        assertEquals("WEAKAND(100) overrides", query.getModel().getQueryTree().toString());
+        assertEquals("overrides", query.getModel().getQueryTree().toString());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class QueryFromProfileTestCase {
 
         Query query = new Query(HttpRequest.createTestRequest("?query=overrides&model=querybest", Method.GET), cRegistry.getComponent("root"));
         assertEquals("overrides", query.properties().get("model.queryString"));
-        assertEquals("WEAKAND(100) overrides", query.getModel().getQueryTree().toString());
+        assertEquals("overrides", query.getModel().getQueryTree().toString());
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/RewriterFeaturesTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/RewriterFeaturesTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.search.query.rewrite;
 
 import static org.junit.Assert.*;
 
-import com.yahoo.prelude.query.WeakAndItem;
 import org.junit.Test;
 
 import com.yahoo.prelude.query.AndItem;
@@ -38,7 +37,7 @@ public class RewriterFeaturesTestCase {
         query.getModel().setExecution(placeholder);
         Item parsed = RewriterFeatures.convertStringToQTree(query, "a b c "
                 + ASCII_ELLIPSIS);
-        assertSame(WeakAndItem.class, parsed.getClass());
+        assertSame(AndItem.class, parsed.getClass());
         assertEquals(4, ((CompositeItem) parsed).getItemCount());
         assertEquals(ASCII_ELLIPSIS, ((CompositeItem) parsed).getItem(3).toString());
     }

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/GenericExpansionRewriterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/GenericExpansionRewriterTestCase.java
@@ -97,7 +97,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testFullPhraseNoMaxRewriteSingleWordFilter() {
-        utils.assertRewrittenQuery("?query=ca&type=all&" +
+        utils.assertRewrittenQuery("?query=ca&" +
                                    "filter=citystate:santa clara ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=false",
                                    "query 'RANK (OR california ca) |citystate:santa |clara |ca'");
@@ -108,7 +108,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testPartialPhraseNoMaxRewriteSingleWordFilter() {
-        utils.assertRewrittenQuery("?query=ca&type=all&" +
+        utils.assertRewrittenQuery("?query=ca&" +
                                    "filter=citystate:santa clara ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=true",
                                    "query 'RANK (OR california ca) |citystate:santa |clara |ca'");
@@ -119,7 +119,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testFullPhraseNoMaxRewriteMultiWordFilter() {
-        utils.assertRewrittenQuery("?query=travel agency&type=all&" +
+        utils.assertRewrittenQuery("?query=travel agency&" +
                                    "filter=citystate:santa clara ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=false",
                                    "query 'RANK (OR ta (AND travel agency)) |citystate:santa |clara |ca'");
@@ -131,7 +131,7 @@ public class GenericExpansionRewriterTestCase {
     @Test
     public void testPartialPhraseNoMaxRewriteMultiWordFilter() {
         utils.assertRewrittenQuery("?query=modern new york city travel phone number&" +
-                                   "filter=citystate:santa clara ca&type=all&" +
+                                   "filter=citystate:santa clara ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=true",
                                    "query 'RANK (AND modern (OR (AND rewrite11 rewrite12) rewrite2 rewrite3 " +
                                    "rewrite4 rewrite5 (AND new york city travel)) (OR pn (AND phone number))) " +
@@ -143,7 +143,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testFullPhraseNoMaxRewriteSingleWord() {
-        utils.assertRewrittenQuery("?query=ca&type=all&" +
+        utils.assertRewrittenQuery("?query=ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=false",
                                    "query 'OR california ca'");
     }
@@ -153,7 +153,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testPartialPhraseNoMaxRewriteSingleWord() {
-        utils.assertRewrittenQuery("?query=ca&type=all&" +
+        utils.assertRewrittenQuery("?query=ca&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=true",
                                    "query 'OR california ca'");
     }
@@ -163,7 +163,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testFullPhraseNoMaxRewriteMultiWord() {
-        utils.assertRewrittenQuery("?query=travel agency&type=all&" +
+        utils.assertRewrittenQuery("?query=travel agency&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=false",
                                    "query 'OR ta (AND travel agency)'");
     }
@@ -173,7 +173,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testFullPhraseNoMaxRewriteMultiWordNoMatch() {
-        utils.assertRewrittenQuery("?query=nyc travel agency&type=all&" +
+        utils.assertRewrittenQuery("?query=nyc travel agency&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=false",
                                    "query 'AND nyc travel agency'");
     }
@@ -183,7 +183,7 @@ public class GenericExpansionRewriterTestCase {
      */
     @Test
     public void testPartialPhraseNoMaxRewriteMultiWord() {
-        utils.assertRewrittenQuery("?query=modern new york city travel phone number&type=all&" +
+        utils.assertRewrittenQuery("?query=modern new york city travel phone number&" +
                                    REWRITER_NAME + "." + RewriterConstants.PARTIAL_PHRASE_MATCH + "=true",
                                    "query 'AND modern (OR (AND rewrite11 rewrite12) rewrite2 rewrite3 rewrite4 rewrite5 "+
                                    "(AND new york city travel)) (OR pn (AND phone number))'");

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/MisspellRewriterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/MisspellRewriterTestCase.java
@@ -47,7 +47,7 @@ public class MisspellRewriterTestCase {
         utils.assertRewrittenQuery("?query=willl+smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true",
-                                   "query 'OR (WEAKAND(100) willl smith) (WEAKAND(100) will smith sugg)'",
+                                   "query 'OR (AND willl smith) (AND will smith sugg)'",
                                    intentModel);
     }
 
@@ -67,7 +67,7 @@ public class MisspellRewriterTestCase {
 
         utils.assertRewrittenQuery("?query=willl+smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true",
-                                   "query 'OR (WEAKAND(100) willl smith) (WEAKAND(100) will smith rw1)'",
+                                   "query 'OR (AND willl smith) (AND will smith rw1)'",
                                    intentModel);
     }
 
@@ -87,7 +87,7 @@ public class MisspellRewriterTestCase {
 
         utils.assertRewrittenQuery("?query=willl+smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true",
-                                   "query 'OR (WEAKAND(100) willl smith) (WEAKAND(100) will smith sugg1)'",
+                                   "query 'OR (AND willl smith) (AND will smith sugg1)'",
                                    intentModel);
     }
 
@@ -104,7 +104,7 @@ public class MisspellRewriterTestCase {
                                                              false, true));
 
         utils.assertRewrittenQuery("?query=willl+smith",
-                                   "query 'WEAKAND(100) willl smith'",
+                                   "query 'AND willl smith'",
                                    intentModel);
     }
 
@@ -123,7 +123,7 @@ public class MisspellRewriterTestCase {
         utils.assertRewrittenQuery("?query=will+smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true",
-                                   "query 'WEAKAND(100) will smith'",
+                                   "query 'AND will smith'",
                                    intentModel);
     }
 

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/NameRewriterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/NameRewriterTestCase.java
@@ -45,7 +45,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testRewritesAsEquivAndOriginalAsUnit() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_EQUIV + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT + "=true",
                                    "query 'OR \"will smith\" (AND will smith movies) " +
@@ -60,7 +60,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testRewritesAsEquiv() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_EQUIV + "=true&",
                                    "query 'OR (AND will smith) (AND will smith movies) " +
                                    "(AND will smith news) (AND will smith imdb) " +
@@ -85,7 +85,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testSingleWordForRewritesAsEquivAndOriginalAsUnit() {
-        utils.assertRewrittenQuery("?query=obama&type=all&" +
+        utils.assertRewrittenQuery("?query=obama&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_EQUIV + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT + "=true",
                                    "query 'OR obama (AND obama \"nobel peace prize\") " +
@@ -102,7 +102,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testRewritesAsUnitEquivAndOriginalAsUnitEquiv() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
                                    "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT_EQUIV +
@@ -119,7 +119,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testSingleWordForRewritesAsUnitEquivAndOriginalAsUnitEquiv() {
-        utils.assertRewrittenQuery("?query=obama&type=all&" +
+        utils.assertRewrittenQuery("?query=obama&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
                                    "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT_EQUIV +
@@ -133,7 +133,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testBoostingQueryForRewritesAsEquivAndOriginalAsUnit() {
-        utils.assertRewrittenQuery("?query=angelina jolie&type=all&" +
+        utils.assertRewrittenQuery("?query=angelina jolie&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_EQUIV + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT + "=true",
                                    "query '\"angelina jolie\"'");
@@ -145,7 +145,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testFSANoMatchForRewritesAsEquivAndOriginalAsUnit() {
-        utils.assertRewrittenQuery("?query=tom cruise&type=all&" +
+        utils.assertRewrittenQuery("?query=tom cruise&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_EQUIV + "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.ORIGINAL_AS_UNIT + "=true",
                                    "query 'AND tom cruise'");
@@ -156,7 +156,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testRewritesAsUnitEquiv() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
                                    "=true",
                                    "query 'OR (AND will smith) \"will smith movies\" " +
@@ -171,7 +171,7 @@ public class NameRewriterTestCase {
      */
     @Test
     public void testRewritesAsUnitEquivAndMaxRewrites() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
                                    "=true&" +
                                    REWRITER_NAME + "." + RewriterConstants.MAX_REWRITES + "=2",

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/QueryRewriteSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/QueryRewriteSearcherTestCase.java
@@ -79,7 +79,7 @@ public class QueryRewriteSearcherTestCase {
         Execution execution = QueryRewriteSearcherTestUtils.createExecutionObj(searchers);
         QueryRewriteSearcherTestUtils utilsWithFakePath = new QueryRewriteSearcherTestUtils(execution);
 
-        utilsWithFakePath.assertRewrittenQuery("?query=will smith&type=all&" +
+        utilsWithFakePath.assertRewrittenQuery("?query=will smith&" +
                                                NAME_REWRITER_NAME + "." +
                                                RewriterConstants.REWRITES_AS_UNIT_EQUIV + "=true",
                                                "query 'AND will smith'");
@@ -91,7 +91,7 @@ public class QueryRewriteSearcherTestCase {
      */
     @Test
     public void testExceptionInRewriter() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&" +
+        utils.assertRewrittenQuery("?query=will smith&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
@@ -117,7 +117,7 @@ public class QueryRewriteSearcherTestCase {
                                   utils.createInterpretation("will smith", 1.0,
                                                              false, true));
 
-        utils.assertRewrittenQuery("?query=willl+smith&type=all&" +
+        utils.assertRewrittenQuery("?query=willl+smith&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/SearchChainDispatcherSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/SearchChainDispatcherSearcherTestCase.java
@@ -77,7 +77,7 @@ public class SearchChainDispatcherSearcherTestCase {
                                   utils.createInterpretation("will smith", 1.0,
                                                              false, true));
 
-        utils.assertRewrittenQuery("?query=willl+smith&type=all&QRWChain=" + US_MARKET_SEARCH_CHAIN + "&" +
+        utils.assertRewrittenQuery("?query=willl+smith&QRWChain=" + US_MARKET_SEARCH_CHAIN + "&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
@@ -98,7 +98,7 @@ public class SearchChainDispatcherSearcherTestCase {
      */
     @Test
     public void testInvalidMarketChain() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&QRWChain=abc&" +
+        utils.assertRewrittenQuery("?query=will smith&QRWChain=abc&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
@@ -112,7 +112,7 @@ public class SearchChainDispatcherSearcherTestCase {
      */
     @Test
     public void testEmptyMarketChain() {
-        utils.assertRewrittenQuery("?query=will smith&type=all&QRWChain=&" +
+        utils.assertRewrittenQuery("?query=will smith&QRWChain=&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +
@@ -161,7 +161,7 @@ public class SearchChainDispatcherSearcherTestCase {
                                   utils.createInterpretation("will smith", 1.0,
                                                              false, true));
 
-        utils.assertRewrittenQuery("?query=willl+smith&type=all&QRWChain=" + US_MARKET_SEARCH_CHAIN + "&" +
+        utils.assertRewrittenQuery("?query=willl+smith&QRWChain=" + US_MARKET_SEARCH_CHAIN + "&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_RW + "=true&" +
                                    MISSPELL_REWRITER_NAME + "." + RewriterConstants.QSS_SUGG + "=true&" +
                                    NAME_REWRITER_NAME + "." + RewriterConstants.REWRITES_AS_UNIT_EQUIV +

--- a/container-search/src/test/java/com/yahoo/search/querytransform/test/NGramSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/querytransform/test/NGramSearcherTestCase.java
@@ -19,7 +19,6 @@ import com.yahoo.prelude.hitfield.JSONString;
 import com.yahoo.prelude.hitfield.XMLString;
 import com.yahoo.prelude.query.AndItem;
 import com.yahoo.prelude.query.Item;
-import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.prelude.querytransform.CJKSearcher;
 import com.yahoo.search.Query;
@@ -107,22 +106,22 @@ public class NGramSearcherTestCase {
         {
             Query q = new Query("?query=abc&restrict=song");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) abc", q.getModel().getQueryTree().toString());
+            assertEquals("abc", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&restrict=music");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) (AND a b c)", q.getModel().getQueryTree().toString());
+            assertEquals("AND a b c", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&search=song");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) abc", q.getModel().getQueryTree().toString());
+            assertEquals("abc", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&search=music");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) (AND a b c)", q.getModel().getQueryTree().toString());
+            assertEquals("AND a b c", q.getModel().getQueryTree().toString());
         }
     }
 
@@ -131,22 +130,22 @@ public class NGramSearcherTestCase {
         {
             Query q = new Query("?query=abc&search=songOnly");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) abc", q.getModel().getQueryTree().toString());
+            assertEquals("abc", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&search=musicOnly");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) (AND a b c)", q.getModel().getQueryTree().toString());
+            assertEquals("AND a b c", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&search=musicAndSong&restrict=music");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) (AND a b c)", q.getModel().getQueryTree().toString());
+            assertEquals("AND a b c", q.getModel().getQueryTree().toString());
         }
         {
             Query q = new Query("?query=abc&search=musicAndSong&restrict=song");
             createMixedSetupExecution().search(q);
-            assertEquals("WEAKAND(100) abc", q.getModel().getQueryTree().toString());
+            assertEquals("abc", q.getModel().getQueryTree().toString());
         }
     }
 
@@ -154,42 +153,42 @@ public class NGramSearcherTestCase {
     public void testNGramRewritingMixedQuery() {
         Query q = new Query("?query=foo+gram3:engul+test:bar");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) foo (AND gram3:eng gram3:ngu gram3:gul) test:bar", q.getModel().getQueryTree().toString());
+        assertEquals("AND foo (AND gram3:eng gram3:ngu gram3:gul) test:bar", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingNGramOnly() {
         Query q = new Query("?query=gram3:engul");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) (AND gram3:eng gram3:ngu gram3:gul)", q.getModel().getQueryTree().toString());
+        assertEquals("AND gram3:eng gram3:ngu gram3:gul", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewriting2NGramsOnly() {
         Query q = new Query("?query=gram3:engul+gram2:123");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) (AND gram3:eng gram3:ngu gram3:gul) (AND gram2:12 gram2:23)", q.getModel().getQueryTree().toString());
+        assertEquals("AND (AND gram3:eng gram3:ngu gram3:gul) (AND gram2:12 gram2:23)", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingShortOnly() {
         Query q = new Query("?query=gram3:en");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) gram3:en", q.getModel().getQueryTree().toString());
+        assertEquals("gram3:en", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingShortInMixes() {
         Query q = new Query("?query=test:a+gram3:en");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) test:a gram3:en", q.getModel().getQueryTree().toString());
+        assertEquals("AND test:a gram3:en", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingPhrase() {
         Query q = new Query("?query=gram3:%22engul+a+holi%22");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) gram3:\"eng ngu gul a hol oli\"", q.getModel().getQueryTree().toString());
+        assertEquals("gram3:\"eng ngu gul a hol oli\"", q.getModel().getQueryTree().toString());
     }
 
     /**
@@ -200,14 +199,14 @@ public class NGramSearcherTestCase {
     public void testNGramRewritingPhraseSingleTerm() {
         Query q = new Query("?query=gram3:%22engul%22");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) (AND gram3:eng gram3:ngu gram3:gul)", q.getModel().getQueryTree().toString());
+        assertEquals("AND gram3:eng gram3:ngu gram3:gul", q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingAdditionalTermInfo() {
         Query q = new Query("?query=gram3:engul!50+foo+gram2:123!150");
         createExecution().search(q);
-        WeakAndItem root = (WeakAndItem)q.getModel().getQueryTree().getRoot();
+        AndItem root = (AndItem)q.getModel().getQueryTree().getRoot();
         AndItem gram3And = (AndItem)root.getItem(0);
         AndItem gram2And = (AndItem)root.getItem(2);
 
@@ -230,14 +229,14 @@ public class NGramSearcherTestCase {
     public void testNGramRewritingExplicitDefault() {
         Query q = new Query("?query=default:engul");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) (AND default:eng default:ngu default:gul)" ,q.getModel().getQueryTree().toString());
+        assertEquals("AND default:eng default:ngu default:gul" ,q.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testNGramRewritingImplicitDefault() {
         Query q = new Query("?query=engul");
         createExecution().search(q);
-        assertEquals("WEAKAND(100) (AND eng ngu gul)", q.getModel().getQueryTree().toString());
+        assertEquals("AND eng ngu gul", q.getModel().getQueryTree().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
@@ -26,7 +26,6 @@ import com.yahoo.prelude.query.IntItem;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.prelude.query.OrItem;
 import com.yahoo.prelude.query.RankItem;
-import com.yahoo.prelude.query.WeakAndItem;
 import com.yahoo.prelude.query.WordItem;
 import com.yahoo.processing.request.CompoundName;
 import com.yahoo.search.Query;
@@ -441,7 +440,7 @@ public class QueryTestCase {
     @Test
     public void testUtf8Decoding() {
         Query q = new Query("/?query=beyonc%C3%A9");
-        assertEquals("WEAKAND(100) beyonc\u00e9", q.getModel().getQueryTree().toString());
+        assertEquals("beyonc\u00e9", q.getModel().getQueryTree().toString());
     }
 
     @Test
@@ -461,7 +460,7 @@ public class QueryTestCase {
     public void testDefaultIndex() {
         Query q = new Query("?query=hi%20hello%20keyword:kanoo%20" +
                             "default:munkz%20%22phrases+too%22&default-index=def");
-        assertEquals("WEAKAND(100) def:hi def:hello keyword:kanoo default:munkz def:\"phrases too\"",
+        assertEquals("AND def:hi def:hello keyword:kanoo default:munkz def:\"phrases too\"",
                      q.getModel().getQueryTree().toString());
     }
 
@@ -475,9 +474,9 @@ public class QueryTestCase {
     @Test
     public void testSimpleQueryParsing() {
         Query q = new Query("/search?query=foobar&offset=10&hits=20");
-        assertEquals("WEAKAND(100) foobar", q.getModel().getQueryTree().toString());
-        assertEquals(10, q.getOffset());
-        assertEquals(20, q.getHits());
+        assertEquals("foobar", q.getModel().getQueryTree().toString());
+        assertEquals(10,q.getOffset());
+        assertEquals(20,q.getHits());
     }
 
     /** "input.*" is an alias for "ranking.feature.*", but just "input" is not */
@@ -551,7 +550,7 @@ public class QueryTestCase {
 
     @Test
     public void testTracing() {
-        Query q = new Query("?query=foo&type=all&traceLevel=2");
+        Query q = new Query("?query=foo&traceLevel=2");
         assertEquals(2, q.getTraceLevel());
         q.trace(true, 1, "trace1");
         q.trace(false,2, "trace2");
@@ -969,12 +968,12 @@ public class QueryTestCase {
     @Test
     public void testImplicitPhraseIsDefault() {
         Query query = new Query(httpEncode("?query=it's fine"));
-        assertEquals("WEAKAND(100) (SAND it s) fine", query.getModel().getQueryTree().toString());
+        assertEquals("AND (SAND it s) fine", query.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testImplicitPhrase() {
-        Query query = new Query(httpEncode("?query=myfield:it's myfield:a.b myfield:c&type=all"));
+        Query query = new Query(httpEncode("?query=myfield:it's myfield:a.b myfield:c"));
 
         SearchDefinition test = new SearchDefinition("test");
         Index myField = new Index("myfield");
@@ -999,9 +998,9 @@ public class QueryTestCase {
         IndexModel indexModel = new IndexModel(test);
         query.getModel().setExecution(new Execution(Execution.Context.createContextStub(new IndexFacts(indexModel))));
 
-        assertEquals("WEAKAND(100) (SAND myfield:it myfield:s) (AND myfield:a myfield:b) myfield:c", query.getModel().getQueryTree().toString());
+        assertEquals("AND (SAND myfield:it myfield:s) myfield:a myfield:b myfield:c", query.getModel().getQueryTree().toString());
         // 'it' and 's' should have connectivity 1
-        WeakAndItem root = (WeakAndItem)query.getModel().getQueryTree().getRoot();
+        AndItem root = (AndItem)query.getModel().getQueryTree().getRoot();
         AndSegmentItem sand = (AndSegmentItem)root.getItem(0);
         WordItem it = (WordItem)sand.getItem(0);
         assertEquals("it", it.getWord());
@@ -1022,12 +1021,11 @@ public class QueryTestCase {
         {
             Query query = new Query(httpEncode("?query=myfield:b.c.d"));
             query.getModel().setExecution(new Execution(Execution.Context.createContextStub(new IndexFacts(indexModel))));
-            assertEquals("WEAKAND(100) (AND myfield:b myfield:c myfield:d)", query.getModel().getQueryTree().toString());
-            WeakAndItem root = (WeakAndItem) query.getModel().getQueryTree().getRoot();
-            AndItem and = (AndItem)root.getItem(0);
-            WordItem b = (WordItem) and.getItem(0);
-            WordItem c = (WordItem) and.getItem(1);
-            WordItem d = (WordItem) and.getItem(2);
+            assertEquals("AND myfield:b myfield:c myfield:d", query.getModel().getQueryTree().toString());
+            AndItem root = (AndItem) query.getModel().getQueryTree().getRoot();
+            WordItem b = (WordItem) root.getItem(0);
+            WordItem c = (WordItem) root.getItem(1);
+            WordItem d = (WordItem) root.getItem(2);
             assertEquals(c, b.getConnectedItem());
             assertEquals(1.0, b.getConnectivity(), 0.00000001);
             assertEquals(d, c.getConnectedItem());
@@ -1037,21 +1035,19 @@ public class QueryTestCase {
         {
             Query query = new Query(httpEncode("?query=myfield:a myfield:b.c.d myfield:e"));
             query.getModel().setExecution(new Execution(Execution.Context.createContextStub(new IndexFacts(indexModel))));
-            assertEquals("WEAKAND(100) myfield:a (AND myfield:b myfield:c myfield:d) myfield:e", query.getModel().getQueryTree().toString());
-            WeakAndItem root = (WeakAndItem) query.getModel().getQueryTree().getRoot();
+            assertEquals("AND myfield:a myfield:b myfield:c myfield:d myfield:e", query.getModel().getQueryTree().toString());
+            AndItem root = (AndItem) query.getModel().getQueryTree().getRoot();
             WordItem a = (WordItem) root.getItem(0);
-            AndItem and = (AndItem)root.getItem(1);
-            WordItem b = (WordItem) and.getItem(0);
-            WordItem c = (WordItem) and.getItem(1);
-            WordItem d = (WordItem) and.getItem(2);
-            WordItem e = (WordItem) root.getItem(2);
+            WordItem b = (WordItem) root.getItem(1);
+            WordItem c = (WordItem) root.getItem(2);
+            WordItem d = (WordItem) root.getItem(3);
+            WordItem e = (WordItem) root.getItem(4);
             assertNull(a.getConnectedItem());
             assertEquals(c, b.getConnectedItem());
             assertEquals(1.0, b.getConnectivity(), 0.00000001);
             assertEquals(d, c.getConnectedItem());
             assertEquals(1.0, c.getConnectivity(), 0.00000001);
             assertNull(d.getConnectedItem());
-            assertEquals("e", e.getIndexedString());
         }
     }
 
@@ -1067,7 +1063,7 @@ public class QueryTestCase {
         IndexModel indexModel = new IndexModel(test);
         query.getModel().setExecution(new Execution(Execution.Context.createContextStub(new IndexFacts(indexModel))));
 
-        assertEquals("WEAKAND(100) myfield:\"'it s' fine\"", query.getModel().getQueryTree().toString());
+        assertEquals("myfield:\"'it s' fine\"", query.getModel().getQueryTree().toString());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/MinimalQueryInserterTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/MinimalQueryInserterTestCase.java
@@ -128,7 +128,7 @@ public class MinimalQueryInserterTestCase {
     public void testSearch() {
         Query query = new Query("search/?query=easilyRecognizedString&yql=select%20ignoredfield%20from%20ignoredsource%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(Language.ENGLISH, query.getModel().getParsingLanguage());
     }
 
@@ -156,7 +156,7 @@ public class MinimalQueryInserterTestCase {
         Query query = new Query("search/?userString=" + encode(japaneseWord) + "&yql=select%20ignoredfield%20from%20ignoredsource%20where%20title%20contains%20%22madonna%22%20and%20userInput(@userString)");
         execution.search(query);
         assertEquals(Language.JAPANESE, query.getModel().getParsingLanguage());
-        assertEquals("AND title:madonna (WEAKAND(100) default:" + japaneseWord + ")", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna default:" + japaneseWord, query.getModel().getQueryTree().toString());
     }
 
     @Test
@@ -165,21 +165,21 @@ public class MinimalQueryInserterTestCase {
         Query query = new Query("search/?query=" + encode(japaneseWord) + "&yql=select%20ignoredfield%20from%20ignoredsource%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
         assertEquals(Language.JAPANESE, query.getModel().getParsingLanguage());
-        assertEquals("AND title:madonna (WEAKAND(100) " + japaneseWord + ")", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna " + japaneseWord, query.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testUserQueryFailsWithoutArgument() {
         Query query = new Query("search/?query=easilyRecognizedString&yql=select%20ignoredfield%20from%20ignoredsource%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
     }
 
     @Test
     public void testSearchFromAllSourcesWithUserSource() {
         Query query = new Query("search/?query=easilyRecognizedString&sources=abc&yql=select%20ignoredfield%20from%20sources%20*%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(0, query.getModel().getSources().size());
     }
 
@@ -187,7 +187,7 @@ public class MinimalQueryInserterTestCase {
     public void testSearchFromAllSourcesWithoutUserSource() {
         Query query = new Query("search/?query=easilyRecognizedString&yql=select%20ignoredfield%20from%20sources%20*%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(0, query.getModel().getSources().size());
     }
 
@@ -195,7 +195,7 @@ public class MinimalQueryInserterTestCase {
     public void testSearchFromSomeSourcesWithoutUserSource() {
         Query query = new Query("search/?query=easilyRecognizedString&yql=select%20ignoredfield%20from%20sources%20sourceA,%20sourceB%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(2, query.getModel().getSources().size());
         assertTrue(query.getModel().getSources().contains("sourceA"));
         assertTrue(query.getModel().getSources().contains("sourceB"));
@@ -205,7 +205,7 @@ public class MinimalQueryInserterTestCase {
     public void testSearchFromSomeSourcesWithUserSource() {
         Query query = new Query("search/?query=easilyRecognizedString&sources=abc&yql=select%20ignoredfield%20from%20sources%20sourceA,%20sourceB%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(3, query.getModel().getSources().size());
         assertTrue(query.getModel().getSources().contains("sourceA"));
         assertTrue(query.getModel().getSources().contains("sourceB"));
@@ -216,7 +216,7 @@ public class MinimalQueryInserterTestCase {
     public final void testSearchFromSomeSourcesWithOverlappingUserSource() {
         final Query query = new Query("search/?query=easilyRecognizedString&sources=abc,sourceA&yql=select%20ignoredfield%20from%20sources%20sourceA,%20sourceB%20where%20title%20contains%20%22madonna%22%20and%20userQuery()");
         execution.search(query);
-        assertEquals("AND title:madonna (WEAKAND(100) easilyRecognizedString)", query.getModel().getQueryTree().toString());
+        assertEquals("AND title:madonna easilyRecognizedString", query.getModel().getQueryTree().toString());
         assertEquals(3, query.getModel().getSources().size());
         assertTrue(query.getModel().getSources().contains("sourceA"));
         assertTrue(query.getModel().getSources().contains("sourceB"));

--- a/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/UserInputTestCase.java
@@ -50,14 +50,14 @@ public class UserInputTestCase {
             URIBuilder builder = searchUri();
             builder.setParameter("yql", "select * from sources * where userInput(\"nalle\")");
             Query query = searchAndAssertNoErrors(builder);
-            assertEquals("select * from sources * where weakAnd(default contains \"nalle\")", query.yqlRepresentation());
+            assertEquals("select * from sources * where default contains \"nalle\"", query.yqlRepresentation());
         }
         {
             URIBuilder builder = searchUri();
             builder.setParameter("nalle", "bamse");
             builder.setParameter("yql", "select * from sources * where userInput(@nalle)");
             Query query = searchAndAssertNoErrors(builder);
-            assertEquals("select * from sources * where weakAnd(default contains \"bamse\")", query.yqlRepresentation());
+            assertEquals("select * from sources * where default contains \"bamse\"", query.yqlRepresentation());
         }
         {
             URIBuilder builder = searchUri();
@@ -139,7 +139,7 @@ public class UserInputTestCase {
         builder.setParameter("yql",
                 "select * from sources * where [{defaultIndex: \"glompf\"}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
-        assertEquals("select * from sources * where weakAnd(glompf contains \"nalle\")", query.yqlRepresentation());
+        assertEquals("select * from sources * where glompf contains \"nalle\"", query.yqlRepresentation());
     }
 
     @Test
@@ -149,7 +149,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{stem: false}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{stem: false}]\"nalle\"))",
+                "select * from sources * where default contains ([{stem: false}]\"nalle\")",
                 query.yqlRepresentation());
     }
 
@@ -160,8 +160,8 @@ public class UserInputTestCase {
         builder.setParameter("yql",
                              "select * from ecitem where rank(([{defaultIndex:\"myfield\"}](userInput(@myinput))))");
         Query query = searchAndAssertNoErrors(builder);
-        assertEquals("select * from ecitem where rank(weakAnd(myfield = (-5)))", query.yqlRepresentation());
-        assertEquals("RANK (WEAKAND(100) myfield:-5)", query.getModel().getQueryTree().getRoot().toString());
+        assertEquals("select * from ecitem where rank(myfield = (-5))", query.yqlRepresentation());
+        assertEquals("RANK myfield:-5", query.getModel().getQueryTree().getRoot().toString());
     }
 
     @Test
@@ -171,7 +171,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{ranked: false}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{ranked: false}]\"nalle\"))",
+                "select * from sources * where default contains ([{ranked: false}]\"nalle\")",
                 query.yqlRepresentation());
     }
 
@@ -182,7 +182,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{filter: true}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{filter: true}]\"nalle\"))",
+                "select * from sources * where default contains ([{filter: true}]\"nalle\")",
                 query.yqlRepresentation());
     }
 
@@ -194,7 +194,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{normalizeCase: false}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{normalizeCase: false}]\"nalle\"))",
+                "select * from sources * where default contains ([{normalizeCase: false}]\"nalle\")",
                 query.yqlRepresentation());
     }
 
@@ -205,7 +205,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{accentDrop: false}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{accentDrop: false}]\"nalle\"))",
+                "select * from sources * where default contains ([{accentDrop: false}]\"nalle\")",
                 query.yqlRepresentation());
     }
 
@@ -216,7 +216,7 @@ public class UserInputTestCase {
                 "select * from sources * where [{usePositionData: false}]userInput(\"nalle\")");
         Query query = searchAndAssertNoErrors(builder);
         assertEquals(
-                "select * from sources * where weakAnd(default contains ([{usePositionData: false}]\"nalle\"))",
+                "select * from sources * where default contains ([{usePositionData: false}]\"nalle\")",
                 query.yqlRepresentation());
     }
 

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -428,7 +428,7 @@ public class YqlParserTestCase {
         assertFalse(root instanceof ExactStringItem);
         assertEquals("yoni jo dima", ((WordItem)root).getWord());
 
-        root = parse("select foo from bar where {grammar:\"all\"}userInput(\"yoni jo dima\")").getRoot();
+        root = parse("select foo from bar where userInput(\"yoni jo dima\")").getRoot();
         assertTrue(root instanceof AndItem);
         AndItem andItem = (AndItem) root;
         assertEquals(3, andItem.getItemCount());
@@ -1064,7 +1064,7 @@ public class YqlParserTestCase {
     @Test
     public void testUrlHostSearchingDefaultAnchors() {
         // Simple query syntax, for reference
-        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:google.com&type=all"), false, true, true);
+        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:google.com"), false, true, true);
 
         // YQL query
         Query yql = new Query();
@@ -1075,7 +1075,7 @@ public class YqlParserTestCase {
     @Test
     public void testUrlHostSearchingNoAnchors() {
         // Simple query syntax, for reference
-        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:google.com*&type=all"), false, false, true);
+        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:google.com*"), false, false, true);
 
         // YQL query
         Query yql = new Query();
@@ -1086,7 +1086,7 @@ public class YqlParserTestCase {
     @Test
     public void testUrlHostSearchingBothAnchors() {
         // Simple query syntax, for reference
-        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:%5Egoogle.com&type=all"), true, true, true); // %5E = ^
+        assertUrlQuery("urlfield.hostname", new Query("?query=urlfield.hostname:%5Egoogle.com"), true, true, true); // %5E = ^
 
         // YQL query
         Query yql = new Query();
@@ -1097,7 +1097,7 @@ public class YqlParserTestCase {
     @Test
     public void testUriNonHostDoesNotCreateAnchors() {
         // Simple query syntax, for reference
-        assertUrlQuery("urlfield", new Query("?query=urlfield:google.com&type=all"), false, false, false);
+        assertUrlQuery("urlfield", new Query("?query=urlfield:google.com"), false, false, false);
 
         // YQL query
         Query yql = new Query();

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -719,8 +719,8 @@ public class SelectTestCase {
     @Test
     public void testOverridingOtherQueryTree() {
         Query query = new Query("?query=default:query");
-        assertEquals("WEAKAND(100) default:query", query.getModel().getQueryTree().toString());
-        assertEquals(Query.Type.WEAKAND, query.getModel().getType());
+        assertEquals("default:query", query.getModel().getQueryTree().toString());
+        assertEquals(Query.Type.ALL, query.getModel().getType());
 
         query.getSelect().setWhereString("{\"contains\" : [\"default\", \"select\"] }");
         assertEquals("default:select", query.getModel().getQueryTree().toString());


### PR DESCRIPTION
Reverts vespa-engine/vespa#23032

Light-weight systemtest fails with:

```
14:46:33 [2022-06-09 14:46:26.217] ERROR   : container        Container.com.yahoo.search.handler.SearchHandler	
14:46:33 	Failed executing query=[WEAKAND[N=100]{
14:46:33 	  WORD[fromSegmented=false index="sddocname" origin="(10 15)" segmentIndex=0 stemmed=false words=false]{
14:46:33 	    "music"
14:46:33 	  }
14:46:33 	}
14:46:33 	] offset=0 hits=0 sources=[] restrict= [] rank profile=default [/search/?query=sddocname:music&hits=0&timeout=60]
14:46:33 	exception=
14:46:33 	java.lang.UnsupportedOperationException: com.yahoo.prelude.query.WeakAndItem
```

Revert or fix