### PR TITLE
Change provisioning lock path

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -213,7 +213,7 @@ public class CuratorDb {
     }
 
     public Mutex lockProvisionState(String provisionStateId) {
-        return curator.lock(lockRoot.append(provisionStatePath()).append(provisionStateId), Duration.ofSeconds(1));
+        return curator.lock(lockRoot.append("provisioning").append("states").append(provisionStateId), Duration.ofSeconds(1));
     }
 
     public Mutex lockOsVersions() {


### PR DESCRIPTION
Noticed that this used a weird lock path:
/controller/v1/locks/controller/v1/provisioning/states/[id]. I don't think we
provision new hosts often enough to bother with a feature flag for this change.

@hmusum or @jonmv