### PR TITLE
- Split rank setup verification code and the binary [run-systemtest]

### DIFF
--- a/searchcore/src/apps/verify_ranksetup/CMakeLists.txt
+++ b/searchcore/src/apps/verify_ranksetup/CMakeLists.txt
@@ -1,12 +1,20 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-vespa_add_executable(searchcore_verify_ranksetup_app
+vespa_add_library(searchcore_verify_ranksetup
     SOURCES
     verify_ranksetup.cpp
-    OUTPUT_NAME vespa-verify-ranksetup-bin
-    INSTALL bin
+    INSTALL lib64
     DEPENDS
     searchcore_fconfig
     searchcore_matching
     searchcore_documentmetastore
 )
-vespa_generate_config(searchcore_verify_ranksetup_app verify-ranksetup.def)
+vespa_generate_config(searchcore_verify_ranksetup verify-ranksetup.def)
+
+vespa_add_executable(searchcore_verify_ranksetup_app
+    SOURCES
+    verify_ranksetup_app.cpp
+    OUTPUT_NAME vespa-verify-ranksetup-bin
+    INSTALL bin
+    DEPENDS
+    searchcore_verify_ranksetup
+)

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup.cpp
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup.cpp
@@ -253,14 +253,10 @@ VerifyRankSetup::verify(const std::string & configid)
     return ok;
 }
 
-bool
-verifyRankSetup(const char * configId, std::string & messages) {
+std::pair<bool, std::vector<vespalib::string>>
+verifyRankSetup(const char * configId) {
     VerifyRankSetup verifier;
     bool ok = verifier.verify(configId);
-    vespalib::asciistream os;
-    for (const auto & m : verifier.getMessages()) {
-        os << m << "\n";
-    }
-    messages = os.str();
-    return ok;
+
+    return {ok, verifier.getMessages()};
 }

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
-#include <string>
+#include <vespa/vespalib/stllike/string.h>
+#include <vector>
 
-bool verifyRankSetup(const char * configId, std::string & messages);
+std::pair<bool, std::vector<vespalib::string>> verifyRankSetup(const char * configId);

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
@@ -1,0 +1,7 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <string>
+
+bool verifyRankSetup(const char * configId, std::string & messages);

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <vespa/vespalib/stllike/string.h>
-#include <vector>
+#include <vespa/searchlib/fef/verify_feature.h>
 
-std::pair<bool, std::vector<vespalib::string>> verifyRankSetup(const char * configId);
+std::pair<bool, std::vector<search::fef::Message>> verifyRankSetup(const char * configId);

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
@@ -20,6 +20,20 @@ App::usage()
     return 1;
 }
 
+namespace {
+ns_log::Logger::LogLevel
+toLogLevel(search::fef::Level level) {
+    switch (level) {
+        case search::fef::Level::INFO:
+            return ns_log::Logger::LogLevel::info;
+        case search::fef::Level::WARNING:
+            return ns_log::Logger::LogLevel::warning;
+        case search::fef::Level::ERROR:
+            return ns_log::Logger::LogLevel::error;
+    }
+    abort();
+}
+}
 int
 App::main(int argc, char **argv)
 {
@@ -30,7 +44,7 @@ App::main(int argc, char **argv)
     auto [ok, messages] = verifyRankSetup(argv[1]);
 
     for (const auto & msg : messages) {
-        LOG(warning, "%s", msg.c_str());
+        VLOG(toLogLevel(msg.first), "%s", msg.second.c_str());
     }
     return ok ? 0 : 1;
 }

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
@@ -1,0 +1,46 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "verify_ranksetup.h"
+#include <vespa/vespalib/util/signalhandler.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("vespa-verify-ranksetup");
+
+class App
+{
+public:
+    int usage();
+    int main(int argc, char **argv);
+};
+
+int
+App::usage()
+{
+    fprintf(stderr, "Usage: vespa-verify-ranksetup <config-id>\n");
+    return 1;
+}
+
+int
+App::main(int argc, char **argv)
+{
+    if (argc != 2) {
+        return usage();
+    }
+
+    std::string messages;
+    bool ok = verifyRankSetup(argv[1], messages);
+
+    if ( ! messages.empty() ) {
+        LOG(info, "%s", messages.c_str());
+    }
+    if (!ok) {
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    vespalib::SignalHandler::PIPE.ignore();
+    App app;
+    return app.main(argc, argv);
+}

--- a/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
+++ b/searchcore/src/apps/verify_ranksetup/verify_ranksetup_app.cpp
@@ -27,16 +27,12 @@ App::main(int argc, char **argv)
         return usage();
     }
 
-    std::string messages;
-    bool ok = verifyRankSetup(argv[1], messages);
+    auto [ok, messages] = verifyRankSetup(argv[1]);
 
