### PR TITLE
Add capability filtering for content layer status pages and metrics [run-systemtest]

### DIFF
--- a/fnet/src/vespa/fnet/frt/require_capabilities.cpp
+++ b/fnet/src/vespa/fnet/frt/require_capabilities.cpp
@@ -29,7 +29,7 @@ FRT_RequireCapabilities::allow(FRT_RPCRequest& req) const noexcept
                                   "Peer at %s with %s. Call requires %s, but peer has %s",
               ((mode == CapabilityEnforcementMode::LogOnly) ? "(Dry-run only, not enforced): " : ""),
               method_name.c_str(), peer_spec.c_str(),
-              to_string(auth_ctx.peer_credentials()).c_str(),
+              auth_ctx.peer_credentials().to_string().c_str(),
               _required_capabilities.to_string().c_str(),
               auth_ctx.capabilities().to_string().c_str());
         return (mode != CapabilityEnforcementMode::Enforce);

--- a/storage/src/vespa/storage/common/statusmetricconsumer.h
+++ b/storage/src/vespa/storage/common/statusmetricconsumer.h
@@ -34,6 +34,10 @@ public:
             const std::string& name = "status");
     ~StatusMetricConsumer() override;
 
+    // Metric reporting requires the "vespa.content.metrics_api" capability
+    CapabilitySet required_capabilities() const noexcept override {
+        return CapabilitySet::of({ Capability::content_metrics_api() });
+    }
     vespalib::string getReportContentType(const framework::HttpUrlPath&) const override;
     bool reportStatus(std::ostream& out, const framework::HttpUrlPath&) const override;
     void updateMetrics(const MetricLockGuard & guard) override;

--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -184,7 +184,7 @@ StatusWebServer::handlePage(const framework::HttpUrlPath& urlpath, vespalib::Por
                 // TODO should print peer address as well; not currently exposed
                 LOG(warning, "Peer with %s denied status page access to '%s' due to insufficient "
                              "credentials (had %s, needed %s)",
-                    vespalib::net::tls::to_string(auth_ctx.peer_credentials()).c_str(),
+                    auth_ctx.peer_credentials().to_string().c_str(),
                     link.c_str(), auth_ctx.capabilities().to_string().c_str(),
                     reporter->required_capabilities().to_string().c_str());
                 request.respond_with_error(403, "Forbidden");

--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.h
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.h
@@ -24,6 +24,7 @@ namespace config {
 namespace storage {
 
 namespace framework {
+    struct StatusReporter;
     struct StatusReporterMap;
     struct ThreadHandle;
     struct ComponentRegister;
@@ -35,10 +36,10 @@ namespace framework {
 class StatusWebServer : private config::IFetcherCallback<vespa::config::content::core::StorStatusConfig>
 {
     class WebServer : public vespalib::Portal::GetHandler {
-        StatusWebServer& _status;
-        vespalib::Portal::SP _server;
+        StatusWebServer&              _status;
+        vespalib::Portal::SP          _server;
         vespalib::ThreadStackExecutor _executor;
-        vespalib::Portal::Token::UP _root;
+        vespalib::Portal::Token::UP   _root;
 
     public:
         WebServer(StatusWebServer&, uint16_t port);
@@ -81,6 +82,9 @@ public:
     int getListenPort() const;
     void handlePage(const framework::HttpUrlPath&, vespalib::Portal::GetRequest request);
 private:
+    void invoke_reporter(const framework::StatusReporter&,
+                         const framework::HttpUrlPath&,
+                         vespalib::Portal::GetRequest&);
     void configure(std::unique_ptr<vespa::config::content::core::StorStatusConfig> config) override;
 };
 

--- a/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
+++ b/vespalib/src/tests/net/tls/openssl_impl/openssl_impl_test.cpp
@@ -622,8 +622,8 @@ TEST_F("Peer credentials are propagated to CryptoCodec", CertFixture) {
     auto& client_creds = f.server->peer_credentials();
     auto& server_creds = f.client->peer_credentials();
 
-    fprintf(stderr, "Client credentials (observed by server): %s\n", to_string(client_creds).c_str());
-    fprintf(stderr, "Server credentials (observed by client): %s\n", to_string(server_creds).c_str());
+    fprintf(stderr, "Client credentials (observed by server): %s\n", client_creds.to_string().c_str());
+    fprintf(stderr, "Server credentials (observed by client): %s\n", server_creds.to_string().c_str());
 
     EXPECT_EQUAL("rockets.wile.example.com", client_creds.common_name);
     ASSERT_EQUAL(2u, client_creds.dns_sans.size());

--- a/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/impl/openssl_tls_context_impl.cpp
@@ -482,7 +482,7 @@ bool OpenSslTlsContextImpl::verify_trusted_certificate(::X509_STORE_CTX* store_c
             // Buffer warnings on peer IP address to avoid log flooding.
             LOGBT(warning, codec_impl.peer_address().ip_address(),
                   "Certificate verification of peer '%s' failed with %s",
-                  codec_impl.peer_address().spec().c_str(), to_string(creds).c_str());
+                  codec_impl.peer_address().spec().c_str(), creds.to_string().c_str());
             return (authz_mode != AuthorizationMode::Enforce);
         }
         // Store away credentials and role set for later use by requests that arrive over this connection.

--- a/vespalib/src/vespa/vespalib/net/tls/peer_credentials.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_credentials.cpp
@@ -14,7 +14,7 @@ PeerCredentials& PeerCredentials::operator=(PeerCredentials&&) noexcept = defaul
 PeerCredentials::~PeerCredentials() = default;
 
 std::ostream& operator<<(std::ostream& os, const PeerCredentials& creds) {
-    os << to_string(creds);
+    os << creds.to_string();
     return os;
 }
 
@@ -36,20 +36,20 @@ void emit_comma_separated_string_list(asciistream& os, stringref title,
 }
 }
 
-vespalib::string to_string(const PeerCredentials& creds) {
+vespalib::string PeerCredentials::to_string() const {
     asciistream os;
     os << "PeerCredentials(";
     bool emit_comma = false;
-    if (!creds.common_name.empty()) {
-        os << "CN '" << creds.common_name << "'";
+    if (!common_name.empty()) {
+        os << "CN '" << common_name << "'";
         emit_comma = true;
     }
-    if (!creds.dns_sans.empty()) {
-        emit_comma_separated_string_list(os, "DNS SANs", creds.dns_sans, emit_comma);
+    if (!dns_sans.empty()) {
+        emit_comma_separated_string_list(os, "DNS SANs", dns_sans, emit_comma);
         emit_comma = true;
     }
-    if (!creds.uri_sans.empty()) {
-        emit_comma_separated_string_list(os, "URI SANs", creds.uri_sans, emit_comma);
+    if (!uri_sans.empty()) {
+        emit_comma_separated_string_list(os, "URI SANs", uri_sans, emit_comma);
     }
     os << ')';
     return os.str();

--- a/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
+++ b/vespalib/src/vespa/vespalib/net/tls/peer_credentials.h
@@ -23,10 +23,10 @@ struct PeerCredentials {
     PeerCredentials(PeerCredentials&&) noexcept;
     PeerCredentials& operator=(PeerCredentials&&) noexcept;
     ~PeerCredentials();
+
+    vespalib::string to_string() const;
 };
 
 std::ostream& operator<<(std::ostream&, const PeerCredentials&);
-
-vespalib::string to_string(const PeerCredentials&);
 
 }


### PR DESCRIPTION
@havardpe please review
@bjorncs FYI

This currently only applies to the port exposed for the content node
or distributor specific status pages and metrics export, _not_ state V1.
