### PR TITLE
Add a grace period before upgrading new nodes

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
@@ -41,6 +41,7 @@ public class Node {
     private final Version wantedVersion;
     private final Version currentOsVersion;
     private final Version wantedOsVersion;
+    private final boolean deferOsUpgrade;
     private final DockerImage currentDockerImage;
     private final DockerImage wantedDockerImage;
     private final ServiceState serviceState;
@@ -76,7 +77,7 @@ public class Node {
 
     private Node(String id, HostName hostname, Optional<HostName> parentHostname, State state, NodeType type,
                  NodeResources resources, Optional<ApplicationId> owner, Version currentVersion, Version wantedVersion,
-                 Version currentOsVersion, Version wantedOsVersion, Optional<Instant> currentFirmwareCheck,
+                 Version currentOsVersion, Version wantedOsVersion, boolean deferOsUpgrade, Optional<Instant> currentFirmwareCheck,
                  Optional<Instant> wantedFirmwareCheck, ServiceState serviceState, Optional<Instant> suspendedSince,
                  long restartGeneration, long wantedRestartGeneration, long rebootGeneration,
                  long wantedRebootGeneration, int cost, int failCount, Optional<String> flavor, String clusterId,
@@ -97,6 +98,7 @@ public class Node {
         this.wantedVersion = Objects.requireNonNull(wantedVersion, "wantedVersion must be non-null");
         this.currentOsVersion = Objects.requireNonNull(currentOsVersion, "currentOsVersion must be non-null");
         this.wantedOsVersion = Objects.requireNonNull(wantedOsVersion, "wantedOsVersion must be non-null");
+        this.deferOsUpgrade = deferOsUpgrade;
         this.currentFirmwareCheck = Objects.requireNonNull(currentFirmwareCheck, "currentFirmwareCheck must be non-null");
         this.wantedFirmwareCheck = Objects.requireNonNull(wantedFirmwareCheck, "wantedFirmwareCheck must be non-null");
         this.serviceState = Objects.requireNonNull(serviceState, "serviceState must be non-null");
@@ -182,6 +184,11 @@ public class Node {
     /** The wanted OS version */
     public Version wantedOsVersion() {
         return wantedOsVersion;
+    }
+
+    /** Returns whether the node is currently deferring any OS upgrade */
+    public boolean deferOsUpgrade() {
+        return deferOsUpgrade;
     }
 
     /** The container image of this is currently running */
@@ -455,6 +462,7 @@ public class Node {
         private Version wantedVersion = Version.emptyVersion;
         private Version currentOsVersion = Version.emptyVersion;
         private Version wantedOsVersion = Version.emptyVersion;
+        private boolean deferOsUpgrade = false;
         private DockerImage currentDockerImage = DockerImage.EMPTY;
         private DockerImage wantedDockerImage = DockerImage.EMPTY;
         private Optional<Instant> currentFirmwareCheck = Optional.empty();
@@ -502,6 +510,7 @@ public class Node {
             this.wantedVersion = node.wantedVersion;
             this.currentOsVersion = node.currentOsVersion;
             this.wantedOsVersion = node.wantedOsVersion;
+            this.deferOsUpgrade = node.deferOsUpgrade;
             this.currentDockerImage = node.currentDockerImage;
             this.wantedDockerImage = node.wantedDockerImage;
             this.serviceState = node.serviceState;
@@ -596,6 +605,11 @@ public class Node {
 
         public Builder wantedOsVersion(Version wantedOsVersion) {
             this.wantedOsVersion = wantedOsVersion;
+            return this;
+        }
+
+        public Builder deferOsUpgrade(boolean deferOsUpgrade) {
+            this.deferOsUpgrade = deferOsUpgrade;
             return this;
         }
 
@@ -761,7 +775,7 @@ public class Node {
 
         public Node build() {
             return new Node(id, hostname, parentHostname, state, type, resources, owner, currentVersion, wantedVersion,
-                            currentOsVersion, wantedOsVersion, currentFirmwareCheck, wantedFirmwareCheck, serviceState,
+                            currentOsVersion, wantedOsVersion, deferOsUpgrade, currentFirmwareCheck, wantedFirmwareCheck, serviceState,
                             suspendedSince, restartGeneration, wantedRestartGeneration, rebootGeneration,
                             wantedRebootGeneration, cost, failCount, flavor, clusterId, clusterType, group, index, retired,
                             wantToRetire, wantToDeprovision, wantToRebuild, down, reservedTo, exclusiveTo, wantedDockerImage,

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -63,6 +63,8 @@ public class NodeRepositoryNode {
     private String currentOsVersion;
     @JsonProperty("wantedOsVersion")
     private String wantedOsVersion;
+    @JsonProperty("deferOsUpgrade")
+    private Boolean deferOsUpgrade;
     @JsonProperty("currentFirmwareCheck")
     private Long currentFirmwareCheck;
     @JsonProperty("wantedFirmwareCheck")
@@ -248,6 +250,14 @@ public class NodeRepositoryNode {
 
     public void setWantedVespaVersion(String wantedVespaVersion) {
         this.wantedVespaVersion = wantedVespaVersion;
+    }
+
+    public Boolean getDeferOsUpgrade() {
+        return deferOsUpgrade;
+    }
+
+    public void setDeferOsUpgrade(Boolean deferOsUpgrade) {
+        this.deferOsUpgrade = deferOsUpgrade;
     }
 
     public Integer getFailCount() {
@@ -441,12 +451,13 @@ public class NodeRepositoryNode {
 
     // --- end
 
+
     @Override
     public String toString() {
         return "NodeRepositoryNode{" +
                "url='" + url + '\'' +
                ", id='" + id + '\'' +
-               ", state=" + state +
+               ", state='" + state + '\'' +
                ", hostname='" + hostname + '\'' +
                ", ipAddresses=" + ipAddresses +
                ", additionalIpAddresses=" + additionalIpAddresses +
@@ -464,11 +475,12 @@ public class NodeRepositoryNode {
                ", wantedVespaVersion='" + wantedVespaVersion + '\'' +
                ", currentOsVersion='" + currentOsVersion + '\'' +
                ", wantedOsVersion='" + wantedOsVersion + '\'' +
+               ", deferOsUpgrade=" + deferOsUpgrade +
                ", currentFirmwareCheck=" + currentFirmwareCheck +
                ", wantedFirmwareCheck=" + wantedFirmwareCheck +
                ", failCount=" + failCount +
-               ", environment=" + environment +
-               ", type=" + type +
+               ", environment='" + environment + '\'' +
+               ", type='" + type + '\'' +
                ", wantedDockerImage='" + wantedDockerImage + '\'' +
                ", currentDockerImage='" + currentDockerImage + '\'' +
                ", parentHostname='" + parentHostname + '\'' +

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -62,7 +62,7 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
     protected boolean expectUpgradeOf(Node node, SystemApplication application, ZoneApi zone) {
         return cloud.equals(zone.getCloudName()) && // Cloud is managed by this upgrader
                application.shouldUpgradeOs() &&     // Application should upgrade in this cloud
-               canUpgrade(node);                    // Node is in an upgradable state
+               canUpgrade(node);
     }
 
     @Override
@@ -101,9 +101,9 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
         return !controller().zoneRegistry().systemZone().getVirtualId().equals(zone.getVirtualId()); // Do not spend budget on controller zone
     }
 
-    /** Returns whether node is in a state where it can be upgraded */
+    /** Returns whether node currently allows upgrades */
     public static boolean canUpgrade(Node node) {
-        return upgradableNodeStates.contains(node.state());
+        return !node.deferOsUpgrade() && upgradableNodeStates.contains(node.state());
     }
 
     private static String name(CloudName cloud) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgraderTest.java
@@ -19,7 +19,9 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -52,18 +54,19 @@ public class OsUpgraderTest {
         OsUpgrader osUpgrader = osUpgrader(upgradePolicy, cloud1, false);
 
         // Bootstrap system
-        List<ZoneId> nonControllerZones = List.of(zone1, zone2, zone3, zone4, zone5).stream()
-                                              .map(ZoneApi::getVirtualId)
-                                              .collect(Collectors.toList());
+        List<ZoneId> nonControllerZones = Stream.of(zone1, zone2, zone3, zone4, zone5)
+                                                .map(ZoneApi::getVirtualId)
+                                                .collect(Collectors.toList());
         tester.configServer().bootstrap(nonControllerZones, List.of(SystemApplication.tenantHost));
         tester.configServer().addNodes(List.of(zone0.getVirtualId()), List.of(SystemApplication.controllerHost));
 
         // Add system application that exists in a real system, but isn't eligible for OS upgrades
         tester.configServer().addNodes(nonControllerZones, List.of(SystemApplication.configServer));
 
-        // Fail a few nodes. Failed nodes should not affect versions
+        // Change state of a few nodes. These should not affect convergence
         failNodeIn(zone1, SystemApplication.tenantHost);
         failNodeIn(zone3, SystemApplication.tenantHost);
+        Node nodeDeferringOsUpgrade = deferOsUpgradeIn(zone2, SystemApplication.tenantHost);
 
         // New OS version released
         Version version1 = Version.fromString("7.1");
@@ -91,7 +94,7 @@ public class OsUpgraderTest {
         completeUpgrade(version1, SystemApplication.tenantHost, zone1);
         statusUpdater.maintain();
         assertEquals(5, nodesOn(version1).size());
-        assertEquals(11, nodesOn(Version.emptyVersion).size());
+        assertEquals(10, nodesOn(Version.emptyVersion).size());
 
         // zone 2 and 3: begins upgrading
         osUpgrader.maintain();
@@ -102,6 +105,10 @@ public class OsUpgraderTest {
 
         // zone 2 and 3: completes upgrade
         completeUpgrade(version1, SystemApplication.tenantHost, zone2, zone3);
+        assertEquals("Current version is unchanged for node deferring OS upgrade", Version.emptyVersion,
+                     nodeRepository().list(zone2.getVirtualId(), NodeFilter.all().hostnames(nodeDeferringOsUpgrade.hostname()))
+                                     .get(0)
+                                     .currentOsVersion());
 
         // zone 4: begins upgrading
         osUpgrader.maintain();
@@ -271,13 +278,23 @@ public class OsUpgraderTest {
                                .collect(Collectors.toList());
     }
 
-    private void failNodeIn(ZoneApi zone, SystemApplication application) {
+    private Node failNodeIn(ZoneApi zone, SystemApplication application) {
+        return patchOneNodeIn(zone, application, (node) -> Node.builder(node).state(Node.State.failed).build());
+    }
+
+    private Node deferOsUpgradeIn(ZoneApi zone, SystemApplication application) {
+        return patchOneNodeIn(zone, application, (node) -> Node.builder(node).deferOsUpgrade(true).build());
+    }
+
+    private Node patchOneNodeIn(ZoneApi zone, SystemApplication application, UnaryOperator<Node> patcher) {
         List<Node> nodes = nodeRepository().list(zone.getVirtualId(), NodeFilter.all().applications(application.id()));
         if (nodes.isEmpty()) {
             throw new IllegalArgumentException("No nodes allocated to " + application.id());
         }
         Node node = nodes.get(0);
-        nodeRepository().putNodes(zone.getVirtualId(), Node.builder(node).state(Node.State.failed).build());
+        Node newNode = patcher.apply(node);
+        nodeRepository().putNodes(zone.getVirtualId(), newNode);
+        return newNode;
     }
 
     /** Simulate OS upgrade of nodes allocated to application. In a real system this is done by the node itself */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.provision.node;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.vespa.hosted.provision.Node;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,6 +49,12 @@ public class History {
         for (Event event : events)
             builder.put(event.type(), event);
         return builder.build();
+    }
+
+    /** Returns the age of this node as best as we can determine: The time since the first event registered for it */
+    public Duration age(Instant now) {
+        Instant oldestEventTime = events.values().stream().map(event -> event.at()).sorted().findFirst().orElse(now);
+        return Duration.between(oldestEventTime, now);
     }
 
     /** Returns the last event of given type, if it is present in this history */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/filter/NodeListFilter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/filter/NodeListFilter.java
@@ -30,4 +30,5 @@ public class NodeListFilter {
     public static Predicate<Node> from(List<Node> nodes) {
         return makePredicate(nodes);
     }
+
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
@@ -7,6 +7,7 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -39,9 +40,10 @@ public class DelegatingOsUpgrader implements OsUpgrader {
     public void upgradeTo(OsVersionTarget target) {
         NodeList activeNodes = nodeRepository.nodes().list(Node.State.active).nodeType(target.nodeType());
         int numberToUpgrade = Math.max(0, maxActiveUpgrades - activeNodes.changingOsVersionTo(target.version()).size());
+        Instant now = nodeRepository.clock().instant();
         NodeList nodesToUpgrade = activeNodes.not().changingOsVersionTo(target.version())
                                              .osVersionIsBefore(target.version())
-                                             .matching(node -> shouldUpgrade(node, nodeRepository.clock().instant()))
+                                             .matching(node -> canUpgradeAt(now, node))
                                              .byIncreasingOsVersion()
                                              .first(numberToUpgrade);
         if (nodesToUpgrade.size() == 0) return;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
@@ -41,6 +41,7 @@ public class DelegatingOsUpgrader implements OsUpgrader {
         int numberToUpgrade = Math.max(0, maxActiveUpgrades - activeNodes.changingOsVersionTo(target.version()).size());
         NodeList nodesToUpgrade = activeNodes.not().changingOsVersionTo(target.version())
                                              .osVersionIsBefore(target.version())
+                                             .matching(node -> shouldUpgrade(node, nodeRepository.clock().instant()))
                                              .byIncreasingOsVersion()
                                              .first(numberToUpgrade);
         if (nodesToUpgrade.size() == 0) return;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
@@ -2,6 +2,11 @@
 package com.yahoo.vespa.hosted.provision.os;
 
 import com.yahoo.config.provision.NodeType;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.node.History;
+
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * Interface for an OS upgrader.
@@ -10,10 +15,17 @@ import com.yahoo.config.provision.NodeType;
  */
 public interface OsUpgrader {
 
+    /** The duration we should leave new nodes along before scheduling OS upgrades */
+    Duration gracePeriod = Duration.ofDays(30);
+
     /** Trigger upgrade to given target */
     void upgradeTo(OsVersionTarget target);
 
     /** Disable OS upgrade for all nodes of given type */
     void disableUpgrade(NodeType type);
+
+    default boolean shouldUpgrade(Node node, Instant now) {
+        return node.history().age(now).toSeconds() > gracePeriod.toSeconds();
+    }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
@@ -3,9 +3,7 @@ package com.yahoo.vespa.hosted.provision.os;
 
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.Node;
-import com.yahoo.vespa.hosted.provision.node.History;
 
-import java.time.Duration;
 import java.time.Instant;
 
 /**
@@ -15,17 +13,15 @@ import java.time.Instant;
  */
 public interface OsUpgrader {
 
-    /** The duration we should leave new nodes along before scheduling OS upgrades */
-    Duration gracePeriod = Duration.ofDays(30);
-
     /** Trigger upgrade to given target */
     void upgradeTo(OsVersionTarget target);
 
     /** Disable OS upgrade for all nodes of given type */
     void disableUpgrade(NodeType type);
 
-    default boolean shouldUpgrade(Node node, Instant now) {
-        return node.history().age(now).toSeconds() > gracePeriod.toSeconds();
+    /** Returns whether node can upgrade at given instant */
+    default boolean canUpgradeAt(Instant instant, Node node) {
+        return true;
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
@@ -47,7 +47,7 @@ public class RebuildingOsUpgrader implements OsUpgrader {
     public void upgradeTo(OsVersionTarget target) {
         NodeList allNodes = nodeRepository.nodes().list();
         Instant now = nodeRepository.clock().instant();
-        rebuildableHosts(target, allNodes).forEach(host -> rebuild(host, target.version(), now));
+        rebuildableHosts(target, allNodes, now).forEach(host -> rebuild(host, target.version(), now));
     }
 
     @Override
@@ -62,7 +62,7 @@ public class RebuildingOsUpgrader implements OsUpgrader {
         return Math.max(0, limit - hostsOfType.rebuilding().size());
     }
 
-    private List<Node> rebuildableHosts(OsVersionTarget target, NodeList allNodes) {
+    private List<Node> rebuildableHosts(OsVersionTarget target, NodeList allNodes, Instant now) {
         NodeList hostsOfTargetType = allNodes.nodeType(target.nodeType());
         int rebuildLimit = rebuildLimit(target.nodeType(), hostsOfTargetType);
 
@@ -76,7 +76,7 @@ public class RebuildingOsUpgrader implements OsUpgrader {
         NodeList candidates = hostsOfTargetType.state(Node.State.active)
                                                .not().rebuilding()
                                                .osVersionIsBefore(target.version())
-                                               .matching(node -> shouldUpgrade(node, nodeRepository.clock().instant()))
+                                               .matching(node -> canUpgradeAt(now, node))
                                                .byIncreasingOsVersion();
         for (Node host : candidates) {
             if (hostsToRebuild.size() == rebuildLimit) break;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
@@ -76,6 +76,7 @@ public class RebuildingOsUpgrader implements OsUpgrader {
         NodeList candidates = hostsOfTargetType.state(Node.State.active)
                                                .not().rebuilding()
                                                .osVersionIsBefore(target.version())
+                                               .matching(node -> shouldUpgrade(node, nodeRepository.clock().instant()))
                                                .byIncreasingOsVersion();
         for (Node host : candidates) {
             if (hostsToRebuild.size() == rebuildLimit) break;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
@@ -38,6 +38,7 @@ public class RetiringOsUpgrader implements OsUpgrader {
         Instant now = nodeRepository.clock().instant();
         NodeList candidates = candidates(now, target, allNodes);
         candidates.not().deprovisioning()
+                  .matching(node -> shouldUpgrade(node, nodeRepository.clock().instant()))
                   .byIncreasingOsVersion()
                   .first(1)
                   .forEach(node -> deprovision(node, target.version(), now));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -161,7 +161,10 @@ class NodesResponse extends SlimeJsonResponse {
         object.setLong("rebootGeneration", node.status().reboot().wanted());
         object.setLong("currentRebootGeneration", node.status().reboot().current());
         node.status().osVersion().current().ifPresent(version -> object.setString("currentOsVersion", version.toFullString()));
-        node.status().osVersion().wanted().ifPresent(version -> object.setString("wantedOsVersion", version.toFullString()));
+        node.status().osVersion().wanted().ifPresent(version -> {
+            object.setString("wantedOsVersion", version.toFullString());
+            object.setBool("deferOsUpgrade", !nodeRepository.osVersions().canUpgrade(node));
+        });
         node.status().firmwareVerifiedAt().ifPresent(instant -> object.setLong("currentFirmwareCheck", instant.toEpochMilli()));
         if (node.type().isHost())
             nodeRepository.firmwareChecks().requiredAfter().ifPresent(after -> object.setLong("wantedFirmwareCheck", after.toEpochMilli()));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OsUpgradeActivatorTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OsUpgradeActivatorTest.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Status;
-import com.yahoo.vespa.hosted.provision.os.OsUpgrader;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
 import org.junit.Test;
 
@@ -49,8 +48,6 @@ public class OsUpgradeActivatorTest {
 
         var allNodes = new ArrayList<>(configHostNodes);
         allNodes.addAll(tenantHostNodes);
-
-        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All nodes are on initial version
         assertEquals(version0, minWantedVersion(allNodes));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OsUpgradeActivatorTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/OsUpgradeActivatorTest.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Allocation;
 import com.yahoo.vespa.hosted.provision.node.Status;
+import com.yahoo.vespa.hosted.provision.os.OsUpgrader;
 import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
 import org.junit.Test;
 
@@ -48,6 +49,8 @@ public class OsUpgradeActivatorTest {
 
         var allNodes = new ArrayList<>(configHostNodes);
         allNodes.addAll(tenantHostNodes);
+
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All nodes are on initial version
         assertEquals(version0, minWantedVersion(allNodes));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
@@ -65,6 +65,13 @@ public class OsVersionsTest {
         // Resume upgrade
         versions.resumeUpgradeOf(NodeType.host, true);
         NodeList allHosts = hostNodes.get();
+        assertFalse("No upgrades of new hosts", allHosts.except(hostOnLaterVersion).stream()
+                                                        .anyMatch(node -> node.status().osVersion().wanted().isPresent()));
+
+        // Resume upgrade after sufficient time
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
+        versions.resumeUpgradeOf(NodeType.host, true);
+        allHosts = hostNodes.get();
         assertTrue("Wanted version is set", allHosts.except(hostOnLaterVersion).stream()
                                                     .allMatch(node -> node.status().osVersion().wanted().isPresent()));
         assertTrue("Wanted version is not set for host on later version",
@@ -98,6 +105,8 @@ public class OsVersionsTest {
         var versions = new OsVersions(tester.nodeRepository(), false, maxActiveUpgrades);
         provisionInfraApplication(totalNodes);
         Supplier<NodeList> hostNodes = () -> tester.nodeRepository().nodes().list().state(Node.State.active).hosts();
+
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // 5 nodes have no version. The other 15 are spread across different versions
         var hostNodesList = hostNodes.get().asList();
@@ -144,6 +153,7 @@ public class OsVersionsTest {
         var versions = new OsVersions(tester.nodeRepository());
         provisionInfraApplication(10);
         Supplier<NodeList> hostNodes = () -> tester.nodeRepository().nodes().list().hosts();
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // Some nodes are targeting an older version
         var version1 = Version.fromString("7.1");
@@ -172,6 +182,7 @@ public class OsVersionsTest {
         Supplier<NodeList> hostNodes = () -> tester.nodeRepository().nodes().list()
                                                    .hosts()
                                                    .not().state(Node.State.deprovisioned);
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // Target is set and upgrade started
         var version1 = Version.fromString("7.1");
@@ -233,6 +244,7 @@ public class OsVersionsTest {
         Supplier<NodeList> hostNodes = () -> tester.nodeRepository().nodes().list()
                                                    .nodeType(NodeType.confighost)
                                                    .not().state(Node.State.deprovisioned);
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // Target is set with zero budget and upgrade started
         var version1 = Version.fromString("7.1");
@@ -255,6 +267,7 @@ public class OsVersionsTest {
         int hostCount = 10;
         provisionInfraApplication(hostCount + 1);
         Supplier<NodeList> hostNodes = () -> tester.nodeRepository().nodes().list().nodeType(NodeType.host);
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All hosts upgrade to first version. Upgrades are delegated
         var version0 = Version.fromString("7.0");
@@ -302,6 +315,7 @@ public class OsVersionsTest {
         assertEquals(0, hostNodes.get().rebuilding().size());
 
         // Next version is within same major. Upgrade mechanism switches to delegated
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
         var version2 = Version.fromString("8.1");
         versions.setTarget(NodeType.host, version2, Duration.ZERO, false);
         versions.resumeUpgradeOf(NodeType.host, true);
@@ -331,6 +345,8 @@ public class OsVersionsTest {
         provisionInfraApplication(hostCount, ApplicationId.from("hosted-vespa", "confighost", "default"), NodeType.confighost);
         Supplier<NodeList> hosts = () -> tester.nodeRepository().nodes().list().nodeType(NodeType.host,
                                                                                          NodeType.confighost);
+
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All hosts upgrade to first version. Upgrades are delegated
         var version0 = Version.fromString("7.0");
@@ -366,6 +382,7 @@ public class OsVersionsTest {
         deployApplication(app1);
         deployApplication(app2);
         Supplier<NodeList> hosts = () -> tester.nodeRepository().nodes().list().nodeType(NodeType.host);
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All hosts are on initial version
         var version0 = Version.fromString("7.0");
@@ -439,6 +456,7 @@ public class OsVersionsTest {
         var versions = new OsVersions(tester.nodeRepository(), false, Integer.MAX_VALUE);
         provisionInfraApplication(hostCount, infraApplication, NodeType.proxyhost);
         Supplier<NodeList> hosts = () -> tester.nodeRepository().nodes().list().nodeType(NodeType.proxyhost);
+        tester.clock().advance(OsUpgrader.gracePeriod.plusDays(1));
 
         // All hosts are on initial version
         var version0 = Version.fromString("7.0");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -6,17 +6,11 @@ import com.yahoo.application.container.handler.Response;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
-import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.applicationmodel.HostName;
-import com.yahoo.vespa.hosted.provision.Node;
-import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.maintenance.OsUpgradeActivator;
 import com.yahoo.vespa.hosted.provision.maintenance.TestMetric;
-import com.yahoo.vespa.hosted.provision.node.Agent;
-import com.yahoo.vespa.hosted.provision.node.History;
-import com.yahoo.vespa.hosted.provision.os.OsUpgrader;
 import com.yahoo.vespa.hosted.provision.testutils.MockNodeRepository;
 import com.yahoo.vespa.hosted.provision.testutils.OrchestratorMock;
 import org.junit.After;
@@ -776,17 +770,7 @@ public class NodesV2ApiTest {
                                    Request.Method.PATCH),
                        "{\"message\":\"Set osVersion to 7.5.2, upgradeBudget to PT0S for nodes of type host\"}");
 
-        var nodeRepository = (NodeRepository)tester.container().components().getComponent(MockNodeRepository.class.getName());
-
-        // Age nodes to pass OS upgrade grace period for new nodes
-        for (Node node : nodeRepository.nodes().list()) {
-            try (NodeMutex lockedNode = nodeRepository.nodes().lockAndGet(node).orElseThrow()) {
-                Node agedNode = node.with(node.history().with(new History.Event(History.Event.Type.provisioned,
-                                                                                Agent.system,
-                                                                                nodeRepository.clock().instant().minus(OsUpgrader.gracePeriod.plusDays(1)))));
-                nodeRepository.nodes().write(agedNode, lockedNode);
-            }
-        }
+        var nodeRepository = (NodeRepository) tester.container().components().getComponent(MockNodeRepository.class.getName());
 
         // Activate target
         var osUpgradeActivator = new OsUpgradeActivator(nodeRepository, Duration.ofDays(1), new TestMetric());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -6,11 +6,17 @@ import com.yahoo.application.container.handler.Response;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
+import com.yahoo.test.ManualClock;
 import com.yahoo.text.Utf8;
 import com.yahoo.vespa.applicationmodel.HostName;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.maintenance.OsUpgradeActivator;
 import com.yahoo.vespa.hosted.provision.maintenance.TestMetric;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.node.History;
+import com.yahoo.vespa.hosted.provision.os.OsUpgrader;
 import com.yahoo.vespa.hosted.provision.testutils.MockNodeRepository;
 import com.yahoo.vespa.hosted.provision.testutils.OrchestratorMock;
 import org.junit.After;
@@ -770,8 +776,19 @@ public class NodesV2ApiTest {
                                    Request.Method.PATCH),
                        "{\"message\":\"Set osVersion to 7.5.2, upgradeBudget to PT0S for nodes of type host\"}");
 
-        // Activate target
         var nodeRepository = (NodeRepository)tester.container().components().getComponent(MockNodeRepository.class.getName());
+
+        // Age nodes to pass OS upgrade grace period for new nodes
+        for (Node node : nodeRepository.nodes().list()) {
+            try (NodeMutex lockedNode = nodeRepository.nodes().lockAndGet(node).orElseThrow()) {
+                Node agedNode = node.with(node.history().with(new History.Event(History.Event.Type.provisioned,
+                                                                                Agent.system,
+                                                                                nodeRepository.clock().instant().minus(OsUpgrader.gracePeriod.plusDays(1)))));
+                nodeRepository.nodes().write(agedNode, lockedNode);
+            }
+        }
+
+        // Activate target
         var osUpgradeActivator = new OsUpgradeActivator(nodeRepository, Duration.ofDays(1), new TestMetric());
         osUpgradeActivator.run();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -38,6 +38,11 @@
   "down": false,
   "history": [
     {
+      "event": "provisioned",
+      "at": 123,
+      "agent": "system"
+    },
+    {
       "event": "readied",
       "at": 123,
       "agent": "system"
@@ -51,19 +56,9 @@
       "event": "activated",
       "at": 123,
       "agent": "application"
-    },
-    {
-      "event": "provisioned",
-      "at": -2678399877,
-      "agent": "system"
     }
   ],
   "log": [
-    {
-      "event": "provisioned",
-      "at": -2678399877,
-      "agent": "system"
-    },
     {
       "event": "provisioned",
       "at": 123,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -38,11 +38,6 @@
   "down": false,
   "history": [
     {
-      "event": "provisioned",
-      "at": 123,
-      "agent": "system"
-    },
-    {
       "event": "readied",
       "at": 123,
       "agent": "system"
@@ -56,9 +51,19 @@
       "event": "activated",
       "at": 123,
       "agent": "application"
+    },
+    {
+      "event": "provisioned",
+      "at": -2678399877,
+      "agent": "system"
     }
   ],
   "log": [
+    {
+      "event": "provisioned",
+      "at": -2678399877,
+      "agent": "system"
+    },
     {
       "event": "provisioned",
       "at": 123,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node1-os-upgrade-complete.json
@@ -30,6 +30,7 @@
   "currentRebootGeneration": 0,
   "currentOsVersion": "7.5.2",
   "wantedOsVersion": "7.5.2",
+  "deferOsUpgrade": false,
   "failCount": 0,
   "wantToRetire": false,
   "preferToRetire": false,


### PR DESCRIPTION
A suggestion to wait a month after provisioning before starting to OS upgrade nodes.

I think this would be helpful for dev/perf as most apps are only worked on for less than this [citation needed], so they would avoid running into (and paying for) OS upgrades. 

Arguably also for dev, if new nodes are added to solve some problem you don't want to immediately introduce new changes, and if the capacity is temporary due to e.g autoscaling why do it at all.