### PR TITLE
JSON output format is not stabilized yet, and will likely change in t…

### DIFF
--- a/client/go/cmd/logfmt/cmd.go
+++ b/client/go/cmd/logfmt/cmd.go
@@ -38,7 +38,7 @@ and converts it to something human-readable`,
 	cmd.Flags().StringVarP(&curOptions.OnlyHostname, "host", "H", "", "select only one host")
 	cmd.Flags().StringVarP(&curOptions.OnlyPid, "pid", "p", "", "select only one process ID")
 	cmd.Flags().StringVarP(&curOptions.OnlyService, "service", "S", "", "select only one service")
-	cmd.Flags().VarP(&curOptions.Format, "format", "F", "select logfmt output format, vespa (default), json or raw are supported")
+	cmd.Flags().VarP(&curOptions.Format, "format", "F", "select logfmt output format, vespa (default), json or raw are supported. The json output format is not stable, and will change in the future.")
 	cmd.Flags().MarkHidden("tc")
 	cmd.Flags().MarkHidden("ts")
 	cmd.Flags().MarkHidden("dequotenewlines")


### PR DESCRIPTION
…he future.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@arnej27959 - we will likely need to change the JSON object somewhat to ensure it maps well to both default managed kubernetes setups in both AWS and GCP.