### PR TITLE
Revert "Restrict server names accepted per connector"

### DIFF
--- a/container-core/abi-spec.json
+++ b/container-core/abi-spec.json
@@ -1236,13 +1236,9 @@
       "public void <init>()",
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$ServerName)",
       "public com.yahoo.jdisc.http.ConnectorConfig$ServerName$Builder fallback(java.lang.String)",
-      "public com.yahoo.jdisc.http.ConnectorConfig$ServerName$Builder allowed(java.lang.String)",
-      "public com.yahoo.jdisc.http.ConnectorConfig$ServerName$Builder allowed(java.util.Collection)",
       "public com.yahoo.jdisc.http.ConnectorConfig$ServerName build()"
     ],
-    "fields": [
-      "public java.util.List allowed"
-    ]
+    "fields": []
   },
   "com.yahoo.jdisc.http.ConnectorConfig$ServerName": {
     "superClass": "com.yahoo.config.InnerNode",
@@ -1253,9 +1249,7 @@
     ],
     "methods": [
       "public void <init>(com.yahoo.jdisc.http.ConnectorConfig$ServerName$Builder)",
-      "public java.lang.String fallback()",
-      "public java.util.List allowed()",
-      "public java.lang.String allowed(int)"
+      "public java.lang.String fallback()"
     ],
     "fields": []
   },

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/ConnectorFactory.java
@@ -9,6 +9,7 @@ import com.yahoo.jdisc.http.ssl.impl.DefaultConnectorSsl;
 import com.yahoo.security.tls.MixedMode;
 import com.yahoo.security.tls.TransportSecurityUtils;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http2.server.AbstractHTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