-    if ( ! messages.empty() ) {
-        LOG(info, "%s", messages.c_str());
+    for (const auto & msg : messages) {
+        LOG(warning, "%s", msg.c_str());
     }
-    if (!ok) {
-        return 1;
-    }
-    return 0;
+    return ok ? 0 : 1;
 }
 
 int main(int argc, char **argv) {

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -119,7 +119,8 @@ Matcher::Matcher(const search::index::Schema &schema, const Properties &props, c
     _rankSetup = std::make_shared<search::fef::RankSetup>(_blueprintFactory, _indexEnv);
     _rankSetup->configure(); // reads config values from the property map
     if (!_rankSetup->compile()) {
-        throw vespalib::IllegalArgumentException(fmt("failed to compile rank setup :\n%s", _rankSetup->getJoinedErrors().c_str()), VESPA_STRLOC);
+        throw vespalib::IllegalArgumentException(fmt("failed to compile rank setup :\n%s",
+                                                     _rankSetup->getJoinedWarnings().c_str()), VESPA_STRLOC);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/matcher.cpp
@@ -32,10 +32,12 @@ using search::MatchingElements;
 using search::attribute::IAttributeContext;
 using search::fef::MatchDataLayout;
 using search::fef::MatchData;
+using search::fef::RankSetup;
 using search::fef::indexproperties::hitcollector::HeapSize;
 using search::queryeval::Blueprint;
 using search::queryeval::SearchIterator;
 using vespalib::Doom;
+using vespalib::make_string_short::fmt;
 
 namespace proton::matching {
 
@@ -117,7 +119,7 @@ Matcher::Matcher(const search::index::Schema &schema, const Properties &props, c
     _rankSetup = std::make_shared<search::fef::RankSetup>(_blueprintFactory, _indexEnv);
     _rankSetup->configure(); // reads config values from the property map
     if (!_rankSetup->compile()) {
-        throw vespalib::IllegalArgumentException("failed to compile rank setup", VESPA_STRLOC);
+        throw vespalib::IllegalArgumentException(fmt("failed to compile rank setup :\n%s", _rankSetup->getJoinedErrors().c_str()), VESPA_STRLOC);
     }
 }
 

--- a/searchlib/src/tests/fef/object_passing/object_passing_test.cpp
+++ b/searchlib/src/tests/fef/object_passing/object_passing_test.cpp
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/stllike/string.h>
-#include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/searchlib/features/valuefeature.h>
 #include <vespa/searchlib/fef/blueprintfactory.h>
 #include <vespa/searchlib/fef/test/indexenvironment.h>
@@ -102,7 +101,7 @@ struct Fixture {
     }
 
     bool verify(const vespalib::string &feature) {
-        std::vector<vespalib::string> errors;
+        std::vector<search::fef::Message> errors;
         return verifyFeature(factory, indexEnv, feature, "unit test", errors);
     }
 };

--- a/searchlib/src/tests/fef/object_passing/object_passing_test.cpp
+++ b/searchlib/src/tests/fef/object_passing/object_passing_test.cpp
@@ -102,7 +102,8 @@ struct Fixture {
     }
 
     bool verify(const vespalib::string &feature) {
-        return verifyFeature(factory, indexEnv, feature, "unit test");
+        std::vector<vespalib::string> errors;
+        return verifyFeature(factory, indexEnv, feature, "unit test", errors);
     }
 };
 

--- a/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
+++ b/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
@@ -6,11 +6,23 @@
 #include <vespa/searchlib/features/valuefeature.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <regex>
 
 using namespace search::features;
 using namespace search::fef::test;
 using namespace search::fef;
 using vespalib::make_string_short::fmt;
+
+typedef bool (*cmp)(const vespalib::string & a, const vespalib::string &b);
+
+bool equal(const vespalib::string & a, const vespalib::string &b) {
+    return a == b;
+}
+
+bool regex(const vespalib::string & a, const vespalib::string &b) {
+    std::regex exp(b.c_str());
+    return std::regex_match(a.c_str(), exp);
+}
 
 struct RankFixture {
     BlueprintFactory factory;
@@ -21,13 +33,12 @@ struct RankFixture {
         factory.addPrototype(std::make_shared<ValueBlueprint>());
     }
 
-    bool verify(const std::string &feature, std::vector<vespalib::string> expected_errors) const {
+    bool verify(const std::string &feature, std::vector<std::pair<cmp, vespalib::string>> expected) const {
         std::vector<vespalib::string> errors;
         bool ok = verifyFeature(factory, indexEnv, feature, "feature verification test", errors);
-        EXPECT_EQUAL(errors.size(), expected_errors.size());
-        for (size_t i(0); i < std::min(errors.size(), expected_errors.size()); i++) {
-            EXPECT_EQUAL(errors[i].size(), expected_errors[i].size());
-            EXPECT_EQUAL(errors[i], expected_errors[i]);
+        EXPECT_EQUAL(errors.size(), expected.size());
+        for (size_t i(0); i < std::min(errors.size(), expected.size()); i++) {
+            EXPECT_TRUE(expected[i].first(errors[i], expected[i].second));
         }
         return ok;
     }
@@ -41,60 +52,62 @@ TEST_F("verify valid rank feature", RankFixture) {
 
 TEST_F("verify unknown feature", RankFixture) {
     EXPECT_FALSE(f1.verify("unknown",
-                           {"invalid rank feature 'unknown': unknown basename: 'unknown'",
-                            "verification failed: rank feature 'unknown' (feature verification test)"}));
+                           {{equal, "invalid rank feature 'unknown': unknown basename: 'unknown'"},
+                            {equal, "verification failed: rank feature 'unknown' (feature verification test)"}}));
 }
 
 TEST_F("verify unknown output", RankFixture) {
     EXPECT_FALSE(f1.verify("value(1, 2, 3).3",
-                           {"invalid rank feature 'value(1,2,3).3': unknown output: '3'",
-                            "verification failed: rank feature 'value(1, 2, 3).3' (feature verification test)"}));
+                           {{equal, "invalid rank feature 'value(1,2,3).3': unknown output: '3'"},
+                            {equal, "verification failed: rank feature 'value(1, 2, 3).3' (feature verification test)"}}));
 }
 
 TEST_F("verify illegal input parameters", RankFixture) {
     EXPECT_FALSE(f1.verify("value.0",
-                           {"invalid rank feature 'value.0': The parameter list used for setting up rank feature value is not valid: Expected 1+1x parameter(s), but got 0",
-                            "verification failed: rank feature 'value.0' (feature verification test)"}));
+                           {{equal, "invalid rank feature 'value.0': The parameter list used for setting up rank feature value is not valid: Expected 1+1x parameter(s), but got 0"},
+                            {equal, "verification failed: rank feature 'value.0' (feature verification test)"}}));
 }
 
 TEST_F("verify illegal feature name", RankFixture) {
     EXPECT_FALSE(f1.verify("value(2).",
-                           {"invalid rank feature 'value(2).': malformed name",
-                            "verification failed: rank feature 'value(2).' (feature verification test)"}));
+                           {{equal, "invalid rank feature 'value(2).': malformed name"},
+                            {equal, "verification failed: rank feature 'value(2).' (feature verification test)"}}));
 }
 
 TEST_F("verify too deep dependency graph", RankFixture) {
     EXPECT_TRUE(f1.verify("chain(basic, 255, 4)", {}));
     EXPECT_FALSE(f1.verify("chain(basic, 256, 4)",
-                           {"invalid rank feature 'value(4)': dependency graph too deep\n"
-                            "  ... needed by rank feature 'chain(basic,1,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,2,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,3,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,4,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,5,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,6,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,7,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,8,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,9,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,10,4)'\n"
-                            "  (skipped 241 entries)\n"
-                            "  ... needed by rank feature 'chain(basic,252,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,253,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,254,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,255,4)'\n"
-                            "  ... needed by rank feature 'chain(basic,256,4)'\n",
-                            "high stack usage: 360848 bytes",
-                            "verification failed: rank feature 'chain(basic, 256, 4)' (feature verification test)"}));
+                           {{equal,
+                             "invalid rank feature 'value(4)': dependency graph too deep\n"
+                             "  ... needed by rank feature 'chain(basic,1,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,2,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,3,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,4,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,5,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,6,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,7,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,8,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,9,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,10,4)'\n"
+                             "  (skipped 241 entries)\n"
+                             "  ... needed by rank feature 'chain(basic,252,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,253,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,254,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,255,4)'\n"
+                             "  ... needed by rank feature 'chain(basic,256,4)'\n"},
+                            {regex, "high stack usage: [0-9]+ bytes"},
+                            {equal, "verification failed: rank feature 'chain(basic, 256, 4)' (feature verification test)"}}));
 }
 
 TEST_F("verify dependency cycle", RankFixture) {
     EXPECT_FALSE(f1.verify("chain(cycle, 4, 2)",
-                           {"invalid rank feature 'chain(cycle,2,2)': dependency cycle detected\n"
-                            "  ... needed by rank feature 'chain(cycle,1,2)'\n"
-                            "  ... needed by rank feature 'chain(cycle,2,2)'\n"
-                            "  ... needed by rank feature 'chain(cycle,3,2)'\n"
-                            "  ... needed by rank feature 'chain(cycle,4,2)'\n",
-                            "verification failed: rank feature 'chain(cycle, 4, 2)' (feature verification test)"}));
+                           {{equal,
+                             "invalid rank feature 'chain(cycle,2,2)': dependency cycle detected\n"
+                             "  ... needed by rank feature 'chain(cycle,1,2)'\n"
+                             "  ... needed by rank feature 'chain(cycle,2,2)'\n"
+                             "  ... needed by rank feature 'chain(cycle,3,2)'\n"
+                             "  ... needed by rank feature 'chain(cycle,4,2)'\n"},
+                            {equal,"verification failed: rank feature 'chain(cycle, 4, 2)' (feature verification test)"}}));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
+++ b/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
@@ -15,6 +15,18 @@ using vespalib::make_string_short::fmt;
 
 typedef bool (*cmp)(const vespalib::string & a, const vespalib::string &b);
 
