### PR TITLE
Hide more details inside BufferState and reduce external API on Buffe…

### DIFF
--- a/searchlib/src/vespa/searchlib/memoryindex/feature_store.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/feature_store.cpp
@@ -68,8 +68,6 @@ FeatureStore::moveFeatures(EntryRef ref, uint64_t bitLen)
     const uint8_t *src = getBits(ref);
     uint64_t byteLen = (bitLen + 7) / 8;
     EntryRef newRef = addFeatures(src, byteLen);
-    // Mark old features as dead
-    _store.incDead(ref, byteLen + Aligner::pad(byteLen));
     return newRef;
 }
 
@@ -117,7 +115,6 @@ FeatureStore::add_features_guard_bytes()
     uint32_t pad = Aligner::pad(len);
     auto result = _store.rawAllocator<uint8_t>(_typeId).alloc(len + pad);
     memset(result.data, 0, len + pad);
-    _store.incDead(result.ref, len + pad);
 }
 
 void

--- a/vespalib/CMakeLists.txt
+++ b/vespalib/CMakeLists.txt
@@ -54,6 +54,7 @@ vespa_define_module(
     src/tests/data/smart_buffer
     src/tests/datastore/array_store
     src/tests/datastore/array_store_config
+    src/tests/datastore/buffer_stats
     src/tests/datastore/buffer_type
     src/tests/datastore/compact_buffer_candidates
     src/tests/datastore/datastore

--- a/vespalib/src/tests/datastore/buffer_stats/CMakeLists.txt
+++ b/vespalib/src/tests/datastore/buffer_stats/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(vespalib_datastore_buffer_stats_test_app TEST
+    SOURCES
+    buffer_stats_test.cpp
+    DEPENDS
+    vespalib
+    GTest::GTest
+)
+vespa_add_test(NAME vespalib_datastore_buffer_stats_test_app COMMAND vespalib_datastore_buffer_stats_test_app)

--- a/vespalib/src/tests/datastore/buffer_stats/buffer_stats_test.cpp
+++ b/vespalib/src/tests/datastore/buffer_stats/buffer_stats_test.cpp
@@ -1,0 +1,34 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/vespalib/datastore/buffer_stats.h>
+#include <vespa/vespalib/datastore/memory_stats.h>
+#include <vespa/vespalib/gtest/gtest.h>
+
+using namespace vespalib::datastore;
+
+TEST(BufferStatsTest, buffer_stats_to_memory_stats)
+{
+    InternalBufferStats buf;
+    buf.set_alloc_elems(17);
+    buf.pushed_back(7);
+    buf.set_dead_elems(5);
+    buf.set_hold_elems(3);
+    buf.inc_extra_used_bytes(13);
+    buf.inc_extra_hold_bytes(11);
+
+    MemoryStats mem;
+    constexpr size_t es = 8;
+    buf.add_to_mem_stats(es, mem);
+
+    EXPECT_EQ(17, mem._allocElems);
+    EXPECT_EQ(7, mem._usedElems);
+    EXPECT_EQ(5, mem._deadElems);
+    EXPECT_EQ(3, mem._holdElems);
+    EXPECT_EQ(17 * es + 13, mem._allocBytes);
+    EXPECT_EQ(7 * es + 13, mem._usedBytes);
+    EXPECT_EQ(5 * es, mem._deadBytes);
+    EXPECT_EQ(3 * es + 11, mem._holdBytes);
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()
+

--- a/vespalib/src/vespa/vespalib/datastore/buffer_stats.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_stats.cpp
@@ -16,14 +16,6 @@ BufferStats::BufferStats()
 }
 
 void
-BufferStats::dec_hold_elems(size_t value)
-{
-    ElemCount elems = hold_elems();
-    assert(elems >= value);
-    _hold_elems.store(elems - value, std::memory_order_relaxed);
-}
-
-void
 BufferStats::add_to_mem_stats(size_t element_size, MemoryStats& stats) const
 {
     size_t extra_used = extra_used_bytes();
@@ -37,13 +29,13 @@ BufferStats::add_to_mem_stats(size_t element_size, MemoryStats& stats) const
     stats._holdBytes += (hold_elems() * element_size) + extra_hold_bytes();
 }
 
-MutableBufferStats::MutableBufferStats()
+InternalBufferStats::InternalBufferStats()
     : BufferStats()
 {
 }
 
 void
-MutableBufferStats::clear()
+InternalBufferStats::clear()
 {
     _alloc_elems.store(0, std::memory_order_relaxed);
     _used_elems.store(0, std::memory_order_relaxed);
@@ -51,6 +43,14 @@ MutableBufferStats::clear()
     _dead_elems.store(0, std::memory_order_relaxed);
     _extra_used_bytes.store(0, std::memory_order_relaxed);
     _extra_hold_bytes.store(0, std::memory_order_relaxed);
+}
+
+void
+InternalBufferStats::dec_hold_elems(size_t value)
+{
+    ElemCount elems = hold_elems();
+    assert(elems >= value);
+    _hold_elems.store(elems - value, std::memory_order_relaxed);
 }
 
 }

