### PR TITLE
Use document::AnnotationType::TERM.  Remove search::linguistics::TERM.

### DIFF
--- a/searchcore/src/tests/proton/docsummary/docsummary.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary.cpp
@@ -8,6 +8,7 @@
 #include <vespa/document/annotation/spanlist.h>
 #include <vespa/document/annotation/spantree.h>
 #include <vespa/document/config/documenttypes_config_fwd.h>
+#include <vespa/document/datatype/annotationtype.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/datatype/tensor_data_type.h>
 #include <vespa/document/datatype/urldatatype.h>
@@ -90,7 +91,6 @@ using document::test::makeBucketSpace;
 using search::TuneFileDocumentDB;
 using search::index::DummyFileHeaderContext;
 using search::linguistics::SPANTREE_NAME;
-using search::linguistics::TERM;
 using search::test::DocBuilder;
 using storage::spi::Timestamp;
 using vespa::config::search::core::ProtonConfig;
@@ -182,9 +182,9 @@ BuildContext::make_annotated_string()
     auto span_list_up = std::make_unique<SpanList>();
     auto span_list = span_list_up.get();
     auto tree = std::make_unique<SpanTree>(SPANTREE_NAME, std::move(span_list_up));
-    tree->annotate(span_list->add(std::make_unique<Span>(0, 3)), *TERM);
+    tree->annotate(span_list->add(std::make_unique<Span>(0, 3)), *AnnotationType::TERM);
     tree->annotate(span_list->add(std::make_unique<Span>(4, 3)),
-                   Annotation(*TERM, std::make_unique<StringFieldValue>("baz")));
+                   Annotation(*AnnotationType::TERM, std::make_unique<StringFieldValue>("baz")));
     StringFieldValue value("foo bar");
     StringFieldValue::SpanTrees trees;
     trees.push_back(std::move(tree));

--- a/searchsummary/src/tests/docsummary/annotation_converter/annotation_converter_test.cpp
+++ b/searchsummary/src/tests/docsummary/annotation_converter/annotation_converter_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/document/annotation/span.h>
 #include <vespa/document/annotation/spanlist.h>
 #include <vespa/document/annotation/spantree.h>
+#include <vespa/document/datatype/annotationtype.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/document/repo/configbuilder.h>
 #include <vespa/document/repo/fixedtyperepo.h>
@@ -16,6 +17,7 @@
 #include <vespa/vespalib/stllike/asciistream.h>
 
 using document::Annotation;
+using document::AnnotationType;
 using document::DocumentType;
 using document::DocumentTypeRepo;
 using document::Span;
@@ -25,7 +27,6 @@ using document::StringFieldValue;
 using search::docsummary::AnnotationConverter;
 using search::docsummary::IJuniperConverter;
 using search::linguistics::SPANTREE_NAME;
-using search::linguistics::TERM;
 using vespalib::Slime;
 using vespalib::slime::SlimeInserter;
 
@@ -95,9 +96,9 @@ AnnotationConverterTest::make_annotated_string()
     auto span_list_up = std::make_unique<SpanList>();
     auto span_list = span_list_up.get();
     auto tree = std::make_unique<SpanTree>(SPANTREE_NAME, std::move(span_list_up));
-    tree->annotate(span_list->add(std::make_unique<Span>(0, 3)), *TERM);
+    tree->annotate(span_list->add(std::make_unique<Span>(0, 3)), *AnnotationType::TERM);
     tree->annotate(span_list->add(std::make_unique<Span>(4, 3)),
-                   Annotation(*TERM, std::make_unique<StringFieldValue>("baz")));
+                   Annotation(*AnnotationType::TERM, std::make_unique<StringFieldValue>("baz")));
     StringFieldValue value("foo bar");
     set_span_tree(value, std::move(tree));
     return value;
@@ -110,8 +111,8 @@ AnnotationConverterTest::make_annotated_chinese_string()
     auto span_list = span_list_up.get();
     auto tree = std::make_unique<SpanTree>(SPANTREE_NAME, std::move(span_list_up));
     // These chinese characters each use 3 bytes in their UTF8 encoding.
-    tree->annotate(span_list->add(std::make_unique<Span>(0, 15)), *TERM);
-    tree->annotate(span_list->add(std::make_unique<Span>(15, 9)), *TERM);
+    tree->annotate(span_list->add(std::make_unique<Span>(0, 15)), *AnnotationType::TERM);
+    tree->annotate(span_list->add(std::make_unique<Span>(15, 9)), *AnnotationType::TERM);
     StringFieldValue value("我就是那个大灰狼");
     set_span_tree(value, std::move(tree));
     return value;

--- a/searchsummary/src/vespa/searchsummary/docsummary/annotation_converter.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/annotation_converter.cpp
@@ -7,6 +7,7 @@
 #include <vespa/document/annotation/annotation.h>
 #include <vespa/document/annotation/spantree.h>
 #include <vespa/document/annotation/spantreevisitor.h>
+#include <vespa/document/datatype/annotationtype.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/juniper/juniper_separators.h>
 #include <vespa/vespalib/stllike/asciistream.h>
@@ -15,6 +16,7 @@
 
 using document::AlternateSpanList;
 using document::Annotation;
+using document::AnnotationType;
 using document::FieldValue;
 using document::SimpleSpanList;
 using document::Span;
@@ -139,7 +141,7 @@ AnnotationConverter::handleIndexingTerms(const StringFieldValue& value)
         // For now, skip any composite spans.
         const auto *span = dynamic_cast<const Span*>(annotation.getSpanNode());
         if ((span != nullptr) && annotation.valid() &&
-            (annotation.getType() == *linguistics::TERM)) {
+            (annotation.getType() == *AnnotationType::TERM)) {
             terms.push_back(std::make_pair(getSpan(*span),
                                            annotation.getFieldValue()));
         }

--- a/searchsummary/src/vespa/searchsummary/docsummary/linguisticsannotation.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/linguisticsannotation.cpp
@@ -1,27 +1,9 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "linguisticsannotation.h"
-#include <vespa/document/datatype/primitivedatatype.h>
-
-using document::AnnotationType;
-using document::DataType;
-using document::PrimitiveDataType;
-using vespalib::string;
 
 namespace search::linguistics {
 
-namespace {
-AnnotationType makeType(int id, string name, const DataType &type) {
-    AnnotationType annotation_type(id, name);
-    annotation_type.setDataType(type);
-    return annotation_type;
-}
-
-const PrimitiveDataType STRING_OBJ(DataType::T_STRING);
-AnnotationType TERM_OBJ(makeType(1, "term", STRING_OBJ));
-}  // namespace
-
-const string SPANTREE_NAME("linguistics");
-const AnnotationType *const TERM(&TERM_OBJ);
+const vespalib::string SPANTREE_NAME("linguistics");
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/linguisticsannotation.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/linguisticsannotation.h
@@ -2,11 +2,10 @@
 
 #pragma once
 
-#include <vespa/document/datatype/annotationtype.h>
+#include <vespa/vespalib/stllike/string.h>
 
 namespace search::linguistics {
 
 extern const vespalib::string SPANTREE_NAME;
-extern const document::AnnotationType *const TERM;
 
 }


### PR DESCRIPTION
@geirst : please review
