### PR TITLE
Restore original semantics of ResultClass::GetIndexFromName() and

### DIFF
--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -322,8 +322,8 @@ assertString(const std::string & exp, const std::string & fieldName,
              DocumentStoreAdapter &dsa, uint32_t id)
 {
     GeneralResultPtr res = getResult(dsa, id);
-    return EXPECT_EQUAL(exp, std::string(res->GetEntry(fieldName.c_str())->_stringval,
-                                         res->GetEntry(fieldName.c_str())->_stringlen));
+    return EXPECT_EQUAL(exp, std::string(res->GetPresentEntry(fieldName.c_str())->_stringval,
+                                         res->GetPresentEntry(fieldName.c_str())->_stringlen));
 }
 
 void
@@ -392,24 +392,24 @@ TEST_F("requireThatAdapterHandlesAllFieldTypes", Fixture)
                              bc.createFieldCacheRepo(f.getResultConfig())->getFieldCache("class0"),
                              f.getMarkupFields());
     GeneralResultPtr res = getResult(dsa, 0);
-    EXPECT_EQUAL(255u,        res->GetEntry("a")->_intval);
-    EXPECT_EQUAL(32767u,      res->GetEntry("b")->_intval);
-    EXPECT_EQUAL(2147483647u, res->GetEntry("c")->_intval);
-    EXPECT_EQUAL(2147483648u, res->GetEntry("d")->_int64val);
-    EXPECT_APPROX(1234.56,    res->GetEntry("e")->_doubleval, 10e-5);
-    EXPECT_APPROX(9876.54,    res->GetEntry("f")->_doubleval, 10e-5);
-    EXPECT_EQUAL("foo",       std::string(res->GetEntry("g")->_stringval,
-                                          res->GetEntry("g")->_stringlen));
-    EXPECT_EQUAL("bar",       std::string(res->GetEntry("h")->_stringval,
-                                          res->GetEntry("h")->_stringlen));
-    EXPECT_EQUAL("baz",       std::string(res->GetEntry("i")->_dataval,
-                                          res->GetEntry("i")->_datalen));
-    EXPECT_EQUAL("qux",       std::string(res->GetEntry("j")->_dataval,
-                                          res->GetEntry("j")->_datalen));
-    EXPECT_EQUAL("<foo>",     std::string(res->GetEntry("k")->_stringval,
-                                          res->GetEntry("k")->_stringlen));
-    EXPECT_EQUAL("{foo:10}",  std::string(res->GetEntry("l")->_stringval,
-                                          res->GetEntry("l")->_stringlen));
+    EXPECT_EQUAL(255u,        res->GetPresentEntry("a")->_intval);
+    EXPECT_EQUAL(32767u,      res->GetPresentEntry("b")->_intval);
+    EXPECT_EQUAL(2147483647u, res->GetPresentEntry("c")->_intval);
+    EXPECT_EQUAL(2147483648u, res->GetPresentEntry("d")->_int64val);
+    EXPECT_APPROX(1234.56,    res->GetPresentEntry("e")->_doubleval, 10e-5);
+    EXPECT_APPROX(9876.54,    res->GetPresentEntry("f")->_doubleval, 10e-5);
+    EXPECT_EQUAL("foo",       std::string(res->GetPresentEntry("g")->_stringval,
+                                          res->GetPresentEntry("g")->_stringlen));
+    EXPECT_EQUAL("bar",       std::string(res->GetPresentEntry("h")->_stringval,
+                                          res->GetPresentEntry("h")->_stringlen));
+    EXPECT_EQUAL("baz",       std::string(res->GetPresentEntry("i")->_dataval,
+                                          res->GetPresentEntry("i")->_datalen));
+    EXPECT_EQUAL("qux",       std::string(res->GetPresentEntry("j")->_dataval,
+                                          res->GetPresentEntry("j")->_datalen));
+    EXPECT_EQUAL("<foo>",     std::string(res->GetPresentEntry("k")->_stringval,
+                                          res->GetPresentEntry("k")->_stringlen));
+    EXPECT_EQUAL("{foo:10}",  std::string(res->GetPresentEntry("l")->_stringval,
+                                          res->GetPresentEntry("l")->_stringlen));
 }
 
 TEST_F("requireThatAdapterHandlesMultipleDocuments", Fixture)
