### PR TITLE
Always use Vespa version in config request when serving config

### DIFF
--- a/configdefinitions/src/vespa/configserver.def
+++ b/configdefinitions/src/vespa/configserver.def
@@ -47,7 +47,7 @@ zoneDnsSuffixes[] string
 # RPC protocol
 maxgetconfigclients int default=1000000
 maxoutputbuffersize int default=65536
-useVespaVersionInRequest bool default=false
+useVespaVersionInRequest bool default=true
 payloadCompressionType enum { UNCOMPRESSED, LZ4 } default=LZ4
 
 # Athenz config


### PR DESCRIPTION
This change means that nodes on a version that there exists no config
model for will not get new config, they will get an error instead.
This means that there will be no longer be possible to get incompatible
config for nodes on another version than one known by the config server.
https://github.com/vespa-engine/vespa/issues/23223

(Note: In hosted Vespa this has been set to true for a long time).