### PR TITLE
Stop using search::index::DocBuilder in DocumentFieldPopulator unit

### DIFF
--- a/searchcore/src/tests/proton/attribute/document_field_populator/document_field_populator_test.cpp
+++ b/searchcore/src/tests/proton/attribute/document_field_populator/document_field_populator_test.cpp
@@ -1,12 +1,13 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/document/datatype/datatype.h>
+#include <vespa/document/repo/configbuilder.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchcore/proton/attribute/document_field_populator.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/integerbase.h>
-#include <vespa/searchlib/index/docbuilder.h>
-#include <vespa/searchcommon/common/schema.h>
-#include <vespa/searchcommon/attribute/config.h>
+#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
@@ -20,33 +21,17 @@ using namespace search::index;
 typedef search::attribute::Config AVConfig;
 typedef search::attribute::BasicType AVBasicType;
 
-Schema::AttributeField
-createAttributeField()
-{
-    return Schema::AttributeField("a1", Schema::DataType::INT32);
-}
-
-Schema
-createSchema()
-{
-    Schema schema;
-    schema.addAttributeField(createAttributeField());
-    return schema;
-}
-
 struct DocContext
 {
-    Schema _schema;
-    DocBuilder _builder;
+    EmptyDocBuilder _builder;
     DocContext()
-        : _schema(createSchema()),
-          _builder(_schema)
+        : _builder([](auto& header) { header.addField("a1", DataType::T_INT); })
     {
     }
     Document::UP create(uint32_t id) {
         vespalib::string docId =
                 vespalib::make_string("id:searchdocument:searchdocument::%u", id);
-        return _builder.startDocument(docId).endDocument();
+        return _builder.make_document(docId);
     }
 };
 

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -1,5 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/document/datatype/datatype.h>
+#include <vespa/document/fieldvalue/intfieldvalue.h>
+#include <vespa/document/repo/configbuilder.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 #include <vespa/searchcore/proton/bucketdb/bucketdbhandler.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
@@ -27,7 +30,7 @@
 #include <vespa/searchcore/proton/test/thread_utils.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchlib/attribute/interlock.h>
-#include <vespa/searchlib/index/docbuilder.h>
+#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/test/directory_handler.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/config-bucketspaces.h>
@@ -258,24 +261,35 @@ struct TwoAttrSchema : public OneAttrSchema
     }
 };
 