--- a/vespalib/src/vespa/vespalib/datastore/buffer_stats.h
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_stats.h
@@ -47,11 +47,7 @@ public:
     size_t extra_used_bytes() const { return _extra_used_bytes.load(std::memory_order_relaxed); }
     size_t extra_hold_bytes() const { return _extra_hold_bytes.load(std::memory_order_relaxed); }
 
-    void inc_dead_elems(size_t value) { _dead_elems.store(dead_elems() + value, std::memory_order_relaxed); }
-    void inc_hold_elems(size_t value) { _hold_elems.store(hold_elems() + value, std::memory_order_relaxed); }
-    void dec_hold_elems(size_t value);
     void inc_extra_used_bytes(size_t value) { _extra_used_bytes.store(extra_used_bytes() + value, std::memory_order_relaxed); }
-    void inc_extra_hold_bytes(size_t value) { _extra_hold_bytes.store(extra_hold_bytes() + value, std::memory_order_relaxed); }
 
     void add_to_mem_stats(size_t element_size, MemoryStats& stats) const;
 };
@@ -59,13 +55,17 @@ public:
 /**
  * Provides low-level access to buffer stats for integration in BufferState.
  */
-class MutableBufferStats : public BufferStats {
+class InternalBufferStats : public BufferStats {
 public:
-    MutableBufferStats();
+    InternalBufferStats();
     void clear();
     void set_alloc_elems(size_t value) { _alloc_elems.store(value, std::memory_order_relaxed); }
     void set_dead_elems(size_t value) { _dead_elems.store(value, std::memory_order_relaxed); }
     void set_hold_elems(size_t value) { _hold_elems.store(value, std::memory_order_relaxed); }
+    void inc_dead_elems(size_t value) { _dead_elems.store(dead_elems() + value, std::memory_order_relaxed); }
+    void inc_hold_elems(size_t value) { _hold_elems.store(hold_elems() + value, std::memory_order_relaxed); }
+    void dec_hold_elems(size_t value);
+    void inc_extra_hold_bytes(size_t value) { _extra_hold_bytes.store(extra_hold_bytes() + value, std::memory_order_relaxed); }
     std::atomic<ElemCount>& used_elems_ref() { return _used_elems; }
     std::atomic<ElemCount>& dead_elems_ref() { return _dead_elems; }
     std::atomic<size_t>& extra_used_bytes_ref() { return _extra_used_bytes; }

--- a/vespalib/src/vespa/vespalib/datastore/datastore.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastore.h
@@ -38,17 +38,6 @@ public:
     ~DataStoreT() override;
 
     /**
-     * Increase number of dead elements in buffer.
-     *
-     * @param ref       Reference to dead stored features
-     * @param dead      Number of newly dead elements
-     */
-    void incDead(EntryRef ref, size_t deadElems) {
-        RefType intRef(ref);
-        DataStoreBase::incDead(intRef.bufferId(), deadElems);
-    }
-
-    /**
      * Free element(s).
      */
     void freeElem(EntryRef ref, size_t numElems) { free_elem_internal(ref, numElems, false); }

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
@@ -300,7 +300,7 @@ DataStoreBase::enableFreeLists()
         if (!bState.isActive() || bState.getCompacting()) {
             continue;
         }
-        bState.free_list().enable(_free_lists[bState.getTypeId()]);
+        bState.enable_free_list(_free_lists[bState.getTypeId()]);
     }
     _freeListsEnabled = true;
 }
@@ -309,7 +309,7 @@ void
 DataStoreBase::disableFreeLists()
 {
     for (BufferState & bState : _states) {
-        bState.free_list().disable();
+        bState.disable_free_list();
     }
     _freeListsEnabled = false;
 }
@@ -321,14 +321,8 @@ DataStoreBase::enableFreeList(uint32_t bufferId)
     if (_freeListsEnabled &&
         state.isActive() &&
         !state.getCompacting()) {
-        state.free_list().enable(_free_lists[state.getTypeId()]);
+        state.enable_free_list(_free_lists[state.getTypeId()]);
     }
-}
-
-void
-DataStoreBase::disableFreeList(uint32_t bufferId)
-{
-    _states[bufferId].free_list().disable();
 }
 
 void
@@ -452,7 +446,7 @@ DataStoreBase::markCompacting(uint32_t bufferId)
     assert(!state.getCompacting());
     state.setCompacting();
     state.disableElemHoldList();
-    state.free_list().disable();
+    state.disable_free_list();
     inc_compaction_count();
 }
 

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.h
@@ -253,12 +253,6 @@ public:
 
     void dropBuffers();
 
-
-    void incDead(uint32_t bufferId, size_t deadElems) {
-        BufferState &state = _states[bufferId];
-        state.stats().inc_dead_elems(deadElems);
-    }
-
     /**
      * Enable free list management.
      * This only works for fixed size elements.


### PR DESCRIPTION
…rStats.

Using incDead() directly is no longer supported as marking elements as dead right before they are put on hold is unnecessary.

@toregge please review