### PR TITLE
Support capability enforcement environment variable in C++ [run-systemtest]

### DIFF
--- a/fnet/src/tests/frt/rpc/CMakeLists.txt
+++ b/fnet/src/tests/frt/rpc/CMakeLists.txt
@@ -10,6 +10,12 @@ vespa_add_test(NAME fnet_invoke_test_app_xor COMMAND fnet_invoke_test_app ENVIRO
 vespa_add_test(NAME fnet_invoke_test_app_tls COMMAND fnet_invoke_test_app ENVIRONMENT "CRYPTOENGINE=tls")
 vespa_add_test(NAME fnet_invoke_test_app_tls_maybe_yes COMMAND fnet_invoke_test_app ENVIRONMENT "CRYPTOENGINE=tls_maybe_yes")
 vespa_add_test(NAME fnet_invoke_test_app_tls_maybe_no COMMAND fnet_invoke_test_app ENVIRONMENT "CRYPTOENGINE=tls_maybe_no")
+vespa_add_test(NAME fnet_invoke_test_app_tls_cap_enforced COMMAND fnet_invoke_test_app
+               ENVIRONMENT "CRYPTOENGINE=tls" "VESPA_TLS_CAPABILITIES_ENFORCEMENT_MODE=enforce")
+vespa_add_test(NAME fnet_invoke_test_app_tls_cap_log_only COMMAND fnet_invoke_test_app
+               ENVIRONMENT "CRYPTOENGINE=tls" "VESPA_TLS_CAPABILITIES_ENFORCEMENT_MODE=log_only")
+vespa_add_test(NAME fnet_invoke_test_app_tls_cap_disable COMMAND fnet_invoke_test_app
+               ENVIRONMENT "CRYPTOENGINE=tls" "VESPA_TLS_CAPABILITIES_ENFORCEMENT_MODE=disable")
 vespa_add_executable(fnet_detach_return_invoke_test_app TEST
     SOURCES
     detach_return_invoke.cpp

--- a/fnet/src/tests/frt/rpc/my_crypto_engine.hpp
+++ b/fnet/src/tests/frt/rpc/my_crypto_engine.hpp
@@ -17,14 +17,17 @@ vespalib::CryptoEngine::SP my_crypto_engine() {
         return std::make_shared<vespalib::XorCryptoEngine>();
     } else if (engine == "tls") {
         fprintf(stderr, "crypto engine: tls\n");
-        return std::make_shared<vespalib::TlsCryptoEngine>(vespalib::test::make_tls_options_for_testing());
+        return std::make_shared<vespalib::TlsCryptoEngine>(
+                vespalib::test::make_telemetry_only_capability_tls_options_for_testing());
     } else if (engine == "tls_maybe_yes") {
         fprintf(stderr, "crypto engine: tls client, mixed server\n");
-        auto tls = std::make_shared<vespalib::TlsCryptoEngine>(vespalib::test::make_tls_options_for_testing());
+        auto tls = std::make_shared<vespalib::TlsCryptoEngine>(
+                vespalib::test::make_telemetry_only_capability_tls_options_for_testing());
         return std::make_shared<vespalib::MaybeTlsCryptoEngine>(std::move(tls), true);
     } else if (engine == "tls_maybe_no") {
         fprintf(stderr, "crypto engine: null client, mixed server\n");
-        auto tls = std::make_shared<vespalib::TlsCryptoEngine>(vespalib::test::make_tls_options_for_testing());
+        auto tls = std::make_shared<vespalib::TlsCryptoEngine>(
+                vespalib::test::make_telemetry_only_capability_tls_options_for_testing());
         return std::make_shared<vespalib::MaybeTlsCryptoEngine>(std::move(tls), false);
     }
     TEST_FATAL(("invalid crypto engine: " + engine).c_str());

--- a/fnet/src/vespa/fnet/frt/require_capabilities.cpp
+++ b/fnet/src/vespa/fnet/frt/require_capabilities.cpp
@@ -4,6 +4,7 @@
 #include "rpcrequest.h"
 #include <vespa/fnet/connection.h>
 #include <vespa/vespalib/net/connection_auth_context.h>
+#include <vespa/vespalib/net/tls/capability_env_config.h>
 
 #include <vespa/log/bufferedlogger.h>
 LOG_SETUP(".fnet.frt.require_capabilities");
@@ -15,15 +16,22 @@ FRT_RequireCapabilities::allow(FRT_RPCRequest& req) const noexcept
 {
     const auto& auth_ctx = req.GetConnection()->auth_context();
     const bool is_authorized = auth_ctx.capabilities().contains_all(_required_capabilities);
-    if (!is_authorized) {
+    if (is_authorized) {
+        return true;
+    } else {
+        const auto mode = capability_enforcement_mode_from_env();
+        if (mode == CapabilityEnforcementMode::Disable) {
+            return true;
+        }
         auto peer_spec = req.GetConnection()->GetPeerSpec();
         std::string method_name(req.GetMethodName(), req.GetMethodNameLen());
-        LOGBT(warning, peer_spec, "Permission denied for RPC method '%s'. "
+        LOGBT(warning, peer_spec, "%sPermission denied for RPC method '%s'. "
                                   "Peer at %s with %s. Call requires %s, but peer has %s",
+              ((mode == CapabilityEnforcementMode::LogOnly) ? "(Dry-run only, not enforced): " : ""),
               method_name.c_str(), peer_spec.c_str(),
               to_string(auth_ctx.peer_credentials()).c_str(),
               _required_capabilities.to_string().c_str(),
               auth_ctx.capabilities().to_string().c_str());
+        return (mode == CapabilityEnforcementMode::Enforce) ? false : true;
     }
-    return is_authorized;
 }

--- a/fnet/src/vespa/fnet/frt/require_capabilities.cpp
+++ b/fnet/src/vespa/fnet/frt/require_capabilities.cpp
@@ -32,6 +32,6 @@ FRT_RequireCapabilities::allow(FRT_RPCRequest& req) const noexcept
               to_string(auth_ctx.peer_credentials()).c_str(),
               _required_capabilities.to_string().c_str(),
               auth_ctx.capabilities().to_string().c_str());
-        return (mode == CapabilityEnforcementMode::Enforce) ? false : true;
+        return (mode != CapabilityEnforcementMode::Enforce);
     }
 }

--- a/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/net/tls/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(vespalib_vespalib_net_tls OBJECT
     authorization_mode.cpp
     auto_reloading_tls_crypto_engine.cpp
     capability.cpp
+    capability_env_config.cpp
     capability_set.cpp
     crypto_codec.cpp
     crypto_codec_adapter.cpp

--- a/vespalib/src/vespa/vespalib/net/tls/capability_env_config.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/capability_env_config.cpp
@@ -1,0 +1,46 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "capability_env_config.h"
+#include <vespa/vespalib/stllike/string.h>
+#include <cstdlib>
+
+#include <vespa/log/log.h>
+LOG_SETUP(".vespalib.net.tls.capability_env_config");
+
+namespace vespalib::net::tls {
+
+namespace {
+
+CapabilityEnforcementMode parse_enforcement_mode_from_env() noexcept {
+    const char* env = getenv("VESPA_TLS_CAPABILITIES_ENFORCEMENT_MODE");
+    vespalib::string mode = env ? env : "";
+    if (mode == "enforce") {
+        return CapabilityEnforcementMode::Enforce;
+    } else if (mode == "log_only") {
+        return CapabilityEnforcementMode::LogOnly;
+    } else if (mode == "disable") {
+        return CapabilityEnforcementMode::Disable;
+    } else if (!mode.empty()) {
+        LOG(warning, "VESPA_TLS_CAPABILITIES_ENFORCEMENT_MODE environment variable has "
+                     "an unsupported value (%s). Falling back to 'enforce'", mode.c_str());
+    }
+    return CapabilityEnforcementMode::Enforce;
+}
+
+}
+
+const char* to_string(CapabilityEnforcementMode mode) noexcept {
+    switch (mode) {
+    case CapabilityEnforcementMode::Enforce: return "Enforce";
+    case CapabilityEnforcementMode::LogOnly: return "LogOnly";
+    case CapabilityEnforcementMode::Disable: return "Disable";
+    default: abort();
+    }
+}
+
+CapabilityEnforcementMode capability_enforcement_mode_from_env() noexcept {
+    static const CapabilityEnforcementMode mode = parse_enforcement_mode_from_env();
+    return mode;
+}
+
+}

--- a/vespalib/src/vespa/vespalib/net/tls/capability_env_config.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/capability_env_config.cpp
@@ -34,8 +34,8 @@ const char* to_string(CapabilityEnforcementMode mode) noexcept {
     case CapabilityEnforcementMode::Enforce: return "Enforce";
     case CapabilityEnforcementMode::LogOnly: return "LogOnly";
     case CapabilityEnforcementMode::Disable: return "Disable";
-    default: abort();
     }
+    abort();
 }
 
 CapabilityEnforcementMode capability_enforcement_mode_from_env() noexcept {

--- a/vespalib/src/vespa/vespalib/net/tls/capability_env_config.h
+++ b/vespalib/src/vespa/vespalib/net/tls/capability_env_config.h
@@ -1,0 +1,16 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+namespace vespalib::net::tls {
+
+enum class CapabilityEnforcementMode {
+    Disable,
+    LogOnly,
+    Enforce
+};
+
+const char* to_string(CapabilityEnforcementMode mode) noexcept;
+
+CapabilityEnforcementMode capability_enforcement_mode_from_env() noexcept;
+
+}

--- a/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.cpp
@@ -5,6 +5,7 @@
 #include "tls_crypto_socket.h"
 #include "protocol_snooping.h"
 #include <vespa/vespalib/data/smart_buffer.h>
+#include <vespa/vespalib/net/connection_auth_context.h>
 #include <vespa/vespalib/util/size_literals.h>
 
 namespace vespalib {
@@ -92,6 +93,10 @@ public:
 MaybeTlsCryptoSocket::MaybeTlsCryptoSocket(SocketHandle socket, std::shared_ptr<AbstractTlsCryptoEngine> tls_engine)
     : _socket(std::make_unique<MyCryptoSocket>(_socket, std::move(socket), std::move(tls_engine)))
 {
+}
+
+std::unique_ptr<net::ConnectionAuthContext> MaybeTlsCryptoSocket::make_auth_context() {
+    return _socket->make_auth_context();
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.h
+++ b/vespalib/src/vespa/vespalib/net/tls/maybe_tls_crypto_socket.h
@@ -33,6 +33,7 @@ public:
     ssize_t flush() override { return _socket->flush(); }
     ssize_t half_close() override { return _socket->half_close(); }
     void drop_empty_buffers() override { _socket->drop_empty_buffers(); }
+    std::unique_ptr<net::ConnectionAuthContext> make_auth_context() override;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options.cpp
@@ -29,6 +29,15 @@ TransportSecurityOptions::TransportSecurityOptions(vespalib::string ca_certs_pem
 {
 }
 
+TransportSecurityOptions::TransportSecurityOptions(const TransportSecurityOptions&) = default;
+TransportSecurityOptions& TransportSecurityOptions::operator=(const TransportSecurityOptions&) = default;
+TransportSecurityOptions::TransportSecurityOptions(TransportSecurityOptions&&) noexcept = default;
+TransportSecurityOptions& TransportSecurityOptions::operator=(TransportSecurityOptions&&) noexcept = default;
+
+TransportSecurityOptions::~TransportSecurityOptions() {
+    secure_memzero(&_private_key_pem[0], _private_key_pem.size());
+}
+
 TransportSecurityOptions TransportSecurityOptions::copy_without_private_key() const {
     return TransportSecurityOptions(_ca_certs_pem, _cert_chain_pem, "",
                                     _authorized_peers, _disable_hostname_validation);
@@ -61,9 +70,5 @@ TransportSecurityOptions::Params::Params(Params&&) noexcept = default;
 
 TransportSecurityOptions::Params&
 TransportSecurityOptions::Params::operator=(TransportSecurityOptions::Params&&) noexcept = default;
-
-TransportSecurityOptions::~TransportSecurityOptions() {
-    secure_memzero(&_private_key_pem[0], _private_key_pem.size());
-}
 
 } // vespalib::net::tls

--- a/vespalib/src/vespa/vespalib/net/tls/transport_security_options.h
+++ b/vespalib/src/vespa/vespalib/net/tls/transport_security_options.h
@@ -46,6 +46,10 @@ public:
     };
 
     explicit TransportSecurityOptions(Params params);
+    TransportSecurityOptions(const TransportSecurityOptions&);
+    TransportSecurityOptions& operator=(const TransportSecurityOptions&);
+    TransportSecurityOptions(TransportSecurityOptions&&) noexcept;
+    TransportSecurityOptions& operator=(TransportSecurityOptions&&) noexcept;
 
     ~TransportSecurityOptions();
 

--- a/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.cpp
+++ b/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.cpp
@@ -1,17 +1,20 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "make_tls_options_for_testing.h"
+#include "peer_policy_utils.h"
 #include <vespa/vespalib/crypto/private_key.h>
 #include <vespa/vespalib/crypto/x509_certificate.h>
 
 namespace {
 
 using namespace vespalib::crypto;
+using namespace vespalib::net::tls;
 
 struct TransientCryptoCredentials {
     CertKeyWrapper root_ca;
     CertKeyWrapper host_creds;
     vespalib::net::tls::TransportSecurityOptions cached_transport_options;
+    vespalib::net::tls::TransportSecurityOptions cached_constrained_transport_options;
 
     TransientCryptoCredentials();
     ~TransientCryptoCredentials();
@@ -29,14 +32,16 @@ struct TransientCryptoCredentials {
         return {std::move(cert), std::move(key)};
     }
 
-    static CertKeyWrapper make_host_creds(const CertKeyWrapper& root_ca_creds) {
+    static CertKeyWrapper make_host_creds(const CertKeyWrapper& root_ca_creds,
+                                          const vespalib::string& extra_san_entry) {
         auto dn = X509Certificate::DistinguishedName()
                 .country("US").state("CA").locality("Sunnyvale")
                 .organization("Wile E. Coyote, Ltd.")
                 .organizational_unit("Unit Testing and Anvil Dropping Division")
                 .add_common_name("localhost"); // Should technically not be needed, but including it anyway.
         auto subject = X509Certificate::SubjectInfo(std::move(dn));
-        subject.add_subject_alt_name("DNS:localhost");
+        subject.add_subject_alt_name("DNS:localhost")
+               .add_subject_alt_name(extra_san_entry);
         auto key = PrivateKey::generate_p256_ec_key();
         auto params = X509Certificate::Params::issued_by(std::move(subject), key, root_ca_creds.cert, root_ca_creds.key);
         params.valid_for = std::chrono::hours(1);
@@ -49,12 +54,18 @@ struct TransientCryptoCredentials {
 
 TransientCryptoCredentials::TransientCryptoCredentials()
     : root_ca(make_root_ca()),
-      host_creds(make_host_creds(root_ca)),
+      host_creds(make_host_creds(root_ca, "DNS:anvils.example")),
       cached_transport_options(vespalib::net::tls::TransportSecurityOptions::Params().
             ca_certs_pem(root_ca.cert->to_pem()).
             cert_chain_pem(host_creds.cert->to_pem()).
             private_key_pem(host_creds.key->private_to_pem()).
-            authorized_peers(vespalib::net::tls::AuthorizedPeers::allow_all_authenticated()))
+            authorized_peers(vespalib::net::tls::AuthorizedPeers::allow_all_authenticated())),
+      cached_constrained_transport_options(vespalib::net::tls::TransportSecurityOptions::Params().
+            ca_certs_pem(root_ca.cert->to_pem()).
+            cert_chain_pem(host_creds.cert->to_pem()).
+            private_key_pem(host_creds.key->private_to_pem()).
+            authorized_peers(authorized_peers({policy_with({required_san_dns("anvils.example")},
+                                                           CapabilitySet::telemetry())})))
 {}
 
 TransientCryptoCredentials::~TransientCryptoCredentials() = default;
@@ -72,6 +83,10 @@ SocketSpec local_spec("tcp/localhost:123");
 
 vespalib::net::tls::TransportSecurityOptions make_tls_options_for_testing() {
     return TransientCryptoCredentials::instance().cached_transport_options;
+}
+
+vespalib::net::tls::TransportSecurityOptions make_telemetry_only_capability_tls_options_for_testing() {
+    return TransientCryptoCredentials::instance().cached_constrained_transport_options;
 }
 
 } // namespace vespalib::test

--- a/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.h
+++ b/vespalib/src/vespa/vespalib/test/make_tls_options_for_testing.h
@@ -20,4 +20,12 @@ extern SocketSpec local_spec;
  **/
 vespalib::net::tls::TransportSecurityOptions make_tls_options_for_testing();
 
+/**
+ * Make security options whose authz rules only grant the telemetry capability
+ * set to the included certificate.
+ *
+ * Only useful for testing capability propagation and filtering.
+ */
+vespalib::net::tls::TransportSecurityOptions make_telemetry_only_capability_tls_options_for_testing();
+
 } // namespace vespalib::test


### PR DESCRIPTION
@havardpe @bjorncs please review

Mirrors Java enforce/log-only/disable semantics, defaulting to enforce.

Also fixes an issue where connection auth context and capabilities
would not be set if a server socket was running in mixed-mode. This
is not a problem in practice since mixed-mode is inherently completely
insecure since it must accept plain-text clients, which implicitly
have all capabilities granted.
