### PR TITLE
Remove uneeded version check

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -92,9 +92,6 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
         Instant start = Instant.now();
         log.log(Level.FINE, () -> "Will build models for " + applicationId);
         Set<Version> versions = modelFactoryRegistry.allVersions();
-        if (applicationPackage.getMajorVersion().isPresent() && applicationPackage.getMajorVersion().get() != wantedNodeVespaVersion.getMajor())
-            throw new IllegalArgumentException("requested node version (" + wantedNodeVespaVersion + ") has a different major version " +
-                                               "than specified in deployment.xml (" + applicationPackage.getMajorVersion().get() + ")");
 
         // If the application specifies a major, skip models on a newer major
         Optional<Integer> requestedMajorVersion = applicationPackage.getMajorVersion();


### PR DESCRIPTION
@bratseth please review. I think I added this condition just because I thought the controller would always ensure this, and it eased my mind, not because it was crucial. It's blocking upgrades from 7 to 8 for non-Java apps in the cloud. 