+namespace search::fef {
+std::ostream &operator<<(std::ostream &os, Level level) {
+    if (level == Level::INFO) {
+        return os << "info";
+    }
+    if (level == Level::WARNING) {
+        return os << "warning";
+    }
+    return os << "error";
+}
+}
+
 bool equal(const vespalib::string & a, const vespalib::string &b) {
     return a == b;
 }
@@ -33,12 +45,13 @@ struct RankFixture {
         factory.addPrototype(std::make_shared<ValueBlueprint>());
     }
 
-    bool verify(const std::string &feature, std::vector<std::pair<cmp, vespalib::string>> expected) const {
-        std::vector<vespalib::string> errors;
+    bool verify(const std::string &feature, std::vector<std::pair<cmp, Message>> expected) const {
+        std::vector<Message> errors;
         bool ok = verifyFeature(factory, indexEnv, feature, "feature verification test", errors);
         EXPECT_EQUAL(errors.size(), expected.size());
         for (size_t i(0); i < std::min(errors.size(), expected.size()); i++) {
-            EXPECT_TRUE(expected[i].first(errors[i], expected[i].second));
+            EXPECT_EQUAL(errors[i].first, expected[i].second.first);
+            EXPECT_TRUE(expected[i].first(errors[i].second, expected[i].second.second));
         }
         return ok;
     }
@@ -52,62 +65,66 @@ TEST_F("verify valid rank feature", RankFixture) {
 
 TEST_F("verify unknown feature", RankFixture) {
     EXPECT_FALSE(f1.verify("unknown",
-                           {{equal, "invalid rank feature 'unknown': unknown basename: 'unknown'"},
-                            {equal, "verification failed: rank feature 'unknown' (feature verification test)"}}));
+                           {{equal, {Level::WARNING, "invalid rank feature 'unknown': unknown basename: 'unknown'"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'unknown' (feature verification test)"}}}));
 }
 
 TEST_F("verify unknown output", RankFixture) {
     EXPECT_FALSE(f1.verify("value(1, 2, 3).3",
-                           {{equal, "invalid rank feature 'value(1,2,3).3': unknown output: '3'"},
-                            {equal, "verification failed: rank feature 'value(1, 2, 3).3' (feature verification test)"}}));
+                           {{equal, {Level::WARNING, "invalid rank feature 'value(1,2,3).3': unknown output: '3'"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'value(1, 2, 3).3' (feature verification test)"}}}));
 }
 
 TEST_F("verify illegal input parameters", RankFixture) {
     EXPECT_FALSE(f1.verify("value.0",
-                           {{equal, "invalid rank feature 'value.0': The parameter list used for setting up rank feature value is not valid: Expected 1+1x parameter(s), but got 0"},
-                            {equal, "verification failed: rank feature 'value.0' (feature verification test)"}}));
+                           {{equal, {Level::WARNING, "invalid rank feature 'value.0':"
+                                                     " The parameter list used for setting up rank feature value is not valid:"
+                                                     " Expected 1+1x parameter(s), but got 0"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'value.0' (feature verification test)"}}}));
 }
 
 TEST_F("verify illegal feature name", RankFixture) {
     EXPECT_FALSE(f1.verify("value(2).",
-                           {{equal, "invalid rank feature 'value(2).': malformed name"},
-                            {equal, "verification failed: rank feature 'value(2).' (feature verification test)"}}));
+                           {{equal, {Level::WARNING, "invalid rank feature 'value(2).': malformed name"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'value(2).' (feature verification test)"}}}));
 }
 
 TEST_F("verify too deep dependency graph", RankFixture) {
     EXPECT_TRUE(f1.verify("chain(basic, 255, 4)", {}));
     EXPECT_FALSE(f1.verify("chain(basic, 256, 4)",
                            {{equal,
-                             "invalid rank feature 'value(4)': dependency graph too deep\n"
-                             "  ... needed by rank feature 'chain(basic,1,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,2,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,3,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,4,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,5,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,6,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,7,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,8,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,9,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,10,4)'\n"
-                             "  (skipped 241 entries)\n"
-                             "  ... needed by rank feature 'chain(basic,252,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,253,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,254,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,255,4)'\n"
-                             "  ... needed by rank feature 'chain(basic,256,4)'\n"},
-                            {regex, "high stack usage: [0-9]+ bytes"},
-                            {equal, "verification failed: rank feature 'chain(basic, 256, 4)' (feature verification test)"}}));
+                             {Level::WARNING,
+                              "invalid rank feature 'value(4)': dependency graph too deep\n"
+                              "  ... needed by rank feature 'chain(basic,1,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,2,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,3,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,4,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,5,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,6,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,7,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,8,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,9,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,10,4)'\n"
+                              "  (skipped 241 entries)\n"
+                              "  ... needed by rank feature 'chain(basic,252,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,253,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,254,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,255,4)'\n"
+                              "  ... needed by rank feature 'chain(basic,256,4)'\n"}},
+                            {regex, {Level::WARNING, "high stack usage: [0-9]+ bytes"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'chain(basic, 256, 4)' (feature verification test)"}}}));
 }
 
 TEST_F("verify dependency cycle", RankFixture) {
     EXPECT_FALSE(f1.verify("chain(cycle, 4, 2)",
                            {{equal,
-                             "invalid rank feature 'chain(cycle,2,2)': dependency cycle detected\n"
-                             "  ... needed by rank feature 'chain(cycle,1,2)'\n"
-                             "  ... needed by rank feature 'chain(cycle,2,2)'\n"
-                             "  ... needed by rank feature 'chain(cycle,3,2)'\n"
-                             "  ... needed by rank feature 'chain(cycle,4,2)'\n"},
-                            {equal,"verification failed: rank feature 'chain(cycle, 4, 2)' (feature verification test)"}}));
+                             {Level::WARNING,
+                              "invalid rank feature 'chain(cycle,2,2)': dependency cycle detected\n"
+                              "  ... needed by rank feature 'chain(cycle,1,2)'\n"
+                              "  ... needed by rank feature 'chain(cycle,2,2)'\n"
+                              "  ... needed by rank feature 'chain(cycle,3,2)'\n"
+                              "  ... needed by rank feature 'chain(cycle,4,2)'\n"}},
+                            {equal, {Level::ERROR, "verification failed: rank feature 'chain(cycle, 4, 2)' (feature verification test)"}}}));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
+++ b/searchlib/src/tests/ranksetup/verify_feature/verify_feature_test.cpp
@@ -4,10 +4,13 @@
 #include <vespa/searchlib/fef/test/indexenvironment.h>
 #include <vespa/searchlib/fef/test/plugin/setup.h>
 #include <vespa/searchlib/features/valuefeature.h>
+#include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/stllike/asciistream.h>
 
 using namespace search::features;
 using namespace search::fef::test;
 using namespace search::fef;
+using vespalib::make_string_short::fmt;
 
 struct RankFixture {
     BlueprintFactory factory;
@@ -15,43 +18,83 @@ struct RankFixture {
 
     RankFixture() : factory(), indexEnv() {
         setup_fef_test_plugin(factory);
-        factory.addPrototype(Blueprint::SP(new ValueBlueprint()));
+        factory.addPrototype(std::make_shared<ValueBlueprint>());
     }
 
-    bool verify(const std::string &feature) const {
-        return verifyFeature(factory, indexEnv, feature, "feature verification test");
+    bool verify(const std::string &feature, std::vector<vespalib::string> expected_errors) const {
+        std::vector<vespalib::string> errors;
+        bool ok = verifyFeature(factory, indexEnv, feature, "feature verification test", errors);
+        EXPECT_EQUAL(errors.size(), expected_errors.size());
+        for (size_t i(0); i < std::min(errors.size(), expected_errors.size()); i++) {
+            EXPECT_EQUAL(errors[i].size(), expected_errors[i].size());
+            EXPECT_EQUAL(errors[i], expected_errors[i]);
+        }
+        return ok;
     }
 };
 
 TEST_F("verify valid rank feature", RankFixture) {
-    EXPECT_TRUE(f1.verify("value(1, 2, 3).0"));
-    EXPECT_TRUE(f1.verify("value(1, 2, 3).1"));
-    EXPECT_TRUE(f1.verify("value(1, 2, 3).2"));
+    EXPECT_TRUE(f1.verify("value(1, 2, 3).0", {}));
+    EXPECT_TRUE(f1.verify("value(1, 2, 3).1", {}));
+    EXPECT_TRUE(f1.verify("value(1, 2, 3).2", {}));
 }
 
 TEST_F("verify unknown feature", RankFixture) {
-    EXPECT_FALSE(f1.verify("unknown"));
+    EXPECT_FALSE(f1.verify("unknown",
+                           {"invalid rank feature 'unknown': unknown basename: 'unknown'",
+                            "verification failed: rank feature 'unknown' (feature verification test)"}));
 }
 
 TEST_F("verify unknown output", RankFixture) {
-    EXPECT_FALSE(f1.verify("value(1, 2, 3).3"));
+    EXPECT_FALSE(f1.verify("value(1, 2, 3).3",
+                           {"invalid rank feature 'value(1,2,3).3': unknown output: '3'",
+                            "verification failed: rank feature 'value(1, 2, 3).3' (feature verification test)"}));
 }
 
 TEST_F("verify illegal input parameters", RankFixture) {
-    EXPECT_FALSE(f1.verify("value.0"));
+    EXPECT_FALSE(f1.verify("value.0",
+                           {"invalid rank feature 'value.0': The parameter list used for setting up rank feature value is not valid: Expected 1+1x parameter(s), but got 0",
+                            "verification failed: rank feature 'value.0' (feature verification test)"}));
 }
 
 TEST_F("verify illegal feature name", RankFixture) {
-    EXPECT_FALSE(f1.verify("value(2)."));
+    EXPECT_FALSE(f1.verify("value(2).",
+                           {"invalid rank feature 'value(2).': malformed name",
+                            "verification failed: rank feature 'value(2).' (feature verification test)"}));
 }
 
 TEST_F("verify too deep dependency graph", RankFixture) {
-    EXPECT_TRUE(f1.verify("chain(basic, 255, 4)"));
-    EXPECT_FALSE(f1.verify("chain(basic, 256, 4)"));
+    EXPECT_TRUE(f1.verify("chain(basic, 255, 4)", {}));
+    EXPECT_FALSE(f1.verify("chain(basic, 256, 4)",
+                           {"invalid rank feature 'value(4)': dependency graph too deep\n"
+                            "  ... needed by rank feature 'chain(basic,1,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,2,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,3,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,4,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,5,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,6,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,7,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,8,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,9,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,10,4)'\n"
+                            "  (skipped 241 entries)\n"
+                            "  ... needed by rank feature 'chain(basic,252,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,253,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,254,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,255,4)'\n"
+                            "  ... needed by rank feature 'chain(basic,256,4)'\n",
+                            "high stack usage: 360848 bytes",
+                            "verification failed: rank feature 'chain(basic, 256, 4)' (feature verification test)"}));
 }
 
 TEST_F("verify dependency cycle", RankFixture) {
-    EXPECT_FALSE(f1.verify("chain(cycle, 4, 2)"));
+    EXPECT_FALSE(f1.verify("chain(cycle, 4, 2)",
+                           {"invalid rank feature 'chain(cycle,2,2)': dependency cycle detected\n"
+                            "  ... needed by rank feature 'chain(cycle,1,2)'\n"
+                            "  ... needed by rank feature 'chain(cycle,2,2)'\n"
+                            "  ... needed by rank feature 'chain(cycle,3,2)'\n"
+                            "  ... needed by rank feature 'chain(cycle,4,2)'\n",
+                            "verification failed: rank feature 'chain(cycle, 4, 2)' (feature verification test)"}));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/vespa/searchlib/fef/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprint.cpp
@@ -5,9 +5,6 @@
 #include <cassert>
 #include <vespa/vespalib/util/stringfmt.h>
 
-#include <vespa/log/log.h>
-LOG_SETUP(".fef.blueprint");
-
 namespace search::fef {
 
 std::optional<FeatureType>

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
@@ -266,7 +266,7 @@ BlueprintResolver::BlueprintResolver(const BlueprintFactory &factory,
       _executorSpecs(),
       _featureMap(),
       _seedMap(),
-      _compileErrors()
+      _warnings()
 {
 }
 
@@ -302,7 +302,7 @@ BlueprintResolver::compile()
                                    for (const auto &seed: _seeds) {
                                        auto ref = compiler.resolve_feature(seed, Blueprint::AcceptInput::ANY);
                                        if (compiler.failed()) {
-                                           _compileErrors = std::move(compiler.errors);
+                                           _warnings = std::move(compiler.errors);
                                            return;
                                        }
                                        _seedMap.emplace(FeatureNameParser(seed).featureName(), ref);
@@ -314,7 +314,7 @@ BlueprintResolver::compile()
     executor.shutdown();
     size_t stack_usage = compiler.stack_usage();
     if (stack_usage > (128_Ki)) {
-        _compileErrors.emplace_back(fmt("high stack usage: %zu bytes", stack_usage));
+        _warnings.emplace_back(fmt("high stack usage: %zu bytes", stack_usage));
     }
     return !compiler.failed();
 }

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.cpp
@@ -7,13 +7,9 @@
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
-#include <stack>
 #include <cassert>
 #include <set>
 #include <thread>
-
-#include <vespa/log/log.h>
-LOG_SETUP(".fef.blueprintresolver");
 
 using vespalib::make_string_short::fmt;
 using vespalib::ThreadStackExecutor;
@@ -63,6 +59,7 @@ struct Compiler : public Blueprint::DependencyHandler {
             : spec(std::move(blueprint)), parser(parser_in) {}
     };
     using Stack = std::vector<Frame>;
+    using Errors = std::vector<vespalib::string>;
 
     struct FrameGuard {
         Stack &stack;
@@ -73,15 +70,16 @@ struct Compiler : public Blueprint::DependencyHandler {
         }
     };
 
-    const BlueprintFactory  &factory;
-    const IIndexEnvironment &index_env;
-    Stack                    resolve_stack;
-    ExecutorSpecList        &spec_list;
-    FeatureMap              &feature_map;
-    std::set<vespalib::string> setup_set;
-    std::set<vespalib::string> failed_set;
-    const char *min_stack;
-    const char *max_stack;
+    const BlueprintFactory     &factory;
+    const IIndexEnvironment    &index_env;
+    Stack                       resolve_stack;
+    Errors                      errors;
+    ExecutorSpecList           &spec_list;
+    FeatureMap                 &feature_map;
+    std::set<vespalib::string>  setup_set;
+    std::set<vespalib::string>  failed_set;
+    const char                 *min_stack;
+    const char                 *max_stack;
 
     Compiler(const BlueprintFactory &factory_in,
              const IIndexEnvironment &index_env_in,
@@ -90,6 +88,7 @@ struct Compiler : public Blueprint::DependencyHandler {
         : factory(factory_in),
           index_env(index_env_in),
           resolve_stack(),
+          errors(),
           spec_list(spec_list_out),
           feature_map(feature_map_out),
           setup_set(),
@@ -138,11 +137,13 @@ struct Compiler : public Blueprint::DependencyHandler {
         if (failed_set.count(feature_name) == 0) {
             failed_set.insert(feature_name);
             auto trace = make_trace(skip_self);
+            vespalib::string msg;
             if (trace.empty()) {
-                LOG(warning, "invalid %s: %s", describe(feature_name).c_str(), reason.c_str());
+                msg = fmt("invalid %s: %s", describe(feature_name).c_str(), reason.c_str());
             } else {
-                LOG(warning, "invalid %s: %s\n%s", describe(feature_name).c_str(), reason.c_str(), trace.c_str());
+                msg = fmt("invalid %s: %s\n%s", describe(feature_name).c_str(), reason.c_str(), trace.c_str());
             }
+            errors.emplace_back(msg);
         }
         probe_stack();
         return FeatureRef();
@@ -264,7 +265,8 @@ BlueprintResolver::BlueprintResolver(const BlueprintFactory &factory,
       _seeds(),
       _executorSpecs(),
       _featureMap(),
-      _seedMap()
+      _seedMap(),
+      _compileErrors()
 {
 }
 
@@ -300,6 +302,7 @@ BlueprintResolver::compile()
                                    for (const auto &seed: _seeds) {
                                        auto ref = compiler.resolve_feature(seed, Blueprint::AcceptInput::ANY);
                                        if (compiler.failed()) {
+                                           _compileErrors = std::move(compiler.errors);
                                            return;
                                        }
                                        _seedMap.emplace(FeatureNameParser(seed).featureName(), ref);
@@ -311,27 +314,9 @@ BlueprintResolver::compile()
     executor.shutdown();
     size_t stack_usage = compiler.stack_usage();
     if (stack_usage > (128_Ki)) {
-        LOG(warning, "high stack usage: %zu bytes", stack_usage);
+        _compileErrors.emplace_back(fmt("high stack usage: %zu bytes", stack_usage));
     }
     return !compiler.failed();
-}
-
-const BlueprintResolver::ExecutorSpecList &
-BlueprintResolver::getExecutorSpecs() const
-{
-    return _executorSpecs;
-}
-
-const BlueprintResolver::FeatureMap &
-BlueprintResolver::getFeatureMap() const
-{
-    return _featureMap;
-}
-
-const BlueprintResolver::FeatureMap &
-BlueprintResolver::getSeedMap() const
-{
-    return _seedMap;
 }
 
 }

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.h
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.h
@@ -24,7 +24,8 @@ class FeatureNameParser;
 class BlueprintResolver
 {
 public:
-    typedef std::shared_ptr<BlueprintResolver> SP;
+    using SP = std::shared_ptr<BlueprintResolver>;
+    using Errors = std::vector<vespalib::string>;
 
     /**
      * Low-level reference to a single output from a feature
@@ -44,7 +45,7 @@ public:
             : executor(executor_in), output(output_in) {}
         bool valid() { return (executor != undef); }
     };
-    typedef std::map<vespalib::string, FeatureRef> FeatureMap;
+    using FeatureMap = std::map<vespalib::string, FeatureRef>;
 
     /**
      * Thin blueprint wrapper with additional information about how
@@ -59,7 +60,7 @@ public:
         ExecutorSpec(Blueprint::SP blueprint_in);
         ~ExecutorSpec();
     };
-    typedef std::vector<ExecutorSpec> ExecutorSpecList;
+    using ExecutorSpecList = std::vector<ExecutorSpec>;
 
     /**
      * The maximum dependency depth. This value is defined to protect
@@ -84,6 +85,7 @@ private:
     ExecutorSpecList              _executorSpecs;
     FeatureMap                    _featureMap;
     FeatureMap                    _seedMap;
+    Errors                        _compileErrors;
 
 public:
     BlueprintResolver(const BlueprintResolver &) = delete;
@@ -134,7 +136,7 @@ public:
      *
      * @return feature executor assembly directions
      **/
-    const ExecutorSpecList &getExecutorSpecs() const;
+    const ExecutorSpecList &getExecutorSpecs() const { return _executorSpecs; }
 
     /**
      * Obtain the location of all named features known to this
@@ -145,7 +147,7 @@ public:
      *
      * @return feature locations
      **/
-    const FeatureMap &getFeatureMap() const;
+    const FeatureMap &getFeatureMap() const { return _featureMap; }
 
     /**
      * Obtain the location of all seeds used by this resolver. This
@@ -156,7 +158,13 @@ public:
      *
      * @return seed locations
      **/
-    const FeatureMap &getSeedMap() const;
+    const FeatureMap &getSeedMap() const { return _seedMap; }
+
+    /**
+     * Will return any accumulated errors during compile
+     * @return list of errors
+     **/
+    const Errors & getCompileErrors() const { return _compileErrors; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/blueprintresolver.h
+++ b/searchlib/src/vespa/searchlib/fef/blueprintresolver.h
@@ -25,7 +25,7 @@ class BlueprintResolver
 {
 public:
     using SP = std::shared_ptr<BlueprintResolver>;
-    using Errors = std::vector<vespalib::string>;
+    using Warnings = std::vector<vespalib::string>;
 
     /**
      * Low-level reference to a single output from a feature
@@ -85,7 +85,7 @@ private:
     ExecutorSpecList              _executorSpecs;
     FeatureMap                    _featureMap;
     FeatureMap                    _seedMap;
-    Errors                        _compileErrors;
+    Warnings                        _warnings;
 
 public:
     BlueprintResolver(const BlueprintResolver &) = delete;
@@ -161,10 +161,10 @@ public:
     const FeatureMap &getSeedMap() const { return _seedMap; }
 
     /**
-     * Will return any accumulated errors during compile
-     * @return list of errors
+     * Will return any accumulated warnings during compile
+     * @return list of warnings
      **/
-    const Errors & getCompileErrors() const { return _compileErrors; }
+    const Warnings & getWarnings() const { return _warnings; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -54,7 +54,7 @@ RankSetup::RankSetup(const BlueprintFactory &factory, const IIndexEnvironment &i
       _match_features(),
       _summaryFeatures(),
       _dumpFeatures(),
-      _compileErrors(),
+      _warnings(),
       _feature_rename_map(),
       _ignoreDefaultRankFeatures(false),
       _compiled(false),
@@ -173,8 +173,8 @@ RankSetup::compileAndCheckForErrors(BlueprintResolver &bpr) {
     bool ok = bpr.compile();
     if ( ! ok ) {
         _compileError = true;
-        const Errors & errors = bpr.getCompileErrors();
-        _compileErrors.insert(_compileErrors.end(), errors.begin(), errors.end());
+        const auto & warnings = bpr.getWarnings();
+        _warnings.insert(_warnings.end(), warnings.begin(), warnings.end());
     }
 }
 bool
@@ -188,7 +188,7 @@ RankSetup::compile()
             _first_phase_resolver->addSeed(_firstPhaseRankFeature);
         } else {
             vespalib::string e = fmt("invalid feature name for initial rank: '%s'", _firstPhaseRankFeature.c_str());
-            _compileErrors.emplace_back(e);
+            _warnings.emplace_back(e);
             _compileError = true;
         }
     }
@@ -199,7 +199,7 @@ RankSetup::compile()
             _second_phase_resolver->addSeed(_secondPhaseRankFeature);
         } else {
             vespalib::string e = fmt("invalid feature name for final rank: '%s'", _secondPhaseRankFeature.c_str());
-            _compileErrors.emplace_back(e);
+            _warnings.emplace_back(e);
             _compileError = true;
         }
     }
@@ -246,9 +246,9 @@ RankSetup::prepareSharedState(const IQueryEnvironment &queryEnv, IObjectStore &o
 }
 
 vespalib::string
-RankSetup::getJoinedErrors() const {
+RankSetup::getJoinedWarnings() const {
     vespalib::asciistream os;
-    for (const auto & m : _compileErrors) {
+    for (const auto & m : _warnings) {
         os << m << "\n";
     }
     return os.str();

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -3,9 +3,9 @@
 #include "ranksetup.h"
 #include "indexproperties.h"
 #include "featurenameparser.h"
+#include <vespa/vespalib/util/stringfmt.h>
 
-#include <vespa/log/log.h>
-LOG_SETUP(".fef.ranksetup");
+using vespalib::make_string_short::fmt;
 
 namespace {
 class VisitorAdapter : public search::fef::IDumpFeatureVisitor
@@ -53,6 +53,7 @@ RankSetup::RankSetup(const BlueprintFactory &factory, const IIndexEnvironment &i
       _match_features(),
       _summaryFeatures(),
       _dumpFeatures(),
+      _compileErrors(),
       _feature_rename_map(),
       _ignoreDefaultRankFeatures(false),
       _compiled(false),
@@ -134,50 +135,59 @@ RankSetup::configure()
 void
 RankSetup::setFirstPhaseRank(const vespalib::string &featureName)
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     _firstPhaseRankFeature = featureName;
 }
 
 void
 RankSetup::setSecondPhaseRank(const vespalib::string &featureName)
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     _secondPhaseRankFeature = featureName;
 }
 
 void
 RankSetup::add_match_feature(const vespalib::string &match_feature)
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     _match_features.push_back(match_feature);
 }
 
 void
 RankSetup::addSummaryFeature(const vespalib::string &summaryFeature)
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     _summaryFeatures.push_back(summaryFeature);
 }
 
 void
 RankSetup::addDumpFeature(const vespalib::string &dumpFeature)
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     _dumpFeatures.push_back(dumpFeature);
 }
 
+void
+RankSetup::compileAndCheckForErrors(BlueprintResolver &bpr) {
+    bool ok = bpr.compile();
+    if ( ! ok ) {
+        _compileError = true;
+        const Errors & errors = bpr.getCompileErrors();
+        _compileErrors.insert(_compileErrors.end(), errors.begin(), errors.end());
+    }
+}
 bool
 RankSetup::compile()
 {
-    LOG_ASSERT(!_compiled);
+    assert(!_compiled);
     if (!_firstPhaseRankFeature.empty()) {
         FeatureNameParser parser(_firstPhaseRankFeature);
         if (parser.valid()) {
             _firstPhaseRankFeature = parser.featureName();
             _first_phase_resolver->addSeed(_firstPhaseRankFeature);
         } else {
-            LOG(warning, "invalid feature name for initial rank: '%s'",
-                _firstPhaseRankFeature.c_str());
+            vespalib::string e = fmt("invalid feature name for initial rank: '%s'", _firstPhaseRankFeature.c_str());
+            _compileErrors.emplace_back(e);
             _compileError = true;
         }
     }
@@ -187,8 +197,8 @@ RankSetup::compile()
             _secondPhaseRankFeature = parser.featureName();
             _second_phase_resolver->addSeed(_secondPhaseRankFeature);
         } else {
-            LOG(warning, "invalid feature name for final rank: '%s'",
-                _secondPhaseRankFeature.c_str());
+            vespalib::string e = fmt("invalid feature name for final rank: '%s'", _secondPhaseRankFeature.c_str());
+            _compileErrors.emplace_back(e);
             _compileError = true;
         }
     }
@@ -206,12 +216,12 @@ RankSetup::compile()
         _dumpResolver->addSeed(feature);
     }
     _indexEnv.hintFeatureMotivation(IIndexEnvironment::RANK);
-    _compileError |= !_first_phase_resolver->compile();
-    _compileError |= !_second_phase_resolver->compile();
-    _compileError |= !_match_resolver->compile();
-    _compileError |= !_summary_resolver->compile();
+    compileAndCheckForErrors(*_first_phase_resolver);
+    compileAndCheckForErrors(*_second_phase_resolver);
+    compileAndCheckForErrors(*_match_resolver);
+    compileAndCheckForErrors(*_summary_resolver);
     _indexEnv.hintFeatureMotivation(IIndexEnvironment::DUMP);
-    _compileError |= !_dumpResolver->compile();
+    compileAndCheckForErrors(*_dumpResolver);
     _compiled = true;
     return !_compileError;
 }
@@ -219,7 +229,7 @@ RankSetup::compile()
 void
 RankSetup::prepareSharedState(const IQueryEnvironment &queryEnv, IObjectStore &objectStore) const
 {
-    LOG_ASSERT(_compiled && !_compileError);
+    assert(_compiled && !_compileError);
     for (const auto &spec : _first_phase_resolver->getExecutorSpecs()) {
         spec.blueprint->prepareSharedState(queryEnv, objectStore);
     }

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -4,6 +4,7 @@
 #include "indexproperties.h"
 #include "featurenameparser.h"
 #include <vespa/vespalib/util/stringfmt.h>
+#include <vespa/vespalib/stllike/asciistream.h>
 
 using vespalib::make_string_short::fmt;
 
@@ -242,6 +243,15 @@ RankSetup::prepareSharedState(const IQueryEnvironment &queryEnv, IObjectStore &o
     for (const auto &spec : _summary_resolver->getExecutorSpecs()) {
         spec.blueprint->prepareSharedState(queryEnv, objectStore);
     }
+}
+
+vespalib::string
+RankSetup::getJoinedErrors() const {
+    vespalib::asciistream os;
+    for (const auto & m : _compileErrors) {
+        os << m << "\n";
+    }
+    return os.str();
 }
 
 }

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -23,6 +23,7 @@ namespace search::fef {
 class RankSetup
 {
 public:
+    using Errors = BlueprintResolver::Errors;
     struct MutateOperation {
     public:
         MutateOperation() : MutateOperation("", "") {}
@@ -62,6 +63,7 @@ private:
     std::vector<vespalib::string> _match_features;
     std::vector<vespalib::string> _summaryFeatures;
     std::vector<vespalib::string> _dumpFeatures;
+    Errors                   _compileErrors;
     StringStringMap          _feature_rename_map;
     bool                     _ignoreDefaultRankFeatures;
     bool                     _compiled;
@@ -80,6 +82,8 @@ private:
     MutateOperation          _mutateOnFirstPhase;
     MutateOperation          _mutateOnSecondPhase;
     MutateOperation          _mutateOnSummary;
+
+    void compileAndCheckForErrors(BlueprintResolver &bp);
 public:
     RankSetup(const RankSetup &) = delete;
     RankSetup &operator=(const RankSetup &) = delete;
@@ -437,6 +441,12 @@ public:
      * @return true if things went ok, false otherwise (dependency issues)
      **/
     bool compile();
+
+    /**
+     * Will return any accumulated errors during compile
+     * @return list of errors
+     */
+    const Errors & getCompileErrors() const { return _compileErrors; }
 
     // These functions create rank programs for different tasks. Note
     // that the setup function must be called on rank programs for

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -447,6 +447,7 @@ public:
      * @return list of errors
      */
     const Errors & getCompileErrors() const { return _compileErrors; }
+    vespalib::string getJoinedErrors() const;
 
     // These functions create rank programs for different tasks. Note
     // that the setup function must be called on rank programs for

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.h
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.h
@@ -23,7 +23,7 @@ namespace search::fef {
 class RankSetup
 {
 public:
-    using Errors = BlueprintResolver::Errors;
+    using Warnings = BlueprintResolver::Warnings;
     struct MutateOperation {
     public:
         MutateOperation() : MutateOperation("", "") {}
@@ -63,7 +63,7 @@ private:
     std::vector<vespalib::string> _match_features;
     std::vector<vespalib::string> _summaryFeatures;
     std::vector<vespalib::string> _dumpFeatures;
-    Errors                   _compileErrors;
+    Warnings                 _warnings;
     StringStringMap          _feature_rename_map;
     bool                     _ignoreDefaultRankFeatures;
     bool                     _compiled;
@@ -443,11 +443,10 @@ public:
     bool compile();
 
     /**
-     * Will return any accumulated errors during compile
-     * @return list of errors
+     * Will return any accumulated warnings during compile
+     * @return joined string of warnings separated by newline
      */
-    const Errors & getCompileErrors() const { return _compileErrors; }
-    vespalib::string getJoinedErrors() const;
+    vespalib::string getJoinedWarnings() const;
 
     // These functions create rank programs for different tasks. Note
     // that the setup function must be called on rank programs for

--- a/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
+++ b/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
@@ -19,8 +19,8 @@ bool verifyFeature(const BlueprintFactory &factory,
     resolver.addSeed(featureName);
     bool result = resolver.compile();
     if (!result) {
-        const BlueprintResolver::Errors & compileErrors(resolver.getCompileErrors());
-        for (const auto & msg : compileErrors) {
+        const BlueprintResolver::Warnings & warnings(resolver.getWarnings());
+        for (const auto & msg : warnings) {
             errors.emplace_back(Level::WARNING, msg);
         }
         vespalib::string msg = fmt("verification failed: %s (%s)",BlueprintResolver::describe_feature(featureName).c_str(), desc.c_str());

--- a/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
+++ b/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
@@ -2,28 +2,29 @@
 
 #include "verify_feature.h"
 #include "blueprintresolver.h"
+#include <vespa/vespalib/util/stringfmt.h>
 
-#include <vespa/log/log.h>
-LOG_SETUP(".fef.verify_feature");
+using vespalib::make_string_short::fmt;
 
-namespace search {
-namespace fef {
+namespace search::fef {
 
 bool verifyFeature(const BlueprintFactory &factory,
                    const IIndexEnvironment &indexEnv,
                    const std::string &featureName,
-                   const std::string &desc)
+                   const std::string &desc,
+                   std::vector<vespalib::string> & errors)
 {
     indexEnv.hintFeatureMotivation(IIndexEnvironment::VERIFY_SETUP);
     BlueprintResolver resolver(factory, indexEnv);
     resolver.addSeed(featureName);
     bool result = resolver.compile();
     if (!result) {
-        LOG(error, "verification failed: %s (%s)",
-            BlueprintResolver::describe_feature(featureName).c_str(), desc.c_str());
+        const BlueprintResolver::Errors & compileErrors(resolver.getCompileErrors());
+        errors.insert(errors.end(), compileErrors.begin(), compileErrors.end());
+        vespalib::string msg = fmt("verification failed: %s (%s)",BlueprintResolver::describe_feature(featureName).c_str(), desc.c_str());
+        errors.emplace_back(msg);
     }
     return result;
 }
 
-} // namespace fef
-} // namespace search
+}

--- a/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
+++ b/searchlib/src/vespa/searchlib/fef/verify_feature.cpp
@@ -12,7 +12,7 @@ bool verifyFeature(const BlueprintFactory &factory,
                    const IIndexEnvironment &indexEnv,
                    const std::string &featureName,
                    const std::string &desc,
-                   std::vector<vespalib::string> & errors)
+                   std::vector<Message> & errors)
 {
     indexEnv.hintFeatureMotivation(IIndexEnvironment::VERIFY_SETUP);
     BlueprintResolver resolver(factory, indexEnv);
@@ -20,9 +20,11 @@ bool verifyFeature(const BlueprintFactory &factory,
     bool result = resolver.compile();
     if (!result) {
         const BlueprintResolver::Errors & compileErrors(resolver.getCompileErrors());
-        errors.insert(errors.end(), compileErrors.begin(), compileErrors.end());
+        for (const auto & msg : compileErrors) {
+            errors.emplace_back(Level::WARNING, msg);
+        }
         vespalib::string msg = fmt("verification failed: %s (%s)",BlueprintResolver::describe_feature(featureName).c_str(), desc.c_str());
-        errors.emplace_back(msg);
+        errors.emplace_back(Level::ERROR, msg);
     }
     return result;
 }

--- a/searchlib/src/vespa/searchlib/fef/verify_feature.h
+++ b/searchlib/src/vespa/searchlib/fef/verify_feature.h
@@ -4,10 +4,8 @@
 
 #include "blueprintfactory.h"
 #include "iindexenvironment.h"
-#include <string>
 
-namespace search {
-namespace fef {
+namespace search::fef {
 
 /**
  * Verify whether a specific feature can be computed. If the feature
@@ -23,8 +21,7 @@ namespace fef {
 bool verifyFeature(const BlueprintFactory &factory,
                    const IIndexEnvironment &indexEnv,
                    const std::string &featureName,
-                   const std::string &desc);
+                   const std::string &desc,
+                   std::vector<vespalib::string> & errors);
 
-} // namespace fef
-} // namespace search
-
+}

--- a/searchlib/src/vespa/searchlib/fef/verify_feature.h
+++ b/searchlib/src/vespa/searchlib/fef/verify_feature.h
@@ -7,6 +7,9 @@
 
 namespace search::fef {
 
+enum class Level {INFO, WARNING, ERROR};
+using Message = std::pair<Level, vespalib::string>;
+
 /**
  * Verify whether a specific feature can be computed. If the feature
  * can not be computed, log a reason why, including feature
@@ -22,6 +25,6 @@ bool verifyFeature(const BlueprintFactory &factory,
                    const IIndexEnvironment &indexEnv,
                    const std::string &featureName,
                    const std::string &desc,
-                   std::vector<vespalib::string> & errors);
+                   std::vector<Message> & errors);
 
 }

--- a/streamingvisitors/src/vespa/searchvisitor/rankmanager.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/rankmanager.cpp
@@ -119,7 +119,7 @@ RankManager::Snapshot::initRankSetup(const BlueprintFactory & factory)
         auto rs = std::make_shared<RankSetup>(factory, ie);
         rs->configure(); // reads config values from the property map
         if (!rs->compile()) {
-            LOG(warning, "Could not compile rank setup for rank profile '%u'. Errors = %s", i, rs->getJoinedErrors().c_str());
+            LOG(warning, "Could not compile rank setup for rank profile '%u'. Errors = %s", i, rs->getJoinedWarnings().c_str());
             return false;
         }
         _rankSetup.push_back(rs);

--- a/streamingvisitors/src/vespa/searchvisitor/rankmanager.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/rankmanager.cpp
@@ -21,6 +21,7 @@ using search::fef::RankSetup;
 using vsm::VsmfieldsHandle;
 using vsm::VSMAdapter;
 using vsm::FieldIdTList;
+using vespalib::make_string_short::fmt;
 
 namespace streaming {
 
@@ -115,10 +116,10 @@ RankManager::Snapshot::initRankSetup(const BlueprintFactory & factory)
     for (uint32_t i = 0; i < _indexEnv.size(); ++i) {
         IndexEnvironment & ie = _indexEnv[i];
 
-        RankSetup::SP rs(new RankSetup(factory, ie));
+        auto rs = std::make_shared<RankSetup>(factory, ie);
         rs->configure(); // reads config values from the property map
         if (!rs->compile()) {
-            LOG(warning, "Could not compile rank setup for rank profile '%u'.", i);
+            LOG(warning, "Could not compile rank setup for rank profile '%u'. Errors = %s", i, rs->getJoinedErrors().c_str());
             return false;
         }
         _rankSetup.push_back(rs);
@@ -127,7 +128,7 @@ RankManager::Snapshot::initRankSetup(const BlueprintFactory & factory)
     LOG(debug, "Number of index environments and rank setups: %u", (uint32_t)_indexEnv.size());
     LOG_ASSERT(_properties.size() == _rankSetup.size());
     for (uint32_t i = 0; i < _properties.size(); ++i) {
-        vespalib::string number = vespalib::make_string("%u", i);
+        vespalib::string number = fmt("%u", i);
         _rpmap[number] = i;
     }
     for (uint32_t i = 0; i < _properties.size(); ++i) {


### PR DESCRIPTION
- Accumulate errors during ranksetup. Report them at the end, and also verify them in some tests.

@havardpe PR