### PR TITLE
Bump onnxruntime to 1.12.1

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -27,7 +27,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <junit5.version>5.8.1</junit5.version>  <!-- TODO: in parent this is named 'junit.version' -->
-        <onnxruntime.version>1.11.0</onnxruntime.version>
+        <onnxruntime.version>1.12.1</onnxruntime.version>
         <!-- END parent/pom.xml -->
 
 

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -111,7 +111,7 @@ BuildRequires: vespa-gtest = 1.11.0
 %define _use_vespa_gtest 1
 BuildRequires: vespa-icu-devel >= 65.1.0-1
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
-BuildRequires: vespa-onnxruntime-devel = 1.11.0
+BuildRequires: vespa-onnxruntime-devel = 1.12.1
 BuildRequires: vespa-openssl-devel >= 1.1.1o-1
 %define _use_vespa_openssl 1
 BuildRequires: vespa-protobuf-devel = 3.19.1
@@ -139,7 +139,7 @@ BuildRequires: vespa-openssl-devel >= 1.1.1o-1
 BuildRequires: vespa-gtest = 1.11.0
 %define _use_vespa_gtest 1
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
-BuildRequires: vespa-onnxruntime-devel = 1.11.0
+BuildRequires: vespa-onnxruntime-devel = 1.12.1
 BuildRequires: vespa-protobuf-devel = 3.19.1
 BuildRequires: vespa-libzstd-devel >= 1.4.5-2
 %endif
@@ -149,7 +149,7 @@ BuildRequires: maven
 BuildRequires: maven-openjdk17
 BuildRequires: openssl-devel
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
-BuildRequires: vespa-onnxruntime-devel = 1.11.0
+BuildRequires: vespa-onnxruntime-devel = 1.12.1
 BuildRequires: vespa-libzstd-devel >= 1.4.5-2
 BuildRequires: protobuf-devel
 %if 0%{?_centos_stream}
@@ -169,7 +169,7 @@ BuildRequires: maven-openjdk17
 %endif
 BuildRequires: openssl-devel
 BuildRequires: vespa-lz4-devel >= 1.9.2-2
-BuildRequires: vespa-onnxruntime-devel = 1.11.0
+BuildRequires: vespa-onnxruntime-devel = 1.12.1
 BuildRequires: vespa-libzstd-devel >= 1.4.5-2
 %if 0%{?fc34}
 BuildRequires: protobuf-devel
@@ -476,7 +476,7 @@ Requires: llvm-libs >= 14.0.0
 Requires: llvm-libs >= 14.0.0
 %endif
 %endif
-Requires: vespa-onnxruntime = 1.11.0
+Requires: vespa-onnxruntime = 1.12.1
 
 %description libs
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1066,7 +1066,7 @@
         <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <mockito.version>4.0.0</mockito.version>
-        <onnxruntime.version>1.11.0</onnxruntime.version> <!-- WARNING: sync cloud-tenant-base-dependencies-enforcer/pom.xml -->
+        <onnxruntime.version>1.12.1</onnxruntime.version> <!-- WARNING: sync cloud-tenant-base-dependencies-enforcer/pom.xml -->
         <org.json.version>20220320</org.json.version>
         <org.lz4.version>1.8.0</org.lz4.version>
         <prometheus.client.version>0.6.0</prometheus.client.version>


### PR DESCRIPTION
This adds arm64 support:
https://github.com/microsoft/onnxruntime/pull/12335

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
