### PR TITLE
re-throw runtime errors to get their stack trace

### DIFF
--- a/client/go/script-utils/main.go
+++ b/client/go/script-utils/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/vespa-engine/vespa/client/go/cmd/clusterstate"
@@ -68,7 +69,9 @@ func main() {
 
 func handleSimplePanic() {
 	if r := recover(); r != nil {
-		if je, ok := r.(error); ok {
+		if rte, ok := r.(runtime.Error); ok {
+			panic(rte)
+		} else if je, ok := r.(error); ok {
 			fmt.Fprintln(os.Stderr, je)
 			os.Exit(1)
 		} else {


### PR DESCRIPTION
@mpolden please review

note: long-term I think we may be better off with having something specific in our panic() calls, which would signal that we really *really* want to just exit with a simple message.
