### PR TITLE
Remove debug log message from startup script

### DIFF
--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -192,7 +192,6 @@ configure_cpu() {
 
 configure_numactl() {
     numactlcmd=$(get_numa_ctl_cmd)
-    log_message debug "starting ${VESPA_SERVICE_NAME} for ${VESPA_CONFIG_ID} with numactl command : $numactlcmd"
 }
 
 configure_gcopts() {


### PR DESCRIPTION
We don't want debug log messages, remove message altogether.