### PR TITLE
Remove 'requireSequencing' as an option.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.model.content;
 
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorDistributormanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
@@ -68,13 +67,6 @@ public class Distributor extends ContentNode implements StorDistributormanagerCo
     public void getConfig(StorServerConfig.Builder builder) {
         super.getConfig(builder);
         provider.getConfig(builder);
-    }
-
-    @Override
-    public void getConfig(StorCommunicationmanagerConfig.Builder builder) {
-        super.getConfig(builder);
-        // Single distributor needs help to encode the messages.
-        builder.mbus.dispatch_on_encode(true);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/StorageNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/StorageNode.java
@@ -6,7 +6,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.config.content.StorFilestorConfig;
 import com.yahoo.vespa.config.content.core.StorBucketmoverConfig;
-import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
@@ -92,12 +91,6 @@ public class StorageNode extends ContentNode implements StorServerConfig.Produce
             builder.num_threads(Math.max(4, (int)getHostResource().realResources().vcpu()));
         }
         cluster.getConfig(builder);
-    }
-
-    @Override
-    public void getConfig(StorCommunicationmanagerConfig.Builder builder) {
-        super.getConfig(builder);
-        builder.mbus.dispatch_on_encode(false);
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/DistributorTest.java
@@ -291,7 +291,7 @@ public class DistributorTest {
         cluster.getChildren().get("0").getConfig(builder);
         StorCommunicationmanagerConfig config = new StorCommunicationmanagerConfig(builder);
         assertTrue(config.mbus().dispatch_on_encode());
-        assertFalse(config.mbus().dispatch_on_decode());
+        assertTrue(config.mbus().dispatch_on_decode());
         assertEquals(4, config.mbus().num_threads());
         assertEquals(StorCommunicationmanagerConfig.Mbus.Optimize_for.LATENCY, config.mbus().optimize_for());
         assertFalse(config.skip_thread());

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/StorageClusterTest.java
@@ -101,8 +101,8 @@ public class StorageClusterTest {
         StorCommunicationmanagerConfig.Builder builder = new StorCommunicationmanagerConfig.Builder();
         storage.getChildren().get("0").getConfig(builder);
         StorCommunicationmanagerConfig config = new StorCommunicationmanagerConfig(builder);
-        assertFalse(config.mbus().dispatch_on_encode());
-        assertFalse(config.mbus().dispatch_on_decode());
+        assertTrue(config.mbus().dispatch_on_encode());
+        assertTrue(config.mbus().dispatch_on_decode());
         assertEquals(4, config.mbus().num_threads());
         assertEquals(StorCommunicationmanagerConfig.Mbus.Optimize_for.LATENCY, config.mbus().optimize_for());
         assertFalse(config.skip_thread());

--- a/documentapi/src/vespa/documentapi/messagebus/documentprotocol.h
+++ b/documentapi/src/vespa/documentapi/messagebus/documentprotocol.h
@@ -292,7 +292,6 @@ public:
     mbus::IRoutingPolicy::UP createPolicy(const mbus::string &name, const mbus::string &param) const override;
     mbus::Blob encode(const vespalib::Version &version, const mbus::Routable &routable) const override;
     mbus::Routable::UP decode(const vespalib::Version &version, mbus::BlobRef data) const override;
-    bool requireSequencing() const override { return false; }
 };
 
 }

--- a/messagebus/src/tests/protocolrepository/protocolrepository.cpp
+++ b/messagebus/src/tests/protocolrepository/protocolrepository.cpp
@@ -13,42 +13,23 @@ private:
 
 public:
 
-    TestProtocol(const string &name)
+    TestProtocol(const string &name) noexcept
         : _name(name)
-    {
-        // empty
-    }
+    { }
 
-    const string &
-    getName() const override
-    {
-        return _name;
-    }
+    const string & getName() const override { return _name; }
 
-    IRoutingPolicy::UP
-    createPolicy(const string &name, const string &param) const override
-    {
-        (void)name;
-        (void)param;
+    IRoutingPolicy::UP createPolicy(const string &, const string &) const override {
         throw std::exception();
     }
 
-    Blob
-    encode(const vespalib::Version &version, const Routable &routable) const override
-    {
-        (void)version;
-        (void)routable;
+    Blob encode(const vespalib::Version &, const Routable &) const override {
         throw std::exception();
     }
 
-    Routable::UP
-    decode(const vespalib::Version &version, BlobRef data) const override
-    {
-        (void)version;
-        (void)data;
+    Routable::UP decode(const vespalib::Version &, BlobRef ) const override {
         throw std::exception();
     }
-    bool requireSequencing() const override { return false; }
 };
 
 int
@@ -58,16 +39,16 @@ Test::Main()
 
     ProtocolRepository repo;
     IProtocol::SP prev;
-    prev = repo.putProtocol(IProtocol::SP(new TestProtocol("foo")));
-    ASSERT_TRUE(prev.get() == NULL);
+    prev = repo.putProtocol(std::make_shared<TestProtocol>("foo"));
+    ASSERT_FALSE(prev);
 
     IRoutingPolicy::SP policy = repo.getRoutingPolicy("foo", "bar", "baz");
-    prev = repo.putProtocol(IProtocol::SP(new TestProtocol("foo")));
-    ASSERT_TRUE(prev.get() != NULL);
+    prev = repo.putProtocol(std::make_shared<TestProtocol>("foo"));
+    ASSERT_TRUE(prev);
     ASSERT_NOT_EQUAL(prev.get(), repo.getProtocol("foo"));
 
     policy = repo.getRoutingPolicy("foo", "bar", "baz");
-    ASSERT_TRUE(policy.get() == NULL);
+    ASSERT_FALSE(policy);
 
     TEST_DONE();
 }

--- a/messagebus/src/vespa/messagebus/iprotocol.h
+++ b/messagebus/src/vespa/messagebus/iprotocol.h
@@ -79,9 +79,6 @@ public:
      * @return The decoded routable.
      */
     virtual Routable::UP decode(const vespalib::Version &version, BlobRef data) const = 0; // throw()
-
-
-    virtual bool requireSequencing() const = 0;
 };
 
 } // namespace mbus

