### PR TITLE
Remove 'user' field in application metadata and add deprecations for … [run-systemtest]

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/DeployData.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/DeployData.java
@@ -10,9 +10,6 @@ import com.yahoo.config.provision.ApplicationId;
  */
 public class DeployData {
 
-    /** Which user deployed */
-    private final String deployedByUser;
-
     private final ApplicationId applicationId;
 
     /** The absolute path to the directory holding the application */
@@ -28,14 +25,23 @@ public class DeployData {
     private final long generation;
     private final long currentlyActiveGeneration;
 
-    public DeployData(String deployedByUser,
+    // TODO: Remove when oldest version in use is 8.13
+    public DeployData(String ignored,
                       String deployedFromDir,
                       ApplicationId applicationId,
                       Long deployTimestamp,
                       boolean internalRedeploy,
                       Long generation,
                       long currentlyActiveGeneration) {
-        this.deployedByUser = deployedByUser;
+        this(deployedFromDir, applicationId, deployTimestamp, internalRedeploy, generation, currentlyActiveGeneration);
+    }
+
+    public DeployData(String deployedFromDir,
+                      ApplicationId applicationId,
+                      Long deployTimestamp,
+                      boolean internalRedeploy,
+                      Long generation,
+                      long currentlyActiveGeneration) {
         this.deployedFromDir = deployedFromDir;
         this.applicationId = applicationId;
         this.deployTimestamp = deployTimestamp;
@@ -43,8 +49,6 @@ public class DeployData {
         this.generation = generation;
         this.currentlyActiveGeneration = currentlyActiveGeneration;
     }
-
-    public String getDeployedByUser() { return deployedByUser; }
 
     public String getDeployedFromDir() { return deployedFromDir; }
 

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
@@ -134,8 +134,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
     }
 
     private static ApplicationMetaData metaDataFromDeployData(File appDir, DeployData deployData) {
-        return new ApplicationMetaData(deployData.getDeployedByUser(),
-                                       deployData.getDeployedFromDir(),
+        return new ApplicationMetaData(deployData.getDeployedFromDir(),
                                        deployData.getDeployTimestamp(),
                                        deployData.isInternalRedeploy(),
                                        deployData.getApplicationId(),
@@ -480,7 +479,6 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
     private static ApplicationMetaData readMetaData(File appDir) {
         String originalAppDir = preprocessed.equals(appDir.getName()) ? appDir.getParentFile().getName() : appDir.getName();
         ApplicationMetaData defaultMetaData = new ApplicationMetaData("n/a",
-                                                                      "n/a",
                                                                       0L,
                                                                       false,
                                                                       ApplicationId.from(TenantName.defaultName(),
@@ -573,7 +571,7 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
     }
 
     @Override
-    public void writeMetaData() throws IOException {
+    public void writeMetaData() {
         File metaFile = applicationFile(appDir, META_FILE_NAME);
         IOUtils.writeFile(metaFile, metaData.asJsonBytes());
     }

--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -71,6 +71,7 @@
       "public"
     ],
     "methods": [
+      "public void <init>(java.lang.String, java.lang.Long, boolean, com.yahoo.config.provision.ApplicationId, java.lang.String, java.lang.Long, long)",
       "public void <init>(java.lang.String, java.lang.String, java.lang.Long, boolean, com.yahoo.config.provision.ApplicationId, java.lang.String, java.lang.Long, long)",
       "public java.lang.String getDeployedByUser()",
       "public java.lang.String getDeployPath()",

--- a/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationMetaData.java
+++ b/config-model-api/src/main/java/com/yahoo/config/application/api/ApplicationMetaData.java
@@ -17,7 +17,6 @@ import java.io.IOException;
  */
 public class ApplicationMetaData {
 
-    private final String deployedByUser;
     private final String deployedFromDir;
     private final long deployTimestamp;
     private final boolean internalRedeploy;
@@ -26,9 +25,15 @@ public class ApplicationMetaData {
     private final long generation;
     private final long previousActiveGeneration;
 
-    public ApplicationMetaData(String deployedByUser, String deployedFromDir, Long deployTimestamp, boolean internalRedeploy,
+    public ApplicationMetaData(String deployedFromDir, Long deployTimestamp, boolean internalRedeploy,
                                ApplicationId applicationId, String checksum, Long generation, long previousActiveGeneration) {
-        this.deployedByUser = deployedByUser;
+        this("unknown", deployedFromDir, deployTimestamp, internalRedeploy, applicationId, checksum, generation, previousActiveGeneration);
+    }
+
+    @Deprecated
+    // TODO: Remove in Vespa 9
+    public ApplicationMetaData(String ignored, String deployedFromDir, Long deployTimestamp, boolean internalRedeploy,
+                               ApplicationId applicationId, String checksum, Long generation, long previousActiveGeneration) {
         this.deployedFromDir = deployedFromDir;
         this.deployTimestamp = deployTimestamp;
         this.internalRedeploy = internalRedeploy;
@@ -40,13 +45,11 @@ public class ApplicationMetaData {
 
     /**
      * Gets the user who deployed the application.
-     * Will return null if a problem occurred while getting metadata
      *
      * @return user name for the user who ran "deploy-application"
      */
-    public String getDeployedByUser() {
-        return deployedByUser;
-    }
+    @Deprecated // TODO: Remove in Vespa 9
+    public String getDeployedByUser() { return "unknown"; }
 
     /**
      * Gets the directory where the application was deployed from.
@@ -86,8 +89,7 @@ public class ApplicationMetaData {
 
     @Override
     public String toString() {
-        return deployedByUser + ", " + deployedFromDir + ", " + deployTimestamp + ", " + generation + ", " +
-               checksum + ", " + previousActiveGeneration;
+        return deployedFromDir + ", " + deployTimestamp + ", " + generation + ", " + checksum + ", " + previousActiveGeneration;
     }
 
     public static ApplicationMetaData fromJsonString(String jsonString) {
@@ -97,8 +99,7 @@ public class ApplicationMetaData {
             Inspector deploy = root.field("deploy");
             Inspector app = root.field("application");
 
-            return new ApplicationMetaData(deploy.field("user").asString(),
-                                           deploy.field("from").asString(),
+            return new ApplicationMetaData(deploy.field("from").asString(),
                                            deploy.field("timestamp").asLong(),
                                            booleanField("internalRedeploy", false, deploy),
                                            ApplicationId.fromSerializedForm(app.field("id").asString()),
@@ -114,7 +115,6 @@ public class ApplicationMetaData {
         Slime slime = new Slime();
         Cursor meta = slime.setObject();
         Cursor deploy = meta.setObject("deploy");
-        deploy.setString("user", deployedByUser);
         deploy.setString("from", deployedFromDir);
         deploy.setLong("timestamp", deployTimestamp);
         deploy.setBool("internalRedeploy", internalRedeploy);

--- a/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
@@ -46,7 +46,6 @@ import java.util.stream.Collectors;
  */
 public class MockApplicationPackage implements ApplicationPackage {
 
-    public static final String DEPLOYED_BY_USER = "user";
     public static final String APPLICATION_NAME = "application";
     public static final long APPLICATION_GENERATION = 1L;
     public static final String MUSIC_SCHEMA = createSchema("music", "foo");
@@ -80,8 +79,7 @@ public class MockApplicationPackage implements ApplicationPackage {
         this.failOnValidateXml = failOnValidateXml;
         queryProfileRegistry = new QueryProfileXMLReader().read(asNamedReaderList(queryProfileType),
                                                                 asNamedReaderList(queryProfile));
-        applicationMetaData = new ApplicationMetaData(DEPLOYED_BY_USER,
-                                                      "dir",
+        applicationMetaData = new ApplicationMetaData("dir",
                                                       0L,
                                                       false,
                                                       ApplicationId.from(TenantName.defaultName(),

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -436,14 +436,12 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     @Override
     public void getConfig(ApplicationMetadataConfig.Builder builder) {
-        if (applicationMetaData != null) {
+        if (applicationMetaData != null)
             builder.name(applicationMetaData.getApplicationId().application().value()).
-                    user(applicationMetaData.getDeployedByUser()).
                     path(applicationMetaData.getDeployPath()).
                     timestamp(applicationMetaData.getDeployTimestamp()).
                     checksum(applicationMetaData.getChecksum()).
                     generation(applicationMetaData.getGeneration());
-        }
     }
 
     /**

--- a/config-model/src/test/java/com/yahoo/config/model/ApplicationDeployTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/ApplicationDeployTest.java
@@ -227,8 +227,7 @@ public class ApplicationDeployTest {
         String appPkg = TESTDIR + "app1";
         IOUtils.copyDirectory(new File(appPkg), tmp);
         ApplicationId applicationId = ApplicationId.from("tenant1", "application1", "instance1");
-        DeployData deployData = new DeployData("foo",
-                                               "bar",
+        DeployData deployData = new DeployData("bar",
                                                applicationId,
                                                13L,
                                                false,
@@ -238,7 +237,6 @@ public class ApplicationDeployTest {
         app.writeMetaData();
         FilesApplicationPackage newApp = FilesApplicationPackage.fromFileWithDeployData(tmp, deployData);
         ApplicationMetaData meta = newApp.getMetaData();
-        assertEquals("foo", meta.getDeployedByUser());
         assertEquals("bar", meta.getDeployPath());
         assertEquals(applicationId, meta.getApplicationId());
         assertEquals(13L, (long)meta.getDeployTimestamp());

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -64,7 +64,6 @@ public class MetricsProxyContainerClusterTest {
         ApplicationMetadataConfig config = builder.build();
         assertEquals(MockApplicationPackage.APPLICATION_GENERATION, config.generation());
         assertEquals(MockApplicationPackage.APPLICATION_NAME, config.name());
-        assertEquals(MockApplicationPackage.DEPLOYED_BY_USER, config.user());
     }
 
     @Test

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -673,12 +673,8 @@ public class SessionRepository {
                                                  boolean internalRedeploy,
                                                  Optional<DeployLogger> deployLogger) {
         long deployTimestamp = System.currentTimeMillis();
-        String user = System.getenv("USER");
-        if (user == null) {
-            user = "unknown";
-        }
-        DeployData deployData = new DeployData(user, userDir.getAbsolutePath(), applicationId, deployTimestamp,
-                                               internalRedeploy, sessionId, currentlyActiveSessionId.orElse(nonExistingActiveSessionId));
+        DeployData deployData = new DeployData(userDir.getAbsolutePath(), applicationId, deployTimestamp, internalRedeploy,
+                                               sessionId, currentlyActiveSessionId.orElse(nonExistingActiveSessionId));
         FilesApplicationPackage app = FilesApplicationPackage.fromFileWithDeployData(configApplicationDir, deployData);
         try {
             app.validateFileExtensions();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/ApplicationRepositoryTest.java
@@ -233,7 +233,6 @@ public class ApplicationRepositoryTest {
         assertEquals(originalApplicationMetaData.getApplicationId(), applicationMetaData.getApplicationId());
         assertEquals(originalApplicationMetaData.getGeneration().longValue(), applicationMetaData.getPreviousActiveGeneration());
         assertNotEquals(originalApplicationMetaData.getGeneration(), applicationMetaData.getGeneration());
-        assertEquals(originalApplicationMetaData.getDeployedByUser(), applicationMetaData.getDeployedByUser());
     }
 
     @Test

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/ZooKeeperClientTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/ZooKeeperClientTest.java
@@ -57,8 +57,7 @@ public class ZooKeeperClientTest {
         zk = new MockCurator();
         ZooKeeperClient zkc = new ZooKeeperClient(zk, new BaseDeployLogger(), appPath);
         ApplicationPackage app = FilesApplicationPackage.fromFileWithDeployData(new File("src/test/apps/zkfeed"),
-                                                                                new DeployData("foo",
-                                                                                               "/bar/baz",
+                                                                                new DeployData("/bar/baz",
                                                                                                ApplicationId.from("default", "appName", "default"),
                                                                                                1345L,
                                                                                                true,
@@ -121,7 +120,6 @@ public class ZooKeeperClientTest {
                 Utf8.toString(zk.getData(appPath.append(META_ZK_PATH)).get()));
         assertTrue(metaData.getChecksum().length() > 0);
         assertTrue(metaData.isInternalRedeploy());
-        assertEquals("foo", metaData.getDeployedByUser());
         assertEquals("/bar/baz", metaData.getDeployPath());
         assertEquals(1345, metaData.getDeployTimestamp().longValue());
         assertEquals(3, metaData.getGeneration().longValue());

--- a/container-core/src/main/resources/configdefinitions/container.core.application-metadata.def
+++ b/container-core/src/main/resources/configdefinitions/container.core.application-metadata.def
@@ -7,7 +7,8 @@ namespace=container.core
 name string default=""
 
 # The user name that deployed the application
-user string default=""
+# TODO: Remove in Vespa 9
+user string default="unknown"
 
 # The directory the application was deployed from
 path string default=""


### PR DESCRIPTION
…usage

User was set in older Vespa versions when deploying locally, not set
anymore and should not be used. Deprecate and add TODOs to remove in
Vespa 9.