### PR TITLE
Upgrade BouncyCastle to 1.72 [run-systemtest]

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -21,7 +21,7 @@
 
         <!-- MUST BE KEPT IN SYNC WITH parent/pom.xml -->
         <athenz.version>1.10.54</athenz.version>
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.72</bouncycastle.version>
         <felix.version>7.0.1</felix.version>
         <httpclient5.version>5.1.3</httpclient5.version>
         <httpclient.version>4.5.13</httpclient.version>
@@ -195,8 +195,9 @@
                                         <include>org.apache.httpcomponents:httpmime:${httpclient.version}:jar:test</include>
                                         <include>org.apache.opennlp:opennlp-tools:1.9.3:jar:test</include>
                                         <include>org.apiguardian:apiguardian-api:1.1.0:jar:test</include>
-                                        <include>org.bouncycastle:bcpkix-jdk15on:[${bouncycastle.version}]:jar:test</include>
-                                        <include>org.bouncycastle:bcprov-jdk15on:[${bouncycastle.version}]:jar:test</include>
+                                        <include>org.bouncycastle:bcpkix-jdk18on:[${bouncycastle.version}]:jar:test</include>
+                                        <include>org.bouncycastle:bcprov-jdk18on:[${bouncycastle.version}]:jar:test</include>
+                                        <include>org.bouncycastle:bcutil-jdk18on:[${bouncycastle.version}]:jar:test</include>
                                         <include>org.eclipse.jetty.alpn:alpn-api:[${jetty-alpn.version}]:jar:test</include>
                                         <include>org.eclipse.jetty.http2:http2-common:[${jetty.version}]:jar:test</include>
                                         <include>org.eclipse.jetty.http2:http2-hpack:[${jetty.version}]:jar:test</include>

--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/container-disc/pom.xml
+++ b/container-disc/pom.xml
@@ -195,10 +195,10 @@
                 hosted-zone-api-jar-with-dependencies.jar,
                 container-apache-http-client-bundle-jar-with-dependencies.jar,
                 security-utils.jar,
-                bcprov-jdk15on-${bouncycastle.version}.jar, <!-- Used by security-utils -->
+                bcprov-jdk18on-${bouncycastle.version}.jar, <!-- Used by security-utils -->
+                bcpkix-jdk18on-${bouncycastle.version}.jar, <!-- Used by security-utils -->
+                bcutil-jdk18on-${bouncycastle.version}.jar, <!-- Used by security-utils -->
                 <!-- END Bundles needed to retrieve config, or used by container-disc -->
-
-                bcpkix-jdk15on-${bouncycastle.version}.jar, <!-- Used by security-utils -->
 
                 jackson-annotations-${jackson2.version}.jar,
                 jackson-core-${jackson2.version}.jar,

--- a/container-test/pom.xml
+++ b/container-test/pom.xml
@@ -32,7 +32,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -40,7 +40,7 @@
          in provided scope when container-test is declared before, and together with, the container artifact -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
 
     <!-- All dependencies that should be visible in test classpath, but not compile classpath,

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -24,7 +24,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcpkix-jdk15on</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.ow2.asm</groupId>

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -840,8 +840,7 @@ fi
 %dir %{_prefix}/lib
 %dir %{_prefix}/lib/jars
 %{_prefix}/lib/jars/application-model-jar-with-dependencies.jar
-%{_prefix}/lib/jars/bcpkix-jdk15on-*.jar
-%{_prefix}/lib/jars/bcprov-jdk15on-*.jar
+%{_prefix}/lib/jars/bc*-jdk18on-*.jar
 %{_prefix}/lib/jars/config-bundle-jar-with-dependencies.jar
 %{_prefix}/lib/jars/configdefinitions-jar-with-dependencies.jar
 %{_prefix}/lib/jars/config-model-api-jar-with-dependencies.jar

--- a/jrt/pom.xml
+++ b/jrt/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <dependency> <!-- required due to bug in maven dependency resolving - bouncycastle is compile scope in security-utils, yet it is not part of test scope here -->
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -791,12 +791,17 @@
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bouncycastle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcutil-jdk18on</artifactId>
                 <version>${bouncycastle.version}</version>
             </dependency>
             <dependency>
@@ -1024,7 +1029,7 @@
                  find zkfacade/src/main/java/org/apache/curator -name package-info.java | \
                      xargs perl -pi -e 's/major = [0-9]+, minor = [0-9]+, micro = [0-9]+/major = 5, minor = 3, micro = 0/g'
         -->
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.72</bouncycastle.version>
         <curator.version>5.3.0</curator.version>
         <commons.codec.version>1.15</commons.codec.version>
         <commons.math3.version>3.6.1</commons.math3.version>

--- a/security-utils/pom.xml
+++ b/security-utils/pom.xml
@@ -24,7 +24,7 @@
     <!-- compile scope -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/security-utils/src/main/java/com/yahoo/security/SubjectAlternativeName.java
+++ b/security-utils/src/main/java/com/yahoo/security/SubjectAlternativeName.java
@@ -2,7 +2,7 @@
 package com.yahoo.security;
 
 import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.ASN1IA5String;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.GeneralName;
@@ -60,7 +60,7 @@ public class SubjectAlternativeName {
             case GeneralName.rfc822Name:
             case GeneralName.dNSName:
             case GeneralName.uniformResourceIdentifier:
-                return DERIA5String.getInstance(name).getString();
+                return ASN1IA5String.getInstance(name).getString();
             case GeneralName.directoryName:
                 return X500Name.getInstance(name).toString();
             case GeneralName.iPAddress:

--- a/vespa-athenz/pom.xml
+++ b/vespa-athenz/pom.xml
@@ -92,7 +92,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-jdk15on</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <!--Exclude all Jackson bundles provided by JDisc -->
                 <exclusion>
@@ -148,7 +148,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcpkix-jdk15on</artifactId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <!--Exclude all Jackson bundles provided by JDisc -->
                 <exclusion>

--- a/vespa-feed-client/pom.xml
+++ b/vespa-feed-client/pom.xml
@@ -21,7 +21,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Migrate to artifact names used by 1.71+

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
