### PR TITLE
QueryBuilder: support ranking.features.featurename

### DIFF
--- a/client/js/app/src/app/pages/querybuilder/context/__test__/query-builder-provider.test.jsx
+++ b/client/js/app/src/app/pages/querybuilder/context/__test__/query-builder-provider.test.jsx
@@ -52,11 +52,20 @@ test('manipulates inputs', () => {
     [ACTION.INPUT_ADD, { id: '2', type: 'location' }],
     [ACTION.INPUT_ADD, { id: '2', type: 'matchPhase' }],
     [ACTION.INPUT_UPDATE, { id: '2.0', value: 'us' }],
+    [ACTION.INPUT_ADD, { id: '2', type: 'features' }],
+    [ACTION.INPUT_ADD, { id: '2.2', type: '' }],
+    [ACTION.INPUT_UPDATE, { id: '2.2.0', type: 'abc' }],
+    [ACTION.INPUT_UPDATE, { id: '2.2.0', value: '123' }],
   ]);
   assert(
     s2,
-    { input: { offset: 12, ranking: { location: 'us', matchPhase: {} } } },
-    { input: 'offset=12&ranking.location=us' },
+    {
+      input: {
+        offset: 12,
+        ranking: { location: 'us', matchPhase: {}, features: { abc: '123' } },
+      },
+    },
+    { input: 'offset=12&ranking.location=us&ranking.features.abc=123' },
     [
       { id: '1', value: '12', type: 'offset' },
       {
@@ -65,6 +74,11 @@ test('manipulates inputs', () => {
         value: [
           { id: '2.0', value: 'us', type: 'location' },
           { id: '2.1', type: 'matchPhase', value: [] },
+          {
+            id: '2.2',
+            type: 'features',
+            value: [{ id: '2.2.0', type: 'abc', value: '123' }],
+          },
         ],
       },
     ]
@@ -146,6 +160,27 @@ test('set query', () => {
       value: [{ id: '0.0', type: 'matchPhase', value: [] }],
     },
   ]);
+
+  assert(
+    '{"ranking":{"features":{"abc":"123","def":"456"}}}',
+    'ranking.features.abc=123&ranking.features.def=456',
+    [
+      {
+        id: '0',
+        type: 'ranking',
+        value: [
+          {
+            id: '0.0',
+            type: 'features',
+            value: [
+              { id: '0.0.0', type: 'abc', value: '123' },
+              { id: '0.0.1', type: 'def', value: '456' },
+            ],
+          },
+        ],
+      },
+    ]
+  );
 
   let msg = "Unknown property 'asd' on root level";
   error('POST', '{"asd":123}', msg);

--- a/client/js/app/src/app/pages/querybuilder/context/__test__/query-builder-provider.test.jsx
+++ b/client/js/app/src/app/pages/querybuilder/context/__test__/query-builder-provider.test.jsx
@@ -158,7 +158,7 @@ test('set query', () => {
   error('POST', '{"yql":"test}', 'Unexpected end of JSON input');
 
   msg =
-    "Property 'ranking' cannot have a value, supported children: features,freshness,listFeatures,location,matchPhase,profile,properties,queryCache,sorting";
+    "Property 'ranking' cannot have a value, supported children: features,freshness,listFeatures,location,matchPhase,matching,profile,properties,queryCache,rerankCount,sorting";
   error('POST', '{"ranking":123}', msg);
   error('GET', 'ranking=123', msg);
 

--- a/client/js/app/src/app/pages/querybuilder/context/parameters.jsx
+++ b/client/js/app/src/app/pages/querybuilder/context/parameters.jsx
@@ -1,43 +1,35 @@
+// https://docs.vespa.ai/en/reference/query-api-reference.html
 export default {
   yql: { name: 'yql', type: 'String' },
+
+  // Native Execution Parameters
   hits: { name: 'hits', type: 'Integer' },
   offset: { name: 'offset', type: 'Integer' },
   queryProfile: { name: 'queryProfile', type: 'String' },
-  noCache: { name: 'noCache', type: 'Boolean' },
   groupingSessionCache: { name: 'groupingSessionCache', type: 'Boolean' },
   searchChain: { name: 'searchChain', type: 'String' },
-  timeout: { name: 'timeout', type: 'Float' },
-  trace: {
-    name: 'trace',
-    type: 'Parent',
-    children: {
-      timestamps: { name: 'timestamps', type: 'Boolean' },
-    },
-  },
-  tracelevel: {
-    name: 'tracelevel',
-    type: 'Parent',
-    children: {
-      rules: { name: 'rules', type: 'Integer' },
-    },
-  },
-  traceLevel: { name: 'traceLevel', type: 'Integer' },
-  explainLevel: { name: 'explainLevel', type: 'Integer' },
-  explainlevel: { name: 'explainlevel', type: 'Integer' },
+  timeout: { name: 'timeout', type: 'Double' },
+  noCache: { name: 'noCache', type: 'Boolean' },
+
+  // Query Model
   model: {
     name: 'model',
     type: 'Parent',
     children: {
       defaultIndex: { name: 'defaultIndex', type: 'String' },
       encoding: { name: 'encoding', type: 'String' },
+      filter: { name: 'filter', type: 'String' },
+      locale: { name: 'locale', type: 'String' },
       language: { name: 'language', type: 'String' },
       queryString: { name: 'queryString', type: 'String' },
-      restrict: { name: 'restrict', type: 'List' },
+      restrict: { name: 'restrict', type: 'String' },
       searchPath: { name: 'searchPath', type: 'String' },
-      sources: { name: 'sources', type: 'List' },
+      sources: { name: 'sources', type: 'String' },
       type: { name: 'type', type: 'String' },
     },
   },
+
+  // Ranking
   ranking: {
     name: 'ranking',
     type: 'Parent',
@@ -50,25 +42,45 @@ export default {
       sorting: { name: 'sorting', type: 'String' },
       freshness: { name: 'freshness', type: 'String' },
       queryCache: { name: 'queryCache', type: 'Boolean' },
+      rerankCount: { name: 'rerankCount', type: 'Integer' },
+      matching: {
+        name: 'matching',
+        type: 'Parent',
+        children: {
+          numThreadsPerSearch: { name: 'numThreadsPerSearch', type: 'Integer' },
+          minHitsPerThread: { name: 'minHitsPerThread', type: 'Integer' },
+          numSearchPartitions: { name: 'numSearchPartitions', type: 'Integer' },
+          termwiseLimit: { name: 'termwiseLimit', type: 'Float' },
+          postFilterThreshold: { name: 'postFilterThreshold', type: 'Float' },
+          approximateThreshold: {
+            name: 'approximateThreshold',
+            type: 'Float',
+          },
+        },
+      },
       matchPhase: {
         name: 'matchPhase',
         type: 'Parent',
         children: {
-          maxHits: { name: 'maxHits', type: 'Long' },
           attribute: { name: 'attribute', type: 'String' },
+          maxHits: { name: 'maxHits', type: 'Integer' },
           ascending: { name: 'ascending', type: 'Boolean' },
           diversity: {
             name: 'diversity',
             type: 'Parent',
             children: {
               attribute: { name: 'attribute', type: 'String' },
-              minGroups: { name: 'minGroups', type: 'Long' },
+              minGroups: { name: 'minGroups', type: 'Integer' },
             },
           },
         },
       },
     },
   },
+
+  // Grouping
+  collapsesize: { name: 'collapsesize', type: 'Integer' },
+  collapsefield: { name: 'collapsefield', type: 'String' },
   collapse: {
     name: 'collapse',
     type: 'Parent',
@@ -76,19 +88,104 @@ export default {
       summary: { name: 'summary', type: 'String' },
     },
   },
-  collapsesize: { name: 'collapsesize', type: 'Integer' },
-  collapsefield: { name: 'collapsefield', type: 'String' },
+  grouping: {
+    name: 'grouping',
+    type: 'Parent',
+    children: {
+      defaultMaxGroups: { name: 'defaultMaxGroups', type: 'Integer' },
+      defaultMaxHits: { name: 'defaultMaxHits', type: 'Integer' },
+      globalMaxGroups: { name: 'globalMaxGroups', type: 'Integer' },
+      defaultPrecisionFactor: {
+        name: 'defaultPrecisionFactor',
+        type: 'Float',
+      },
+    },
+  },
+
+  // Presentation
   presentation: {
     name: 'presentation',
     type: 'Parent',
     children: {
       bolding: { name: 'bolding', type: 'Boolean' },
-      format: { name: 'format', type: 'String' },
-      summary: { name: 'summary', type: 'String' },
+      format: {
+        name: 'format',
+        type: 'Parent',
+        children: {
+          tensors: { name: 'tensors', type: 'String' },
+        },
+      },
       template: { name: 'template', type: 'String' },
+      summary: { name: 'summary', type: 'String' },
       timing: { name: 'timing', type: 'Boolean' },
     },
   },
+
+  // Tracing
+  trace: {
+    name: 'trace',
+    type: 'Parent',
+    children: {
+      level: { name: 'level', type: 'Integer' },
+      explainLevel: { name: 'explainLevel', type: 'Integer' },
+      profileDepth: { name: 'profileDepth', type: 'Integer' },
+      timestamps: { name: 'timestamps', type: 'Boolean' },
+      query: { name: 'query', type: 'Boolean' },
+    },
+  },
+
+  // Semantic Rules
+  rules: {
+    name: 'rules',
+    type: 'Parent',
+    children: {
+      off: { name: 'off', type: 'Boolean' },
+      rulebase: { name: 'rulebase', type: 'String' },
+    },
+  },
+  tracelevel: {
+    name: 'tracelevel',
+    type: 'Parent',
+    children: {
+      rules: { name: 'rules', type: 'Integer' },
+    },
+  },
+
+  // Dispatch
+  dispatch: {
+    name: 'dispatch',
+    type: 'Parent',
+    children: {
+      topKProbability: { name: 'topKProbability', type: 'Float' },
+    },
+  },
+
+  // Other
+  recall: { name: 'recall', type: 'String' },
+  user: { name: 'user', type: 'String' },
+  hitcountestimate: { name: 'hitcountestimate', type: 'Boolean' },
+  metrics: {
+    name: 'metrics',
+    type: 'Parent',
+    children: {
+      ignore: { name: 'ignore', type: 'Boolean' },
+    },
+  },
+  weakAnd: {
+    name: 'weakAnd',
+    type: 'Parent',
+    children: {
+      replace: { name: 'replace', type: 'Boolean' },
+    },
+  },
+  wand: {
+    name: 'wand',
+    type: 'Parent',
+    children: {
+      hits: { name: 'hits', type: 'Integer' },
+    },
+  },
+
   streaming: {
     name: 'streaming',
     type: 'Parent',
@@ -98,23 +195,6 @@ export default {
       selection: { name: 'selection', type: 'String' },
       priority: { name: 'priority', type: 'String' },
       maxbucketspervisitor: { name: 'maxbucketspervisitor', type: 'Integer' },
-    },
-  },
-  rules: {
-    name: 'rules',
-    type: 'Parent',
-    children: {
-      off: { name: 'off', type: 'Boolean' },
-      rulebase: { name: 'rulebase', type: 'String' },
-    },
-  },
-  recall: { name: 'recall', type: 'List' },
-  user: { name: 'user', type: 'String' },
-  metrics: {
-    name: 'metrics',
-    type: 'Parent',
-    children: {
-      ignore: { name: 'ignore', type: 'Boolean' },
     },
   },
 };

--- a/client/js/app/src/app/pages/querybuilder/context/parameters.jsx
+++ b/client/js/app/src/app/pages/querybuilder/context/parameters.jsx
@@ -35,7 +35,7 @@ export default {
     type: 'Parent',
     children: {
       location: { name: 'location', type: 'String' },
-      features: { name: 'features', type: 'String' },
+      features: { name: 'features', type: 'Parent', children: 'String' },
       listFeatures: { name: 'listFeatures', type: 'Boolean' },
       profile: { name: 'profile', type: 'String' },
       properties: { name: 'properties', type: 'String' },

--- a/client/js/app/src/app/pages/querybuilder/context/query-builder-provider.jsx
+++ b/client/js/app/src/app/pages/querybuilder/context/query-builder-provider.jsx
@@ -60,7 +60,10 @@ function jsonToInputs(json, parent = root) {
   return Object.entries(json).map(([key, value], i) => {
     const node = {
       id: parent.id ? `${parent.id}.${i}` : i.toString(),
-      type: parent.type.children[key],
+      type:
+        typeof parent.type.children === 'string'
+          ? { name: key, type: parent.type.children }
+          : parent.type.children[key],
     };
     if (!node.type) {
       const location = parent.type.name
@@ -86,7 +89,7 @@ function jsonToInputs(json, parent = root) {
 }
 
 function parseInput(value, type) {
-  if (type === 'Integer' || type === 'Long') return parseInt(value);
+  if (type === 'Integer') return parseInt(value);
   if (type === 'Float') return parseFloat(value);
   if (type === 'Boolean') return value.toLowerCase() === 'true';
   return value;
@@ -98,7 +101,10 @@ function inputAdd(params, { id: parentId, type: typeName }) {
 
   const nextId = parseInt(last(last(parent.value)?.id?.split('.')) ?? -1) + 1;
   const id = parentId ? `${parentId}.${nextId}` : nextId.toString();
-  const type = parent.type.children[typeName];
+  const type =
+    typeof parent.type.children === 'string'
+      ? { name: typeName, type: parent.type.children }
+      : parent.type.children[typeName];
 
   parent.value.push({ id, value: type.children ? [] : '', type });
 
@@ -110,7 +116,10 @@ function inputUpdate(params, { id, type, value }) {
   const node = findInput(cloned, id);
   if (type) {
     const parent = findInput(cloned, id.substring(0, id.lastIndexOf('.')));
-    const newType = parent.type.children[type];
+    const newType =
+      typeof parent.type.children === 'string'
+        ? { name: type, type: parent.type.children }
+        : parent.type.children[type];
     if ((node.type.children != null) !== (newType.children != null))
       node.value = newType.children ? [] : '';
     node.type = newType;

--- a/client/js/app/src/app/pages/querybuilder/query-filters/query-filters.jsx
+++ b/client/js/app/src/app/pages/querybuilder/query-filters/query-filters.jsx
@@ -26,17 +26,32 @@ function AddProperty(props) {
 }
 
 function Input({ id, value, types, type }) {
-  const options = { [type.name]: type, ...types };
   return (
     <>
       <Box sx={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-        <Select
-          sx={{ flex: 1 }}
-          data={Object.values(options).map(({ name }) => name)}
-          onChange={(type) => dispatch(ACTION.INPUT_UPDATE, { id, type })}
-          value={type.name}
-          searchable
-        />
+        {types ? (
+          <Select
+            sx={{ flex: 1 }}
+            data={Object.values({ [type.name]: type, ...types }).map(
+              ({ name }) => name
+            )}
+            onChange={(type) => dispatch(ACTION.INPUT_UPDATE, { id, type })}
+            value={type.name}
+            searchable
+          />
+        ) : (
+          <TextInput
+            sx={{ flex: 1 }}
+            onChange={(event) =>
+              dispatch(ACTION.INPUT_UPDATE, {
+                id,
+                type: event.currentTarget.value,
+              })
+            }
+            placeholder="String"
+            value={type.name}
+          />
+        )}
         {!type.children && (
           <TextInput
             sx={{ flex: 1 }}
@@ -75,16 +90,20 @@ function Input({ id, value, types, type }) {
 
 function Inputs({ id, type, inputs }) {
   const usedTypes = inputs.map(({ type }) => type.name);
-  const remainingTypes = Object.fromEntries(
-    Object.entries(type).filter(([name]) => !usedTypes.includes(name))
-  );
-  const firstRemaining = Object.keys(remainingTypes)[0];
+  const remainingTypes =
+    typeof type === 'string'
+      ? null
+      : Object.fromEntries(
+          Object.entries(type).filter(([name]) => !usedTypes.includes(name))
+        );
+  const firstRemaining = remainingTypes ? Object.keys(remainingTypes)[0] : '';
+
   return (
     <Container sx={{ rowGap: '5px' }}>
       {inputs.map(({ id, value, type }) => (
         <Input key={id} types={remainingTypes} {...{ id, value, type }} />
       ))}
-      {firstRemaining && (
+      {firstRemaining != null && (
         <>
           {id != null ? (
             <Container sx={{ justifyContent: 'start' }}>


### PR DESCRIPTION
* Removes `traceLevel`, `explainLevel` and `explainlevel` aliases
* Adds 
  * `model.{filter,locale}`
  * `ranking.{rerankCount,matching}`
  * `grouping.{defaultMaxGroups,defaultMaxHits,globalMaxGroups,defaultPrecisionFactor}`
  * `presentation.summary`
  * `trace.{level,explainLevel,profileDepth,query}`
  * `dispatch.topKProbability`
  * `hitcountestimate`
  * `weakAnd.replace`
  * `wand.hits`
* Replaces `presentation.format` with `presentation.format.tensors`
* Query builder now has all parameters documented in https://docs.vespa.ai/en/reference/query-api-reference.html except:
  * `noCache` and `streaming.{userid,groupname,selection,priority,maxbucketspervisitor}`: supported by query builder but are not documented (on that page)
  * `select`: Seems like there are 2 types of select and at least 1 of them is covered by `yql`?
* Allows user defined key-values under `ranking.features` (Fixes #24475)