### PR TITLE
- Use a common scratchpad for serializing the different parts of the …

### DIFF
--- a/component/src/main/java/com/yahoo/component/ComponentId.java
+++ b/component/src/main/java/com/yahoo/component/ComponentId.java
@@ -16,19 +16,11 @@ public final class ComponentId implements Comparable<ComponentId> {
     private final Spec<Version> spec;
     private final boolean anonymous;
 
-    private static AtomicInteger threadIdCounter = new AtomicInteger(0);
+    private static final AtomicInteger threadIdCounter = new AtomicInteger(0);
 
-    private static ThreadLocal<Counter> threadLocalUniqueId = new ThreadLocal<Counter>() {
-        @Override protected Counter initialValue() {
-            return new Counter();
-        }
-    };
+    private static final ThreadLocal<Counter> threadLocalUniqueId = ThreadLocal.withInitial(Counter::new);
 
-    private static ThreadLocal<String> threadId = new ThreadLocal<String>() {
-        @Override protected String initialValue() {
-            return new String("_" + threadIdCounter.getAndIncrement() + "_");
-        }
-    };
+    private static final ThreadLocal<String> threadId = ThreadLocal.withInitial(() -> "_" + threadIdCounter.getAndIncrement() + "_");
 
     /** Precomputed string value */
     private final String stringValue;
@@ -97,9 +89,8 @@ public final class ComponentId implements Comparable<ComponentId> {
     @Override
     public boolean equals(Object o) {
         if (o == this) return true;
-        if ( ! (o instanceof ComponentId)) return false;
+        if ( ! (o instanceof ComponentId c)) return false;
 
-        ComponentId c = (ComponentId) o;
         if (isAnonymous() || c.isAnonymous()) // TODO: Stop doing this
             return false;
 
@@ -221,7 +212,7 @@ public final class ComponentId implements Comparable<ComponentId> {
         return new ComponentId(splitter.name, Version.fromString(splitter.version), splitter.namespace, true);
     }
 
-    private final class VersionHandler implements Spec.VersionHandler<Version> {
+    private static final class VersionHandler implements Spec.VersionHandler<Version> {
 
         @Override
         public Version emptyVersion() {

--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.prelude.query;
 
-
 import com.yahoo.collections.CopyOnWriteHashMap;
 import com.yahoo.compress.IntegerCompressor;
 import com.yahoo.language.Language;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/MapConverter.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/MapConverter.java
@@ -18,14 +18,10 @@ import java.util.function.Consumer;
  */
 public class MapConverter {
 
-    public static void convertMapTensors(Map<String, Object> map, Consumer<TensorProperty.Builder> inserter) {
-        GrowableByteBuffer buffer = null;
+    public static void convertMapTensors(GrowableByteBuffer buffer, Map<String, Object> map, Consumer<TensorProperty.Builder> inserter) {
         for (var entry : map.entrySet()) {
             var value = entry.getValue();
             if (value instanceof Tensor tensor) {
-                if (buffer == null) {
-                    buffer = new GrowableByteBuffer(4096);
-                }
                 buffer.clear();
                 TypedBinaryFormat.encode(tensor, buffer);
                 inserter.accept(TensorProperty.newBuilder().setName(entry.getKey()).setValue(ByteString.copyFrom(buffer.getByteBuffer().flip())));
@@ -51,10 +47,10 @@ public class MapConverter {
         }
     }
 
-    public static void convertMultiMap(Map<String, List<Object>> map,
+    public static void convertMultiMap(GrowableByteBuffer buffer,
+                                       Map<String, List<Object>> map,
                                        Consumer<StringProperty.Builder> stringInserter,
                                        Consumer<TensorProperty.Builder> tensorInserter) {
-        GrowableByteBuffer buffer = null;
         for (var entry : map.entrySet()) {
             if (entry.getValue() != null) {
                 var key = entry.getKey();
@@ -62,9 +58,6 @@ public class MapConverter {
                 for (var value : entry.getValue()) {
                     if (value != null) {
                         if (value instanceof Tensor tensor) {
-                            if (buffer == null) {
-                                buffer = new GrowableByteBuffer(4096);
-                            }
                             buffer.clear();
                             TypedBinaryFormat.encode(tensor, buffer);
                             tensorInserter.accept(TensorProperty.newBuilder().setName(key).setValue(ByteString.copyFrom(buffer.getByteBuffer().flip())));

--- a/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
+++ b/container-search/src/main/java/com/yahoo/search/query/QueryTree.java
@@ -140,22 +140,18 @@ public class QueryTree extends CompositeItem {
         else if (b == null || b instanceof NullItem) {
             return a;
         }
-        else if (a instanceof NotItem && b instanceof NotItem) {
-            NotItem notItemA = (NotItem)a;
-            NotItem notItemB = (NotItem)b;
+        else if (a instanceof NotItem notItemA && b instanceof NotItem notItemB) {
             NotItem combined = new NotItem();
             combined.addPositiveItem(and(notItemA.getPositiveItem(), notItemB.getPositiveItem()));
             notItemA.negativeItems().forEach(item -> combined.addNegativeItem(item));
             notItemB.negativeItems().forEach(item -> combined.addNegativeItem(item));
             return combined;
         }
-        else if (a instanceof NotItem){
-            NotItem notItem = (NotItem)a;
+        else if (a instanceof NotItem notItem){
             notItem.addPositiveItem(b);
             return a;
         }
-        else if (b instanceof NotItem){
-            NotItem notItem = (NotItem)b;
+        else if (b instanceof NotItem notItem){
             notItem.addPositiveItem(a);
             return notItem;
         }
@@ -179,17 +175,16 @@ public class QueryTree extends CompositeItem {
     }
 
     private static void getPositiveTerms(Item item, List<IndexedItem> terms) {
-        if (item instanceof NotItem) {
-            getPositiveTerms(((NotItem) item).getPositiveItem(), terms);
-        } else if (item instanceof PhraseItem) {
-            PhraseItem pItem = (PhraseItem)item;
-            terms.add(pItem);
-        } else if (item instanceof CompositeItem) {
-            for (Iterator<Item> i = ((CompositeItem) item).getItemIterator(); i.hasNext();) {
+        if (item instanceof NotItem notItem) {
+            getPositiveTerms(notItem.getPositiveItem(), terms);
+        } else if (item instanceof PhraseItem phraseItem) {
+            terms.add(phraseItem);
+        } else if (item instanceof CompositeItem compositeItem) {
+            for (Iterator<Item> i = compositeItem.getItemIterator(); i.hasNext();) {
                 getPositiveTerms(i.next(), terms);
             }
-        } else if (item instanceof TermItem) {
-            terms.add((TermItem)item);
+        } else if (item instanceof TermItem termItem) {
+            terms.add(termItem);
         }
     }
 
@@ -203,8 +198,7 @@ public class QueryTree extends CompositeItem {
 
     private int countItemsRecursively(Item item) {
         int children = 0;
-        if (item instanceof CompositeItem) {
-            CompositeItem composite = (CompositeItem)item;
+        if (item instanceof CompositeItem composite) {
             for (ListIterator<Item> i = composite.getItemIterator(); i.hasNext(); ) {
                 children += countItemsRecursively(i.next());
             }

--- a/vespajlib/src/main/java/com/yahoo/io/GrowableByteBuffer.java
+++ b/vespajlib/src/main/java/com/yahoo/io/GrowableByteBuffer.java
@@ -90,7 +90,7 @@ public class GrowableByteBuffer implements Comparable<GrowableByteBuffer> {
     //ByteBuffers and keep track of global position etc., much like
     //GrowableBufferOutputStream does it.
 
-    protected void grow(int newSize) {
+    public void grow(int newSize) {
         //create new buffer:
         ByteBuffer newByteBuf;
         if (buffer.isDirect()) {
@@ -104,7 +104,7 @@ public class GrowableByteBuffer implements Comparable<GrowableByteBuffer> {
         //copy old contents and set correct position:
         int oldPos = buffer.position();
         newByteBuf.position(0);
-        buffer.position(0);
+        buffer.flip();
         newByteBuf.put(buffer);
         newByteBuf.position(oldPos);
 


### PR DESCRIPTION
…query.

- Use a threadlocal for the scratchpad. This avoids costly resizing, or initialiing too large buffer for every query. Using a thread local is fine now that we limit the number of search threads to a reasonable number = #cores * 2.

@bratseth PR