### PR TITLE
Revert "switch to script-utils for security-env"

### DIFF
--- a/client/go/script-utils/main.go
+++ b/client/go/script-utils/main.go
@@ -27,8 +27,6 @@ func main() {
 	switch action {
 	case "export-env":
 		vespa.ExportDefaultEnvToSh()
-	case "security-env":
-		vespa.ExportSecurityEnvToSh()
 	case "ipv6-only":
 		if vespa.HasOnlyIpV6() {
 			os.Exit(0)
@@ -45,7 +43,6 @@ func main() {
 		cobra.Execute()
 	default:
 		fmt.Fprintf(os.Stderr, "unknown action '%s'\n", action)
-		fmt.Fprintln(os.Stderr, "actions: export-env, ipv6-only, security-env")
-		fmt.Fprintln(os.Stderr, "(also: vespa-deploy, vespa-logfmt)")
+		fmt.Fprintln(os.Stderr, "actions: export-env, ipv6-only, vespa-deploy, vespa-logfmt")
 	}
 }

--- a/security-tools/src/main/sh/vespa-curl-wrapper
+++ b/security-tools/src/main/sh/vespa-curl-wrapper
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-# Uses security-env to call curl with paths to credentials.
+# Uses vespa-security-env to call curl with paths to credentials.
 # This script should be installed in libexec only. It is not public api.
 
 # BEGIN environment bootstrap section
@@ -79,7 +79,7 @@ findhost
 
 set -e
 
-eval $($VESPA_HOME/libexec/vespa/script-utils security-env)
+eval $($VESPA_HOME/bin/vespa-security-env)
 
 CURL_PARAMETERS=("$@")
 

--- a/vespaclient/src/sh/vespa-get-cluster-state
+++ b/vespaclient/src/sh/vespa-get-cluster-state
@@ -74,6 +74,6 @@ findhost
 
 # END environment bootstrap section
 
-eval $($VESPA_HOME/libexec/vespa/script-utils security-env)
+eval $($VESPA_HOME/bin/vespa-security-env)
 
 exec $VESPA_HOME/libexec/vespa/GetClusterState.pl "$@"

--- a/vespaclient/src/sh/vespa-get-node-state
+++ b/vespaclient/src/sh/vespa-get-node-state
@@ -74,6 +74,6 @@ findhost
 
 # END environment bootstrap section
 
-eval $($VESPA_HOME/libexec/vespa/script-utils security-env)
+eval $($VESPA_HOME/bin/vespa-security-env)
 
 exec $VESPA_HOME/libexec/vespa/GetNodeState.pl "$@"

--- a/vespaclient/src/sh/vespa-set-node-state
+++ b/vespaclient/src/sh/vespa-set-node-state
@@ -74,6 +74,6 @@ findhost
 
 # END environment bootstrap section
 
-eval $($VESPA_HOME/libexec/vespa/script-utils security-env)
+eval $($VESPA_HOME/bin/vespa-security-env)
 
 exec $VESPA_HOME/libexec/vespa/SetNodeState.pl "$@"


### PR DESCRIPTION
Reverts vespa-engine/vespa#23962
It seems this broke the performance tests