### PR TITLE
Factor out XML string escaping and use for internal legacy status pages [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -14,12 +14,15 @@
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/string_escape.h>
 #include <xxhash.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".persistence.filestor.handler.impl");
 
 using document::BucketSpace;
+using vespalib::xml_attribute_escaped;
+using vespalib::xml_content_escaped;
 
 namespace storage {
 
@@ -1338,8 +1341,8 @@ FileStorHandlerImpl::Stripe::dumpQueueHtml(std::ostream & os) const
 
     const PriorityIdx& idx = bmi::get<1>(*_queue);
     for (const auto & entry : idx) {
-        os << "<li>" << entry._command->toString() << " (priority: "
-           << (int)entry._command->getPriority() << ")</li>\n";
+        os << "<li>" << xml_content_escaped(entry._command->toString()) << " (priority: "
+           << static_cast<int>(entry._command->getPriority()) << ")</li>\n";
     }
 }
 
@@ -1379,8 +1382,9 @@ FileStorHandlerImpl::Stripe::dumpQueue(std::ostream & os) const
 
     const PriorityIdx& idx = bmi::get<1>(*_queue);
     for (const auto & entry : idx) {
-        os << entry._bucket.getBucketId() << ": " << entry._command->toString() << " (priority: "
-           << (int)entry._command->getPriority() << ")\n";
+        os << entry._bucket.getBucketId() << ": "
+           << xml_content_escaped(entry._command->toString())
+           << " (priority: " << static_cast<int>(entry._command->getPriority()) << ")\n";
     }
 }
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -23,6 +23,7 @@
 #include <vespa/vespalib/util/cpu_usage.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
+#include <vespa/vespalib/util/string_escape.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <vespa/config/subscription/configuri.h>
 #include <vespa/config/helper/configfetcher.hpp>
