### PR TITLE
Don't drop single value non-attribute byte/short/int/long field due to

### DIFF
--- a/searchsummary/src/vespa/searchsummary/docsummary/check_undefined_value_visitor.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/check_undefined_value_visitor.cpp
@@ -28,11 +28,8 @@ CheckUndefinedValueVisitor::visit(const document::BoolFieldValue&)
 }
 
 void
-CheckUndefinedValueVisitor::visit(const document::ByteFieldValue& value)
+CheckUndefinedValueVisitor::visit(const document::ByteFieldValue&)
 {
-    if (isUndefined(value.getValue())) {
-        _is_undefined = true;
-    }
 }
 
 void
@@ -57,19 +54,13 @@ CheckUndefinedValueVisitor::visit(const document::FloatFieldValue& value)
 }
 
 void
-CheckUndefinedValueVisitor::visit(const document::IntFieldValue& value)
+CheckUndefinedValueVisitor::visit(const document::IntFieldValue&)
 {
-    if (isUndefined(value.getValue())) {
-        _is_undefined = true;
-    }
 }
 
 void
-CheckUndefinedValueVisitor::visit(const document::LongFieldValue& value)
+CheckUndefinedValueVisitor::visit(const document::LongFieldValue&)
 {
-    if (isUndefined(value.getValue())) {
-        _is_undefined = true;
-    }
 }
 
 void
@@ -91,11 +82,8 @@ CheckUndefinedValueVisitor::visit(const document::RawFieldValue&)
 }
 
 void
-CheckUndefinedValueVisitor::visit(const document::ShortFieldValue& value)
+CheckUndefinedValueVisitor::visit(const document::ShortFieldValue&)
 {
-    if (isUndefined(value.getValue())) {
-        _is_undefined = true;
-    }
 }
 
 void

--- a/searchsummary/src/vespa/searchsummary/docsummary/check_undefined_value_visitor.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/check_undefined_value_visitor.h
@@ -7,8 +7,9 @@
 namespace search::docsummary {
 
 /*
- * This class checks if field value is considered the same value as undefined
- * values for attribute vectors.
+ * This class checks if field value is considered the same value as
+ * undefined values string/double/float attribute vectors or empty
+ * array/map/weighted set.
  */
 class CheckUndefinedValueVisitor : public document::ConstFieldValueVisitor
 {
@@ -16,16 +17,16 @@ class CheckUndefinedValueVisitor : public document::ConstFieldValueVisitor
     void visit(const document::AnnotationReferenceFieldValue&) override;
     void visit(const document::ArrayFieldValue& value) override;
     void visit(const document::BoolFieldValue&) override;
-    void visit(const document::ByteFieldValue& value) override;
+    void visit(const document::ByteFieldValue&) override;
     void visit(const document::Document&) override;
     void visit(const document::DoubleFieldValue& value) override;
     void visit(const document::FloatFieldValue& value) override;
-    void visit(const document::IntFieldValue& value) override;
-    void visit(const document::LongFieldValue& value) override;
+    void visit(const document::IntFieldValue&) override;
+    void visit(const document::LongFieldValue&) override;
     void visit(const document::MapFieldValue& value) override;
     void visit(const document::PredicateFieldValue&) override;
     void visit(const document::RawFieldValue&) override;
-    void visit(const document::ShortFieldValue& value) override;
+    void visit(const document::ShortFieldValue&) override;
     void visit(const document::StringFieldValue& value) override;
     void visit(const document::StructFieldValue&) override;
     void visit(const document::WeightedSetFieldValue& value) override;


### PR DESCRIPTION
undefined value.

@geirst : please review
@baldersheim : FYI
 