### PR TITLE
Move related non-local variables to same translation unit to ensure

### DIFF
--- a/vdslib/src/vespa/vdslib/state/CMakeLists.txt
+++ b/vdslib/src/vespa/vdslib/state/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(vdslib_state OBJECT
     SOURCES
+    globals.cpp
     nodetype.cpp
     node.cpp
     state.cpp

--- a/vdslib/src/vespa/vdslib/state/clusterstate.cpp
+++ b/vdslib/src/vespa/vdslib/state/clusterstate.cpp
@@ -1,5 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "clusterstate.h"
+#include "globals.h"
 
 #include <vespa/vespalib/text/stringtokenizer.h>
 #include <vespa/document/util/stringutil.h>
@@ -12,6 +13,11 @@
 LOG_SETUP(".vdslib.state.cluster");
 
 using vespalib::IllegalArgumentException;
+
+using storage::lib::clusterstate::_G_defaultSDState;
+using storage::lib::clusterstate::_G_defaultDDState;
+using storage::lib::clusterstate::_G_defaultSUState;
+using storage::lib::clusterstate::_G_defaultDUState;
 
 namespace storage::lib {
 
@@ -266,10 +272,6 @@ ClusterState::getNodeCount(const NodeType& type) const
 }
 
 namespace {
-    NodeState _G_defaultSDState(NodeType::STORAGE, State::DOWN);
-    NodeState _G_defaultDDState(NodeType::DISTRIBUTOR, State::DOWN);
-    NodeState _G_defaultSUState(NodeType::STORAGE, State::UP);
-    NodeState _G_defaultDUState(NodeType::DISTRIBUTOR, State::UP);
     [[noreturn]] void throwUnknownType(const Node & node) __attribute__((noinline));
     void throwUnknownType(const Node & node) {
         throw vespalib::IllegalStateException("Unknown node type " + node.getType().toString(), VESPA_STRLOC);

--- a/vdslib/src/vespa/vdslib/state/globals.cpp
+++ b/vdslib/src/vespa/vdslib/state/globals.cpp
@@ -1,0 +1,24 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "globals.h"
+
+namespace storage::lib {
+
+const State State::UNKNOWN("Unknown", "-", 0, true,  true,  false, false, false);
+const State State::MAINTENANCE("Maintenance", "m", 1, false, false, true,  true,  false);
+const State State::DOWN("Down", "d", 2, false, false, true,  true,  true);
+const State State::STOPPING("Stopping", "s", 3, true,  true,  false, false, true);
+const State State::INITIALIZING("Initializing", "i", 4, true,  true,  false, false, true);
+const State State::RETIRED("Retired", "r", 5, false, false, true, true,  false);
+const State State::UP("Up", "u", 6, true,  true,  true,  true,  true);
+
+}
+
+namespace storage::lib::clusterstate {
+
+NodeState _G_defaultSDState(NodeType::STORAGE, State::DOWN);
+NodeState _G_defaultDDState(NodeType::DISTRIBUTOR, State::DOWN);
+NodeState _G_defaultSUState(NodeType::STORAGE, State::UP);
+NodeState _G_defaultDUState(NodeType::DISTRIBUTOR, State::UP);
+
+}

--- a/vdslib/src/vespa/vdslib/state/globals.h
+++ b/vdslib/src/vespa/vdslib/state/globals.h
@@ -1,0 +1,13 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "state.h"
+#include "nodestate.h"
+
+namespace storage::lib::clusterstate {
+
+extern NodeState _G_defaultSDState;
+extern NodeState _G_defaultDDState;
+extern NodeState _G_defaultSUState;
+extern NodeState _G_defaultDUState;
+
+}

--- a/vdslib/src/vespa/vdslib/state/state.cpp
+++ b/vdslib/src/vespa/vdslib/state/state.cpp
@@ -6,14 +6,6 @@
 
 namespace storage::lib {
 
-const State State::UNKNOWN("Unknown", "-", 0, true,  true,  false, false, false);
-const State State::MAINTENANCE("Maintenance", "m", 1, false, false, true,  true,  false);
-const State State::DOWN("Down", "d", 2, false, false, true,  true,  true);
-const State State::STOPPING("Stopping", "s", 3, true,  true,  false, false, true);
-const State State::INITIALIZING("Initializing", "i", 4, true,  true,  false, false, true);
-const State State::RETIRED("Retired", "r", 5, false, false, true, true,  false);
-const State State::UP("Up", "u", 6, true,  true,  true,  true,  true);
-
 const State&
 State::get(vespalib::stringref serialized)
 {


### PR DESCRIPTION
ordered dynamic initialization.

@vekterli : please review
