### PR TITLE
Access log: use same definition of authority as HttpRequestFactory

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/AccessLogRequestLog.java
@@ -76,7 +76,7 @@ class AccessLogRequestLog extends AbstractLifeCycle implements org.eclipse.jetty
             addNonNullValue(builder, request.getProtocol(), RequestLogEntry.Builder::httpVersion);
             addNonNullValue(builder, request.getScheme(), RequestLogEntry.Builder::scheme);
             addNonNullValue(builder, request.getHeader("User-Agent"), RequestLogEntry.Builder::userAgent);
-            addNonNullValue(builder, request.getHeader("Host"), RequestLogEntry.Builder::hostString);
+            addNonNullValue(builder, request.getServerName(), RequestLogEntry.Builder::hostString);
             addNonNullValue(builder, request.getHeader("Referer"), RequestLogEntry.Builder::referer);
             addNonNullValue(builder, request.getQueryString(), RequestLogEntry.Builder::rawQuery);
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
