### PR TITLE
Add capabilities and RPC filters for sentinel and internal Proton APIs [run-systemtest]

### DIFF
--- a/vespalib/src/tests/net/tls/capabilities/capabilities_test.cpp
+++ b/vespalib/src/tests/net/tls/capabilities/capabilities_test.cpp
@@ -38,12 +38,14 @@ TEST("CapabilitySet instances are equality comparable") {
 }
 
 TEST("Can get underlying name of all Capability instances") {
-    EXPECT_EQUAL(Capability::content_storage_api().name(),  "vespa.content.storage_api"sv);
-    EXPECT_EQUAL(Capability::content_document_api().name(), "vespa.content.document_api"sv);
-    EXPECT_EQUAL(Capability::content_search_api().name(),   "vespa.content.search_api"sv);
-    EXPECT_EQUAL(Capability::slobrok_api().name(),          "vespa.slobrok.api"sv);
-    EXPECT_EQUAL(Capability::content_status_pages().name(), "vespa.content.status_pages"sv);
-    EXPECT_EQUAL(Capability::content_metrics_api().name(),  "vespa.content.metrics_api"sv);
+    EXPECT_EQUAL(Capability::content_storage_api().name(),      "vespa.content.storage_api"sv);
+    EXPECT_EQUAL(Capability::content_document_api().name(),     "vespa.content.document_api"sv);
+    EXPECT_EQUAL(Capability::content_search_api().name(),       "vespa.content.search_api"sv);
+    EXPECT_EQUAL(Capability::content_proton_admin_api().name(), "vespa.content.proton_admin_api"sv);
+    EXPECT_EQUAL(Capability::slobrok_api().name(),              "vespa.slobrok.api"sv);
+    EXPECT_EQUAL(Capability::config_sentinel_api().name(),      "vespa.config.sentinel_api"sv);
+    EXPECT_EQUAL(Capability::content_status_pages().name(),     "vespa.content.status_pages"sv);
+    EXPECT_EQUAL(Capability::content_metrics_api().name(),      "vespa.content.metrics_api"sv);
     EXPECT_EQUAL(Capability::content_cluster_controller_internal_state_api().name(),
                  "vespa.content.cluster_controller.internal_state_api"sv);
 }
@@ -69,12 +71,14 @@ void check_capability_set_mapping(const std::string& name, CapabilitySet expecte
 }
 
 TEST("All known capabilities can be looked up by name") {
-    check_capability_mapping("vespa.content.storage_api",  Capability::content_storage_api());
-    check_capability_mapping("vespa.content.document_api", Capability::content_document_api());
-    check_capability_mapping("vespa.content.search_api",   Capability::content_search_api());
-    check_capability_mapping("vespa.slobrok.api",          Capability::slobrok_api());
-    check_capability_mapping("vespa.content.status_pages", Capability::content_status_pages());
-    check_capability_mapping("vespa.content.metrics_api",  Capability::content_metrics_api());
+    check_capability_mapping("vespa.content.storage_api",      Capability::content_storage_api());
+    check_capability_mapping("vespa.content.document_api",     Capability::content_document_api());
+    check_capability_mapping("vespa.content.search_api",       Capability::content_search_api());
+    check_capability_mapping("vespa.content.proton_admin_api", Capability::content_proton_admin_api());
+    check_capability_mapping("vespa.slobrok.api",              Capability::slobrok_api());
+    check_capability_mapping("vespa.config.sentinel_api",      Capability::config_sentinel_api());
+    check_capability_mapping("vespa.content.status_pages",     Capability::content_status_pages());
+    check_capability_mapping("vespa.content.metrics_api",      Capability::content_metrics_api());
     check_capability_mapping("vespa.content.cluster_controller.internal_state_api",
                              Capability::content_cluster_controller_internal_state_api());
 }

--- a/vespalib/src/vespa/vespalib/net/tls/capability.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/capability.cpp
@@ -16,8 +16,10 @@ constexpr std::array<std::string_view, Capability::max_value_count()> capability
     "vespa.content.storage_api"sv,
     "vespa.content.document_api"sv,
     "vespa.content.search_api"sv,
+    "vespa.content.proton_admin_api"sv,
     "vespa.content.cluster_controller.internal_state_api"sv,
     "vespa.slobrok.api"sv,
+    "vespa.config.sentinel_api"sv,
     "vespa.content.status_pages"sv,
     "vespa.content.metrics_api"sv,
 };
@@ -40,8 +42,10 @@ std::optional<Capability> Capability::find_capability(const string& cap_name) no
         {"vespa.content.storage_api",                           content_storage_api()},
         {"vespa.content.document_api",                          content_document_api()},
         {"vespa.content.search_api",                            content_search_api()},
+        {"vespa.content.proton_admin_api",                      content_proton_admin_api()},
         {"vespa.content.cluster_controller.internal_state_api", content_cluster_controller_internal_state_api()},
         {"vespa.slobrok.api",                                   slobrok_api()},
+        {"vespa.config.sentinel_api",                           config_sentinel_api()},
         {"vespa.content.status_pages",                          content_status_pages()},
         {"vespa.content.metrics_api",                           content_metrics_api()},
     });

--- a/vespalib/src/vespa/vespalib/net/tls/capability.h
+++ b/vespalib/src/vespa/vespalib/net/tls/capability.h
@@ -23,12 +23,15 @@ private:
     // Each ID value corresponds to a unique single-bit position.
     // These values shall never be exposed outside the running process, i.e. they
     // must be possible to change arbitrarily internally across versions.
+    // Changes must be reflected in capabilities_test.cpp
     enum class Id : uint32_t {
         ContentStorageApi = 0, // Must start at zero
         ContentDocumentApi,
         ContentSearchApi,
+        ContentProtonAdminApi,
         ContentClusterControllerInternalStateApi,
         SlobrokApi,
+        ConfigSentinelApi,
         ContentStatusPages,
         ContentMetricsApi,
         // When adding a capability ID to the end, max_value_count() MUST be updated
@@ -80,12 +83,20 @@ public:
         return Capability(Id::ContentSearchApi);
     }
 
+    constexpr static Capability content_proton_admin_api() noexcept {
+        return Capability(Id::ContentProtonAdminApi);
+    }
+
     constexpr static Capability content_cluster_controller_internal_state_api() noexcept {
         return Capability(Id::ContentClusterControllerInternalStateApi);
     }
 
     constexpr static Capability slobrok_api() noexcept {
         return Capability(Id::SlobrokApi);
+    }
+
+    constexpr static Capability config_sentinel_api() noexcept {
+        return Capability(Id::ConfigSentinelApi);
     }
 
     constexpr static Capability content_status_pages() noexcept {


### PR DESCRIPTION
@havardpe please review
@bjorncs FYI. Note that this brings C++ and Java capability definitions out of sync. This is fine for now; we need to do a second pass of all capabilities and reconcile these anyway.
