### PR TITLE
Add 'paged' support for reference attribute fields.

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/processing/PagedAttributeValidator.java
+++ b/config-model/src/main/java/com/yahoo/schema/processing/PagedAttributeValidator.java
@@ -48,7 +48,6 @@ public class PagedAttributeValidator extends Processor {
     private boolean isSupportedType(Attribute attribute) {
         var type = attribute.getType();
         return (type != Attribute.Type.PREDICATE) &&
-                (type != Attribute.Type.REFERENCE) &&
                 (isSupportedTensorType(attribute.tensorType()));
     }
 

--- a/config-model/src/test/java/com/yahoo/schema/processing/PagedAttributeValidatorTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/PagedAttributeValidatorTestCase.java
@@ -59,8 +59,14 @@ public class PagedAttributeValidatorTestCase {
     }
 
     private void assertPagedSupported(String fieldType) throws ParseException {
-        var appBuilder = createFromString(getSd(fieldType));
-        var attribute = appBuilder.getSchema().getAttribute("foo");
+        assertPagedSupported(fieldType, Optional.empty());
+    }
+
+    private void assertPagedSupported(String fieldType, Optional<String> parentSd) throws ParseException {
+        var appBuilder = parentSd.isPresent() ?
+                createFromStrings(new BaseDeployLogger(), parentSd.get(), getSd(fieldType)) :
+                createFromString(getSd(fieldType));
+        var attribute = appBuilder.getSchema("test").getAttribute("foo");
         assertTrue(attribute.isPaged());
     }
 
@@ -75,8 +81,8 @@ public class PagedAttributeValidatorTestCase {
     }
 
     @Test
-    void reference_attribute_does_not_support_paged_setting() throws ParseException {
-        assertPagedSettingNotSupported("reference<parent>", Optional.of(getSd("parent", "int")));
+    void reference_attribute_support_paged_setting() throws ParseException {
+        assertPagedSupported("reference<parent>", Optional.of(getSd("parent", "int")));
     }
 
     private void assertPagedSettingNotSupported(String fieldType) throws ParseException {

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -61,7 +61,7 @@ allow_paged(const search::attribute::Config& config)
         return false;
     }
     using Type = search::attribute::BasicType::Type;
-    if (config.basicType() == Type::REFERENCE || config.basicType() == Type::PREDICATE) {
+    if (config.basicType() == Type::PREDICATE) {
         return false;
     }
     if (config.basicType() == Type::TENSOR) {

--- a/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_attribute.cpp
@@ -46,11 +46,11 @@ ReferenceAttribute::ReferenceAttribute(const vespalib::stringref baseFileName)
 
 ReferenceAttribute::ReferenceAttribute(const vespalib::stringref baseFileName, const Config & cfg)
     : NotImplementedAttribute(baseFileName, cfg),
-      _store({}),
-      _indices(cfg.getGrowStrategy(), getGenerationHolder()),
+      _store(get_memory_allocator()),
+      _indices(cfg.getGrowStrategy(), getGenerationHolder(), get_initial_alloc()),
       _compaction_spec(),
       _gidToLidMapperFactory(),
-      _referenceMappings(getGenerationHolder(), getCommittedDocIdLimitRef())
+      _referenceMappings(getGenerationHolder(), getCommittedDocIdLimitRef(), get_initial_alloc())
 {
     setEnum(true);
 }

--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.cpp
@@ -8,11 +8,13 @@
 
 namespace search::attribute {
 
-ReferenceMappings::ReferenceMappings(GenerationHolder &genHolder, const std::atomic<uint32_t>& committedDocIdLimit)
-    : _reverseMappingIndices(vespalib::GrowStrategy(16, 1.0, 0, 0), genHolder),
+ReferenceMappings::ReferenceMappings(GenerationHolder& genHolder,
+                                     const std::atomic<uint32_t>& committedDocIdLimit,
+                                     const vespalib::alloc::Alloc& initial_alloc)
+    : _reverseMappingIndices(vespalib::GrowStrategy(16, 1.0, 0, 0), genHolder, initial_alloc),
       _targetLidLimit(0),
       _reverseMapping(),
-      _targetLids(vespalib::GrowStrategy(16, 1.0, 0, 0), genHolder),
+      _targetLids(vespalib::GrowStrategy(16, 1.0, 0, 0), genHolder, initial_alloc),
       _committedDocIdLimit(committedDocIdLimit)
 {
 }

--- a/searchlib/src/vespa/searchlib/attribute/reference_mappings.h
+++ b/searchlib/src/vespa/searchlib/attribute/reference_mappings.h
@@ -49,7 +49,8 @@ public:
     // Class used to map from target lid to source lids
     using ReverseMappingRefs = vespalib::ConstArrayRef<AtomicEntryRef>;
 
-    ReferenceMappings(GenerationHolder &genHolder, const std::atomic<uint32_t>& committedDocIdLimit);
+    ReferenceMappings(GenerationHolder &genHolder, const std::atomic<uint32_t>& committedDocIdLimit,
+                      const vespalib::alloc::Alloc& initial_alloc);
 
     ~ReferenceMappings();
 


### PR DESCRIPTION
The memory usage (in bytes) of a reference attribute can be calculated as follows:
num_child_docs * 8 + num_parent_docs * 24 + num_child_docs_where_parent_reference_is_set * 4.

When using 'paged' the btrees used in the reverse mapping from parent lid to child lids are still memory allocated.
This is the num_child_docs_where_parent_reference_is_set part of the equation above.

@toregge please review
