### PR TITLE
Change matched elements filter docsum field writer to insert an empty

### DIFF
--- a/searchsummary/src/tests/docsummary/matched_elements_filter/matched_elements_filter_test.cpp
+++ b/searchsummary/src/tests/docsummary/matched_elements_filter/matched_elements_filter_test.cpp
@@ -257,9 +257,9 @@ TEST_F(MatchedElementsFilterTest, filters_elements_in_array_field_value)
                                         "{'name':'c','weight':7}]");
     expect_filtered("array", {0, 1, 100}, "[]");
     set_empty_values();
-    expect_filtered("array", {}, "[]");
+    expect_filtered("array", {}, "null");
     set_skip_set_values();
-    expect_filtered("array", {}, "[]");
+    expect_filtered("array", {}, "null");
 }
 
 TEST_F(MatchedElementsFilterTest, matching_elements_fields_is_setup_for_array_field_value)
@@ -281,9 +281,9 @@ TEST_F(MatchedElementsFilterTest, filters_elements_in_map_field_value)
                                       "{'key':'c','value':{'name':'c','weight':7}}]");
     expect_filtered("map", {0, 1, 100}, "[]");
     set_empty_values();
-    expect_filtered("map", {}, "[]");
+    expect_filtered("map", {}, "null");
     set_skip_set_values();
-    expect_filtered("map", {}, "[]");
+    expect_filtered("map", {}, "null");
 }
 
 TEST_F(MatchedElementsFilterTest, filter_elements_in_weighed_set_field_value)
@@ -295,9 +295,9 @@ TEST_F(MatchedElementsFilterTest, filter_elements_in_weighed_set_field_value)
     expect_filtered("wset", {0, 1, 2}, "[{'item':'a','weight':13},{'item':'b','weight':15},{'item':'c','weight':17}]");
     expect_filtered("wset", {0, 1, 100}, "[]");
     set_empty_values();
-    expect_filtered("wset", {}, "[]");
+    expect_filtered("wset", {}, "null");
     set_skip_set_values();
-    expect_filtered("wset", {}, "[]");
+    expect_filtered("wset", {}, "null");
 }
 
 TEST_F(MatchedElementsFilterTest, matching_elements_fields_is_setup_for_map_field_value)

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
@@ -77,7 +77,6 @@ filter_matching_elements_in_input_field_while_converting_to_slime(const FieldVal
     auto& literal = static_cast<const LiteralFieldValueB&>(*converted);
     vespalib::stringref buf = literal.getValueRef();
     if (buf.empty()) {
-        target.insertArray(0);
         return;
     }
     Slime input_field_as_slime;
@@ -95,8 +94,6 @@ MatchedElementsFilterDFW::insertField(uint32_t docid, const IDocsumStoreDocument
     auto field_value = doc->get_field_value(_input_field_name);
     if (field_value) {
         filter_matching_elements_in_input_field_while_converting_to_slime(*field_value, get_matching_elements(docid, *state), target);
-    } else {
-        target.insertArray(0);
     }
 }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
@@ -76,6 +76,10 @@ filter_matching_elements_in_input_field_while_converting_to_slime(const FieldVal
     assert(converted->isLiteral());
     auto& literal = static_cast<const LiteralFieldValueB&>(*converted);
     vespalib::stringref buf = literal.getValueRef();
+    if (buf.empty()) {
+        target.insertArray(0);
+        return;
+    }
     Slime input_field_as_slime;
     BinaryFormat::decode(vespalib::Memory(buf.data(), buf.size()), input_field_as_slime);
     inject(input_field_as_slime.get(), target);
@@ -91,6 +95,8 @@ MatchedElementsFilterDFW::insertField(uint32_t docid, const IDocsumStoreDocument
     auto field_value = doc->get_field_value(_input_field_name);
     if (field_value) {
         filter_matching_elements_in_input_field_while_converting_to_slime(*field_value, get_matching_elements(docid, *state), target);
+    } else {
+        target.insertArray(0);
     }
 }
 


### PR DESCRIPTION
array if input field is empty or not set. This was the old behavior
when jsonstring entries were stored in docsum blobs.

@geirst : please review
@baldersheim : FYI
