### PR TITLE
waste less time in second phase ranking

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/document_scorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/document_scorer.cpp
@@ -34,8 +34,12 @@ DocumentScorer::DocumentScorer(RankProgram &rankProgram,
 void
 DocumentScorer::score(TaggedHits &hits)
 {
+    if (hits.empty()) {
+        return;
+    }
     auto sort_on_docid = [](const TaggedHit &a, const TaggedHit &b){ return (a.first.first < b.first.first); };
     std::sort(hits.begin(), hits.end(), sort_on_docid);
+    _searchItr.initRange(hits.front().first.first, hits.back().first.first + 1);
     for (auto &hit: hits) {
         hit.first.second = doScore(hit.first.first);
     }


### PR DESCRIPTION
avoid setting up second phase ranking for threads with no hits to rank
in second phase.

call initRange with actual docid range when preparing to perform
second phase ranking. This should make sure that eager iterators find
the first hit immediately.

@baldersheim please review