### PR TITLE
Propagate load balancer IP to routing policies

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/LoadBalancer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/LoadBalancer.java
@@ -19,15 +19,17 @@ public class LoadBalancer {
     private final ApplicationId application;
     private final ClusterSpec.Id cluster;
     private final Optional<DomainName> hostname;
+    private final Optional<String> ipAddress;
     private final State state;
     private final Optional<String> dnsZone;
 
-    public LoadBalancer(String id, ApplicationId application, ClusterSpec.Id cluster, Optional<DomainName> hostname, State state,
-                        Optional<String> dnsZone) {
+    public LoadBalancer(String id, ApplicationId application, ClusterSpec.Id cluster, Optional<DomainName> hostname,
+                        Optional<String> ipAddress, State state, Optional<String> dnsZone) {
         this.id = Objects.requireNonNull(id, "id must be non-null");
         this.application = Objects.requireNonNull(application, "application must be non-null");
         this.cluster = Objects.requireNonNull(cluster, "cluster must be non-null");
         this.hostname = Objects.requireNonNull(hostname, "hostname must be non-null");
+        this.ipAddress = Objects.requireNonNull(ipAddress, "ipAddress must be non-null");
         this.state = Objects.requireNonNull(state, "state must be non-null");
         this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
     }
@@ -46,6 +48,10 @@ public class LoadBalancer {
 
     public Optional<DomainName> hostname() {
         return hostname;
+    }
+
+    public Optional<String> ipAddress() {
+        return ipAddress;
     }
 
     public Optional<String> dnsZone() {

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/MemoryNameService.java
@@ -33,8 +33,8 @@ public class MemoryNameService implements NameService {
     }
 
     @Override
-    public Record createCname(RecordName name, RecordData canonicalName) {
-        var record = new Record(Record.Type.CNAME, name, canonicalName);
+    public Record createRecord(Record.Type type, RecordName name, RecordData canonicalName) {
+        var record = new Record(type, name, canonicalName);
         add(record);
         return record;
     }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/NameService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/dns/NameService.java
@@ -12,13 +12,14 @@ import java.util.Set;
 public interface NameService {
 
     /**
-     * Create a new CNAME record
+     * Create a new record
      *
-     * @param name          The alias to create (lhs of the record)
-     * @param canonicalName The canonical name which the alias should point to (rhs of the record). This must be a FQDN.
+     * @param type The DNS type of record to make, only a small set of types are supported, check with the implementation
+     * @param name Name of the record, e.g. a FQDN for records of type A
+     * @param data Data of the record, e.g. IP address for records of type A
      * @return The created record
      */
-    Record createCname(RecordName name, RecordData canonicalName);
+    Record createRecord(Record.Type type, RecordName name, RecordData data);
 
     /**
      * Create a non-standard ALIAS record pointing to given targets. Implementations of this are expected to be

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/MockTesterCloud.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/stubs/MockTesterCloud.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.controller.api.integration.stubs;
 
 import ai.vespa.http.DomainName;
+import com.google.common.net.InetAddresses;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.LogEntry;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.TestReport;
@@ -12,7 +13,6 @@ import com.yahoo.vespa.hosted.controller.api.integration.dns.RecordName;
 
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -60,12 +60,10 @@ public class MockTesterCloud implements TesterCloud {
 
     @Override
     public Optional<InetAddress> resolveHostName(DomainName hostname) {
-        try {
-            return Optional.of(InetAddress.getByAddress(new byte[]{ 1, 2, 3, 4 }));
-        }
-        catch (UnknownHostException e) {
-            throw new IllegalStateException("should not happen");
-        }
+        return nameService.findRecords(Record.Type.A, RecordName.from(hostname.value())).stream()
+                .findFirst()
+                .map(record -> InetAddresses.forString(record.data().asString()))
+                .or(() -> Optional.of(InetAddresses.forString("1.2.3.4")));
     }
 
     @Override

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -268,9 +268,9 @@ public class RoutingController {
             // Register names in DNS
             Rotation rotation = rotationRepository.requireRotation(assignedRotation.rotationId());
             for (var endpoint : rotationEndpoints) {
-                controller.nameServiceForwarder().createCname(RecordName.from(endpoint.dnsName()),
-                                                              RecordData.fqdn(rotation.name()),
-                                                              Priority.normal);
+                controller.nameServiceForwarder().createRecord(
+                        new Record(Record.Type.CNAME, RecordName.from(endpoint.dnsName()), RecordData.fqdn(rotation.name())),
+                        Priority.normal);
                 List<String> names = List.of(endpoint.dnsName(),
                                              // Include rotation ID as a valid name of this container endpoint
                                              // (required by global routing health checks)
@@ -305,9 +305,9 @@ public class RoutingController {
             ZoneId targetZone = targetZones.iterator().next();
             String vipHostname = controller.zoneRegistry().getVipHostname(targetZone)
                                            .orElseThrow(() -> new IllegalArgumentException("No VIP configured for zone " + targetZone));
-            controller.nameServiceForwarder().createCname(RecordName.from(endpoint.dnsName()),
-                                                          RecordData.fqdn(vipHostname),
-                                                          Priority.normal);
+            controller.nameServiceForwarder().createRecord(
+                    new Record(Record.Type.CNAME, RecordName.from(endpoint.dnsName()), RecordData.fqdn(vipHostname)),
+                    Priority.normal);
         }
         Map<ClusterSpec.Id, EndpointList> applicationEndpointsByCluster = applicationEndpoints.groupingBy(Endpoint::cluster);
         for (var kv : applicationEndpointsByCluster.entrySet()) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecord.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/CreateRecord.java
@@ -19,7 +19,7 @@ public class CreateRecord implements NameServiceRequest {
     /** DO NOT USE. Public for serialization purposes */
     public CreateRecord(Record record) {
         this.record = Objects.requireNonNull(record, "record must be non-null");
-        if (record.type() != Record.Type.CNAME) {
+        if (record.type() != Record.Type.CNAME && record.type() != Record.Type.A) {
             throw new IllegalArgumentException("Record of type " + record.type() + " is not supported: " + record);
         }
     }
@@ -38,7 +38,7 @@ public class CreateRecord implements NameServiceRequest {
             }
         });
         if (records.isEmpty()) {
-            nameService.createCname(record.name(), record.data());
+            nameService.createRecord(record.type(), record.name(), record.data());
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceForwarder.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/dns/NameServiceForwarder.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.controller.dns;
 
 import com.yahoo.transaction.Mutex;
-import com.yahoo.vespa.curator.Lock;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.AliasTarget;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.NameService;
 import com.yahoo.vespa.hosted.controller.api.integration.dns.Record;
@@ -43,9 +42,9 @@ public class NameServiceForwarder {
         this.db = Objects.requireNonNull(db, "db must be non-null");
     }
 
-    /** Create or update a CNAME record with given name and data */
-    public void createCname(RecordName name, RecordData canonicalName, NameServiceQueue.Priority priority) {
-        forward(new CreateRecord(new Record(Record.Type.CNAME, name, canonicalName)), priority);
+    /** Create or update a given record */
+    public void createRecord(Record record, NameServiceQueue.Priority priority) {
+        forward(new CreateRecord(record), priority);
     }
 
     /** Create or update an ALIAS record with given name and targets */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicies.java
@@ -332,8 +332,8 @@ public class RoutingPolicies {
     private void updateZoneDnsOf(RoutingPolicy policy) {
         for (var endpoint : policy.zoneEndpointsIn(controller.system(), RoutingMethod.exclusive, controller.zoneRegistry())) {
             var name = RecordName.from(endpoint.dnsName());
-            var data = RecordData.fqdn(policy.canonicalName().value());
-            nameServiceForwarderIn(policy.id().zone()).createCname(name, data, Priority.normal);
+            var record = new Record(Record.Type.CNAME, name, RecordData.fqdn(policy.canonicalName().value()));
+            nameServiceForwarderIn(policy.id().zone()).createRecord(record, Priority.normal);
         }
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -271,7 +271,8 @@ public class DeploymentContext {
         var clusterId = "default-inactive";
         var id = new RoutingPolicyId(instanceId, Id.from(clusterId), zone);
         var policies = new LinkedHashMap<>(tester.controller().routing().policies().read(instanceId).asMap());
-        policies.put(id, new RoutingPolicy(id, HostName.of("lb-host"),
+        policies.put(id, new RoutingPolicy(id, Optional.of(HostName.of("lb-host")),
+                                           Optional.empty(),
                                            Optional.empty(),
                                            Set.of(EndpointId.of("default")),
                                            Set.of(),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -402,6 +402,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
                                                                    id.applicationId(),
                                                                    cluster,
                                                                    Optional.of(HostName.of("lb-0--" + id.applicationId().toFullString() + "--" + id.zoneId().toString())),
+                                                                   Optional.empty(),
                                                                    LoadBalancer.State.active,
                                                                    Optional.of("dns-zone-1"))));
         }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
@@ -38,20 +38,29 @@ public class RoutingPolicySerializerTest {
                 ClusterSpec.Id.from("my-cluster2"),
                 ZoneId.from("prod", "us-north-2"));
         var policies = List.of(new RoutingPolicy(id1,
-                        HostName.of("long-and-ugly-name"),
+                        Optional.of(HostName.of("long-and-ugly-name")),
+                        Optional.empty(),
                         Optional.of("zone1"),
                         instanceEndpoints,
                         applicationEndpoints,
                         new RoutingPolicy.Status(true, RoutingStatus.DEFAULT)),
                 new RoutingPolicy(id2,
-                        HostName.of("long-and-ugly-name-2"),
+                        Optional.of(HostName.of("long-and-ugly-name-2")),
+                        Optional.empty(),
                         Optional.empty(),
                         instanceEndpoints,
                         Set.of(),
                         new RoutingPolicy.Status(false,
                                 new RoutingStatus(RoutingStatus.Value.out,
                                         RoutingStatus.Agent.tenant,
-                                        Instant.ofEpochSecond(123)))));
+                                        Instant.ofEpochSecond(123)))),
+                new RoutingPolicy(id1,
+                        Optional.empty(),
+                        Optional.of("127.0.0.1"),
+                        Optional.of("zone2"),
+                        instanceEndpoints,
+                        applicationEndpoints,
+                        new RoutingPolicy.Status(true, RoutingStatus.DEFAULT)));
         var serialized = serializer.fromSlime(owner, serializer.toSlime(policies));
         assertEquals(policies.size(), serialized.size());
         for (Iterator<RoutingPolicy> it1 = policies.iterator(), it2 = serialized.iterator(); it1.hasNext(); ) {
@@ -59,6 +68,7 @@ public class RoutingPolicySerializerTest {
             var actual = it2.next();
             assertEquals(expected.id(), actual.id());
             assertEquals(expected.canonicalName(), actual.canonicalName());
+            assertEquals(expected.ipAddress(), actual.ipAddress());
             assertEquals(expected.dnsZone(), actual.dnsZone());
             assertEquals(expected.instanceEndpoints(), actual.instanceEndpoints());
             assertEquals(expected.applicationEndpoints(), actual.applicationEndpoints());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
@@ -45,7 +45,7 @@ public class LoadBalancerInstance {
         return hostname;
     }
 
-    /** IP address this load balancer */
+    /** IP address of this load balancer */
     public Optional<String> ipAddress() {
         return ipAddress;
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
@@ -17,26 +17,37 @@ import java.util.Set;
  */
 public class LoadBalancerInstance {
 
-    private final DomainName hostname;
+    private final Optional<DomainName> hostname;
+    private final Optional<String> ipAddress;
     private final Optional<DnsZone> dnsZone;
     private final Set<Integer> ports;
     private final Set<String> networks;
     private final Set<Real> reals;
     private final Optional<CloudAccount> cloudAccount;
 
-    public LoadBalancerInstance(DomainName hostname, Optional<DnsZone> dnsZone, Set<Integer> ports, Set<String> networks,
-                                Set<Real> reals, Optional<CloudAccount> cloudAccount) {
+    public LoadBalancerInstance(Optional<DomainName> hostname, Optional<String> ipAddress, Optional<DnsZone> dnsZone, Set<Integer> ports,
+                                Set<String> networks, Set<Real> reals, Optional<CloudAccount> cloudAccount) {
         this.hostname = Objects.requireNonNull(hostname, "hostname must be non-null");
+        this.ipAddress = Objects.requireNonNull(ipAddress, "ip must be non-null");
         this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
         this.ports = ImmutableSortedSet.copyOf(requirePorts(ports));
         this.networks = ImmutableSortedSet.copyOf(Objects.requireNonNull(networks, "networks must be non-null"));
         this.reals = ImmutableSortedSet.copyOf(Objects.requireNonNull(reals, "targets must be non-null"));
         this.cloudAccount = Objects.requireNonNull(cloudAccount, "cloudAccount must be non-null");
+
+        if (hostname.isEmpty() == ipAddress.isEmpty())
+            throw new IllegalArgumentException("Exactly 1 of hostname=%s and ipAddress=%s must be set".formatted(
+                    hostname.map(DomainName::value).orElse("<empty>"), ipAddress.orElse("<empty>")));
     }
 
     /** Fully-qualified domain name of this load balancer. This hostname can be used for query and feed */
-    public DomainName hostname() {
+    public Optional<DomainName> hostname() {
         return hostname;
+    }
+
+    /** IP address this load balancer */
+    public Optional<String> ipAddress() {
+        return ipAddress;
     }
 
     /** ID of the DNS zone associated with this */
@@ -66,7 +77,7 @@ public class LoadBalancerInstance {
 
     /** Returns a copy of this with reals set to given reals */
     public LoadBalancerInstance withReals(Set<Real> reals) {
-        return new LoadBalancerInstance(hostname, dnsZone, ports, networks, reals, cloudAccount);
+        return new LoadBalancerInstance(hostname, ipAddress, dnsZone, ports, networks, reals, cloudAccount);
     }
 
     private static Set<Integer> requirePorts(Set<Integer> ports) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
@@ -55,7 +55,8 @@ public class LoadBalancerServiceMock implements LoadBalancerService {
             throw new IllegalArgumentException("Refusing to remove all reals from load balancer " + id);
         }
         var instance = new LoadBalancerInstance(
-                DomainName.of("lb-" + spec.application().toShortString() + "-" + spec.cluster().value()),
+                Optional.of(DomainName.of("lb-" + spec.application().toShortString() + "-" + spec.cluster().value())),
+                Optional.empty(),
                 Optional.of(new DnsZone("zone-id-1")),
                 Collections.singleton(4443),
                 ImmutableSet.of("10.2.3.0/24", "10.4.5.0/24"),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
@@ -28,7 +28,8 @@ public class SharedLoadBalancerService implements LoadBalancerService {
 
     @Override
     public LoadBalancerInstance create(LoadBalancerSpec spec, boolean force) {
-        return new LoadBalancerInstance(DomainName.of(vipHostname),
+        return new LoadBalancerInstance(Optional.of(DomainName.of(vipHostname)),
+                                        Optional.empty(),
                                         Optional.empty(),
                                         Set.of(4443),
                                         Set.of(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -38,7 +38,7 @@ public class LoadBalancerSerializer {
 
     private static final String idField = "id";
     private static final String hostnameField = "hostname";
-    private static final String lbIpAddressField = "ipAdress";
+    private static final String lbIpAddressField = "ipAddress";
     private static final String stateField = "state";
     private static final String changedAtField = "changedAt";
     private static final String dnsZoneField = "dnsZone";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersResponse.java
@@ -56,7 +56,8 @@ public class LoadBalancersResponse extends SlimeJsonResponse {
             lbObject.setString("tenant", lb.id().application().tenant().value());
             lbObject.setString("instance", lb.id().application().instance().value());
             lbObject.setString("cluster", lb.id().cluster().value());
-            lb.instance().ifPresent(instance -> lbObject.setString("hostname", instance.hostname().value()));
+            lb.instance().flatMap(LoadBalancerInstance::hostname).ifPresent(hostname -> lbObject.setString("hostname", hostname.value()));
+            lb.instance().flatMap(LoadBalancerInstance::ipAddress).ifPresent(ipAddress -> lbObject.setString("ipAddress", ipAddress));
             lb.instance().flatMap(LoadBalancerInstance::dnsZone).ifPresent(dnsZone -> lbObject.setString("dnsZone", dnsZone.id()));
 
             Cursor networkArray = lbObject.setArray("networks");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerServiceTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerServiceTest.java
@@ -28,7 +28,7 @@ public class SharedLoadBalancerServiceTest {
     public void test_create_lb() {
         var lb = loadBalancerService.create(new LoadBalancerSpec(applicationId, clusterId, reals, Optional.empty()), false);
 
-        assertEquals(HostName.of("vip.example.com"), lb.hostname());
+        assertEquals(Optional.of(HostName.of("vip.example.com")), lb.hostname());
         assertEquals(Optional.empty(), lb.dnsZone());
         assertEquals(Set.of(), lb.networks());
         assertEquals(Set.of(4443), lb.ports());


### PR DESCRIPTION
The net effect of this is that zonal endpoints in GCP will become an `A` record to LB IP instead of a `CNAME` record to `<reverse IP>.bc.googleusercontent.com`.

In next PR the goal is to create Weighted record with a Route53 health check for the routing policies where the IP is specified instead of hostname, but continue using ALIAS latency record (since the weighted record will be in the same hosted zone).