### PR TITLE
Stabilize metrics-proxy tests

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/service/HttpMetricFetcher.java
@@ -2,12 +2,6 @@
 package ai.vespa.metricsproxy.service;
 
 import ai.vespa.util.http.hc5.VespaAsyncHttpClientBuilder;
-
-import java.io.InputStream;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.logging.Level;
-
 import com.yahoo.yolean.Exceptions;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -21,7 +15,11 @@ import org.apache.hc.core5.http.nio.support.classic.AbstractClassicEntityConsume
 import org.apache.hc.core5.util.Timeout;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -100,6 +98,7 @@ public abstract class HttpMetricFetcher {
         CloseableHttpAsyncClient client =  VespaAsyncHttpClientBuilder.create()
                 .setUserAgent("metrics-proxy-http-client")
                 .setDefaultRequestConfig(RequestConfig.custom()
+                                                 .setConnectionRequestTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT))
                                                  .setConnectTimeout(Timeout.ofMilliseconds(CONNECTION_TIMEOUT))
                                                  .setResponseTimeout(Timeout.ofMilliseconds(SOCKET_TIMEOUT))
                                                  .build())

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MockHttpServer.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/service/MockHttpServer.java
@@ -15,7 +15,7 @@ import java.net.InetSocketAddress;
 public class MockHttpServer {
 
     private String response;
-    private HttpServer server;
+    private final HttpServer server;
 
     /**
      * Mock http server that will return response as body
@@ -46,10 +46,12 @@ public class MockHttpServer {
 
     private class MyHandler implements HttpHandler {
         public void handle(HttpExchange t) throws IOException {
-            t.sendResponseHeaders(200, response.length());
-            OutputStream os = t.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+            synchronized (MockHttpServer.this) {
+                t.sendResponseHeaders(200, response != null ? response.length() : 0);
+                try (OutputStream os = t.getResponseBody()) {
+                    if (response != null) os.write(response.getBytes());
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Synchronize access to 'response' field. Handle null response.
Ensure output stream is closed. Specify timeout for request connection from pool.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
