### PR TITLE
avoid dereferencing nil, add unit test

### DIFF
--- a/client/go/util/io.go
+++ b/client/go/util/io.go
@@ -16,20 +16,20 @@ import (
 
 // Returns true if the given path exists
 func PathExists(path string) bool {
-	_, err := os.Stat(path)
-	return !errors.Is(err, os.ErrNotExist)
+	info, err := os.Stat(path)
+	return !errors.Is(err, os.ErrNotExist) && info != nil
 }
 
 // Returns true if the given path points to an existing directory
 func IsDirectory(path string) bool {
 	info, err := os.Stat(path)
-	return !errors.Is(err, os.ErrNotExist) && info.IsDir()
+	return !errors.Is(err, os.ErrNotExist) && info != nil && info.IsDir()
 }
 
 // Returns true if the given path points to an existing file
 func IsRegularFile(path string) bool {
 	info, err := os.Stat(path)
-	return !errors.Is(err, os.ErrNotExist) && info.Mode().IsRegular()
+	return !errors.Is(err, os.ErrNotExist) && info != nil && info.Mode().IsRegular()
 }
 
 // Returns the content of a reader as a string

--- a/client/go/util/io_test.go
+++ b/client/go/util/io_test.go
@@ -1,0 +1,43 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathExists(t *testing.T) {
+	assert.Equal(t, true, PathExists("io.go"))
+	assert.Equal(t, false, PathExists("nosuchthing.go"))
+
+	tmpDir := t.TempDir()
+	err := os.MkdirAll(tmpDir+"/no", 0755)
+	assert.Nil(t, err)
+	err = os.MkdirAll(tmpDir+"/no/such", 0)
+	assert.Nil(t, err)
+	assert.Equal(t, false, PathExists(tmpDir+"/no/such/thing.go"))
+}
+
+func TestIsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := os.MkdirAll(tmpDir+"/no", 0755)
+	assert.Nil(t, err)
+	assert.Equal(t, true, IsDirectory(tmpDir+"/no"))
+	err = os.MkdirAll(tmpDir+"/no/such", 0)
+	assert.Nil(t, err)
+	assert.Equal(t, true, IsDirectory(tmpDir+"/no/such"))
+	assert.Equal(t, false, IsDirectory(tmpDir+"/no/such/thing.go"))
+}
+
+func TestIsRegularFile(t *testing.T) {
+	assert.Equal(t, true, IsRegularFile("io.go"))
+	assert.Equal(t, false, IsRegularFile("."))
+	tmpDir := t.TempDir()
+	err := os.MkdirAll(tmpDir+"/no", 0755)
+	assert.Nil(t, err)
+	err = os.MkdirAll(tmpDir+"/no/such", 0)
+	assert.Nil(t, err)
+	assert.Equal(t, false, IsRegularFile(tmpDir+"/no/such/thing.go"))
+}


### PR DESCRIPTION
@bratseth please review
note: I don't quite understand why the code does
`  !errors.Is(err, os.ErrNotExist)`
instead of just
`  err != nil`

@ean FYI
