### PR TITLE
Reapply "Make it possible to limit number of log lines returned"

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/handler/LogHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/LogHandler.java
@@ -4,21 +4,15 @@ package com.yahoo.container.handler;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.container.core.LogHandlerConfig;
 import com.yahoo.container.jdisc.AsyncHttpResponse;
-import com.yahoo.container.jdisc.ContentChannelOutputStream;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.container.jdisc.ThreadedHttpRequestHandler;
 import com.yahoo.jdisc.handler.CompletionHandler;
 import com.yahoo.jdisc.handler.ContentChannel;
 
-import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.concurrent.Executor;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 
 public class LogHandler extends ThreadedHttpRequestHandler {
@@ -42,6 +36,8 @@ public class LogHandler extends ThreadedHttpRequestHandler {
                                .map(Long::valueOf).map(Instant::ofEpochMilli).orElse(Instant.MIN);
         Instant to = Optional.ofNullable(request.getProperty("to"))
                              .map(Long::valueOf).map(Instant::ofEpochMilli).orElse(Instant.MAX);
+        long maxLines = Optional.ofNullable(request.getProperty("maxLines"))
+                                .map(Long::valueOf).orElse(100_000L);
         Optional<String> hostname = Optional.ofNullable(request.getProperty("hostname"));
 
         return new AsyncHttpResponse(200) {
@@ -50,7 +46,7 @@ public class LogHandler extends ThreadedHttpRequestHandler {
             @Override
             public void render(OutputStream output, ContentChannel networkChannel, CompletionHandler handler) {
                 try (output) {
-                    logReader.writeLogs(output, from, to, hostname);
+                    logReader.writeLogs(output, from, to, maxLines, hostname);
                 }
                 catch (Throwable t) {
                     log.log(Level.WARNING, "Failed reading logs from " + from + " to " + to, t);
@@ -61,7 +57,5 @@ public class LogHandler extends ThreadedHttpRequestHandler {
             }
         };
     }
-
-
 
 }

--- a/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
@@ -59,9 +59,10 @@ class LogReader {
         this.logFilePattern = logFilePattern;
     }
 
-    void writeLogs(OutputStream out, Instant from, Instant to, Optional<String> hostname) {
+    void writeLogs(OutputStream out, Instant from, Instant to, long maxLines, Optional<String> hostname) {
         double fromSeconds = from.getEpochSecond() + from.getNano() / 1e9;
         double toSeconds = to.getEpochSecond() + to.getNano() / 1e9;
+        long linesWritten = 0;
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(out));
         for (List<Path> logs : getMatchingFiles(from, to)) {
             List<LogLineIterator> logLineIterators = new ArrayList<>();
@@ -73,6 +74,7 @@ class LogReader {
                 Iterator<LineWithTimestamp> lines = Iterators.mergeSorted(logLineIterators,
                                                                           Comparator.comparingDouble(LineWithTimestamp::timestamp));
                 while (lines.hasNext()) {
+                    if (linesWritten++ >= maxLines) return;
                     String line = lines.next().line();
                     writer.write(line);
                     writer.newLine();
@@ -187,16 +189,7 @@ class LogReader {
 
     }
 
-    private static class LineWithTimestamp {
-        final String line;
-        final double timestamp;
-        LineWithTimestamp(String line, double timestamp) {
-            this.line = line;
-            this.timestamp = timestamp;
-        }
-        String line() { return line; }
-        double timestamp() { return timestamp; }
-    }
+    private record LineWithTimestamp(String line, double timestamp) { }
 
     /** Returns log files which may have relevant entries, grouped and sorted by {@link #extractTimestamp(Path)} — the first and last group must be filtered. */
     private List<List<Path>> getMatchingFiles(Instant from, Instant to) {

--- a/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/LogReader.java
@@ -189,7 +189,16 @@ class LogReader {
 
     }
 
-    private record LineWithTimestamp(String line, double timestamp) { }
+    private static class LineWithTimestamp {
+        final String line;
+        final double timestamp;
+        LineWithTimestamp(String line, double timestamp) {
+            this.line = line;
+            this.timestamp = timestamp;
+        }
+        String line() { return line; }
+        double timestamp() { return timestamp; }
+    }
 
     /** Returns log files which may have relevant entries, grouped and sorted by {@link #extractTimestamp(Path)} — the first and last group must be filtered. */
     private List<List<Path>> getMatchingFiles(Instant from, Instant to) {

--- a/container-core/src/test/java/com/yahoo/container/handler/LogHandlerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/LogHandlerTest.java
@@ -51,7 +51,7 @@ public class LogHandlerTest {
         }
 
         @Override
-        protected void writeLogs(OutputStream out, Instant from, Instant to, Optional<String> hostname)  {
+        protected void writeLogs(OutputStream out, Instant from, Instant to, long maxLines, Optional<String> hostname)  {
             try {
                 if (to.isAfter(Instant.ofEpochMilli(1000))) {
                     out.write("newer log".getBytes());

--- a/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
+++ b/container-core/src/test/java/com/yahoo/container/handler/LogReaderTest.java
@@ -37,7 +37,7 @@ public class LogReaderTest {
 
     @BeforeEach
     public void setup() throws IOException {
-        logDirectory = newFolder(folder, "opt/vespa/logs").toPath();
+        logDirectory = Files.createDirectories(folder.toPath().resolve("opt/vespa/logs"));
         // Log archive paths and file names indicate what hour they contain logs for, with the start of that hour.
         // Multiple entries may exist for each hour.
         Files.createDirectories(logDirectory.resolve("1970/01/01"));
@@ -59,7 +59,7 @@ public class LogReaderTest {
     void testThatLogsOutsideRangeAreExcluded() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*"));
-        logReader.writeLogs(baos, Instant.ofEpochMilli(150), Instant.ofEpochMilli(3601050), Optional.empty());
+        logReader.writeLogs(baos, Instant.ofEpochMilli(150), Instant.ofEpochMilli(3601050), 100, Optional.empty());
 
         assertEquals(log100 + logv11 + log110, baos.toString(UTF_8));
     }
@@ -68,7 +68,7 @@ public class LogReaderTest {
     void testThatLogsNotMatchingRegexAreExcluded() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*-1.*"));
-        logReader.writeLogs(baos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), Optional.empty());
+        logReader.writeLogs(baos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), 100, Optional.empty());
 
         assertEquals(log101 + logv11, baos.toString(UTF_8));
     }
@@ -78,7 +78,7 @@ public class LogReaderTest {
     void testZippedStreaming() {
         ByteArrayOutputStream zippedBaos = new ByteArrayOutputStream();
         LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*"));
-        logReader.writeLogs(zippedBaos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), Optional.empty());
+        logReader.writeLogs(zippedBaos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), 100, Optional.empty());
 
         assertEquals(log101 + log100 + logv11 + log110 + log200 + logv, zippedBaos.toString(UTF_8));
     }
@@ -87,9 +87,18 @@ public class LogReaderTest {
     void logsForSingeNodeIsRetrieved() {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*"));
-        logReader.writeLogs(baos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), Optional.of("node2.com"));
+        logReader.writeLogs(baos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), 100, Optional.of("node2.com"));
 
         assertEquals(log101 + log100 + log200, baos.toString(UTF_8));
+    }
+
+    @Test
+    void logsLimitedToMaxLines() {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        LogReader logReader = new LogReader(logDirectory, Pattern.compile(".*"));
+        logReader.writeLogs(baos, Instant.EPOCH, Instant.EPOCH.plus(Duration.ofDays(2)), 2, Optional.of("node2.com"));
+
+        assertEquals(log101 + log100, baos.toString(UTF_8));
     }
 
     private byte[] compress1(String input) throws IOException {
@@ -100,18 +109,9 @@ public class LogReaderTest {
         return baos.toByteArray();
     }
 
-    private byte[] compress2(String input) throws IOException {
+    private byte[] compress2(String input) {
         byte[] data = input.getBytes();
         return new ZstdCompressor().compress(data, 0, data.length);
-    }
-
-    private static File newFolder(File root, String... subDirs) throws IOException {
-        String subFolder = String.join("/", subDirs);
-        File result = new File(root, subFolder);
-        if (!result.mkdirs()) {
-            throw new IOException("Couldn't create folders " + root);
-        }
-        return result;
     }
 
 }


### PR DESCRIPTION
Same as #24154 but without the `record`
```
Failed reading logs from 1970-01-01T00:00:00Z to +1000000000-12-31T23:59:59.999999999Z
exception=
java.lang.ClassFormatError: Weaving hook failed.
	at com.yahoo.container.handler.LogReader$LogLineIterator.readNext(LogReader.java:181)
	at com.yahoo.container.handler.LogReader$LogLineIterator.<init>(LogReader.java:143)
	at com.yahoo.container.handler.LogReader.writeLogs(LogReader.java:72)
	at com.yahoo.container.handler.LogHandler$1.render(LogHandler.java:49)
	at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.render(ThreadedHttpRequestHandler.java:117)
	at com.yahoo.container.jdisc.ThreadedHttpRequestHandler.handleRequest(ThreadedHttpRequestHandler.java:89)
	at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.processRequest(ThreadedRequestHandler.java:191)
	at com.yahoo.container.jdisc.ThreadedRequestHandler$RequestTask.run(ThreadedRequestHandler.java:185)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.UnsupportedOperationException: Records requires ASM8
	... 11 more
```