### PR TITLE
Revert "Modules are no longer dependency of JDK8 based clients"

### DIFF
--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -66,6 +66,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${vespaClients.jdk.releaseVersion}</release>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -9,7 +9,7 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>security-utils</artifactId>
-  <packaging>container-plugin</packaging>
+  <packaging>bundle</packaging>
   <version>8-SNAPSHOT</version>
 
   <dependencies>
@@ -17,13 +17,6 @@
     <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>annotations</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <!-- Needed for bundle-plugin to generate import-package statements in OSGi manifest for javax packages -->
-      <groupId>com.yahoo.vespa</groupId>
-      <artifactId>jdisc_core</artifactId>
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
@@ -78,11 +71,37 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <release>${vespaClients.jdk.releaseVersion}</release>
+          <showDeprecation>true</showDeprecation>
+        </configuration>
       </plugin>
       <plugin>
-        <groupId>com.yahoo.vespa</groupId>
-        <artifactId>bundle-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>parse-version</id>
+            <goals>
+              <goal>parse-version</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Build with maven-bundle-plugin to avoid depending on jdisc_core to get the correct Import-Packages -->
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
+            <Export-Package>com.yahoo.security.*;version=1.0.0;-noimport:=true</Export-Package>
+            <_nouses>true</_nouses> <!-- Don't include 'uses' directives for package exports -->
+            <_fixupmessages>"Classes found in the wrong directory"</_fixupmessages> <!-- Hide warnings for bouncycastle multi-release jars -->
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Reverts vespa-engine/vespa#23464

Seems like this broke system-tests:

[10:31:51.668] [2022-07-12 10:31:33.360] WARNING : configserver     Container.com.yahoo.jdisc.core.ApplicationLoader	Exception thrown while activating application.\nexception=\ncom.yahoo.container.di.componentgraph.core.ComponentNode$ComponentConstructorException: Error constructing 'com.yahoo.vespa.orchestrator.controller.RetryingClusterControllerClientFactory': null\nCaused by: java.lang.NoClassDefFoundError: com/fasterxml/jackson/databind/ObjectMapper\n\tat com.yahoo.security.tls.json.TransportSecurityOptionsJsonSerializer.<clinit>(TransportSecurityOptionsJsonSerializer.java:32)\n\tat com.yahoo.security.tls.TransportSecurityOptions.fromJsonFile(TransportSecurityOptions.java:70)\n\tat com.yahoo.security.tls.ConfigFileBasedTlsContext.<init>(ConfigFileBasedTlsContext.java:57)\n\tat com.yahoo.security.tls.ConfigFileBasedTlsContext.<init>(ConfigFileBasedTlsContext.java:49)\n\tat com.yahoo.security.tls.TransportSecurityUtils$SystemTlsContext.<init>(TransportSecurityUtils.java:90)\n\tat com.yahoo.security.tls.TransportSecurityUtils.getSystemTlsContext(TransportSecurityUtils.java:77)\n\tat ai.vespa.util.http.hc5.VespaHttpClientBuilder.addSslSocketFactory(VespaHttpClientBuilder.java:67)\n\tat ai.vespa.util.http.hc5.VespaHttpClientBuilder.create(VespaHttpClientBuilder.java:53)\n\tat ai.vespa.util.http.hc5.VespaHttpClientBuilder.create(VespaHttpClientBuilder.java:46)\n\tat ai.vespa.util.http.hc5.VespaHttpClientBuilder.create(VespaHttpClientBuilder.java:41)\n\tat ai.vespa.util.http.hc5.VespaHttpClientBuilder.create(VespaHttpClientBuilder.java:37)\nCaused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.databind.ObjectMapper not found by security-utils [12]\n\tat org.apache.felix.framework.BundleWiringImpl.findClassOrResourceByDelegation(BundleWiringImpl.java:1585)\n\tat org.apache.felix.framework.BundleWiringImpl.access$300(BundleWiringImpl.java:79)\n\tat org.apache.felix.framework.BundleWiringImpl$BundleClassLoader.loadClass(BundleWiringImpl.java:1970)\n\tat java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)\n\t... 11 more\n