### PR TITLE
Avoid multiple definitions of juniper::QueryItem.

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -67,7 +67,7 @@ public abstract class Item implements Cloneable {
 
     }
 
-    // These must match the definitions in searchlib/src/searchlib/parsequery/parse.h
+    // These must match the definitions in searchlib/src/vespa/searchlib/parsequery/item_creator.h
     public enum ItemCreator {
 
         ORIG(0),

--- a/searchlib/src/vespa/searchlib/parsequery/item_creator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/item_creator.h
@@ -1,0 +1,20 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace search::parseitem {
+
+/** A tag identifying the origin of a query node.
+ *  Note that descendants may originate from elsewhere.
+ *  Used in search::ParseItem and in Juniper.
+ *  If changes necessary:
+ *  NB! Append at end of list - corresponding type used in search
+ *  container and updates of these two types must be synchronized.
+ *  (container-search/src/main/java/com/yahoo/prelude/query/Item.java)
+ */
+enum class ItemCreator {
+    CREA_ORIG = 0, // Original user query
+    CREA_FILTER    // Automatically applied filter (no specific type)
+};
+
+}

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "item_creator.h"
 #include <vespa/searchlib/query/weight.h>
 #include <vespa/vespalib/stllike/string.h>
 
@@ -23,7 +24,7 @@ class ParseItem
 {
 public:
     /** The type of the item is from this set of values.
-        It is important that these defines match those in prelude/source/com/yahoo/prelude/query/Item.java */
+        It is important that these defines match those in container-search/src/main/java/com/yahoo/prelude/query/Item.java */
     enum ItemType {
         ITEM_OR                    =   0,
         ITEM_AND                   =   1,
@@ -62,15 +63,8 @@ public:
     };
 
     /** A tag identifying the origin of this query node.
-     *  Note that descendants may originate from elsewhere.
-     *  If changes necessary:
-     *  NB! Append at end of list - corresponding type
-     *  used in Juniper and updates of these two types must be synchronized.
-     *  (juniper/src/query.h)
      */
-    enum ItemCreator {
-        CREA_ORIG = 0  // Original user query
-    };
+    using ItemCreator = parseitem::ItemCreator;
 
     enum ItemFeatures {
         IF_WEIGHT         = 0x20, // item has rank weight

--- a/searchsummary/src/tests/juniper/queryvisitor_test.cpp
+++ b/searchsummary/src/tests/juniper/queryvisitor_test.cpp
@@ -4,9 +4,22 @@
 
 #include <vespa/juniper/queryhandle.h>
 #include <vespa/juniper/queryvisitor.h>
+#include <vespa/juniper/query_item.h>
 #include <vespa/vespalib/stllike/string.h>
 
 using namespace juniper;
+
+struct MyQueryItem : public QueryItem
+{
+    MyQueryItem()
+        : QueryItem()
+    { }
+    ~MyQueryItem() override = default;
+
+    vespalib::stringref get_index() const override { return {}; }
+    int get_weight() const override { return 0; }
+    ItemCreator get_creator() const override { return ItemCreator::CREA_ORIG; }
+};
 
 class MyQuery : public juniper::IQuery
 {
@@ -17,17 +30,9 @@ public:
     MyQuery(const vespalib::string &term) : _term(term) {}
 
     virtual bool Traverse(IQueryVisitor* v) const override {
-        v->VisitKeyword(nullptr, _term.c_str(), _term.size());
+        MyQueryItem item;
+        v->VisitKeyword(&item, _term.c_str(), _term.size());
         return true;
-    }
-    virtual int Weight(const QueryItem*) const override {
-        return 0;
-    }
-    virtual ItemCreator Creator(const QueryItem*) const override {
-        return ItemCreator::CREA_ORIG;
-    }
-    virtual const char* Index(const QueryItem*, size_t*) const override {
-        return "my_index";
     }
     virtual bool UsefulIndex(const QueryItem*) const override {
         return true;

--- a/searchsummary/src/vespa/juniper/query.h
+++ b/searchsummary/src/vespa/juniper/query.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/searchlib/parsequery/item_creator.h>
 #include <cstddef>
 #include <cstdint>
 
@@ -27,12 +28,7 @@
 
 namespace juniper {
 
-enum ItemCreator
-{
-    CREA_ORIG = 0,  // Original user query
-    CREA_FILTER    // Automatically applied filter (no specific type)
-};
-
+using ItemCreator = search::parseitem::ItemCreator;
 
 // For debugging purposes: return a text string with the creator enum name
 const char* creator_text(ItemCreator);
@@ -55,23 +51,6 @@ public:
      *  and calls to the appropriate Visitor functions.
      */
     virtual bool Traverse(IQueryVisitor* v) const = 0;
-
-    /** @param item A query item to check
-     *  @return A weight assigned to this term (default 100 (%) )
-     */
-    virtual int Weight(const QueryItem* item) const = 0;
-
-    /** @param item A query item to check
-     *  @return The creator module associated with this term
-     */
-    virtual ItemCreator Creator(const QueryItem* item) const = 0;
-
-    /** Return a text string representing any index specification used for this term
-     *  @param item A query item to check
-     *  @param length the length of the returned string
-     *  @return A text containing the name of the index associated with this term
-     */
-    virtual const char* Index(const QueryItem* item, size_t* length) const = 0;
 
     /** Check if the index specification associated with the query item is useful from
      *  a Juniper perspective (see fsearchrc, highlightindexes parameter)

--- a/searchsummary/src/vespa/juniper/query_item.h
+++ b/searchsummary/src/vespa/juniper/query_item.h
@@ -1,0 +1,24 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+
+namespace search::parseitem { enum class ItemCreator; }
+
+namespace juniper {
+
+using ItemCreator = search::parseitem::ItemCreator;
+
+/*
+ * Interface class for juniper query items.
+ */
+class QueryItem {
+public:
+    virtual ~QueryItem() = default;
+    virtual vespalib::stringref get_index() const = 0;
+    virtual int get_weight() const = 0;
+    virtual ItemCreator get_creator() const = 0;
+};
+
+};

--- a/searchsummary/src/vespa/juniper/querymodifier.cpp
+++ b/searchsummary/src/vespa/juniper/querymodifier.cpp
@@ -47,17 +47,9 @@ void QueryModifier::AddRewriter(const char* index_name, IRewriter* rewriter,
 
 
 /* Return any configured reducer/expander for the index, if any */
-Rewriter* QueryModifier::FindRewriter(const char* index_name)
+Rewriter* QueryModifier::FindRewriter(vespalib::stringref index_name)
 {
     return _rewriters.find(index_name);
 }
-
-
-Rewriter* QueryModifier::FindRewriter(const char* index_name, const size_t length)
-{
-    std::string idx_name(index_name, length);
-    return _rewriters.find(index_name);
-}
-
 
 } // end namespace juniper

--- a/searchsummary/src/vespa/juniper/querymodifier.h
+++ b/searchsummary/src/vespa/juniper/querymodifier.h
@@ -4,6 +4,7 @@
 #include "simplemap.h"
 #include "query.h"
 #include "rewriter.h"
+#include <vespa/vespalib/stllike/string.h>
 #include <string>
 #include <vector>
 
@@ -63,8 +64,7 @@ public:
     inline bool HasRewriters() { return _has_expanders || _has_reducers; }
 
     /* Return any configured reducer/expander for the index, if any */
-    Rewriter* FindRewriter(const char* index_name);
-    Rewriter* FindRewriter(const char* index_name, const size_t length);
+    Rewriter* FindRewriter(vespalib::stringref index_name);
 
     /* Delete/dereference all rewriters (needed for testing/debugging) */
     void FlushRewriters();

--- a/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/keywordextractor.cpp
@@ -13,7 +13,7 @@ namespace search::docsummary {
 
 bool useful(search::ParseItem::ItemCreator creator)
 {
-    return creator == search::ParseItem::CREA_ORIG;
+    return creator == search::ParseItem::ItemCreator::CREA_ORIG;
 }
 
 


### PR DESCRIPTION
Use single definition of ItemCreator enumeration in C++.

@geirst : please review
@baldersheim : FYI