@@ -887,16 +888,17 @@ void FileStorManager::onFlush(bool downwards)
 void
 FileStorManager::reportHtmlStatus(std::ostream& out, const framework::HttpUrlPath& path) const
 {
-    bool showStatus = !path.hasAttribute("thread");
-    bool verbose = path.hasAttribute("verbose");
+    using vespalib::xml_attribute_escaped;
 
-        // Print menu
+    bool showStatus = !path.hasAttribute("thread");
+    bool verbose    = path.hasAttribute("verbose");
+    // Print menu
     out << "<font size=\"-1\">[ <a href=\"/\">Back to top</a>"
         << " | <a href=\"?" << (verbose ? "verbose" : "")
         << "\">Main filestor manager status page</a>"
         << " | <a href=\"?" << (verbose ? "notverbose" : "verbose");
     if (!showStatus) {
-        out << "&thread=" << path.get("thread", std::string(""));
+        out << "&thread=" << xml_attribute_escaped(path.get("thread", std::string("")));
     }
     out << "\">" << (verbose ? "Less verbose" : "More verbose") << "</a>\n"
         << " ]</font><br><br>\n";

--- a/storage/src/vespa/storage/storageserver/mergethrottler.cpp
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.cpp
@@ -11,6 +11,7 @@
 #include <vespa/config/helper/configfetcher.hpp>
 #include <vespa/config/subscription/configuri.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/string_escape.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <cassert>
 
@@ -1313,6 +1314,8 @@ void
 MergeThrottler::reportHtmlStatus(std::ostream& out,
                                  const framework::HttpUrlPath&) const
 {
+    using vespalib::xml_content_escaped;
+
     std::lock_guard lock(_stateLock);
     if (_use_dynamic_throttling) {
         out << "<p>Dynamic throttle policy; window size min/max: ["
@@ -1333,7 +1336,7 @@ MergeThrottler::reportHtmlStatus(std::ostream& out,
     if (!_merges.empty()) {
         out << "<ul>\n";
         for (auto& m : _merges) {
-            out << "<li>" << m.second.getMergeCmdString();
+            out << "<li>" << xml_content_escaped(m.second.getMergeCmdString());
             if (m.second.isExecutingLocally()) {
                 out << " <strong>(";
                 if (m.second.isInCycle()) {
@@ -1364,7 +1367,7 @@ MergeThrottler::reportHtmlStatus(std::ostream& out,
             // The queue always owns its messages, thus this is safe
             out << "<li>Pri "
                 << static_cast<unsigned int>(qm._msg->getPriority())
-                << ": " << *qm._msg;
+                << ": " << xml_content_escaped(qm._msg->toString());
             out << "</li>\n";
         }
         out << "</ol>\n";

--- a/storage/src/vespa/storage/storageserver/statemanager.cpp
+++ b/storage/src/vespa/storage/storageserver/statemanager.cpp
@@ -9,9 +9,9 @@
 #include <vespa/storageapi/messageapi/storagemessage.h>
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vdslib/state/clusterstate.h>
-#include <vespa/vespalib/io/fileutil.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/string_escape.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <fstream>
@@ -99,19 +99,20 @@ void
 StateManager::reportHtmlStatus(std::ostream& out,
                                const framework::HttpUrlPath& path) const
 {
+    using vespalib::xml_content_escaped;
     (void) path;
     {
         std::lock_guard lock(_stateLock);
-        const auto &baseLineClusterState = _systemState->getBaselineClusterState();
+        const auto& baseLineClusterState = _systemState->getBaselineClusterState();
         out << "<h1>Current system state</h1>\n"
-            << "<code>" << baseLineClusterState->toString(true) << "</code>\n"
+            << "<code>" << xml_content_escaped(baseLineClusterState->toString(true)) << "</code>\n"
             << "<h1>Current node state</h1>\n"
             << "<code>" << baseLineClusterState->getNodeState(lib::Node(
                         _component.getNodeType(), _component.getIndex())
                                                      ).toString(true)
             << "</code>\n"
             << "<h1>Reported node state</h1>\n"
-            << "<code>" << _nodeState->toString(true) << "</code>\n"
+            << "<code>" << xml_content_escaped(_nodeState->toString(true)) << "</code>\n"
             << "<h1>Pending state requests</h1>\n"
             << _queuedStateRequests.size() << "\n"
             << "<h1>System state history</h1>\n"
@@ -119,7 +120,7 @@ StateManager::reportHtmlStatus(std::ostream& out,
             << "<th>Received at time</th><th>State</th></tr>\n";
         for (auto it = _systemStateHistory.rbegin(); it != _systemStateHistory.rend(); ++it) {
             out << "<tr><td>" << it->first << "</td><td>"
-                << *it->second->getBaselineClusterState() << "</td></tr>\n";
+                << xml_content_escaped(it->second->getBaselineClusterState()->toString()) << "</td></tr>\n";
         }
         out << "</table>\n";
     }

--- a/storage/src/vespa/storage/visiting/visitor.cpp
+++ b/storage/src/vespa/storage/visiting/visitor.cpp
@@ -2,15 +2,15 @@
 
 #include "visitor.h"
 #include "visitormetrics.h"
-#include <vespa/persistence/spi/docentry.h>
-#include <vespa/storageframework/generic/clock/timer.h>
-#include <vespa/storageapi/message/datagram.h>
-#include <vespa/storage/persistence/messages.h>
-#include <vespa/documentapi/messagebus/messages/visitor.h>
 #include <vespa/document/select/node.h>
 #include <vespa/document/fieldset/fieldsets.h>
-#include <vespa/vespalib/stllike/hash_map.hpp>
+#include <vespa/documentapi/messagebus/messages/visitor.h>
+#include <vespa/persistence/spi/docentry.h>
+#include <vespa/storageapi/message/datagram.h>
+#include <vespa/storageframework/generic/clock/timer.h>
+#include <vespa/storage/persistence/messages.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/util/string_escape.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <unordered_map>
 #include <sstream>
@@ -932,10 +932,12 @@ Visitor::continueVisitor()
 void
 Visitor::getStatus(std::ostream& out, bool verbose) const
 {
+    using vespalib::xml_content_escaped;
+
     out << "<table border=\"1\"><tr><td>Property</td><td>Value</td></tr>\n";
 
     out << "<tr><td>Visitor id</td><td>" << _visitorId << "</td></tr>\n";
-    out << "<tr><td>Visitor name</td><td>" << _id << "</td></tr>\n";
+    out << "<tr><td>Visitor name</td><td>" << xml_content_escaped(_id) << "</td></tr>\n";
 
     out << "<tr><td>Number of buckets to visit</td><td>" << _buckets.size()
         << "</td></tr>\n";
@@ -953,7 +955,7 @@ Visitor::getStatus(std::ostream& out, bool verbose) const
         << "</td></tr>\n";
 
     out << "<tr><td>Current status</td><td>"
-        << _result << "</td></tr>\n";
+        << xml_content_escaped(_result.toString()) << "</td></tr>\n";
 
     out << "<tr><td>Failed</td><td>" << (failed() ? "true" : "false")
         << "</td></tr>\n";
@@ -973,28 +975,28 @@ Visitor::getStatus(std::ostream& out, bool verbose) const
         out << "<tr><td>Called completed visitor</td><td>"
             << (_calledCompletedVisitor ? "true" : "false") << "</td></tr>\n";
         out << "<tr><td>Visiting fields</td><td>"
-            << _visitorOptions._fieldSet
+            << xml_content_escaped(_visitorOptions._fieldSet)
             << "</td></tr>\n";
         out << "<tr><td>Visiting removes</td><td>"
             << (_visitorOptions._visitRemoves ? "true" : "false")
             << "</td></tr>\n";
         out << "<tr><td>Control destination</td><td>";
         if (_controlDestination.get()) {
-            out << _controlDestination->toString();
+            out << xml_content_escaped(_controlDestination->toString());
         } else {
             out << "nil";
         }
         out << "</td></tr>\n";
         out << "<tr><td>Data destination</td><td>";
         if (_dataDestination.get()) {
-            out << _dataDestination->toString();
+            out << xml_content_escaped(_dataDestination->toString());
         } else {
             out << "nil";
         }
         out << "</td></tr>\n";
         out << "<tr><td>Document selection</td><td>";
         if (_documentSelection.get()) {
-            out << *_documentSelection;
+            out << xml_content_escaped(_documentSelection->toString());
         } else {
             out << "nil";
         }
@@ -1052,7 +1054,7 @@ Visitor::getStatus(std::ostream& out, bool verbose) const
     for (auto& idAndMeta : _visitorTarget._messageMeta) {
         const VisitorTarget::MessageMeta& meta(idAndMeta.second);
         out << "Message #" << idAndMeta.first << " <b>"
-            << meta.messageText << "</b> ";
+            << xml_content_escaped(meta.messageText) << "</b> ";
         if (meta.retryCount > 0) {
             out << "Retried " << meta.retryCount << " times. ";
         }

--- a/storage/src/vespa/storage/visiting/visitorthread.cpp
+++ b/storage/src/vespa/storage/visiting/visitorthread.cpp
@@ -2,18 +2,16 @@
 
 #include "visitorthread.h"
 #include "messages.h"
+#include <vespa/document/base/exceptions.h>
 #include <vespa/document/select/bodyfielddetector.h>
 #include <vespa/document/select/parser.h>
 #include <vespa/messagebus/rpcmessagebus.h>
+#include <vespa/storageapi/message/datagram.h>
 #include <vespa/storage/common/statusmessages.h>
 #include <vespa/storage/config/config-stor-server.h>
-#include <vespa/storageapi/message/datagram.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/util/exceptions.h>
-#include <vespa/document/base/exceptions.h>
-#include <vespa/vespalib/stllike/hash_map.hpp>
 #include <locale>
-#include <sstream>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".visitor.thread");

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -189,6 +189,7 @@ vespa_define_module(
     src/tests/util/rcuvector
     src/tests/util/reusable_set
     src/tests/util/size_literals
+    src/tests/util/string_escape
     src/tests/valgrind
     src/tests/visit_ranges
     src/tests/invokeservice

--- a/vespalib/src/tests/util/string_escape/CMakeLists.txt
+++ b/vespalib/src/tests/util/string_escape/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_util_string_escape_test_app TEST
+    SOURCES
+    string_escape_test.cpp
+    DEPENDS
+    vespalib
+    GTest::GTest
+)
+vespa_add_test(NAME vespalib_util_string_escape_test_app COMMAND vespalib_util_string_escape_test_app)

--- a/vespalib/src/tests/util/string_escape/string_escape_test.cpp
+++ b/vespalib/src/tests/util/string_escape/string_escape_test.cpp
@@ -1,0 +1,44 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/util/string_escape.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace vespalib;
+using namespace ::testing;
+
+TEST(StringEscapeTest, xml_attribute_special_chars_are_escaped) {
+    // We always escape both " and ' since we don't know the quoting context of the enclosing attribute.
+    EXPECT_EQ(xml_attribute_escaped("<>&\"'"), "&lt;&gt;&amp;&quot;&#39;");
+}
+
+TEST(StringEscapeTest, xml_attribute_regular_chars_are_not_escaped) {
+    // Far from exhaustive, but should catch obvious mess-ups.
+    EXPECT_EQ(xml_attribute_escaped("09azAZ.,()[]$!"), "09azAZ.,()[]$!");
+}
+
+TEST(StringEscapeTest, control_characters_are_escaped_in_attributes) {
+    EXPECT_EQ(xml_attribute_escaped("\n"), "&#10;");
+    EXPECT_EQ(xml_attribute_escaped("\r"), "&#13;");
+    EXPECT_EQ(xml_attribute_escaped(stringref("\x00", 1)), "&#0;"); // Can't just invoke strlen with null byte :)
+    EXPECT_EQ(xml_attribute_escaped("\x1f"), "&#31;");
+}
+
+TEST(StringEscapeTest, xml_content_special_chars_are_escaped) {
+    EXPECT_EQ(xml_content_escaped("<>&"), "&lt;&gt;&amp;");
+}
+
+TEST(StringEscapeTest, xml_content_regular_chars_are_not_escaped) {
+    EXPECT_EQ(xml_content_escaped("09azAZ.,()[]$!"), "09azAZ.,()[]$!");
+    // Newlines are not escaped in content
+    EXPECT_EQ(xml_content_escaped("\n"), "\n");
+    // Quotes are not escaped in content
+    EXPECT_EQ(xml_content_escaped("\"'"), "\"'");
+}
+
+TEST(StringEscapeTest, control_characters_are_escaped_in_content) {
+    EXPECT_EQ(xml_content_escaped("\r"), "&#13;");
+    EXPECT_EQ(xml_content_escaped(stringref("\x00", 1)), "&#0;");
+    EXPECT_EQ(xml_content_escaped("\x1f"), "&#31;");
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -88,6 +88,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     singleexecutor.cpp
     small_vector.cpp
     stash.cpp
+    string_escape.cpp
     string_hash.cpp
     stringfmt.cpp
     testclock.cpp

--- a/vespalib/src/vespa/vespalib/util/string_escape.cpp
+++ b/vespalib/src/vespa/vespalib/util/string_escape.cpp
@@ -1,0 +1,79 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "string_escape.h"
+#include <vespa/vespalib/stllike/asciistream.h>
+#include <vector>
+#include <ostream>
+
+namespace vespalib {
+
+namespace {
+
+std::vector<bool> precompute_escaped_xml_chars() {
+    std::vector<bool> vec(256, false);
+    for (uint32_t i=0; i<32; ++i) {
+        vec[i] = true;
+    }
+    vec['\n'] = false;
+    vec['<'] = true;
+    vec['>'] = true;
+    vec['&'] = true;
+    return vec;
+}
+
+std::vector<bool> escaped_xml_chars = precompute_escaped_xml_chars();
+
+template <typename StreamT>
+void do_write_xml_content_escaped(StreamT& out, vespalib::stringref str) {
+    for (const char s : str) {
+        if (escaped_xml_chars[static_cast<uint8_t>(s)]) {
+            if      (s == '<') out << "&lt;";
+            else if (s == '>') out << "&gt;";
+            else if (s == '&') out << "&amp;";
+            else {
+                out << "&#" << static_cast<int>(s) << ";";
+            }
+        } else {
+            out << s;
+        }
+    }
+}
+
+}
+
+vespalib::string xml_attribute_escaped(vespalib::stringref str) {
+    vespalib::asciistream ost;
+    for (const char s : str) {
+        if (s == '"' || s == '\'' || s == '\n'
+            || escaped_xml_chars[static_cast<uint8_t>(s)])
+        {
+            if      (s == '<')  ost << "&lt;";
+            else if (s == '>')  ost << "&gt;";
+            else if (s == '&')  ost << "&amp;";
+            else if (s == '"')  ost << "&quot;";
+            else if (s == '\'') ost << "&#39;";
+            else {
+                ost << "&#" << static_cast<int>(s) << ";";
+            }
+        } else {
+            ost << s;
+        }
+    }
+    return ost.str();
+}
+
+vespalib::string xml_content_escaped(vespalib::stringref str) {
+    vespalib::asciistream out;
+    do_write_xml_content_escaped(out, str);
+    return out.str();
+}
+
+void write_xml_content_escaped(vespalib::asciistream& out, vespalib::stringref str) {
+    do_write_xml_content_escaped(out, str);
+}
+
+void write_xml_content_escaped(std::ostream& out, vespalib::stringref str) {
+    do_write_xml_content_escaped(out, str);
+}
+
+}

--- a/vespalib/src/vespa/vespalib/util/string_escape.h
+++ b/vespalib/src/vespa/vespalib/util/string_escape.h
@@ -1,0 +1,26 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/stllike/string.h>
+#include <iosfwd>
+
+namespace vespalib {
+
+/**
+ * Returns input string but where the following characters are escaped:
+ *   - all control chars < char value 32
+ *   - <, >, &, " and '
+ */
+[[nodiscard]] vespalib::string xml_attribute_escaped(vespalib::stringref s);
+
+/**
+ * Returns input string but where the following characters are escaped:
+ *   - all control chars < char value 32, _except_ linebreak
+ *   - <, > and &
+ */
+[[nodiscard]] vespalib::string xml_content_escaped(vespalib::stringref s);
+void write_xml_content_escaped(vespalib::asciistream& out, vespalib::stringref s);
+void write_xml_content_escaped(std::ostream& out, vespalib::stringref s);
+
+}


### PR DESCRIPTION
@geirst please review
@bjorncs FYI

The best approach would of course be to turn things on the head and always escape everything that _isn't_ explicitly trusted, but that would require significant rewrites of the legacy rendering code for these internal pages.
