### PR TITLE
Fix release day and add system-dependent cooldown

### DIFF
--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
@@ -104,8 +104,8 @@
       "targetVersion": true,
       "upgradeBudget": "PT24H",
       "scheduledAt": 1234,
-      "nextVersion": "8.2.1.20211227",
-      "nextScheduledAt": 7200000,
+      "nextVersion": "8.2.1.20211228",
+      "nextScheduledAt": 1640743200000,
       "cloud": "cloud2",
       "nodes": [
         {


### PR DESCRIPTION
This will ensure that we schedule a precise version instead of a lower bound,
and that upgrades to the next release always happens in CD systems earlier than
public/main.

@jonmv