### PR TITLE
Add quota to the billing API

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2Test.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2Test.java
@@ -124,7 +124,7 @@ public class BillingApiHandlerV2Test extends ControllerContainerCloudTest {
 
         var accountantRequest = request("/billing/v2/accountant").roles(Role.hostedAccountant());
         tester.assertResponse(accountantRequest, """
-                {"tenants":[{"tenant":"tenant1","plan":{"id":"trial","name":"Free Trial - for testing purposes"},"collection":"AUTO","lastBill":null,"unbilled":"0.00"}]}""");
+                {"tenants":[{"tenant":"tenant1","plan":{"id":"trial","name":"Free Trial - for testing purposes"},"quota":{"budget":-1.0},"collection":"AUTO","lastBill":null,"unbilled":"0.00"}]}""");
     }
 
     @Test


### PR DESCRIPTION
Doing this so that we can remove it from the application API and
save us some SQL calls in the tenant view.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
