### PR TITLE
Reduce time we keep file references

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/CachedFilesMaintainer.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/CachedFilesMaintainer.java
@@ -2,9 +2,7 @@
 package com.yahoo.vespa.config.proxy.filedistribution;
 
 import com.yahoo.io.IOUtils;
-import java.util.logging.Level;
 import com.yahoo.vespa.filedistribution.FileDownloader;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -31,7 +29,7 @@ class CachedFilesMaintainer implements Runnable {
 
     private static final File defaultUrlDownloadDir = UrlDownloadRpcServer.downloadDir;
     private static final File defaultFileReferencesDownloadDir = FileDownloader.defaultDownloadDirectory;
-    private static final Duration defaultDurationToKeepFiles = Duration.ofDays(30);
+    private static final Duration defaultDurationToKeepFiles = Duration.ofDays(14);
 
     private final File urlDownloadDir;
     private final File fileReferencesDownloadDir;


### PR DESCRIPTION
Reduce the time we keep file references. If we delete one that we later need the config proxy will take care of downloading it again