### PR TITLE
Support partial infrastructure upgrades

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/NodeSlice.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/NodeSlice.java
@@ -1,0 +1,46 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision.zone;
+
+import java.util.Objects;
+import java.util.OptionalDouble;
+import java.util.OptionalLong;
+
+/**
+ * A slice of nodes, satisfied by either a minimum count or a fraction.
+ *
+ * @author mpolden
+ */
+public record NodeSlice(OptionalDouble fraction, OptionalLong minCount) {
+
+    public static final NodeSlice ALL = minCount(Long.MAX_VALUE);
+
+    public NodeSlice {
+        Objects.requireNonNull(fraction);
+        Objects.requireNonNull(minCount);
+        if (fraction.isEmpty() == minCount.isEmpty()) {
+            throw new IllegalArgumentException("Exactly one of 'fraction' or 'minCount' must be set");
+        }
+        if (fraction.isPresent() && fraction.getAsDouble() > 1.0D) {
+            throw new IllegalArgumentException("Fraction must be <= 1.0, got " + fraction.getAsDouble());
+        }
+    }
+
+    /** Returns whether this slice is satisfied by given node count, out of totalCount */
+    public boolean satisfiedBy(long count, long totalCount) {
+        if (fraction.isPresent()) {
+            return count >= totalCount * fraction.getAsDouble();
+        }
+        return count >= Math.min(minCount.orElse(0), totalCount);
+    }
+
+    /** Returns a slice matching the given fraction of nodes */
+    public static NodeSlice fraction(double fraction) {
+        return new NodeSlice(OptionalDouble.of(fraction), OptionalLong.empty());
+    }
+
+    /** Returns a slice matching the given minimum number of nodes */
+    public static NodeSlice minCount(long count) {
+        return new NodeSlice(OptionalDouble.empty(), OptionalLong.of(count));
+    }
+
+}

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/zone/NodeSlice.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/zone/NodeSlice.java
@@ -28,7 +28,7 @@ public record NodeSlice(OptionalDouble fraction, OptionalLong minCount) {
     /** Returns whether this slice is satisfied by given node count, out of totalCount */
     public boolean satisfiedBy(long count, long totalCount) {
         if (fraction.isPresent()) {
-            return count >= totalCount * fraction.getAsDouble();
+            return count + 1e-9 >= totalCount * fraction.getAsDouble();
         }
         return count >= Math.min(minCount.orElse(0), totalCount);
     }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/zone/NodeSliceTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/zone/NodeSliceTest.java
@@ -1,0 +1,32 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.provision.zone;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author mpolden
+ */
+public class NodeSliceTest {
+
+    @Test
+    void node_slice() {
+        NodeSlice fraction = NodeSlice.fraction(0.6);
+        assertFalse(fraction.satisfiedBy(0, 4));
+        assertFalse(fraction.satisfiedBy(1, 4));
+        assertFalse(fraction.satisfiedBy(2, 4));
+        assertTrue(fraction.satisfiedBy(3, 4));
+        assertTrue(fraction.satisfiedBy(4, 4));
+        assertTrue(fraction.satisfiedBy(5, 4));
+
+        NodeSlice fixed = NodeSlice.minCount(5);
+        assertFalse(fixed.satisfiedBy(0, 5));
+        assertFalse(fixed.satisfiedBy(4, 5));
+        assertTrue(fixed.satisfiedBy(3, 3));
+        assertTrue(fixed.satisfiedBy(5, 5));
+        assertTrue(fixed.satisfiedBy(6, 5));
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.versions;
 import com.google.common.collect.ImmutableMap;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudName;
+import com.yahoo.config.provision.zone.UpgradePolicy;
 import com.yahoo.config.provision.zone.ZoneApi;
 import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.NodeFilter;
@@ -83,6 +84,7 @@ public record OsVersionStatus(Map<OsVersion, List<NodeVersion>> versions) {
     private static List<ZoneApi> zonesToUpgrade(Controller controller) {
         return controller.zoneRegistry().osUpgradePolicies().stream()
                          .flatMap(upgradePolicy -> upgradePolicy.steps().stream())
+                         .map(UpgradePolicy.Step::zones)
                          .flatMap(Collection::stream)
                          .toList();
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneApiMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ZoneApiMock.java
@@ -76,6 +76,11 @@ public class ZoneApiMock implements ZoneApi {
         return Objects.hash(id);
     }
 
+    @Override
+    public String toString() {
+        return id.toString();
+    }
+
     public static class Builder {
 
         private SystemName systemName = SystemName.defaultSystem();


### PR DESCRIPTION
This allows infrastructure upgrades (Vespa or OS) to proceed with the next
step/zone after some subset of hosts have completed upgrading. The minimum
number of hosts is set by the upgrade policy.

Merge together with internal PR.

@jonmv