### PR TITLE
Set property 'clustertype' for container cluster

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -282,7 +282,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         container.setOwner(this);
         container.setClusterName(name);
         container.setProp("clustername", name)
-                 .setProp("index", this.containers.size());
+                 .setProp("index", this.containers.size())
+                 .setProp("clustertype", "container");
         containers.add(container);
     }
 


### PR DESCRIPTION
Missing, seen in output from deploy:

    In cluster 'foo' of type '':
      Restart services of type 'qrserver' because:
          1) # RPC server listen port.
    qr.rpc.port has changed from 19103 to 19101
          2) # RPC server listen port
    qr.rpc.port has changed from 19104 to 19101
          3) # RPC server listen port
    qr.rpc.port has changed from 19105 to 19101
