### PR TITLE
Deprecate ConfigGetter

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/ConfigGetter.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigGetter.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.config.subscription;
 
-
 import com.yahoo.config.ConfigInstance;
 
 /**
@@ -13,7 +12,9 @@ import com.yahoo.config.ConfigInstance;
  * command-line tools.
  *
  * @author gjoranv
+ * @deprecated Use config builders where possible
  */
+@Deprecated
 public class ConfigGetter<T extends ConfigInstance> {
 
     private final Class<T> clazz;

--- a/config/src/test/java/com/yahoo/config/subscription/ConfigGetterTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/ConfigGetterTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author gjoranv
  */
+@SuppressWarnings("deprecation")
 public class ConfigGetterTest {
     private final ConfigSourceSet sourceSet = new ConfigSourceSet("config-getter-test");
 

--- a/config/src/test/java/com/yahoo/config/subscription/FunctionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/FunctionTest.java
@@ -2,20 +2,16 @@
 package com.yahoo.config.subscription;
 
 import com.yahoo.foo.FunctionTestConfig;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -28,6 +24,7 @@ import static org.junit.Assert.fail;
  *
  * @author gjoranv
  */
+@SuppressWarnings("deprecation")
 public class FunctionTest {
 
     public static final String PATH = "src/test/resources/configs/function-test/";

--- a/config/src/test/java/com/yahoo/config/subscription/NamespaceTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/NamespaceTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertEquals;
 public class NamespaceTest {
 
     @Test
+    @SuppressWarnings("deprecation")
     public void verifyConfigClassWithExplicitNamespace() {
         NamespaceConfig config = new ConfigGetter<>(NamespaceConfig.class).getConfig("raw: a 0\n");
         assertEquals(0, config.a());

--- a/config/src/test/java/com/yahoo/config/subscription/UnicodeTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/UnicodeTest.java
@@ -22,6 +22,7 @@ public class UnicodeTest {
      * received correctly from the server
      */
     @Test
+    @SuppressWarnings("deprecation")
     public void testUnicodeConfigReading() {
         ConfigGetter<UnicodeConfig> getter = new ConfigGetter<>(UnicodeConfig.class);
         UnicodeConfig config = getter.getConfig("file:src/test/resources/configs/unicode/unicode.cfg");

--- a/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ComponentGraphTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ComponentGraphTest.java
@@ -50,6 +50,7 @@ public class ComponentGraphTest {
             super();
         }
 
+        @SuppressWarnings("deprecation")
         public <T extends ConfigInstance> ConfigMap add(Class<T> clazz, String configId) {
             ConfigKey<T> key = new ConfigKey<>(clazz, configId);
             put(key, ConfigGetter.getConfig(key.getConfigClass(), key.getConfigId()));

--- a/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ReuseComponentsTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ReuseComponentsTest.java
@@ -62,6 +62,7 @@ public class ReuseComponentsTest {
         SimpleComponent throwsException = getComponent(newGraph, SimpleComponent.class);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void require_that_component_is_not_reused_when_config_is_changed() {
         Class<ComponentTakingConfig> componentClass = ComponentTakingConfig.class;
@@ -80,6 +81,7 @@ public class ReuseComponentsTest {
         assertNotSame(instance2, instance);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void require_that_component_is_not_reused_when_injected_component_is_changed() {
         Function<String, ComponentGraph> buildGraph = config -> {
@@ -144,6 +146,7 @@ public class ReuseComponentsTest {
         assertNotSame(newSimpleComponentRegistry, oldSimpleComponentRegistry);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void require_that_injected_component_is_reused_even_when_dependent_component_is_changed() {
         Function<String, ComponentGraph> buildGraph = config -> {

--- a/container-messagebus/src/main/java/com/yahoo/messagebus/shared/SharedMessageBus.java
+++ b/container-messagebus/src/main/java/com/yahoo/messagebus/shared/SharedMessageBus.java
@@ -1,12 +1,9 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.messagebus.shared;
 
+import com.yahoo.cloud.config.SlobroksConfig;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.jdisc.AbstractResource;
-
-import java.util.Objects;
-import java.util.logging.Level;
-
 import com.yahoo.messagebus.DestinationSessionParams;
 import com.yahoo.messagebus.IntermediateSessionParams;
 import com.yahoo.messagebus.MessageBus;
@@ -15,8 +12,8 @@ import com.yahoo.messagebus.SourceSessionParams;
 import com.yahoo.messagebus.network.Network;
 import com.yahoo.messagebus.network.rpc.RPCNetwork;
 import com.yahoo.messagebus.network.rpc.RPCNetworkParams;
-import com.yahoo.cloud.config.SlobroksConfig;
-
+import java.util.Objects;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -57,6 +54,7 @@ public class SharedMessageBus extends AbstractResource {
         return new SharedMessageBus(new MessageBus(newNetwork(netParams), mbusParams));
     }
 
+    @SuppressWarnings("deprecation")
     private static Network newNetwork(RPCNetworkParams params) {
         SlobroksConfig cfg = params.getSlobroksConfig();
         if (cfg == null) {

--- a/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileConfigurer.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profile/config/QueryProfileConfigurer.java
@@ -21,6 +21,7 @@ import java.util.Set;
  */
 public class QueryProfileConfigurer {
 
+    @SuppressWarnings("deprecation")
     public static QueryProfileRegistry createFromConfigId(String configId) {
         return createFromConfig(ConfigGetter.getConfig(QueryProfilesConfig.class, configId));
     }

--- a/container-search/src/test/java/com/yahoo/prelude/IndexFactsFactory.java
+++ b/container-search/src/test/java/com/yahoo/prelude/IndexFactsFactory.java
@@ -23,6 +23,7 @@ public abstract class IndexFactsFactory {
 
     }
 
+    @SuppressWarnings("deprecation")
     private static <T extends ConfigInstance> T resolveConfig(Class<T> configClass, String configId) {
         if (configId == null) return null;
         return ConfigGetter.getConfig(configClass, configId);

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParsingTester.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParsingTester.java
@@ -62,6 +62,7 @@ public class ParsingTester {
      * Returns an unfrozen version of the IndexFacts this will use.
      * This can be used to add new indexes and passing the resulting IndexFacts to the constructor of this.
      */
+    @SuppressWarnings("deprecation")
     public static IndexFacts createIndexFacts() {
         String indexInfoConfigID = "file:src/test/java/com/yahoo/prelude/query/parser/test/parseindexinfo.cfg";
         ConfigGetter<IndexInfoConfig> getter = new ConfigGetter<>(IndexInfoConfig.class);

--- a/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/querytransform/test/StemmingSearcherTestCase.java
@@ -96,6 +96,7 @@ public class StemmingSearcherTestCase {
                    "WEAKAND(100) notnoun:tower notnoun:tower notnoun:tow");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testEmptyIndexInfo() {
         String indexInfoConfigID = "file:src/test/java/com/yahoo/prelude/querytransform/test/emptyindexinfo.cfg";

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/QuotingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/QuotingSearcherTestCase.java
@@ -4,21 +4,18 @@ package com.yahoo.prelude.searcher.test;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.language.simple.SimpleLinguistics;
-import com.yahoo.prelude.searcher.QrQuotetableConfig;
-import com.yahoo.search.rendering.RendererRegistry;
-import com.yahoo.search.result.Hit;
-import com.yahoo.search.result.Relevance;
-import com.yahoo.search.Query;
-import com.yahoo.search.Result;
 import com.yahoo.prelude.fastsearch.FastHit;
 import com.yahoo.prelude.hitfield.HitField;
-import com.yahoo.search.Searcher;
+import com.yahoo.prelude.searcher.QrQuotetableConfig;
 import com.yahoo.prelude.searcher.QuotingSearcher;
+import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.result.Hit;
+import com.yahoo.search.result.Relevance;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchchain.testutil.DocumentSourceSearcher;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,6 +31,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class QuotingSearcherTestCase {
 
+    @SuppressWarnings("deprecation")
     public static QuotingSearcher createQuotingSearcher(String configId) {
         QrQuotetableConfig config = new ConfigGetter<>(QrQuotetableConfig.class).getConfig(configId);
         return new QuotingSearcher(new ComponentId("QuotingSearcher"), config);

--- a/container-search/src/test/java/com/yahoo/prelude/searcher/test/ValidateSortingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/searcher/test/ValidateSortingSearcherTestCase.java
@@ -2,24 +2,23 @@
 package com.yahoo.prelude.searcher.test;
 
 import com.yahoo.component.chain.Chain;
-import com.yahoo.language.simple.SimpleLinguistics;
-import com.yahoo.search.Searcher;
-import com.yahoo.search.rendering.RendererRegistry;
-import com.yahoo.search.searchchain.Execution;
-import com.yahoo.vespa.config.search.AttributesConfig;
-import com.yahoo.search.config.ClusterConfig;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.prelude.searcher.ValidateSortingSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
+import com.yahoo.search.Searcher;
+import com.yahoo.search.config.ClusterConfig;
+import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.test.QueryTestCase;
+import com.yahoo.vespa.config.search.AttributesConfig;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Check sorting validation behaves OK.
@@ -30,6 +29,7 @@ public class ValidateSortingSearcherTestCase {
 
     private final ValidateSortingSearcher searcher;
 
+    @SuppressWarnings("deprecation")
     public ValidateSortingSearcherTestCase() {
         QrSearchersConfig.Builder qrsCfg = new QrSearchersConfig.Builder();
         qrsCfg.searchcluster(new QrSearchersConfig.Searchcluster.Builder().name("giraffes"));

--- a/container-search/src/test/java/com/yahoo/prelude/semantics/test/ConfigurationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/semantics/test/ConfigurationTestCase.java
@@ -4,18 +4,16 @@ package com.yahoo.prelude.semantics.test;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.language.simple.SimpleLinguistics;
-import com.yahoo.prelude.semantics.SemanticRulesConfig;
-import com.yahoo.search.Query;
 import com.yahoo.prelude.semantics.RuleBase;
 import com.yahoo.prelude.semantics.RuleBaseException;
+import com.yahoo.prelude.semantics.SemanticRulesConfig;
 import com.yahoo.prelude.semantics.SemanticSearcher;
+import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
-import com.yahoo.search.rendering.RendererRegistry;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.test.QueryTestCase;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +26,7 @@ import static org.junit.Assert.fail;
  *
  * @author bratseth
  */
+@SuppressWarnings("deprecation")
 public class ConfigurationTestCase {
 
     private static final String root="src/test/java/com/yahoo/prelude/semantics/test/rulebases/";

--- a/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
@@ -1,6 +1,17 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.test;
 
+import com.google.common.collect.ImmutableList;
+import com.yahoo.config.subscription.ConfigGetter;
+import com.yahoo.language.process.StemMode;
+import com.yahoo.prelude.Index;
+import com.yahoo.prelude.IndexFacts;
+import com.yahoo.prelude.IndexModel;
+import com.yahoo.prelude.SearchDefinition;
+import com.yahoo.search.Query;
+import com.yahoo.search.config.IndexInfoConfig;
+import com.yahoo.search.searchchain.Execution;
+import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -8,32 +19,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
-
-import com.google.common.collect.ImmutableList;
-import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.container.QrSearchersConfig;
-import com.yahoo.search.config.IndexInfoConfig;
-import com.yahoo.search.config.IndexInfoConfig.Indexinfo;
-import com.yahoo.search.config.IndexInfoConfig.Indexinfo.Alias;
-import com.yahoo.search.config.IndexInfoConfig.Indexinfo.Command;
-import com.yahoo.language.process.StemMode;
-import com.yahoo.prelude.Index;
-import com.yahoo.prelude.IndexFacts;
-import com.yahoo.prelude.IndexModel;
-import com.yahoo.prelude.SearchDefinition;
-import com.yahoo.search.Query;
-import com.yahoo.search.searchchain.Execution;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 /**
  * Tests using synthetic index names for IndexFacts class.
@@ -45,6 +35,7 @@ public class IndexFactsTestCase {
 
     private static final String INDEXFACTS_TESTING = "file:src/test/java/com/yahoo/prelude/test/indexfactstesting.cfg";
 
+    @SuppressWarnings("deprecation")
     private IndexFacts createIndexFacts() {
         ConfigGetter<IndexInfoConfig> getter = new ConfigGetter<>(IndexInfoConfig.class);
         IndexInfoConfig config = getter.getConfig(INDEXFACTS_TESTING);

--- a/container-search/src/test/java/com/yahoo/search/query/rewrite/test/QueryRewriteSearcherTestUtils.java
+++ b/container-search/src/test/java/com/yahoo/search/query/rewrite/test/QueryRewriteSearcherTestUtils.java
@@ -40,6 +40,7 @@ public class QueryRewriteSearcherTestUtils {
      *
      * @param configPath path for the searcher config
      */
+    @SuppressWarnings("deprecation")
     public static RewritesConfig createConfigObj(String configPath) {
         return new ConfigGetter<>(RewritesConfig.class).getConfig(configPath);
     }

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateFuzzySearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateFuzzySearcherTestCase.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.searchers;
 
-import com.yahoo.config.subscription.ConfigGetter;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
@@ -13,10 +12,9 @@ import com.yahoo.search.query.parser.ParserEnvironment;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.yql.YqlParser;
-import com.yahoo.vespa.config.search.AttributesConfig.Attribute;
 import com.yahoo.vespa.config.search.AttributesConfig;
+import com.yahoo.vespa.config.search.AttributesConfig.Attribute;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -33,35 +31,25 @@ public class ValidateFuzzySearcherTestCase {
     List<String> attributes;
 
     public ValidateFuzzySearcherTestCase() {
-        int i = 0;
         attributes = new ArrayList<>();
-        StringBuilder attributeConfig = new StringBuilder();
+        AttributesConfig.Builder configBuilder = new AttributesConfig.Builder();
+        List<AttributesConfig.Attribute.Builder> attributesList = new ArrayList<>();
         for (Attribute.Datatype.Enum attr: Attribute.Datatype.Enum.values()) {
             for (Attribute.Collectiontype.Enum ctype: Attribute.Collectiontype.Enum.values()) {
+                AttributesConfig.Attribute.Builder attributesBuilder = new AttributesConfig.Attribute.Builder();
                 String attributeName = attr.name().toLowerCase() + "_" + ctype.name().toLowerCase();
+                attributesBuilder.name(attributeName);
+                attributesBuilder.datatype(attr);
+                attributesBuilder.collectiontype(ctype);
+                attributesList.add(attributesBuilder);
 
-                attributeConfig.append("attribute[" + i + "].name ");
-                attributeConfig.append(attributeName);
-                attributeConfig.append("\n");
-
-                attributeConfig.append("attribute[" + i + "].datatype ");
-                attributeConfig.append(attr.name());
-                attributeConfig.append("\n");
-
-                attributeConfig.append("attribute[" + i + "].collectiontype ");
-                attributeConfig.append(ctype.name());
-                attributeConfig.append("\n");
-
-                i += 1;
                 attributes.add(attributeName);
             }
         }
+        configBuilder.attribute(attributesList);
+        AttributesConfig config = configBuilder.build();
 
-        searcher = new ValidateFuzzySearcher(ConfigGetter.getConfig(
-                AttributesConfig.class,
-                "raw: " +
-                        "attribute[" + attributes.size() + "]\n" +
-                        attributeConfig));
+        searcher = new ValidateFuzzySearcher(config);
     }
 
     private String makeQuery(String attribute, String query, int maxEditDistance, int prefixLength) {

--- a/container-search/src/test/java/com/yahoo/search/searchers/ValidateNearestNeighborTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/ValidateNearestNeighborTestCase.java
@@ -2,27 +2,21 @@
 package com.yahoo.search.searchers;
 
 import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.config.subscription.FileSource;
-import com.yahoo.config.subscription.RawSource;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.IndexModel;
 import com.yahoo.prelude.SearchDefinition;
 import com.yahoo.search.Query;
+import com.yahoo.search.Result;
+import com.yahoo.search.query.QueryTree;
 import com.yahoo.search.query.parser.Parsable;
 import com.yahoo.search.query.parser.ParserEnvironment;
-import com.yahoo.search.query.QueryTree;
-import com.yahoo.search.Result;
 import com.yahoo.search.result.ErrorMessage;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.yql.YqlParser;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.config.search.AttributesConfig;
-
-import com.yahoo.vespa.config.search.RankProfilesConfig;
 import org.junit.Test;
-
-import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -34,6 +28,7 @@ public class ValidateNearestNeighborTestCase {
 
     ValidateNearestNeighborSearcher searcher;
 
+    @SuppressWarnings("deprecation")
     public ValidateNearestNeighborTestCase() {
         searcher = new ValidateNearestNeighborSearcher(
                 ConfigGetter.getConfig(AttributesConfig.class,

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/ValidateMatchPhaseSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/ValidateMatchPhaseSearcherTestCase.java
@@ -3,7 +3,6 @@ package com.yahoo.search.searchers.test;
 
 import com.yahoo.component.chain.Chain;
 import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.config.subscription.RawSource;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.searchers.ValidateMatchPhaseSearcher;
@@ -15,7 +14,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author baldersheim
@@ -24,6 +23,7 @@ public class ValidateMatchPhaseSearcherTestCase {
 
     private final ValidateMatchPhaseSearcher searcher;
 
+    @SuppressWarnings("deprecation")
     public ValidateMatchPhaseSearcherTestCase() {
         searcher = new ValidateMatchPhaseSearcher(
                 ConfigGetter.getConfig(AttributesConfig.class,

--- a/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
+++ b/docprocs/src/test/java/com/yahoo/docprocs/indexing/IndexingProcessorTestCase.java
@@ -125,6 +125,7 @@ public class IndexingProcessorTestCase {
         return lst.get(0);
     }
 
+    @SuppressWarnings("deprecation")
     private static IndexingProcessor newProcessor(String configId) {
         return new IndexingProcessor(new DocumentTypeManager(ConfigGetter.getConfig(DocumentmanagerConfig.class, configId)),
                                      ConfigGetter.getConfig(IlscriptsConfig.class, configId),

--- a/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelTester.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelTester.java
@@ -2,7 +2,6 @@
 package ai.vespa.models.evaluation;
 
 import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.config.subscription.FileSource;
 import com.yahoo.filedistribution.fileacquirer.MockFileAcquirer;
 import com.yahoo.path.Path;
 import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
@@ -10,7 +9,6 @@ import com.yahoo.vespa.config.search.RankProfilesConfig;
 import com.yahoo.vespa.config.search.core.OnnxModelsConfig;
 import com.yahoo.vespa.config.search.core.RankingConstantsConfig;
 import com.yahoo.vespa.config.search.core.RankingExpressionsConfig;
-
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -31,8 +29,8 @@ public class ModelTester {
 
     public Map<String, Model> models() { return models; }
 
+    @SuppressWarnings("deprecation")
     private static Map<String, Model> createModels(String path) {
-
         RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId(path, "rank-profiles.cfg"));
         RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId(path, "ranking-constants.cfg"));
         RankingExpressionsConfig expressionsConfig = ConfigGetter.getConfig(RankingExpressionsConfig.class, fileConfigId(path, "ranking-expressions.cfg"));

--- a/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelsEvaluatorTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/evaluation/ModelsEvaluatorTest.java
@@ -2,7 +2,6 @@
 package ai.vespa.models.evaluation;
 
 import com.yahoo.config.subscription.ConfigGetter;
-import com.yahoo.config.subscription.FileSource;
 import com.yahoo.filedistribution.fileacquirer.MockFileAcquirer;
 import com.yahoo.path.Path;
 import com.yahoo.searchlib.rankingexpression.ExpressionFunction;
@@ -15,7 +14,6 @@ import com.yahoo.vespa.config.search.core.RankingConstantsConfig;
 import com.yahoo.vespa.config.search.core.RankingExpressionsConfig;
 import com.yahoo.yolean.Exceptions;
 import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -128,6 +126,7 @@ public class ModelsEvaluatorTest {
     // TODO: Test argument-less function
     // TODO: Test with nested functions
 
+    @SuppressWarnings("deprecation")
     private ModelsEvaluator createModels() {
         RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
         RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));

--- a/model-evaluation/src/test/java/ai/vespa/models/evaluation/OnnxEvaluatorTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/evaluation/OnnxEvaluatorTest.java
@@ -51,6 +51,7 @@ public class OnnxEvaluatorTest {
         assertEquals(function.evaluate(), Tensor.from("tensor<float>(d0[2],d1[1]):[0.63931,0.67574]"));
     }
 
+    @SuppressWarnings("deprecation")
     private ModelsEvaluator createModels() {
         RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
         RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/ModelsEvaluationHandlerTest.java
@@ -257,6 +257,7 @@ public class ModelsEvaluationHandlerTest {
         handler.assertResponse(url, properties, 200, expected);
     }
 
+    @SuppressWarnings("deprecation")
     static private ModelsEvaluator createModels() {
         RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
         RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));

--- a/model-evaluation/src/test/java/ai/vespa/models/handler/OnnxEvaluationHandlerTest.java
+++ b/model-evaluation/src/test/java/ai/vespa/models/handler/OnnxEvaluationHandlerTest.java
@@ -117,6 +117,7 @@ public class OnnxEvaluationHandlerTest {
         handler.assertResponse(url, properties, 200, expected);
     }
 
+    @SuppressWarnings("deprecation")
     static private ModelsEvaluator createModels() {
         RankProfilesConfig config = ConfigGetter.getConfig(RankProfilesConfig.class, fileConfigId("rank-profiles.cfg"));
         RankingConstantsConfig constantsConfig = ConfigGetter.getConfig(RankingConstantsConfig.class, fileConfigId("ranking-constants.cfg"));

--- a/vdslib/src/test/java/com/yahoo/vdslib/distribution/DistributionTestFactory.java
+++ b/vdslib/src/test/java/com/yahoo/vdslib/distribution/DistributionTestFactory.java
@@ -108,6 +108,7 @@ public class DistributionTestFactory extends CrossPlatformTestFactory {
         }
     }
 
+    @SuppressWarnings("deprecation")
     private static StorDistributionConfig.Builder deserializeConfig(String s) {
         return new StorDistributionConfig.Builder(
                 new ConfigGetter<>(StorDistributionConfig.class).getConfig("raw:" + s));

--- a/vespaclient-core/src/main/java/com/yahoo/vespaclient/ClusterList.java
+++ b/vespaclient-core/src/main/java/com/yahoo/vespaclient/ClusterList.java
@@ -20,6 +20,7 @@ public class ClusterList {
         this.contentClusters = List.copyOf(contentClusters);
     }
 
+    @SuppressWarnings("deprecation")
     public ClusterList(String configId) {
         this(new ConfigGetter<>(ClusterListConfig.class).getConfig(configId));
     }


### PR DESCRIPTION
Not sure if this is worth it, as we have no replacement for e.g. command-line clients. A lot of work to rewrite usage to using config builders, so done only in one place here.