### PR TITLE
Better error handling if both schemas/ and searchdefinitions/ exist [run-systemtest]

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -841,15 +841,24 @@ public class SessionRepository {
         File schemasDir = applicationDir.resolve(ApplicationPackage.SCHEMAS_DIR.getRelative()).toFile();
         File sdDir = applicationDir.resolve(ApplicationPackage.SEARCH_DEFINITIONS_DIR.getRelative()).toFile();
         if (sdDir.exists() && sdDir.isDirectory()) {
-            File[] sdFiles = sdDir.listFiles();
-            if (sdFiles != null) {
-                Files.createDirectories(schemasDir.toPath());
-                Arrays.asList(sdFiles).forEach(file -> Exceptions.uncheck(
-                        () -> Files.move(file.toPath(),
-                                         schemasDir.toPath().resolve(file.toPath().getFileName()),
-                                         StandardCopyOption.REPLACE_EXISTING)));
+            try {
+                File[] sdFiles = sdDir.listFiles();
+                if (sdFiles != null) {
+                    Files.createDirectories(schemasDir.toPath());
+                    Arrays.asList(sdFiles).forEach(file -> Exceptions.uncheck(
+                            () -> Files.move(file.toPath(),
+                                             schemasDir.toPath().resolve(file.toPath().getFileName()),
+                                             StandardCopyOption.REPLACE_EXISTING)));
+                }
+                Files.delete(sdDir.toPath());
+            } catch (IOException | UncheckedIOException e) {
+                if (schemasDir.exists() && schemasDir.isDirectory())
+                    throw new InvalidApplicationException(
+                            "Both " + ApplicationPackage.SCHEMAS_DIR.getRelative() + " and " + ApplicationPackage.SEARCH_DEFINITIONS_DIR +
+                                    " exists in application package, please remove " + ApplicationPackage.SEARCH_DEFINITIONS_DIR, e);
+                else
+                    throw e;
             }
-            Files.delete(sdDir.toPath());
         }
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -854,8 +854,8 @@ public class SessionRepository {
             } catch (IOException | UncheckedIOException e) {
                 if (schemasDir.exists() && schemasDir.isDirectory())
                     throw new InvalidApplicationException(
-                            "Both " + ApplicationPackage.SCHEMAS_DIR.getRelative() + " and " + ApplicationPackage.SEARCH_DEFINITIONS_DIR +
-                                    " exists in application package, please remove " + ApplicationPackage.SEARCH_DEFINITIONS_DIR, e);
+                            "Both " + ApplicationPackage.SCHEMAS_DIR.getRelative() + "/ and " + ApplicationPackage.SEARCH_DEFINITIONS_DIR +
+                                    "/ exist in application package, please remove " + ApplicationPackage.SEARCH_DEFINITIONS_DIR + "/", e);
                 else
                     throw e;
             }


### PR DESCRIPTION
If something fails when having both directories, throw an InvalidApplicationException with an explanation about what to do

Since we just rethrow the exception this should not change behavior (e.g. when bootstrapping config servers), only what feedback the customer gets.