### PR TITLE
Use larger timeout for global handler timeout

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -206,7 +206,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
             } else {
                 deployLogger.log(Level.INFO, "Services did not converge on new config generation " +
                         response.wantedGeneration + ", current generation: " + response.currentGeneration + ", will retry");
-                try { Thread.sleep(10_000); } catch (InterruptedException e) { /* ignore */ }
+                try { Thread.sleep(5_000); } catch (InterruptedException e) { /* ignore */ }
             }
         }
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationApiHandler.java
@@ -100,7 +100,7 @@ public class ApplicationApiHandler extends SessionHandler {
 
     @Override
     public Duration getTimeout() {
-        return zookeeperBarrierTimeout.plus(Duration.ofSeconds(10));
+        return zookeeperBarrierTimeout.plus(Duration.ofSeconds(30));
     }
 
     private TenantName validateTenant(HttpRequest request) {


### PR DESCRIPTION
Make sure that we use a larger timeout, some internal timeouts might be large
enough so that this global timeout is reached and we return with status code 504
and empty response