@@ -433,11 +433,11 @@ TEST_F("requireThatAdapterHandlesMultipleDocuments", Fixture)
                              f.getMarkupFields());
     { // doc 0
         GeneralResultPtr res = getResult(dsa, 0);
-        EXPECT_EQUAL(1000u, res->GetEntry("a")->_intval);
+        EXPECT_EQUAL(1000u, res->GetPresentEntry("a")->_intval);
     }
     { // doc 1
         GeneralResultPtr res = getResult(dsa, 1);
-        EXPECT_EQUAL(2000u, res->GetEntry("a")->_intval);
+        EXPECT_EQUAL(2000u, res->GetPresentEntry("a")->_intval);
     }
     { // doc 2
         DocsumStoreValue docsum = dsa.getMappedDocsum(2);
@@ -445,7 +445,7 @@ TEST_F("requireThatAdapterHandlesMultipleDocuments", Fixture)
     }
     { // doc 0 (again)
         GeneralResultPtr res = getResult(dsa, 0);
-        EXPECT_EQUAL(1000u, res->GetEntry("a")->_intval);
+        EXPECT_EQUAL(1000u, res->GetPresentEntry("a")->_intval);
     }
     EXPECT_EQUAL(0u, bc._str.lastSyncToken());
     uint64_t flushToken = bc._str.initFlush(bc._serialNum - 1);
@@ -466,8 +466,8 @@ TEST_F("requireThatAdapterHandlesDocumentIdField", Fixture)
                              bc.createFieldCacheRepo(f.getResultConfig())->getFieldCache("class4"),
                              f.getMarkupFields());
     GeneralResultPtr res = getResult(dsa, 0);
-    EXPECT_EQUAL("id:ns:searchdocument::0", std::string(res->GetEntry("documentid")->_stringval,
-                                                        res->GetEntry("documentid")->_stringlen));
+    EXPECT_EQUAL("id:ns:searchdocument::0", std::string(res->GetPresentEntry("documentid")->_stringval,
+                                                        res->GetPresentEntry("documentid")->_stringlen));
 }
 
 GlobalId gid1 = DocumentId("id:ns:searchdocument::1").getGlobalId(); // lid 1
