### PR TITLE
Do not log DNS warnings to application package in hosted context

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
@@ -61,7 +61,7 @@ public class MockRoot extends AbstractConfigProducerRoot {
 
     public MockRoot(String rootConfigId, DeployState deployState) {
         super(rootConfigId);
-        hostSystem = new HostSystem(this, "hostsystem", deployState.getProvisioner(), deployState.getDeployLogger());
+        hostSystem = new HostSystem(this, "hostsystem", deployState.getProvisioner(), deployState.getDeployLogger(), deployState.isHosted());
         this.deployState = deployState;
         fileReferencesRepository = new FileReferencesRepository(deployState.getFileRegistry());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
@@ -230,7 +230,9 @@ public class VespaDomBuilder extends VespaModelBuilder {
                                                                                    deployState.getDocumentModel(),
                                                                                    deployState.getVespaVersion(),
                                                                                    deployState.getProperties().applicationId());
-            root.setHostSystem(new HostSystem(root, "hosts", deployState.getProvisioner(), deployState.getDeployLogger()));
+            root.setHostSystem(new HostSystem(root, "hosts", deployState.getProvisioner(),
+                                              deployState.getDeployLogger(),
+                                              deployState.isHosted()));
             new Client(root);
             return root;
         }


### PR DESCRIPTION
Hosts (e.g. config servers) are automatically reprovisioned at times, so there
may be a short window where a given hostname does not resolve.

DNS setup is also validated elsewhere in a hosted context.

@gjoranv