### PR TITLE
probe base directory

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -149,7 +149,20 @@ const vespalib::string CUSTOM_COMPONENT_API_PATH = "/state/v1/custom/component";
 VESPA_THREAD_STACK_TAG(proton_initialize_executor)
 VESPA_THREAD_STACK_TAG(proton_close_executor)
 
+void ensureWritableDir(const vespalib::string &dirName) {
+    int pidnum = ::getpid();
+    int secnum = ::time(0);
+    auto pidstr = std::to_string(pidnum);
+    auto secstr = std::to_string(secnum);
+    auto filename = dirName + "/tmp.file." + pidstr + "." + secstr;
+    vespalib::File probe(filename);
+    probe.open(vespalib::File::CREATE);
+    probe.write("probe\n", 6, 0);
+    probe.close();
+    probe.unlink();
 }
+
+} // namespace <unnamed>
 
 Proton::ProtonFileHeaderContext::ProtonFileHeaderContext(const vespalib::string &creator)
     : _hostName(),
@@ -278,6 +291,7 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
 {
     assert( _initStarted && ! _initComplete );
     const ProtonConfig &protonConfig = configSnapshot->getProtonConfig();
+    ensureWritableDir(protonConfig.basedir);
     const HwInfo & hwInfo = configSnapshot->getHwInfo();
     _hw_info = hwInfo;
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -150,12 +150,9 @@ VESPA_THREAD_STACK_TAG(proton_initialize_executor)
 VESPA_THREAD_STACK_TAG(proton_close_executor)
 
 void ensureWritableDir(const vespalib::string &dirName) {
-    int pidnum = ::getpid();
-    int secnum = ::time(0);
-    auto pidstr = std::to_string(pidnum);
-    auto secstr = std::to_string(secnum);
-    auto filename = dirName + "/tmp.file." + pidstr + "." + secstr;
+    auto filename = dirName + "/tmp.filesystem.probe";
     vespalib::File probe(filename);
+    probe.unlink();
     probe.open(vespalib::File::CREATE);
     probe.write("probe\n", 6, 0);
     probe.close();


### PR DESCRIPTION
* this is mainly useful for the case where the filesystem
  with our data is mounted read-only because the OS detected
  that something was bad.

@toregge please review
