### PR TITLE
Use getActivatedTime() for last deployed time for an app [run-systemtest]

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/Deployer.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/Deployer.java
@@ -54,7 +54,7 @@ public interface Deployer {
      */
     Optional<Deployment> deployFromLocalActive(ApplicationId application, Duration timeout, boolean bootstrap);
 
-    /** Returns the time the current local active session was created, or empty if there is no local active session */
+    /** Returns the time the current local active session was activated, or empty if there is no local active session */
     Optional<Instant> lastDeployTime(ApplicationId application);
 
     /** Whether the deployer is bootstrapping, some users of the deployer will want to hold off with deployments in that case. */

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -437,7 +437,9 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
     public Optional<Instant> lastDeployTime(ApplicationId application) {
         Tenant tenant = tenantRepository.getTenant(application.tenant());
         if (tenant == null) return Optional.empty();
-        return getActiveSession(tenant, application).map(Session::getCreateTime);
+        Optional<Instant> activatedTime = getActiveSession(tenant, application).map(Session::getActivatedTime);
+        log.log(Level.FINE, application + " last activated " + activatedTime.orElse(Instant.EPOCH));
+        return activatedTime;
     }
 
     public ApplicationId activate(Tenant tenant,

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandler.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.http.v2;
 
-import java.time.Duration;
-
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.application.api.ApplicationMetaData;
 import com.yahoo.config.provision.ApplicationId;
@@ -12,14 +10,15 @@ import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.jdisc.Request;
 import com.yahoo.jdisc.handler.ResponseHandler;
-import java.util.logging.Level;
 import com.yahoo.vespa.config.server.ApplicationRepository;
-import com.yahoo.vespa.config.server.http.v2.response.SessionActiveResponse;
-import com.yahoo.vespa.config.server.tenant.Tenant;
-import com.yahoo.vespa.config.server.tenant.TenantRepository;
 import com.yahoo.vespa.config.server.TimeoutBudget;
 import com.yahoo.vespa.config.server.http.SessionHandler;
 import com.yahoo.vespa.config.server.http.Utils;
+import com.yahoo.vespa.config.server.http.v2.response.SessionActiveResponse;
+import com.yahoo.vespa.config.server.tenant.Tenant;
+import com.yahoo.vespa.config.server.tenant.TenantRepository;
+import java.time.Duration;
+import java.util.logging.Level;
 
 /**
  * Handler that activates a session given by tenant and id (PUT).

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/Session.java
@@ -115,6 +115,10 @@ public abstract class Session implements Comparable<Session>  {
         return sessionZooKeeperClient.readCreateTime();
     }
 
+    public Instant getActivatedTime() {
+        return sessionZooKeeperClient.readActivatedTime();
+    }
+
     public void setApplicationId(ApplicationId applicationId) {
         sessionZooKeeperClient.writeApplicationId(applicationId);
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -235,7 +235,7 @@ public class SessionRepository {
     public ConfigChangeActions prepareLocalSession(Session session, DeployLogger logger, PrepareParams params, Instant now) {
         params.vespaVersion().ifPresent(version -> {
             if ( ! params.isBootstrap() && ! modelFactoryRegistry.allVersions().contains(version))
-                throw new UnknownVespaVersionException("Vespa version '" + version + "' not known by this configserver");
+                throw new UnknownVespaVersionException("Vespa version '" + version + "' not known by this config server");
         });
 
         applicationRepo.createApplication(params.getApplicationId()); // TODO jvenstad: This is wrong, but it has to be done now, since preparation can change the application ID of a session :(

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionZooKeeperClient.java
@@ -33,7 +33,7 @@ import com.yahoo.vespa.config.server.zookeeper.ZKApplicationPackage;
 import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.curator.transaction.CuratorOperations;
 import com.yahoo.vespa.curator.transaction.CuratorTransaction;
-
+import org.apache.zookeeper.data.Stat;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.List;
@@ -237,6 +237,11 @@ public class SessionZooKeeperClient {
     public Instant readCreateTime() {
         Optional<byte[]> data = curator.getData(getCreateTimePath());
         return data.map(d -> Instant.ofEpochSecond(Long.parseLong(Utf8.toString(d)))).orElse(Instant.EPOCH);
+    }
+
+    public Instant readActivatedTime() {
+        Optional<Stat> statData = curator.getStat(sessionStatusPath);
+        return statData.map(s -> Instant.ofEpochMilli(s.getMtime())).orElse(Instant.EPOCH);
     }
 
     private Path getCreateTimePath() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ApplicationMaintainer.java
@@ -89,7 +89,7 @@ public abstract class ApplicationMaintainer extends NodeRepositoryMaintainer {
         }
     }
 
-    /** Returns the last time application was deployed. Epoch is returned if the application has never been deployed. */
+    /** Returns the last time application was activated. Epoch is returned if the application has never been deployed. */
     protected final Instant getLastDeployTime(ApplicationId application) {
         return deployer.lastDeployTime(application).orElse(Instant.EPOCH);
     }


### PR DESCRIPTION
Use getActivatedTime() instead of getCreatedTime in lastDeployTime().
getCreatedTime() gives time a new session was created, not when it was
activated, which is what we usually want.
