### PR TITLE
Chose correct "redundancy" for coverage estimation. Current default i…

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InterleavedSearchInvoker.java
@@ -127,7 +127,7 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         groupingResultAggregator.toAggregatedHit().ifPresent(h -> result.getResult().hits().add(h));
 
         insertNetworkErrors(result.getResult());
-        CoverageAggregator adjusted = coverageAggregator.adjustedDegradedCoverage((int)searchCluster.dispatchConfig().searchableCopies(), timeoutHandler);
+        CoverageAggregator adjusted = coverageAggregator.adjustedDegradedCoverage(redundancyForCoverage(searchCluster.dispatchConfig()), timeoutHandler);
         result.getResult().setCoverage(adjusted.createCoverage(timeoutHandler, searchCluster.dispatchConfig().computeCoverageFromTargetActiveDocs()));
 
         int needed = query.getOffset() + query.getHits();
@@ -136,6 +136,10 @@ public class InterleavedSearchInvoker extends SearchInvoker implements ResponseM
         }
         query.setOffset(0);  // Now we are all trimmed down
         return result;
+    }
+
+    private int redundancyForCoverage(DispatchConfig config) {
+        return (int)(config.computeCoverageFromTargetActiveDocs() ? config.redundancy() : config.searchableCopies());
     }
 
     private void insertNetworkErrors(Result result) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/InterleavedSearchInvokerTest.java
@@ -21,10 +21,10 @@ import com.yahoo.searchlib.aggregation.MinAggregationResult;
 import com.yahoo.searchlib.expression.IntegerResultNode;
 import com.yahoo.searchlib.expression.StringResultNode;
 import com.yahoo.test.ManualClock;
+import com.yahoo.vespa.config.search.DispatchConfig;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.function.ToLongFunction;
 import java.util.stream.StreamSupport;
 
 import static com.yahoo.container.handler.Coverage.DEGRADED_BY_MATCH_PHASE;
@@ -56,52 +55,55 @@ public class InterleavedSearchInvokerTest {
     @Test
     void requireThatAdaptiveTimeoutsAreNotUsedWithFullCoverageRequirement() throws IOException {
         SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(100.0), 1, 3);
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 3);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 3)) {
 
-        expectedEvents.add(new Event(5000, 100, 0));
-        expectedEvents.add(new Event(4900, 100, 1));
-        expectedEvents.add(new Event(4800, 100, 2));
+            expectedEvents.add(new Event(5000, 100, 0));
+            expectedEvents.add(new Event(4900, 100, 1));
+            expectedEvents.add(new Event(4800, 100, 2));
 
-        invoker.search(query, null);
+            invoker.search(query, null);
 
-        assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
+            assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
+        }
     }
 
     @Test
     void requireThatTimeoutsAreNotMarkedAsAdaptive() throws IOException {
         SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(100.0), 1, 3);
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 3);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 3)) {
 
-        expectedEvents.add(new Event(5000, 300, 0));
-        expectedEvents.add(new Event(4700, 300, 1));
-        expectedEvents.add(null);
+            expectedEvents.add(new Event(5000, 300, 0));
+            expectedEvents.add(new Event(4700, 300, 1));
+            expectedEvents.add(null);
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
-        assertNull(result.hits().getErrorHit(), "Result is not marked as an error");
-        var message = findTrace(result, "Backend communication timeout");
-        assertTrue(message.isPresent(), "Timeout should be reported in a trace message");
-        assertTrue(result.getCoverage(false).isDegradedByTimeout(), "Degradation reason is a normal timeout");
+            assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
+            assertNull(result.hits().getErrorHit(), "Result is not marked as an error");
+            var message = findTrace(result, "Backend communication timeout");
+            assertTrue(message.isPresent(), "Timeout should be reported in a trace message");
+            assertTrue(result.getCoverage(false).isDegradedByTimeout(), "Degradation reason is a normal timeout");
+        }
     }
 
     @Test
     void requireThatAdaptiveTimeoutDecreasesTimeoutWhenCoverageIsReached() throws IOException {
         SearchCluster cluster = new MockSearchCluster("!", createDispatchConfig(50.0), 1, 4);
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 4);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 4)) {
 
-        expectedEvents.add(new Event(5000, 100, 0));
-        expectedEvents.add(new Event(4900, 100, 1));
-        expectedEvents.add(new Event(2400, 100, 2));
-        expectedEvents.add(new Event(0, 0, null));
+            expectedEvents.add(new Event(5000, 100, 0));
+            expectedEvents.add(new Event(4900, 100, 1));
+            expectedEvents.add(new Event(2400, 100, 2));
+            expectedEvents.add(new Event(0, 0, null));
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
-        assertNull(result.hits().getErrorHit(), "Result is not marked as an error");
-        var message = findTrace(result, "Backend communication timeout");
-        assertTrue(message.isPresent(), "Timeout should be reported in a trace message");
-        assertTrue(result.getCoverage(false).isDegradedByAdapativeTimeout(), "Degradataion reason is an adaptive timeout");
+            assertTrue(expectedEvents.isEmpty(), "All test scenario events processed");
+            assertNull(result.hits().getErrorHit(), "Result is not marked as an error");
+            var message = findTrace(result, "Backend communication timeout");
+            assertTrue(message.isPresent(), "Timeout should be reported in a trace message");
+            assertTrue(result.getCoverage(false).isDegradedByAdapativeTimeout(), "Degradataion reason is an adaptive timeout");
+        }
     }
 
     @Test
