### PR TITLE
Make two-phase GC work for parent-child with subset of replicas indexed [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -7,7 +7,7 @@
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/node_supported_features_repo.h>
 #include <vespa/storageapi/message/removelocation.h>
-#include <vespa/vespalib/stllike/hash_set.hpp>
+#include <vespa/vespalib/stllike/hash_map.hpp>
 #include <algorithm>
 
 #include <vespa/log/log.h>
@@ -20,8 +20,7 @@ GarbageCollectionOperation::GarbageCollectionOperation(const ClusterContext& clu
       _tracker(cluster_ctx),
       _phase(Phase::NotStarted),
       _cluster_state_version_at_phase1_start_time(0),
-      _phase1_replies_received(0),
-      _remove_candidate_set(),
+      _remove_candidates(),
       _replica_info(),
       _max_documents_removed(0),
       _is_done(false)
@@ -50,7 +49,11 @@ bool GarbageCollectionOperation::all_involved_nodes_support_two_phase_gc() const
 }
 
 std::vector<spi::IdAndTimestamp> GarbageCollectionOperation::compile_phase_two_send_set() const {
-    std::vector<spi::IdAndTimestamp> docs_to_remove(_remove_candidate_set.begin(), _remove_candidate_set.end());
+    std::vector<spi::IdAndTimestamp> docs_to_remove;
+    docs_to_remove.reserve(_remove_candidates.size());
+    for (const auto& cand : _remove_candidates) {
+        docs_to_remove.emplace_back(cand.first, cand.second);
+    }
     // Use timestamp order to provide test determinism and allow for backend linear merging (if needed).
     // Tie-break on GID upon collisions (which technically should never happen...!)
     auto ts_then_gid_order = [](const spi::IdAndTimestamp& lhs, const spi::IdAndTimestamp& rhs) noexcept {
@@ -155,36 +158,24 @@ void GarbageCollectionOperation::handle_ok_legacy_reply(uint16_t from_node, cons
     update_replica_response_info_from_reply(from_node, reply);
 }
 
-GarbageCollectionOperation::RemoveCandidateSet
-GarbageCollectionOperation::steal_selection_matches_as_set(api::RemoveLocationReply& reply) {
+GarbageCollectionOperation::RemoveCandidates
+GarbageCollectionOperation::steal_selection_matches_as_candidates(api::RemoveLocationReply& reply) {
     auto candidates = reply.steal_selection_matches();
-    RemoveCandidateSet set;
-    set.resize(candidates.size());
+    RemoveCandidates as_map;
+    as_map.resize(candidates.size());
     for (auto& cand : candidates) {
-        set.insert(std::move(cand));
+        as_map.insert(std::make_pair(std::move(cand.id), cand.timestamp));
     }
-    return set;
+    return as_map;
 }
 
 void GarbageCollectionOperation::handle_ok_phase1_reply(api::RemoveLocationReply& reply) {
     assert(reply.documents_removed() == 0);
-    if (_phase1_replies_received == 0) {
-        // Establish baseline candidate set. Since we require an intersection between all
-        // sets, the number of candidates can never be _greater_ than that of the first reply.
-        _remove_candidate_set = steal_selection_matches_as_set(reply);
-    } else if (!_remove_candidate_set.empty()) {
-        auto their_set = steal_selection_matches_as_set(reply);
-        std::vector<spi::IdAndTimestamp> to_remove;
-        for (auto& our_cand : _remove_candidate_set) {
-            if (!their_set.contains(our_cand)) {
-                to_remove.emplace_back(our_cand);
-            }
-        }
-        for (auto& rm_entry : to_remove) {
-            _remove_candidate_set.erase(rm_entry);
-        }
+    auto their_matches = steal_selection_matches_as_candidates(reply);
+    for (auto& new_cand : their_matches) {
+        auto& maybe_existing_ts = _remove_candidates[new_cand.first];
+        maybe_existing_ts = std::max(new_cand.second, maybe_existing_ts);
     }
-    ++_phase1_replies_received;
 }
 
 void GarbageCollectionOperation::handle_ok_phase2_reply(uint16_t from_node, const api::RemoveLocationReply& reply) {
@@ -220,30 +211,30 @@ void GarbageCollectionOperation::on_metadata_read_phase_done(DistributorStripeMe
         mark_operation_complete();
         return;
     }
-    std::vector<spi::IdAndTimestamp> already_pending_write;
-    for (auto& cand : _remove_candidate_set) {
-        auto maybe_seq_token = sender.operation_sequencer().try_acquire(getBucket().getBucketSpace(), cand.id);
+    std::vector<document::DocumentId> already_pending_write;
+    for (auto& cand : _remove_candidates) {
+        auto maybe_seq_token = sender.operation_sequencer().try_acquire(getBucket().getBucketSpace(), cand.first);
         if (maybe_seq_token.valid()) {
             _gc_write_locks.emplace_back(std::move(maybe_seq_token));
             LOG(spam, "GC(%s): acquired write lock for '%s'; adding to GC set",
-                getBucket().toString().c_str(), cand.id.toString().c_str());
+                getBucket().toString().c_str(), cand.first.toString().c_str());
         } else {
-            already_pending_write.emplace_back(cand);
+            already_pending_write.emplace_back(cand.first);
             LOG(spam, "GC(%s): failed to acquire write lock for '%s'; not including in GC set",
-                getBucket().toString().c_str(), cand.id.toString().c_str());
+                getBucket().toString().c_str(), cand.first.toString().c_str());
         }
     }
     for (auto& rm_entry : already_pending_write) {
-        _remove_candidate_set.erase(rm_entry);
+        _remove_candidates.erase(rm_entry);
     }
-    if (_remove_candidate_set.empty()) {
+    if (_remove_candidates.empty()) {
         update_last_gc_timestamp_in_db(); // Nothing to remove now, try again later.
         mark_operation_complete();
         return;
     }
     LOG(debug, "GC(%s): Sending phase 2 GC with %zu entries (with acquired write locks). "
                "%zu documents had pending writes and could not be GCd at this time",
-        getBucket().toString().c_str(), _remove_candidate_set.size(), already_pending_write.size());
+        getBucket().toString().c_str(), _remove_candidates.size(), already_pending_write.size());
     transition_to(Phase::WriteRemovesPhase);
     send_current_phase_remove_locations(sender);
 }


### PR DESCRIPTION
@geirst please review

The previous iteration of GC 1st phase candidate set computation required
_all_ replicas to agree that a particular document should be removed
for it to be passed on to the second phase. I.e. the intersection of all
nodes' document sets. This does not work as expected when the GC
expression references imported fields _and_ `searchable-copies` is
less than `redundancy`, as the required index structures are not present
across all replicas. The result was that eligible documents were never
removed.

This commit changes the candidate set semantics to instead use a
union of document IDs, using the maximum observed timestamp in the case
of conflicts for the same ID. This mirrors the end result of the legacy
behavior, but does not require merging in order to propagate tombstones
from the indexed replicas to those without. It also greatly simplifies
the candidate computation code.
