### PR TITLE
Disable patch when _vespa_llvm_version is not defined.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -492,7 +492,7 @@ nearest neighbor search used for low-level benchmarking.
 %endif
 %else
 %setup -q
-%if 0%{?el8} && %{_vespa_llvm_version} < 13
+%if 0%{?el8} && %{?_vespa_llvm_version}%{!?_vespa_llvm_version:13} < 13
 if grep -qs 'result_pair<R>(' /usr/include/llvm/ADT/STLExtras.h
 then
   patch /usr/include/llvm/ADT/STLExtras.h < dist/STLExtras.h.diff


### PR DESCRIPTION
@aressem : please review

This removes the need for PR #24238 
