### PR TITLE
Fix cost field name

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -44,6 +44,7 @@ import com.yahoo.vespa.hosted.provision.node.filter.ParentHostFilter;
 import com.yahoo.vespa.hosted.provision.restapi.NodesResponse.ResponseType;
 import com.yahoo.vespa.orchestrator.Orchestrator;
 import com.yahoo.yolean.Exceptions;
+
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -453,8 +454,8 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
         Slime slime = new Slime();
         Cursor root = slime.setObject();
 
-        root.setDouble("total-cost", stats.totalCost());
-        root.setDouble("total-allocated-cost", stats.totalAllocatedCost());
+        root.setDouble("totalCost", stats.totalCost());
+        root.setDouble("totalAllocatedCost", stats.totalAllocatedCost());
         toSlime(stats.load(), root.setObject("load"));
         toSlime(stats.activeLoad(), root.setObject("activeLoad"));
         Cursor applicationsArray = root.setArray("applications");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/stats.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/stats.json
@@ -1,6 +1,6 @@
 {
-  "total-cost" : 8.591999999999999,
-  "total-allocated-cost": 5.356,
+  "totalCost": 8.591999999999999,
+  "totalAllocatedCost": 5.356,
   "load": {
     "cpu": 0.0,
     "memory": 0.0,


### PR DESCRIPTION
Controller node-repository client expects camel case https://github.com/vespa-engine/vespa/blob/58a7c193360e6aca3da295592f8b5ab5fcf6424e/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepoStatsData.java#L19
The other fields in this API also use camel case