### PR TITLE
Use a larger content node flavor by default

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -90,23 +90,33 @@ public class CapacityPolicies {
             }
 
             return (requiresExclusiveHost(clusterSpec.type(), exclusive)
-                    ? versioned(clusterSpec, Map.of(new Version("0"), smallestExclusiveResources()))
-                    : versioned(clusterSpec, Map.of(new Version("0"), smallestSharedResources())))
+                    ? versioned(clusterSpec, Map.of(new Version(0), smallestExclusiveResources()))
+                    : versioned(clusterSpec, Map.of(new Version(0), smallestSharedResources())))
                     .with(architecture);
         }
 
-        return zone.getCloud().dynamicProvisioning()
-               ? versioned(clusterSpec, Map.of(new Version("0"), new NodeResources(2.0, 8, 50, 0.3)))
-               : versioned(clusterSpec, Map.of(new Version("0"), new NodeResources(1.5, 8, 50, 0.3)));
+        if (clusterSpec.type() == ClusterSpec.Type.content) {
+            // TODO: Simplify when no application is on an older version than 8.75
+            return zone.getCloud().dynamicProvisioning()
+                   ? versioned(clusterSpec, Map.of(new Version(0), new NodeResources(2.0, 8, 50, 0.3),
+                                                   new Version(8, 75), new NodeResources(2, 16, 300, 0.3)))
+                   : versioned(clusterSpec, Map.of(new Version(0), new NodeResources(1.5, 8, 50, 0.3),
+                                                   new Version(8, 75), new NodeResources(2, 16, 300, 0.3)));
+        }
+        else {
+            return zone.getCloud().dynamicProvisioning()
+                   ? versioned(clusterSpec, Map.of(new Version(0), new NodeResources(2.0, 8, 50, 0.3)))
+                   : versioned(clusterSpec, Map.of(new Version(0), new NodeResources(1.5, 8, 50, 0.3)));
+        }
     }
 
     private NodeResources clusterControllerResources(ClusterSpec clusterSpec, boolean exclusive) {
         if (requiresExclusiveHost(clusterSpec.type(), exclusive)) {
-            return versioned(clusterSpec, Map.of(new Version("0"), smallestExclusiveResources()));
+            return versioned(clusterSpec, Map.of(new Version(0), smallestExclusiveResources()));
         }
-        return versioned(clusterSpec, Map.of(new Version("0"), new NodeResources(0.25, 1.14, 10, 0.3),
-                                             new Version("7.586.50"), new NodeResources(0.25, 1.333, 10, 0.3),
-                                             new Version("7.586.54"), new NodeResources(0.25, 1.14, 10, 0.3)));
+        return versioned(clusterSpec, Map.of(new Version(0), new NodeResources(0.25, 1.14, 10, 0.3),
+                                             new Version(7, 586, 50), new NodeResources(0.25, 1.333, 10, 0.3),
+                                             new Version(7, 586, 54), new NodeResources(0.25, 1.14, 10, 0.3)));
     }
 
     private Architecture adminClusterArchitecture(ApplicationId instance) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.autoscale;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.Cloud;
@@ -148,7 +149,12 @@ public class Fixture {
         }
 
         public Fixture.Builder clusterType(ClusterSpec.Type type) {
-            cluster = ClusterSpec.request(type, cluster.id()).vespaVersion("7").build();
+            cluster = ClusterSpec.request(type, cluster.id()).vespaVersion(cluster.vespaVersion()).build();
+            return this;
+        }
+
+        public Fixture.Builder vespaVersion(Version version) {
+            cluster = ClusterSpec.request(cluster.type(), cluster.id()).vespaVersion(version).build();
             return this;
         }
 


### PR DESCRIPTION
The previous flavor makes people run of out resources too often when trying vector search.
