### PR TITLE
Avoid holding ref to last generated operation

### DIFF
--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -97,9 +97,9 @@ ExternalOperationHandler::~ExternalOperationHandler() = default;
 bool
 ExternalOperationHandler::handleMessage(const std::shared_ptr<api::StorageMessage>& msg, Operation::SP& op)
 {
-    _op = Operation::SP();
+    _op.reset();
     bool retVal = msg->callHandler(*this, msg);
-    op = _op;
+    op = std::move(_op); // Don't maintain any strong refs in _op after we've passed it on.
     return retVal;
 }
 


### PR DESCRIPTION
@bjorncs please review

Move ref away to avoid an unneeded refcount bump and avoid leaving
behind a lingering strong reference to the last generated operation.

Noticed this while working on two-phase GC with write-locking and wondered
why on earth the write lock was still held for the last Put that was sent through
the distributor...! Note that this would never have affected external operations,
since we always cleared the previously active op _prior_ to processing a new one.
