### PR TITLE
- Use c++11 for loops

### DIFF
--- a/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
+++ b/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
@@ -3,8 +3,11 @@
 #include <vespa/searchcore/proton/matching/match_phase_limiter.h>
 #include <vespa/searchlib/queryeval/termasstring.h>
 #include <vespa/searchlib/queryeval/andsearchstrict.h>
+#include <vespa/searchlib/queryeval/searchable.h>
 #include <vespa/searchlib/queryeval/fake_requestcontext.h>
+#include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
 #include <vespa/searchlib/engine/trace.h>
 #include <vespa/vespalib/data/slime/slime.h>
 
@@ -14,6 +17,7 @@ using search::queryeval::SearchIterator;
 using search::queryeval::Searchable;
 using search::queryeval::Blueprint;
 using search::queryeval::SimpleLeafBlueprint;
+using search::queryeval::IRequestContext;
 using search::queryeval::FieldSpec;
 using search::queryeval::FieldSpecBaseList;
 using search::queryeval::AndSearchStrict;
@@ -78,9 +82,9 @@ struct MockBlueprint : SimpleLeafBlueprint {
 
 struct MockSearchable : Searchable {
     size_t create_cnt = 0;
-    virtual Blueprint::UP createBlueprint(const search::queryeval::IRequestContext & requestContext,
-                                          const FieldSpec &field,
-                                          const search::query::Node &term) override
+    Blueprint::UP createBlueprint(const IRequestContext & requestContext,
+                                  const FieldSpec &field,
+                                  const search::query::Node &term) override
     {
         (void) requestContext;
         ++create_cnt;

--- a/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.h
@@ -2,13 +2,19 @@
 
 #pragma once
 
-#include <vespa/searchlib/queryeval/searchable.h>
 #include <vespa/vespalib/stllike/string.h>
-#include <vespa/searchlib/queryeval/searchiterator.h>
-#include <vespa/searchlib/queryeval/blueprint.h>
-
-#include <vespa/searchlib/fef/matchdata.h>
+#include <vector>
+#include <memory>
 #include <mutex>
+#include <atomic>
+
+namespace search::queryeval {
+    class Searchable;
+    class IRequestContext;
+    class SearchIterator;
+    class Blueprint;
+}
+namespace search::fef { class MatchData; }
 
 namespace proton::matching {
     
@@ -31,23 +37,22 @@ public:
                      double diversityCutoffFactor,
                      DiversityCutoffStrategy diversityCutoffStrategy);
     ~AttributeLimiter();
-    search::queryeval::SearchIterator::UP create_search(size_t want_hits, size_t max_group_size, bool strictSearch);
+    std::unique_ptr<search::queryeval::SearchIterator> create_search(size_t want_hits, size_t max_group_size, bool strictSearch);
     bool was_used() const;
     ssize_t getEstimatedHits() const;
     static DiversityCutoffStrategy toDiversityCutoffStrategy(vespalib::stringref strategy);
 private:
-    const vespalib::string & toString(DiversityCutoffStrategy strategy);
-    search::queryeval::Searchable            & _searchable_attributes;
-    const search::queryeval::IRequestContext & _requestContext;
-    vespalib::string                           _attribute_name;
-    bool                                       _descending;
-    vespalib::string                           _diversity_attribute;
-    std::mutex                                 _lock;
-    std::vector<search::fef::MatchData::UP>    _match_datas;
-    search::queryeval::Blueprint::UP           _blueprint;
-    std::atomic<ssize_t>                       _estimatedHits;
-    double                                     _diversityCutoffFactor;
-    DiversityCutoffStrategy                    _diversityCutoffStrategy;
+    search::queryeval::Searchable                      & _searchable_attributes;
+    const search::queryeval::IRequestContext           & _requestContext;
+    vespalib::string                                     _attribute_name;
+    bool                                                 _descending;
+    vespalib::string                                     _diversity_attribute;
+    std::mutex                                           _lock;
+    std::vector<std::unique_ptr<search::fef::MatchData>> _match_datas;
+    std::unique_ptr<search::queryeval::Blueprint>        _blueprint;
+    std::atomic<ssize_t>                                 _estimatedHits;
+    double                                               _diversityCutoffFactor;
+    DiversityCutoffStrategy                              _diversityCutoffStrategy;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/match_phase_limit_calculator.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_phase_limit_calculator.h
@@ -2,10 +2,7 @@
 
 #pragma once
 
-#include "isearchcontext.h"
-#include <vespa/vespalib/stllike/string.h>
-#include <vespa/searchlib/queryeval/searchiterator.h>
-#include <vespa/searchlib/queryeval/blueprint.h>
+#include <algorithm>
 
 namespace proton::matching {
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_phase_limiter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_phase_limiter.cpp
@@ -3,15 +3,13 @@
 #include "match_phase_limiter.h"
 #include <vespa/searchlib/queryeval/andsearchstrict.h>
 #include <vespa/vespalib/data/slime/cursor.h>
-#include <vespa/log/log.h>
 
+#include <vespa/log/log.h>
 LOG_SETUP(".proton.matching.match_phase_limiter");
 
 using search::queryeval::SearchIterator;
 using search::queryeval::Searchable;
 using search::queryeval::IRequestContext;
-using search::queryeval::AndSearchStrict;
-using search::queryeval::NoUnpack;
 
 namespace proton::matching {
 
@@ -70,7 +68,8 @@ LimitedSearch::visitMembers(vespalib::ObjectVisitor &visitor) const
 
 MatchPhaseLimiter::MatchPhaseLimiter(uint32_t docIdLimit, Searchable &searchable_attributes,
                                      IRequestContext & requestContext,
-                                     DegradationParams degradation, DiversityParams diversity)
+                                     const DegradationParams & degradation,
+                                     const DiversityParams &diversity)
     : _postFilterMultiplier(degradation.post_filter_multiplier),
       _maxFilterCoverage(degradation.max_filter_coverage),
       _calculator(degradation.max_hits, diversity.min_groups, degradation.sample_percentage),

--- a/searchcore/src/vespa/searchcore/proton/matching/match_phase_limiter.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_phase_limiter.h
@@ -4,11 +4,7 @@
 
 #include "match_phase_limit_calculator.h"
 #include "attribute_limiter.h"
-
-#include <vespa/searchlib/queryeval/searchable.h>
-#include <vespa/vespalib/stllike/string.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
-#include <vespa/searchlib/queryeval/blueprint.h>
 #include <atomic>
 
 namespace proton::matching {
@@ -52,7 +48,7 @@ struct MaybeMatchPhaseLimiter {
     virtual SearchIterator::UP maybe_limit(SearchIterator::UP search, double match_freq, size_t num_docs, Cursor * trace) = 0;
     virtual void updateDocIdSpaceEstimate(size_t searchedDocIdSpace, size_t remainingDocIdSpace) = 0;
     virtual size_t getDocIdSpaceEstimate() const = 0;
-    virtual ~MaybeMatchPhaseLimiter() {}
+    virtual ~MaybeMatchPhaseLimiter() = default;
 };
 
 /**
@@ -113,7 +109,7 @@ class MatchPhaseLimiter : public MaybeMatchPhaseLimiter
 private:
     class Coverage {
     public:
-        Coverage(uint32_t docIdLimit) :
+        explicit Coverage(uint32_t docIdLimit) :
             _docIdLimit(docIdLimit),
             _searched(0)
         { }
@@ -139,7 +135,8 @@ public:
     MatchPhaseLimiter(uint32_t docIdLimit,
                       search::queryeval::Searchable &searchable_attributes,
                       search::queryeval::IRequestContext & requestContext,
-                      DegradationParams degradation, DiversityParams diversity);
+                      const DegradationParams & degradation,
+                      const DiversityParams & diversity);
     bool is_enabled() const override { return true; }
     bool was_limited() const override { return _limiter_factory.was_used(); }
     size_t sample_hits_per_thread(size_t num_threads) const override {

--- a/searchlib/src/apps/tests/memoryindexstress_test.cpp
+++ b/searchlib/src/apps/tests/memoryindexstress_test.cpp
@@ -11,6 +11,7 @@
 #include <vespa/searchlib/queryeval/fake_search.h>
 #include <vespa/searchlib/queryeval/fake_searchable.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
+#include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/test/index/mock_field_length_inspector.h>
 #include <vespa/document/annotation/spanlist.h>
 #include <vespa/document/annotation/spantree.h>
@@ -328,8 +329,7 @@ Fixture::readWork(uint32_t cnt)
         FieldSpec field(fieldName, fieldId, handle);
         FieldSpecList fields;
         fields.add(field);
-        Blueprint::UP result = index.createBlueprint(requestContext,
-                                                     fields, term);
+        Blueprint::UP result = index.createBlueprint(requestContext, fields, term);
         if (!EXPECT_TRUE(result.get() != 0)) {
             LOG(error, "Did not get blueprint");
             break;

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -10,9 +10,9 @@
 #include <vespa/searchlib/query/tree/simplequery.h>
 #include <vespa/searchlib/queryeval/booleanmatchiteratorwrapper.h>
 #include <vespa/searchlib/queryeval/fake_requestcontext.h>
-#include <vespa/searchlib/queryeval/fake_search.h>
 #include <vespa/searchlib/queryeval/fake_searchable.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
+#include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/stringfmt.h>

--- a/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
@@ -4,6 +4,7 @@
 
 #include <vespa/searchlib/queryeval/fake_searchable.h>
 #include <vespa/searchlib/queryeval/fake_requestcontext.h>
+#include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/query/tree/intermediatenodes.h>
 #include <vespa/searchlib/query/tree/termnodes.h>
 #include <vespa/searchlib/query/tree/simplequery.h>

--- a/searchlib/src/vespa/searchcommon/attribute/basictype.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/basictype.cpp
@@ -1,6 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchcommon/attribute/basictype.h>
+#include "basictype.h"
 #include <vespa/vespalib/util/exceptions.h>
 
 namespace search::attribute {

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.h
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.h
@@ -3,16 +3,13 @@
 #pragma once
 
 #include <vespa/searchlib/queryeval/searchable.h>
-#include <vespa/searchlib/attribute/iattributemanager.h>
-#include <vespa/searchlib/queryeval/irequestcontext.h>
 
 namespace search {
 
 class AttributeBlueprintFactory : public queryeval::Searchable
 {
 public:
-    // implements Searchable
-    queryeval::Blueprint::UP
+    std::unique_ptr<queryeval::Blueprint>
     createBlueprint(const queryeval::IRequestContext & requestContext,
                     const queryeval::FieldSpec &field,
                     const query::Node &term) override;

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.h
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.h
@@ -133,13 +133,13 @@ public:
      */
     BitVector::UP readBitVector(const LookupResult &lookupRes) const;
 
-    queryeval::Blueprint::UP createBlueprint(const queryeval::IRequestContext & requestContext,
-                                             const queryeval::FieldSpec &field,
-                                             const query::Node &term) override;
+    std::unique_ptr<queryeval::Blueprint> createBlueprint(const queryeval::IRequestContext & requestContext,
+                                                          const queryeval::FieldSpec &field,
+                                                          const query::Node &term) override;
 
-    queryeval::Blueprint::UP createBlueprint(const queryeval::IRequestContext & requestContext,
-                                             const queryeval::FieldSpecList &fields,
-                                             const query::Node &term) override;
+    std::unique_ptr<queryeval::Blueprint> createBlueprint(const queryeval::IRequestContext & requestContext,
+                                                          const queryeval::FieldSpecList &fields,
+                                                          const query::Node &term) override;
 
     /**
      * Get the size on disk of this index.

--- a/searchlib/src/vespa/searchlib/memoryindex/memory_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/memory_index.h
@@ -60,11 +60,6 @@ private:
     vespalib::hash_set<uint32_t> _indexedDocs; // documents in memory index
     const uint64_t      _staticMemoryFootprint;
 
-    MemoryIndex(const MemoryIndex &) = delete;
-    MemoryIndex(MemoryIndex &&) = delete;
-    MemoryIndex &operator=(const MemoryIndex &) = delete;
-    MemoryIndex &operator=(MemoryIndex &&) = delete;
-
     void updateMaxDocId(uint32_t docId) {
         if (docId > _maxDocId) {
             _maxDocId = docId;
@@ -99,7 +94,11 @@ public:
                 ISequencedTaskExecutor& invertThreads,
                 ISequencedTaskExecutor& pushThreads);
 
-    ~MemoryIndex();
+    MemoryIndex(const MemoryIndex &) = delete;
+    MemoryIndex(MemoryIndex &&) = delete;
+    MemoryIndex &operator=(const MemoryIndex &) = delete;
+    MemoryIndex &operator=(MemoryIndex &&) = delete;
+    ~MemoryIndex() override;
 
     const index::Schema &getSchema() const { return _schema; }
 
@@ -141,13 +140,14 @@ public:
     void dump(index::IndexBuilder &indexBuilder);
 
     // Implements Searchable
-    queryeval::Blueprint::UP createBlueprint(const queryeval::IRequestContext & requestContext,
-                                             const queryeval::FieldSpec &field,
-                                             const query::Node &term) override;
+    std::unique_ptr<queryeval::Blueprint> createBlueprint(const queryeval::IRequestContext & requestContext,
+                                                          const queryeval::FieldSpec &field,
+                                                          const query::Node &term) override;
 
-    queryeval::Blueprint::UP createBlueprint(const queryeval::IRequestContext & requestContext,
-                                             const queryeval::FieldSpecList &fields,
-                                             const query::Node &term) override {
+    std::unique_ptr<queryeval::Blueprint> createBlueprint(const queryeval::IRequestContext & requestContext,
+                                                          const queryeval::FieldSpecList &fields,
+                                                          const query::Node &term) override
+    {
         return queryeval::Searchable::createBlueprint(requestContext, fields, term);
     }
 

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -259,12 +259,12 @@ private:
     void updateState() const;
 
 protected:
-    void notifyChange() override final;
+    void notifyChange() final;
     virtual State calculateState() const = 0;
 
 public:
     StateCache() : _stale(true), _state(FieldSpecBaseList()) {}
-    const State &getState() const override final {
+    const State &getState() const final {
         if (_stale) {
             updateState();
         }
@@ -296,7 +296,7 @@ protected:
     // conflicting collections of field specs.
     FieldSpecBaseList mixChildrenFields() const;
 
-    State calculateState() const override final;
+    State calculateState() const final;
 
     virtual bool isPositive(size_t index) const { (void) index; return true; }
 
@@ -309,9 +309,9 @@ public:
     IntermediateBlueprint();
     ~IntermediateBlueprint() override;
 
-    void setDocIdLimit(uint32_t limit) override final;
+    void setDocIdLimit(uint32_t limit) final;
 
-    void optimize(Blueprint* &self) override final;
+    void optimize(Blueprint* &self) final;
     void set_global_filter(const GlobalFilter &global_filter, double estimated_hit_ratio) override;
 
     IndexList find(const IPredicate & check) const;
@@ -333,7 +333,7 @@ public:
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
-    void freeze() override final;
+    void freeze() final;
 
     UnpackInfo calculateUnpackInfo(const fef::MatchData & md) const;
     bool isIntermediate() const override { return true; }
@@ -346,7 +346,7 @@ private:
     State _state;
 
 protected:
-    void optimize(Blueprint* &self) override final;
+    void optimize(Blueprint* &self) final;
     void setEstimate(HitEstimate est);
     void set_cost_tier(uint32_t value);
     void set_allow_termwise_eval(bool value);
@@ -356,10 +356,10 @@ protected:
     LeafBlueprint(const FieldSpecBaseList &fields, bool allow_termwise_eval);
 public:
     ~LeafBlueprint() override;
-    const State &getState() const override final { return _state; }
-    void setDocIdLimit(uint32_t limit) override final { Blueprint::setDocIdLimit(limit); }
+    const State &getState() const final { return _state; }
+    void setDocIdLimit(uint32_t limit) final { Blueprint::setDocIdLimit(limit); }
     void fetchPostings(const ExecuteInfo &execInfo) override;
-    void freeze() override final;
+    void freeze() final;
     SearchIteratorUP createSearch(fef::MatchData &md, bool strict) const override;
 
     virtual SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const = 0;
@@ -367,14 +367,14 @@ public:
 
 // for leaf nodes representing a single term
 struct SimpleLeafBlueprint : LeafBlueprint {
-    SimpleLeafBlueprint(const FieldSpecBase &field) : LeafBlueprint(FieldSpecBaseList().add(field), true) {}
-    SimpleLeafBlueprint(const FieldSpecBaseList &fields) : LeafBlueprint(fields, true) {}
+    explicit SimpleLeafBlueprint(const FieldSpecBase &field) : LeafBlueprint(FieldSpecBaseList().add(field), true) {}
+    explicit SimpleLeafBlueprint(const FieldSpecBaseList &fields) : LeafBlueprint(fields, true) {}
 };
 
 // for leaf nodes representing more complex structures like wand/phrase
 struct ComplexLeafBlueprint : LeafBlueprint {
-    ComplexLeafBlueprint(const FieldSpecBase &field) : LeafBlueprint(FieldSpecBaseList().add(field), false) {}    
-    ComplexLeafBlueprint(const FieldSpecBaseList &fields) : LeafBlueprint(fields, false) {}
+    explicit ComplexLeafBlueprint(const FieldSpecBase &field) : LeafBlueprint(FieldSpecBaseList().add(field), false) {}
+    explicit ComplexLeafBlueprint(const FieldSpecBaseList &fields) : LeafBlueprint(fields, false) {}
 };
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/create_blueprint_visitor_helper.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "searchable.h"
+#include "field_spec.h"
 #include "termasstring.h"
 #include <vespa/searchlib/query/tree/intermediatenodes.h>
 #include <vespa/searchlib/query/tree/queryvisitor.h>
@@ -12,13 +12,17 @@
 
 namespace search::queryeval {
 
+class IRequestContext;
+class Searchable;
+class Blueprint;
+
 class CreateBlueprintVisitorHelper : public query::QueryVisitor
 {
 private:
     const IRequestContext & _requestContext;
     Searchable            & _searchable;
     FieldSpec               _field;
-    Blueprint::UP           _result;
+    std::unique_ptr<Blueprint>  _result;
 
 protected:
     const IRequestContext & getRequestContext() const { return _requestContext; }
@@ -30,7 +34,7 @@ public:
     template <typename T>
     void setResult(std::unique_ptr<T> result) { _result = std::move(result); }
 
-    Blueprint::UP getResult();
+    std::unique_ptr<Blueprint> getResult();
 
     const FieldSpec &getField() const { return _field; }
 

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "searchable.h"
+#include "blueprint.h"
 #include <vespa/searchlib/fef/matchdatalayout.h>
 
 namespace search::fef { class TermFieldMatchData; }
@@ -16,11 +16,10 @@ class DotProductBlueprint : public ComplexLeafBlueprint
     std::vector<int32_t>    _weights;
     std::vector<Blueprint*> _terms;
 
-    DotProductBlueprint(const DotProductBlueprint &); // disabled
-    DotProductBlueprint &operator=(const DotProductBlueprint &); // disabled
-
 public:
-    DotProductBlueprint(const FieldSpec &field);
+    explicit DotProductBlueprint(const FieldSpec &field);
+    DotProductBlueprint(const DotProductBlueprint &) = delete;
+    DotProductBlueprint &operator=(const DotProductBlueprint &) = delete;
     ~DotProductBlueprint() override;
 
     // used by create visitor
@@ -29,9 +28,7 @@ public:
     // used by create visitor
     void addTerm(Blueprint::UP term, int32_t weight);
 
-    SearchIteratorUP
-    createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda,
-                     bool strict) const override;
+    SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
     SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;

--- a/searchlib/src/vespa/searchlib/queryeval/fake_searchable.h
+++ b/searchlib/src/vespa/searchlib/queryeval/fake_searchable.h
@@ -4,8 +4,7 @@
 
 #include "searchable.h"
 #include "fake_result.h"
-
-#include <string>
+#include <vespa/vespalib/stllike/string.h>
 #include <map>
 
 namespace search::queryeval {
@@ -65,10 +64,11 @@ public:
                               const FakeResult &result);
 
     using Searchable::createBlueprint;
-    Blueprint::UP createBlueprint(const IRequestContext & requestContext,
-                                  const FieldSpec &field,
-                                  const search::query::Node &term) override;
-    ~FakeSearchable();
+    std::unique_ptr<queryeval::Blueprint>
+    createBlueprint(const IRequestContext & requestContext,
+                    const FieldSpec &field,
+                    const search::query::Node &term) override;
+    ~FakeSearchable() override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
@@ -5,8 +5,6 @@
 #include "andnotsearch.h"
 #include "sourceblendersearch.h"
 #include <vespa/searchlib/common/bitvectoriterator.h>
-#include <vespa/searchlib/fef/termfieldmatchdataarray.h>
-#include <vespa/vespalib/util/optimized.h>
 #include <vespa/vespalib/hwaccelrated/iaccelrated.h>
 
 namespace search::queryeval {

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "searchable.h"
+#include "blueprint.h"
 #include <vespa/searchlib/fef/matchdatalayout.h>
 
 namespace search::fef { class TermFieldMatchData; }
@@ -23,7 +23,7 @@ public:
     SameElementBlueprint(const vespalib::string &field_name_in, bool expensive);
     SameElementBlueprint(const SameElementBlueprint &) = delete;
     SameElementBlueprint &operator=(const SameElementBlueprint &) = delete;
-    ~SameElementBlueprint();
+    ~SameElementBlueprint() override;
 
     // no match data
     bool isWhiteList() const override { return true; }

--- a/searchlib/src/vespa/searchlib/queryeval/searchable.h
+++ b/searchlib/src/vespa/searchlib/queryeval/searchable.h
@@ -2,14 +2,16 @@
 
 #pragma once
 
-#include "field_spec.h"
-#include "blueprint.h"
-#include <vespa/searchlib/queryeval/irequestcontext.h>
-#include <vector>
+#include <memory>
 
 namespace search::query { class Node; }
 
 namespace search::queryeval {
+
+class Blueprint;
+class IRequestContext;
+class FieldSpec;
+class FieldSpecList;
 
 /**
  * Abstract class extended by components to expose content that can be
@@ -29,9 +31,9 @@ protected:
      * @param field the field to search
      * @param term the query tree term
      **/
-    virtual Blueprint::UP createBlueprint(const IRequestContext & requestContext,
-                                          const FieldSpec &field,
-                                          const search::query::Node &term) = 0;
+    virtual std::unique_ptr<Blueprint> createBlueprint(const IRequestContext & requestContext,
+                                                       const FieldSpec &field,
+                                                       const search::query::Node &term) = 0;
 
 public:
     typedef std::shared_ptr<Searchable> SP;
@@ -48,9 +50,9 @@ public:
      * @param fields the set of fields to search
      * @param term the query tree term
      **/
-    virtual Blueprint::UP createBlueprint(const IRequestContext & requestContext,
-                                          const FieldSpecList &fields,
-                                          const search::query::Node &term);
+    virtual std::unique_ptr<Blueprint> createBlueprint(const IRequestContext & requestContext,
+                                                       const FieldSpecList &fields,
+                                                       const search::query::Node &term);
     virtual ~Searchable() = default;
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include "searchable.h"
-#include "irequestcontext.h"
+#include "blueprint.h"
 #include <vespa/searchlib/fef/matchdatalayout.h>
 
 namespace search::fef { class TermFieldMatchData; }

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "searchable.h"
+#include "blueprint.h"
 #include <vespa/searchlib/fef/matchdatalayout.h>
 #include <vector>
 
@@ -18,12 +18,11 @@ class WeightedSetTermBlueprint : public ComplexLeafBlueprint
     std::vector<int32_t>    _weights;
     std::vector<Blueprint*> _terms;
 
-    WeightedSetTermBlueprint(const WeightedSetTermBlueprint &); // disabled
-    WeightedSetTermBlueprint &operator=(const WeightedSetTermBlueprint &); // disabled
-
 public:
     WeightedSetTermBlueprint(const FieldSpec &field);
-    ~WeightedSetTermBlueprint();
+    WeightedSetTermBlueprint(const WeightedSetTermBlueprint &) = delete;
+    WeightedSetTermBlueprint &operator=(const WeightedSetTermBlueprint &) = delete;
+    ~WeightedSetTermBlueprint() override;
 
     // used by create visitor
     // matches signature in dot product blueprint for common blueprint


### PR DESCRIPTION
- add 'explicit'
- only 'override' OR 'final', not both.
- Reduce code visibility.

@toregge PR