### PR TITLE
Add group-normalized redundancy to Dispatch config [run-systemtest]

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -322,8 +322,12 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
     }
 
     public void handleRedundancy(Redundancy redundancy) {
-        if (hasIndexedCluster())
+        if (hasIndexedCluster()) {
+            // Important: these must all be the normalized "within a single leaf group" values,
+            // _not_ the cluster-wide, cross-group values.
             indexedCluster.setSearchableCopies(redundancy.readyCopies());
+            indexedCluster.setRedundancy(redundancy.finalRedundancy());
+        }
         this.redundancy = redundancy;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/DispatchGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/DispatchGroup.java
@@ -54,6 +54,8 @@ public class DispatchGroup {
 
     public int getSearchableCopies() { return sc.getSearchableCopies(); }
 
+    public int getRedundancy() { return sc.getRedundancy(); }
+
     static class Iterator implements java.util.Iterator<SearchInterface> {
 
         private java.util.Iterator<Map<Integer, SearchInterface>> it1;

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -54,6 +54,7 @@ public class IndexedSearchCluster extends SearchCluster
     private final MultipleDocumentDatabasesConfigProducer documentDbsConfigProducer;
 
     private int searchableCopies = 1;
+    private int redundancy = 1;
 
     private final DispatchGroup rootDispatch;
     private DispatchSpec dispatchSpec;
@@ -263,6 +264,14 @@ public class IndexedSearchCluster extends SearchCluster
         this.searchableCopies = searchableCopies;
     }
 
+    public int getRedundancy() {
+        return redundancy;
+    }
+
+    public void setRedundancy(int redundancy) {
+        this.redundancy = redundancy;
+    }
+
     public void setDispatchSpec(DispatchSpec dispatchSpec) {
         if (dispatchSpec.getNumDispatchGroups() != null) {
             this.dispatchSpec = new DispatchSpec.Builder().setGroups
@@ -310,6 +319,7 @@ public class IndexedSearchCluster extends SearchCluster
             builder.maxHitsPerNode(tuning.dispatch.getMaxHitsPerPartition());
 
         builder.searchableCopies(rootDispatch.getSearchableCopies());
+        builder.redundancy(rootDispatch.getRedundancy());
         if (searchCoverage != null) {
             if (searchCoverage.getMinimum() != null)
                 builder.minSearchCoverage(searchCoverage.getMinimum() * 100.0);

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/cluster/ClusterTest.java
@@ -63,6 +63,7 @@ public class ClusterTest {
         assertEquals(0.23, config.minWaitAfterCoverageFactor(), DELTA);
         assertEquals(0.58, config.maxWaitAfterCoverageFactor(), DELTA);
         assertEquals(2, config.searchableCopies());
+        assertEquals(3, config.redundancy());
         assertEquals(DispatchConfig.DistributionPolicy.ADAPTIVE, config.distributionPolicy());
     }
 
@@ -80,6 +81,7 @@ public class ClusterTest {
         cluster.getSearch().getConfig(builder);
         DispatchConfig config = new DispatchConfig(builder);
         assertEquals(2, config.searchableCopies());
+        assertEquals(3, config.redundancy());
         assertEquals(93.0, config.minActivedocsPercentage(), DELTA);
         assertEquals(DispatchConfig.DistributionPolicy.ROUNDROBIN, config.distributionPolicy());
         assertEquals(77, config.maxHitsPerNode());
@@ -94,6 +96,7 @@ public class ClusterTest {
         cluster.getSearch().getConfig(builder);
         DispatchConfig config = new DispatchConfig(builder);
         assertEquals(2, config.searchableCopies());
+        assertEquals(3, config.redundancy());
         assertEquals(DispatchConfig.DistributionPolicy.ADAPTIVE, config.distributionPolicy());
         assertEquals(1.0, config.maxWaitAfterCoverageFactor(), DELTA);
         assertEquals(0, config.minWaitAfterCoverageFactor(), DELTA);

--- a/configdefinitions/src/vespa/dispatch.def
+++ b/configdefinitions/src/vespa/dispatch.def
@@ -33,8 +33,12 @@ useMultilevelDispatch bool default=false
 # Dispatch only to local nodes. DEPRECATED: The container will automatically do this when it is appropriate.
 useLocalNode bool default=false
 
-# Number of document copies
+# Number of document replicas _per group_ that will be indexed in a stable cluster.
 searchableCopies long default=1
+
+# Number of document replicas _per group_ that will be present in a stable cluster.
+# Should always be >= searchableCopies.
+redundancy long default=1
 
 # Minimum search coverage required before returning the results of a query
 minSearchCoverage double default=100


### PR DESCRIPTION
@baldersheim please review

Will allow the degraded coverage calculation to use in-group redundancy in addition to the existing searchable-copies config as part of its heuristics.