@@ -960,14 +960,14 @@ TEST_F("requireThatUrisAreUsed", Fixture)
     GeneralResultPtr res = getResult(dsa, 1);
     {
         vespalib::Slime slime;
-        decode(res->GetEntry("uriarray"), slime);
+        decode(res->GetPresentEntry("uriarray"), slime);
         EXPECT_TRUE(slime.get().valid());
         EXPECT_EQUAL("http://www.example.com:82/fluke?ab=2#8",  asVstring(slime.get()[0]));
         EXPECT_EQUAL("http://www.flickr.com:82/fluke?ab=2#9", asVstring(slime.get()[1]));
     }
     {
         vespalib::Slime slime;
-        decode(res->GetEntry("uriwset"), slime);
+        decode(res->GetPresentEntry("uriwset"), slime);
         EXPECT_TRUE(slime.get().valid());
         EXPECT_EQUAL(4L, slime.get()[0]["weight"].asLong());
         EXPECT_EQUAL(7L, slime.get()[1]["weight"].asLong());
@@ -1089,14 +1089,14 @@ TEST_F("requireThatRawFieldsWorks", Fixture)
     GeneralResultPtr res = getResult(dsa, 1);
     {
         vespalib::Slime slime;
-        decode(res->GetEntry("araw"), slime);
+        decode(res->GetPresentEntry("araw"), slime);
         EXPECT_TRUE(slime.get().valid());
         EXPECT_EQUAL(vespalib::Base64::encode(raw1a0), b64encode(slime.get()[0]));
         EXPECT_EQUAL(vespalib::Base64::encode(raw1a1), b64encode(slime.get()[1]));
     }
     {
         vespalib::Slime slime;
-        decode(res->GetEntry("wraw"), slime);
+        decode(res->GetPresentEntry("wraw"), slime);
         EXPECT_TRUE(slime.get().valid());
         EXPECT_EQUAL(46L, slime.get()[0]["weight"].asLong());
         EXPECT_EQUAL(45L, slime.get()[1]["weight"].asLong());

--- a/searchsummary/src/tests/docsumformat/docsum-pack.cpp
+++ b/searchsummary/src/tests/docsumformat/docsum-pack.cpp
@@ -113,7 +113,7 @@ MyApp::Equal(GeneralResult *a, GeneralResult *b)
 void
 MyApp::TestIntValue(uint32_t line, GeneralResult *gres, const char *field, uint32_t value)
 {
-    ResEntry *entry = (gres != nullptr) ? gres->GetEntry(field) : nullptr;
+    ResEntry *entry = (gres != nullptr) ? gres->GetPresentEntry(field) : nullptr;
 
     bool rc = (entry != nullptr &&
                entry->_type == RES_INT &&
@@ -125,7 +125,7 @@ MyApp::TestIntValue(uint32_t line, GeneralResult *gres, const char *field, uint3
 void
 MyApp::TestDoubleValue(uint32_t line, GeneralResult *gres, const char *field, double value)
 {
-    ResEntry *entry = (gres != nullptr) ? gres->GetEntry(field) : nullptr;
+    ResEntry *entry = (gres != nullptr) ? gres->GetPresentEntry(field) : nullptr;
 
     bool rc = (entry != nullptr &&
                entry->_type == RES_DOUBLE &&
@@ -137,7 +137,7 @@ MyApp::TestDoubleValue(uint32_t line, GeneralResult *gres, const char *field, do
 void
 MyApp::TestInt64Value(uint32_t line, GeneralResult *gres, const char *field, uint64_t value)
 {
-    ResEntry *entry = (gres != nullptr) ? gres->GetEntry(field) : nullptr;
+    ResEntry *entry = (gres != nullptr) ? gres->GetPresentEntry(field) : nullptr;
 
     bool rc = (entry != nullptr &&
                entry->_type == RES_INT64 &&
@@ -150,7 +150,7 @@ MyApp::TestInt64Value(uint32_t line, GeneralResult *gres, const char *field, uin
 void
 MyApp::TestStringValue(uint32_t line, GeneralResult *gres, const char *field, const char *value)
 {
-    ResEntry *entry = (gres != nullptr) ? gres->GetEntry(field) : nullptr;
+    ResEntry *entry = (gres != nullptr) ? gres->GetPresentEntry(field) : nullptr;
 
     bool rc = (entry != nullptr &&
                entry->_type == RES_STRING &&
@@ -168,7 +168,7 @@ MyApp::TestStringValue(uint32_t line, GeneralResult *gres, const char *field, co
 void
 MyApp::TestDataValue(uint32_t line, GeneralResult *gres, const char *field, const char *value)
 {
-    ResEntry *entry = (gres != nullptr) ? gres->GetEntry(field) : nullptr;
+    ResEntry *entry = (gres != nullptr) ? gres->GetPresentEntry(field) : nullptr;
 
     bool rc = (entry != nullptr &&
                entry->_type == RES_DATA &&

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumfieldwriter.cpp
@@ -64,10 +64,10 @@ CopyDFW::Init(const ResultConfig & config, const char *inputField)
         LOG(warning, "no docsum format contains field '%s'; copied fields will be empty", inputField);
     }
 
-    for (const auto & field : config) {
-        const ResConfigEntry *entry = field.GetEntry(field.GetIndexFromEnumValue(_inputFieldEnumValue));
+    for (const auto & result_class : config) {
+        const ResConfigEntry *entry = result_class.GetEntry(result_class.GetIndexFromEnumValue(_inputFieldEnumValue));
 
-        if (entry != nullptr &&
+        if (entry != nullptr && !entry->_not_present &&
             !IsRuntimeCompatible(entry->_type, RES_INT) &&
             !IsRuntimeCompatible(entry->_type, RES_DOUBLE) &&
             !IsRuntimeCompatible(entry->_type, RES_INT64) &&
@@ -75,7 +75,7 @@ CopyDFW::Init(const ResultConfig & config, const char *inputField)
             !IsRuntimeCompatible(entry->_type, RES_DATA)) {
 
             LOG(warning, "cannot use docsum field '%s' as input to copy; type conflict with result class %d (%s)",
-                inputField, field.GetClassID(), field.GetClassName());
+                inputField, result_class.GetClassID(), result_class.GetClassName());
             return false;
         }
     }
@@ -87,7 +87,7 @@ CopyDFW::insertField(uint32_t /*docid*/, GeneralResult *gres, GetDocsumsState *,
                      vespalib::slime::Inserter &target)
 {
     int idx = gres->GetClass()->GetIndexFromEnumValue(_inputFieldEnumValue);
-    ResEntry *entry = gres->GetEntry(idx);
+    ResEntry *entry = gres->GetPresentEntry(idx);
 
     if (entry == nullptr) {
         const auto* document = gres->get_document();

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
@@ -201,7 +201,7 @@ DynamicDocsumWriter::insertDocsum(const ResolveClassInfo & rci, uint32_t docid, 
                 } else {
                     int inIdx = rci.inputClass->GetIndexFromEnumValue(outCfg->_enumValue);
                     const ResConfigEntry *inCfg = rci.inputClass->GetEntry(inIdx);
-                    if (inCfg != nullptr && inCfg->_type == outCfg->_type) {
+                    if (inCfg != nullptr && inCfg->_type == outCfg->_type && !inCfg->_not_present) {
                         // copy field
                         const ResEntry *entry = gres.GetEntry(inIdx);
                         LOG_ASSERT(entry != nullptr);
@@ -302,10 +302,10 @@ DynamicDocsumWriter::Override(const char *fieldName, IDocsumFieldWriter *writer)
         ++_numFieldWriterStates;
     }
 
-    for (auto & entry : *_resultConfig) {
+    for (auto & result_class : *_resultConfig) {
 
-        if (entry.GetIndexFromEnumValue(fieldEnumValue) >= 0) {
-            ResultClass::DynamicInfo *info = entry.getDynamicInfo();
+        if (result_class.GetIndexFromEnumValue(fieldEnumValue) >= 0) {
+            ResultClass::DynamicInfo *info = result_class.getDynamicInfo();
             info->_overrideCnt++;
             if (writer->IsGenerated())
                 info->_generateCnt++;

--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -332,7 +332,7 @@ JuniperTeaserDFW::Init(
         const ResConfigEntry *entry =
             it->GetEntry(it->GetIndexFromEnumValue(_inputFieldEnumValue));
 
-        if (entry != nullptr &&
+        if (entry != nullptr && !entry->_not_present &&
             !IsRuntimeCompatible(entry->_type, RES_STRING) &&
             !IsRuntimeCompatible(entry->_type, RES_DATA))
         {
@@ -347,7 +347,7 @@ JuniperTeaserDFW::Init(
 vespalib::stringref
 DynamicTeaserDFW::getJuniperInput(GeneralResult *gres) {
     int idx = gres->GetClass()->GetIndexFromEnumValue(_inputFieldEnumValue);
-    ResEntry *entry = gres->GetEntry(idx);
+    ResEntry *entry = gres->GetPresentEntry(idx);
     if (entry != nullptr) {
         const char *buf;
         uint32_t    buflen;

--- a/searchsummary/src/vespa/searchsummary/docsummary/general_result.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/general_result.cpp
@@ -49,25 +49,17 @@ GeneralResult::~GeneralResult()
 }
 
 ResEntry *
-GeneralResult::GetEntry(uint32_t idx)
-{
-    return (idx < _entrycnt) ? &_entries[idx] : nullptr;
-}
-
-ResEntry *
-GeneralResult::GetEntry(const char *name)
+GeneralResult::GetPresentEntry(const char *name)
 {
     int idx = _resClass->GetIndexFromName(name);
-
-    return (idx >= 0 && (uint32_t)idx < _entrycnt) ? &_entries[idx] : nullptr;
+    return GetPresentEntry(idx);
 }
 
-
 ResEntry *
-GeneralResult::GetEntryFromEnumValue(uint32_t value)
+GeneralResult::GetPresentEntryFromEnumValue(uint32_t value)
 {
     int idx = _resClass->GetIndexFromEnumValue(value);
-    return (idx >= 0 && (uint32_t)idx < _entrycnt) ? &_entries[idx] : nullptr;
+    return GetPresentEntry(idx);
 }
 
 std::unique_ptr<document::FieldValue>

--- a/searchsummary/src/vespa/searchsummary/docsummary/general_result.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/general_result.h
@@ -32,9 +32,16 @@ public:
     ~GeneralResult();
 
     const ResultClass *GetClass() const { return _resClass; }
-    ResEntry *GetEntry(uint32_t idx);
-    ResEntry *GetEntry(const char *name);
-    ResEntry *GetEntryFromEnumValue(uint32_t val);
+    ResEntry *GetEntry(uint32_t idx) { return (idx < _entrycnt) ? &_entries[idx] : nullptr; }
+    ResEntry *GetPresentEntry(uint32_t idx) {
+        if (idx >= _entrycnt) {
+            return nullptr;
+        }
+        ResEntry* entry = &_entries[idx];
+        return entry->_not_present ? nullptr : entry;
+    }
+    ResEntry *GetPresentEntry(const char *name);
+    ResEntry *GetPresentEntryFromEnumValue(uint32_t val);
     std::unique_ptr<document::FieldValue> get_field_value(const vespalib::string& field_name) const;
     bool unpack(const char *buf, const size_t buflen);
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
@@ -93,7 +93,7 @@ filter_matching_elements_in_input_field_while_converting_to_slime(const FieldVal
 bool
 resolve_input_field_as_slime(GeneralResult& result, int entry_idx, Slime& input_field_as_slime)
 {
-    ResEntry* entry = result.GetEntry(entry_idx);
+    ResEntry* entry = result.GetPresentEntry(entry_idx);
     if (entry != nullptr) {
         decode_input_field_to_slime(*entry, input_field_as_slime);
         return true;

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultclass.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultclass.cpp
@@ -26,11 +26,7 @@ int
 ResultClass::GetIndexFromName(const char* name) const
 {
     NameIdMap::const_iterator found(_nameMap.find(name));
-    if (found == _nameMap.end()) {
-        return -1;
-    }
-    int idx = found->second;
-    return _entries[idx]._not_present ? -1 : idx;
+    return (found != _nameMap.end()) ? found->second : -1;
 }
 
 bool

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
@@ -238,7 +238,7 @@ public:
      * GeneralResult::GetEntry(string) method; no need to call it
      * directly.
      *
-     * @return field index or -1 if not found or _not_present is set.
+     * @return field index or -1 if not found
      **/
     int GetIndexFromName(const char* name) const;
 
@@ -255,15 +255,11 @@ public:
      * call it directly. NOTE3: You need to call the CreateEnumMap
      * method before calling this one.
      *
-     * @return field index or -1 if not found or _not_present is set.
+     * @return field index or -1 if not found
      **/
     int GetIndexFromEnumValue(uint32_t value) const
     {
-        if (value >= _enumMap.size()) {
-            return -1;
-        }
-        int idx = _enumMap[value];
-        return ((idx < 0) || _entries[idx]._not_present) ? -1 : idx;
+        return (value < _enumMap.size()) ? _enumMap[value] : -1;
     }
 
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/textextractordfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/textextractordfw.cpp
@@ -31,7 +31,7 @@ TextExtractorDFW::insertField(uint32_t, GeneralResult *gres, GetDocsumsState *, 
                               vespalib::slime::Inserter &target)
 {
     vespalib::string extracted;
-    ResEntry * entry = gres->GetEntryFromEnumValue(_inputFieldEnum);
+    ResEntry * entry = gres->GetPresentEntryFromEnumValue(_inputFieldEnum);
     if (entry != nullptr) {
         const char * buf = nullptr;
         uint32_t buflen = 0;


### PR DESCRIPTION
ResultClass::GetIndexFromEnumValue. Caller must check for entry being present.

Rename GeneralResult member functions that checks for entry being present.

@geirst : please review
