### PR TITLE
Calculate distance raw score lazily

### DIFF
--- a/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/closenessfeature.cpp
@@ -5,6 +5,7 @@
 #include "utils.h"
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchlib/fef/properties.h>
+#include <vespa/searchlib/tensor/distance_calculator.h>
 #include <vespa/vespalib/util/stash.h>
 
 #include <vespa/log/log.h>
@@ -49,6 +50,9 @@ ConvertRawScoreToCloseness::execute(uint32_t docId)
         const TermFieldMatchData *tfmd = _md->resolveTermField(elem.handle);
         if (tfmd->getDocId() == docId) {
             feature_t converted = tfmd->getRawScore();
+            max_closeness = std::max(max_closeness, converted);
+        } else if (elem.calc) {
+            feature_t converted = elem.calc->calc_raw_score(docId);
             max_closeness = std::max(max_closeness, converted);
         }
     }

--- a/searchlib/src/vespa/searchlib/features/closenessfeature.h
+++ b/searchlib/src/vespa/searchlib/features/closenessfeature.h
@@ -45,6 +45,7 @@ public:
         return fef::ParameterDescriptions().desc().string().desc().string().string();
     }
     bool setup(const fef::IIndexEnvironment & env, const fef::ParameterList & params) override;
+    void prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const override;
     fef::FeatureExecutor &createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const override;
 };
 

--- a/searchlib/src/vespa/searchlib/features/distance_calculator_bundle.cpp
+++ b/searchlib/src/vespa/searchlib/features/distance_calculator_bundle.cpp
@@ -3,13 +3,81 @@
 #include "distance_calculator_bundle.h"
 #include "utils.h"
 #include <vespa/searchlib/fef/iqueryenvironment.h>
+#include <vespa/searchlib/fef/query_value.h>
 #include <vespa/searchlib/tensor/distance_calculator.h>
+#include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/issue.h>
 
 using search::fef::ITermData;
 using search::fef::IllegalHandle;
+using search::fef::InvalidValueTypeException;
+using search::fef::QueryValue;
 using search::fef::TermFieldHandle;
