### PR TITLE
Node-Repo: Always lock by application ID

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -402,15 +402,6 @@ public final class Node implements Nodelike {
                         exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount);
     }
 
-    /** Returns a new Node without an allocation. */
-    public Node withoutAllocation() {
-        return new Node(id, ipConfig, hostname, parentHostname, flavor, status, state,
-                        Optional.empty(), history, type, reports, modelName, reservedTo,
-                        exclusiveToApplicationId, exclusiveToClusterType, switchHostname, trustStoreItems,
-                        cloudAccount);
-    }
-
-
     /** Returns a copy of this node with IP config set to the given value. */
     public Node with(IP.Config ipConfig) {
         return new Node(id, ipConfig, hostname, parentHostname, flavor, status, state,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -118,7 +118,8 @@ public class NodeRepository extends AbstractComponent {
         this.db = new CuratorDatabaseClient(flavors, curator, clock, useCuratorClientCache, nodeCacheSize);
         this.zone = zone;
         this.clock = clock;
-        this.nodes = new Nodes(db, zone, clock, orchestrator);
+        this.applications = new Applications(db);
+        this.nodes = new Nodes(db, zone, clock, orchestrator, applications);
         this.flavors = flavors;
         this.resourcesCalculator = provisionServiceProvider.getHostResourcesCalculator();
         this.nameResolver = nameResolver;
@@ -128,7 +129,6 @@ public class NodeRepository extends AbstractComponent {
         this.containerImages = new ContainerImages(containerImage, tenantContainerImage);
         this.archiveUris = new ArchiveUris(db);
         this.jobControl = new JobControl(new JobControlFlags(db, flagSource));
-        this.applications = new Applications(db);
         this.loadBalancers = new LoadBalancers(db);
         this.metricsDb = metricsDb;
         this.orchestrator = orchestrator;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
@@ -8,6 +8,7 @@ import com.yahoo.transaction.Mutex;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.persistence.CuratorDatabaseClient;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,6 +61,16 @@ public class Applications {
 
     public void remove(ApplicationTransaction transaction) {
         db.deleteApplication(transaction);
+    }
+
+    /** Create a lock which provides exclusive rights to making changes to the given application */
+    public Mutex lock(ApplicationId application) {
+        return db.lock(application);
+    }
+
+    /** Create a lock with a timeout which provides exclusive rights to making changes to the given application */
+    public Mutex lock(ApplicationId application, Duration timeout) {
+        return db.lock(application, timeout);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainer.java
@@ -73,7 +73,7 @@ public class AutoscalingMaintainer extends NodeRepositoryMaintainer {
         // Lock and write if there are state updates and/or we should autoscale now
         if (advice.isPresent() && !cluster.get().targetResources().equals(advice.target()) ||
             (updatedCluster != cluster.get() || !advice.reason().equals(cluster.get().autoscalingStatus()))) {
-            try (var lock = nodeRepository().nodes().lock(applicationId)) {
+            try (var lock = nodeRepository().applications().lock(applicationId)) {
                 application = nodeRepository().applications().get(applicationId);
                 if (application.isEmpty()) return;
                 cluster = application.get().cluster(clusterId);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirer.java
@@ -23,18 +23,18 @@ import java.util.List;
  */
 public class DirtyExpirer extends Expirer {
 
-    private final boolean keepAllocationOnExpiry;
+    private final boolean wantToDeprovisionOnExpiry;
 
     DirtyExpirer(NodeRepository nodeRepository, Duration dirtyTimeout, Metric metric) {
         super(Node.State.dirty, History.Event.Type.deallocated, nodeRepository, dirtyTimeout, metric);
-        // Do not keep allocation in dynamically provisioned zones so that the hosts can be deprovisioned
-        this.keepAllocationOnExpiry = ! nodeRepository.zone().cloud().dynamicProvisioning();
+        // Deprovision hosts in dynamically provisioned on expiry
+        this.wantToDeprovisionOnExpiry = nodeRepository.zone().cloud().dynamicProvisioning();
     }
 
     @Override
     protected void expire(List<Node> expired) {
         for (Node expiredNode : expired)
-            nodeRepository().nodes().fail(expiredNode.hostname(), keepAllocationOnExpiry, Agent.DirtyExpirer, "Node is stuck in dirty");
+            nodeRepository().nodes().fail(expiredNode.hostname(), wantToDeprovisionOnExpiry, Agent.DirtyExpirer, "Node is stuck in dirty");
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainer.java
@@ -132,7 +132,7 @@ public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
         }
 
         excessHosts.forEach(host -> {
-            Optional<NodeMutex> optionalMutex = nodeRepository().nodes().lockAndGet(host, Optional.of(Duration.ofSeconds(10)));
+            Optional<NodeMutex> optionalMutex = nodeRepository().nodes().lockAndGet(host, Duration.ofSeconds(10));
             if (optionalMutex.isEmpty()) return;
             try (NodeMutex mutex = optionalMutex.get()) {
                 if (host.state() != mutex.node().state()) return;
@@ -156,7 +156,8 @@ public class DynamicProvisioningMaintainer extends NodeRepositoryMaintainer {
     private void replaceRootDisk(NodeList nodes) {
         NodeList softRebuildingHosts = nodes.rebuilding(true);
         for (var host : softRebuildingHosts) {
-            Optional<NodeMutex> optionalMutex = nodeRepository().nodes().lockAndGet(host, Optional.of(Duration.ofSeconds(10)));
+            Optional<NodeMutex> optionalMutex = nodeRepository().nodes().lockAndGet(host, Duration.ofSeconds(10));
+            if (optionalMutex.isEmpty()) return;
             try (NodeMutex mutex = optionalMutex.get()) {
                 // Re-check flag while holding lock
                 host = mutex.node();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/FailedExpirer.java
@@ -102,7 +102,7 @@ public class FailedExpirer extends NodeRepositoryMaintainer {
                                                         .mapToList(Node::hostname);
 
                 if (unparkedChildren.isEmpty()) {
-                    nodeRepository.nodes().park(candidate.hostname(), false, Agent.FailedExpirer,
+                    nodeRepository.nodes().park(candidate.hostname(), true, Agent.FailedExpirer,
                                                 "Parked by FailedExpirer due to hardware issue or high fail count");
                 } else {
                     log.info(String.format("Expired failed node %s with hardware issue was not parked because of " +

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -146,7 +146,11 @@ public class LoadBalancerExpirer extends NodeRepositoryMaintainer {
     }
 
     private List<Node> allocatedNodes(LoadBalancerId loadBalancer) {
-        return nodeRepository().nodes().list().owner(loadBalancer.application()).cluster(loadBalancer.cluster()).asList();
+        return nodeRepository().nodes()
+                .list(Node.State.active, Node.State.inactive, Node.State.reserved)
+                .owner(loadBalancer.application())
+                .cluster(loadBalancer.cluster())
+                .asList();
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -107,7 +107,7 @@ class MaintenanceDeployment implements Closeable {
         Duration timeout = Duration.ofSeconds(3);
         try {
             // Use a short lock to avoid interfering with change deployments
-            return Optional.of(nodeRepository.nodes().lock(application, timeout));
+            return Optional.of(nodeRepository.applications().lock(application, timeout));
         }
         catch (ApplicationLockException e) {
             log.log(Level.INFO, () -> "Could not lock " + application + " for maintenance deployment within " + timeout);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeHealthTracker.java
@@ -63,7 +63,7 @@ public class NodeHealthTracker extends NodeRepositoryMaintainer {
 
             // Lock and update status
             ApplicationId owner = node.get().allocation().get().owner();
-            try (var lock = nodeRepository().nodes().lock(owner)) {
+            try (var lock = nodeRepository().applications().lock(owner)) {
                 node = getNode(hostname.toString(), owner, lock); // Re-get inside lock
                 if (node.isEmpty()) return; // Node disappeared or changed allocation
                 attempts.add(1);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ScalingSuggestionsMaintainer.java
@@ -64,7 +64,7 @@ public class ScalingSuggestionsMaintainer extends NodeRepositoryMaintainer {
         var suggestion = autoscaler.suggest(application, cluster.get(), clusterNodes);
         if (suggestion.isEmpty()) return true;
         // Wait only a short time for the lock to avoid interfering with change deployments
-        try (Mutex lock = nodeRepository().nodes().lock(applicationId, Duration.ofSeconds(1))) {
+        try (Mutex lock = nodeRepository().applications().lock(applicationId, Duration.ofSeconds(1))) {
             // empty suggested resources == keep the current allocation, so we record that
             var suggestedResources = suggestion.target().orElse(clusterNodes.not().retired().toResources());
             applications().get(applicationId).ifPresent(a -> updateSuggestion(suggestedResources, clusterId, a, lock));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -98,7 +98,7 @@ public class GroupPreparer {
     /// Note that this will write to the node repo.
     private List<Node> prepareWithLocks(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes,
                                         List<Node> surplusActiveNodes, NodeIndices indices, int wantedGroups) {
-        try (Mutex lock = nodeRepository.nodes().lock(application);
+        try (Mutex lock = nodeRepository.applications().lock(application);
              Mutex allocationLock = nodeRepository.nodes().lockUnallocated()) {
             NodesAndHosts<LockedNodeList> allNodesAndHosts = NodesAndHosts.create(nodeRepository.nodes().list(allocationLock));
             NodeAllocation allocation = prepareAllocation(application, cluster, requestedNodes, surplusActiveNodes,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/InfraDeployerImpl.java
@@ -89,7 +89,7 @@ public class InfraDeployerImpl implements InfraDeployer {
         public void prepare() {
             if (prepared) return;
 
-            try (Mutex lock = nodeRepository.nodes().lock(application.getApplicationId())) {
+            try (Mutex lock = nodeRepository.applications().lock(application.getApplicationId())) {
                 NodeType nodeType = application.getCapacity().type();
                 Version targetVersion = infrastructureVersions.getTargetVersionFor(nodeType);
                 hostSpecs = provisioner.prepare(application.getApplicationId(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -139,7 +139,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
 
     @Override
     public ProvisionLock lock(ApplicationId application) {
-        return new ProvisionLock(application, nodeRepository.nodes().lock(application));
+        return new ProvisionLock(application, nodeRepository.applications().lock(application));
     }
 
     /**
@@ -147,7 +147,7 @@ public class NodeRepositoryProvisioner implements Provisioner {
      * and updates the application store with the received min and max.
      */
     private ClusterResources decideTargetResources(ApplicationId applicationId, ClusterSpec clusterSpec, Capacity requested) {
-        try (Mutex lock = nodeRepository.nodes().lock(applicationId)) {
+        try (Mutex lock = nodeRepository.applications().lock(applicationId)) {
             var application = nodeRepository.applications().get(applicationId).orElse(Application.empty(applicationId))
                               .withCluster(clusterSpec.id(), clusterSpec.isExclusive(), requested);
             nodeRepository.applications().put(application, lock);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationPatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationPatcher.java
@@ -35,7 +35,7 @@ public class ApplicationPatcher implements AutoCloseable {
             throw new UncheckedIOException("Error reading request body", e);
         }
         // Use same timeout for acquiring lock as client timeout for patch request
-        this.lock = nodeRepository.nodes().lock(applicationId, Duration.ofSeconds(30));
+        this.lock = nodeRepository.applications().lock(applicationId, Duration.ofSeconds(30));
         try {
             this.application = nodeRepository.applications().require(applicationId);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -179,7 +179,7 @@ public class MockNodeRepository extends NodeRepository {
                                                                              clock().instant())));
         cluster1 = cluster1.withTarget(Optional.of(new ClusterResources(4, 1,
                                                                         new NodeResources(3, 16, 100, 1))));
-        try (Mutex lock = nodes().lock(app1Id)) {
+        try (Mutex lock = applications().lock(app1Id)) {
             applications().put(app1.with(cluster1), lock);
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTest.java
@@ -40,7 +40,7 @@ public class NodeRepositoryTest {
         assertEquals(4, tester.nodeRepository().nodes().list().size());
 
         for (var hostname : List.of("host2", "cfghost1")) {
-            tester.nodeRepository().nodes().park(hostname, true, Agent.system, "Parking to unit test");
+            tester.nodeRepository().nodes().park(hostname, false, Agent.system, "Parking to unit test");
             tester.nodeRepository().nodes().removeRecursively(hostname);
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
@@ -113,7 +113,7 @@ public class Fixture {
         var application = application();
         application = application.with(application.status().withCurrentReadShare(currentReadShare)
                                                   .withMaxReadShare(maxReadShare));
-        tester.nodeRepository().applications().put(application, tester.nodeRepository().nodes().lock(applicationId));
+        tester.nodeRepository().applications().put(application, tester.nodeRepository().applications().lock(applicationId));
     }
 
     public static class Builder {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcherTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcherTest.java
@@ -81,7 +81,7 @@ public class MetricsV2MetricsFetcherTest {
 
         {
             httpClient.cannedResponse = cannedResponseForApplication2;
-            try (Mutex lock = tester.nodeRepository().nodes().lock(application1)) {
+            try (Mutex lock = tester.nodeRepository().applications().lock(application1)) {
                 tester.nodeRepository().nodes().write(tester.nodeRepository().nodes().list(Node.State.active).owner(application2)
                         .first().get().retire(tester.clock().instant()), lock);
             }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DirtyExpirerTest.java
@@ -62,7 +62,7 @@ public class DirtyExpirerTest {
         tester.clock().advance(expiryTimeout.plusSeconds(1));
         expirer.run();
         assertEquals(Node.State.failed, tester.nodeRepository().nodes().list().first().get().state());
-        assertEquals(dynamicProvisioning, tester.nodeRepository().nodes().list().first().get().allocation().isEmpty());
+        assertEquals(dynamicProvisioning, tester.nodeRepository().nodes().list().first().get().status().wantToDeprovision());
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
@@ -594,7 +594,7 @@ public class DynamicProvisioningMaintainerTest {
         assertEquals(Node.State.failed, tester.nodeRepository.nodes().node(host43.hostname()).get().state());
 
         // Last child is parked
-        tester.nodeRepository.nodes().park(host42.hostname(), true, Agent.system, getClass().getSimpleName());
+        tester.nodeRepository.nodes().park(host42.hostname(), false, Agent.system, getClass().getSimpleName());
 
         // Host and children can now be removed
         tester.maintainer.maintain();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/PeriodicApplicationMaintainerTest.java
@@ -66,7 +66,7 @@ public class PeriodicApplicationMaintainerTest {
         // Fail and park some nodes
         nodeRepository.nodes().fail(nodeRepository.nodes().list().owner(fixture.app1).asList().get(3).hostname(), Agent.system, "Failing to unit test");
         nodeRepository.nodes().fail(nodeRepository.nodes().list().owner(fixture.app2).asList().get(0).hostname(), Agent.system, "Failing to unit test");
-        nodeRepository.nodes().park(nodeRepository.nodes().list().owner(fixture.app2).asList().get(4).hostname(), true, Agent.system, "Parking to unit test");
+        nodeRepository.nodes().park(nodeRepository.nodes().list().owner(fixture.app2).asList().get(4).hostname(), false, Agent.system, "Parking to unit test");
         int failedInApp1 = 1;
         int failedOrParkedInApp2 = 2;
         assertEquals(fixture.wantedNodesApp1 - failedInApp1, nodeRepository.nodes().list(Node.State.active).owner(fixture.app1).size());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/os/OsVersionsTest.java
@@ -592,7 +592,7 @@ public class OsVersionsTest {
             Optional<Version> wantedOsVersion = node.status().osVersion().wanted();
             if (node.status().wantToDeprovision()) {
                 ApplicationId application = node.allocation().get().owner();
-                tester.nodeRepository().nodes().park(node.hostname(), false, Agent.system,
+                tester.nodeRepository().nodes().park(node.hostname(), true, Agent.system,
                                                      getClass().getSimpleName());
                 tester.nodeRepository().nodes().removeRecursively(node.hostname());
                 node = provisionInfraApplication(1, application, nodeType).get(0);
@@ -607,7 +607,7 @@ public class OsVersionsTest {
             Optional<Version> wantedOsVersion = node.status().osVersion().wanted();
             if (node.status().wantToRebuild()) {
                 ApplicationId application = node.allocation().get().owner();
-                tester.nodeRepository().nodes().park(node.hostname(), false, Agent.system,
+                tester.nodeRepository().nodes().park(node.hostname(), true, Agent.system,
                                                      getClass().getSimpleName());
                 tester.nodeRepository().nodes().removeRecursively(node.hostname());
                 Node newNode = Node.create(node.id(), node.ipConfig(), node.hostname(), node.flavor(), node.type())

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -165,10 +165,10 @@ public class ProvisioningTest {
         Set<Integer> state1Indexes = state1.allHosts.stream().map(hostSpec -> hostSpec.membership().get().index()).collect(Collectors.toSet());
 
         // deallocate 2 nodes with index 0
-        NodeMutex node1 = tester.nodeRepository().nodes().lockAndGet(tester.removeOne(state1.container0).hostname()).get();
-        NodeMutex node2 = tester.nodeRepository().nodes().lockAndGet(tester.removeOne(state1.content0).hostname()).get();
-        tester.nodeRepository().nodes().write(node1.node().withoutAllocation(), node1);
-        tester.nodeRepository().nodes().write(node2.node().withoutAllocation(), node1);
+        Node node1 = tester.nodeRepository().nodes().node(tester.removeOne(state1.container0).hostname()).get();
+        Node node2 = tester.nodeRepository().nodes().node(tester.removeOne(state1.content0).hostname()).get();
+        tester.nodeRepository().nodes().removeRecursively(node1, true);
+        tester.nodeRepository().nodes().removeRecursively(node2, true);
 
         // redeploy to get new nodes
         SystemState state2 = prepare(app1, 2, 2, 3, 3, defaultResources, tester);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -250,7 +250,7 @@ public class ProvisioningTester {
     }
 
     public void deactivate(ApplicationId applicationId) {
-        try (var lock = nodeRepository.nodes().lock(applicationId)) {
+        try (var lock = nodeRepository.applications().lock(applicationId)) {
             NestedTransaction deactivateTransaction = new NestedTransaction();
             nodeRepository.remove(new ApplicationTransaction(new ProvisionLock(applicationId, lock),
                                                              deactivateTransaction));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
@@ -599,7 +599,7 @@ public class VirtualNodeProvisioningTest {
         tester.activate(app1, cluster1, Capacity.from(new ClusterResources(5, 1, r)));
         tester.activate(app1, cluster1, Capacity.from(new ClusterResources(2, 1, r)));
 
-        var tx = new ApplicationTransaction(new ProvisionLock(app1, tester.nodeRepository().nodes().lock(app1)), new NestedTransaction());
+        var tx = new ApplicationTransaction(new ProvisionLock(app1, tester.nodeRepository().applications().lock(app1)), new NestedTransaction());
         tester.nodeRepository().nodes().deactivate(tester.nodeRepository().nodes().list(Node.State.active).owner(app1).retired().asList(), tx);
         tx.nested().commit();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationPatcherTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ApplicationPatcherTest.java
@@ -20,7 +20,7 @@ public class ApplicationPatcherTest {
     public void testPatching() {
         NodeRepositoryTester tester = new NodeRepositoryTester();
         Application application = Application.empty(ApplicationId.from("t1", "a1", "i1"));
-        tester.nodeRepository().applications().put(application, tester.nodeRepository().nodes().lock(application.id()));
+        tester.nodeRepository().applications().put(application, tester.nodeRepository().applications().lock(application.id()));
         String patch = "{ \"currentReadShare\" :0.4, \"maxReadShare\": 1.0 }";
         ApplicationPatcher patcher = new ApplicationPatcher(new ByteArrayInputStream(patch.getBytes()),
                                                             application.id(),


### PR DESCRIPTION
I've looked at the usage of all the locking methods that I could find in node-repo and created a graph of all paths where we take more than 1 lock concurrently:
![image](https://user-images.githubusercontent.com/3785505/198291857-b962df18-3336-40d8-8bee-e62e099b5915.png)

Red boxes are the application locks. Green is the "unallocated" lock, i.e. the lock we take when we want to modify a node that does not have any allocation, when we are allocating or doing anything that could affect allocation (e.g. adding/removing nodes). The cyan boxes are the `lock(Node)` methods which will take either the application or the unallocated lock depending on if the given node has `Allocation` set or not. Finally, yellow is the session lock in `configserver` module, probably not relevant for this.

Gradient that goes top-down means we first take the top colored lock, then while still holding it, the bottom colored lock. Gradient that goes sideways means first take the left colored lock, then release it, then take the right colored lock.

We have already eliminated the obvious deadlocks, but they still occasionally happen. The reason for that are the cyan boxes which may take either lock depending on the node allocation state, before taking the other locks.

This PR turns all the cyan boxes red:
* All infrastructure nodes will lock by their application ID, which we know ahead of time even if the node is not yet allocated.
* Tenant nodes will continue locking by the application in their `Allocation`, but we will no longer ever remove `Allocation` from a node. Since nodes are created with an `Allocation`, that means that all tenant nodes should effectively always have it (though actually enforcing it will require rewriting many unit tests :cry: )