### PR TITLE
Only optimize boolean expressions on primitives

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/expressiontransforms/BooleanExpressionTransformer.java
+++ b/config-model/src/main/java/com/yahoo/schema/expressiontransforms/BooleanExpressionTransformer.java
@@ -36,12 +36,12 @@ public class BooleanExpressionTransformer extends ExpressionTransformer<Transfor
             node = transformChildren(composite, context);
 
         if (node instanceof OperationNode arithmetic)
-            node = transformBooleanArithmetics(arithmetic);
+            node = transformBooleanArithmetics(arithmetic, context);
 
         return node;
     }
 
-    private ExpressionNode transformBooleanArithmetics(OperationNode node) {
+    private ExpressionNode transformBooleanArithmetics(OperationNode node, TransformContext context) {
         Iterator<ExpressionNode> child = node.children().iterator();
 
         // Transform in precedence order:
@@ -51,30 +51,35 @@ public class BooleanExpressionTransformer extends ExpressionTransformer<Transfor
             Operator op = it.next();
             if ( ! stack.isEmpty()) {
                 while (stack.size() > 1 && ! op.hasPrecedenceOver(stack.peek().op)) {
-                    popStack(stack);
+                    popStack(stack, context);
                 }
             }
             stack.push(new ChildNode(op, child.next()));
         }
         while (stack.size() > 1)
-            popStack(stack);
+            popStack(stack, context);
         return stack.getFirst().child;
     }
 
