### PR TITLE
Set provided scope for jupiter-api in dep-man

### DIFF
--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -94,6 +94,13 @@
 
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${vespa.junit.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-engine</artifactId>
                 <version>${vespa.junit.version}</version>
             </dependency>


### PR DESCRIPTION
@bjorncs what do you think? Several users have had to exclude jupiter-api from, e.g., jupiter-params, to build their app ...