### PR TITLE
Inject default threadpool to handlers 2 [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -36,7 +36,7 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
     protected boolean messageBusEnabled() { return false; }
 
     private void addLogHandler() {
-        Handler<?> logHandler = Handler.fromClassName(ContainerCluster.LOG_HANDLER_CLASS);
+        Handler logHandler = Handler.fromClassName(ContainerCluster.LOG_HANDLER_CLASS);
         logHandler.addServerBindings(SystemBindingPattern.fromHttpPath("/logs"));
         addComponent(logHandler);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -118,7 +118,7 @@ public class ClusterControllerContainer extends Container implements
                          ZOOKEEPER_SERVER_BUNDLE);
     }
 
-    private void addHandler(Handler<?> h, String path) {
+    private void addHandler(Handler h, String path) {
         h.addServerBindings(SystemBindingPattern.fromHttpPath(path));
         super.addHandler(h);
     }
@@ -138,7 +138,7 @@ public class ClusterControllerContainer extends Container implements
     }
 
     private void addHandler(String id, String className, String path, ComponentSpecification bundle) {
-        addHandler(new Handler<>(createComponentModel(id, className, bundle)), path);
+        addHandler(new Handler(createComponentModel(id, className, bundle)), path);
     }
 
     private ReindexingContext reindexingContext() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -119,12 +119,12 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
     }
 
     private void addHttpHandler(Class<? extends ThreadedHttpRequestHandler> clazz, String bindingPath) {
-        Handler<AbstractConfigProducer<?>> metricsHandler = createMetricsHandler(clazz, bindingPath);
+        Handler metricsHandler = createMetricsHandler(clazz, bindingPath);
         addComponent(metricsHandler);
     }
 