@@ -109,20 +111,21 @@ public class InterleavedSearchInvokerTest {
         SearchCluster cluster = new MockSearchCluster("!", 1, 2);
         invokers.add(new MockInvoker(0, createCoverage(50155, 50155, 50155, 1, 1, 0)));
         invokers.add(new MockInvoker(1, createCoverage(49845, 49845, 49845, 1, 1, 0)));
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0)) {
 
-        expectedEvents.add(new Event(null, 100, 0));
-        expectedEvents.add(new Event(null, 200, 1));
+            expectedEvents.add(new Event(null, 100, 0));
+            expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        Coverage cov = result.getCoverage(true);
-        assertEquals(100000L, cov.getDocs());
-        assertEquals(2, cov.getNodes());
-        assertTrue(cov.getFull());
-        assertEquals(100, cov.getResultPercentage());
-        assertEquals(1, cov.getResultSets());
-        assertEquals(1, cov.getFullResultSets());
+            Coverage cov = result.getCoverage(true);
+            assertEquals(100000L, cov.getDocs());
+            assertEquals(2, cov.getNodes());
+            assertTrue(cov.getFull());
+            assertEquals(100, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(1, cov.getFullResultSets());
+        }
     }
 
     @Test
@@ -130,21 +133,22 @@ public class InterleavedSearchInvokerTest {
         SearchCluster cluster = new MockSearchCluster("!", 1, 2);
         invokers.add(new MockInvoker(0, createCoverage(10101, 50155, 50155, 1, 1, DEGRADED_BY_MATCH_PHASE)));
         invokers.add(new MockInvoker(1, createCoverage(13319, 49845, 49845, 1, 1, DEGRADED_BY_MATCH_PHASE)));
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0)) {
 
-        expectedEvents.add(new Event(null, 100, 0));
-        expectedEvents.add(new Event(null, 200, 1));
+            expectedEvents.add(new Event(null, 100, 0));
+            expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        Coverage cov = result.getCoverage(true);
-        assertEquals(23420L, cov.getDocs());
-        assertEquals(2, cov.getNodes());
-        assertFalse(cov.getFull());
-        assertEquals(23, cov.getResultPercentage());
-        assertEquals(1, cov.getResultSets());
-        assertEquals(0, cov.getFullResultSets());
-        assertTrue(cov.isDegradedByMatchPhase());
+            Coverage cov = result.getCoverage(true);
+            assertEquals(23420L, cov.getDocs());
+            assertEquals(2, cov.getNodes());
+            assertFalse(cov.getFull());
+            assertEquals(23, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(0, cov.getFullResultSets());
+            assertTrue(cov.isDegradedByMatchPhase());
+        }
     }
 
     @Test
