### PR TITLE
Support standard IO streams for several encryption tool commands

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
@@ -27,7 +27,7 @@ public class CliUtils {
             return stdIn;
         } else {
             var inputPath = Paths.get(pathOrDash);
-            if (!inputPath.toFile().exists()) {
+            if (!Files.exists(inputPath)) {
                 throw new IllegalArgumentException("Input file '%s' does not exist".formatted(inputPath.toString()));
             }
             return Files.newInputStream(inputPath);

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/CliUtils.java
@@ -3,6 +3,12 @@ package com.yahoo.vespa.security.tool;
 
 import org.apache.commons.cli.CommandLine;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * @author vekterli
  */
@@ -14,6 +20,27 @@ public class CliUtils {
             throw new IllegalArgumentException("Required argument '--%s' must be provided".formatted(option));
         }
         return value;
+    }
+
+    public static InputStream inputStreamFromFileOrStream(String pathOrDash, InputStream stdIn) throws IOException {
+        if ("-".equals(pathOrDash)) {
+            return stdIn;
+        } else {
+            var inputPath = Paths.get(pathOrDash);
+            if (!inputPath.toFile().exists()) {
+                throw new IllegalArgumentException("Input file '%s' does not exist".formatted(inputPath.toString()));
+            }
+            return Files.newInputStream(inputPath);
+        }
+    }
+
+    public static OutputStream outputStreamToFileOrStream(String pathOrDash, OutputStream stdOut) throws IOException {
+        if ("-".equals(pathOrDash)) {
+            return stdOut;
+        } else {
+            // TODO fail if file already exists?
+            return Files.newOutputStream(Paths.get(pathOrDash));
+        }
     }
 
 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/Main.java
@@ -10,6 +10,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
@@ -26,16 +27,18 @@ import java.util.Optional;
  */
 public class Main {
 
+    private final InputStream stdIn;
     private final PrintStream stdOut;
     private final PrintStream stdError;
 
-    Main(PrintStream stdOut, PrintStream stdError) {
+    Main(InputStream stdIn, PrintStream stdOut, PrintStream stdError) {
+        this.stdIn = stdIn;
         this.stdOut = stdOut;
         this.stdError = stdError;
     }
 
     public static void main(String[] args) {
-        var program = new Main(System.out, System.err);
+        var program = new Main(System.in, System.out, System.err);
         int returnCode = program.execute(args, System.getenv());
         System.exit(returnCode);
     }
@@ -82,7 +85,7 @@ public class Main {
                 CliOptions.printToolSpecificHelp(stdOut, tool.name(), toolDesc, cliOpts);
                 return 0;
             }
-            var invocation = new ToolInvocation(cmdLine, envVars, stdOut, stdError, debugMode);
+            var invocation = new ToolInvocation(cmdLine, envVars, stdIn, stdOut, stdError, debugMode);
             return tool.invoke(invocation);
         } catch (ParseException e) {
             return handleException("Failed to parse command line arguments: " + e.getMessage(), e, debugMode);

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/ToolInvocation.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/ToolInvocation.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.security.tool;
 
 import org.apache.commons.cli.CommandLine;
 
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Map;
 
@@ -11,6 +12,7 @@ import java.util.Map;
  */
 public record ToolInvocation(CommandLine arguments,
                              Map<String, String> envVars,
+                             InputStream stdIn,
                              PrintStream stdOut,
                              PrintStream stdError,
                              boolean debugMode) {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
@@ -4,8 +4,8 @@ package com.yahoo.vespa.security.tool.crypto;
 import javax.crypto.Cipher;
 import javax.crypto.CipherOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * @author vekterli
@@ -13,23 +13,18 @@ import java.nio.file.Path;
 public class CipherUtils {
 
     /**
-     * Streams the contents of fromPath into toPath after being wrapped by the input cipher.
-     * Depending on the Cipher mode, this either encrypts a plaintext file into ciphertext,
-     * or decrypts a ciphertext file into plaintext.
+     * Streams the contents of an input stream into an output stream after being wrapped by the input cipher.
+     * Depending on the Cipher mode, this either encrypts a plaintext stream into ciphertext,
+     * or decrypts a ciphertext stream into plaintext.
      *
-     * @param fromPath source file path to read from
-     * @param toPath destination file path to write to
+     * @param input source stream to read from
+     * @param output destination stream to write to
      * @param cipher a Cipher in either ENCRYPT or DECRYPT mode
      * @throws IOException if any file operation fails
      */
-    public static void streamEncipherFileContents(Path fromPath, Path toPath, Cipher cipher) throws IOException {
-        if (fromPath.equals(toPath)) {
-            throw new IllegalArgumentException("Can't use same file as both input and output for enciphering");
-        }
-        try (var inStream     = Files.newInputStream(fromPath);
-             var outStream    = Files.newOutputStream(toPath);
-             var cipherStream = new CipherOutputStream(outStream, cipher)) {
-            inStream.transferTo(cipherStream);
+    public static void streamEncipher(InputStream input, OutputStream output, Cipher cipher) throws IOException {
+        try (var cipherStream = new CipherOutputStream(output, cipher)) {
+            input.transferTo(cipherStream);
             cipherStream.flush();
         }
     }

--- a/vespaclient-java/src/test/java/com/yahoo/vespa/security/tool/CryptoToolsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespa/security/tool/CryptoToolsTest.java
@@ -230,8 +230,8 @@ public class CryptoToolsTest {
         assertEquals("", procOut.stdOut());
         assertEquals("", procOut.stdErr());
 
-        assertTrue(privPath.toFile().exists());
-        assertTrue(pubPath.toFile().exists());
+        assertTrue(Files.exists(privPath));
+        assertTrue(Files.exists(pubPath));
 
         var encryptedPath = pathInTemp("encrypted.bin");
         // TODO support (and test) public key via file
@@ -247,7 +247,7 @@ public class CryptoToolsTest {
         var token = procOut.stdOut();
         assertFalse(token.isBlank());
 
-        assertTrue(encryptedPath.toFile().exists());
+        assertTrue(Files.exists(encryptedPath));
 
         var decryptedPath = pathInTemp("decrypted.txt");
         procOut = runMain(List.of(
@@ -279,8 +279,8 @@ public class CryptoToolsTest {
         assertEquals("", procOut.stdOut());
         assertEquals("", procOut.stdErr());
 
-        assertTrue(privPath.toFile().exists());
-        assertTrue(pubPath.toFile().exists());
+        assertTrue(Files.exists(privPath));
+        assertTrue(Files.exists(pubPath));
 
         var encryptedPath = pathInTemp("encrypted.bin");
         // Encryption emits token on stdout, so can't support ciphertext output via that channel.
@@ -297,7 +297,7 @@ public class CryptoToolsTest {
         var token = procOut.stdOut();
         assertFalse(token.isBlank());
 
-        assertTrue(encryptedPath.toFile().exists());
+        assertTrue(Files.exists(encryptedPath));
 
         procOut = runMain(List.of(
                 "decrypt",

--- a/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
@@ -2,6 +2,9 @@ usage: vespa-security decrypt <encrypted file> <options>
 Decrypts a file using a provided token and a secret private key. The file
 must previously have been encrypted using the public key component of the
 given private key.
+
+To decrypt the contents of STDIN, specify an input file of '-' (without
+the quotes).
  -h,--help                               Show help
  -i,--key-id <arg>                       Numeric ID of recipient key. If
                                          this is not provided, the key ID
@@ -9,7 +12,9 @@ given private key.
                                          not verified.
  -k,--recipient-private-key-file <arg>   Recipient private key file
  -o,--output-file <arg>                  Output file for decrypted
-                                         plaintext
+                                         plaintext. Specify '-' (without
+                                         the quotes) to write plaintext to
+                                         STDOUT instead of a file.
  -t,--token <arg>                        Token generated when the input
                                          file was encrypted
 Note: this is a BETA tool version; its interface may be changed at any

--- a/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
@@ -3,6 +3,9 @@ One-way encrypts a file using the public key of a recipient. A public
 token is printed on standard out. The recipient can use this token to
 decrypt the file using their private key. The token does not have to be
 kept secret.
+
+To encrypt the contents of STDIN, specify an input file of '-' (without
+the quotes).
  -h,--help                         Show help
  -i,--key-id <arg>                 Numeric ID of recipient key
  -o,--output-file <arg>            Output file (will be truncated if it


### PR DESCRIPTION
@bjorncs please review

Useful for avoiding the need for intermediate files, such as when piping the output of decryption to a Zstd decompressor.

Adds stdio support to:
 * Encryption input (can't add to output since token is printed verbatim to stdout already)
 * Decryption input
 * Decryption output

Specified by substituting the file name with a single `-` character.