### PR TITLE
Upgrade commons-text from 1.6 to 1.10 due to security vulnerability.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.6</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
@toregge or @bjorncs or @tokle or @aressem PR