### PR TITLE
Use only hostname as dimension for USE_WIREGUARD_ON_TENANT_HOSTS

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -399,7 +399,7 @@ public class Flags {
             List.of("andreer", "gjoranv"), "2022-09-28", "2023-04-01",
             "Set up a WireGuard endpoint on config servers",
             "Takes effect on configserver restart",
-            ZONE_ID, NODE_TYPE);
+            HOSTNAME);
 
     public static final UnboundBooleanFlag USE_WIREGUARD_ON_TENANT_HOSTS = defineFeatureFlag(
             "use-wireguard-on-tenant-hosts", false,


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
