### PR TITLE
Avoid bucket DB race during content node cluster state transition [run-systemtest]

### DIFF
--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -62,11 +62,12 @@ private:
      * after distributor unification is equal to all cluster states seen after.
      */
     uint32_t _firstEqualClusterStateVersion;
-    /**
-     * The last cluster state version seen. We must ensure we dont answer to
-     * cluster states we haven't seen.
-     */
-    uint32_t _lastClusterStateSeen;
+    // The most current cluster state versions that we've observed on the way _down_
+    // through the chain, i.e. prior to being enabled on the node.
+    uint32_t _last_cluster_state_version_initiated;
+    // The most current cluster state we've observed on the way _up_ through the
+    // chain, i.e. after being enabled on the node.
+    uint32_t _last_cluster_state_version_completed;
     /**
      * The unified version of the last cluster state.
      */
@@ -104,6 +105,8 @@ public:
     StorBucketDatabase::Entry getBucketInfo(const document::Bucket &id) const;
 
     void force_db_sweep_and_metric_update() { updateMetrics(true); }
+
+    bool onUp(const std::shared_ptr<api::StorageMessage>&) override;
 
 private:
     friend struct BucketManagerTest;
@@ -198,8 +201,8 @@ private:
      */
     bool replyConflictsWithConcurrentOperation(const api::BucketReply& reply) const;
     bool enqueueIfBucketHasConflicts(const api::BucketReply::SP& reply);
-    bool onUp(const std::shared_ptr<api::StorageMessage>&) override;
     bool onSetSystemState(const std::shared_ptr<api::SetSystemStateCommand>&) override;
+    bool onSetSystemStateReply(const std::shared_ptr<api::SetSystemStateReply>&) override;
     bool onCreateBucket(const std::shared_ptr<api::CreateBucketCommand>&) override;
     bool onMergeBucket(const std::shared_ptr<api::MergeBucketCommand>&) override;
     bool onRemove(const std::shared_ptr<api::RemoveCommand>&) override;


### PR DESCRIPTION
@geirst please review
@baldersheim FYI

It was possible for a distributor bucket fetch request to be processed _after_ a cluster state was enabled (and internally propagated) on the content node, but _before_ all side effects of this enabling were complete and fully visible. This could cause inconsistent information to be returned to the distributor, causing nodes to get out of sync bucket metadata.

This commit handles such transition periods by introducing an implicit barrier between observing the incoming command and outgoing reply for a particular cluster state version. Upon observing the reply for a version, all side effects must already be visible since the reply is only sent once internal state processing is complete (both above and below the SPI). Until initiated and completed versions converge, requests are rejected and will be transparently retried by the distributors.