+using search::tensor::DistanceCalculator;
+using vespalib::Issue;
 
 namespace search::features {
+
+namespace {
+
+void
+prepare_query_tensor(const fef::IQueryEnvironment& env,
+                     fef::IObjectStore& store,
+                     const vespalib::string& query_tensor_name,
+                     const vespalib::string& feature_name)
+{
+    try {
+        auto qvalue = QueryValue::from_config(query_tensor_name, env.getIndexEnvironment());
+        qvalue.prepare_shared_state(env, store);
+    } catch (const InvalidValueTypeException& ex) {
+        Issue::report("%s feature: Query tensor '%s' has invalid type '%s'.",
+                      feature_name.c_str(), query_tensor_name.c_str(), ex.type_str().c_str());
+    }
+}
+
+std::unique_ptr<DistanceCalculator>
+make_distance_calculator(const fef::IQueryEnvironment& env,
+                         const search::attribute::IAttributeVector& attr,
+                         const vespalib::string& query_tensor_name,
+                         const vespalib::string& feature_name)
+{
+    try {
+        auto qvalue = QueryValue::from_config(query_tensor_name, env.getIndexEnvironment());
+        const auto* query_tensor = qvalue.lookup_value(env.getObjectStore());
+        if (query_tensor == nullptr) {
+            Issue::report("%s feature: Query tensor '%s' is not found in the object store.",
+                          feature_name.c_str(), query_tensor_name.c_str());
+            return {};
+        }
+        return DistanceCalculator::make_with_validation(attr, *query_tensor);
+    } catch (const InvalidValueTypeException& ex) {
+        Issue::report("%s feature: Query tensor '%s' has invalid type '%s'.",
+                      feature_name.c_str(), query_tensor_name.c_str(), ex.type_str().c_str());
+    } catch (const vespalib::IllegalArgumentException& ex) {
+        Issue::report("%s feature: Could not create distance calculator for attribute '%s' and query tensor '%s': %s.",
+                      feature_name.c_str(), attr.getName().c_str(), query_tensor_name.c_str(), ex.getMessage().c_str());
+    }
+    return {};
+}
+
+const search::attribute::IAttributeVector*
+resolve_attribute_for_field(const fef::IQueryEnvironment& env,
+                            uint32_t field_id,
+                            const vespalib::string& feature_name)
+{
+    const auto* field = env.getIndexEnvironment().getField(field_id);
+    if (field != nullptr) {
+        const auto* attr = env.getAttributeContext().getAttribute(field->name());
+        if (attr == nullptr) {
+            Issue::report("%s feature: The attribute vector '%s' for field id '%u' doesn't exist.",
+                          feature_name.c_str(), field->name().c_str(), field_id);
+        }
+        return attr;
+    }
+    return nullptr;
+}
+
+}
 
 DistanceCalculatorBundle::Element::Element(fef::TermFieldHandle handle_in)
     : handle(handle_in),
@@ -17,34 +85,86 @@ DistanceCalculatorBundle::Element::Element(fef::TermFieldHandle handle_in)
 {
 }
 
+DistanceCalculatorBundle::Element::Element(fef::TermFieldHandle handle_in, std::unique_ptr<search::tensor::DistanceCalculator> calc_in)
+    : handle(handle_in),
+      calc(std::move(calc_in))
+{
+}
+
 DistanceCalculatorBundle::Element::~Element() = default;
 
 DistanceCalculatorBundle::DistanceCalculatorBundle(const fef::IQueryEnvironment& env,
-                                                   uint32_t field_id)
+                                                   uint32_t field_id,
+                                                   const vespalib::string& feature_name)
+
     : _elems()
 {
     _elems.reserve(env.getNumTerms());
+    const auto* attr = resolve_attribute_for_field(env, field_id, feature_name);
     for (uint32_t i = 0; i < env.getNumTerms(); ++i) {
         search::fef::TermFieldHandle handle = util::getTermFieldHandle(env, i, field_id);
         if (handle != search::fef::IllegalHandle) {
-            _elems.emplace_back(handle);
+            const auto* term = env.getTerm(i);
+            if (term->query_tensor_name().has_value() && (attr != nullptr)) {
+                _elems.emplace_back(handle, make_distance_calculator(env, *attr, term->query_tensor_name().value(), feature_name));
+            } else {
+                _elems.emplace_back(handle);
+            }
         }
     }
 }
 
 DistanceCalculatorBundle::DistanceCalculatorBundle(const fef::IQueryEnvironment& env,
-                                                   const vespalib::string& label)
+                                                   const vespalib::string& label,
+                                                   const vespalib::string& feature_name)
     : _elems()
 {
-    const ITermData *term = util::getTermByLabel(env, label);
+    const ITermData* term = util::getTermByLabel(env, label);
     if (term != nullptr) {
         // expect numFields() == 1
         for (uint32_t i = 0; i < term->numFields(); ++i) {
-            TermFieldHandle handle = term->field(i).getHandle();
+            const auto& term_field = term->field(i);
+            TermFieldHandle handle = term_field.getHandle();
             if (handle != IllegalHandle) {
-                _elems.emplace_back(handle);
+                std::unique_ptr<DistanceCalculator> calc;
+                if (term->query_tensor_name().has_value()) {
+                    const auto* attr = resolve_attribute_for_field(env, term_field.getFieldId(), feature_name);
+                    if (attr != nullptr) {
+                        calc = make_distance_calculator(env, *attr, term->query_tensor_name().value(), feature_name);
+                    }
+                }
+                _elems.emplace_back(handle, std::move(calc));
             }
         }
+    }
+}
+
+void
+DistanceCalculatorBundle::prepare_shared_state(const fef::IQueryEnvironment& env,
+                                               fef::IObjectStore& store,
+                                               uint32_t field_id,
+                                               const vespalib::string& feature_name)
+{
+    for (uint32_t i = 0; i < env.getNumTerms(); ++i) {
+        search::fef::TermFieldHandle handle = util::getTermFieldHandle(env, i, field_id);
+        if (handle != search::fef::IllegalHandle) {
+            const auto* term = env.getTerm(i);
+            if (term->query_tensor_name().has_value()) {
+                prepare_query_tensor(env, store, term->query_tensor_name().value(), feature_name);
+            }
+        }
+    }
+}
+
+void
+DistanceCalculatorBundle::prepare_shared_state(const fef::IQueryEnvironment& env,
+                                               fef::IObjectStore& store,
+                                               const vespalib::string& label,
+                                               const vespalib::string& feature_name)
+{
+    const auto* term = util::getTermByLabel(env, label);
+    if ((term != nullptr) && term->query_tensor_name().has_value()) {
+        prepare_query_tensor(env, store, term->query_tensor_name().value(), feature_name);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/features/distance_calculator_bundle.h
+++ b/searchlib/src/vespa/searchlib/features/distance_calculator_bundle.h
@@ -8,7 +8,10 @@
 #include <vector>
 
 namespace search::tensor { class DistanceCalculator; }
-namespace search::fef { class IQueryEnvironment; }
+namespace search::fef {
+class IObjectStore;
+class IQueryEnvironment;
+}
 
 namespace search::features {
 
@@ -25,16 +28,32 @@ public:
         std::unique_ptr<search::tensor::DistanceCalculator> calc;
         Element(Element&& rhs) noexcept = default; // Needed as std::vector::reserve() is used.
         Element(fef::TermFieldHandle handle_in);
+        Element(fef::TermFieldHandle handle_in, std::unique_ptr<search::tensor::DistanceCalculator> calc_in);
         ~Element();
     };
 private:
     std::vector<Element> _elems;
 
 public:
-    DistanceCalculatorBundle(const fef::IQueryEnvironment& env, uint32_t field_id);
-    DistanceCalculatorBundle(const fef::IQueryEnvironment& env, const vespalib::string& label);
+    DistanceCalculatorBundle(const fef::IQueryEnvironment& env,
+                             uint32_t field_id,
+                             const vespalib::string& feature_name);
+
+    DistanceCalculatorBundle(const fef::IQueryEnvironment& env,
+                             const vespalib::string& label,
+                             const vespalib::string& feature_name);
 
     const std::vector<Element>& elements() const { return _elems; }
+
+    static void prepare_shared_state(const fef::IQueryEnvironment& env,
+                                     fef::IObjectStore& store,
+                                     uint32_t field_id,
+                                     const vespalib::string& feature_name);
+
+    static void prepare_shared_state(const fef::IQueryEnvironment& env,
+                                     fef::IObjectStore& store,
+                                     const vespalib::string& label,
+                                     const vespalib::string& feature_name);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/features/distancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.cpp
@@ -7,6 +7,7 @@
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchlib/common/geo_location_spec.h>
 #include <vespa/searchlib/fef/matchdata.h>
+#include <vespa/searchlib/tensor/distance_calculator.h>
 #include <vespa/vespalib/geo/zcurve.h>
 #include <vespa/vespalib/util/issue.h>
 #include <vespa/vespalib/util/stash.h>
@@ -57,6 +58,10 @@ ConvertRawscoreToDistance::execute(uint32_t docId)
         const TermFieldMatchData *tfmd = _md->resolveTermField(elem.handle);
         if (tfmd->getDocId() == docId) {
             feature_t invdist = tfmd->getRawScore();
+            feature_t converted = (1.0 / invdist) - 1.0;
+            min_distance = std::min(min_distance, converted);
+        } else if (elem.calc) {
+            feature_t invdist = elem.calc->calc_raw_score(docId);
             feature_t converted = (1.0 / invdist) - 1.0;
             min_distance = std::min(min_distance, converted);
         }

--- a/searchlib/src/vespa/searchlib/features/distancefeature.cpp
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.cpp
@@ -37,13 +37,13 @@ public:
 };
 
 ConvertRawscoreToDistance::ConvertRawscoreToDistance(const fef::IQueryEnvironment &env, uint32_t fieldId)
-  : _bundle(env, fieldId),
+  : _bundle(env, fieldId, "distance"),
     _md(nullptr)
 {
 }
 
 ConvertRawscoreToDistance::ConvertRawscoreToDistance(const fef::IQueryEnvironment &env, const vespalib::string &label)
-  : _bundle(env, label),
+  : _bundle(env, label, "distance"),
     _md(nullptr)
 {
 }
@@ -231,6 +231,17 @@ DistanceBlueprint::setup(const IIndexEnvironment & env,
         LOG(error, "field '%s' must be an attribute for rank feature %s\n", arg.c_str(), getName().c_str());
     }
     return false;
+}
+
+void
+DistanceBlueprint::prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const
+{
+    if (_use_nns_tensor) {
+        DistanceCalculatorBundle::prepare_shared_state(env, store, _attr_id, "distance");
+    }
+    if (_use_item_label) {
+        DistanceCalculatorBundle::prepare_shared_state(env, store, _arg_string, "distance");
+    }
 }
 
 FeatureExecutor &

