### PR TITLE
Disallow absolute root in MockApplicationPackage

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockApplicationPackage.java
@@ -69,6 +69,10 @@ public class MockApplicationPackage implements ApplicationPackage {
                                      String schemaDir,
                                      String deploymentSpec, String validationOverrides, boolean failOnValidateXml,
                                      String queryProfile, String queryProfileType) {
+        if (root.isAbsolute()) {
+            throw new IllegalArgumentException("Root must be relative");
+            // because this is later converted to a com.yahoo.path.Path, which is implicitly relative
+        }
         this.root = root;
         this.hostsS = hosts;
         this.servicesS = services;

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessControlTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessControlTest.java
@@ -29,7 +29,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Element;
 
+import java.io.File;
 import java.io.StringReader;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -401,7 +403,7 @@ public class AccessControlTest extends ContainerModelBuilderTestBase {
     @Test
     public void security_clients_pem_is_picked_up() {
         var applicationPackage = new MockApplicationPackage.Builder()
-                .withRoot(applicationFolder.getRoot())
+                .withRoot(relativeApplicationFolder())
                 .build();
 
         applicationPackage.getFile(Path.fromString("security")).createDirectory();
@@ -418,7 +420,7 @@ public class AccessControlTest extends ContainerModelBuilderTestBase {
     @Test
     public void operator_certificates_are_joined_with_clients_pem() {
         var applicationPackage = new MockApplicationPackage.Builder()
-                .withRoot(applicationFolder.getRoot())
+                .withRoot(relativeApplicationFolder())
                 .build();
 
         var applicationTrustCert = X509CertificateUtils.toPem(
@@ -541,6 +543,10 @@ public class AccessControlTest extends ContainerModelBuilderTestBase {
                 .filter(binding -> binding.chainId().toId().equals(filerChain))
                 .map(binding -> binding.binding().patternString())
                 .collect(Collectors.toSet());
+    }
+
+    private File relativeApplicationFolder() {
+        return Paths.get(System.getProperty("user.dir")).relativize(applicationFolder.getRoot().toPath()).toFile();
     }
 
 }


### PR DESCRIPTION
Before this change, an absolute path was treated as a relative one. So test data
ended up in this (surprising) directory:

```
~/y/vespa master$ ll ./config-model/Users/mpolden/y/vespa/config-model/target/
total 0
drwxr-xr-x 3 mpolden staff 96 Jul 12 15:24 junit4128625600353247086
drwxr-xr-x 3 mpolden staff 96 Jul 12 15:24 junit8496400184577411104
```

@hmusum