### PR TITLE
Make sure to return response when request times out

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDirectory.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/filedistribution/FileDirectory.java
@@ -60,16 +60,13 @@ public class FileDirectory  {
     public File getFile(FileReference reference) {
         ensureRootExist();
         File dir = new File(getPath(reference));
-        if (!dir.exists()) {
+        if (!dir.exists())
             throw new IllegalArgumentException("File reference '" + reference.value() + "' with absolute path '" + dir.getAbsolutePath() + "' does not exist.");
-        }
-        if (!dir.isDirectory()) {
+        if (!dir.isDirectory())
             throw new IllegalArgumentException("File reference '" + reference.value() + "' with absolute path '" + dir.getAbsolutePath() + "' is not a directory.");
-        }
         File [] files = dir.listFiles(new Filter());
-        if (files == null || files.length == 0) {
+        if (files == null || files.length == 0)
             throw new IllegalArgumentException("File reference '" + reference.value() + "' with absolute path '" + dir.getAbsolutePath() + " does not contain any files");
-        }
         return files[0];
     }
 
@@ -82,7 +79,7 @@ public class FileDirectory  {
         if (file.isDirectory()) {
             return Files.walk(file.toPath(), 100).map(path -> {
                 try {
-                    log.log(Level.FINE, () -> "Calculating hash for '" + path + "'");
+                    log.log(Level.FINEST, () -> "Calculating hash for '" + path + "'");
                     return hash(path.toFile(), hasher);
                 } catch (IOException e) {
                     log.log(Level.WARNING, "Failed getting hash from '" + path + "'");

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -566,7 +566,10 @@ public class RpcServer implements Runnable, ReloadListener, TenantListener {
         rpcAuthorizer.authorizeFileRequest(request)
                 .thenRun(() -> { // okay to do in authorizer thread as serveFile is async
                     FileServer.Receiver receiver = new ChunkedFileReceiver(request.target());
-                    fileServer.serveFile(request.parameters().get(0).asString(), request.parameters().get(1).asInt32() == 0, request, receiver);
+                    fileServer.serveFile(new FileReference(request.parameters().get(0).asString()),
+                                         request.parameters().get(1).asInt32() == 0,
+                                         request,
+                                         receiver);
                 });
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/filedistribution/FileServerTest.java
@@ -75,7 +75,7 @@ public class FileServerTest {
         File dir = getFileServerRootDir();
         IOUtils.writeFile(dir + "/12y/f1", "dummy-data", true);
         CompletableFuture<byte []> content = new CompletableFuture<>();
-        fileServer.startFileServing("12y", new FileReceiver(content));
+        fileServer.startFileServing(new FileReference("12y"), new FileReceiver(content));
         assertEquals(new String(content.get()), "dummy-data");
     }
 

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileReferenceDownloader.java
@@ -112,11 +112,12 @@ public class FileReferenceDownloader {
         FileReference fileReference = fileReferenceDownload.fileReference();
         if (validateResponse(request)) {
             log.log(Level.FINE, () -> "Request callback, OK. Req: " + request + "\nSpec: " + connection);
-            if (request.returnValues().get(0).asInt32() == 0) {
+            int errorCode = request.returnValues().get(0).asInt32();
+            if (errorCode == 0) {
                 log.log(Level.FINE, () -> "Found " + fileReference + " available at " + connection.getAddress());
                 return true;
             } else {
-                log.log(logLevel, fileReference + " not found at " + connection.getAddress());
+                log.log(logLevel, fileReference + " not found or timed out (error code " +  errorCode + ") at " + connection.getAddress());
                 return false;
             }
         } else {


### PR DESCRIPTION
Return with new error code 2. Clients only check for error code 0,
so a new error code is handled implicitly also by old clients