### PR TITLE
Not all proton trace children have traces

### DIFF
--- a/client/js/app/src/app/pages/querybuilder/TransformVespaTrace.jsx
+++ b/client/js/app/src/app/pages/querybuilder/TransformVespaTrace.jsx
@@ -128,6 +128,10 @@ function createProtonSpans(children, parentID) {
     [{ refType: 'CHILD_OF', traceID: traceID, spanID: parentID }]
   );
   data.push(newSpan);
+  // eslint-disable-next-line no-prototype-builtins
+  if (!child.hasOwnProperty('traces')) {
+    return;
+  }
   let traces = child['traces'];
   for (let k = 0; k < traces.length; k++) {
     let trace = traces[k];


### PR DESCRIPTION
E.g.
````
{
    timestamp: 61,
    message: [
        {
            start_time: "2022-08-19 13:52:13.930 UTC",
            distribution-key: 42,
            duration_ms: 0.213922
        }
    ]
},
````