@@ -152,21 +156,22 @@ public class InterleavedSearchInvokerTest {
         SearchCluster cluster = new MockSearchCluster("!", 1, 2);
         invokers.add(new MockInvoker(0, createCoverage(5000, 50155, 50155, 1, 1, DEGRADED_BY_TIMEOUT)));
         invokers.add(new MockInvoker(1, createCoverage(4900, 49845, 49845, 1, 1, DEGRADED_BY_TIMEOUT)));
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0)) {
 
-        expectedEvents.add(new Event(null, 100, 0));
-        expectedEvents.add(new Event(null, 200, 1));
+            expectedEvents.add(new Event(null, 100, 0));
+            expectedEvents.add(new Event(null, 200, 1));
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        Coverage cov = result.getCoverage(true);
-        assertEquals(9900L, cov.getDocs());
-        assertEquals(2, cov.getNodes());
-        assertFalse(cov.getFull());
-        assertEquals(10, cov.getResultPercentage());
-        assertEquals(1, cov.getResultSets());
-        assertEquals(0, cov.getFullResultSets());
-        assertTrue(cov.isDegradedByTimeout());
+            Coverage cov = result.getCoverage(true);
+            assertEquals(9900L, cov.getDocs());
+            assertEquals(2, cov.getNodes());
+            assertFalse(cov.getFull());
+            assertEquals(10, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(0, cov.getFullResultSets());
+            assertTrue(cov.isDegradedByTimeout());
+        }
     }
 
     @Test
@@ -174,22 +179,23 @@ public class InterleavedSearchInvokerTest {
         SearchCluster cluster = new MockSearchCluster("!", 1, 2);
         invokers.add(new MockInvoker(0, createCoverage(50155, 50155, 50155, 1, 1, 0)));
         invokers.add(new MockInvoker(1, createCoverage(49845, 49845, 49845, 1, 1, 0)));
-        SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0);
+        try (SearchInvoker invoker = createInterleavedInvoker(cluster, new Group(0, List.of()), 0)) {
 
-        expectedEvents.add(new Event(null, 100, 0));
-        expectedEvents.add(null);
+            expectedEvents.add(new Event(null, 100, 0));
+            expectedEvents.add(null);
 
-        Result result = invoker.search(query, null);
+            Result result = invoker.search(query, null);
 
-        Coverage cov = result.getCoverage(true);
-        assertEquals(50155L, cov.getDocs());
-        assertEquals(1, cov.getNodes());
-        assertEquals(2, cov.getNodesTried());
-        assertFalse(cov.getFull());
-        assertEquals(50, cov.getResultPercentage());
-        assertEquals(1, cov.getResultSets());
-        assertEquals(0, cov.getFullResultSets());
-        assertTrue(cov.isDegradedByTimeout());
+            Coverage cov = result.getCoverage(true);
+            assertEquals(50155L, cov.getDocs());
+            assertEquals(1, cov.getNodes());
+            assertEquals(2, cov.getNodesTried());
+            assertFalse(cov.getFull());
+            assertEquals(50, cov.getResultPercentage());
+            assertEquals(1, cov.getResultSets());
+            assertEquals(0, cov.getFullResultSets());
+            assertTrue(cov.isDegradedByTimeout());
+        }
     }
 
     static class MetaHit extends Hit {
@@ -209,24 +215,25 @@ public class InterleavedSearchInvokerTest {
     private static final List<Double> B5Aux = Arrays.asList(9.0,8.0,-3.0,7.0,6.0,1.0, -1.0);
 
     private void validateThatTopKProbabilityOverrideTakesEffect(Double topKProbability, int expectedK, Group group) throws IOException {
-        InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, group);
-        query.setHits(8);
-        query.properties().set(Dispatcher.topKProbability, topKProbability);
-        SearchInvoker [] invokers = invoker.invokers().toArray(new SearchInvoker[0]);
-        Result result = invoker.search(query, null);
-        assertEquals(2, invokers.length);
-        assertEquals(expectedK, ((MockInvoker)invokers[0]).hitsRequested);
-        assertEquals(8, result.hits().size());
-        assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(9.0, result.hits().get(1).getRelevance().getScore(), DELTA);
-        assertEquals(8.5, result.hits().get(2).getRelevance().getScore(), DELTA);
-        assertEquals(8.0, result.hits().get(3).getRelevance().getScore(), DELTA);
-        assertEquals(7.5, result.hits().get(4).getRelevance().getScore(), DELTA);
-        assertEquals(7.0, result.hits().get(5).getRelevance().getScore(), DELTA);
-        assertEquals(6.0, result.hits().get(6).getRelevance().getScore(), DELTA);
-        assertEquals(3.0, result.hits().get(7).getRelevance().getScore(), DELTA);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(8, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, group)) {
+            query.setHits(8);
+            query.properties().set(Dispatcher.topKProbability, topKProbability);
+            SearchInvoker[] invokers = invoker.invokers().toArray(new SearchInvoker[0]);
+            Result result = invoker.search(query, null);
+            assertEquals(2, invokers.length);
+            assertEquals(expectedK, ((MockInvoker) invokers[0]).hitsRequested);
+            assertEquals(8, result.hits().size());
+            assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(9.0, result.hits().get(1).getRelevance().getScore(), DELTA);
+            assertEquals(8.5, result.hits().get(2).getRelevance().getScore(), DELTA);
+            assertEquals(8.0, result.hits().get(3).getRelevance().getScore(), DELTA);
+            assertEquals(7.5, result.hits().get(4).getRelevance().getScore(), DELTA);
+            assertEquals(7.0, result.hits().get(5).getRelevance().getScore(), DELTA);
+            assertEquals(6.0, result.hits().get(6).getRelevance().getScore(), DELTA);
+            assertEquals(3.0, result.hits().get(7).getRelevance().getScore(), DELTA);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(8, result.getQuery().getHits());
+        }
     }
 
     @Test
