### PR TITLE
Revert "Do not claim that you have asked nodes that were in a known failed st…"

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -168,6 +168,9 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
             } else {
                 query.trace(message, 2);
             }
+            int failed = alreadyFailedNodes.size();
+            askedNodes += failed;
+            answeredNodes += failed;
         }
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#23434
I suggest we revert this one until we know for sure what is the less erroneous solution.
#23439 probably removes a large source of these error conditions.
