### PR TITLE
Get the Vespa version for flags from the model version

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -380,7 +380,7 @@ public class ModelContextImpl implements ModelContext {
         private final Optional<CloudAccount> cloudAccount;
 
         public Properties(ApplicationId applicationId,
-                          Version nodeVespaVersion,
+                          Version modelVersion,
                           ConfigserverConfig configserverConfig,
                           Zone zone,
                           Set<ContainerEndpoint> endpoints,
@@ -394,7 +394,7 @@ public class ModelContextImpl implements ModelContext {
                           SecretStore secretStore,
                           List<X509Certificate> operatorCertificates,
                           Optional<CloudAccount> cloudAccount) {
-            this.featureFlags = new FeatureFlags(flagSource, applicationId, nodeVespaVersion);
+            this.featureFlags = new FeatureFlags(flagSource, applicationId, modelVersion);
             this.applicationId = applicationId;
             this.multitenant = configserverConfig.multitenant() || configserverConfig.hostedVespa() || Boolean.getBoolean("multitenant");
             this.configServerSpecs = fromConfig(configserverConfig);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ActivatedModelsBuilder.java
@@ -99,7 +99,7 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
                                             Version wantedNodeVespaVersion) {
         log.log(Level.FINE, () -> String.format("Loading model version %s for session %s application %s",
                                                 modelFactory.version(), applicationGeneration, applicationId));
-        ModelContext.Properties modelContextProperties = createModelContextProperties(applicationId, wantedNodeVespaVersion, applicationPackage);
+        ModelContext.Properties modelContextProperties = createModelContextProperties(applicationId, modelFactory.version(), applicationPackage);
         Provisioned provisioned = new Provisioned();
         ModelContext modelContext = new ModelContextImpl(
                 applicationPackage,
@@ -143,9 +143,11 @@ public class ActivatedModelsBuilder extends ModelsBuilder<Application> {
         return Optional.of(value);
     }
 
-    private ModelContext.Properties createModelContextProperties(ApplicationId applicationId, Version wantedNodeVespaVersion, ApplicationPackage applicationPackage) {
+    private ModelContext.Properties createModelContextProperties(ApplicationId applicationId,
+                                                                 Version modelVersion,
+                                                                 ApplicationPackage applicationPackage) {
         return new ModelContextImpl.Properties(applicationId,
-                                               wantedNodeVespaVersion,
+                                               modelVersion,
                                                configserverConfig,
                                                zone(),
                                                ImmutableSet.copyOf(new ContainerEndpointsCache(TenantRepository.getTenantPath(tenant), curator).read(applicationId)),


### PR DESCRIPTION
A flag value which depends on Vespa version should not take
effect immediately when a deployment wants that version
but only for nodes which are actually upgraded to that version.

Take the flag version from the Vespa model version to achieve this.

@hakonhall and @hmusum and/or @arnej27959  please review.

(I'm going to clean this up a bit, but I wanted to keep the change small for now.)