-    private void popStack(Deque<ChildNode> stack) {
+    private void popStack(Deque<ChildNode> stack, TransformContext context) {
         ChildNode rhs = stack.pop();
         ChildNode lhs = stack.peek();
 
+        boolean primitives = isPrimitive(lhs.child, context) && isPrimitive(rhs.child, context);
         ExpressionNode combination;
-        if (rhs.op == Operator.and)
+        if (primitives && rhs.op == Operator.and)
             combination = andByIfNode(lhs.child, rhs.child);
-        else if (rhs.op == Operator.or)
+        else if (primitives && rhs.op == Operator.or)
             combination = orByIfNode(lhs.child, rhs.child);
         else {
             combination = resolve(lhs, rhs);
             lhs.artificial = true;
         }
         lhs.child = combination;
+    }
+
+    private boolean isPrimitive(ExpressionNode node, TransformContext context) {
+        return node.type(context.types()).rank() == 0;
     }
 
     private static OperationNode resolve(ChildNode left, ChildNode right) {

--- a/config-model/src/test/derived/neuralnet/neuralnet.sd
+++ b/config-model/src/test/derived/neuralnet/neuralnet.sd
@@ -3,6 +3,10 @@ schema neuralnet {
 
     document neuralnet {
 
+        field uniqueRCount type double {
+            indexing: attribute
+        }
+
         field pinned type int {
             indexing: attribute
         }

--- a/config-model/src/test/derived/neuralnet_noqueryprofile/neuralnet.sd
+++ b/config-model/src/test/derived/neuralnet_noqueryprofile/neuralnet.sd
@@ -3,6 +3,10 @@ schema neuralnet {
 
     document neuralnet {
 
+        field uniqueRCount type double {
+            indexing: attribute
+        }
+
         field pinned type int {
             indexing: attribute
         }

--- a/config-model/src/test/derived/neuralnet_noqueryprofile/schema-info.cfg
+++ b/config-model/src/test/derived/neuralnet_noqueryprofile/schema-info.cfg
@@ -10,6 +10,9 @@ schema[].summaryclass[].fields[].name "documentid"
 schema[].summaryclass[].fields[].type "longstring"
 schema[].summaryclass[].fields[].dynamic false
 schema[].summaryclass[].name "attributeprefetch"
+schema[].summaryclass[].fields[].name "uniqueRCount"
+schema[].summaryclass[].fields[].type "double"
+schema[].summaryclass[].fields[].dynamic false
 schema[].summaryclass[].fields[].name "pinned"
 schema[].summaryclass[].fields[].type "integer"
 schema[].summaryclass[].fields[].dynamic false

--- a/config-model/src/test/derived/rankingexpression/rankexpression.sd
+++ b/config-model/src/test/derived/rankingexpression/rankexpression.sd
@@ -3,6 +3,14 @@ schema rankexpression {
   
   document rankexpression {
 
+    field nrtgmp type double {
+      indexing: attribute
+    }
+
+    field glmpfw type double {
+      indexing: attribute
+    }
+
     field artist type string {
       indexing: summary | index
     }

--- a/config-model/src/test/derived/rankingexpression/summary.cfg
+++ b/config-model/src/test/derived/rankingexpression/summary.cfg
@@ -24,9 +24,15 @@ classes[].fields[].source ""
 classes[].fields[].name "documentid"
 classes[].fields[].command "documentid"
 classes[].fields[].source ""
-classes[].id 1736696699
+classes[].id 399614584
 classes[].name "attributeprefetch"
 classes[].omitsummaryfeatures false
+classes[].fields[].name "nrtgmp"
+classes[].fields[].command "attribute"
+classes[].fields[].source "nrtgmp"
+classes[].fields[].name "glmpfw"
+classes[].fields[].command "attribute"
+classes[].fields[].source "glmpfw"
 classes[].fields[].name "year"
 classes[].fields[].command "attribute"
 classes[].fields[].source "year"

--- a/config-model/src/test/java/com/yahoo/schema/expressiontransforms/BooleanExpressionTransformerTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/expressiontransforms/BooleanExpressionTransformerTestCase.java
@@ -2,10 +2,13 @@
 package com.yahoo.schema.expressiontransforms;
 
 import com.yahoo.searchlib.rankingexpression.RankingExpression;
+import com.yahoo.searchlib.rankingexpression.Reference;
 import com.yahoo.searchlib.rankingexpression.evaluation.MapContext;
 import com.yahoo.searchlib.rankingexpression.evaluation.MapTypeContext;
 import com.yahoo.searchlib.rankingexpression.rule.OperationNode;
 import com.yahoo.searchlib.rankingexpression.transform.TransformContext;
+import com.yahoo.tensor.TensorType;
+import com.yahoo.tensor.evaluation.TypeContext;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -20,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class BooleanExpressionTransformerTestCase {
 
     @Test
-    public void testTransformer() throws Exception {
+    public void booleanTransformation() throws Exception {
         assertTransformed("if (a, b, false)", "a && b");
         assertTransformed("if (a, true, b)", "a || b");
         assertTransformed("if (a, true, b + c)", "a || b + c");
@@ -33,16 +36,17 @@ public class BooleanExpressionTransformerTestCase {
     }
 
     @Test
-    public void testIt() throws Exception {
-        assertTransformed("if(1 - 1, true, 1 - 1)", "1 - 1 || 1 - 1");
+    public void noTransformationOnTensorTypes() throws Exception {
+        var typeContext = new MapTypeContext();
+        typeContext.setType(Reference.fromIdentifier("tensorA"), TensorType.fromSpec("tensor(x{})"));
+        typeContext.setType(Reference.fromIdentifier("tensorB"), TensorType.fromSpec("tensor(x{})"));
+        assertUntransformed("tensorA && tensorB", typeContext);
+        assertTransformed("a && (tensorA * tensorB)","a && ( tensorA * tensorB)", typeContext);
     }
 
     @Test
     public void testNotSkewingNonBoolean() throws Exception {
-        assertTransformed("a + b + c * d + e + f", "a + b + c * d + e + f");
-        var expr = new BooleanExpressionTransformer()
-                .transform(new RankingExpression("a + b + c * d + e + f"),
-                        new TransformContext(Map.of(), new MapTypeContext()));
+        var expr = assertTransformed("a + b + c * d + e + f", "a + b + c * d + e + f");
         assertTrue(expr.getRoot() instanceof OperationNode);
         OperationNode root = (OperationNode) expr.getRoot();
         assertEquals(5, root.operators().size());
@@ -51,41 +55,53 @@ public class BooleanExpressionTransformerTestCase {
 
     @Test
     public void testTransformPreservesPrecedence() throws Exception {
-        assertUnTransformed("a");
-        assertUnTransformed("a + b");
-        assertUnTransformed("a + b + c");
-        assertUnTransformed("a * b");
-        assertUnTransformed("a + b * c + d");
-        assertUnTransformed("a + b + c * d + e + f");
-        assertUnTransformed("a * b + c + d + e * f");
-        assertUnTransformed("(a * b) + c + d + e * f");
-        assertUnTransformed("(a * b + c) + d + e * f");
-        assertUnTransformed("a * (b + c) + d + e * f");
-        assertUnTransformed("(a * b) + (c + (d + e)) * f");
+        assertUntransformed("a");
+        assertUntransformed("a + b");
+        assertUntransformed("a + b + c");
+        assertUntransformed("a * b");
+        assertUntransformed("a + b * c + d");
+        assertUntransformed("a + b + c * d + e + f");
+        assertUntransformed("a * b + c + d + e * f");
+        assertUntransformed("(a * b) + c + d + e * f");
+        assertUntransformed("(a * b + c) + d + e * f");
+        assertUntransformed("a * (b + c) + d + e * f");
+        assertUntransformed("(a * b) + (c + (d + e)) * f");
     }
 
-    private void assertUnTransformed(String input) throws Exception {
-        assertTransformed(input, input);
+    private void assertUntransformed(String input) throws Exception {
+        assertUntransformed(input, new MapTypeContext());
     }
 
-    private void assertTransformed(String expected, String input) throws Exception {
+    private void assertUntransformed(String input, MapTypeContext typeContext) throws Exception {
+        assertTransformed(input, input, typeContext);
+    }
+
+    private RankingExpression assertTransformed(String expected, String input) throws Exception {
+        return assertTransformed(expected, input, new MapTypeContext());
+    }
+
+    private RankingExpression assertTransformed(String expected, String input, MapTypeContext typeContext) throws Exception {
+        MapContext context = contextWithSingleLetterVariables(typeContext);
         var transformedExpression = new BooleanExpressionTransformer()
                                             .transform(new RankingExpression(input),
-                                                       new TransformContext(Map.of(), new MapTypeContext()));
+                                                       new TransformContext(Map.of(), typeContext));
 
         assertEquals(new RankingExpression(expected), transformedExpression, "Transformed as expected");
 
-        MapContext context = contextWithSingleLetterVariables();
         var inputExpression = new RankingExpression(input);
         assertEquals(inputExpression.evaluate(context).asBoolean(),
                      transformedExpression.evaluate(context).asBoolean(),
                      "Transform and original input are equivalent");
+        return transformedExpression;
     }
 
-    private MapContext contextWithSingleLetterVariables() {
+    private MapContext contextWithSingleLetterVariables(MapTypeContext typeContext) {
         var context = new MapContext();
-        for (int i = 0; i < 26; i++)
-            context.put(Character.toString(i + 97), Math.floorMod(i, 2));
+        for (int i = 0; i < 26; i++) {
+            String name = Character.toString(i + 97);
+            typeContext.setType(Reference.fromIdentifier(name), TensorType.empty);
+            context.put(name, Math.floorMod(i, 2));
+        }
         return context;
     }
 


### PR DESCRIPTION
Only transform a && b to if(a, b, false) etc.
if both a and b are primitives, not tensors,
as if requires both branches to return the same type.