--- a/searchlib/src/vespa/searchlib/features/distancefeature.h
+++ b/searchlib/src/vespa/searchlib/features/distancefeature.h
@@ -63,6 +63,7 @@ public:
         return fef::ParameterDescriptions().desc().string().desc().string().string();
     }
     bool setup(const fef::IIndexEnvironment & env, const fef::ParameterList & params) override;
+    void prepareSharedState(const fef::IQueryEnvironment& env, fef::IObjectStore& store) const override;
     fef::FeatureExecutor &createExecutor(const fef::IQueryEnvironment &env, vespalib::Stash &stash) const override;
 };
 

--- a/searchlib/src/vespa/searchlib/fef/query_value.cpp
+++ b/searchlib/src/vespa/searchlib/fef/query_value.cpp
@@ -161,6 +161,8 @@ QueryValue::QueryValue(const vespalib::string& key, const vespalib::eval::ValueT
 {
 }
 
+QueryValue::~QueryValue() = default;
+
 QueryValue
 QueryValue::from_config(const vespalib::string& key, const IIndexEnvironment& env)
 {

--- a/searchlib/src/vespa/searchlib/fef/query_value.h
+++ b/searchlib/src/vespa/searchlib/fef/query_value.h
@@ -59,6 +59,7 @@ private:
 public:
     QueryValue();
     QueryValue(const vespalib::string& key, const vespalib::eval::ValueType& type);
+    ~QueryValue();
 
     /**
      * Create a QueryValue using properties from the given index environment to extract the value type.

--- a/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
+++ b/searchlib/src/vespa/searchlib/tensor/distance_calculator.h
@@ -42,6 +42,11 @@ public:
     const vespalib::eval::Value& query_tensor() const { return *_query_tensor; }
     const DistanceFunction& function() const { return *_dist_fun; }
 
+    double calc_raw_score(uint32_t docid) const {
+        double distance = _dist_fun->calc(_query_tensor_cells, _attr_tensor.extract_cells_ref(docid));
+        return _dist_fun->to_rawscore(distance);
+    }
+
     double calc_with_limit(uint32_t docid, double limit) const {
         return _dist_fun->calc_with_limit(_query_tensor_cells, _attr_tensor.extract_cells_ref(docid), limit);
     }


### PR DESCRIPTION
This is done in the distance and closeness rank features if the raw score was not calculated during matching.
This fixes https://github.com/vespa-engine/vespa/issues/22016.

@toregge please review
@jobergum FYI