@@ -81,9 +82,16 @@ public class ConnectorFactory {
 
     public ServerConnector createConnector(final Metric metric, final Server server, JettyConnectionLogger connectionLogger,
                                            ConnectionMetricAggregator connectionMetricAggregator) {
-        return new JDiscServerConnector(
+        ServerConnector connector = new JDiscServerConnector(
                 connectorConfig, metric, server, connectionLogger, connectionMetricAggregator,
                 createConnectionFactories(metric).toArray(ConnectionFactory[]::new));
+        connector.setPort(connectorConfig.listenPort());
+        connector.setName(connectorConfig.name());
+        connector.setAcceptQueueSize(connectorConfig.acceptQueueSize());
+        connector.setReuseAddress(connectorConfig.reuseAddress());
+        connector.setIdleTimeout(toMillis(connectorConfig.idleTimeout()));
+        connector.addBean(HttpCompliance.RFC7230);
+        return connector;
     }
 
     private List<ConnectionFactory> createConnectionFactories(Metric metric) {

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JDiscServerConnector.java
@@ -3,7 +3,6 @@ package com.yahoo.jdisc.http.server.jetty;
 
 import com.yahoo.jdisc.Metric;
 import com.yahoo.jdisc.http.ConnectorConfig;
-import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Server;
@@ -51,15 +50,7 @@ class JDiscServerConnector extends ServerConnector {
         }
         addBean(connectionLogger);
         addBean(connectionMetricAggregator);
-        setPort(config.listenPort());
-        setName(config.name());
-        setAcceptQueueSize(config.acceptQueueSize());
-        setReuseAddress(config.reuseAddress());
-        setIdleTimeout(toMillis(config.idleTimeout()));
-        addBean(HttpCompliance.RFC7230);
     }
-
-    private static long toMillis(double seconds) { return (long)(seconds * 1000); }
 
     @Override
     protected void configure(final Socket socket) {

--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/JettyHttpServer.java
@@ -14,6 +14,7 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.jmx.ConnectorServer;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -138,51 +139,43 @@ public class JettyHttpServer extends AbstractServerProvider {
     private HandlerCollection getHandlerCollection(ServerConfig serverConfig,
                                                    List<JDiscServerConnector> connectors,
                                                    ServletHolder jdiscServlet) {
-        HandlerCollection connectorSpecificHandlers = new HandlerCollection();
-        for (JDiscServerConnector connector : connectors) {
-            ServletContextHandler servletContextHandler = createServletContextHandler(connector);
-            servletContextHandler.addServlet(jdiscServlet, "/*");
+        ServletContextHandler servletContextHandler = createServletContextHandler();
+        servletContextHandler.addServlet(jdiscServlet, "/*");
 
-            List<ConnectorConfig> connectorConfigs = connectors.stream().map(JDiscServerConnector::connectorConfig).collect(toList());
-            var secureRedirectHandler = new SecuredRedirectHandler(connectorConfigs);
-            secureRedirectHandler.setHandler(servletContextHandler);
+        List<ConnectorConfig> connectorConfigs = connectors.stream().map(JDiscServerConnector::connectorConfig).collect(toList());
+        var secureRedirectHandler = new SecuredRedirectHandler(connectorConfigs);
+        secureRedirectHandler.setHandler(servletContextHandler);
 
-            var proxyHandler = new HealthCheckProxyHandler(connectors);
-            proxyHandler.setHandler(secureRedirectHandler);
+        var proxyHandler = new HealthCheckProxyHandler(connectors);
+        proxyHandler.setHandler(secureRedirectHandler);
 
-            var authEnforcer = new TlsClientAuthenticationEnforcer(connectorConfigs);
-            authEnforcer.setHandler(proxyHandler);
+        var authEnforcer = new TlsClientAuthenticationEnforcer(connectorConfigs);
+        authEnforcer.setHandler(proxyHandler);
 
-            GzipHandler gzipHandler = newGzipHandler(serverConfig);
-            gzipHandler.setHandler(authEnforcer);
+        GzipHandler gzipHandler = newGzipHandler(serverConfig);
+        gzipHandler.setHandler(authEnforcer);
 
-            HttpResponseStatisticsCollector statisticsCollector =
-                    new HttpResponseStatisticsCollector(serverConfig.metric().monitoringHandlerPaths(),
-                                                        serverConfig.metric().searchHandlerPaths());
-            statisticsCollector.setHandler(gzipHandler);
-            for (String agent : serverConfig.metric().ignoredUserAgents()) {
-                statisticsCollector.ignoreUserAgent(agent);
-            }
-            StatisticsHandler statisticsHandler = newStatisticsHandler();
-            statisticsHandler.setHandler(statisticsCollector);
-
-            connectorSpecificHandlers.addHandler(statisticsHandler);
+        HttpResponseStatisticsCollector statisticsCollector =
+                new HttpResponseStatisticsCollector(serverConfig.metric().monitoringHandlerPaths(),
+                                                    serverConfig.metric().searchHandlerPaths());
+        statisticsCollector.setHandler(gzipHandler);
+        for (String agent : serverConfig.metric().ignoredUserAgents()) {
+            statisticsCollector.ignoreUserAgent(agent);
         }
 
-        return connectorSpecificHandlers;
+        StatisticsHandler statisticsHandler = newStatisticsHandler();
+        statisticsHandler.setHandler(statisticsCollector);
+
+        HandlerCollection handlerCollection = new HandlerCollection();
+        handlerCollection.setHandlers(new Handler[] { statisticsHandler });
+        return handlerCollection;
     }
 
-    private ServletContextHandler createServletContextHandler(JDiscServerConnector connector) {
-        var ctx = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
-        ctx.setContextPath("/");
-        ctx.setDisplayName(getDisplayName(listenedPorts));
-        List<String> allowedServerNames = connector.connectorConfig().serverName().allowed();
-        if (allowedServerNames.isEmpty()) {
-            ctx.setVirtualHosts(new String[]{"@%s".formatted(connector.getName())});
-        } else {
-            ctx.setVirtualHosts(allowedServerNames.toArray(new String[0]));
-        }
-        return ctx;
+    private ServletContextHandler createServletContextHandler() {
+        ServletContextHandler servletContextHandler = new ServletContextHandler(ServletContextHandler.NO_SECURITY | ServletContextHandler.NO_SESSIONS);
+        servletContextHandler.setContextPath("/");
+        servletContextHandler.setDisplayName(getDisplayName(listenedPorts));
+        return servletContextHandler;
     }
 
     private static String getDisplayName(List<Integer> ports) {

--- a/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -138,5 +138,3 @@ http2.maxConcurrentStreams int default=4096
 # Override the default server name when authority is missing from request.
 serverName.fallback string default=""
 
-# The list of accepted server names. Empty list to accept any. Elements follows format of 'serverName.default'.
-serverName.allowed[] string

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -743,7 +743,7 @@ public class HttpServerTest {
     }
 
     @Test
-    void fallbackServerNameCanBeOverridden() throws Exception {
+    void requestThatFallbackServerNameCanBeOverridden() throws Exception {
         String fallbackHostname = "myhostname";
         JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
                 new UriRequestHandler(),
@@ -752,26 +752,10 @@ public class HttpServerTest {
                         .serverName(new ConnectorConfig.ServerName.Builder().fallback(fallbackHostname)));
         int listenPort = driver.server().getListenPort();
         HttpGet req = new HttpGet("http://localhost:" + listenPort + "/");
-        req.setHeader("Host", null);
+        req.addHeader("Host", null);
         driver.client().execute(req)
                 .expectStatusCode(is(OK))
                 .expectContent(containsString("http://" + fallbackHostname + ":" + listenPort + "/"));
-        assertTrue(driver.close());
-    }
-
-    @Test
-    void acceptedServerNamesCanBeRestricted() throws Exception {
-        String requiredServerName = "myhostname";
-        JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
-                new EchoRequestHandler(),
-                new ServerConfig.Builder(),
-                new ConnectorConfig.Builder()
-                        .serverName(new ConnectorConfig.ServerName.Builder().allowed(requiredServerName)));
-        int listenPort = driver.server().getListenPort();
-        HttpGet req = new HttpGet("http://localhost:" + listenPort + "/");
-        req.setHeader("Host", requiredServerName);
-        driver.client().execute(req).expectStatusCode(is(OK));
-        driver.client().get("/").expectStatusCode(is(NOT_FOUND));
         assertTrue(driver.close());
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#24322

Containers fail to start with:

[2022-10-06 10:39:01.979] WARNING container        Container.org.eclipse.jetty.server.HttpChannel
        /status.html
        exception=
        java.lang.IllegalStateException: s=HANDLING rs=ASYNC os=OPEN is=IDLE awp=false se=false i=true al=3
        at org.eclipse.jetty.server.HttpChannelState.startAsync(HttpChannelState.java:534)
        at org.eclipse.jetty.server.Request.startAsync(Request.java:2343)
        at com.yahoo.jdisc.http.server.jetty.HealthCheckProxyHandler.handle(HealthCheckProxyHandler.java:103)
        at com.yahoo.jdisc.http.server.jetty.TlsClientAuthenticationEnforcer.handle(TlsClientAuthenticationEnforcer.java:43)
        at org.eclipse.jetty.server.handler.gzip.GzipHandler.handle(GzipHandler.java:693)
        at com.yahoo.jdisc.http.server.jetty.HttpResponseStatisticsCollector.handle(HttpResponseStatisticsCollector.java:94)
        at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:181)
        at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:146)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:487)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:732)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:479)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.base/java.lang.Thread.run(Thread.java:833)