### PR TITLE
Handle response from prepare properly

### DIFF
--- a/client/go/cmd/deploy.go
+++ b/client/go/cmd/deploy.go
@@ -132,6 +132,7 @@ func newPrepareCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("could not write session id: %w", err)
 			}
 			cli.printSuccess("Prepared ", color.CyanString(pkg.Path), " with session ", result.ID)
+			printPrepareLog(cli.Stderr, result)
 			return nil
 		},
 	}

--- a/client/go/cmd/deploy_test.go
+++ b/client/go/cmd/deploy_test.go
@@ -121,7 +121,7 @@ func assertDeploy(applicationPackage string, arguments []string, t *testing.T) {
 func assertPrepare(applicationPackage string, arguments []string, t *testing.T) {
 	t.Helper()
 	client := &mock.HTTPClient{}
-	client.NextResponseString(200, `{"session-id":"42"}`)
+	client.NextResponseString(200, `{"session-id":"42","message":"Session 42 for tenant 'default' prepared.","log":[{"level":"WARNING","message":"Warning message 1","time": 1430134091319}]}`)
 	cli, stdout, _ := newTestCLI(t)
 	cli.httpClient = client
 	assert.Nil(t, cli.Run(arguments...))

--- a/client/go/cmd/deploy_test.go
+++ b/client/go/cmd/deploy_test.go
@@ -121,6 +121,7 @@ func assertDeploy(applicationPackage string, arguments []string, t *testing.T) {
 func assertPrepare(applicationPackage string, arguments []string, t *testing.T) {
 	t.Helper()
 	client := &mock.HTTPClient{}
+	client.NextResponseString(200, `{"session-id":"42"}`)
 	client.NextResponseString(200, `{"session-id":"42","message":"Session 42 for tenant 'default' prepared.","log":[{"level":"WARNING","message":"Warning message 1","time": 1430134091319}]}`)
 	cli, stdout, _ := newTestCLI(t)
 	cli.httpClient = client

--- a/client/go/vespa/deploy.go
+++ b/client/go/vespa/deploy.go
@@ -143,7 +143,23 @@ func Prepare(deployment DeploymentOptions) (PrepareResult, error) {
 	if err := checkResponse(req, response, serviceDescription); err != nil {
 		return PrepareResult{}, err
 	}
-	return result, nil
+	var jsonResponse struct {
+		SessionID string                   `json:"session-id"`
+		Log       []LogLinePrepareResponse `json:"log"`
+	}
+	jsonDec := json.NewDecoder(response.Body)
+	if err := jsonDec.Decode(&jsonResponse); err != nil {
+		return PrepareResult{}, err
+	}
+	var id int64
+	id, err = strconv.ParseInt(jsonResponse.SessionID, 10, 64)
+	if err != nil {
+		return PrepareResult{}, err
+	}
+	return PrepareResult{
+		ID:       id,
+		LogLines: jsonResponse.Log,
+	}, err
 }
 
 // Activate deployment with sessionID from a past prepare


### PR DESCRIPTION
Works as expected when testing this manually against a config server, but unit test fails with:

    deploy_test.go:17:
        	Error Trace:	deploy_test.go:127
        	            				deploy_test.go:17
        	Error:      	Expected nil, but got: &errors.errorString{s:"EOF"}
        	Test:       	TestPrepareZip
    deploy_test.go:17:
        	Error Trace:	deploy_test.go:128
        	            				deploy_test.go:17
        	Error:      	Not equal:
        	            	expected: "Success: Prepared testdata/applications/withTarget/target/application.zip with session 42\n"
        	            	actual  : ""

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,2 +1 @@
        	            	-Success: Prepared testdata/applications/withTarget/target/application.zip with session 42

        	Test:       	TestPrepareZip

@mpolden or @ean any idea what happens here? Looks like it fails with EOF when getting response from mock client? Not too familiar with Go and how the mock is connected to the tests, any help appreciated

