### PR TITLE
Modules are no longer dependency of JDK8 based clients

### DIFF
--- a/http-utils/pom.xml
+++ b/http-utils/pom.xml
@@ -66,10 +66,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>${vespaClients.jdk.releaseVersion}</release>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -71,10 +71,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>${vespaClients.jdk.releaseVersion}</release>
-          <showDeprecation>true</showDeprecation>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -89,7 +85,10 @@
         </executions>
       </plugin>
       <plugin>
-        <!-- Build with maven-bundle-plugin to avoid depending on jdisc_core to get the correct Import-Packages -->
+        <!--
+        Build with maven-bundle-plugin to avoid depending on jdisc_core to get the correct Import-Packages
+        Jackson and BC compile scope dependencies are not embedded. Packages are instead imported through manifest.
+        -->
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
         <extensions>true</extensions>


### PR DESCRIPTION
Same as previous PR, but keeps the original build using Felix's bundle plugin