### PR TITLE
Remove existing load balancer if account changes

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/exception/LoadBalancerServiceException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/exception/LoadBalancerServiceException.java
@@ -10,6 +10,10 @@ import com.yahoo.config.provision.TransientException;
  */
 public class LoadBalancerServiceException extends TransientException {
 
+    public LoadBalancerServiceException(String message) {
+        super(message);
+    }
+
     public LoadBalancerServiceException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
@@ -68,7 +68,7 @@ public class LoadBalancer {
 
     public enum State {
 
-        /** This load balancer has been provisioned and reserved for an application */
+        /** The load balancer has been provisioned and reserved for an application */
         reserved,
 
         /**
@@ -80,6 +80,9 @@ public class LoadBalancer {
 
         /** The load balancer is in active use by an application */
         active,
+
+        /** The load balancer should be removed immediately by {@link LoadBalancerExpirer} */
+        removable,
 
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDatabaseClient.java
@@ -87,7 +87,7 @@ public class CuratorDatabaseClient {
     }
 
     public List<String> cluster() {
-        return db.cluster().stream().map(HostName::value).collect(Collectors.toUnmodifiableList());
+        return db.cluster().stream().map(HostName::value).toList();
     }
 
     private void initZK() {
@@ -162,7 +162,7 @@ public class CuratorDatabaseClient {
     }
 
     /**
-     * Writes the given nodes to the given state (whether or not they are already in this state or another),
+     * Writes the given nodes to the given state (whether they are already in this state or another),
      * and returns a copy of the incoming nodes in their persisted state.
      *
      * @param  toState the state to write the nodes to
@@ -305,19 +305,18 @@ public class CuratorDatabaseClient {
     }
 
     private String toDir(Node.State state) {
-        switch (state) {
-            case active: return "allocated"; // legacy name
-            case dirty: return "dirty";
-            case failed: return "failed";
-            case inactive: return "deallocated"; // legacy name
-            case parked : return "parked";
-            case provisioned: return "provisioned";
-            case ready: return "ready";
-            case reserved: return "reserved";
-            case deprovisioned: return "deprovisioned";
-            case breakfixed: return "breakfixed";
-            default: throw new RuntimeException("Node state " + state + " does not map to a directory name");
-        }
+        return switch (state) {
+            case active -> "allocated"; // legacy name
+            case dirty -> "dirty";
+            case failed -> "failed";
+            case inactive -> "deallocated"; // legacy name
+            case parked -> "parked";
+            case provisioned -> "provisioned";
+            case ready -> "ready";
+            case reserved -> "reserved";
+            case deprovisioned -> "deprovisioned";
+            case breakfixed -> "breakfixed";
+        };
     }
 
     /** Acquires the single cluster-global, reentrant lock for all non-active nodes */
@@ -513,7 +512,7 @@ public class CuratorDatabaseClient {
         return db.getChildren(loadBalancersPath).stream()
                  .map(LoadBalancerId::fromSerializedForm)
                  .filter(predicate)
-                 .collect(Collectors.toUnmodifiableList());
+                 .toList();
     }
 
     /** Returns a given number of unique provision indices */
@@ -524,7 +523,7 @@ public class CuratorDatabaseClient {
         int firstIndex = (int) provisionIndexCounter.add(count) - count;
         return IntStream.range(0, count)
                         .mapToObj(i -> firstIndex + i)
-                        .collect(Collectors.toList());
+                        .toList();
     }
 
     public CacheStats cacheStats() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -121,6 +121,7 @@ public class LoadBalancerSerializer {
             case active -> "active";
             case inactive -> "inactive";
             case reserved -> "reserved";
+            case removable -> "removable";
         };
     }
 
@@ -129,6 +130,7 @@ public class LoadBalancerSerializer {
             case "active" -> LoadBalancer.State.active;
             case "inactive" -> LoadBalancer.State.inactive;
             case "reserved" -> LoadBalancer.State.reserved;
+            case "removable" -> LoadBalancer.State.removable;
             default -> throw new IllegalArgumentException("No serialization defined for state string '" + state + "'");
         };
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -117,21 +117,20 @@ public class LoadBalancerSerializer {
     }
 
     private static String asString(LoadBalancer.State state) {
-        switch (state) {
-            case active: return "active";
-            case inactive: return "inactive";
-            case reserved: return "reserved";
-            default: throw new IllegalArgumentException("No serialization defined for state enum '" + state + "'");
-        }
+        return switch (state) {
+            case active -> "active";
+            case inactive -> "inactive";
+            case reserved -> "reserved";
+        };
     }
 
     private static LoadBalancer.State stateFromString(String state) {
-        switch (state) {
-            case "active": return LoadBalancer.State.active;
-            case "inactive": return LoadBalancer.State.inactive;
-            case "reserved": return LoadBalancer.State.reserved;
-            default: throw new IllegalArgumentException("No serialization defined for state string '" + state + "'");
-        }
+        return switch (state) {
+            case "active" -> LoadBalancer.State.active;
+            case "inactive" -> LoadBalancer.State.inactive;
+            case "reserved" -> LoadBalancer.State.reserved;
+            default -> throw new IllegalArgumentException("No serialization defined for state string '" + state + "'");
+        };
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 // 1) (new) -> reserved -> active
 // 2) active | reserved -> inactive
 // 3) inactive -> active | (removed)
+// 4) active | reserved | inactive -> removable
+// 5) removable -> (removed)
 public class LoadBalancerProvisioner {
 
     private static final Logger log = Logger.getLogger(LoadBalancerProvisioner.class.getName());
@@ -190,9 +192,14 @@ public class LoadBalancerProvisioner {
             newLoadBalancer = loadBalancer.get().with(instance);
             fromState = newLoadBalancer.state();
         }
-        // Always store load balancer so that LoadBalancerExpirer can expire partially provisioned load balancers
+        if (!inAccount(cloudAccount, newLoadBalancer)) {
+            // We have a load balancer, but in the wrong account. Load balancer must be removed before we can
+            // provision a new one in the wanted account
+            newLoadBalancer = newLoadBalancer.with(LoadBalancer.State.removable, now);
+        }
+        // Always store the load balancer. LoadBalancerExpirer will remove unwanted ones
         db.writeLoadBalancer(newLoadBalancer, fromState);
-        requireInstance(id, instance);
+        requireInstance(id, instance, cloudAccount);
     }
 
     private void activate(ApplicationTransaction transaction, ClusterSpec.Id cluster, NodeList nodes) {
@@ -206,7 +213,7 @@ public class LoadBalancerProvisioner {
         LoadBalancer.State state = instance.isPresent() ? LoadBalancer.State.active : loadBalancer.get().state();
         LoadBalancer newLoadBalancer = loadBalancer.get().with(instance).with(state, now);
         db.writeLoadBalancers(List.of(newLoadBalancer), loadBalancer.get().state(), transaction.nested());
-        requireInstance(id, instance);
+        requireInstance(id, instance, loadBalancer.get().instance().get().cloudAccount());
     }
 
     /** Provision or reconfigure a load balancer instance, if necessary */
@@ -276,6 +283,11 @@ public class LoadBalancerProvisioner {
         return ids;
     }
 
+    /** Returns whether load balancer is provisioned in given account */
+    private static boolean inAccount(Optional<CloudAccount> cloudAccount, LoadBalancer loadBalancer) {
+        return loadBalancer.instance().isEmpty() || loadBalancer.instance().get().cloudAccount().equals(cloudAccount);
+    }
+
     /** Returns whether load balancer has given reals */
     private static boolean hasReals(Optional<LoadBalancer> loadBalancer, Set<Real> reals) {
         if (loadBalancer.isEmpty()) return false;
@@ -299,11 +311,13 @@ public class LoadBalancerProvisioner {
         return reachable;
     }
 
-    private static void requireInstance(LoadBalancerId id, Optional<LoadBalancerInstance> instance) {
+    private static void requireInstance(LoadBalancerId id, Optional<LoadBalancerInstance> instance, Optional<CloudAccount> cloudAccount) {
         if (instance.isEmpty()) {
             // Signal that load balancer is not ready yet
-            throw new LoadBalancerServiceException("Could not (re)configure " + id + ". The operation will be retried on next deployment",
-                                                   null);
+            throw new LoadBalancerServiceException("Could not (re)configure " + id + ". The operation will be retried on next deployment");
+        }
+        if (!instance.get().cloudAccount().equals(cloudAccount)) {
+            throw new LoadBalancerServiceException("Could not (re)configure " + id + " due to change in cloud account. The operation will be retried on next deployment");
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisioner.java
@@ -161,7 +161,7 @@ public class LoadBalancerProvisioner {
         return db.readLoadBalancerIds().stream()
                  .filter(id -> id.application().tenant().equals(tenant) &&
                                id.application().application().equals(application))
-                 .collect(Collectors.toUnmodifiableList());
+                 .toList();
     }
 
     /** Require that load balancer IDs do not clash. This prevents name clashing when compacting endpoint DNS names */
@@ -293,12 +293,8 @@ public class LoadBalancerProvisioner {
         Set<String> reachable = new LinkedHashSet<>(node.ipConfig().primary());
         // Remove addresses unreachable by the load balancer service
         switch (service.protocol()) {
-            case ipv4:
-                reachable.removeIf(IP::isV6);
-                break;
-            case ipv6:
-                reachable.removeIf(IP::isV4);
-                break;
+            case ipv4 -> reachable.removeIf(IP::isV6);
+            case ipv6 -> reachable.removeIf(IP::isV4);
         }
         return reachable;
     }


### PR DESCRIPTION
If the tenant changes the account for a deployment, e.g. from the default Vespa
account to the tenant's own account, we must ensure that the LB is provisioned
in the correct account.

@bratseth

FYI @ean