### PR TITLE
Expose more information in content node search reply trace.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matchengine/matchengine.cpp
@@ -168,6 +168,8 @@ MatchEngine::performSearch(search::engine::SearchRequest::Source req)
     ret->setDistributionKey(_distributionKey);
     if ((ret->request->trace().getLevel() > 0) && ret->request->trace().hasTrace()) {
         ret->request->trace().getRoot().setLong("distribution-key", _distributionKey);
+        DocTypeName doc_type(*ret->request);
+        ret->request->trace().getRoot().setString("document-type", doc_type.getName());
         ret->request->trace().done();
         search::fef::Properties & trace = ret->propertiesMap.lookupCreate("trace");
         vespalib::SmartBuffer output(4_Ki);

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -116,6 +116,9 @@ private:
 class AttributeFieldBlueprint : public SimpleLeafBlueprint
 {
 private:
+    // Must take a copy of the query term for visitMembers()
+    // as only a few ISearchContext implementations exposes the query term.
+    vespalib::string _query_term;
     ISearchContext::UP _search_context;
     enum Type {INT, FLOAT, OTHER};
     Type _type;
@@ -123,6 +126,7 @@ private:
     AttributeFieldBlueprint(const FieldSpec &field, const IAttributeVector &attribute,
                             QueryTermSimple::UP term, const attribute::SearchContextParams &params)
         : SimpleLeafBlueprint(field),
+          _query_term(term->getTermString()),
           _search_context(attribute.createSearchContext(std::move(term), params)),
           _type(OTHER)
     {
@@ -196,6 +200,7 @@ AttributeFieldBlueprint::visitMembers(vespalib::ObjectVisitor &visitor) const
 {
     LeafBlueprint::visitMembers(visitor);
     visit(visitor, "attribute", _search_context->attributeName());
+    visit(visitor, "query_term", _query_term);
 }
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
@@ -388,7 +388,7 @@ public:
         const DiskIndex::LookupResult & lookupRes = _cache.lookup(termStr, _fieldId);
         if (lookupRes.valid()) {
             bool useBitVector = _field.isFilter();
-            setResult(std::make_unique<DiskTermBlueprint>(_field, _diskIndex, std::make_unique<DiskIndex::LookupResult>(lookupRes), useBitVector));
+            setResult(std::make_unique<DiskTermBlueprint>(_field, _diskIndex, termStr, std::make_unique<DiskIndex::LookupResult>(lookupRes), useBitVector));
         } else {
             setResult(std::make_unique<EmptyBlueprint>(_field));
         }

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
@@ -3,8 +3,9 @@
 #include "disktermblueprint.h"
 #include <vespa/searchlib/common/bitvectoriterator.h>
 #include <vespa/searchlib/queryeval/booleanmatchiteratorwrapper.h>
-#include <vespa/searchlib/queryeval/intermediate_blueprints.h>
 #include <vespa/searchlib/queryeval/filter_wrapper.h>
+#include <vespa/searchlib/queryeval/intermediate_blueprints.h>
+#include <vespa/vespalib/objects/visit.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
@@ -14,7 +15,7 @@ using search::BitVectorIterator;
 using search::fef::TermFieldMatchDataArray;
 using search::index::Schema;
 using search::queryeval::BooleanMatchIteratorWrapper;
-using search::queryeval::FieldSpecBase;
+using search::queryeval::FieldSpec;
 using search::queryeval::FieldSpecBaseList;
 using search::queryeval::SearchIterator;
 using search::queryeval::LeafBlueprint;
@@ -32,13 +33,15 @@ getName(uint32_t indexId)
 
 }
 
-DiskTermBlueprint::DiskTermBlueprint(const FieldSpecBase & field,
+DiskTermBlueprint::DiskTermBlueprint(const FieldSpec & field,
                                      const DiskIndex & diskIndex,
+                                     const vespalib::string& query_term,
                                      DiskIndex::LookupResult::UP lookupRes,
                                      bool useBitVector) :
     SimpleLeafBlueprint(field),
     _field(field),
     _diskIndex(diskIndex),
+    _query_term(query_term),
     _lookupRes(std::move(lookupRes)),
     _useBitVector(useBitVector),
     _fetchPostingsDone(false),
@@ -92,6 +95,14 @@ DiskTermBlueprint::createFilterSearch(bool strict, FilterConstraint) const
         wrapper->wrap(_postingHandle->createIterator(_lookupRes->counts, tfmda, _useBitVector));
     }
     return wrapper;
+}
+
+void
+DiskTermBlueprint::visitMembers(vespalib::ObjectVisitor& visitor) const
+{
+    SimpleLeafBlueprint::visitMembers(visitor);
+    visit(visitor, "field_name", _field.getName());
+    visit(visitor, "query_term", _query_term);
 }
 
 } // namespace

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -13,8 +13,9 @@ namespace search::diskindex {
 class DiskTermBlueprint : public queryeval::SimpleLeafBlueprint
 {
 private:
-    queryeval::FieldSpecBase         _field;
+    queryeval::FieldSpec             _field;
     const DiskIndex               &  _diskIndex;
+    vespalib::string                 _query_term;
     DiskIndex::LookupResult::UP      _lookupRes;
     bool                             _useBitVector;
     bool                             _fetchPostingsDone;
@@ -30,8 +31,9 @@ public:
      * @param lookupRes    the result after disk dictionary lookup.
      * @param useBitVector whether or not we should use bit vector.
      **/
-    DiskTermBlueprint(const queryeval::FieldSpecBase & field,
+    DiskTermBlueprint(const queryeval::FieldSpec & field,
                       const DiskIndex & diskIndex,
+                      const vespalib::string& query_term,
                       DiskIndex::LookupResult::UP lookupRes,
                       bool useBitVector);
 
@@ -42,6 +44,8 @@ public:
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
 
     std::unique_ptr<queryeval::SearchIterator> createFilterSearch(bool strict, FilterConstraint) const override;
+
+    void visitMembers(vespalib::ObjectVisitor& visitor) const override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.h
@@ -103,7 +103,7 @@ public:
                                                        fef::TermFieldMatchDataArray match_data) const;
 
     std::unique_ptr<queryeval::SimpleLeafBlueprint> make_term_blueprint(const vespalib::string& term,
-                                                                        const queryeval::FieldSpecBase& field,
+                                                                        const queryeval::FieldSpec& field,
                                                                         uint32_t field_id) override;
 };
 

--- a/searchlib/src/vespa/searchlib/memoryindex/i_field_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/i_field_index.h
@@ -36,7 +36,7 @@ public:
     virtual void dump(search::index::IndexBuilder& indexBuilder) = 0;
 
     virtual std::unique_ptr<queryeval::SimpleLeafBlueprint> make_term_blueprint(const vespalib::string& term,
-                                                                                const queryeval::FieldSpecBase& field,
+                                                                                const queryeval::FieldSpec& field,
                                                                                 uint32_t field_id) = 0;
 
     // Should only be directly used by unit tests


### PR DESCRIPTION
This should make it easier to correlate the backend query blueprints with the actual query terms.

@toregge please review
@jobergum FYI