@@ -261,68 +268,74 @@ public class InterleavedSearchInvokerTest {
 
     @Test
     void requireThatMergeOfConcreteHitsObeySorting() throws IOException {
-        InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, new Group(0, List.of()));
-        query.setHits(12);
-        Result result = invoker.search(query, null);
-        assertEquals(10, result.hits().size());
-        assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(1.0, result.hits().get(9).getRelevance().getScore(), DELTA);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(12, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, new Group(0, List.of()))) {
+            query.setHits(12);
+            Result result = invoker.search(query, null);
+            assertEquals(10, result.hits().size());
+            assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(1.0, result.hits().get(9).getRelevance().getScore(), DELTA);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(12, result.getQuery().getHits());
+        }
 
-        invoker = createInterLeavedTestInvoker(B5, A5, new Group(0, List.of()));
-        result = invoker.search(query, null);
-        assertEquals(10, result.hits().size());
-        assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(1.0, result.hits().get(9).getRelevance().getScore(), DELTA);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(12, result.getQuery().getHits());
+        try ( InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(B5, A5, new Group(0, List.of()))) {
+            Result result = invoker.search(query, null);
+            assertEquals(10, result.hits().size());
+            assertEquals(11.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(1.0, result.hits().get(9).getRelevance().getScore(), DELTA);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(12, result.getQuery().getHits());
+        }
     }
 
     @Test
     void requireThatMergeOfConcreteHitsObeyOffset() throws IOException {
-        InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, new Group(0, List.of()));
-        query.setHits(3);
-        query.setOffset(5);
-        Result result = invoker.search(query, null);
-        assertEquals(3, result.hits().size());
-        assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(3, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5, B5, new Group(0, List.of()))) {
+            query.setHits(3);
+            query.setOffset(5);
+            Result result = invoker.search(query, null);
+            assertEquals(3, result.hits().size());
+            assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(3, result.getQuery().getHits());
+        }
 
-        invoker = createInterLeavedTestInvoker(B5, A5, new Group(0, List.of()));
-        query.setOffset(5);
-        result = invoker.search(query, null);
-        assertEquals(3, result.hits().size());
-        assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(3, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(B5, A5, new Group(0, List.of()))) {
+            query.setOffset(5);
+            Result result = invoker.search(query, null);
+            assertEquals(3, result.hits().size());
+            assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(3, result.getQuery().getHits());
+        }
     }
 
     @Test
     void requireThatMergeOfConcreteHitsObeyOffsetWithAuxilliaryStuff() throws IOException {
-        InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5Aux, B5Aux, new Group(0, List.of()));
-        query.setHits(3);
-        query.setOffset(5);
-        Result result = invoker.search(query, null);
-        assertEquals(7, result.hits().size());
-        assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
-        assertTrue(result.hits().get(3) instanceof MetaHit);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(3, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(A5Aux, B5Aux, new Group(0, List.of()))) {
+            query.setHits(3);
+            query.setOffset(5);
+            Result result = invoker.search(query, null);
+            assertEquals(7, result.hits().size());
+            assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
+            assertTrue(result.hits().get(3) instanceof MetaHit);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(3, result.getQuery().getHits());
+        }
 
