### PR TITLE
Write provisioned hosts to ZK early

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -46,10 +46,8 @@ public class History {
 
     private static ImmutableMap<Event.Type, Event> toImmutableMap(Collection<Event> events) {
         ImmutableMap.Builder<Event.Type, Event> builder = new ImmutableMap.Builder<>();
-        for (Event event : events) {
-            if (event.type() == Event.Type.requested) continue; // TODO (freva): Remove requested event after 8.70
+        for (Event event : events)
             builder.put(event.type(), event);
-        }
         return builder.build();
     }
 
@@ -182,8 +180,6 @@ public class History {
             down,
             // The active node came up according to the service monitor
             up,
-            // The node made a config request, indicating it is live
-            requested,
             // The node resources/flavor were changed
             resized(false),
             // The node was rebooted

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -423,7 +423,6 @@ public class NodeSerializer {
             case "deallocated" : return History.Event.Type.deallocated;
             case "down" : return History.Event.Type.down;
             case "up" : return History.Event.Type.up;
-            case "requested" : return History.Event.Type.requested;
             case "resized" : return History.Event.Type.resized;
             case "rebooted" : return History.Event.Type.rebooted;
             case "osUpgraded" : return History.Event.Type.osUpgraded;
@@ -450,7 +449,6 @@ public class NodeSerializer {
             case deallocated : return "deallocated";
             case down : return "down";
             case up : return "up";
-            case requested: return "requested";
             case resized: return "resized";
             case rebooted: return "rebooted";
             case osUpgraded: return "osUpgraded";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -60,10 +61,10 @@ public class MockHostProvisioner implements HostProvisioner {
     }
 
     @Override
-    public List<ProvisionedHost> provisionHosts(List<Integer> provisionIndices, NodeType hostType, NodeResources resources,
-                                                ApplicationId applicationId, Version osVersion, HostSharing sharing,
-                                                Optional<ClusterSpec.Type> clusterType,
-                                                Optional<CloudAccount> cloudAccount) {
+    public void provisionHosts(List<Integer> provisionIndices, NodeType hostType, NodeResources resources,
+                               ApplicationId applicationId, Version osVersion, HostSharing sharing,
+                               Optional<ClusterSpec.Type> clusterType, Optional<CloudAccount> cloudAccount,
+                               Consumer<List<ProvisionedHost>> provisionedHostsConsumer) {
         Flavor hostFlavor = this.hostFlavor.orElseGet(() -> flavors.stream().filter(f -> compatible(f, resources))
                                                                    .findFirst()
                                                                    .orElseThrow(() -> new NodeAllocationException("No host flavor matches " + resources, true)));
@@ -82,7 +83,7 @@ public class MockHostProvisioner implements HostProvisioner {
                                           cloudAccount));
         }
         provisionedHosts.addAll(hosts);
-        return hosts;
+        provisionedHostsConsumer.accept(hosts);
     }
 
     @Override


### PR DESCRIPTION
Must be merged with internal PR.

For certain cloud providers we may get enough information to be able to create `Node`s representing the hosts and write them to ZK early and then wait for the rest of the provision request to finish. This PR ensures that we this to ZK as soon as possible, so that if the config server is suddenly stopped, we wont lose track of these hosts.