### PR TITLE
Show compile version in deployment/v1

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/deployment/DeploymentApiHandler.java
@@ -14,6 +14,7 @@ import com.yahoo.restapi.UriBuilder;
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Slime;
 import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.api.integration.deployment.ApplicationVersion;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.JobType;
 import com.yahoo.vespa.hosted.controller.application.ApplicationList;
 import com.yahoo.vespa.hosted.controller.application.Change;
@@ -174,6 +175,8 @@ public class DeploymentApiHandler extends ThreadedHttpRequestHandler {
                       instanceObject.setString("upgradePolicy", toString(status.application().deploymentSpec().instance(instance.instance())
                                                                                .map(DeploymentInstanceSpec::upgradePolicy)
                                                                                .orElse(DeploymentSpec.UpgradePolicy.defaultPolicy)));
+                      status.application().revisions().last().flatMap(ApplicationVersion::compileVersion)
+                            .ifPresent(compiled -> instanceObject.setString("compileVersion", compiled.toFullString()));
                       Cursor jobsArray = instanceObject.setArray("jobs");
                       status.jobSteps().forEach((job, jobStatus) -> {
                           if ( ! job.application().equals(instance)) return;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/responses/root.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/deployment/responses/root.json
@@ -37,6 +37,7 @@
           "instance": "default",
           "upgrading": false,
           "upgradePolicy": "default",
+          "compileVersion": "6.1.0",
           "jobs": [
             {
               "name": "system-test",
@@ -77,6 +78,7 @@
           "instance": "i2",
           "upgrading": false,
           "upgradePolicy": "default",
+          "compileVersion": "6.1.0",
           "jobs": [
             {
               "name": "production-us-west-1"
@@ -184,6 +186,7 @@
           "instance": "default",
           "upgrading": true,
           "upgradePolicy": "default",
+          "compileVersion": "6.1.0",
           "jobs": [
             {
               "name": "system-test",
@@ -263,6 +266,7 @@
           "instance": "i1",
           "upgrading": false,
           "upgradePolicy": "default",
+          "compileVersion": "6.1.0",
           "jobs": [
             {
               "name": "system-test",
@@ -322,6 +326,7 @@
           "instance": "i2",
           "upgrading": true,
           "upgradePolicy": "default",
+          "compileVersion": "6.1.0",
           "jobs": [
             {
               "name": "production-us-west-1",


### PR DESCRIPTION
@freva please review and merge. 
@frodelu we can use this to show an icon denoting custom Java components in the operator deployments view, and show the compile version on mouseover of that?