### PR TITLE
Ensure comp.platform for all changes of change, and do not override p…

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -91,10 +91,8 @@ public class DeploymentTrigger {
                                             && acceptNewRevision(status, instanceName, outstanding.revision().get());
                 application = application.with(instanceName,
                                                instance -> withRemainingChange(instance,
-                                                                               status.withCompatibilityPlatform((deployOutstanding ? outstanding
-                                                                                                                                   : Change.empty())
-                                                                                                                        .onTopOf(instance.change()),
-                                                                                                         instanceName),
+                                                                               deployOutstanding ? outstanding.onTopOf(instance.change())
+                                                                                                 : instance.change(),
                                                                                status));
             }
             applications().store(application);
@@ -430,7 +428,8 @@ public class DeploymentTrigger {
             remaining = remaining.withoutPlatform();
         if (status.hasCompleted(instance.name(), change.withoutPlatform()))
             remaining = remaining.withoutApplication();
-        return instance.withChange(remaining);
+
+        return instance.withChange(status.withCompatibilityPlatform(remaining, instance.name()));
     }
 
     // ---------- Version and job helpers ----------


### PR DESCRIPTION
…resent ones

@mpolden please review and merge.

Without this, a pin to downgrade majors would be cleared by the relatively new code which aimed to ensure a previous pin from a previous downgrade didn't stop a new, attempted upgrade, across incompatible majors ... Gosh :) 
Also, I think it's better to ensure the compatibility platform is always added (when manipulating change through other means than making a new submission).