### PR TITLE
Remove println

### DIFF
--- a/configgen/src/main/java/com/yahoo/config/codegen/JavaClassBuilder.java
+++ b/configgen/src/main/java/com/yahoo/config/codegen/JavaClassBuilder.java
@@ -47,7 +47,6 @@ public class JavaClassBuilder implements ClassBuilder {
             try (PrintStream out = new PrintStream(new FileOutputStream(outFile))) {
                 out.print(getConfigClass(className));
             }
-            System.err.println(outFile.getPath() + " successfully written.");
         } catch (FileNotFoundException e) {
             throw new CodegenRuntimeException(e);
         }


### PR DESCRIPTION
This causes extra noise when doing a `--quiet` build. Probably not needed?

@gjoranv