### PR TITLE
Refactor ArrayStore to support generic type id to array size mappers.

### DIFF
--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -167,10 +167,10 @@ TEST_F("control static sizes", NumberFixture(3)) {
     EXPECT_EQUAL(440u, sizeof(f.store));
     EXPECT_EQUAL(296u, sizeof(NumberFixture::ArrayStoreType::DataStoreType));
 #else
-    EXPECT_EQUAL(472u, sizeof(f.store));
+    EXPECT_EQUAL(488u, sizeof(f.store));
     EXPECT_EQUAL(328u, sizeof(NumberFixture::ArrayStoreType::DataStoreType));
 #endif
-    EXPECT_EQUAL(96u, sizeof(NumberFixture::ArrayStoreType::SmallArrayType));
+    EXPECT_EQUAL(112u, sizeof(NumberFixture::ArrayStoreType::SmallBufferType));
     MemoryUsage usage = f.store.getMemoryUsage();
     EXPECT_EQUAL(960u, usage.allocatedBytes());
     EXPECT_EQUAL(32u, usage.usedBytes());

--- a/vespalib/src/vespa/vespalib/datastore/array_store_config.h
+++ b/vespalib/src/vespa/vespalib/datastore/array_store_config.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
+#include <functional>
 #include <vector>
 
 namespace vespalib::datastore {
@@ -42,21 +44,21 @@ private:
     bool _enable_free_lists;
 
     /**
-     * Setup an array store with arrays of size [1-(allocSpecs.size()-1)] allocated in buffers and
-     * larger arrays are heap allocated. The allocation spec for a given array size is found in the given vector.
+     * Setup an array store where buffer type ids [1-(allocSpecs.size()-1)] are used to allocate small arrays in datastore buffers and
+     * larger arrays are heap allocated. The allocation spec for a given buffer type is found in the given vector.
      * Allocation spec for large arrays is located at position 0.
      */
     ArrayStoreConfig(const AllocSpecVector &allocSpecs);
 
 public:
     /**
-     * Setup an array store with arrays of size [1-maxSmallArraySize] allocated in buffers
+     * Setup an array store where buffer type ids [1-maxSmallArrayTypeId] are used to allocate small arrays in datastore buffers
      * with the given default allocation spec. Larger arrays are heap allocated.
      */
-    ArrayStoreConfig(size_t maxSmallArraySize, const AllocSpec &defaultSpec);
+    ArrayStoreConfig(uint32_t maxSmallArrayTypeId, const AllocSpec &defaultSpec);
 
-    size_t maxSmallArraySize() const { return _allocSpecs.size() - 1; }
-    const AllocSpec &specForSize(size_t arraySize) const;
+    uint32_t maxSmallArrayTypeId() const { return _allocSpecs.size() - 1; }
+    const AllocSpec &spec_for_type_id(uint32_t type_id) const;
     ArrayStoreConfig& enable_free_lists(bool enable) & noexcept {
         _enable_free_lists = enable;
         return *this;
@@ -70,7 +72,8 @@ public:
     /**
      * Generate a config that is optimized for the given memory huge page size.
      */
-    static ArrayStoreConfig optimizeForHugePage(size_t maxSmallArraySize,
+    static ArrayStoreConfig optimizeForHugePage(uint32_t maxSmallArrayTypeId,
+                                                std::function<size_t(uint32_t)> type_id_to_array_size,
                                                 size_t hugePageSize,
                                                 size_t smallPageSize,
                                                 size_t entrySize,

--- a/vespalib/src/vespa/vespalib/datastore/array_store_type_mapper.h
+++ b/vespalib/src/vespa/vespalib/datastore/array_store_type_mapper.h
@@ -1,0 +1,28 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "large_array_buffer_type.h"
+#include "small_array_buffer_type.h"
+
+namespace vespalib::datastore {
+
+/**
+ * This class provides a 1-to-1 mapping between type ids and array sizes for small arrays in an array store.
+ *
+ * This means that buffers for type id 1 stores arrays of size 1, buffers for type id 2 stores arrays of size 2, and so on.
+ * Type id 0 is always reserved for large arrays allocated on the heap.
+ *
+ * A more complex mapping can be used by creating a custom mapper and BufferType implementations.
+ */
+template <typename EntryT>
+class ArrayStoreTypeMapper {
+public:
+    using SmallBufferType = SmallArrayBufferType<EntryT>;
+    using LargeBufferType = LargeArrayBufferType<EntryT>;
+
+    uint32_t get_type_id(size_t array_size) const { return array_size; }
+    size_t get_array_size(uint32_t type_id) const { return type_id; }
+};
+
+}


### PR DESCRIPTION
The default type mapper uses a 1-to-1 mapping between type id and array size for small arrays.

@toregge please review