### PR TITLE
Add min and max numbers for expired sessions to delete MERGEOK

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -358,6 +358,8 @@ public class SessionRepository {
         log.log(Level.FINE, () -> "Remote sessions for tenant " + tenantName + ": " + remoteSessionsFromZooKeeper);
 
         int deleted = 0;
+        // Avoid deleting too many in one run
+        int deleteMax = (int) Math.min(1000, Math.max(10, remoteSessionsFromZooKeeper.size() * 0.01));
         for (long sessionId : remoteSessionsFromZooKeeper) {
             Session session = remoteSessionCache.get(sessionId);
             if (session == null) {
@@ -370,8 +372,7 @@ public class SessionRepository {
                 deleteRemoteSessionFromZooKeeper(session);
                 deleted++;
             }
-            // Avoid deleting too many in one run
-            if (deleted >= 2)
+            if (deleted >= deleteMax)
                 break;
         }
         return deleted;


### PR DESCRIPTION
In zones with a lot of deployments per time unit (e.g. cd zones
when there are many runs for one version) we need to delete more
expired sessions per run, otherwise the number of zookeeper nodes
will increase over time