### PR TITLE
Allow path prefix alias for legacy content status pages [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
@@ -376,8 +376,8 @@ BucketManager::reportStatus(std::ostream& out,
     } else {
         framework::PartlyHtmlStatusReporter htmlReporter(*this);
         htmlReporter.reportHtmlHeader(out, path);
-            // Print menu
-        out << "<font size=\"-1\">[ <a href=\"/\">Back to top</a>"
+        // Print menu
+        out << "<font size=\"-1\">[ <a href=\"../\">Back to top</a>"
             << " | <a href=\"?showall\">Show all buckets</a> ]</font>";
         htmlReporter.reportHtmlFooter(out, path);
     }

--- a/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/status/statuswebserver.cpp
@@ -169,10 +169,21 @@ void
 StatusWebServer::handlePage(const framework::HttpUrlPath& urlpath, vespalib::Portal::GetRequest request)
 {
     vespalib::string link(urlpath.getPath());
-    if (!link.empty() && link[0] == '/') link = link.substr(1);
+
+    // We allow a fixed path prefix that aliases down to whatever is provided after the prefix.
+    vespalib::stringref optional_status_path_prefix = "/contentnode-status/v1/";
+    if (link.starts_with(optional_status_path_prefix)) {
+        link = link.substr(optional_status_path_prefix.size());
+    }
+
+    if (!link.empty() && link[0] == '/') {
+        link = link.substr(1);
+    }
 
     size_t slashPos = link.find('/');
-    if (slashPos != std::string::npos) link = link.substr(0, slashPos);
+    if (slashPos != std::string::npos) {
+        link = link.substr(0, slashPos);
+    }
 
     if ( ! link.empty()) {
         const framework::StatusReporter *reporter = _reporterMap.getStatusReporter(link);

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -893,7 +893,7 @@ FileStorManager::reportHtmlStatus(std::ostream& out, const framework::HttpUrlPat
     bool showStatus = !path.hasAttribute("thread");
     bool verbose    = path.hasAttribute("verbose");
     // Print menu
-    out << "<font size=\"-1\">[ <a href=\"/\">Back to top</a>"
+    out << "<font size=\"-1\">[ <a href=\"../\">Back to top</a>"
         << " | <a href=\"?" << (verbose ? "verbose" : "")
         << "\">Main filestor manager status page</a>"
         << " | <a href=\"?" << (verbose ? "notverbose" : "verbose");

--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -566,7 +566,7 @@ VisitorManager::reportHtmlStatus(std::ostream& out,
     bool showAll = path.hasAttribute("allvisitors");
 
         // Print menu
-    out << "<font size=\"-1\">[ <a href=\"/\">Back to top</a>"
+    out << "<font size=\"-1\">[ <a href=\"../\">Back to top</a>"
         << " | <a href=\"?" << (verbose ? "verbose" : "")
         << "\">Main visitor manager status page</a>"
         << " | <a href=\"?allvisitors" << (verbose ? "&verbose" : "")


### PR DESCRIPTION
@geirst please review
@andreer @tokle FYI

This lets status pages that today are served at the root `/` path be aliased under `/contentnode-status/v1/`. Legacy paths continue working as before. Also changed existing status page absolute paths to relative to avoid having to care about this particular detail internally.

Note: both distributor and search/storage node process status pages use the `/contentnode-status/v1/` prefix, as they're both technically processes that are part of a _logical_ content node.
