### PR TITLE
Revert "Simplify as record"

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HealthCheckProxyHandler.java
@@ -259,10 +259,18 @@ class HealthCheckProxyHandler extends HandlerWrapper {
         }
     }
 
-    private record StatusResponse(long createdAt, int statusCode, String contentType, byte[] content) {
+    private static class StatusResponse {
+        final long createdAt = System.nanoTime();
+        final int statusCode;
+        final String contentType;
+        final byte[] content;
+
         StatusResponse(int statusCode, String contentType, byte[] content) {
-            this(System.nanoTime(), statusCode, contentType, content);
+            this.statusCode = statusCode;
+            this.contentType = contentType;
+            this.content = content;
         }
+
         boolean isExpired() { return System.nanoTime() - createdAt > Duration.ofSeconds(1).toNanos(); }
     }
 }


### PR DESCRIPTION
This reverts commit 8e4148724284d27c0dd99d8b7d2753df400abc95.
Aries Spifly does not handle class weaving using JDK17 features.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
