### PR TITLE
fix(sec): upgrade http2-server to 10.0.10

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -42,7 +42,7 @@
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
         <javax.ws.rs-api.version>2.0.1</javax.ws.rs-api.version>
         <jaxb.version>2.3.0</jaxb.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>10.0.10</jetty.version>
         <jetty-alpn.version>1.1.3.v20160715</jetty-alpn.version>
         <org.lz4.version>1.8.0</org.lz4.version>
         <org.json.version>20220320</org.json.version>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Upgrade http2-server from 9.4.48.v20220622 to 10.0.10 for vulnerability fix:
- [CVE-2022-2048](https://www.oscs1024.com/hd/MPS-2022-18061)