### PR TITLE
Reduce interval for DynamicProvisioningMaintainer to 3 minutes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -125,7 +125,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
 
         DefaultTimes(Zone zone, Deployer deployer) {
             autoscalingInterval = Duration.ofMinutes(15);
-            dynamicProvisionerInterval = Duration.ofMinutes(5);
+            dynamicProvisionerInterval = Duration.ofMinutes(3);
             failedExpirerInterval = Duration.ofMinutes(10);
             failGrace = Duration.ofMinutes(30);
             infrastructureProvisionInterval = Duration.ofMinutes(3);


### PR DESCRIPTION
Waiting for provisioning hosts takes a really long time, resuming
provisioning more often might help a little.

Unless there is a good reason this interval is so high?