### PR TITLE
Rename search::index::EmptyDocBuilder to search::test::DocBuilder.

### DIFF
--- a/searchcore/src/tests/proton/attribute/document_field_populator/CMakeLists.txt
+++ b/searchcore/src/tests/proton/attribute/document_field_populator/CMakeLists.txt
@@ -5,5 +5,6 @@ vespa_add_executable(searchcore_document_field_populator_test_app TEST
     DEPENDS
     searchcore_attribute
     searchcore_pcommon
+    searchlib_test
 )
 vespa_add_test(NAME searchcore_document_field_populator_test_app COMMAND searchcore_document_field_populator_test_app)

--- a/searchcore/src/tests/proton/attribute/document_field_populator/document_field_populator_test.cpp
+++ b/searchcore/src/tests/proton/attribute/document_field_populator/document_field_populator_test.cpp
@@ -7,7 +7,7 @@
 #include <vespa/searchcore/proton/attribute/document_field_populator.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/integerbase.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
@@ -16,14 +16,14 @@ LOG_SETUP("document_field_populator_test");
 using namespace document;
 using namespace proton;
 using namespace search;
-using namespace search::index;
+using search::test::DocBuilder;
 
 typedef search::attribute::Config AVConfig;
 typedef search::attribute::BasicType AVBasicType;
 
 struct DocContext
 {
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
     DocContext()
         : _builder([](auto& header) { header.addField("a1", DataType::T_INT); })
     {

--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -51,8 +51,8 @@
 #include <vespa/searchlib/attribute/interlock.h>
 #include <vespa/searchlib/engine/docsumapi.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/tensor/tensor_attribute.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/searchlib/transactionlog/nosyncproxy.h>
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/searchsummary/docsummary/i_docsum_field_writer_factory.h>
@@ -91,6 +91,7 @@ using search::TuneFileDocumentDB;
 using search::index::DummyFileHeaderContext;
 using search::linguistics::SPANTREE_NAME;
 using search::linguistics::TERM;
+using search::test::DocBuilder;
 using storage::spi::Timestamp;
 using vespa::config::search::core::ProtonConfig;
 using vespa::config::content::core::BucketspacesConfig;
@@ -128,7 +129,7 @@ private:
     vespalib::string _dir;
 };
 
-class BuildContext : public EmptyDocBuilder
+class BuildContext : public DocBuilder
 {
 public:
     DirMaker _dmk;
@@ -155,7 +156,7 @@ public:
 };
 
 BuildContext::BuildContext(AddFieldsType add_fields)
-    : EmptyDocBuilder(add_fields),
+    : DocBuilder(add_fields),
       _dmk("summary"),
       _fixed_repo(get_repo(), get_document_type()),
       _summaryExecutor(4, 128_Ki),

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -30,8 +30,8 @@
 #include <vespa/searchcore/proton/test/thread_utils.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchlib/attribute/interlock.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/test/directory_handler.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/config-bucketspaces.h>
 #include <vespa/config/subscription/sourcespec.h>
@@ -63,6 +63,7 @@ using proton::bucketdb::IBucketDBHandler;
 using proton::bucketdb::IBucketDBHandlerInitializer;
 using vespalib::IDestructorCallback;
 using search::test::DirectoryHandler;
+using search::test::DocBuilder;
 using searchcorespi::IFlushTarget;
 using searchcorespi::index::IThreadingService;
 using storage::spi::Timestamp;
@@ -261,7 +262,7 @@ struct TwoAttrSchema : public OneAttrSchema
     }
 };
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 get_add_fields(bool has_attr2)
 {
     return [has_attr2](auto& header) {
@@ -276,7 +277,7 @@ struct MyConfigSnapshot
 {
     typedef std::unique_ptr<MyConfigSnapshot> UP;
     Schema _schema;
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
     DocumentDBConfig::SP _cfg;
     BootstrapConfig::SP  _bootstrap;
     MyConfigSnapshot(FNET_Transport & transport, const Schema &schema, const vespalib::string &cfgDir)
@@ -760,7 +761,7 @@ template <typename FixtureType>
 struct DocumentHandler
 {
     FixtureType &_f;
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
     DocumentHandler(FixtureType &f) : _f(f), _builder(get_add_fields(f._baseSchema.getNumAttributeFields() > 1)) {}
     static constexpr uint32_t BUCKET_USED_BITS = 8;
     static DocumentId createDocId(uint32_t docId)

--- a/searchcore/src/tests/proton/documentdb/feedhandler/feedhandler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedhandler/feedhandler_test.cpp
@@ -33,8 +33,8 @@
 #include <vespa/searchcore/proton/server/ireplayconfig.h>
 #include <vespa/searchcore/proton/test/dummy_feed_view.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/searchlib/transactionlog/translogserver.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/lambdatask.h>
@@ -59,6 +59,7 @@ using search::SerialNum;
 using search::index::schema::CollectionType;
 using search::index::schema::DataType;
 using vespalib::makeLambdaTask;
+using search::test::DocBuilder;
 using search::transactionlog::TransLogServer;
 using search::transactionlog::DomainConfig;
 using storage::spi::RemoveResult;
@@ -276,7 +277,7 @@ MyFeedView::~MyFeedView() = default;
 
 struct SchemaContext {
     Schema::SP      schema;
-    EmptyDocBuilder builder;
+    DocBuilder builder;
     SchemaContext();
     SchemaContext(bool has_i2);
     ~SchemaContext();
@@ -320,7 +321,7 @@ SchemaContext::addField(vespalib::stringref fieldName)
 struct DocumentContext {
     Document::SP  doc;
     BucketId      bucketId;
-    DocumentContext(const vespalib::string &docId, EmptyDocBuilder &builder) :
+    DocumentContext(const vespalib::string &docId, DocBuilder &builder) :
         doc(builder.make_document(docId)),
         bucketId(BucketFactory::getBucketId(doc->getId()))
     {
@@ -340,7 +341,7 @@ TensorDataType tensor1DType(ValueType::from_spec("tensor(x{})"));
 struct UpdateContext {
     DocumentUpdate::SP update;
     BucketId           bucketId;
-    UpdateContext(const vespalib::string &docId, EmptyDocBuilder &builder) :
+    UpdateContext(const vespalib::string &docId, DocBuilder &builder) :
         update(std::make_shared<DocumentUpdate>(builder.get_repo(), builder.get_document_type(), DocumentId(docId))),
         bucketId(BucketFactory::getBucketId(update->getId()))
     {

--- a/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/feedview/feedview_test.cpp
@@ -26,7 +26,7 @@
 #include <vespa/searchcore/proton/test/threading_service_observer.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/stllike/asciistream.h>
@@ -49,6 +49,7 @@ using vespalib::GateCallback;
 using search::SearchableStats;
 using search::index::schema::CollectionType;
 using search::index::schema::DataType;
+using search::test::DocBuilder;
 using searchcorespi::IndexSearchable;
 using storage::spi::BucketChecksum;
 using storage::spi::BucketInfo;
@@ -436,7 +437,7 @@ MyTransport::~MyTransport() = default;
 struct SchemaContext
 {
     Schema::SP      _schema;
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
     SchemaContext();
     ~SchemaContext();
     std::shared_ptr<const document::DocumentTypeRepo> getRepo() const { return _builder.get_repo_sp(); }
@@ -466,16 +467,16 @@ struct DocumentContext
     BucketId           bid;
     Timestamp          ts;
     typedef std::vector<DocumentContext> List;
-    DocumentContext(const vespalib::string &docId, uint64_t timestamp, EmptyDocBuilder &builder);
+    DocumentContext(const vespalib::string &docId, uint64_t timestamp, DocBuilder &builder);
     ~DocumentContext();
-    void addFieldUpdate(EmptyDocBuilder &builder, const vespalib::string &fieldName) {
+    void addFieldUpdate(DocBuilder &builder, const vespalib::string &fieldName) {
         const document::Field &field = builder.get_document_type().getField(fieldName);
         upd->addUpdate(document::FieldUpdate(field));
     }
     document::GlobalId gid() const { return doc->getId().getGlobalId(); }
 };
 
-DocumentContext::DocumentContext(const vespalib::string &docId, uint64_t timestamp, EmptyDocBuilder& builder)
+DocumentContext::DocumentContext(const vespalib::string &docId, uint64_t timestamp, DocBuilder& builder)
     : doc(builder.make_document(docId)),
       upd(std::make_shared<DocumentUpdate>(builder.get_repo(), builder.get_document_type(), doc->getId())),
       bid(BucketFactory::getNumBucketBits(), doc->getId().getGlobalId().convertToBucketId().getRawId()),
@@ -555,7 +556,7 @@ struct FixtureBase
         return getMetaStore().getMetaData(doc_.doc->getId().getGlobalId());
     }
 
-    EmptyDocBuilder &getBuilder() { return sc._builder; }
+    DocBuilder &getBuilder() { return sc._builder; }
 
     DocumentContext doc(const vespalib::string &docId, uint64_t timestamp) {
         return DocumentContext(docId, timestamp, getBuilder());

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_common.h
@@ -24,7 +24,7 @@ using document::Document;
 using document::DocumentId;
 using document::DocumentTypeRepo;
 using namespace proton;
-using search::index::EmptyDocBuilder;
+using search::test::DocBuilder;
 using namespace search;
 using namespace vespalib;
 using vespalib::IDestructorCallback;
@@ -63,7 +63,7 @@ struct MyScanIterator : public IDocumentScanIterator {
 };
 
 struct MyHandler : public ILidSpaceCompactionHandler {
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
     std::vector<LidUsageStats> _stats;
     std::vector<LidVector> _lids;
     mutable uint32_t _moveFromLid;
@@ -107,14 +107,14 @@ struct MyStorer : public IOperationStorer {
     CommitResult startCommit(DoneCallback) override;
 };
 
-struct MyFeedView : public test::DummyFeedView {
+struct MyFeedView : public proton::test::DummyFeedView {
     explicit MyFeedView(std::shared_ptr<const DocumentTypeRepo> repo)
-        : test::DummyFeedView(std::move(repo))
+        : proton::test::DummyFeedView(std::move(repo))
     {
     }
 };
 
-struct MyDocumentStore : public test::DummyDocumentStore {
+struct MyDocumentStore : public proton::test::DummyDocumentStore {
     Document::SP _readDoc;
     mutable uint32_t _readLid;
     MyDocumentStore();

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_handler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_handler_test.cpp
@@ -5,7 +5,7 @@
 #include <vespa/vespalib/gtest/gtest.h>
 
 struct HandlerTest : public ::testing::Test {
-    EmptyDocBuilder _docBuilder;
+    DocBuilder _docBuilder;
     std::shared_ptr<bucketdb::BucketDBOwner> _bucketDB;
     MyDocumentStore _docStore;
     MySubDb _subDb;

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
@@ -116,7 +116,7 @@ JobTestBase::compact() {
 
 void
 JobTestBase::notifyNodeRetired(bool nodeRetired) {
-    test::BucketStateCalculator::SP calc = std::make_shared<test::BucketStateCalculator>();
+    proton::test::BucketStateCalculator::SP calc = std::make_shared<proton::test::BucketStateCalculator>();
     calc->setNodeRetired(nodeRetired);
     _clusterStateHandler.notifyClusterStateChanged(calc);
 }

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.h
@@ -10,8 +10,8 @@
 namespace storage::spi::dummy { class DummyBucketExecutor; }
 struct JobTestBase : public ::testing::Test {
     vespalib::MonitoredRefCount _refCount;
-    test::ClusterStateHandler _clusterStateHandler;
-    test::DiskMemUsageNotifier _diskMemUsageNotifier;
+    proton::test::ClusterStateHandler _clusterStateHandler;
+    proton::test::DiskMemUsageNotifier _diskMemUsageNotifier;
     std::unique_ptr<storage::spi::dummy::DummyBucketExecutor> _bucketExecutor;
     std::unique_ptr<vespalib::SyncableThreadExecutor> _singleExecutor;
     std::unique_ptr<searchcorespi::index::ISyncableThreadService> _master;

--- a/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/storeonlyfeedview/storeonlyfeedview_test.cpp
@@ -14,7 +14,7 @@
 #include <vespa/searchcore/proton/test/mock_summary_adapter.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchcore/proton/test/thread_utils.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/testkit/testapp.h>
@@ -33,8 +33,8 @@ using namespace proton;
 using search::DocumentIdT;
 using vespalib::IDestructorCallback;
 using search::SerialNum;
-using search::index::EmptyDocBuilder;
 using search::index::Schema;
+using search::test::DocBuilder;
 using storage::spi::Timestamp;
 using vespalib::make_string;
 
@@ -60,7 +60,7 @@ public:
 };
 
 std::shared_ptr<const DocumentTypeRepo> myGetDocumentTypeRepo() {
-    EmptyDocBuilder builder;
+    DocBuilder builder;
     std::shared_ptr<const DocumentTypeRepo> repo = builder.get_repo_sp();
     ASSERT_TRUE(repo.get());
     return repo;

--- a/searchcore/src/tests/proton/feed_and_search/CMakeLists.txt
+++ b/searchcore/src/tests/proton/feed_and_search/CMakeLists.txt
@@ -3,5 +3,6 @@ vespa_add_executable(searchcore_feed_and_search_test_app TEST
     SOURCES
     feed_and_search.cpp
     DEPENDS
+    searchlib_test
 )
 vespa_add_test(NAME searchcore_feed_and_search_test_app COMMAND searchcore_feed_and_search_test_app)

--- a/searchcore/src/tests/proton/feed_and_search/feed_and_search.cpp
+++ b/searchcore/src/tests/proton/feed_and_search/feed_and_search.cpp
@@ -12,10 +12,10 @@
 #include <vespa/searchlib/diskindex/fusion.h>
 #include <vespa/searchlib/diskindex/indexbuilder.h>
 #include <vespa/searchlib/fef/fef.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/memory_index.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/test/index/mock_field_length_inspector.h>
 #include <vespa/searchlib/query/base.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
@@ -48,10 +48,8 @@ using search::fef::MatchData;
 using search::fef::MatchDataLayout;
 using search::fef::TermFieldHandle;
 using search::fef::TermFieldMatchData;
-using search::index::EmptyDocBuilder;
 using search::index::DummyFileHeaderContext;
 using search::index::Schema;
-using search::index::StringFieldBuilder;
 using search::index::test::MockFieldLengthInspector;
 using search::memoryindex::MemoryIndex;
 using search::query::SimpleStringTerm;
@@ -61,6 +59,8 @@ using search::queryeval::FieldSpec;
 using search::queryeval::FieldSpecList;
 using search::queryeval::SearchIterator;
 using search::queryeval::Searchable;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using std::ostringstream;
 using vespalib::string;
 
@@ -118,7 +118,7 @@ Schema getSchema() {
     return schema;
 }
 
-Document::UP buildDocument(EmptyDocBuilder & doc_builder, int id,
+Document::UP buildDocument(DocBuilder & doc_builder, int id,
                            const string &word) {
     ostringstream ost;
     ost << "id:ns:searchdocument::" << id;
@@ -169,7 +169,7 @@ void Test::requireThatMemoryIndexCanBeDumpedAndSearched() {
     auto indexFieldInverter = vespalib::SequencedTaskExecutor::create(invert_executor, 2);
     auto indexFieldWriter = vespalib::SequencedTaskExecutor::create(write_executor, 2);
     MemoryIndex memory_index(schema, MockFieldLengthInspector(), *indexFieldInverter, *indexFieldWriter);
-    EmptyDocBuilder doc_builder([](auto& header) { header.addField(field_name, DataType::T_STRING); });
+    DocBuilder doc_builder([](auto& header) { header.addField(field_name, DataType::T_STRING); });
 
     Document::UP doc = buildDocument(doc_builder, doc_id1, word1);
     memory_index.insertDocument(doc_id1, *doc, {});

--- a/searchcore/src/tests/proton/index/fusionrunner_test.cpp
+++ b/searchcore/src/tests/proton/index/fusionrunner_test.cpp
@@ -11,9 +11,9 @@
 #include <vespa/searchlib/diskindex/diskindex.h>
 #include <vespa/searchlib/diskindex/indexbuilder.h>
 #include <vespa/searchlib/fef/matchdatalayout.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/memory_index.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
 #include <vespa/searchlib/test/index/mock_field_length_inspector.h>
@@ -43,10 +43,8 @@ using search::fef::MatchData;
 using search::fef::MatchDataLayout;
 using search::fef::TermFieldHandle;
 using search::fef::TermFieldMatchData;
-using search::index::EmptyDocBuilder;
 using search::index::DummyFileHeaderContext;
 using search::index::Schema;
-using search::index::StringFieldBuilder;
 using search::index::schema::DataType;
 using search::index::test::MockFieldLengthInspector;
 using search::memoryindex::MemoryIndex;
@@ -57,6 +55,8 @@ using search::queryeval::FieldSpec;
 using search::queryeval::FieldSpecList;
 using search::queryeval::ISourceSelector;
 using search::queryeval::SearchIterator;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using searchcorespi::index::FusionRunner;
 using searchcorespi::index::FusionSpec;
 using std::set;
@@ -155,7 +155,7 @@ void Test::tearDown() {
     _selector.reset(0);
 }
 
-Document::UP buildDocument(EmptyDocBuilder & doc_builder, int id, const string &word) {
+Document::UP buildDocument(DocBuilder & doc_builder, int id, const string &word) {
     vespalib::asciistream ost;
     ost << "id:ns:searchdocument::" << id;
     auto doc = doc_builder.make_document(ost.str());
@@ -163,7 +163,7 @@ Document::UP buildDocument(EmptyDocBuilder & doc_builder, int id, const string &
     return doc;
 }
 
-void addDocument(EmptyDocBuilder & doc_builder, MemoryIndex &index, ISourceSelector &selector,
+void addDocument(DocBuilder & doc_builder, MemoryIndex &index, ISourceSelector &selector,
                  uint8_t index_id, uint32_t docid, const string &word) {
     Document::UP doc = buildDocument(doc_builder, docid, word);
     index.insertDocument(docid, *doc, {});
@@ -187,7 +187,7 @@ void Test::createIndex(const string &dir, uint32_t id, bool fusion) {
     _selector->setDefaultSource(id - _selector->getBaseId());
 
     Schema schema = getSchema();
-    EmptyDocBuilder doc_builder([](auto& header) { header.addField(field_name, document::DataType::T_STRING); });
+    DocBuilder doc_builder([](auto& header) { header.addField(field_name, document::DataType::T_STRING); });
     MemoryIndex memory_index(schema, MockFieldLengthInspector(),
                              _service.write().indexFieldInverter(),
                              _service.write().indexFieldWriter());

--- a/searchcore/src/tests/proton/index/index_writer/index_writer_test.cpp
+++ b/searchcore/src/tests/proton/index/index_writer/index_writer_test.cpp
@@ -3,7 +3,7 @@
 #include <vespa/searchcore/proton/index/index_writer.h>
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/searchcore/proton/test/mock_index_manager.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
@@ -14,6 +14,7 @@ using namespace proton;
 using namespace search;
 using namespace search::index;
 using namespace searchcorespi;
+using search::test::DocBuilder;
 using vespalib::IDestructorCallback;
 
 using document::Document;
@@ -29,7 +30,7 @@ toString(const std::vector<SerialNum> &vec)
     return oss.str();
 }
 
-struct MyIndexManager : public test::MockIndexManager
+struct MyIndexManager : public proton::test::MockIndexManager
 {
     typedef std::map<uint32_t, std::vector<SerialNum> > LidMap;
     LidMap puts;
@@ -82,7 +83,7 @@ struct Fixture
     IIndexManager::SP iim;
     MyIndexManager   &mim;
     IndexWriter      iw;
-    EmptyDocBuilder   builder;
+    DocBuilder   builder;
     Document::UP      dummyDoc;
     Fixture()
         : iim(new MyIndexManager()),

--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -13,9 +13,9 @@
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 #include <vespa/searchlib/common/flush_token.h>
 #include <vespa/searchlib/common/serialnum.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/compact_words_store.h>
 #include <vespa/searchlib/memoryindex/document_inverter.h>
 #include <vespa/searchlib/memoryindex/document_inverter_context.h>
@@ -48,16 +48,16 @@ using search::TuneFileAttributes;
 using search::TuneFileIndexManager;
 using search::TuneFileIndexing;
 using vespalib::datastore::EntryRef;
-using search::index::EmptyDocBuilder;
 using search::index::DummyFileHeaderContext;
 using search::index::FieldLengthInfo;
 using search::index::Schema;
-using search::index::StringFieldBuilder;
 using search::index::schema::DataType;
 using search::index::test::MockFieldLengthInspector;
 using search::memoryindex::CompactWordsStore;
 using search::memoryindex::FieldIndexCollection;
 using search::queryeval::Source;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using std::set;
 using std::string;
 using vespalib::makeLambdaTask;
@@ -95,7 +95,7 @@ void removeTestData() {
     std::filesystem::remove_all(std::filesystem::path(index_dir));
 }
 
-Document::UP buildDocument(EmptyDocBuilder &doc_builder, int id,
+Document::UP buildDocument(DocBuilder &doc_builder, int id,
                            const string &word) {
     vespalib::asciistream ost;
     ost << "id:ns:searchdocument::" << id;
@@ -117,7 +117,7 @@ struct IndexManagerTest : public ::testing::Test {
     TransportAndExecutorService _service;
     std::unique_ptr<IndexManager> _index_manager;
     Schema _schema;
-    EmptyDocBuilder _builder;
+    DocBuilder _builder;
 
     IndexManagerTest()
         : _serial_num(0),

--- a/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/CMakeLists.txt
+++ b/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/CMakeLists.txt
@@ -4,5 +4,6 @@ vespa_add_executable(searchcore_document_reprocessing_handler_test_app TEST
     document_reprocessing_handler_test.cpp
     DEPENDS
     searchcore_reprocessing
+    searchlib_test
 )
 vespa_add_test(NAME searchcore_document_reprocessing_handler_test_app COMMAND searchcore_document_reprocessing_handler_test_app)

--- a/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/document_reprocessing_handler_test.cpp
+++ b/searchcore/src/tests/proton/reprocessing/document_reprocessing_handler/document_reprocessing_handler_test.cpp
@@ -3,12 +3,12 @@
 LOG_SETUP("document_reprocessing_handler_test");
 
 #include <vespa/searchcore/proton/reprocessing/document_reprocessing_handler.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/testkit/testapp.h>
 
 using namespace document;
 using namespace proton;
-using namespace search::index;
+using search::test::DocBuilder;
 
 template <typename ReprocessingType>
 struct MyProcessor : public ReprocessingType
@@ -32,7 +32,7 @@ const vespalib::string DOC_ID = "id:test:searchdocument::0";
 struct FixtureBase
 {
     DocumentReprocessingHandler _handler;
-    EmptyDocBuilder _docBuilder;
+    DocBuilder _docBuilder;
     FixtureBase(uint32_t docIdLimit);
     ~FixtureBase();
     std::shared_ptr<Document> createDoc() {

--- a/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/test/CMakeLists.txt
@@ -20,4 +20,5 @@ vespa_add_library(searchcore_test STATIC
     searchcore_server
     searchcore_fconfig
     searchcorespi
+    searchlib_test
 )

--- a/searchcore/src/vespa/searchcore/proton/test/userdocumentsbuilder.h
+++ b/searchcore/src/vespa/searchcore/proton/test/userdocumentsbuilder.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "userdocuments.h"
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 namespace proton::test {
@@ -13,7 +13,7 @@ namespace proton::test {
 class UserDocumentsBuilder
 {
 private:
-    search::index::EmptyDocBuilder _builder;
+    search::test::DocBuilder _builder;
     UserDocuments             _docs;
 public:
     UserDocumentsBuilder();

--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -169,7 +169,6 @@ vespa_define_module(
     src/tests/groupingengine
     src/tests/hitcollector
     src/tests/index/field_length_calculator
-    src/tests/index/string_field_builder
     src/tests/indexmetainfo
     src/tests/ld-library-path
     src/tests/memoryindex/compact_words_store
@@ -225,6 +224,7 @@ vespa_define_module(
     src/tests/tensor/tensor_buffer_operations
     src/tests/tensor/tensor_buffer_store
     src/tests/tensor/tensor_buffer_type_mapper
+    src/tests/test/string_field_builder
     src/tests/transactionlog
     src/tests/transactionlogstress
     src/tests/true

--- a/searchlib/src/tests/diskindex/fusion/CMakeLists.txt
+++ b/searchlib/src/tests/diskindex/fusion/CMakeLists.txt
@@ -3,7 +3,7 @@ vespa_add_executable(searchlib_fusion_test_app TEST
     SOURCES
     fusion_test.cpp
     DEPENDS
-    searchlib
+    searchlib_test
     GTest::GTest
     AFTER
     searchlib_vespa-index-inspect_app

--- a/searchlib/src/tests/diskindex/fusion/fusion_test.cpp
+++ b/searchlib/src/tests/diskindex/fusion/fusion_test.cpp
@@ -12,9 +12,9 @@
 #include <vespa/searchlib/diskindex/zcposoccrandread.h>
 #include <vespa/searchlib/fef/fieldpositionsiterator.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/index/schemautil.h>
 #include <vespa/searchlib/memoryindex/document_inverter.h>
 #include <vespa/searchlib/memoryindex/document_inverter_context.h>
@@ -52,6 +52,8 @@ using search::common::FileHeaderContext;
 using search::index::schema::CollectionType;
 using search::index::schema::DataType;
 using search::index::test::MockFieldLengthInspector;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using vespalib::SequencedTaskExecutor;
 
 using namespace index;
@@ -119,7 +121,7 @@ toString(FieldPositionsIterator posItr, bool hasElements = false, bool hasWeight
 }
 
 std::unique_ptr<Document>
-make_doc10(EmptyDocBuilder &b)
+make_doc10(DocBuilder &b)
 {
     auto doc = b.make_document("id:ns:searchdocument::10");
     StringFieldBuilder sfb(b);
@@ -154,7 +156,7 @@ make_schema(bool interleaved_features)
     return schema;
 }
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 make_add_fields()
 {
     return [](auto& header) { using namespace document::config_builder;
@@ -342,7 +344,7 @@ FusionTest::requireThatFusionIsWorking(const vespalib::string &prefix, bool dire
                                addField("f2").addField("f3").
                                addField("f4"));
     FieldIndexCollection fic(schema, MockFieldLengthInspector());
-    EmptyDocBuilder b(make_add_fields());
+    DocBuilder b(make_add_fields());
     StringFieldBuilder sfb(b);
     auto invertThreads = SequencedTaskExecutor::create(invert_executor, 2);
     auto pushThreads = SequencedTaskExecutor::create(push_executor, 2);
@@ -486,7 +488,7 @@ FusionTest::make_simple_index(const vespalib::string &dump_dir, const IFieldLeng
     FieldIndexCollection fic(_schema, field_length_inspector);
     uint32_t numDocs = 20;
     uint32_t numWords = 1000;
-    EmptyDocBuilder b(make_add_fields());
+    DocBuilder b(make_add_fields());
     auto invertThreads = SequencedTaskExecutor::create(invert_executor, 2);
     auto pushThreads = SequencedTaskExecutor::create(push_executor, 2);
     DocumentInverterContext inv_context(_schema, *invertThreads, *pushThreads, fic);

--- a/searchlib/src/tests/memoryindex/document_inverter/document_inverter_test.cpp
+++ b/searchlib/src/tests/memoryindex/document_inverter/document_inverter_test.cpp
@@ -5,9 +5,9 @@
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/document/repo/configbuilder.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/field_length_calculator.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/document_inverter_context.h>
 #include <vespa/searchlib/memoryindex/field_index_remover.h>
 #include <vespa/searchlib/memoryindex/field_inverter.h>
@@ -24,18 +24,18 @@
 namespace search::memoryindex {
 
 using document::Document;
-using index::EmptyDocBuilder;
 using index::FieldLengthCalculator;
 using index::Schema;
-using index::StringFieldBuilder;
 using index::schema::CollectionType;
 using index::schema::DataType;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using vespalib::SequencedTaskExecutor;
 using vespalib::ISequencedTaskExecutor;
 
 namespace {
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 make_add_fields()
 {
     return [](auto& header) { using namespace document::config_builder;
@@ -48,7 +48,7 @@ make_add_fields()
 }
 
 Document::UP
-makeDoc10(EmptyDocBuilder &b)
+makeDoc10(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::10");
@@ -57,7 +57,7 @@ makeDoc10(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc11(EmptyDocBuilder &b)
+makeDoc11(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::11");
@@ -67,7 +67,7 @@ makeDoc11(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc12(EmptyDocBuilder &b)
+makeDoc12(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::12");
@@ -76,7 +76,7 @@ makeDoc12(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc13(EmptyDocBuilder &b)
+makeDoc13(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::13");
@@ -85,7 +85,7 @@ makeDoc13(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc14(EmptyDocBuilder &b)
+makeDoc14(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::14");
@@ -94,7 +94,7 @@ makeDoc14(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc15(EmptyDocBuilder &b)
+makeDoc15(DocBuilder &b)
 {
     return b.make_document("id:ns:searchdocument::15");
 }
@@ -106,7 +106,7 @@ VESPA_THREAD_STACK_TAG(push_executor)
 
 struct DocumentInverterTest : public ::testing::Test {
     Schema _schema;
-    EmptyDocBuilder _b;
+    DocBuilder _b;
     std::unique_ptr<ISequencedTaskExecutor> _invertThreads;
     std::unique_ptr<ISequencedTaskExecutor> _pushThreads;
     WordStore                       _word_store;

--- a/searchlib/src/tests/memoryindex/field_index/field_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/field_index/field_index_test.cpp
@@ -13,10 +13,8 @@
 #include <vespa/searchlib/diskindex/zcposoccrandread.h>
 #include <vespa/searchlib/fef/fieldpositionsiterator.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/docidandfeatures.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
-#include <vespa/searchlib/index/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/document_inverter.h>
 #include <vespa/searchlib/memoryindex/document_inverter_context.h>
 #include <vespa/searchlib/memoryindex/field_index_collection.h>
@@ -24,6 +22,8 @@
 #include <vespa/searchlib/memoryindex/ordered_field_index_inserter.h>
 #include <vespa/searchlib/memoryindex/posting_iterator.h>
 #include <vespa/searchlib/queryeval/iterators.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/test/index/mock_field_length_inspector.h>
 #include <vespa/searchlib/test/memoryindex/wrap_inserter.h>
 #include <vespa/vespalib/btree/btreenodeallocator.hpp>
@@ -56,6 +56,8 @@ using queryeval::SearchIterator;
 using search::index::schema::CollectionType;
 using search::index::schema::DataType;
 using search::index::test::MockFieldLengthInspector;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using vespalib::GenerationHandler;
 using vespalib::ISequencedTaskExecutor;
 using vespalib::SequencedTaskExecutor;
@@ -518,7 +520,7 @@ make_single_field_schema()
     return result;
 }
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 make_single_add_fields()
 {
     return [](auto& header) { header.addField("f0", document::DataType::T_STRING); };
@@ -725,7 +727,7 @@ make_multi_field_schema()
     return result;
 }
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 make_multi_field_add_fields()
 {
     return [](auto& header) { using namespace document::config_builder;
@@ -938,13 +940,13 @@ class InverterTest : public ::testing::Test {
 public:
     Schema _schema;
     FieldIndexCollection _fic;
-    EmptyDocBuilder _b;
+    DocBuilder _b;
     std::unique_ptr<ISequencedTaskExecutor> _invertThreads;
     std::unique_ptr<ISequencedTaskExecutor> _pushThreads;
     DocumentInverterContext _inv_context;
     DocumentInverter _inv;
 
-    InverterTest(const Schema& schema, EmptyDocBuilder::AddFieldsType add_fields)
+    InverterTest(const Schema& schema, DocBuilder::AddFieldsType add_fields)
         : _schema(schema),
           _fic(_schema, MockFieldLengthInspector()),
           _b(add_fields),
@@ -1173,7 +1175,7 @@ make_uri_schema()
     return result;
 }
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 make_uri_add_fields()
 {
     return [](auto& header) { using namespace document::config_builder;

--- a/searchlib/src/tests/memoryindex/field_inverter/field_inverter_test.cpp
+++ b/searchlib/src/tests/memoryindex/field_inverter/field_inverter_test.cpp
@@ -6,9 +6,9 @@
 #include <vespa/document/fieldvalue/weightedsetfieldvalue.h>
 #include <vespa/document/repo/configbuilder.h>
 #include <vespa/searchcommon/common/schema.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/field_length_calculator.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/field_index_remover.h>
 #include <vespa/searchlib/memoryindex/field_inverter.h>
 #include <vespa/searchlib/memoryindex/word_store.h>
@@ -22,11 +22,11 @@ namespace search {
 using document::ArrayFieldValue;
 using document::Document;
 using document::WeightedSetFieldValue;
-using index::EmptyDocBuilder;
 using index::Schema;
-using index::StringFieldBuilder;
 using index::schema::CollectionType;
 using index::schema::DataType;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 
 using namespace index;
 
@@ -35,7 +35,7 @@ namespace memoryindex {
 namespace {
 
 Document::UP
-makeDoc10(EmptyDocBuilder &b)
+makeDoc10(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::10");
@@ -44,7 +44,7 @@ makeDoc10(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc11(EmptyDocBuilder &b)
+makeDoc11(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::11");
@@ -54,7 +54,7 @@ makeDoc11(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc12(EmptyDocBuilder &b)
+makeDoc12(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::12");
@@ -63,7 +63,7 @@ makeDoc12(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc13(EmptyDocBuilder &b)
+makeDoc13(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::13");
@@ -72,7 +72,7 @@ makeDoc13(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc14(EmptyDocBuilder &b)
+makeDoc14(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::14");
@@ -81,13 +81,13 @@ makeDoc14(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc15(EmptyDocBuilder &b)
+makeDoc15(DocBuilder &b)
 {
     return b.make_document("id:ns:searchdocument::15");
 }
 
 Document::UP
-makeDoc16(EmptyDocBuilder &b)
+makeDoc16(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::16");
@@ -96,7 +96,7 @@ makeDoc16(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc17(EmptyDocBuilder &b)
+makeDoc17(DocBuilder &b)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::17");
@@ -115,7 +115,7 @@ makeDoc17(EmptyDocBuilder &b)
 vespalib::string corruptWord = "corruptWord";
 
 Document::UP
-makeCorruptDocument(EmptyDocBuilder &b, size_t wordOffset)
+makeCorruptDocument(DocBuilder &b, size_t wordOffset)
 {
     StringFieldBuilder sfb(b);
     auto doc = b.make_document("id:ns:searchdocument::18");
@@ -141,7 +141,7 @@ makeCorruptDocument(EmptyDocBuilder &b, size_t wordOffset)
 
 struct FieldInverterTest : public ::testing::Test {
     Schema _schema;
-    EmptyDocBuilder _b;
+    DocBuilder _b;
     WordStore                       _word_store;
     FieldIndexRemover               _remover;
     test::OrderedFieldIndexInserterBackend _inserter_backend;
@@ -158,7 +158,7 @@ struct FieldInverterTest : public ::testing::Test {
         return schema;
     }
 
-    static EmptyDocBuilder::AddFieldsType
+    static DocBuilder::AddFieldsType
     make_add_fields()
     {
         return [](auto& header) { using namespace document::config_builder;

--- a/searchlib/src/tests/memoryindex/memory_index/CMakeLists.txt
+++ b/searchlib/src/tests/memoryindex/memory_index/CMakeLists.txt
@@ -3,7 +3,7 @@ vespa_add_executable(searchlib_memory_index_test_app TEST
     SOURCES
     memory_index_test.cpp
     DEPENDS
-    searchlib
+    searchlib_test
     GTest::GTest
 )
 vespa_add_test(NAME searchlib_memory_index_test_app COMMAND searchlib_memory_index_test_app)

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -7,9 +7,9 @@
 #include <vespa/searchlib/fef/matchdata.h>
 #include <vespa/searchlib/fef/matchdatalayout.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/i_field_length_inspector.h>
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/memory_index.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
 #include <vespa/searchlib/queryeval/booleanmatchiteratorwrapper.h>
@@ -36,6 +36,8 @@ using vespalib::makeLambdaTask;
 using search::query::Node;
 using search::query::SimplePhrase;
 using search::query::SimpleStringTerm;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 using vespalib::ISequencedTaskExecutor;
 using vespalib::SequencedTaskExecutor;
 using namespace search::fef;
@@ -80,7 +82,7 @@ struct Index {
     std::unique_ptr<ISequencedTaskExecutor> _invertThreads;
     std::unique_ptr<ISequencedTaskExecutor> _pushThreads;
     MemoryIndex  index;
-    EmptyDocBuilder builder;
+    DocBuilder builder;
     StringFieldBuilder sfb;
     std::unique_ptr<Document> builder_doc;
     uint32_t     docid;

--- a/searchlib/src/tests/memoryindex/url_field_inverter/url_field_inverter_test.cpp
+++ b/searchlib/src/tests/memoryindex/url_field_inverter/url_field_inverter_test.cpp
@@ -10,13 +10,13 @@
 #include <vespa/document/repo/configbuilder.h>
 #include <vespa/document/repo/fixedtyperepo.h>
 #include <vespa/searchcommon/common/schema.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
 #include <vespa/searchlib/index/field_length_calculator.h>
 #include <vespa/searchlib/index/schema_index_fields.h>
-#include <vespa/searchlib/index/string_field_builder.h>
 #include <vespa/searchlib/memoryindex/field_index_remover.h>
 #include <vespa/searchlib/memoryindex/field_inverter.h>
 #include <vespa/searchlib/memoryindex/word_store.h>
+#include <vespa/searchlib/test/doc_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/searchlib/test/memoryindex/ordered_field_index_inserter.h>
 #include <vespa/searchlib/test/memoryindex/ordered_field_index_inserter_backend.h>
 #include <vespa/vespalib/gtest/gtest.h>
@@ -30,6 +30,8 @@ using document::UrlDataType;
 using document::WeightedSetFieldValue;
 using index::schema::CollectionType;
 using index::schema::DataType;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 
 using namespace index;
 
@@ -40,7 +42,7 @@ namespace {
 const vespalib::string url = "url";
 
 Document::UP
-makeDoc10Single(EmptyDocBuilder &b)
+makeDoc10Single(DocBuilder &b)
 {
     auto doc = b.make_document("id:ns:searchdocument::10");
     auto url_value = b.make_struct("url");
@@ -58,7 +60,7 @@ makeDoc10Single(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc10Array(EmptyDocBuilder &b)
+makeDoc10Array(DocBuilder &b)
 {
     auto doc = b.make_document("id:ns:searchdocument::10");
     StringFieldBuilder sfb(b);
@@ -84,7 +86,7 @@ makeDoc10Array(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc10WeightedSet(EmptyDocBuilder &b)
+makeDoc10WeightedSet(DocBuilder &b)
 {
     auto doc = b.make_document("id:ns:searchdocument::10");
     StringFieldBuilder sfb(b);
@@ -112,7 +114,7 @@ makeDoc10WeightedSet(EmptyDocBuilder &b)
 }
 
 Document::UP
-makeDoc10Empty(EmptyDocBuilder &b)
+makeDoc10Empty(DocBuilder &b)
 {
     return b.make_document("id:ns:searchdocument::10");
 }
@@ -121,7 +123,7 @@ makeDoc10Empty(EmptyDocBuilder &b)
 
 struct UrlFieldInverterTest : public ::testing::Test {
     Schema _schema;
-    EmptyDocBuilder _b;
+    DocBuilder _b;
     WordStore                       _word_store;
     FieldIndexRemover               _remover;
     test::OrderedFieldIndexInserterBackend _inserter_backend;
@@ -138,7 +140,7 @@ struct UrlFieldInverterTest : public ::testing::Test {
     }
 
     UrlFieldInverterTest(Schema::CollectionType collectionType,
-                         EmptyDocBuilder::AddFieldsType add_fields)
+                         DocBuilder::AddFieldsType add_fields)
         : _schema(makeSchema(collectionType)),
           _b(add_fields),
           _word_store(),
@@ -193,16 +195,16 @@ struct UrlFieldInverterTest : public ::testing::Test {
 
 UrlFieldInverterTest::~UrlFieldInverterTest() = default;
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 add_single_url = [](auto& header) {
                      header.addField("url", UrlDataType::getInstance().getId()); };
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 add_array_url = [](auto& header) {
                     using namespace document::config_builder;
                     header.addField("url", Array(UrlDataType::getInstance().getId())); };
 
-EmptyDocBuilder::AddFieldsType
+DocBuilder::AddFieldsType
 add_wset_url = [](auto& header) {
                     using namespace document::config_builder;
                     header.addField("url", Wset(UrlDataType::getInstance().getId())); };

--- a/searchlib/src/tests/test/string_field_builder/CMakeLists.txt
+++ b/searchlib/src/tests/test/string_field_builder/CMakeLists.txt
@@ -3,7 +3,7 @@ vespa_add_executable(searchlib_string_field_builder_test_app TEST
     SOURCES
     string_field_builder_test.cpp
     DEPENDS
-    searchlib
+    searchlib_test
     GTest::GTest
 )
 vespa_add_test(NAME searchlib_string_field_builder_test_app COMMAND searchlib_string_field_builder_test_app)

--- a/searchlib/src/tests/test/string_field_builder/string_field_builder_test.cpp
+++ b/searchlib/src/tests/test/string_field_builder/string_field_builder_test.cpp
@@ -1,13 +1,13 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchlib/index/string_field_builder.h>
+#include <vespa/searchlib/test/string_field_builder.h>
 #include <vespa/document/annotation/annotation.h>
 #include <vespa/document/annotation/span.h>
 #include <vespa/document/annotation/spanlist.h>
 #include <vespa/document/annotation/spantree.h>
 #include <vespa/document/datatype/annotationtype.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
-#include <vespa/searchlib/index/empty_doc_builder.h>
+#include <vespa/searchlib/test/doc_builder.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <cassert>
 #include <iostream>
@@ -18,8 +18,8 @@ using document::Span;
 using document::SpanNode;
 using document::SpanTree;
 using document::StringFieldValue;
-using search::index::EmptyDocBuilder;
-using search::index::StringFieldBuilder;
+using search::test::DocBuilder;
+using search::test::StringFieldBuilder;
 
 namespace
 {
@@ -70,7 +70,7 @@ std::ostream& operator<<(std::ostream& os, const MyAnnotation& ann) {
 class StringFieldBuilderTest : public testing::Test
 {
 protected:
-    EmptyDocBuilder    edb;
+    DocBuilder    db;
     StringFieldBuilder sfb;
     StringFieldBuilderTest();
     ~StringFieldBuilderTest();
@@ -80,8 +80,8 @@ protected:
 
 StringFieldBuilderTest::StringFieldBuilderTest()
     : testing::Test(),
-      edb(),
-      sfb(edb)
+      db(),
+      sfb(db)
 {
 }
 

--- a/searchlib/src/vespa/searchlib/index/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/index/CMakeLists.txt
@@ -4,7 +4,6 @@ vespa_add_library(searchlib_searchlib_index OBJECT
     dictionaryfile.cpp
     docidandfeatures.cpp
     dummyfileheadercontext.cpp
-    empty_doc_builder.cpp
     indexbuilder.cpp
     postinglisthandle.cpp
     postinglistcounts.cpp
@@ -13,7 +12,6 @@ vespa_add_library(searchlib_searchlib_index OBJECT
     postinglistparams.cpp
     schemautil.cpp
     schema_index_fields.cpp
-    string_field_builder.cpp
     uri_field.cpp
     DEPENDS
 )

--- a/searchlib/src/vespa/searchlib/test/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/test/CMakeLists.txt
@@ -2,12 +2,14 @@
 vespa_add_library(searchlib_test
     SOURCES
     document_weight_attribute_helper.cpp
+    doc_builder.cpp
     imported_attribute_fixture.cpp
     initrange.cpp
     make_attribute_map_lookup_node.cpp
     mock_attribute_context.cpp
     mock_attribute_manager.cpp
     searchiteratorverifier.cpp
+    string_field_builder.cpp
     $<TARGET_OBJECTS:searchlib_test_fakedata>
     $<TARGET_OBJECTS:searchlib_searchlib_test_diskindex>
     $<TARGET_OBJECTS:searchlib_test_gtest_migration>

--- a/searchlib/src/vespa/searchlib/test/doc_builder.cpp
+++ b/searchlib/src/vespa/searchlib/test/doc_builder.cpp
@@ -1,6 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "empty_doc_builder.h"
+#include "doc_builder.h"
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/fieldvalue/arrayfieldvalue.h>
 #include <vespa/document/fieldvalue/document.h>
@@ -22,12 +22,12 @@ using document::MapFieldValue;
 using document::StructFieldValue;
 using document::WeightedSetFieldValue;
 
-namespace search::index {
+namespace search::test {
 
 namespace {
 
 DocumenttypesConfig
-get_document_types_config(EmptyDocBuilder::AddFieldsType add_fields)
+get_document_types_config(DocBuilder::AddFieldsType add_fields)
 {
     using namespace document::config_builder;
     DocumenttypesConfigBuilderHelper builder;
@@ -41,23 +41,23 @@ get_document_types_config(EmptyDocBuilder::AddFieldsType add_fields)
 
 }
 
-EmptyDocBuilder::EmptyDocBuilder()
-    : EmptyDocBuilder([](auto&) noexcept {})
+DocBuilder::DocBuilder()
+    : DocBuilder([](auto&) noexcept {})
 {
 }
 
-EmptyDocBuilder::EmptyDocBuilder(AddFieldsType add_fields)
+DocBuilder::DocBuilder(AddFieldsType add_fields)
     : _document_types_config(std::make_shared<const DocumenttypesConfig>(get_document_types_config(add_fields))),
       _repo(DocumentTypeRepoFactory::make(*_document_types_config)),
       _document_type(_repo->getDocumentType("searchdocument"))
 {
 }
 
-EmptyDocBuilder::~EmptyDocBuilder() = default;
+DocBuilder::~DocBuilder() = default;
 
 
 std::unique_ptr<Document>
-EmptyDocBuilder::make_document(vespalib::string document_id)
+DocBuilder::make_document(vespalib::string document_id)
 {
     auto doc = std::make_unique<Document>(get_document_type(), DocumentId(document_id));
     doc->setRepo(get_repo());
@@ -65,7 +65,7 @@ EmptyDocBuilder::make_document(vespalib::string document_id)
 }
 
 const DataType&
-EmptyDocBuilder::get_data_type(const vespalib::string &name) const
+DocBuilder::get_data_type(const vespalib::string &name) const
 {
     const DataType *type = _repo->getDataType(*_document_type, name);
     assert(type);
@@ -73,7 +73,7 @@ EmptyDocBuilder::get_data_type(const vespalib::string &name) const
 }
 
 ArrayFieldValue
-EmptyDocBuilder::make_array(vespalib::stringref field_name)
+DocBuilder::make_array(vespalib::stringref field_name)
 {
     auto& field = _document_type->getField(field_name);
     auto& field_type = field.getDataType();
@@ -81,7 +81,7 @@ EmptyDocBuilder::make_array(vespalib::stringref field_name)
     return {field_type};
 }
 MapFieldValue
-EmptyDocBuilder::make_map(vespalib::stringref field_name)
+DocBuilder::make_map(vespalib::stringref field_name)
 {
     auto& field = _document_type->getField(field_name);
     auto& field_type = field.getDataType();
@@ -91,7 +91,7 @@ EmptyDocBuilder::make_map(vespalib::stringref field_name)
 }
 
 WeightedSetFieldValue
-EmptyDocBuilder::make_wset(vespalib::stringref field_name)
+DocBuilder::make_wset(vespalib::stringref field_name)
 {
     auto& field = _document_type->getField(field_name);
     auto& field_type = field.getDataType();
@@ -100,7 +100,7 @@ EmptyDocBuilder::make_wset(vespalib::stringref field_name)
 }
 
 StructFieldValue
-EmptyDocBuilder::make_struct(vespalib::stringref field_name)
+DocBuilder::make_struct(vespalib::stringref field_name)
 {
     auto& field = _document_type->getField(field_name);
     auto& field_type = field.getDataType();
@@ -109,7 +109,7 @@ EmptyDocBuilder::make_struct(vespalib::stringref field_name)
 }
 
 StructFieldValue
-EmptyDocBuilder::make_url()
+DocBuilder::make_url()
 {
     return {get_data_type("url")};
 }

--- a/searchlib/src/vespa/searchlib/test/doc_builder.h
+++ b/searchlib/src/vespa/searchlib/test/doc_builder.h
@@ -20,21 +20,21 @@ class WeightedSetFieldValue;
 namespace document::config::internal { class InternalDocumenttypesType; }
 namespace document::config_builder { struct Struct; }
 
-namespace search::index {
+namespace search::test {
 
 /*
  * Class used to make empty search documents.
  */
-class EmptyDocBuilder {
+class DocBuilder {
     using DocumenttypesConfig = const document::config::internal::InternalDocumenttypesType;
     std::shared_ptr<const DocumenttypesConfig>        _document_types_config;
     std::shared_ptr<const document::DocumentTypeRepo> _repo;
     const document::DocumentType*                     _document_type;
 public:
     using AddFieldsType = std::function<void(document::config_builder::Struct&)>;
-    EmptyDocBuilder();
-    explicit EmptyDocBuilder(AddFieldsType add_fields);
-    ~EmptyDocBuilder();
+    DocBuilder();
+    explicit DocBuilder(AddFieldsType add_fields);
+    ~DocBuilder();
     const document::DocumentTypeRepo& get_repo() const noexcept { return *_repo; }
     std::shared_ptr<const document::DocumentTypeRepo> get_repo_sp() const noexcept { return _repo; }
     const document::DocumentType& get_document_type() const noexcept { return *_document_type; }

--- a/searchlib/src/vespa/searchlib/test/string_field_builder.cpp
+++ b/searchlib/src/vespa/searchlib/test/string_field_builder.cpp
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "string_field_builder.h"
-#include "empty_doc_builder.h"
+#include "doc_builder.h"
 #include <vespa/document/annotation/annotation.h>
 #include <vespa/document/annotation/span.h>
 #include <vespa/document/annotation/spanlist.h>
@@ -23,7 +23,7 @@ using document::SpanTree;
 using vespalib::Utf8Reader;
 using vespalib::Utf8Writer;
 
-namespace search::index {
+namespace search::test {
 
 namespace {
 
@@ -31,14 +31,14 @@ const vespalib::string SPANTREE_NAME("linguistics");
 
 }
 
-StringFieldBuilder::StringFieldBuilder(const EmptyDocBuilder& empty_doc_builder)
+StringFieldBuilder::StringFieldBuilder(const DocBuilder& doc_builder)
     : _value(),
       _span_start(0u),
       _span_list(nullptr),
       _span_tree(),
       _last_span(nullptr),
       _url_mode(false),
-      _repo(empty_doc_builder.get_repo(), empty_doc_builder.get_document_type())
+      _repo(doc_builder.get_repo(), doc_builder.get_document_type())
 {
 }
 

--- a/searchlib/src/vespa/searchlib/test/string_field_builder.h
+++ b/searchlib/src/vespa/searchlib/test/string_field_builder.h
@@ -13,9 +13,9 @@ class SpanTree;
 class StringFieldValue;
 }
 
-namespace search::index {
+namespace search::test {
 
-class EmptyDocBuilder;
+class DocBuilder;
 
 /*
  * Helper class to build annotated string field.
@@ -31,7 +31,7 @@ class StringFieldBuilder {
     void start_annotate();
     void add_span();
 public:
-    StringFieldBuilder(const EmptyDocBuilder& empty_doc_builder);
+    StringFieldBuilder(const DocBuilder& doc_builder);
     ~StringFieldBuilder();
     StringFieldBuilder& url_mode(bool url_mode_) noexcept { _url_mode = url_mode_; return *this; }
     StringFieldBuilder& token(const vespalib::string& val, bool is_word);


### PR DESCRIPTION
Rename search::index::StringFieldBuilder to search::test::StringFieldBuilder.

@geirst : please review