-    static Handler<AbstractConfigProducer<?>> createMetricsHandler(Class<? extends ThreadedHttpRequestHandler> clazz, String bindingPath) {
-        Handler<AbstractConfigProducer<?>> metricsHandler = new Handler<>(
+    static Handler createMetricsHandler(Class<? extends ThreadedHttpRequestHandler> clazz, String bindingPath) {
+        Handler metricsHandler = new Handler(
                 new ComponentModel(clazz.getName(), null, METRICS_PROXY_BUNDLE_NAME, null));
         metricsHandler.addServerBindings(
                 SystemBindingPattern.fromHttpPath(bindingPath),

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/UriBindingsValidator.java
@@ -24,7 +24,7 @@ class UriBindingsValidator extends Validator {
     @Override
     public void validate(VespaModel model, DeployState deployState) {
         for (ApplicationContainerCluster cluster : model.getContainerClusters().values()) {
-            for (Handler<?> handler : cluster.getHandlers()) {
+            for (Handler handler : cluster.getHandlers()) {
                 for (BindingPattern binding : handler.getServerBindings()) {
                     validateUserBinding(binding, model, deployState);
                 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
@@ -5,7 +5,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
-import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.UserBindingPattern;
 import org.w3c.dom.Element;
@@ -22,7 +21,7 @@ public class DomClientProviderBuilder extends DomHandlerBuilder {
 
     @Override
     protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element clientElement) {
-        Handler<? super Component<?, ?>> client = createHandler(clientElement);
+        Handler client = createHandler(clientElement);
 
         for (Element binding : XML.getChildren(clientElement, "binding"))
             client.addClientBindings(UserBindingPattern.fromPattern(XML.getValue(binding)));

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -9,15 +9,12 @@ import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.BindingPattern;
-import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.UserBindingPattern;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
 import org.w3c.dom.Element;
 
-import java.util.List;
 import java.util.Set;
-import java.util.logging.Level;
 
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_1;
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.METRICS_V2_HANDLER_BINDING_2;
@@ -29,7 +26,7 @@ import static java.util.logging.Level.INFO;
 /**
  * @author gjoranv
  */
-public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler<?>> {
+public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Handler> {
 
     private static final Set<BindingPattern> reservedBindings =
             Set.of(METRICS_V2_HANDLER_BINDING_1,
@@ -45,8 +42,8 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
     }
 
     @Override
-    protected Handler<?> doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element handlerElement) {
-        Handler<? super Component<?, ?>> handler = createHandler(handlerElement);
+    protected Handler doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element handlerElement) {
+        Handler handler = createHandler(handlerElement);
 
         for (Element binding : XML.getChildren(handlerElement, "binding"))
             addServerBinding(handler, UserBindingPattern.fromPattern(XML.getValue(binding)), deployState.getDeployLogger());
@@ -56,18 +53,18 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         return handler;
     }
 
-    Handler<? super Component<?, ?>> createHandler(Element handlerElement) {
+    Handler createHandler(Element handlerElement) {
         BundleInstantiationSpecification bundleSpec = BundleInstantiationSpecificationBuilder.build(handlerElement);
-        return new Handler<>(new ComponentModel(bundleSpec));
+        return new Handler(new ComponentModel(bundleSpec));
     }
 
-    private void addServerBinding(Handler<? super Component<?, ?>> handler, BindingPattern binding, DeployLogger log) {
+    private void addServerBinding(Handler handler, BindingPattern binding, DeployLogger log) {
         throwIfBindingIsReserved(binding, handler);
         handler.addServerBindings(binding);
         removeExistingServerBinding(binding, handler, log);
     }
 
-    private void throwIfBindingIsReserved(BindingPattern binding, Handler<?> newHandler) {
+    private void throwIfBindingIsReserved(BindingPattern binding, Handler newHandler) {
         for (var reserved : reservedBindings) {
             if (binding.hasSamePattern(reserved)) {
                 throw new IllegalArgumentException("Binding '" + binding.patternString() + "' is a reserved Vespa binding and " +
@@ -76,7 +73,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
         }
     }
 
-    private void removeExistingServerBinding(BindingPattern binding, Handler<?> newHandler, DeployLogger log) {
+    private void removeExistingServerBinding(BindingPattern binding, Handler newHandler, DeployLogger log) {
         for (var handler : cluster.getHandlers()) {
             for (BindingPattern serverBinding : handler.getServerBindings()) {
                 if (serverBinding.hasSamePattern(binding)) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -81,7 +81,7 @@ public class ContainerDocumentApi {
 
     private static Handler createHandler(String className, Threadpool executor) {
         return new Handler(new ComponentModel(className, null, "vespaclient-container-plugin"),
-                             executor);
+                           executor);
     }
 
     public static final class HandlerOptions {

--- a/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/clients/ContainerDocumentApi.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.clients;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.ContainerCluster;
@@ -60,11 +59,11 @@ public class ContainerDocumentApi {
 
     public boolean ignoreUndefinedFields() { return ignoreUndefinedFields; }
 
-    private static Handler<AbstractConfigProducer<?>> newVespaClientHandler(String componentId,
-                                                                            String bindingSuffix,
-                                                                            HandlerOptions handlerOptions,
-                                                                            Threadpool executor) {
-        Handler<AbstractConfigProducer<?>> handler = createHandler(componentId, executor);
+    private static Handler newVespaClientHandler(String componentId,
+                                                 String bindingSuffix,
+                                                 HandlerOptions handlerOptions,
+                                                 Threadpool executor) {
+        Handler handler = createHandler(componentId, executor);
         if (handlerOptions.bindings.isEmpty()) {
             handler.addServerBindings(
                     SystemBindingPattern.fromHttpPath(bindingSuffix),
@@ -80,8 +79,8 @@ public class ContainerDocumentApi {
         return handler;
     }
 
-    private static Handler<AbstractConfigProducer<?>> createHandler(String className, Threadpool executor) {
-        return new Handler<>(new ComponentModel(className, null, "vespaclient-container-plugin"),
+    private static Handler createHandler(String className, Threadpool executor) {
+        return new Handler(new ComponentModel(className, null, "vespaclient-container-plugin"),
                              executor);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -147,7 +147,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
    }
 
     private void addMetricsHandler(String handlerClass, BindingPattern rootBinding, BindingPattern innerBinding) {
-        Handler<AbstractConfigProducer<?>> handler = new Handler<>(
+        Handler handler = new Handler(
                 new ComponentModel(handlerClass, null, null, null));
         handler.addServerBindings(rootBinding, innerBinding);
         addComponent(handler);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -76,7 +76,7 @@ public abstract class Container extends AbstractService implements
     private final boolean dumpHeapOnShutdownTimeout;
     private final double shutdownTimeoutS;
 
-    private final ComponentGroup<Handler<?>> handlers = new ComponentGroup<>(this, "handler");
+    private final ComponentGroup<Handler> handlers = new ComponentGroup<>(this, "handler");
     private final ComponentGroup<Component<?, ?>> components = new ComponentGroup<>(this, "components");
 
     private final JettyHttpServer defaultHttpServer;
@@ -113,7 +113,7 @@ public abstract class Container extends AbstractService implements
     /** True if this container is retired (slated for removal) */
     public boolean isRetired() { return retired; }
 
-    public ComponentGroup<Handler<?>> getHandlers() {
+    public ComponentGroup<Handler> getHandlers() {
         return handlers;
     }
 
@@ -129,7 +129,7 @@ public abstract class Container extends AbstractService implements
         addComponent(new SimpleComponent(new ComponentModel(idSpec, classSpec, bundleSpec)));
     }
 
-    public final void addHandler(Handler<?> h) {
+    public final void addHandler(Handler h) {
         handlers.addComponent(h);
     }
     

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -131,7 +131,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     public static final BindingPattern VIP_HANDLER_BINDING = SystemBindingPattern.fromHttpPath("/status.html");
 
     public static final Set<Path> SEARCH_AND_DOCPROC_BUNDLES = Stream.of(
-                    PlatformBundles.searchAndDocprocBundle, "container-search-gui", "docprocs", "linguistics-components")
+                    PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE, "container-search-gui", "docprocs", "linguistics-components")
             .map(PlatformBundles::absoluteBundlePath).collect(Collectors.toSet());
 
     private final String name;
@@ -229,7 +229,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public void addDefaultRootHandler() {
         Handler handler = new Handler(
-                new ComponentModel(BundleInstantiationSpecification.getFromStrings(
+                new ComponentModel(BundleInstantiationSpecification.fromStrings(
                         BINDINGS_OVERVIEW_HANDLER_CLASS, null, null), null));  // null bundle, as the handler is in container-disc
         handler.addServerBindings(ROOT_HANDLER_BINDING);
         addComponent(handler);
@@ -237,7 +237,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
     public void addApplicationStatusHandler() {
         Handler statusHandler = new Handler(
-                new ComponentModel(BundleInstantiationSpecification.getFromStrings(
+                new ComponentModel(BundleInstantiationSpecification.fromStrings(
                         APPLICATION_STATUS_HANDLER_CLASS, null, null), null));  // null bundle, as the handler is in container-disc
         statusHandler.addServerBindings(SystemBindingPattern.fromHttpPath("/ApplicationStatus"));
         addComponent(statusHandler);
@@ -320,7 +320,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         ProcessingHandler<?> processingHandler = new ProcessingHandler<>(
                 processingChains,
-                BundleInstantiationSpecification.getFromStrings(PROCESSING_HANDLER_CLASS, null, null));
+                BundleInstantiationSpecification.fromStrings(PROCESSING_HANDLER_CLASS, null, null));
 
         for (BindingPattern binding: serverBindings)
             processingHandler.addServerBindings(binding);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -318,7 +318,6 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         this.processingChains = processingChains;
 
-        // Cannot use the class object for ProcessingHandler, because its superclass is not accessible
         ProcessingHandler<?> processingHandler = new ProcessingHandler<>(processingChains, PROCESSING_HANDLER_CLASS);
 
         for (BindingPattern binding: serverBindings)

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -73,6 +73,8 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.yahoo.vespa.model.container.component.chain.ProcessingHandler.PROCESSING_HANDLER_CLASS;
+
 /**
  * Parent class for all container cluster types.
  *
@@ -308,8 +310,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         // Cannot use the class object for ProcessingHandler, because its superclass is not accessible
         ProcessingHandler<?> processingHandler = new ProcessingHandler<>(
                 processingChains,
-                "com.yahoo.processing.handler.ProcessingHandler",
-                 null);
+                PROCESSING_HANDLER_CLASS,
+                null);
 
         for (BindingPattern binding: serverBindings)
             processingHandler.addServerBindings(binding);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -221,14 +221,14 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void addMetricStateHandler() {
-        Handler<AbstractConfigProducer<?>> stateHandler = new Handler<>(
+        Handler stateHandler = new Handler(
                 new ComponentModel(STATE_HANDLER_CLASS, null, null, null));
         stateHandler.addServerBindings(STATE_HANDLER_BINDING_1, STATE_HANDLER_BINDING_2);
         addComponent(stateHandler);
     }
 
     public void addDefaultRootHandler() {
-        Handler<AbstractConfigProducer<?>> handler = new Handler<>(
+        Handler handler = new Handler(
                 new ComponentModel(BundleInstantiationSpecification.getFromStrings(
                         BINDINGS_OVERVIEW_HANDLER_CLASS, null, null), null));  // null bundle, as the handler is in container-disc
         handler.addServerBindings(ROOT_HANDLER_BINDING);
@@ -236,7 +236,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void addApplicationStatusHandler() {
-        Handler<AbstractConfigProducer<?>> statusHandler = new Handler<>(
+        Handler statusHandler = new Handler(
                 new ComponentModel(BundleInstantiationSpecification.getFromStrings(
                         APPLICATION_STATUS_HANDLER_CLASS, null, null), null));  // null bundle, as the handler is in container-disc
         statusHandler.addServerBindings(SystemBindingPattern.fromHttpPath("/ApplicationStatus"));
@@ -244,19 +244,19 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     }
 
     public void addVipHandler() {
-        Handler<?> vipHandler = Handler.fromClassName(FileStatusHandlerComponent.CLASS);
+        Handler vipHandler = Handler.fromClassName(FileStatusHandlerComponent.CLASS);
         vipHandler.addServerBindings(VIP_HANDLER_BINDING);
         addComponent(vipHandler);
     }
 
     public final void addComponent(Component<?, ?> component) {
         componentGroup.addComponent(component);
-        if (component instanceof Handler<?> handler) {
+        if (component instanceof Handler handler) {
             ensureHandlerHasThreadpool(handler);
         }
     }
 
-    private void ensureHandlerHasThreadpool(Handler<?> handler) {
+    private void ensureHandlerHasThreadpool(Handler handler) {
         if (! handler.hasCustomThreadPool) {
             handler.inject(defaultHandlerThreadpool);
         }
@@ -378,9 +378,8 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         return containerDocproc.getChains();
     }
 
-    @SuppressWarnings("unchecked")
-    public Collection<Handler<?>> getHandlers() {
-        return (Collection<Handler<?>>)(Collection)componentGroup.getComponents(Handler.class);
+    public Collection<Handler> getHandlers() {
+        return componentGroup.getComponents(Handler.class);
     }
 
     public void setSecretStore(SecretStore secretStore) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -318,7 +318,9 @@ public abstract class ContainerCluster<CONTAINER extends Container>
 
         this.processingChains = processingChains;
 
-        ProcessingHandler<?> processingHandler = new ProcessingHandler<>(processingChains, PROCESSING_HANDLER_CLASS);
+        ProcessingHandler<?> processingHandler = new ProcessingHandler<>(
+                processingChains,
+                BundleInstantiationSpecification.getFromStrings(PROCESSING_HANDLER_CLASS, null, null));
 
         for (BindingPattern binding: serverBindings)
             processingHandler.addServerBindings(binding);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerModelEvaluation.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerModelEvaluation.java
@@ -63,8 +63,8 @@ public class ContainerModelEvaluation implements
         rankProfileList.getConfig(builder);
     }
 
-    public static Handler<?> getHandler() {
-        Handler<?> handler = new Handler<>(new ComponentModel(REST_HANDLER_NAME, null, EVALUATION_BUNDLE_NAME));
+    public static Handler getHandler() {
+        Handler handler = new Handler(new ComponentModel(REST_HANDLER_NAME, null, EVALUATION_BUNDLE_NAME));
         handler.addServerBindings(
                 SystemBindingPattern.fromHttpPath(REST_BINDING_PATH),
                 SystemBindingPattern.fromHttpPath(REST_BINDING_PATH + "/*"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
@@ -17,7 +17,7 @@ import java.util.Optional;
  *
  * @author bjorncs
  */
-public class ContainerThreadpool extends SimpleComponent implements ContainerThreadpoolConfig.Producer {
+public abstract class ContainerThreadpool extends SimpleComponent implements ContainerThreadpoolConfig.Producer {
 
     private final String name;
     private final UserOptions userOptions;
@@ -32,8 +32,13 @@ public class ContainerThreadpool extends SimpleComponent implements ContainerThr
         this.userOptions = userOptions;
     }
 
+    // Must be implemented by subclasses to set values that may be overridden by user options.
+    protected abstract void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder);
+
     @Override
     public void getConfig(ContainerThreadpoolConfig.Builder builder) {
+        setDefaultConfigValues(builder);
+
         builder.name(this.name);
         if (userOptions != null) {
             builder.maxThreads(userOptions.maxThreads);
@@ -41,9 +46,6 @@ public class ContainerThreadpool extends SimpleComponent implements ContainerThr
             builder.queueSize(userOptions.queueSize);
         }
     }
-
-    protected Optional<UserOptions> userOptions() { return Optional.ofNullable(userOptions); }
-    protected boolean hasUserOptions() { return userOptions().isPresent(); }
 
     public static class UserOptions {
         private final int maxThreads;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerThreadpool.java
@@ -24,7 +24,7 @@ public abstract class ContainerThreadpool extends SimpleComponent implements Con
 
     public ContainerThreadpool(String name, UserOptions userOptions) {
         super(new ComponentModel(
-                BundleInstantiationSpecification.getFromStrings(
+                BundleInstantiationSpecification.fromStrings(
                         "threadpool@" + name,
                         ContainerThreadpoolImpl.class.getName(),
                         null)));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
@@ -19,7 +19,7 @@ class DefaultThreadpoolProvider extends SimpleComponent implements ThreadpoolCon
 
     DefaultThreadpoolProvider(ContainerCluster<?> cluster, int defaultWorkerThreads) {
         super(new ComponentModel(
-                BundleInstantiationSpecification.getFromStrings(
+                BundleInstantiationSpecification.fromStrings(
                         "default-threadpool",
                         ThreadPoolProvider.class.getName(),
                         null)));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/IdentityProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/IdentityProvider.java
@@ -33,7 +33,7 @@ public class IdentityProvider extends SimpleComponent implements IdentityConfig.
                             URI ztsUrl,
                             String athenzDnsSuffix,
                             Zone zone) {
-        super(new ComponentModel(BundleInstantiationSpecification.getFromStrings(CLASS, CLASS, BUNDLE)));
+        super(new ComponentModel(BundleInstantiationSpecification.fromStrings(CLASS, CLASS, BUNDLE)));
         this.domain = domain;
         this.service = service;
         this.loadBalancerName = loadBalancerName;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container;
 
+import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.vespa.defaults.Defaults;
 
 import java.nio.file.Path;
@@ -28,7 +29,7 @@ public class PlatformBundles {
     }
 
     public static final Path LIBRARY_PATH = Paths.get(Defaults.getDefaults().underVespaHome("lib/jars"));
-    public static final String searchAndDocprocBundle = "container-search-and-docproc";
+    public static final String SEARCH_AND_DOCPROC_BUNDLE = BundleInstantiationSpecification.CONTAINER_SEARCH_AND_DOCPROC;
 
     public static Set<Path> commonVespaBundles() {
         var bundles = new LinkedHashSet<Path>();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/DiscBindingsConfigGenerator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/DiscBindingsConfigGenerator.java
@@ -14,16 +14,16 @@ import static java.util.stream.Collectors.toList;
  */
 public class DiscBindingsConfigGenerator {
 
-    public static Map<String, Handlers.Builder> generate(Collection<? extends Handler<?>> handlers) {
+    public static Map<String, Handlers.Builder> generate(Collection<? extends Handler> handlers) {
         Map<String, Handlers.Builder> handlerBuilders = new LinkedHashMap<>();
 
-        for (Handler<?> handler : handlers) {
+        for (Handler handler : handlers) {
             handlerBuilders.putAll(generate(handler));
         }
         return handlerBuilders;
     }
 
-    public static <T extends Handler<?>> Map<String, Handlers.Builder> generate(T handler) {
+    public static <T extends Handler> Map<String, Handlers.Builder> generate(T handler) {
         if (handler.getServerBindings().isEmpty() && handler.getClientBindings().isEmpty())
             return Collections.emptyMap();
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -17,8 +17,6 @@ import java.util.Set;
  * Models a jdisc RequestHandler (including ClientProvider).
  * RequestHandlers always have at least one server binding,
  * while ClientProviders have at least one client binding.
- * <p>
- * Note that this is also used to model vespa handlers (which do not have any bindings)
  *
  * @author gjoranv
  */

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -2,7 +2,9 @@
 package com.yahoo.vespa.model.container.component;
 
 import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,8 +27,24 @@ public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<
     private final Set<BindingPattern> serverBindings = new LinkedHashSet<>();
     private final List<BindingPattern> clientBindings = new ArrayList<>();
 
+    public final boolean hasCustomThreadPool;
+
     public Handler(ComponentModel model) {
+        this(model, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    public Handler(ComponentModel model, ContainerThreadpool threadpool) {
         super(model);
+
+        // The default threadpool is always added to the cluster, so cannot be added here.
+        if (threadpool != null) {
+            hasCustomThreadPool = true;
+            addComponent((CHILD) threadpool);
+            inject(threadpool);
+        } else {
+            hasCustomThreadPool = false;
+        }
     }
 
     public static Handler<AbstractConfigProducer<?>> fromClassName(String className) {
@@ -51,6 +69,26 @@ public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<
 
     public final List<BindingPattern> getClientBindings() {
         return Collections.unmodifiableList(clientBindings);
+    }
+
+
+    /**
+     * The default threadpool for all handlers, except those that declare their own, e.g. SearchHandler.
+     */
+    public static class DefaultHandlerThreadpool extends ContainerThreadpool {
+
+        public DefaultHandlerThreadpool() {
+            super("default-handler-common", null);
+        }
+
+        @Override
+        public void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
+            builder.maxThreadExecutionTimeSeconds(190)
+                    .keepAliveTime(5.0)
+                    .maxThreads(-2)
+                    .minThreads(-2)
+                    .queueSize(-40);
+        }
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Handler.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.component;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.ContainerThreadpool;
@@ -20,7 +19,7 @@ import java.util.Set;
  *
  * @author gjoranv
  */
-public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<CHILD, ComponentModel> {
+public class Handler extends Component<Component<?, ?>, ComponentModel> {
 
     private final Set<BindingPattern> serverBindings = new LinkedHashSet<>();
     private final List<BindingPattern> clientBindings = new ArrayList<>();
@@ -31,22 +30,21 @@ public class Handler<CHILD extends AbstractConfigProducer<?>> extends Component<
         this(model, null);
     }
 
-    @SuppressWarnings("unchecked")
     public Handler(ComponentModel model, ContainerThreadpool threadpool) {
         super(model);
 
         // The default threadpool is always added to the cluster, so cannot be added here.
         if (threadpool != null) {
             hasCustomThreadPool = true;
-            addComponent((CHILD) threadpool);
+            addComponent(threadpool);
             inject(threadpool);
         } else {
             hasCustomThreadPool = false;
         }
     }
 
-    public static Handler<AbstractConfigProducer<?>> fromClassName(String className) {
-        return new Handler<>(new ComponentModel(className, null, null, null));
+    public static Handler fromClassName(String className) {
+        return new Handler(new ComponentModel(className, null, null, null));
     }
 
     public void addServerBindings(BindingPattern... bindings) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
@@ -17,7 +17,7 @@ public class SimpleComponent extends Component<AbstractConfigProducer<?>, Compon
     }
 
     public SimpleComponent(String className) {
-        this(new ComponentModel(BundleInstantiationSpecification.getFromStrings(className, null, null)));
+        this(new ComponentModel(BundleInstantiationSpecification.fromStrings(className, null, null)));
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
@@ -4,8 +4,6 @@ package com.yahoo.vespa.model.container.component.chain;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
-import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.component.Handler;
 
@@ -16,7 +14,7 @@ import com.yahoo.vespa.model.container.component.Handler;
  * @author gjoranv
  */
 public class ProcessingHandler<CHAINS extends Chains<?>>
-        extends Handler<AbstractConfigProducer<?>>
+        extends Handler
         implements ChainsConfig.Producer {
 
     public static final String PROCESSING_HANDLER_CLASS = "com.yahoo.processing.handler.ProcessingHandler";

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
@@ -17,6 +17,7 @@ public class ProcessingHandler<CHAINS extends Chains<?>>
         extends Handler
         implements ChainsConfig.Producer {
 
+    // Cannot use the class object for ProcessingHandler, because its superclass is not accessible
     public static final String PROCESSING_HANDLER_CLASS = "com.yahoo.processing.handler.ProcessingHandler";
 
     protected final CHAINS chains;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
@@ -17,6 +17,8 @@ public class ProcessingHandler<CHAINS extends Chains<?>>
         extends Handler<AbstractConfigProducer<?>>
         implements ChainsConfig.Producer {
 
+    public static final String PROCESSING_HANDLER_CLASS = "com.yahoo.processing.handler.ProcessingHandler";
+
     protected final CHAINS chains;
 
     public ProcessingHandler(CHAINS chains, String handlerClass) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
@@ -22,12 +22,13 @@ public class ProcessingHandler<CHAINS extends Chains<?>>
 
     protected final CHAINS chains;
 
-    public ProcessingHandler(CHAINS chains, String handlerClass) {
-        this(chains, BundleInstantiationSpecification.getInternalProcessingSpecificationFromStrings(handlerClass, null), null);
+    // Create a handler that uses the default threadpool for handlers
+    public ProcessingHandler(CHAINS chains, BundleInstantiationSpecification spec) {
+        this(chains, spec, null);
     }
 
     public ProcessingHandler(CHAINS chains, BundleInstantiationSpecification spec, ContainerThreadpool threadpool) {
-        super(new ComponentModel(spec, null), threadpool);
+        super(new ComponentModel(spec), threadpool);
         this.chains = chains;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ProcessingHandler.java
@@ -5,6 +5,8 @@ import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.vespa.model.container.Container;
+import com.yahoo.vespa.model.container.ContainerThreadpool;
 import com.yahoo.vespa.model.container.component.Handler;
 
 
@@ -22,15 +24,11 @@ public class ProcessingHandler<CHAINS extends Chains<?>>
     protected final CHAINS chains;
 
     public ProcessingHandler(CHAINS chains, String handlerClass) {
-        this(chains, BundleInstantiationSpecification.getInternalProcessingSpecificationFromStrings(handlerClass, null));
+        this(chains, BundleInstantiationSpecification.getInternalProcessingSpecificationFromStrings(handlerClass, null), null);
     }
 
-    public ProcessingHandler(CHAINS chains, String handlerClass, String bundle) {
-        this(chains, BundleInstantiationSpecification.getFromStrings(handlerClass, null, bundle));
-    }
-
-    private ProcessingHandler(CHAINS chains, BundleInstantiationSpecification spec) {
-        super(new ComponentModel(spec, null));
+    public ProcessingHandler(CHAINS chains, BundleInstantiationSpecification spec, ContainerThreadpool threadpool) {
+        super(new ComponentModel(spec, null), threadpool);
         this.chains = chains;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -26,7 +26,9 @@ public class DocprocChains extends Chains<DocprocChain> {
 
     public DocprocChains(AbstractConfigProducer<?> parent, String subId) {
         super(parent, subId);
-        docprocHandler = new ProcessingHandler<>(this, "com.yahoo.docproc.jdisc.DocumentProcessingHandler");
+        docprocHandler = new ProcessingHandler<>(
+                this,
+                BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings("com.yahoo.docproc.jdisc.DocumentProcessingHandler", null));
         addComponent(docprocHandler);
         addComponent(
                 new SimpleComponent(

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -9,6 +9,7 @@ import com.yahoo.docproc.jdisc.observability.DocprocsStatusExtension;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
@@ -28,13 +29,10 @@ public class DocprocChains extends Chains<DocprocChain> {
         super(parent, subId);
         docprocHandler = new ProcessingHandler<>(
                 this,
-                BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings("com.yahoo.docproc.jdisc.DocumentProcessingHandler", null));
+                BundleInstantiationSpecification.fromSearchAndDocproc("com.yahoo.docproc.jdisc.DocumentProcessingHandler"));
         addComponent(docprocHandler);
-        addComponent(
-                new SimpleComponent(
-                        new ComponentModel(
-                                BundleInstantiationSpecification.getInternalProcessingSpecificationFromStrings(
-                                        DocprocsStatusExtension.class.getName(), null), null)));
+        addComponent(new SimpleComponent(
+                new ComponentModel(DocprocsStatusExtension.class.getName(), null, PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE)));
 
         if (! (getParent() instanceof ApplicationContainerCluster)) {
             // All application containers already have a DocumentTypeManager,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/MbusClient.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/MbusClient.java
@@ -6,13 +6,12 @@ import com.yahoo.component.ComponentSpecification;
 import com.yahoo.container.jdisc.config.SessionConfig;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.vespa.model.container.component.Handler;
 
 /**
  * @author Einar M R Rosenvinge
  */
-public class MbusClient extends Handler<AbstractConfigProducer<?>> implements SessionConfig.Producer {
+public class MbusClient extends Handler implements SessionConfig.Producer {
     private static final ComponentSpecification CLASSNAME =
             ComponentSpecification.fromString("com.yahoo.container.jdisc.messagebus.MbusClientProvider");
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/AccessControl.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/AccessControl.java
@@ -51,7 +51,7 @@ public class AccessControl {
         private final String domain;
         private ClientAuthentication clientAuthentication = ClientAuthentication.need;
         private final Set<BindingPattern> excludeBindings = new LinkedHashSet<>();
-        private Collection<Handler<?>> handlers = Collections.emptyList();
+        private Collection<Handler> handlers = Collections.emptyList();
         public Builder(String domain) {
             this.domain = domain;
         }
@@ -79,12 +79,12 @@ public class AccessControl {
     public final String domain;
     public final ClientAuthentication clientAuthentication;
     private final Set<BindingPattern> excludedBindings;
-    private final Collection<Handler<?>> handlers;
+    private final Collection<Handler> handlers;
 
     private AccessControl(String domain,
                           ClientAuthentication clientAuthentication,
                           Set<BindingPattern> excludedBindings,
-                          Collection<Handler<?>> handlers) {
+                          Collection<Handler> handlers) {
         this.domain = domain;
         this.clientAuthentication = clientAuthentication;
         this.excludedBindings = Collections.unmodifiableSet(excludedBindings);
@@ -119,7 +119,7 @@ public class AccessControl {
     public Set<BindingPattern> excludedBindings() { return excludedBindings; }
 
     /** all handlers (that are known by the access control components) **/
-    public Collection<Handler<?>> handlers() { return handlers; }
+    public Collection<Handler> handlers() { return handlers; }
 
     public static boolean hasHandlerThatNeedsProtection(ApplicationContainerCluster cluster) {
         return cluster.getHandlers().stream()
@@ -135,7 +135,7 @@ public class AccessControl {
         for (BindingPattern excludedBinding : excludedBindings) {
             http.getBindings().add(createAccessControlExcludedBinding(excludedBinding));
         }
-        for (Handler<?> handler : handlers) {
+        for (Handler handler : handlers) {
             if (isExcludedHandler(handler)) {
                 for (BindingPattern binding : handler.getServerBindings()) {
                     http.getBindings().add(createAccessControlExcludedBinding(binding));
@@ -188,9 +188,9 @@ public class AccessControl {
 
     private static Chain<Filter> createChain(ComponentId id) { return new Chain<>(FilterChains.emptyChainSpec(id)); }
 
-    private static boolean isExcludedHandler(Handler<?> handler) { return EXCLUDED_HANDLERS.contains(handler.getClassId().getName()); }
+    private static boolean isExcludedHandler(Handler handler) { return EXCLUDED_HANDLERS.contains(handler.getClassId().getName()); }
 
-    private static boolean hasNonMbusBinding(Handler<?> handler) {
+    private static boolean hasNonMbusBinding(Handler handler) {
         return handler.getServerBindings().stream().anyMatch(binding -> ! binding.scheme().equals("mbus"));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
@@ -25,7 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.yahoo.vespa.model.container.PlatformBundles.searchAndDocprocBundle;
+import static com.yahoo.vespa.model.container.PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE;
 
 /**
  * @author gjoranv
@@ -56,9 +56,9 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
         this.owningCluster = cluster;
         this.options = options;
 
-        owningCluster.addComponent(Component.fromClassAndBundle(QUERY_PROFILE_REGISTRY_CLASS, searchAndDocprocBundle));
-        owningCluster.addComponent(Component.fromClassAndBundle(com.yahoo.search.schema.SchemaInfo.class.getName(), searchAndDocprocBundle));
-        owningCluster.addComponent(Component.fromClassAndBundle(SearchStatusExtension.class.getName(), searchAndDocprocBundle));
+        owningCluster.addComponent(Component.fromClassAndBundle(QUERY_PROFILE_REGISTRY_CLASS, SEARCH_AND_DOCPROC_BUNDLE));
+        owningCluster.addComponent(Component.fromClassAndBundle(com.yahoo.search.schema.SchemaInfo.class.getName(), SEARCH_AND_DOCPROC_BUNDLE));
+        owningCluster.addComponent(Component.fromClassAndBundle(SearchStatusExtension.class.getName(), SEARCH_AND_DOCPROC_BUNDLE));
         cluster.addSearchAndDocprocBundles();
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
@@ -32,7 +32,7 @@ public class DispatcherComponent extends Component<AbstractConfigProducer<?>, Co
         String dispatcherComponentId = "dispatcher." + indexedSearchCluster.getClusterName(); // used by ClusterSearcher
         return new ComponentModel(dispatcherComponentId,
                                   com.yahoo.search.dispatch.Dispatcher.class.getName(),
-                                  PlatformBundles.searchAndDocprocBundle);
+                                  PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/GUIHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/GUIHandler.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.model.container.component.Handler;
@@ -10,7 +9,7 @@ import com.yahoo.vespa.model.container.component.Handler;
 /**
  * @author  Henrik Høiness
  */
-public class GUIHandler extends Handler<AbstractConfigProducer<?>> {
+public class GUIHandler extends Handler {
 
     public static final String BUNDLE = "container-search-gui";
     public static final String CLASS = "com.yahoo.search.query.gui.GUIHandler";

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/GUIHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/GUIHandler.java
@@ -20,7 +20,7 @@ public class GUIHandler extends Handler {
     }
 
     public static BundleInstantiationSpecification bundleSpec(String className, String bundle) {
-        return BundleInstantiationSpecification.getFromStrings(className, className, bundle);
+        return BundleInstantiationSpecification.fromStrings(className, className, bundle);
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/RpcResourcePoolComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/RpcResourcePoolComponent.java
@@ -13,6 +13,6 @@ public class RpcResourcePoolComponent extends Component<RpcResourcePoolComponent
 
     private static ComponentModel toComponentModel(String clusterName) {
         String componentId = "rpcresourcepool." + clusterName;
-        return new ComponentModel(componentId, com.yahoo.search.dispatch.rpc.RpcResourcePool.class.getName(), PlatformBundles.searchAndDocprocBundle);
+        return new ComponentModel(componentId, com.yahoo.search.dispatch.rpc.RpcResourcePool.class.getName(), PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
@@ -5,10 +5,13 @@ import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.chain.ProcessingHandler;
 import org.w3c.dom.Element;
 
 import java.util.Arrays;
 import java.util.List;
+
+import static com.yahoo.vespa.model.container.component.chain.ProcessingHandler.PROCESSING_HANDLER_CLASS;
 
 /**
  * This object builds a bundle instantiation spec from an XML element.
@@ -39,7 +42,7 @@ public class BundleInstantiationSpecificationBuilder {
     private static void validate(BundleInstantiationSpecification instSpec) {
         List<String> forbiddenClasses = Arrays.asList(
                 SearchHandler.HANDLER_CLASS,
-                "com.yahoo.processing.handler.ProcessingHandler");
+                PROCESSING_HANDLER_CLASS);
 
         for (String forbiddenClass: forbiddenClasses) {
             if (forbiddenClass.equals(instSpec.getClassName())) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilder.java
@@ -5,7 +5,6 @@ import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.vespa.model.container.PlatformBundles;
-import com.yahoo.vespa.model.container.component.chain.ProcessingHandler;
 import org.w3c.dom.Element;
 
 import java.util.Arrays;
@@ -33,7 +32,7 @@ public class BundleInstantiationSpecificationBuilder {
 
     private static BundleInstantiationSpecification setBundleForSearchAndDocprocComponents(BundleInstantiationSpecification spec) {
         if (PlatformBundles.isSearchAndDocprocClass(spec.getClassName()))
-            return spec.inBundle(PlatformBundles.searchAndDocprocBundle);
+            return spec.inBundle(PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
         else
             return spec;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/CloudSecretStore.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/CloudSecretStore.java
@@ -21,7 +21,7 @@ public class CloudSecretStore extends SimpleComponent implements SecretStoreConf
     private final List<StoreConfig> configList;
 
     public CloudSecretStore() {
-        super(new ComponentModel(BundleInstantiationSpecification.getFromStrings(CLASS, CLASS, BUNDLE)));
+        super(new ComponentModel(BundleInstantiationSpecification.fromStrings(CLASS, CLASS, BUNDLE)));
         configList = new ArrayList<>();
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -222,7 +222,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
         if (deployState.zone().system().isPublic()) {
             BindingPattern bindingPattern = SystemBindingPattern.fromHttpPath("/validate-secret-store");
-            Handler<AbstractConfigProducer<?>> handler = new Handler<>(
+            Handler handler = new Handler(
                     new ComponentModel("com.yahoo.jdisc.cloud.aws.AwsParameterStoreValidationHandler", null, "jdisc-cloud-aws", null));
             handler.addServerBindings(bindingPattern);
             cluster.addComponent(handler);
@@ -897,7 +897,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     }
 
     private void addGUIHandler(ApplicationContainerCluster cluster) {
-        Handler<?> guiHandler = new GUIHandler();
+        Handler guiHandler = new GUIHandler();
         guiHandler.addServerBindings(SystemBindingPattern.fromHttpPath(GUIHandler.BINDING_PATH));
         cluster.addComponent(guiHandler);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -30,6 +30,7 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
+import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.logging.FileConnectionLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.schema.OnnxModel;
@@ -886,8 +887,9 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
     private void addSearchHandler(ApplicationContainerCluster cluster, Element searchElement) {
         // Magic spell is needed to receive the chains config :-|
-        cluster.addComponent(new ProcessingHandler<>(cluster.getSearch().getChains(),
-                                                     "com.yahoo.search.searchchain.ExecutionFactory"));
+        cluster.addComponent(new ProcessingHandler<>(
+                cluster.getSearch().getChains(),
+                BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings("com.yahoo.search.searchchain.ExecutionFactory", null)));
 
         cluster.addComponent(
                 new SearchHandler(

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -889,7 +889,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         // Magic spell is needed to receive the chains config :-|
         cluster.addComponent(new ProcessingHandler<>(
                 cluster.getSearch().getChains(),
-                BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings("com.yahoo.search.searchchain.ExecutionFactory", null)));
+                BundleInstantiationSpecification.fromSearchAndDocproc("com.yahoo.search.searchchain.ExecutionFactory")));
 
         cluster.addComponent(
                 new SearchHandler(

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml;
 
+import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerThreadpool;
@@ -11,6 +12,8 @@ import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
 
 import java.util.List;
 
+import static com.yahoo.container.bundle.BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings;
+
 /**
  * Component definition for {@link com.yahoo.search.handler.SearchHandler}
  *
@@ -19,38 +22,32 @@ import java.util.List;
 class SearchHandler extends ProcessingHandler<SearchChains> {
 
     static final String HANDLER_CLASS = com.yahoo.search.handler.SearchHandler.class.getName();
+    static final BundleInstantiationSpecification HANDLER_SPEC = getInternalHandlerSpecificationFromStrings(HANDLER_CLASS, null);
     static final BindingPattern DEFAULT_BINDING = SystemBindingPattern.fromHttpPath("/search/*");
 
     SearchHandler(ApplicationContainerCluster cluster,
                   List<BindingPattern> bindings,
                   ContainerThreadpool.UserOptions threadpoolOptions) {
-        super(cluster.getSearchChains(), HANDLER_CLASS);
+        super(cluster.getSearchChains(), HANDLER_SPEC, new Threadpool(threadpoolOptions));
         bindings.forEach(this::addServerBindings);
-        Threadpool threadpool = new Threadpool(cluster, threadpoolOptions);
-        inject(threadpool);
-        addComponent(threadpool);
     }
 
-    private static class Threadpool extends ContainerThreadpool {
-        private final ApplicationContainerCluster cluster;
 
-        Threadpool(ApplicationContainerCluster cluster, UserOptions options) {
+    private static class Threadpool extends ContainerThreadpool {
+
+        Threadpool(UserOptions options) {
             super("search-handler", options);
-            this.cluster = cluster;
         }
 
         @Override
-        public void getConfig(ContainerThreadpoolConfig.Builder builder) {
-            super.getConfig(builder);
-
-            builder.maxThreadExecutionTimeSeconds(190);
-            builder.keepAliveTime(5.0);
-
-            // User options overrides below configuration
-            if (hasUserOptions()) return;
-            builder.maxThreads(-2).minThreads(-2).queueSize(-40);
+        public void setDefaultConfigValues(ContainerThreadpoolConfig.Builder builder) {
+            builder.maxThreadExecutionTimeSeconds(190)
+                    .keepAliveTime(5.0)
+                    .maxThreads(-2)
+                    .minThreads(-2)
+                    .queueSize(-40);
         }
 
-
     }
+
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/SearchHandler.java
@@ -5,6 +5,7 @@ import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.handler.threadpool.ContainerThreadpoolConfig;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerThreadpool;
+import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.BindingPattern;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.component.chain.ProcessingHandler;
@@ -12,7 +13,7 @@ import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
 
 import java.util.List;
 
-import static com.yahoo.container.bundle.BundleInstantiationSpecification.getInternalHandlerSpecificationFromStrings;
+import static com.yahoo.container.bundle.BundleInstantiationSpecification.fromSearchAndDocproc;
 
 /**
  * Component definition for {@link com.yahoo.search.handler.SearchHandler}
@@ -22,7 +23,7 @@ import static com.yahoo.container.bundle.BundleInstantiationSpecification.getInt
 class SearchHandler extends ProcessingHandler<SearchChains> {
 
     static final String HANDLER_CLASS = com.yahoo.search.handler.SearchHandler.class.getName();
-    static final BundleInstantiationSpecification HANDLER_SPEC = getInternalHandlerSpecificationFromStrings(HANDLER_CLASS, null);
+    static final BundleInstantiationSpecification HANDLER_SPEC = fromSearchAndDocproc(HANDLER_CLASS);
     static final BindingPattern DEFAULT_BINDING = SystemBindingPattern.fromHttpPath("/search/*");
 
     SearchHandler(ApplicationContainerCluster cluster,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/document/DocumentFactoryBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/document/DocumentFactoryBuilder.java
@@ -31,7 +31,7 @@ public class DocumentFactoryBuilder {
             String concDocFactory=pkg+"."+CONCRETE_DOC_FACTORY_CLASS;
             String bundle = e.getAttribute("bundle");
             Component<AbstractConfigProducer<?>, ComponentModel> component = new Component<>(
-                    new ComponentModel(BundleInstantiationSpecification.getFromStrings(concDocFactory, concDocFactory, bundle)));
+                    new ComponentModel(BundleInstantiationSpecification.fromStrings(concDocFactory, concDocFactory, bundle)));
             if (!cluster.getComponentsMap().containsKey(component.getComponentId())) cluster.addComponent(component);
             types.put(type, concDocFactory);
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -70,7 +70,7 @@ public class MetricsProxyContainerClusterTest {
     @Test
     public void http_handlers_are_set_up() {
         VespaModel model = getModel(servicesWithAdminOnly(), self_hosted);
-        Collection<Handler<?>> handlers = model.getAdmin().getMetricsProxyCluster().getHandlers();
+        Collection<Handler> handlers = model.getAdmin().getMetricsProxyCluster().getHandlers();
         Collection<ComponentSpecification> handlerClasses = handlers.stream().map(Component::getClassId).collect(toList());
 
         assertTrue(handlerClasses.contains(ComponentSpecification.fromString(MetricsV1Handler.class.getName())));

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
@@ -89,7 +89,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
         assertNotNull(getVespaAccessLog("default"));
 
         { // vespa
-            Component<?, ?> accessLogComponent = getContainerComponent("default", VespaAccessLog.class.getName());
+            Component<?, ?> accessLogComponent = getComponent("default", VespaAccessLog.class.getName());
             assertNotNull(accessLogComponent);
             assertEquals(VespaAccessLog.class.getName(), accessLogComponent.getClassId().getName(), VespaAccessLog.class.getName());
             AccessLogConfig config = root.getConfig(AccessLogConfig.class, "default/component/com.yahoo.container.logging.VespaAccessLog");
@@ -101,7 +101,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
         }
 
         { // json
-            Component<?, ?> accessLogComponent = getContainerComponent("default", JSONAccessLog.class.getName());
+            Component<?, ?> accessLogComponent = getComponent("default", JSONAccessLog.class.getName());
             assertNotNull(accessLogComponent);
             assertEquals(JSONAccessLog.class.getName(), accessLogComponent.getClassId().getName(), JSONAccessLog.class.getName());
             AccessLogConfig config = root.getConfig(AccessLogConfig.class, "default/component/com.yahoo.container.logging.JSONAccessLog");
@@ -124,7 +124,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
                 nodesXml,
                 "</container>" );
         createModel(root, clusterElem);
-        Component<?, ?> connectionLogComponent = getContainerComponent("default", FileConnectionLog.class.getName());
+        Component<?, ?> connectionLogComponent = getComponent("default", FileConnectionLog.class.getName());
         assertNotNull(connectionLogComponent);
         ConnectionLogConfig config = root.getConfig(ConnectionLogConfig.class, "default/component/com.yahoo.container.logging.FileConnectionLog");
         assertEquals("default", config.cluster());
@@ -140,7 +140,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
                 nodesXml,
                 "</container>" );
         createModel(root, clusterElem);
-        Component<?, ?> fileConnectionLogComponent = getContainerComponent("default", FileConnectionLog.class.getName());
+        Component<?, ?> fileConnectionLogComponent = getComponent("default", FileConnectionLog.class.getName());
         assertNull(fileConnectionLogComponent);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/BundleInstantiationSpecificationBuilderTest.java
@@ -29,7 +29,7 @@ public class BundleInstantiationSpecificationBuilderTest {
     @Test
     public void bundle_is_replaced_for_internal_class() {
         String internalClass = GroupingValidator.class.getName();
-        verifyExpectedBundle(internalClass, null, PlatformBundles.searchAndDocprocBundle);
+        verifyExpectedBundle(internalClass, null, PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerDocumentApiBuilderTest.java
@@ -30,11 +30,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBase {
 
-    private Map<String, Handler<?>> getHandlers(String clusterName) {
+    private Map<String, Handler> getHandlers(String clusterName) {
         ContainerCluster<?> cluster = (ContainerCluster<?>) root.getChildren().get(clusterName);
-        Map<String, Handler<?>> handlerMap = new HashMap<>();
-        Collection<Handler<?>> handlers = cluster.getHandlers();
-        for (Handler<?> handler : handlers) {
+        Map<String, Handler> handlerMap = new HashMap<>();
+        Collection<Handler> handlers = cluster.getHandlers();
+        for (Handler handler : handlers) {
             assertFalse(handlerMap.containsKey(handler.getComponentId().toString()));  //die on overwrites
             handlerMap.put(handler.getComponentId().toString(), handler);
         }
@@ -56,7 +56,7 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
     }
 
     private void verifyCustomBindings(String id) {
-        Handler<?> handler = getHandlers("cluster1").get(id);
+        Handler handler = getHandlers("cluster1").get(id);
 
         assertTrue(handler.getServerBindings().contains(UserBindingPattern.fromHttpPath("/document-api/reserved-for-internal-use/feedapi")));
         assertTrue(handler.getServerBindings().contains(UserBindingPattern.fromHttpPath("/document-api/reserved-for-internal-use/feedapi/")));
@@ -73,7 +73,7 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
                 "</container>");
         createModel(root, elem);
 
-        Map<String, Handler<?>> handlerMap = getHandlers("cluster1");
+        Map<String, Handler> handlerMap = getHandlers("cluster1");
 
         assertNotNull(handlerMap.get("com.yahoo.container.handler.VipStatusHandler"));
         assertNotNull(handlerMap.get("com.yahoo.container.handler.observability.ApplicationStatusHandler"));
@@ -112,8 +112,8 @@ public class ContainerDocumentApiBuilderTest extends ContainerModelBuilderTestBa
                 "</container>");
         root = new MockRoot("root", new MockApplicationPackage.Builder().build());
         createModel(root, elem);
-        Map<String, Handler<?>> handlers = getHandlers("cluster1");
-        Handler<?> feedApiHandler = handlers.get("com.yahoo.vespa.http.server.FeedHandler");
+        Map<String, Handler> handlers = getHandlers("cluster1");
+        Handler feedApiHandler = handlers.get("com.yahoo.vespa.http.server.FeedHandler");
         Set<String> injectedComponentIds = feedApiHandler.getInjectedComponentIds();
         assertTrue(injectedComponentIds.contains("threadpool@feedapi-handler"));
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -198,10 +198,10 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     public void builtin_handlers_get_default_threadpool() {
         createBasicContainerModel();
 
-        Handler<?> h1 = getHandler("default", ApplicationStatusHandler.class.getName());
+        Handler h1 = getHandler("default", ApplicationStatusHandler.class.getName());
         assertTrue(h1.getInjectedComponentIds().contains("threadpool@default-handler-common"));
 
-        Handler<?> h2 = getHandler("default", BindingsOverviewHandler.class.getName());
+        Handler h2 = getHandler("default", BindingsOverviewHandler.class.getName());
         assertTrue(h2.getInjectedComponentIds().contains("threadpool@default-handler-common"));
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -42,6 +42,7 @@ import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
 import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.content.utils.ContentClusterUtils;
 import com.yahoo.vespa.model.test.VespaModelTester;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
@@ -191,6 +192,17 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         } catch (RuntimeException e) {
             assertThat(e.getMessage(), containsString("cannot reserve port"));
         }
+    }
+
+    @Test
+    public void builtin_handlers_get_default_threadpool() {
+        createBasicContainerModel();
+
+        Handler<?> h1 = getHandler("default", ApplicationStatusHandler.class.getName());
+        assertTrue(h1.getInjectedComponentIds().contains("threadpool@default-handler-common"));
+
+        Handler<?> h2 = getHandler("default", BindingsOverviewHandler.class.getName());
+        assertTrue(h2.getInjectedComponentIds().contains("threadpool@default-handler-common"));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -21,7 +21,6 @@ import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
-import com.yahoo.container.ComponentsConfig;
 import com.yahoo.container.QrConfig;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.core.VipStatusConfig;
@@ -41,7 +40,6 @@ import com.yahoo.vespa.model.container.ApplicationContainer;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
-import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.content.utils.ContentClusterUtils;
 import com.yahoo.vespa.model.test.VespaModelTester;
@@ -61,20 +59,15 @@ import java.util.stream.Collectors;
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static com.yahoo.test.LinePatternMatcher.containsLineWithPattern;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
-import static com.yahoo.vespa.model.container.ContainerCluster.ROOT_HANDLER_BINDING;
-import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
 import static com.yahoo.vespa.model.container.component.chain.ProcessingHandler.PROCESSING_HANDLER_CLASS;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -218,68 +211,6 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     }
 
     @Test
-    public void default_root_handler_binding_can_be_stolen_by_user_configured_handler() {
-        Element clusterElem = DomBuilderTest.parse(
-                "<container id='default' version='1.0'>" +
-                        "  <handler id='userRootHandler'>" +
-                        "    <binding>" + ROOT_HANDLER_BINDING.patternString() + "</binding>" +
-                        "  </handler>" +
-                        "</container>");
-        createModel(root, clusterElem);
-
-        // The handler is still set up.
-        ComponentsConfig.Components userRootHandler = getComponent(componentsConfig(), BindingsOverviewHandler.class.getName());
-        assertNotNull(userRootHandler);
-
-        // .. but it has no bindings
-        var discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default");
-        assertNull(discBindingsConfig.handlers(BindingsOverviewHandler.class.getName()));
-    }
-
-    @Test
-    public void reserved_binding_cannot_be_stolen_by_user_configured_handler() {
-        Element clusterElem = DomBuilderTest.parse(
-                "<container id='default' version='1.0'>" +
-                        "  <handler id='userHandler'>" +
-                        "    <binding>" + STATE_HANDLER_BINDING_1.patternString() + "</binding>" +
-                        "  </handler>" +
-                        "</container>");
-        try {
-            createModel(root, clusterElem);
-            fail("Expected exception when stealing a reserved binding.");
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage(), is("Binding 'http://*/state/v1' is a reserved Vespa binding " +
-                                                  "and cannot be used by handler: userHandler"));
-        }
-    }
-
-    @Test
-    public void handler_bindings_are_included_in_discBindings_config() {
-        createClusterWithJDiscHandler();
-        String discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default").toString();
-        assertThat(discBindingsConfig, containsString(".serverBindings[0] \"http://*/binding0\""));
-        assertThat(discBindingsConfig, containsString(".serverBindings[1] \"http://*/binding1\""));
-    }
-
-    @Test
-    public void handlers_are_included_in_components_config() {
-        createClusterWithJDiscHandler();
-        assertThat(componentsConfig().toString(), containsString(".id \"discHandler\""));
-    }
-
-    private void createClusterWithJDiscHandler() {
-        Element clusterElem = DomBuilderTest.parse(
-                "<container id='default' version='1.0'>",
-                "  <handler id='discHandler'>",
-                "    <binding>http://*/binding0</binding>",
-                "    <binding>http://*/binding1</binding>",
-                "  </handler>",
-                "</container>");
-
-        createModel(root, clusterElem);
-    }
-
-    @Test
     public void processing_handler_bindings_can_be_overridden() {
         Element clusterElem = DomBuilderTest.parse(
                 "<container id='default' version='1.0'>",
@@ -381,20 +312,6 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         assertEquals(2, cluster.getContainers().size());
         assertEquals(root.getConfig(QrMonitorConfig.class, "default/container.0").requesttimeout(), 111);
         assertEquals(root.getConfig(QrMonitorConfig.class, "default/container.1").requesttimeout(), 222);
-    }
-
-    @Test
-    public void nested_components_are_injected_to_handlers() {
-        Element clusterElem = DomBuilderTest.parse(
-                "<container id='default' version='1.0'>",
-                "  <handler id='myHandler'>",
-                "    <component id='injected' />",
-                "  </handler>",
-                "</container>");
-
-        createModel(root, clusterElem);
-        Component<?,?> handler = getContainerComponent("default", "myHandler");
-        assertThat(handler.getInjectedComponentIds(), hasItem("injected@myHandler"));
     }
 
     @Test

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -41,6 +41,7 @@ import com.yahoo.vespa.model.container.ApplicationContainer;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModelEvaluation;
+import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.content.utils.ContentClusterUtils;
 import com.yahoo.vespa.model.test.VespaModelTester;
@@ -62,6 +63,7 @@ import static com.yahoo.test.LinePatternMatcher.containsLineWithPattern;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
 import static com.yahoo.vespa.model.container.ContainerCluster.ROOT_HANDLER_BINDING;
 import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
+import static com.yahoo.vespa.model.container.component.chain.ProcessingHandler.PROCESSING_HANDLER_CLASS;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -324,10 +326,17 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     @Test
     public void processingHandler_gets_only_processing_chains_in_chains_config()  {
         createClusterWithProcessingAndSearchChains();
-        String processingHandlerConfigId = "default/component/com.yahoo.processing.handler.ProcessingHandler";
+        String processingHandlerConfigId = "default/component/" + PROCESSING_HANDLER_CLASS;
         String chainsConfig = getChainsConfig(processingHandlerConfigId);
         assertThat(chainsConfig, containsLineWithPattern(".*\\.id \"testProcessor@default\"$"));
         assertThat(chainsConfig, not(containsLineWithPattern(".*\\.id \"testSearcher@default\"$")));
+    }
+
+    @Test
+    public void processingHandler_is_instantiated_from_the_default_bundle() {
+        createClusterWithProcessingAndSearchChains();
+        ComponentsConfig.Components config = getComponent(componentsConfig(), PROCESSING_HANDLER_CLASS);
+        assertEquals(PROCESSING_HANDLER_CLASS, config.bundle());
     }
 
     private void createClusterWithProcessingAndSearchChains() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -21,6 +21,7 @@ import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provisioning.FlavorsConfig;
+import com.yahoo.container.ComponentsConfig;
 import com.yahoo.container.QrConfig;
 import com.yahoo.container.core.ChainsConfig;
 import com.yahoo.container.core.VipStatusConfig;
@@ -266,7 +267,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
     @Test
     public void processingHandler_is_instantiated_from_the_default_bundle() {
         createClusterWithProcessingAndSearchChains();
-        ComponentsConfig.Components config = getComponent(componentsConfig(), PROCESSING_HANDLER_CLASS);
+        ComponentsConfig.Components config = getComponentInConfig(componentsConfig(), PROCESSING_HANDLER_CLASS);
         assertEquals(PROCESSING_HANDLER_CLASS, config.bundle());
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTestBase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTestBase.java
@@ -13,6 +13,7 @@ import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.ContainerModel;
 import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.search.ContainerSearch;
 import org.junit.Before;
 import org.w3c.dom.Element;
@@ -94,7 +95,7 @@ public abstract class ContainerModelBuilderTestBase {
         return root.getConfig(ComponentsConfig.class, "default");
     }
 
-    protected ComponentsConfig.Components getComponent(ComponentsConfig componentsConfig, String id) {
+    protected ComponentsConfig.Components getComponentInConfig(ComponentsConfig componentsConfig, String id) {
         for (ComponentsConfig.Components component : componentsConfig.components()) {
             if (component.id().equals(id))
                 return component;
@@ -106,9 +107,16 @@ public abstract class ContainerModelBuilderTestBase {
         return (ApplicationContainerCluster) root.getChildren().get(clusterId);
     }
 
-    public Component<?, ?> getContainerComponent(String clusterId, String componentId) {
+    public Component<?, ?> getComponent(String clusterId, String componentId) {
         return getContainerCluster(clusterId).getComponentsMap().get(
                 ComponentId.fromString(componentId));
+    }
+
+    public Handler<?> getHandler(String clusterId, String componentId) {
+        Component<?,?> component = getComponent(clusterId, componentId);
+        if (! (component instanceof Handler<?>))
+            throw new RuntimeException("Component is not a handler: " + componentId);
+        return (Handler<?>) component;
     }
 
     void assertComponentConfigured(ApplicationContainerCluster cluster, String componentId) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTestBase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTestBase.java
@@ -112,11 +112,11 @@ public abstract class ContainerModelBuilderTestBase {
                 ComponentId.fromString(componentId));
     }
 
-    public Handler<?> getHandler(String clusterId, String componentId) {
+    public Handler getHandler(String clusterId, String componentId) {
         Component<?,?> component = getComponent(clusterId, componentId);
-        if (! (component instanceof Handler<?>))
+        if (! (component instanceof Handler))
             throw new RuntimeException("Component is not a handler: " + componentId);
-        return (Handler<?>) component;
+        return (Handler) component;
     }
 
     void assertComponentConfigured(ApplicationContainerCluster cluster, String componentId) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
@@ -1,0 +1,118 @@
+package com.yahoo.vespa.model.container.xml;
+
+import com.yahoo.config.model.builder.xml.test.DomBuilderTest;
+import com.yahoo.container.ComponentsConfig;
+import com.yahoo.container.jdisc.JdiscBindingsConfig;
+import com.yahoo.container.usability.BindingsOverviewHandler;
+import com.yahoo.vespa.model.container.ApplicationContainerCluster;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.container.component.Handler;
+import org.junit.Test;
+import org.w3c.dom.Element;
+
+import static com.yahoo.vespa.model.container.ContainerCluster.ROOT_HANDLER_BINDING;
+import static com.yahoo.vespa.model.container.ContainerCluster.STATE_HANDLER_BINDING_1;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for container model building with custom handlers.
+ *
+ * @author gjoranv
+ */
+public class HandlerBuilderTest extends ContainerModelBuilderTestBase {
+
+    @Test
+    public void handlers_are_included_in_components_config() {
+        createClusterWithJDiscHandler();
+        assertThat(componentsConfig().toString(), containsString(".id \"discHandler\""));
+    }
+
+    @Test
+    public void handler_bindings_are_included_in_discBindings_config() {
+        createClusterWithJDiscHandler();
+        String discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default").toString();
+        assertThat(discBindingsConfig, containsString(".serverBindings[0] \"http://*/binding0\""));
+        assertThat(discBindingsConfig, containsString(".serverBindings[1] \"http://*/binding1\""));
+    }
+
+    @Test
+    public void nested_components_are_injected_to_handlers() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container id='default' version='1.0'>",
+                "  <handler id='myHandler'>",
+                "    <component id='injected' />",
+                "  </handler>",
+                "</container>");
+
+        createModel(root, clusterElem);
+        Component<?,?> handler = getContainerComponent("default", "myHandler");
+        assertThat(handler.getInjectedComponentIds(), hasItem("injected@myHandler"));
+    }
+
+    @Test
+    public void default_root_handler_binding_can_be_stolen_by_user_configured_handler() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container id='default' version='1.0'>" +
+                        "  <handler id='userRootHandler'>" +
+                        "    <binding>" + ROOT_HANDLER_BINDING.patternString() + "</binding>" +
+                        "  </handler>" +
+                        "</container>");
+        createModel(root, clusterElem);
+
+        // The handler is still set up.
+        ComponentsConfig.Components userRootHandler = getComponent(componentsConfig(), BindingsOverviewHandler.class.getName());
+        assertNotNull(userRootHandler);
+
+        // .. but it has no bindings
+        var discBindingsConfig = root.getConfig(JdiscBindingsConfig.class, "default");
+        assertNull(discBindingsConfig.handlers(BindingsOverviewHandler.class.getName()));
+    }
+
+    @Test
+    public void reserved_binding_cannot_be_stolen_by_user_configured_handler() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container id='default' version='1.0'>" +
+                        "  <handler id='userHandler'>" +
+                        "    <binding>" + STATE_HANDLER_BINDING_1.patternString() + "</binding>" +
+                        "  </handler>" +
+                        "</container>");
+        try {
+            createModel(root, clusterElem);
+            fail("Expected exception when stealing a reserved binding.");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Binding 'http://*/state/v1' is a reserved Vespa binding " +
+                                                  "and cannot be used by handler: userHandler"));
+        }
+    }
+
+    @Test
+    public void custom_handler_gets_default_threadpool() {
+        createClusterWithJDiscHandler();
+        ApplicationContainerCluster cluster = (ApplicationContainerCluster)root.getChildren().get("default");
+        Handler<?> handler = cluster.getHandlers().stream()
+                .filter(h -> h.getComponentId().toString().equals("discHandler"))
+                .findAny().orElseThrow();
+
+        assertTrue(handler.getInjectedComponentIds().contains("threadpool@default-handler-common"));
+    }
+
+    private void createClusterWithJDiscHandler() {
+        Element clusterElem = DomBuilderTest.parse(
+                "<container id='default' version='1.0'>",
+                "  <handler id='discHandler'>",
+                "    <binding>http://*/binding0</binding>",
+                "    <binding>http://*/binding1</binding>",
+                "  </handler>",
+                "</container>");
+
+        createModel(root, clusterElem);
+    }
+
+}

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
@@ -96,7 +96,7 @@ public class HandlerBuilderTest extends ContainerModelBuilderTestBase {
     public void custom_handler_gets_default_threadpool() {
         createClusterWithJDiscHandler();
         ApplicationContainerCluster cluster = (ApplicationContainerCluster)root.getChildren().get("default");
-        Handler<?> handler = cluster.getHandlers().stream()
+        Handler handler = cluster.getHandlers().stream()
                 .filter(h -> h.getComponentId().toString().equals("discHandler"))
                 .findAny().orElseThrow();
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/HandlerBuilderTest.java
@@ -52,7 +52,7 @@ public class HandlerBuilderTest extends ContainerModelBuilderTestBase {
                 "</container>");
 
         createModel(root, clusterElem);
-        Component<?,?> handler = getContainerComponent("default", "myHandler");
+        Component<?,?> handler = getComponent("default", "myHandler");
         assertThat(handler.getInjectedComponentIds(), hasItem("injected@myHandler"));
     }
 
@@ -67,7 +67,7 @@ public class HandlerBuilderTest extends ContainerModelBuilderTestBase {
         createModel(root, clusterElem);
 
         // The handler is still set up.
-        ComponentsConfig.Components userRootHandler = getComponent(componentsConfig(), BindingsOverviewHandler.class.getName());
+        ComponentsConfig.Components userRootHandler = getComponentInConfig(componentsConfig(), BindingsOverviewHandler.class.getName());
         assertNotNull(userRootHandler);
 
         // .. but it has no bindings

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -53,7 +53,7 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
         ApplicationContainerCluster cluster = (ApplicationContainerCluster)root.getChildren().get("default");
 
         GUIHandler guiHandler = null;
-        for (Handler<?> handler : cluster.getHandlers()) {
+        for (Handler handler : cluster.getHandlers()) {
             if (handler instanceof GUIHandler) {
                 guiHandler = (GUIHandler) handler;
             }
@@ -230,7 +230,7 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
 
         createModel(root, clusterElem);
 
-        Handler<?> searchHandler = getHandler("default", SearchHandler.HANDLER_CLASS);
+        Handler searchHandler = getHandler("default", SearchHandler.HANDLER_CLASS);
         assertTrue(searchHandler.getInjectedComponentIds().contains("threadpool@search-handler"));
 
         ContainerThreadpoolConfig config = root.getConfig(

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.fail;
 /**
  * @author gjoranv
  */
-public class ApplicationBuilderTest extends ContainerModelBuilderTestBase {
+public class SearchBuilderTest extends ContainerModelBuilderTestBase {
 
     private ChainsConfig chainsConfig() {
         return root.getConfig(ChainsConfig.class, "default/component/com.yahoo.search.handler.SearchHandler");

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/SearchBuilderTest.java
@@ -230,12 +230,7 @@ public class SearchBuilderTest extends ContainerModelBuilderTestBase {
 
         createModel(root, clusterElem);
 
-        ApplicationContainerCluster cluster = (ApplicationContainerCluster)root.getChildren().get("default");
-        Handler<?> searchHandler = cluster.getHandlers().stream()
-                .filter(h -> h.getComponentId().toString().equals(SearchHandler.HANDLER_CLASS))
-                .findAny()
-                .get();
-
+        Handler<?> searchHandler = getHandler("default", SearchHandler.HANDLER_CLASS);
         assertTrue(searchHandler.getInjectedComponentIds().contains("threadpool@search-handler"));
 
         ContainerThreadpoolConfig config = root.getConfig(

--- a/config-model/src/test/schema-test-files/services.xml
+++ b/config-model/src/test/schema-test-files/services.xml
@@ -193,6 +193,9 @@
     <handler id="jdisc-handler">
       <binding>http://*:*/HelloWorld</binding>
       <binding>http://*:*/Status</binding>
+      <component id="injected-to-handler">
+        <config name="foo"/>
+      </component>
     </handler>
 
     <server id="server-provider">

--- a/container-core/src/main/java/com/yahoo/container/bundle/BundleInstantiationSpecification.java
+++ b/container-core/src/main/java/com/yahoo/container/bundle/BundleInstantiationSpecification.java
@@ -14,6 +14,8 @@ import com.yahoo.component.ComponentSpecification;
  */
 public final class BundleInstantiationSpecification {
 
+    public static final String CONTAINER_SEARCH_AND_DOCPROC = "container-search-and-docproc";
+
     public final ComponentId id;
     public final ComponentSpecification classId;
     public final ComponentSpecification bundle;
@@ -31,34 +33,21 @@ public final class BundleInstantiationSpecification {
         assert (classId!= null);
     }
 
-    private static final String defaultInternalBundle = "container-search-and-docproc";
-
-    private static BundleInstantiationSpecification getInternalSpecificationFromString(String idSpec, String classSpec) {
-        return new BundleInstantiationSpecification(
-                new ComponentSpecification(idSpec),
-                (classSpec == null || classSpec.isEmpty())?  null  : new ComponentSpecification(classSpec),
-                new ComponentSpecification(defaultInternalBundle));
+    /**
+     * Create spec for a component from the container-search-and-docproc bundle with the given class name as id.
+     */
+    public static BundleInstantiationSpecification fromSearchAndDocproc(String className) {
+        return fromSearchAndDocproc(new ComponentSpecification(className), null);
     }
 
-    public static BundleInstantiationSpecification getInternalSearcherSpecification(ComponentSpecification idSpec,
-                                                                                    ComponentSpecification classSpec) {
-        return new BundleInstantiationSpecification(idSpec, classSpec, new ComponentSpecification(defaultInternalBundle));
+    /**
+     * Create spec for a component from the container-search-and-docproc bundle with the given id and classId.
+     */
+    public static BundleInstantiationSpecification fromSearchAndDocproc(ComponentSpecification id, ComponentSpecification classId) {
+        return new BundleInstantiationSpecification(id, classId, new ComponentSpecification(CONTAINER_SEARCH_AND_DOCPROC));
     }
 
-    // TODO: These are the same for now because they are in the same bundle.
-    public static BundleInstantiationSpecification getInternalHandlerSpecificationFromStrings(String idSpec, String classSpec) {
-        return getInternalSpecificationFromString(idSpec, classSpec);
-    }
-
-    public static BundleInstantiationSpecification getInternalProcessingSpecificationFromStrings(String idSpec, String classSpec) {
-        return getInternalSpecificationFromString(idSpec, classSpec);
-    }
-
-    public static BundleInstantiationSpecification getInternalSearcherSpecificationFromStrings(String idSpec, String classSpec) {
-        return getInternalSpecificationFromString(idSpec, classSpec);
-    }
-
-    public static BundleInstantiationSpecification getFromStrings(String idSpec, String classSpec, String bundleSpec) {
+    public static BundleInstantiationSpecification fromStrings(String idSpec, String classSpec, String bundleSpec) {
         return new BundleInstantiationSpecification(
                 new ComponentSpecification(idSpec),
                 (classSpec == null || classSpec.isEmpty())?  null  : new ComponentSpecification(classSpec),

--- a/container-core/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-core/src/main/java/com/yahoo/container/di/Container.java
@@ -299,7 +299,7 @@ public class Container {
     }
 
     private static BundleInstantiationSpecification bundleInstantiationSpecification(ComponentsConfig.Components config) {
-        return BundleInstantiationSpecification.getFromStrings(config.id(), config.classId(), config.bundle());
+        return BundleInstantiationSpecification.fromStrings(config.id(), config.classId(), config.bundle());
     }
 
     public static class ComponentGraphResult {

--- a/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/ThreadedHttpRequestHandler.java
@@ -50,7 +50,7 @@ public abstract class ThreadedHttpRequestHandler extends ThreadedRequestHandler 
         this(executor, metric, false);
     }
 
-    // TODO: move Inject annotation here!
+    // TODO: deprecate this and the Context class. The context component set up in the model does not get a dedicated thread pool.
     public ThreadedHttpRequestHandler(Context context) {
         this(context.executor, context.metric);
     }

--- a/container-core/src/main/java/com/yahoo/osgi/provider/model/ComponentModel.java
+++ b/container-core/src/main/java/com/yahoo/osgi/provider/model/ComponentModel.java
@@ -26,7 +26,7 @@ public class ComponentModel {
     }
 
     public ComponentModel(String idSpec, String classSpec, String bundleSpec, String configId) {
-        this(BundleInstantiationSpecification.getFromStrings(idSpec, classSpec, bundleSpec), configId);
+        this(BundleInstantiationSpecification.fromStrings(idSpec, classSpec, bundleSpec), configId);
     }
 
     // For vespamodel
@@ -36,7 +36,7 @@ public class ComponentModel {
 
     // For vespamodel
     public ComponentModel(String idSpec, String classSpec, String bundleSpec) {
-        this(BundleInstantiationSpecification.getFromStrings(idSpec, classSpec, bundleSpec));
+        this(BundleInstantiationSpecification.fromStrings(idSpec, classSpec, bundleSpec));
     }
 
     public ComponentId getComponentId() {

--- a/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ComponentGraphTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/componentgraph/core/ComponentGraphTest.java
@@ -102,7 +102,7 @@ public class ComponentGraphTest {
     }
 
     @Test
-    public void component_can_be_injected_into_another_component() {
+    public void component_can_be_explicitly_injected_into_another_component() {
         Node injectedComponent = mockComponentNode(SimpleComponent.class);
         Node targetComponent = mockComponentNode(ComponentTakingComponent.class);
         targetComponent.inject(injectedComponent);
@@ -117,6 +117,22 @@ public class ComponentGraphTest {
 
         ComponentTakingComponent instance = componentGraph.getInstance(ComponentTakingComponent.class);
         assertNotNull(instance);
+        assertSame(injectedComponent.instance.get(), instance.injectedComponent);
+    }
+
+    @Test
+    public void explicitly_injected_components_may_be_unused() {
+        Node notUsingInjected = mockComponentNode(SimpleComponent.class);
+        Node injectedComponent = mockComponentNode(SimpleComponent2.class);
+        notUsingInjected.inject(injectedComponent);
+
+        ComponentGraph componentGraph = new ComponentGraph();
+        componentGraph.add(injectedComponent);
+        componentGraph.add(notUsingInjected);
+        componentGraph.complete();
+
+        SimpleComponent instanceNotUsingInjected = componentGraph.getInstance(SimpleComponent.class);
+        assertNotNull(instanceNotUsingInjected);
     }
 
     @Test
@@ -514,7 +530,7 @@ public class ComponentGraphTest {
     }
 
     public static class ComponentTakingComponent extends AbstractComponent {
-        private final SimpleComponent injectedComponent;
+        final SimpleComponent injectedComponent;
 
         public ComponentTakingComponent(SimpleComponent injectedComponent) {
             assertNotNull(injectedComponent);

--- a/container-core/src/test/java/com/yahoo/osgi/provider/model/ComponentModelTest.java
+++ b/container-core/src/test/java/com/yahoo/osgi/provider/model/ComponentModelTest.java
@@ -14,7 +14,7 @@ public class ComponentModelTest {
     @Test
     public void create_from_instantiation_spec() {
         ComponentModel model = new ComponentModel(
-                BundleInstantiationSpecification.getFromStrings("id", "class", "bundle"));
+                BundleInstantiationSpecification.fromStrings("id", "class", "bundle"));
         verifyBundleSpec(model);
     }
 
@@ -26,7 +26,7 @@ public class ComponentModelTest {
     @Test
     public void create_from_instantiation_spec_and_config_id() throws Exception {
         ComponentModel model = new ComponentModel(
-                BundleInstantiationSpecification.getFromStrings("id", "class", "bundle"), "configId");
+                BundleInstantiationSpecification.fromStrings("id", "class", "bundle"), "configId");
         verifyBundleSpec(model);
         assertEquals("configId", model.configId);
     }

--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/VespaSearchers.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/VespaSearchers.java
@@ -78,7 +78,7 @@ public class VespaSearchers {
         for (Class c : searchers) {
             searcherModels.add(
                     new ChainedComponentModel(
-                            BundleInstantiationSpecification.getInternalSearcherSpecificationFromStrings(c.getName(), null),
+                            BundleInstantiationSpecification.fromSearchAndDocproc(c.getName()),
                             Dependencies.emptyDependencies()));
         }
         return searcherModels;

--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/FederationSearcherModel.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/FederationSearcherModel.java
@@ -24,9 +24,11 @@ public class FederationSearcherModel extends ChainedComponentModel {
     public final List<TargetSpec> targets;
     public final boolean inheritDefaultSources;
 
-    public FederationSearcherModel(ComponentSpecification componentId, Dependencies dependencies,
-                                   List<TargetSpec> targets, boolean inheritDefaultSources) {
-        super(BundleInstantiationSpecification.getInternalSearcherSpecification(componentId, federationSearcherComponentSpecification),
+    public FederationSearcherModel(ComponentSpecification componentId,
+                                   Dependencies dependencies,
+                                   List<TargetSpec> targets,
+                                   boolean inheritDefaultSources) {
+        super(BundleInstantiationSpecification.fromSearchAndDocproc(componentId, federationSearcherComponentSpecification),
               dependencies);
         this.inheritDefaultSources = inheritDefaultSources;
         this.targets = ImmutableList.copyOf(targets);

--- a/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
+++ b/container-search/src/main/java/com/yahoo/search/searchchain/model/federation/LocalProviderSpec.java
@@ -63,9 +63,7 @@ public class LocalProviderSpec {
         for (Class<? extends Searcher> c : searchers) {
             searcherModels.add(
                     new ChainedComponentModel(
-                            BundleInstantiationSpecification.getInternalSearcherSpecificationFromStrings(
-                                    c.getName(),
-                                    null),
+                            BundleInstantiationSpecification.fromSearchAndDocproc(c.getName()),
                             Dependencies.emptyDependencies()));
         }
 


### PR DESCRIPTION
FYI: @baldersheim 

The previous attempt tried to create ProcessingHandler from `container-search-and-docproc` instead of `container-disc`, and there was no unit test.

Unit test is added in the first commit. The second last commit fixes the issue, while the last commit just simplifies the over-complicated BundleInstantiationSpec. Remaining commits are (almost) the same as #23442 