### PR TITLE
Fail deployment if node count is not given for content cluster in hosted

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -54,7 +54,7 @@ public class Content extends ConfigModel {
     // Dependencies to other models
     private final AdminModel adminModel;
 
-    // to find or add the docproc container and supplement cluster controllers with clusters having less then 3 nodes
+    // to find or add the docproc container and supplement cluster controllers with clusters having less than 3 nodes
     private final Collection<ContainerModel> containers;
 
     @SuppressWarnings("UnusedDeclaration") // Created by reflection in ConfigModelRepo

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/StorageGroup.java
@@ -442,6 +442,11 @@ public class StorageGroup {
                 nodeRequirement = Optional.of(NodesSpecification.from(nodesElement.get(), context));
             else if (nodesElement.isEmpty() && subGroups.isEmpty() && context.getDeployState().isHosted()) // request one node
                 nodeRequirement = Optional.of(NodesSpecification.nonDedicated(1, context));
+            else if (nodesElement.isPresent() && nodesElement.get().stringAttribute("count") == null && context.getDeployState().isHosted())
+                throw new IllegalArgumentException("""
+                                                           Clusters in hosted environments must have a <nodes count='N'> tag
+                                                           matching all zones, and having no <node> subtags,
+                                                           see https://cloud.vespa.ai/en/reference/services""");
             else // Nodes or groups explicitly listed - resolve in GroupBuilder
                 nodeRequirement = Optional.empty();
 


### PR DESCRIPTION
Node count must be given for other zones than those that are manually deployed.