### PR TITLE
Fix dnf repo query sort order to return the latest Vespa version.

### DIFF
--- a/screwdriver/release-rpms.sh
+++ b/screwdriver/release-rpms.sh
@@ -12,7 +12,7 @@ fi
 readonly VESPA_RELEASE="$1"
 readonly VESPA_REF="$2"
 
-VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/centos-stream-8-x86_64 --repoid=vespa -q vespa | tail -1 | cut -d: -f2 | cut -d- -f1)
+VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/centos-stream-8-x86_64 --repoid=vespa -q vespa | cut -d: -f2 | cut -d- -f1 | sort -V | tail -1)
 echo "Latest RPM on Copr: $VESPA_RPM"
 
 if [ "$VESPA_RELEASE" == "$VESPA_RPM" ]; then
@@ -33,7 +33,7 @@ dist/release-vespa-rpm.sh $VESPA_RELEASE $VESPA_REF
 
 while [ "$VESPA_RELEASE" != "$VESPA_RPM" ]; do
   dnf clean --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/centos-stream-8-x86_64 --repoid=vespa metadata
-  VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/centos-stream-8-x86_64 --repoid=vespa -q vespa | tail -1 | cut -d: -f2 | cut -d- -f1)
+  VESPA_RPM=$(dnf repoquery --repofrompath=vespa,https://copr-be.cloud.fedoraproject.org/results/@vespa/vespa/centos-stream-8-x86_64 --repoid=vespa -q vespa | cut -d: -f2 | cut -d- -f1 | sort -V | tail -1)
   echo "RPM: $VESPA_RPM"
   sleep 150
 done


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This had an unexpected sort order compared to the old yum on CentOS 7.
