### PR TITLE
Dont fail coredump reports if /proc/cpuinfo is missing microcode info…

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/StorageMaintainer.java
@@ -226,7 +226,7 @@ public class StorageMaintainer {
         String output = uncheck(() -> Files.readAllLines(Paths.get("/proc/cpuinfo")).stream()
                 .filter(line -> line.startsWith("microcode"))
                 .findFirst()
-                .orElseThrow(() -> ConvergenceException.ofError("No microcode information found in /proc/cpuinfo")));
+                .orElse("microcode : UNKNOWN"));
 
         String[] results = output.split(":");
         if (results.length != 2) {


### PR DESCRIPTION
…rmation.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
