### PR TITLE
Add session id to response for prepare and activate requests [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionActiveResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionActiveResponse.java
@@ -18,6 +18,7 @@ public class SessionActiveResponse extends SlimeJsonResponse {
         Cursor root = metaData.get();
 
         root.setString("tenant", tenantName.value());
+        root.setString("session-id", Long.toString(sessionId));
         root.setString("message", message);
         root.setString("url", "http://" + request.getHost() + ":" + request.getPort() +
                 "/application/v2/tenant/" + tenantName +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionPrepareAndActivateResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionPrepareAndActivateResponse.java
@@ -25,6 +25,7 @@ public class SessionPrepareAndActivateResponse extends SlimeJsonResponse {
         Cursor root = slime.get();
 
         root.setString("tenant", tenantName.value());
+        root.setString("session-id", Long.toString(result.sessionId()));
         root.setString("url", "http://" + request.getHost() + ":" + request.getPort() +
                 "/application/v2/tenant/" + tenantName +
                 "/application/" + applicationId.application().value() +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionPrepareResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SessionPrepareResponse.java
@@ -31,6 +31,7 @@ public class SessionPrepareResponse extends SlimeJsonResponse {
 
         Cursor root = deployLog.get().type() != Type.NIX ? deployLog.get() : deployLog.setObject();
         root.setString("tenant", tenantName.value());
+        root.setString("session-id", Long.toString(sessionId));
         root.setString("activate", "http://" + request.getHost() + ":" + request.getPort() +
                 "/application/v2/tenant/" + tenantName.value() + "/session/" + sessionId + "/active");
         root.setString("message", "Session " + sessionId + " for tenant '" + tenantName.value() + "' prepared.");

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/http/v2/SessionActiveHandlerTest.java
@@ -155,7 +155,10 @@ public class SessionActiveHandlerTest {
     private void assertActivationMessageOK(ActivateRequest activateRequest, String message) throws IOException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         new JsonFormat(true).encode(byteArrayOutputStream, activateRequest.getMetaData().getSlime());
-        assertTrue(message.contains("\"tenant\":\"" + tenantName + "\",\"message\":\"Session " + activateRequest.getSessionId() + activatedMessage));
+        long sessionId = activateRequest.getSessionId();
+        assertTrue(message.contains("\"tenant\":\"" + tenantName));
+        assertTrue(message.contains("\"session-id\":\"" + sessionId));
+        assertTrue(message.contains("\"message\":\"Session " + sessionId + activatedMessage));
         assertTrue(message.contains("/application/v2/tenant/" + tenantName +
                 "/application/" + appName +
                 "/environment/" + "prod" +


### PR DESCRIPTION
Adding session id, as documented in the API docs