### PR TITLE
Add * to valid jvm pattern for debug address, self-hosted

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1037,7 +1037,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
      */
      private static class JvmOptions {
 
-        private static final Pattern validPattern = Pattern.compile("-[a-zA-z0-9=:./,+-]+");
+        private static final Pattern validPattern = Pattern.compile("-[a-zA-z0-9=:./,+-*]+");
         // debug port will not be available in hosted, don't allow
         private static final Pattern invalidInHostedatttern = Pattern.compile("-Xrunjdwp:transport=.*");
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -1037,7 +1037,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
      */
      private static class JvmOptions {
 
-        private static final Pattern validPattern = Pattern.compile("-[a-zA-z0-9=:./,+-*]+");
+        private static final Pattern validPattern = Pattern.compile("-[a-zA-z0-9=:./,+*-]+");
         // debug port will not be available in hosted, don't allow
         private static final Pattern invalidInHostedatttern = Pattern.compile("-Xrunjdwp:transport=.*");
 


### PR DESCRIPTION
- I am quite sure * inside [] is a literal match, not a quantifier, so no escaping
- did not yet run all unit tests, can hold merge for now

When deploying, I get
```
Success: Deployed target/application.zip
WARNING Invalid or misplaced JVM options in services.xml: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005. See https://docs.vespa.ai/en/reference/services-container.html#jvm
```

but deployment succeeds, and I am able to debug, so it is OK self-hosted - but I think it is better without the warning unless this has side-effects