### PR TITLE
GNU source is not required for boost stacktrace on darwin.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/signalhandler.cpp
+++ b/vespalib/src/vespa/vespalib/util/signalhandler.cpp
@@ -2,6 +2,9 @@
 
 #include "signalhandler.h"
 #include "backtrace.h"
+#ifdef __APPLE__
+#define BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED
+#endif
 #include <boost/stacktrace/safe_dump_to.hpp> // Header-only dependency
 #include <boost/stacktrace/frame.hpp>
 #include <array>


### PR DESCRIPTION
@baldersheim : please review
