### PR TITLE
Return empty log if getting log fails and we just deployed

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -750,7 +750,7 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
 
     public HttpResponse getLogs(ApplicationId applicationId, Optional<DomainName> hostname, String apiParams) {
         String logServerURI = getLogServerURI(applicationId, hostname) + apiParams;
-        return logRetriever.getLogs(logServerURI);
+        return logRetriever.getLogs(logServerURI, lastDeployTime(applicationId));
     }
 
     // ---------------- Methods to do call against tester containers in hosted ------------------------------

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ServerCache.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ServerCache.java
@@ -24,7 +24,7 @@ public class ServerCache {
     private final ConfigDefinitionRepo builtinConfigDefinitions;
     private final ConfigDefinitionRepo userConfigDefinitions;
 
-    // NOTE: The reason we do a double mapping here is to de-dupe configs that have the same md5.
+    // NOTE: The reason we do a double mapping here is to de-dupe configs that have the same checksum.
     private final Map<ConfigCacheKey, PayloadChecksum> checksums = new ConcurrentHashMap<>();
     private final Map<PayloadChecksum, ConfigResponse> checksumToConfig = new ConcurrentHashMap<>();
     private final Object [] stripedLocks = new Object[113];

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
@@ -6,8 +6,12 @@ import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.yolean.Exceptions;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author olaaun
@@ -16,11 +20,20 @@ public class LogRetriever {
 
     private final CloseableHttpClient httpClient = VespaHttpClientBuilder.create().build();
 
-    public HttpResponse getLogs(String logServerUri) {
+    public HttpResponse getLogs(String logServerUri, Optional<Instant> deployTime) {
         HttpGet get = new HttpGet(logServerUri);
         try {
             return new ProxyResponse(httpClient.execute(get));
         } catch (IOException e) {
+            // It takes some time before nodes are up after first-time deployment, return empty log for up to 1 minute
+            // if getting logs fail
+            if (deployTime.isPresent() && Instant.now().isAfter(deployTime.get().minus(Duration.ofMinutes(1))))
+                return new HttpResponse(200) {
+                    @Override
+                    public void render(OutputStream outputStream) throws IOException {
+                        outputStream.write("".getBytes(StandardCharsets.UTF_8));
+                    }
+                };
             return HttpErrorResponse.internalServerError("Failed to get logs: " + Exceptions.toMessageString(e));
         }
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
@@ -27,7 +27,7 @@ public class LogRetriever {
         } catch (IOException e) {
             // It takes some time before nodes are up after first-time deployment, return empty log for up to 1 minute
             // if getting logs fail
-            if (deployTime.isPresent() && Instant.now().isAfter(deployTime.get().minus(Duration.ofMinutes(1))))
+            if (deployTime.isPresent() && Instant.now().isBefore(deployTime.get().plus(Duration.ofMinutes(1))))
                 return new HttpResponse(200) {
                     @Override
                     public void render(OutputStream outputStream) throws IOException {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -7,7 +7,6 @@ import com.yahoo.component.Version;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.SimpletypesConfig;
 import com.yahoo.config.application.api.ApplicationMetaData;
-import com.yahoo.config.model.NullConfigModelRegistry;
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.provision.AllocatedHosts;
@@ -57,7 +56,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
-
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -75,6 +74,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.IntStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -245,10 +245,13 @@ public class ApplicationRepositoryTest {
     }
 
     @Test
-    public void getLogs() {
+    public void getLogs() throws IOException {
         deployApp(testAppLogServerWithContainer);
         HttpResponse response = applicationRepository.getLogs(applicationId(), Optional.empty(), "");
         assertEquals(200, response.getStatus());
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        response.render(buffer);
+        assertEquals("log line", buffer.toString(UTF_8));
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/MockLogRetriever.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/MockLogRetriever.java
@@ -7,6 +7,8 @@ import com.yahoo.vespa.config.server.http.LogRetriever;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Optional;
 
 /**
  * @author olaa
@@ -14,21 +16,14 @@ import java.nio.charset.StandardCharsets;
 public class MockLogRetriever extends LogRetriever {
 
     @Override
-    public HttpResponse getLogs(String logServerUri) {
-        return new MockHttpResponse();
-    }
+    public HttpResponse getLogs(String logServerUri, Optional<Instant>deployTime ) {
+        return new HttpResponse(200) {
+            @Override
+            public void render(OutputStream outputStream) throws IOException {
+                outputStream.write("log line".getBytes(StandardCharsets.UTF_8));
+            }
 
-    private static class MockHttpResponse extends HttpResponse {
-
-        private MockHttpResponse() {
-            super(200);
-        }
-
-        @Override
-        public void render(OutputStream outputStream) throws IOException {
-            outputStream.write("log line".getBytes(StandardCharsets.UTF_8));
-        }
-
+        };
     }
 
 }


### PR DESCRIPTION
Return empty log if unable to get log up to 1 minute after deployment (this is what
happens in cd and test zones when new nodes need to be started before any logging is done). Now we get lots of warnings in config server vespa logs due to this