--- a/messagebus/src/vespa/messagebus/network/rpcsend.h
+++ b/messagebus/src/vespa/messagebus/network/rpcsend.h
@@ -83,9 +83,9 @@ public:
 
     void invoke(FRT_RPCRequest *req);
 private:
-    void doRequest(FRT_RPCRequest *req, const IProtocol * protocol, std::unique_ptr<Params> params);
+    void doRequest(FRT_RPCRequest *req);
     void doRequestDone(FRT_RPCRequest *req);
-    void doHandleReply(const IProtocol * protocol, std::unique_ptr<Reply> reply);
+    void doHandleReply(std::unique_ptr<Reply> reply);
     void attach(RPCNetwork &net) final override;
     void handleDiscard(Context ctx) final override;
     void sendByHandover(RoutingNode &recipient, const vespalib::Version &version,

--- a/messagebus/src/vespa/messagebus/testlib/simpleprotocol.h
+++ b/messagebus/src/vespa/messagebus/testlib/simpleprotocol.h
@@ -72,7 +72,6 @@ public:
     IRoutingPolicy::UP createPolicy(const string &name, const string &param) const override;
     Blob encode(const vespalib::Version &version, const Routable &routable) const override;
     Routable::UP decode(const vespalib::Version &version, BlobRef data) const override;
-    virtual bool requireSequencing() const override { return false; }
 };
 
 } // namespace mbus

--- a/storage/src/vespa/storage/config/stor-communicationmanager.def
+++ b/storage/src/vespa/storage/config/stor-communicationmanager.def
@@ -51,7 +51,7 @@ mbus.dispatch_on_encode bool default=true restart
 ## Enable to use above thread pool for decoding replies
 ## False will use network(fnet) thread
 ## Todo: Change default once verified in large scale deployment.
-mbus.dispatch_on_decode bool default=false restart
+mbus.dispatch_on_decode bool default=true restart
 
 ## Skip messenger thread on reply
 ## Experimental

--- a/storage/src/vespa/storageapi/mbusprot/storageprotocol.h
+++ b/storage/src/vespa/storageapi/mbusprot/storageprotocol.h
@@ -22,7 +22,6 @@ public:
     mbus::IRoutingPolicy::UP createPolicy(const mbus::string& name, const mbus::string& param) const override;
     mbus::Blob encode(const vespalib::Version&, const mbus::Routable&) const override;
     mbus::Routable::UP decode(const vespalib::Version&, mbus::BlobRef) const override;
-    bool requireSequencing() const override { return true; }
 private:
     ProtocolSerialization5_0 _serializer5_0;
     ProtocolSerialization5_1 _serializer5_1;


### PR DESCRIPTION
As a consequence move protocol and params resolution to common code so that it is always handled in the decoding/encoding thread.

@vekterli PR