### PR TITLE
Add new summary transform for all 'documentid' summary fields.

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/SummaryClass.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/SummaryClass.java
@@ -59,7 +59,7 @@ public class SummaryClass extends Derived {
     /** MUST be called after all other fields are added */
     private void deriveImplicitFields(DocumentSummary summary, Map<String, SummaryClassField> fields) {
         if (summary.getName().equals("default")) {
-            addField(SummaryClass.DOCUMENT_ID_FIELD, DataType.STRING, fields);
+            addField(SummaryClass.DOCUMENT_ID_FIELD, DataType.STRING, SummaryTransform.DOCUMENT_ID, fields);
         }
     }
 
@@ -70,10 +70,6 @@ public class SummaryClass extends Derived {
             }
             addField(summaryField.getName(), summaryField.getDataType(), summaryField.getTransform(), fields);
         }
-    }
-
-    private void addField(String name, DataType type, Map<String, SummaryClassField> fields) {
-        addField(name, type, null, fields);
     }
 
     private void addField(String name, DataType type,

--- a/config-model/src/main/java/com/yahoo/schema/processing/AddExtraFieldsToDocument.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/AddExtraFieldsToDocument.java
@@ -39,6 +39,7 @@ public class AddExtraFieldsToDocument extends Processor {
                     case DYNAMICBOLDED:
                     case DYNAMICTEASER:
                     case TEXTEXTRACTOR:
+                    case DOCUMENT_ID: // TODO: Adding the 'documentid' field should no longer be needed when the docsum framework in the backend has been simplified and the transform is always used.
                         addSummaryField(schema, document, summaryField, validate);
                         break;
                     default:

--- a/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/Processing.java
@@ -52,6 +52,7 @@ public class Processing {
                 ImplicitSummaries::new,
                 ImplicitSummaryFields::new,
                 AdjustPositionSummaryFields::new,
+                SummaryTransformForDocumentId::new,
                 SummaryConsistency::new,
                 SummaryNamesFieldCollisions::new,
                 SummaryFieldsMustHaveValidSource::new,

--- a/config-model/src/main/java/com/yahoo/schema/processing/SummaryTransformForDocumentId.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/SummaryTransformForDocumentId.java
@@ -1,0 +1,32 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.schema.processing;
+
+import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.schema.RankProfileRegistry;
+import com.yahoo.schema.Schema;
+import com.yahoo.schema.derived.SummaryClass;
+import com.yahoo.vespa.documentmodel.SummaryTransform;
+import com.yahoo.vespa.model.container.search.QueryProfiles;
+
+/**
+ * Adds the corresponding summary transform for all "documentid" summary fields.
+ *
+ * @author geirst
+ */
+public class SummaryTransformForDocumentId extends Processor {
+
+    public SummaryTransformForDocumentId(Schema schema, DeployLogger deployLogger, RankProfileRegistry rankProfileRegistry, QueryProfiles queryProfiles) {
+        super(schema, deployLogger, rankProfileRegistry, queryProfiles);
+    }
+
+    @Override
+    public void process(boolean validate, boolean documentsOnly) {
+        for (var summary : schema.getSummaries().values()) {
+            for (var summaryField : summary.getSummaryFields().values()) {
+                if (summaryField.getName().equals(SummaryClass.DOCUMENT_ID_FIELD)) {
+                    summaryField.setTransform(SummaryTransform.DOCUMENT_ID);
+                }
+            }
+        }
+    }
+}

--- a/config-model/src/main/java/com/yahoo/vespa/documentmodel/SummaryTransform.java
+++ b/config-model/src/main/java/com/yahoo/vespa/documentmodel/SummaryTransform.java
@@ -23,7 +23,8 @@ public enum SummaryTransform {
     ATTRIBUTECOMBINER("attributecombiner"),
     MATCHED_ELEMENTS_FILTER("matchedelementsfilter"),
     MATCHED_ATTRIBUTE_ELEMENTS_FILTER("matchedattributeelementsfilter"),
-    COPY("copy");
+    COPY("copy"),
+    DOCUMENT_ID("documentid");
 
     private final String name;
 

--- a/config-model/src/test/derived/imported_struct_fields/summarymap.cfg
+++ b/config-model/src/test/derived/imported_struct_fields/summarymap.cfg
@@ -1,4 +1,7 @@
 defaultoutputclass -1
+override[].field "documentid"
+override[].command "documentid"
+override[].arguments ""
 override[].field "my_elem_array"
 override[].command "attributecombiner"
 override[].arguments ""


### PR DESCRIPTION
This prepares for no longer inserting 'documentid' fields in the docsum blob in the backend.
Instead such fields will be produced using a docsum field writer (transform) that uses the document instance to get the id.

@toregge please review

This depends on the PR that implements the new docsum field writer (transform).