### PR TITLE
Simplify state version checks by requiring exact version match [run-systemtest]

### DIFF
--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -631,6 +631,10 @@ public:
         return std::make_shared<api::RequestBucketInfoCommand>(makeBucketSpace(), 0, *_state);
     }
 
+    auto createFullFetchCommand(const lib::ClusterState& explicit_state) const {
+        return std::make_shared<api::RequestBucketInfoCommand>(makeBucketSpace(), 0, explicit_state);
+    }
+
     auto createFullFetchCommandWithHash(vespalib::stringref hash) const {
         return std::make_shared<api::RequestBucketInfoCommand>(makeBucketSpace(), 0, *_state, hash);
     }
@@ -1271,7 +1275,7 @@ TEST_F(BucketManagerTest, bounce_request_on_state_change_barrier_not_reached) {
     _top->waitForMessage(api::MessageType::SETSYSTEMSTATE_REPLY, MESSAGE_WAIT_TIME);
     (void)_top->getRepliesOnce();
 
-    _top->sendDown(f.createFullFetchCommand());
+    _top->sendDown(f.createFullFetchCommand(new_state));
     replies = f.awaitAndGetReplies(1);
     {
         auto& reply = dynamic_cast<api::RequestBucketInfoReply&>(*replies[0]);

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -57,21 +57,12 @@ private:
     using ConflictingBuckets = std::unordered_set<document::BucketId, document::BucketId::hash>;
     ReplyQueue _queuedReplies;
     ConflictingBuckets _conflictingBuckets;
-    /**
-     * Keeps the version number of the first cluster state version seen that
-     * after distributor unification is equal to all cluster states seen after.
-     */
-    uint32_t _firstEqualClusterStateVersion;
     // The most current cluster state versions that we've observed on the way _down_
     // through the chain, i.e. prior to being enabled on the node.
     uint32_t _last_cluster_state_version_initiated;
     // The most current cluster state we've observed on the way _up_ through the
     // chain, i.e. after being enabled on the node.
     uint32_t _last_cluster_state_version_completed;
-    /**
-     * The unified version of the last cluster state.
-     */
-    std::string _lastUnifiedClusterState;
     bool _doneInitialized;
     size_t _requestsCurrentlyProcessing;
     ServiceLayerComponent _component;


### PR DESCRIPTION
@geirst please review

The existing state unification logic was likely to help ensure that various distributor availability-states were treated as if they were simply Up, but the distributor has not been able to even _be_ in other available states than Up for many years. So it's effectively pointless.

Remove unification entirely and instead require both the distributor and content node to be mutually in sync with the exact cluster state version.

