### PR TITLE
Adjust api for DocsumWriter and DocsumFieldWriter:

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
@@ -85,7 +85,7 @@ DocsumContext::createSlimeReply()
         Cursor &docSumC = array.addObject();
         ObjectSymbolInserter inserter(docSumC, docsumSym);
         if ((docId != search::endDocId) && rci.outputClass != nullptr) {
-            _docsumWriter.insertDocsum(rci, docId, &_docsumState, &_docsumStore, inserter);
+            _docsumWriter.insertDocsum(rci, docId, _docsumState, &_docsumStore, inserter);
         }
         num_ok++;
     }

--- a/searchsummary/src/tests/docsummary/attribute_combiner/attribute_combiner_test.cpp
+++ b/searchsummary/src/tests/docsummary/attribute_combiner/attribute_combiner_test.cpp
@@ -91,7 +91,7 @@ AttributeCombinerTest::assertWritten(const vespalib::string &exp_slime_as_json, 
 {
     vespalib::Slime act;
     vespalib::slime::SlimeInserter inserter(act);
-    writer->insertField(docId, nullptr, &state, search::docsummary::RES_JSONSTRING, inserter);
+    writer->insertField(docId, nullptr, state, inserter);
 
     SlimeValue exp(exp_slime_as_json);
     EXPECT_EQ(exp.slime, act);

--- a/searchsummary/src/tests/docsummary/attributedfw/attributedfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/attributedfw/attributedfw_test.cpp
@@ -69,7 +69,7 @@ public:
     void expect_field(const vespalib::string& exp_slime_as_json, uint32_t docid) {
         vespalib::Slime act;
         vespalib::slime::SlimeInserter inserter(act);
-        _writer->insertField(docid, nullptr, &_state, search::docsummary::RES_JSONSTRING, inserter);
+        _writer->insertField(docid, nullptr, _state, inserter);
 
         SlimeValue exp(exp_slime_as_json);
         EXPECT_EQ(exp.slime, act);

--- a/searchsummary/src/tests/docsummary/matched_elements_filter/matched_elements_filter_test.cpp
+++ b/searchsummary/src/tests/docsummary/matched_elements_filter/matched_elements_filter_test.cpp
@@ -218,7 +218,7 @@ private:
         Slime slime;
         SlimeInserter inserter(slime);
 
-        writer->insertField(doc_id, doc.get(), &state, ResType::RES_JSONSTRING, inserter);
+        writer->insertField(doc_id, doc.get(), state, inserter);
         return slime;
     }
 

--- a/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
+++ b/searchsummary/src/tests/docsummary/positionsdfw_test.cpp
@@ -132,14 +132,13 @@ void checkWritePositionField(AttrType &attr,
     MyAttributeManager attribute_man(attr);
     PositionsDFW::UP writer = PositionsDFW::create(attr.getName().c_str(), &attribute_man, false);
     ASSERT_TRUE(writer.get());
-    ResType res_type = RES_JSONSTRING;
     MyGetDocsumsStateCallback callback;
     GetDocsumsState state(callback);
     state._attributes.push_back(&attr);
 
     vespalib::Slime target;
     vespalib::slime::SlimeInserter inserter(target);
-    writer->insertField(doc_id, &state, res_type, inserter);
+    writer->insertField(doc_id, state, inserter);
 
     test::SlimeValue expected(expect_json);
     EXPECT_EQUAL(expected.slime, target);

--- a/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
+++ b/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
@@ -55,7 +55,7 @@ struct DocsumFixture : IDocsumStore, GetDocsumsStateCallback {
         Slime slimeOut;
         SlimeInserter inserter(slimeOut);
         auto rci = writer->resolveClassInfo(state._args.getResultClassName());
-        writer->insertDocsum(rci, 1u, &state, this, inserter);
+        writer->insertDocsum(rci, 1u, state, this, inserter);
         vespalib::SmartBuffer buf(4_Ki);
         BinaryFormat::encode(slimeOut, buf);
         EXPECT_GREATER(BinaryFormat::decode(buf.obtain(), slime), 0u);

--- a/searchsummary/src/vespa/searchsummary/docsummary/attribute_combiner_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/attribute_combiner_dfw.cpp
@@ -49,15 +49,15 @@ AttributeCombinerDFW::create(const vespalib::string &fieldName, IAttributeContex
 }
 
 void
-AttributeCombinerDFW::insertField(uint32_t docid, GetDocsumsState *state, ResType, vespalib::slime::Inserter &target) const
+AttributeCombinerDFW::insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const
 {
-    auto& fieldWriterState = state->_fieldWriterStates[_stateIndex];
+    auto& fieldWriterState = state._fieldWriterStates[_stateIndex];
     if (!fieldWriterState) {
         const MatchingElements *matching_elements = nullptr;
         if (_filter_elements) {
-            matching_elements = &state->get_matching_elements(*_matching_elems_fields);
+            matching_elements = &state.get_matching_elements(*_matching_elems_fields);
         }
-        fieldWriterState = allocFieldWriterState(*state->_attrCtx, state->get_stash(), matching_elements);
+        fieldWriterState = allocFieldWriterState(*state._attrCtx, state.get_stash(), matching_elements);
     }
     fieldWriterState->insertField(docid, target);
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/attribute_combiner_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/attribute_combiner_dfw.h
@@ -39,7 +39,7 @@ public:
     bool setFieldWriterStateIndex(uint32_t fieldWriterStateIndex) override;
     static std::unique_ptr<DocsumFieldWriter> create(const vespalib::string &fieldName, search::attribute::IAttributeContext &attrCtx,
                                                      bool filter_elements, std::shared_ptr<MatchingElementsFields> matching_elems_fields);
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/attributedfw.cpp
@@ -53,16 +53,16 @@ public:
     explicit SingleAttrDFW(const vespalib::string & attrName) :
         AttrDFW(attrName)
     { }
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType, Inserter &target) const override;
-    bool isDefaultValue(uint32_t docid, const GetDocsumsState * state) const override {
-        return get_attribute(*state).isUndefined(docid);
+    void insertField(uint32_t docid, GetDocsumsState& state, Inserter &target) const override;
+    bool isDefaultValue(uint32_t docid, const GetDocsumsState& state) const override {
+        return get_attribute(state).isUndefined(docid);
     }
 };
 
 void
-SingleAttrDFW::insertField(uint32_t docid, GetDocsumsState * state, ResType, Inserter &target) const
+SingleAttrDFW::insertField(uint32_t docid, GetDocsumsState& state, Inserter &target) const
 {
-    const auto& v = get_attribute(*state);
+    const auto& v = get_attribute(state);
     switch (v.getBasicType()) {
     case BasicType::Type::UINT2:
     case BasicType::Type::UINT4:
@@ -253,7 +253,7 @@ public:
         }
     }
     bool setFieldWriterStateIndex(uint32_t fieldWriterStateIndex) override;
-    void insertField(uint32_t docid, GetDocsumsState* state, ResType, Inserter& target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, Inserter& target) const override;
 };
 
 bool
@@ -301,16 +301,16 @@ make_field_writer_state(const vespalib::string& field_name, const IAttributeVect
 }
 
 void
-MultiAttrDFW::insertField(uint32_t docid, GetDocsumsState *state, ResType, vespalib::slime::Inserter &target) const
+MultiAttrDFW::insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const
 {
-    auto& field_writer_state = state->_fieldWriterStates[_state_index];
+    auto& field_writer_state = state._fieldWriterStates[_state_index];
     if (!field_writer_state) {
         const MatchingElements *matching_elements = nullptr;
         if (_filter_elements) {
-            matching_elements = &state->get_matching_elements(*_matching_elems_fields);
+            matching_elements = &state.get_matching_elements(*_matching_elems_fields);
         }
-        const auto& attr = get_attribute(*state);
-        field_writer_state = make_field_writer_state(getAttributeName(), attr, state->get_stash(), matching_elements);
+        const auto& attr = get_attribute(state);
+        field_writer_state = make_field_writer_state(getAttributeName(), attr, state.get_stash(), matching_elements);
     }
     field_writer_state->insertField(docid, target);
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/copy_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/copy_dfw.cpp
@@ -17,7 +17,7 @@ CopyDFW::CopyDFW(const vespalib::string& inputField)
 CopyDFW::~CopyDFW() = default;
 
 void
-CopyDFW::insertField(uint32_t, const IDocsumStoreDocument* doc, GetDocsumsState *, ResType,
+CopyDFW::insertField(uint32_t, const IDocsumStoreDocument* doc, GetDocsumsState&,
                      vespalib::slime::Inserter &target) const
 {
     if (doc != nullptr) {

--- a/searchsummary/src/vespa/searchsummary/docsummary/copy_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/copy_dfw.h
@@ -21,8 +21,7 @@ public:
     ~CopyDFW() override;
 
     bool IsGenerated() const override { return false; }
-    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state, ResType type,
-                     vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer.cpp
@@ -13,7 +13,7 @@ DocsumFieldWriter::getAttributeName() const
 }
 
 bool
-DocsumFieldWriter::isDefaultValue(uint32_t, const GetDocsumsState*) const
+DocsumFieldWriter::isDefaultValue(uint32_t, const GetDocsumsState&) const
 {
     return false;
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer.h
@@ -24,9 +24,9 @@ public:
     }
     virtual ~DocsumFieldWriter() = default;
     virtual bool IsGenerated() const = 0;
-    virtual void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const = 0;
+    virtual void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state, vespalib::slime::Inserter &target) const = 0;
     virtual const vespalib::string & getAttributeName() const;
-    virtual bool isDefaultValue(uint32_t docid, const GetDocsumsState * state) const;
+    virtual bool isDefaultValue(uint32_t docid, const GetDocsumsState& state) const;
     void setIndex(size_t v) { _index = v; }
     size_t getIndex() const { return _index; }
     virtual bool setFieldWriterStateIndex(uint32_t fieldWriterStateIndex);

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.cpp
@@ -48,7 +48,7 @@ DynamicDocsumWriter::resolveOutputClass(vespalib::stringref summaryClass) const
 }
 
 void
-DynamicDocsumWriter::insertDocsum(const ResolveClassInfo & rci, uint32_t docid, GetDocsumsState *state,
+DynamicDocsumWriter::insertDocsum(const ResolveClassInfo & rci, uint32_t docid, GetDocsumsState& state,
                                   IDocsumStore *docinfos, Inserter& topInserter)
 {
     if (rci.outputClass == nullptr) {
@@ -61,10 +61,10 @@ DynamicDocsumWriter::insertDocsum(const ResolveClassInfo & rci, uint32_t docid, 
         for (uint32_t i = 0; i < rci.outputClass->GetNumEntries(); ++i) {
             const ResConfigEntry *resCfg = rci.outputClass->GetEntry(i);
             const DocsumFieldWriter *writer = resCfg->_docsum_field_writer.get();
-            if (state->_args.needField(resCfg->_name) && ! writer->isDefaultValue(docid, state)) {
+            if (state._args.needField(resCfg->_name) && ! writer->isDefaultValue(docid, state)) {
                 const Memory field_name(resCfg->_name.data(), resCfg->_name.size());
                 ObjectInserter inserter(docsum, field_name);
-                writer->insertField(docid, nullptr, state, resCfg->_type, inserter);
+                writer->insertField(docid, nullptr, state, inserter);
             }
         }
     } else {
@@ -77,13 +77,13 @@ DynamicDocsumWriter::insertDocsum(const ResolveClassInfo & rci, uint32_t docid, 
         vespalib::slime::Cursor & docsum = topInserter.insertObject();
         for (uint32_t i = 0; i < rci.outputClass->GetNumEntries(); ++i) {
             const ResConfigEntry *outCfg = rci.outputClass->GetEntry(i);
-            if ( ! state->_args.needField(outCfg->_name)) continue;
+            if ( ! state._args.needField(outCfg->_name)) continue;
             const DocsumFieldWriter *writer = outCfg->_docsum_field_writer.get();
             const Memory field_name(outCfg->_name.data(), outCfg->_name.size());
             ObjectInserter inserter(docsum, field_name);
             if (writer != nullptr) {
                 if (! writer->isDefaultValue(docid, state)) {
-                    writer->insertField(docid, doc.get(), state, outCfg->_type, inserter);
+                    writer->insertField(docid, doc.get(), state, inserter);
                 }
             } else {
                 if (doc) {

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.h
@@ -37,7 +37,7 @@ public:
 
     virtual ~IDocsumWriter() = default;
     virtual void InitState(const search::IAttributeManager & attrMan, GetDocsumsState& state, const ResolveClassInfo& rci) = 0;
-    virtual void insertDocsum(const ResolveClassInfo & rci, uint32_t docid, GetDocsumsState *state,
+    virtual void insertDocsum(const ResolveClassInfo & rci, uint32_t docid, GetDocsumsState& state,
                               IDocsumStore *docinfos, Inserter & target) = 0;
     virtual ResolveClassInfo resolveClassInfo(vespalib::stringref outputClassName) const = 0;
 };
@@ -61,7 +61,7 @@ public:
     const ResultConfig *GetResultConfig() { return _resultConfig.get(); }
 
     void InitState(const search::IAttributeManager & attrMan, GetDocsumsState& state, const ResolveClassInfo& rci) override;
-    void insertDocsum(const ResolveClassInfo & outputClassInfo, uint32_t docid, GetDocsumsState *state,
+    void insertDocsum(const ResolveClassInfo & outputClassInfo, uint32_t docid, GetDocsumsState& state,
                       IDocsumStore *docinfos, Inserter & inserter) override;
 
     ResolveClassInfo resolveClassInfo(vespalib::stringref outputClassName) const override;

--- a/searchsummary/src/vespa/searchsummary/docsummary/document_id_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/document_id_dfw.cpp
@@ -10,7 +10,7 @@ DocumentIdDFW::DocumentIdDFW() = default;
 DocumentIdDFW::~DocumentIdDFW() = default;
 
 void
-DocumentIdDFW::insertField(uint32_t, const IDocsumStoreDocument* doc, GetDocsumsState *, ResType,
+DocumentIdDFW::insertField(uint32_t, const IDocsumStoreDocument* doc, GetDocsumsState&,
                            vespalib::slime::Inserter &target) const
 {
     if (doc != nullptr) {

--- a/searchsummary/src/vespa/searchsummary/docsummary/document_id_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/document_id_dfw.h
@@ -16,7 +16,7 @@ public:
     DocumentIdDFW();
     ~DocumentIdDFW() override;
     bool IsGenerated() const override { return false; }
-    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/dynamicteaserdfw.cpp
@@ -143,11 +143,11 @@ JuniperConverter::insert_juniper_field(const document::StringFieldValue& input, 
 }
 
 void
-DynamicTeaserDFW::insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state, ResType,
+DynamicTeaserDFW::insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state,
                               vespalib::slime::Inserter &target) const
 {
     if (doc != nullptr) {
-        JuniperConverter converter(*this, docid, *state);
+        JuniperConverter converter(*this, docid, state);
         doc->insert_juniper_field(_input_field_name, target, converter);
     }
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/empty_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/empty_dfw.cpp
@@ -9,7 +9,7 @@ EmptyDFW::EmptyDFW() = default;
 EmptyDFW::~EmptyDFW() = default;
 
 void
-EmptyDFW::insertField(uint32_t, GetDocsumsState *, ResType, vespalib::slime::Inserter &target) const
+EmptyDFW::insertField(uint32_t, GetDocsumsState&, vespalib::slime::Inserter &target) const
 {
     // insert explicitly-empty field?
     // target.insertNix();

--- a/searchsummary/src/vespa/searchsummary/docsummary/empty_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/empty_dfw.h
@@ -16,7 +16,7 @@ public:
     ~EmptyDFW() override;
 
     bool IsGenerated() const override { return true; }
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/geoposdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/geoposdfw.cpp
@@ -55,14 +55,14 @@ void fmtZcurve(int64_t zval, vespalib::slime::Inserter &target, bool useV8geoPos
 }
 
 void
-GeoPositionDFW::insertField(uint32_t docid, GetDocsumsState * dsState, ResType, vespalib::slime::Inserter &target) const
+GeoPositionDFW::insertField(uint32_t docid, GetDocsumsState& dsState, vespalib::slime::Inserter &target) const
 {
     using vespalib::slime::Cursor;
     using vespalib::slime::ObjectSymbolInserter;
     using vespalib::slime::Symbol;
     using vespalib::slime::ArrayInserter;
 
-    const auto& attribute = get_attribute(*dsState);
+    const auto& attribute = get_attribute(dsState);
     if (attribute.hasMultiValue()) {
         uint32_t entries = attribute.getValueCount(docid);
         if (entries == 0 && _useV8geoPositions) return;

--- a/searchsummary/src/vespa/searchsummary/docsummary/geoposdfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/geoposdfw.h
@@ -16,7 +16,7 @@ private:
 public:
     typedef std::unique_ptr<GeoPositionDFW> UP;
     GeoPositionDFW(const vespalib::string & attrName, bool useV8geoPositions);
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
     static UP create(const char *attribute_name, const IAttributeManager *attribute_manager, bool useV8geoPositions);
 };
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/juniperdfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/juniperdfw.h
@@ -48,8 +48,8 @@ class DynamicTeaserDFW : public JuniperTeaserDFW
 public:
     explicit DynamicTeaserDFW(const juniper::Juniper * juniper) : JuniperTeaserDFW(juniper) { }
 
-    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state,
-                     ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state,
+                     vespalib::slime::Inserter &target) const override;
     void insert_juniper_field(uint32_t docid, vespalib::stringref input, GetDocsumsState& state, vespalib::slime::Inserter& inserter) const;
 };
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.cpp
@@ -63,12 +63,12 @@ MatchedElementsFilterDFW::create(const std::string& input_field_name,
 MatchedElementsFilterDFW::~MatchedElementsFilterDFW() = default;
 
 void
-MatchedElementsFilterDFW::insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state,
-                                      ResType, vespalib::slime::Inserter& target) const
+MatchedElementsFilterDFW::insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state,
+                                      vespalib::slime::Inserter& target) const
 {
     auto field_value = doc->get_field_value(_input_field_name);
     if (field_value) {
-        SummaryFieldConverter::insert_summary_field_with_filter(*field_value, target, get_matching_elements(docid, *state));
+        SummaryFieldConverter::insert_summary_field_with_filter(*field_value, target, get_matching_elements(docid, state));
     }
 }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/matched_elements_filter_dfw.h
@@ -34,8 +34,8 @@ public:
                                                      std::shared_ptr<MatchingElementsFields> matching_elems_fields);
     ~MatchedElementsFilterDFW() override;
     bool IsGenerated() const override { return false; }
-    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState *state,
-                     ResType, vespalib::slime::Inserter& target) const override;
+    void insertField(uint32_t docid, const IDocsumStoreDocument* doc, GetDocsumsState& state,
+                     vespalib::slime::Inserter& target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/positionsdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/positionsdfw.cpp
@@ -34,16 +34,16 @@ using search::common::Location;
 using search::common::GeoGcd;
 
 LocationAttrDFW::AllLocations
-LocationAttrDFW::getAllLocations(GetDocsumsState *state) const
+LocationAttrDFW::getAllLocations(GetDocsumsState& state) const
 {
     AllLocations retval;
-    if (! state->_args.locations_possible()) {
+    if (! state._args.locations_possible()) {
         return retval;
     }
-    if (state->_parsedLocations.empty()) {
-        state->parse_locations();
+    if (state._parsedLocations.empty()) {
+        state.parse_locations();
     }
-    for (const auto & loc : state->_parsedLocations) {
+    for (const auto & loc : state._parsedLocations) {
         if (loc.location.valid()) {
             LOG(debug, "found location(field %s) for DFW(field %s)\n",
                 loc.field_name.c_str(), getAttributeName().c_str());
@@ -56,7 +56,7 @@ LocationAttrDFW::getAllLocations(GetDocsumsState *state) const
     }
     if (retval.empty()) {
         // avoid doing things twice
-        state->_args.locations_possible(false);
+        state._args.locations_possible(false);
     }
     return retval;
 }
@@ -69,13 +69,13 @@ AbsDistanceDFW::AbsDistanceDFW(const vespalib::string & attrName)
 { }
 
 uint64_t
-AbsDistanceDFW::findMinDistance(uint32_t docid, GetDocsumsState *state,
+AbsDistanceDFW::findMinDistance(uint32_t docid, GetDocsumsState& state,
                                 const std::vector<const GeoLoc *> &locations) const
 {
     // ensure result fits in Java "int"
     uint64_t absdist = std::numeric_limits<int32_t>::max();
     uint64_t sqdist = absdist*absdist;
-    const auto& attribute = get_attribute(*state);
+    const auto& attribute = get_attribute(state);
     for (auto location : locations) {
         int32_t docx = 0;
         int32_t docy = 0;
@@ -95,7 +95,7 @@ AbsDistanceDFW::findMinDistance(uint32_t docid, GetDocsumsState *state,
 }
 
 void
-AbsDistanceDFW::insertField(uint32_t docid, GetDocsumsState *state, ResType, vespalib::slime::Inserter &target) const
+AbsDistanceDFW::insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const
 {
     const auto & all_locations = getAllLocations(state);
     if (all_locations.empty()) {
@@ -220,12 +220,12 @@ void insertV8FromAttr(const attribute::IAttributeVector &attribute, uint32_t doc
 } // namespace
 
 void
-PositionsDFW::insertField(uint32_t docid, GetDocsumsState * dsState, ResType, vespalib::slime::Inserter &target) const
+PositionsDFW::insertField(uint32_t docid, GetDocsumsState& dsState, vespalib::slime::Inserter &target) const
 {
     if (_useV8geoPositions) {
-        insertV8FromAttr(get_attribute(*dsState), docid, target);
+        insertV8FromAttr(get_attribute(dsState), docid, target);
     } else {
-        insertFromAttr(get_attribute(*dsState), docid, target);
+        insertFromAttr(get_attribute(dsState), docid, target);
     }
 }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/positionsdfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/positionsdfw.h
@@ -31,20 +31,20 @@ public:
             return matching.empty() ? other : matching;
         }
     };
-    AllLocations getAllLocations(GetDocsumsState *state) const;
+    AllLocations getAllLocations(GetDocsumsState& state) const;
 };
 
 class AbsDistanceDFW : public LocationAttrDFW
 {
 private:
-    uint64_t findMinDistance(uint32_t docid, GetDocsumsState *state,
+    uint64_t findMinDistance(uint32_t docid, GetDocsumsState& state,
                              const std::vector<const GeoLoc *> &locations) const;
 public:
     explicit AbsDistanceDFW(const vespalib::string & attrName);
 
     bool IsGenerated() const override { return true; }
-    void insertField(uint32_t docid, GetDocsumsState *state,
-                     ResType, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state,
+                     vespalib::slime::Inserter &target) const override;
 
     static std::unique_ptr<DocsumFieldWriter> create(const char *attribute_name, const IAttributeManager *index_man);
 
@@ -60,7 +60,7 @@ public:
     typedef std::unique_ptr<PositionsDFW> UP;
     PositionsDFW(const vespalib::string & attrName, bool useV8geoPositions);
     bool IsGenerated() const override { return true; }
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
     static UP create(const char *attribute_name, const IAttributeManager *index_man, bool useV8geoPositions);
 };
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.cpp
@@ -12,17 +12,17 @@ RankFeaturesDFW::RankFeaturesDFW() = default;
 RankFeaturesDFW::~RankFeaturesDFW() = default;
 
 void
-RankFeaturesDFW::insertField(uint32_t docid, GetDocsumsState *state,
-                             ResType, vespalib::slime::Inserter &target) const
+RankFeaturesDFW::insertField(uint32_t docid, GetDocsumsState& state,
+                             vespalib::slime::Inserter &target) const
 {
-    if ( !state->_rankFeatures ) {
-        state->_callback.FillRankFeatures(*state);
-        if (state->_rankFeatures.get() == nullptr) { // still no rank features to write
+    if ( !state._rankFeatures ) {
+        state._callback.FillRankFeatures(state);
+        if (state._rankFeatures.get() == nullptr) { // still no rank features to write
             return;
         }
     }
-    const FeatureSet::StringVector & names = state->_rankFeatures->getNames();
-    const FeatureSet::Value * values = state->_rankFeatures->getFeaturesByDocId(docid);
+    const FeatureSet::StringVector & names = state._rankFeatures->getNames();
+    const FeatureSet::Value * values = state._rankFeatures->getFeaturesByDocId(docid);
     if (values == nullptr) { return; }
 
     vespalib::slime::Cursor& obj = target.insertObject();

--- a/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/rankfeaturesdfw.h
@@ -14,7 +14,7 @@ public:
     RankFeaturesDFW & operator=(const RankFeaturesDFW &) = delete;
     ~RankFeaturesDFW() override;
     bool IsGenerated() const override { return true; }
-    void insertField(uint32_t docid, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/simple_dfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/simple_dfw.cpp
@@ -5,9 +5,9 @@
 namespace search::docsummary {
 
 void
-SimpleDFW::insertField(uint32_t docid, const IDocsumStoreDocument *, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const
+SimpleDFW::insertField(uint32_t docid, const IDocsumStoreDocument *, GetDocsumsState& state, vespalib::slime::Inserter &target) const
 {
-    insertField(docid, state, type, target);
+    insertField(docid, state, target);
 }
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/simple_dfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/simple_dfw.h
@@ -13,8 +13,8 @@ namespace search::docsummary {
 class SimpleDFW : public DocsumFieldWriter
 {
 public:
-    virtual void insertField(uint32_t docid, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const = 0;
-    void insertField(uint32_t docid, const IDocsumStoreDocument*, GetDocsumsState *state, ResType type, vespalib::slime::Inserter &target) const override;
+    virtual void insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const = 0;
+    void insertField(uint32_t docid, const IDocsumStoreDocument*, GetDocsumsState& state, vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.cpp
@@ -18,19 +18,19 @@ SummaryFeaturesDFW::~SummaryFeaturesDFW() = default;
 static vespalib::Memory _M_cached("vespa.summaryFeatures.cached");
 
 void
-SummaryFeaturesDFW::insertField(uint32_t docid, GetDocsumsState *state, ResType, vespalib::slime::Inserter &target) const
+SummaryFeaturesDFW::insertField(uint32_t docid, GetDocsumsState& state, vespalib::slime::Inserter &target) const
 {
-    if (state->_omit_summary_features) {
+    if (state._omit_summary_features) {
         return;
     }
-    if ( ! state->_summaryFeatures) {
-        state->_callback.FillSummaryFeatures(*state);
-        if ( !state->_summaryFeatures) { // still no summary features to write
+    if ( ! state._summaryFeatures) {
+        state._callback.FillSummaryFeatures(state);
+        if ( !state._summaryFeatures) { // still no summary features to write
             return;
         }
     }
-    const FeatureSet::StringVector &names = state->_summaryFeatures->getNames();
-    const FeatureSet::Value *values = state->_summaryFeatures->getFeaturesByDocId(docid);
+    const FeatureSet::StringVector &names = state._summaryFeatures->getNames();
+    const FeatureSet::Value *values = state._summaryFeatures->getFeaturesByDocId(docid);
     if (values == nullptr) { return; }
 
     vespalib::slime::Cursor& obj = target.insertObject();
@@ -42,7 +42,7 @@ SummaryFeaturesDFW::insertField(uint32_t docid, GetDocsumsState *state, ResType,
             obj.setDouble(name, values[i].as_double());
         }
     }
-    if (state->_summaryFeaturesCached) {
+    if (state._summaryFeaturesCached) {
         obj.setDouble(_M_cached, 1.0);
     } else {
         obj.setDouble(_M_cached, 0.0);

--- a/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/summaryfeaturesdfw.h
@@ -14,8 +14,8 @@ public:
     SummaryFeaturesDFW & operator=(const SummaryFeaturesDFW &) = delete;
     ~SummaryFeaturesDFW() override;
     bool IsGenerated() const override { return true; }
-    void insertField(uint32_t docid, GetDocsumsState *state,
-                     ResType type, vespalib::slime::Inserter &target) const override;
+    void insertField(uint32_t docid, GetDocsumsState& state,
+                     vespalib::slime::Inserter &target) const override;
 };
 
 }

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -173,7 +173,7 @@ SearchVisitor::SummaryGenerator::fillSummary(AttributeVector::DocId lid, const H
         vespalib::Slime slime;
         vespalib::slime::SlimeInserter inserter(slime);
         auto& sds = get_streaming_docsums_state(summaryClass);
-        _docsumWriter->insertDocsum(sds.get_resolve_class_info(), lid, &sds.get_state(), _docsumFilter.get(), inserter);
+        _docsumWriter->insertDocsum(sds.get_resolve_class_info(), lid, sds.get_state(), _docsumFilter.get(), inserter);
         _buf.reset();
         vespalib::WritableMemory magicId = _buf.reserve(4);
         memcpy(magicId.data, &search::docsummary::SLIME_MAGIC_ID, 4);


### PR DESCRIPTION
Pass reference to state instead of pointer.
Drop unused ResType argument.

@geirst : please review
