### PR TITLE
ConfigurationRuntimeException when building model means invalid package

### DIFF
--- a/config-lib/src/main/java/com/yahoo/config/ConfigurationRuntimeException.java
+++ b/config-lib/src/main/java/com/yahoo/config/ConfigurationRuntimeException.java
@@ -4,7 +4,6 @@ package com.yahoo.config;
 /**
  * This exception is thrown on internal errors in the configuration system.
  */
-@SuppressWarnings("serial")
 public class ConfigurationRuntimeException extends RuntimeException {
     public ConfigurationRuntimeException(String message) {
         super(message);

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/modelfactory/ModelsBuilder.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.config.server.modelfactory;
 
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.Version;
+import com.yahoo.config.ConfigurationRuntimeException;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.HostProvisioner;
@@ -133,7 +134,7 @@ public abstract class ModelsBuilder<MODELRESULT extends ModelResult> {
                     log.log(Level.FINE, applicationId + ": Skipping major version " + majorVersion, e);
                 }
                 else {
-                    if (e instanceof IllegalArgumentException) {
+                    if (e instanceof IllegalArgumentException || e instanceof ConfigurationRuntimeException) {
                         var wrapped = new InvalidApplicationException("Error loading " + applicationId, e);
                         deployLogger.logApplicationPackage(Level.SEVERE, Exceptions.toMessageString(wrapped));
                         throw wrapped;


### PR DESCRIPTION
@bratseth please review and merge if you think it's right. Otherwise, errors in, e.g., services.xml with config for nonexistent keys results in a HTTP 500 and no usable information propagated back through the controller. 