### PR TITLE
enable making string handles directly from numbers

### DIFF
--- a/eval/src/vespa/eval/instruction/generic_peek.cpp
+++ b/eval/src/vespa/eval/instruction/generic_peek.cpp
@@ -252,12 +252,10 @@ struct SparsePlan {
     SparseState make_state(const Getter &get_child_value) const {
         SmallVector<Handle> handles;
         SmallVector<string_id> view_addr;
-        char buf[24];
         for (const auto & dim : lookup_specs) {
             if (dim.has_child()) {
                 int64_t child_value = get_child_value(dim.get_child_idx());
-                auto res = std::to_chars(buf, buf + sizeof(buf), child_value, 10);
-                handles.emplace_back(vespalib::stringref(buf, res.ptr - buf));
+                handles.push_back(Handle::handle_from_number(child_value));
                 view_addr.push_back(handles.back().id());
             } else {
                 view_addr.push_back(dim.get_label_name());

--- a/vespalib/src/tests/shared_string_repo/shared_string_repo_test.cpp
+++ b/vespalib/src/tests/shared_string_repo/shared_string_repo_test.cpp
@@ -498,6 +498,24 @@ TEST("require that basic multi-handle usage works") {
 
 //-----------------------------------------------------------------------------
 
+void verify_same_enum(int64_t num, const vespalib::string &str) {
+    Handle n = Handle::handle_from_number(num);
+    Handle s(str);
+    EXPECT_EQUAL(n.id().value(), s.id().value());
+}
+
+TEST("require that numeric label resolving works as expected") {
+    TEST_DO(verify_same_enum(-123, "-123"););
+    TEST_DO(verify_same_enum(-1, "-1"););
+    TEST_DO(verify_same_enum(0, "0"););
+    TEST_DO(verify_same_enum(123, "123"););
+    TEST_DO(verify_same_enum(9999999, "9999999"););
+    TEST_DO(verify_same_enum(10000000, "10000000"););
+    TEST_DO(verify_same_enum(999999999999, "999999999999"););
+}
+
+//-----------------------------------------------------------------------------
+
 #if 0
 // needs a lot of memory or tweaking of PART_LIMIT
 TEST("allocate handles until we run out") {

--- a/vespalib/src/vespa/vespalib/util/shared_string_repo.cpp
+++ b/vespalib/src/vespa/vespalib/util/shared_string_repo.cpp
@@ -116,6 +116,13 @@ SharedStringRepo::stats()
     return stats;
 }
 
+SharedStringRepo::Handle
+SharedStringRepo::Handle::handle_from_number_slow(int64_t value) {
+    char buf[24];
+    auto res = std::to_chars(buf, buf + sizeof(buf), value, 10);
+    return Handle(vespalib::stringref(buf, res.ptr - buf));
+}
+
 SharedStringRepo::Handles::Handles()
     : _handles()
 {

--- a/vespalib/src/vespa/vespalib/util/shared_string_repo.h
+++ b/vespalib/src/vespa/vespalib/util/shared_string_repo.h
@@ -263,6 +263,7 @@ public:
     private:
         string_id _id;
         Handle(string_id weak_id) : _id(_repo.copy(weak_id)) {}
+        static Handle handle_from_number_slow(int64_t value);
     public:
         Handle() noexcept : _id() {}
         Handle(vespalib::stringref str) : _id(_repo.resolve(str)) {}
@@ -290,6 +291,12 @@ public:
         uint32_t hash() const noexcept { return _id.hash(); }
         vespalib::string as_string() const { return _repo.as_string(_id); }
         static Handle handle_from_id(string_id weak_id) { return Handle(weak_id); }
+        static Handle handle_from_number(int64_t value) {
+            if ((value < 0) || (value > FAST_ID_MAX)) {
+                return handle_from_number_slow(value);
+            }
+            return Handle(string_id(value + 1));
+        }
         static vespalib::string string_from_id(string_id weak_id) { return _repo.as_string(weak_id); }
         ~Handle() { _repo.reclaim(_id); }
     };


### PR DESCRIPTION
used in peek/slice to avoid having to convert small numbers to strings
before resolving the enum values.

@baldersheim please review
@arnej27959 FYI