+EmptyDocBuilder::AddFieldsType
+get_add_fields(bool has_attr2)
+{
+    return [has_attr2](auto& header) {
+               header.addField("attr1", DataType::T_INT);
+               if (has_attr2) {
+                   header.addField("attr2", DataType::T_INT);
+               }
+           };
+}
+
 struct MyConfigSnapshot
 {
     typedef std::unique_ptr<MyConfigSnapshot> UP;
     Schema _schema;
-    DocBuilder _builder;
+    EmptyDocBuilder _builder;
     DocumentDBConfig::SP _cfg;
     BootstrapConfig::SP  _bootstrap;
     MyConfigSnapshot(FNET_Transport & transport, const Schema &schema, const vespalib::string &cfgDir)
         : _schema(schema),
-          _builder(_schema),
+          _builder(get_add_fields(_schema.getNumAttributeFields() > 1)),
           _cfg(),
           _bootstrap()
     {
-        auto documenttypesConfig = std::make_shared<DocumenttypesConfig>(_builder.getDocumenttypesConfig());
+        auto documenttypesConfig = std::make_shared<DocumenttypesConfig>(_builder.get_documenttypes_config());
         auto tuneFileDocumentDB = std::make_shared<TuneFileDocumentDB>();
         _bootstrap = std::make_shared<BootstrapConfig>(1,
                                  documenttypesConfig,
-                                 _builder.getDocumentTypeRepo(),
+                                 _builder.get_repo_sp(),
                                  std::make_shared<ProtonConfig>(),
                                  std::make_shared<FiledistributorrpcConfig>(),
                                  std::make_shared<BucketspacesConfig>(),
@@ -746,8 +760,8 @@ template <typename FixtureType>
 struct DocumentHandler
 {
     FixtureType &_f;
-    DocBuilder _builder;
-    DocumentHandler(FixtureType &f) : _f(f), _builder(f._baseSchema) {}
+    EmptyDocBuilder _builder;
+    DocumentHandler(FixtureType &f) : _f(f), _builder(get_add_fields(f._baseSchema.getNumAttributeFields() > 1)) {}
     static constexpr uint32_t BUCKET_USED_BITS = 8;
     static DocumentId createDocId(uint32_t docId)
     {
@@ -755,16 +769,16 @@ struct DocumentHandler
                                                 "searchdocument::%u", docId));
     }
     Document::UP createEmptyDoc(uint32_t docId) {
-        return _builder.startDocument
-            (vespalib::make_string("id:searchdocument:searchdocument::%u",
-                                   docId)).
-            endDocument();
+        auto id = vespalib::make_string("id:searchdocument:searchdocument::%u",
+                                        docId);
+        return _builder.make_document(id);
     }
     Document::UP createDoc(uint32_t docId, int64_t attr1Value, int64_t attr2Value) {
-        return _builder.startDocument
-                (vespalib::make_string("id:searchdocument:searchdocument::%u", docId)).
-                startAttributeField("attr1").addInt(attr1Value).endField().
-                startAttributeField("attr2").addInt(attr2Value).endField().endDocument();
+        auto id = vespalib::make_string("id:searchdocument:searchdocument::%u", docId);
+        auto doc = _builder.make_document(id);
+        doc->setValue("attr1", IntFieldValue(attr1Value));
+        doc->setValue("attr2", IntFieldValue(attr2Value));
+        return doc;
     }
     PutOperation createPut(Document::UP doc, Timestamp timestamp, SerialNum serialNum) {
         proton::test::Document testDoc(Document::SP(doc.release()), 0, timestamp);

--- a/searchlib/src/vespa/searchlib/index/empty_doc_builder.cpp
+++ b/searchlib/src/vespa/searchlib/index/empty_doc_builder.cpp
@@ -4,6 +4,7 @@
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/document/repo/document_type_repo_factory.h>
 #include <vespa/document/repo/configbuilder.h>
 #include <cassert>
 
@@ -11,6 +12,7 @@ using document::DataType;
 using document::Document;
 using document::DocumentId;
 using document::DocumentTypeRepo;
+using document::DocumentTypeRepoFactory;
 
 namespace search::index {
 
@@ -32,7 +34,8 @@ get_document_types_config(EmptyDocBuilder::AddFieldsType add_fields)
 }
 
 EmptyDocBuilder::EmptyDocBuilder(AddFieldsType add_fields)
-    : _repo(std::make_shared<const DocumentTypeRepo>(get_document_types_config(add_fields))),
+    : _document_types_config(std::make_shared<const DocumenttypesConfig>(get_document_types_config(add_fields))),
+      _repo(DocumentTypeRepoFactory::make(*_document_types_config)),
       _document_type(_repo->getDocumentType("searchdocument"))
 {
 }

--- a/searchlib/src/vespa/searchlib/index/empty_doc_builder.h
+++ b/searchlib/src/vespa/searchlib/index/empty_doc_builder.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <functional>
 #include <memory>
@@ -12,6 +13,7 @@ class Document;
 class DocumentType;
 class DocumentTypeRepo;
 }
+namespace document::config::internal { class InternalDocumenttypesType; }
 namespace document::config_builder { struct Struct; }
 
 namespace search::index {
@@ -20,6 +22,8 @@ namespace search::index {
  * Class used to make empty search documents.
  */
 class EmptyDocBuilder {
+    using DocumenttypesConfig = const document::config::internal::InternalDocumenttypesType;
+    std::shared_ptr<const DocumenttypesConfig>        _document_types_config;
     std::shared_ptr<const document::DocumentTypeRepo> _repo;
     const document::DocumentType*                     _document_type;
 public:
@@ -31,6 +35,7 @@ public:
     const document::DocumentType& get_document_type() const noexcept { return *_document_type; }
     std::unique_ptr<document::Document> make_document(vespalib::string document_id);
     const document::DataType &get_data_type(const vespalib::string &name) const;
+    const DocumenttypesConfig& get_documenttypes_config() const noexcept { return *_document_types_config; }
 };
 
 }


### PR DESCRIPTION
test and document subdbs unit test.

@geirst : please review
