### PR TITLE
Remove application-model from vespa RPM (already present in vespa-jars RPM).

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -747,7 +747,6 @@ fi
 %{_prefix}/include
 %dir %{_prefix}/lib
 %dir %{_prefix}/lib/jars
-%{_prefix}/lib/jars/application-model-jar-with-dependencies.jar
 %{_prefix}/lib/jars/application-preprocessor-jar-with-dependencies.jar
 %{_prefix}/lib/jars/athenz-identity-provider-service-jar-with-dependencies.jar
 %{_prefix}/lib/jars/cloud-tenant-cd-jar-with-dependencies.jar


### PR DESCRIPTION
@geirst : please review
@hakonhall : FYI
