### PR TITLE
Use the default Dockerfile when building release container images.

### DIFF
--- a/screwdriver/release-container-image.sh
+++ b/screwdriver/release-container-image.sh
@@ -26,7 +26,7 @@ cd $BUILD_DIR
 git clone --depth 1 https://github.com/vespa-engine/docker-image
 cd docker-image
 
-docker build --build-arg VESPA_VERSION=$VESPA_VERSION --file Dockerfile.stream8 \
+docker build --build-arg VESPA_VERSION=$VESPA_VERSION --file Dockerfile \
        --tag docker.io/vespaengine/vespa:$VESPA_VERSION --tag docker.io/vespaengine/vespa:latest \
        --tag ghcr.io/vespa-engine/vespa:$VESPA_VERSION  --tag ghcr.io/vespa-engine/vespa:latest .
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
