### PR TITLE
Optimize resolving and usage of summary result class.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/docsumcontext.cpp
@@ -71,20 +71,21 @@ makeSlimeParams(size_t chunkSize) {
 vespalib::Slime::UP
 DocsumContext::createSlimeReply()
 {
-    IDocsumWriter::ResolveClassInfo rci = _docsumWriter.resolveClassInfo(_docsumState._args.getResultClassName());
+    IDocsumWriter::ResolveClassInfo rci = _docsumWriter.resolveClassInfo(_docsumState._args.getResultClassName(),
+                                                                         _docsumState._args.get_fields());
     _docsumWriter.InitState(_attrMgr, _docsumState, rci);
     const size_t estimatedChunkSize(std::min(0x200000ul, _docsumState._docsumbuf.size()*0x400ul));
     vespalib::Slime::UP response(std::make_unique<vespalib::Slime>(makeSlimeParams(estimatedChunkSize)));
     Cursor & root = response->setObject();
     Cursor & array = root.setArray(DOCSUMS);
     const Symbol docsumSym = response->insert(DOCSUM);
-    _docsumState._omit_summary_features = (rci.outputClass != nullptr) ? rci.outputClass->omit_summary_features() : true;
+    _docsumState._omit_summary_features = (rci.res_class != nullptr) ? rci.res_class->omit_summary_features() : true;
     uint32_t num_ok(0);
     for (uint32_t docId : _docsumState._docsumbuf) {
         if (_request.expired() ) { break; }
         Cursor &docSumC = array.addObject();
         ObjectSymbolInserter inserter(docSumC, docsumSym);
-        if ((docId != search::endDocId) && rci.outputClass != nullptr) {
+        if ((docId != search::endDocId) && rci.res_class != nullptr) {
             _docsumWriter.insertDocsum(rci, docId, _docsumState, &_docsumStore, inserter);
         }
         num_ok++;

--- a/searchsummary/CMakeLists.txt
+++ b/searchsummary/CMakeLists.txt
@@ -21,6 +21,7 @@ vespa_define_module(
     src/tests/docsummary/attributedfw
     src/tests/docsummary/document_id_dfw
     src/tests/docsummary/matched_elements_filter
+    src/tests/docsummary/result_class
     src/tests/docsummary/slime_filler
     src/tests/docsummary/slime_summary
     src/tests/juniper

--- a/searchsummary/src/tests/docsummary/result_class/CMakeLists.txt
+++ b/searchsummary/src/tests/docsummary/result_class/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchsummary_result_class_test_app TEST
+    SOURCES
+    result_class_test.cpp
+    DEPENDS
+    searchsummary
+    GTest::GTest
+)
+vespa_add_test(NAME searchsummary_result_class_test_app COMMAND searchsummary_result_class_test_app)

--- a/searchsummary/src/tests/docsummary/result_class/result_class_test.cpp
+++ b/searchsummary/src/tests/docsummary/result_class/result_class_test.cpp
@@ -1,0 +1,43 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchsummary/docsummary/docsum_field_writer.h>
+#include <vespa/searchsummary/docsummary/resultclass.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <memory>
+
+using namespace search::docsummary;
+
+class MockWriter : public DocsumFieldWriter {
+private:
+    bool _generated;
+public:
+    MockWriter(bool generated) : _generated(generated) {}
+    bool IsGenerated() const override { return _generated; }
+    virtual void insertField(uint32_t, const IDocsumStoreDocument*, GetDocsumsState&, vespalib::slime::Inserter &) const override {}
+};
+
+TEST(ResultClassTest, subset_of_fields_in_class_are_generated)
+{    
+    ResultClass rc("test");
+    rc.AddConfigEntry("from_disk");
+    rc.AddConfigEntry("generated", std::make_unique<MockWriter>(true));
+    rc.AddConfigEntry("not_generated", std::make_unique<MockWriter>(false));
+
+    EXPECT_FALSE(rc.all_fields_generated({}));
+    EXPECT_FALSE(rc.all_fields_generated({"from_disk", "generated", "not_generated"}));
+    EXPECT_FALSE(rc.all_fields_generated({"generated", "not_generated"}));
+    EXPECT_TRUE(rc.all_fields_generated({"generated"}));
+    EXPECT_FALSE(rc.all_fields_generated({"not_generated"}));
+}
+
+TEST(ResultClassTest, all_fields_in_class_are_generated)
+{
+    ResultClass rc("test");
+    rc.AddConfigEntry("generated_1", std::make_unique<MockWriter>(true));
+    rc.AddConfigEntry("generated_2", std::make_unique<MockWriter>(true));
+
+    EXPECT_TRUE(rc.all_fields_generated({}));
+    EXPECT_TRUE(rc.all_fields_generated({"generated_1"}));
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
+++ b/searchsummary/src/tests/docsummary/slime_summary/slime_summary_test.cpp
@@ -55,7 +55,7 @@ struct SlimeSummaryTest : testing::Test, IDocsumStore, GetDocsumsStateCallback {
     void getDocsum(Slime &slime) {
         Slime slimeOut;
         SlimeInserter inserter(slimeOut);
-        auto rci = writer->resolveClassInfo(state._args.getResultClassName());
+        auto rci = writer->resolveClassInfo(state._args.getResultClassName(), {});
         writer->insertDocsum(rci, 1u, state, this, inserter);
         vespalib::SmartBuffer buf(4_Ki);
         BinaryFormat::encode(slimeOut, buf);

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsumwriter.h
@@ -2,17 +2,16 @@
 
 #pragma once
 
+#include "docsum_field_writer.h"
+#include "docsumstore.h"
 #include "juniperproperties.h"
 #include "resultclass.h"
 #include "resultconfig.h"
-#include "docsumstore.h"
-#include "docsum_field_writer.h"
 #include <vespa/fastlib/text/unicodeutil.h>
 #include <vespa/fastlib/text/wordfolder.h>
+#include <vespa/vespalib/stllike/string.h>
 
-namespace search {
-    class IAttributeManager;
-}
+namespace search { class IAttributeManager; }
 
 namespace vespalib { class Slime; }
 
@@ -27,11 +26,11 @@ class IDocsumWriter
 public:
     using Inserter = vespalib::slime::Inserter;
     struct ResolveClassInfo {
-        bool allGenerated;
-        const ResultClass *outputClass;
+        bool all_fields_generated;
+        const ResultClass* res_class;
         ResolveClassInfo()
-            : allGenerated(false),
-              outputClass(nullptr)
+            : all_fields_generated(false),
+              res_class(nullptr)
         { }
     };
 
@@ -39,7 +38,8 @@ public:
     virtual void InitState(const search::IAttributeManager & attrMan, GetDocsumsState& state, const ResolveClassInfo& rci) = 0;
     virtual void insertDocsum(const ResolveClassInfo & rci, uint32_t docid, GetDocsumsState& state,
                               IDocsumStore *docinfos, Inserter & target) = 0;
-    virtual ResolveClassInfo resolveClassInfo(vespalib::stringref outputClassName) const = 0;
+    virtual ResolveClassInfo resolveClassInfo(vespalib::stringref class_name,
+                                              const vespalib::hash_set<vespalib::string>& fields) const = 0;
 };
 
 //--------------------------------------------------------------------------
@@ -49,8 +49,6 @@ class DynamicDocsumWriter : public IDocsumWriter
 private:
     std::unique_ptr<ResultConfig>                         _resultConfig;
     std::unique_ptr<KeywordExtractor>                     _keywordExtractor;
-
-    ResolveClassInfo resolveOutputClass(vespalib::stringref outputClassName) const;
 
 public:
     DynamicDocsumWriter(std::unique_ptr<ResultConfig> config, std::unique_ptr<KeywordExtractor> extractor);
@@ -64,7 +62,8 @@ public:
     void insertDocsum(const ResolveClassInfo & outputClassInfo, uint32_t docid, GetDocsumsState& state,
                       IDocsumStore *docinfos, Inserter & inserter) override;
 
-    ResolveClassInfo resolveClassInfo(vespalib::stringref outputClassName) const override;
+    ResolveClassInfo resolveClassInfo(vespalib::stringref class_name,
+                                      const vespalib::hash_set<vespalib::string>& fields) const override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.cpp
@@ -39,13 +39,8 @@ GetDocsumArgs::SetStackDump(uint32_t stackDumpLen, const char *stackDump)
 }
 
 bool
-GetDocsumArgs::needField(vespalib::stringref field) const {
+GetDocsumArgs::need_field(vespalib::stringref field) const {
     return _fields.empty() || _fields.contains(field);
-}
-
-void
-GetDocsumArgs::add_field(vespalib::stringref field) {
-    _fields.insert(field);
 }
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/getdocsumargs.h
@@ -46,8 +46,9 @@ public:
     bool dumpFeatures() const { return _dumpFeatures; }
 
     const fef::Properties &highlightTerms() const { return _highlightTerms; }
-    bool needField(vespalib::stringref field) const;
-    void add_field(vespalib::stringref field);
+    void set_fields(const FieldSet& fields_in) { _fields = fields_in; }
+    const FieldSet& get_fields() const { return _fields; }
+    bool need_field(vespalib::stringref field) const;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/res_config_entry.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/res_config_entry.cpp
@@ -5,14 +5,22 @@
 
 namespace search::docsummary {
 
-ResConfigEntry::ResConfigEntry() noexcept
-    : _name(),
-      _docsum_field_writer()
+ResConfigEntry::ResConfigEntry(const vespalib::string& name_in) noexcept
+    : _name(name_in),
+      _writer(),
+      _generated(false)
 {
 }
 
 ResConfigEntry::~ResConfigEntry() = default;
 
 ResConfigEntry::ResConfigEntry(ResConfigEntry&&) noexcept = default;
+
+void
+ResConfigEntry::set_writer(std::unique_ptr<DocsumFieldWriter> writer_in)
+{
+    _writer = std::move(writer_in);
+    _generated = _writer ? _writer->IsGenerated() : false;
+}
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/res_config_entry.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/res_config_entry.h
@@ -12,12 +12,19 @@ class DocsumFieldWriter;
 /**
  * This struct describes a single docsum field (name and type).
  **/
-struct ResConfigEntry {
+class ResConfigEntry {
+private:
     vespalib::string _name;
-    std::unique_ptr<DocsumFieldWriter> _docsum_field_writer;
-    ResConfigEntry() noexcept;
+    std::unique_ptr<DocsumFieldWriter> _writer;
+    bool _generated;
+public:
+    ResConfigEntry(const vespalib::string& name_in) noexcept;
     ~ResConfigEntry();
     ResConfigEntry(ResConfigEntry&&) noexcept;
+    void set_writer(std::unique_ptr<DocsumFieldWriter> writer);
+    const vespalib::string& name() const { return _name; }
+    DocsumFieldWriter* writer() const { return _writer.get(); }
+    bool is_generated() const { return _generated; }
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultclass.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include "res_config_entry.h"
-#include <vespa/vespalib/stllike/string.h>
 #include <vespa/vespalib/stllike/hash_map.h>
+#include <vespa/vespalib/stllike/hash_set.h>
+#include <vespa/vespalib/stllike/string.h>
 
 namespace search::docsummary {
 
@@ -66,14 +67,6 @@ public:
     ~ResultClass();
 
     /**
-     * Obtain reference to dynamic field data for this result class.
-     *
-     * @return reference to dynamic field data.
-     **/
-    DynamicInfo& getDynamicInfo() noexcept { return _dynInfo; }
-    const DynamicInfo& getDynamicInfo() const noexcept { return _dynInfo; }
-
-    /**
      * Obtain the number of config entries (size of the
      * ResConfigEntry array) held by this result class.
      *
@@ -119,6 +112,13 @@ public:
     const ResConfigEntry *GetEntry(uint32_t offset) const {
         return (offset < _entries.size()) ? &_entries[offset] : nullptr;
     }
+
+    /**
+     * Returns whether the given fields are generated in this result class (do not require the document instance).
+     *
+     * If the given fields set is empty, check all fields defined in this result class.
+     */
+    bool all_fields_generated(const vespalib::hash_set<vespalib::string>& fields) const;
 
     void set_omit_summary_features(bool value) {
         _omit_summary_features = value;

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -145,13 +145,15 @@ SearchVisitor::SummaryGenerator::get_streaming_docsums_state(const vespalib::str
     if (itr != _docsum_states.end()) {
         return *itr->second;
     }
-    auto rci = _docsumWriter->resolveClassInfo(summary_class);
+    vespalib::hash_set<vespalib::string> fields;
+    for (const auto& field: _summaryFields) {
+        fields.insert(field);
+    }
+    auto rci = _docsumWriter->resolveClassInfo(summary_class, fields);
     auto state = std::make_unique<StreamingDocsumsState>(_callback, rci);
     auto &ds = state->get_state();
     ds._args.setResultClassName(summary_class);
-    for (const auto &field: _summaryFields) {
-        ds._args.add_field(field);
-    }
+    ds._args.set_fields(fields);
     if (_dump_features.has_value()) {
         ds._args.dumpFeatures(_dump_features.value());
     }

--- a/streamingvisitors/src/vespa/vsm/vsm/docsumfilter.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/docsumfilter.cpp
@@ -311,7 +311,7 @@ void DocsumFilter::init(const FieldMap & fieldMap, const FieldPathMapT & fieldPa
                 const ResConfigEntry &entry = *resClass->GetEntry(i);
                 const DocsumTools::FieldSpec & toolsSpec = inputSpecs[i];
                 _fields.push_back(DocsumFieldSpec(toolsSpec.getCommand()));
-                LOG(debug, "About to prepare field spec for summary field '%s'", entry._name.c_str());
+                LOG(debug, "About to prepare field spec for summary field '%s'", entry.name().c_str());
                 prepareFieldSpec(_fields.back(), toolsSpec, fieldMap, fieldPathMap);
             }
             assert(entryCnt == _fields.size());

--- a/streamingvisitors/src/vespa/vsm/vsm/vsm-adapter.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/vsm-adapter.cpp
@@ -92,12 +92,12 @@ DocsumTools::obtainFieldNames(const FastS_VsmsummaryHandle &cfg)
         for (uint32_t i = 0; i < _resultClass->GetNumEntries(); ++i) {
             const ResConfigEntry * entry = _resultClass->GetEntry(i);
             _fieldSpecs.emplace_back();
-            _fieldSpecs.back().setOutputName(entry->_name);
+            _fieldSpecs.back().setOutputName(entry->name());
             bool found = false;
             if (cfg) {
                 // check if we have this summary field in the vsmsummary config
                 for (uint32_t j = 0; j < cfg->fieldmap.size() && !found; ++j) {
-                    if (entry->_name == cfg->fieldmap[j].summary.c_str()) {
+                    if (entry->name() == cfg->fieldmap[j].summary.c_str()) {
                         for (uint32_t k = 0; k < cfg->fieldmap[j].document.size(); ++k) {
                             _fieldSpecs.back().getInputNames().push_back(cfg->fieldmap[j].document[k].field);
                         }
@@ -108,7 +108,7 @@ DocsumTools::obtainFieldNames(const FastS_VsmsummaryHandle &cfg)
             }
             if (!found) {
                 // use yourself as input
-                _fieldSpecs.back().getInputNames().push_back(entry->_name);
+                _fieldSpecs.back().getInputNames().push_back(entry->name());
             }
         }
     } else {


### PR DESCRIPTION
If an explicit set of fields is specified in the docsum request, we avoid reading the document instance from disk if all those fields are generated on the fly.

@toregge please review