### PR TITLE
Only rethrow IOException as RuntimeException when creating session [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/InvalidApplicationException.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/InvalidApplicationException.java
@@ -6,9 +6,9 @@ package com.yahoo.vespa.config.server.http;
  */
 public class InvalidApplicationException extends IllegalArgumentException {
 
-    public InvalidApplicationException(String message) {
-        super(message);
-    }
+    public InvalidApplicationException(String message) { super(message); }
+
+    public InvalidApplicationException(Throwable t) { super(t); }
 
     public InvalidApplicationException(String message, Throwable e) {
         super(message, e);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -30,6 +30,7 @@ import com.yahoo.vespa.config.server.configchange.ConfigChangeActions;
 import com.yahoo.vespa.config.server.deploy.TenantFileSystemDirs;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
 import com.yahoo.vespa.config.server.filedistribution.FileDistributionFactory;
+import com.yahoo.vespa.config.server.http.InvalidApplicationException;
 import com.yahoo.vespa.config.server.http.UnknownVespaVersionException;
 import com.yahoo.vespa.config.server.modelfactory.ActivatedModelsBuilder;
 import com.yahoo.vespa.config.server.modelfactory.AllocatedHostsFromAllModels;
@@ -727,7 +728,7 @@ public class SessionRepository {
                 UnboundStringFlag flag = PermanentFlags.APPLICATION_FILES_WITH_UNKNOWN_EXTENSION;
                 String value = flag.bindTo(flagSource).with(APPLICATION_ID, applicationId.serializedForm()).value();
                 switch (value) {
-                    case "FAIL" -> throw e;
+                    case "FAIL" -> throw new InvalidApplicationException(e);
                     case "LOG" -> deployLogger.ifPresent(logger -> logger.logApplicationPackage(Level.WARNING, e.getMessage()));
                     default -> log.log(Level.WARNING, "Unknown value for flag " + flag.id() + ": " + value);
                 }
@@ -754,7 +755,7 @@ public class SessionRepository {
             waiter.awaitCompletion(Duration.ofSeconds(Math.min(120, timeoutBudget.timeLeft().getSeconds())));
             addLocalSession(session);
             return session;
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RuntimeException("Error creating session " + sessionId, e);
         }
     }

--- a/configserver/src/test/apps/hosted-invalid-file-extension/deployment.xml
+++ b/configserver/src/test/apps/hosted-invalid-file-extension/deployment.xml
@@ -1,0 +1,7 @@
+<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<deployment version='1.0'>
+  <prod>
+    <region active="true">us-north-1</region>
+    <region active="true">us-north-2</region>
+  </prod>
+</deployment>

--- a/configserver/src/test/apps/hosted-invalid-file-extension/services.xml
+++ b/configserver/src/test/apps/hosted-invalid-file-extension/services.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
+<services version="1.0">
+
+  <container version="1.0">
+    <http>
+      <filtering>
+        <access-control domain="myDomain" write="true" />
+      </filtering>
+      <server id="foo"/>
+    </http>
+    <search/>
+    <nodes count='1'/>
+  </container>
+
+</services>

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -501,7 +501,6 @@ public class HostedDeployTest {
                                                                    .fileReferencesDir(uncheck(() -> Files.createTempDirectory("configdefinitions")).toString())))
                 .modelFactory(createHostedModelFactory(Version.fromString("8.7.6"), Clock.systemUTC()))
                 .build();
-        System.out.println("hostedvespa=" + tester.applicationRepository().configserverConfig().hostedVespa());
         try {
             tester.deployApp("src/test/apps/hosted-invalid-file-extension/", "8.7.6");
             fail();

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployTest.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.config.server.deploy;
 
+import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.model.api.ConfigChangeAction;
@@ -36,6 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.nio.file.Files;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -49,6 +51,7 @@ import java.util.stream.IntStream;
 import static com.yahoo.vespa.config.server.deploy.DeployTester.CountingModelFactory;
 import static com.yahoo.vespa.config.server.deploy.DeployTester.createFailingModelFactory;
 import static com.yahoo.vespa.config.server.deploy.DeployTester.createHostedModelFactory;
+import static com.yahoo.yolean.Exceptions.uncheck;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -486,6 +489,26 @@ public class HostedDeployTest {
         assertEquals(Optional.of(ApplicationReindexing.empty()
                                                       .withPending("cluster", "music", prepareResult.sessionId())),
                      tester.tenant().getApplicationRepo().database().readReindexingStatus(tester.applicationId()));
+    }
+
+    @Test
+    public void testThatAppWithFilesWithInvalidFileExtensionFails() {
+        DeployTester tester = new DeployTester.Builder(temporaryFolder)
+                .configserverConfig(new ConfigserverConfig(new ConfigserverConfig.Builder()
+                                                                   .hostedVespa(true)
+                                                                   .configServerDBDir(uncheck(() -> Files.createTempDirectory("serverdb")).toString())
+                                                                   .configDefinitionsDir(uncheck(() -> Files.createTempDirectory("configdefinitions")).toString())
+                                                                   .fileReferencesDir(uncheck(() -> Files.createTempDirectory("configdefinitions")).toString())))
+                .modelFactory(createHostedModelFactory(Version.fromString("8.7.6"), Clock.systemUTC()))
+                .build();
+        System.out.println("hostedvespa=" + tester.applicationRepository().configserverConfig().hostedVespa());
+        try {
+            tester.deployApp("src/test/apps/hosted-invalid-file-extension/", "8.7.6");
+            fail();
+        } catch (InvalidApplicationException e) {
+            assertEquals("java.lang.IllegalArgumentException: File in application package with unknown extension: schemas/file-with-invalid.extension, please delete or move file to another directory.",
+                         e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Otherwise we will return responses as internal server instead of e.g. invalid application package.

Also throw more precise InvalidApplicationException if validating file extensions fail.