-        invoker = createInterLeavedTestInvoker(B5Aux, A5Aux, new Group(0, List.of()));
-        query.setOffset(5);
-        result = invoker.search(query, null);
-        assertEquals(7, result.hits().size());
-        assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
-        assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
-        assertTrue(result.hits().get(3) instanceof MetaHit);
-        assertEquals(0, result.getQuery().getOffset());
-        assertEquals(3, result.getQuery().getHits());
+        try (InterleavedSearchInvoker invoker = createInterLeavedTestInvoker(B5Aux, A5Aux, new Group(0, List.of()))) {
+            query.setOffset(5);
+            Result result = invoker.search(query, null);
+            assertEquals(7, result.hits().size());
+            assertEquals(7.0, result.hits().get(0).getRelevance().getScore(), DELTA);
+            assertEquals(3.0, result.hits().get(2).getRelevance().getScore(), DELTA);
+            assertTrue(result.hits().get(3) instanceof MetaHit);
+            assertEquals(0, result.getQuery().getOffset());
+            assertEquals(3, result.getQuery().getHits());
+        }
     }
 
     @Test
@@ -350,12 +363,15 @@ public class InterleavedSearchInvokerTest {
                         .addAggregationResult(new MinAggregationResult().setMin(new IntegerResultNode(6)).setTag(3))));
         invokers.add(new MockInvoker(0).setHits(List.of(new GroupingListHit(List.of(grouping2)))));
 
-        InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, cluster, new Group(0, List.of()), Collections.emptySet());
-        invoker.responseAvailable(invokers.get(0));
-        invoker.responseAvailable(invokers.get(1));
-        Result result = invoker.search(query, null);
-        assertEquals(1, ((GroupingListHit) result.hits().get(0)).getGroupingList().size());
-
+        try (InterleavedSearchInvoker invoker = new InterleavedSearchInvoker(Timer.monotonic, invokers, cluster, new Group(0, List.of()), Collections.emptySet())) {
+            invoker.responseAvailable(invokers.get(0));
+            invoker.responseAvailable(invokers.get(1));
+            Result result = invoker.search(query, null);
+            assertEquals(1, ((GroupingListHit) result.hits().get(0)).getGroupingList().size());
+        }
+        for (SearchInvoker invoker : invokers) {
+            invoker.close();
+        }
     }
 
     private static InterleavedSearchInvoker createInterLeavedTestInvoker(List<Double> a, List<Double> b, Group group) {

--- a/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/MockSearchCluster.java
@@ -105,14 +105,14 @@ public class MockSearchCluster extends SearchCluster {
         return createDispatchConfig(100.0, nodes);
     }
     public static DispatchConfig createDispatchConfig(List<Node> nodes) {
-        return createDispatchConfig(100.0, nodes);
+        return createDispatchConfig(100.0, nodes).build();
     }
 
     public static DispatchConfig createDispatchConfig(double minSearchCoverage, Node... nodes) {
-        return createDispatchConfig(minSearchCoverage, Arrays.asList(nodes));
+        return createDispatchConfig(minSearchCoverage, Arrays.asList(nodes)).build();
     }
 
-    public static DispatchConfig createDispatchConfig(double minSearchCoverage, List<Node> nodes) {
+    public static DispatchConfig.Builder createDispatchConfig(double minSearchCoverage, List<Node> nodes) {
         DispatchConfig.Builder builder = new DispatchConfig.Builder();
         builder.minActivedocsPercentage(88.0);
         builder.minSearchCoverage(minSearchCoverage);
@@ -125,7 +125,7 @@ public class MockSearchCluster extends SearchCluster {
         for (Node n : nodes) {
             builder.node(new DispatchConfig.Node.Builder().key(n.key()).host(n.hostname()).port(port++).group(n.group()));
         }
-        return new DispatchConfig(builder);
+        return builder;
     }
 
 }


### PR DESCRIPTION
…s to use searchable-copies.

But when we flip to use target-active directly from the backend we need to use redundancy.

@vekterli PR