### PR TITLE
Let vespa_add_test ENVIRONMENT take multiple keywords in cmake_parse_arguments

### DIFF
--- a/functions.cmake
+++ b/functions.cmake
@@ -400,7 +400,7 @@ function(__is_command_a_script COMMAND RESULT_VAR)
 endfunction()
 
 function(vespa_add_test)
-    cmake_parse_arguments(ARG "NO_VALGRIND;RUN_SERIAL;BENCHMARK" "NAME;WORKING_DIRECTORY;ENVIRONMENT;COST" "COMMAND;DEPENDS" ${ARGN})
+    cmake_parse_arguments(ARG "NO_VALGRIND;RUN_SERIAL;BENCHMARK" "NAME;WORKING_DIRECTORY;COST" "COMMAND;DEPENDS;ENVIRONMENT" ${ARGN})
 
     if(NOT RUN_BENCHMARKS AND ARG_BENCHMARK)
         return()


### PR DESCRIPTION
@toregge please review

Move from `one_value_keywords` to `multi_value_keywords` arg.
