### PR TITLE
Go back to previous variant of default node resources for content clu…

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -96,12 +96,13 @@ public class CapacityPolicies {
         }
 
         if (clusterSpec.type() == ClusterSpec.Type.content) {
-            // TODO: Simplify when no application is on an older version than 8.75
+            // TODO: Simplify when no application is on an older version than 8.78
             return zone.cloud().dynamicProvisioning()
                    ? versioned(clusterSpec, Map.of(new Version(0), new NodeResources(2.0, 8, 50, 0.3),
                                                    new Version(8, 75), new NodeResources(2, 16, 300, 0.3)))
                    : versioned(clusterSpec, Map.of(new Version(0), new NodeResources(1.5, 8, 50, 0.3),
-                                                   new Version(8, 75), new NodeResources(2, 16, 300, 0.3)));
+                                                   new Version(8, 75), new NodeResources(2, 16, 300, 0.3),
+                                                   new Version(8, 78), new NodeResources(1.5, 8, 50, 0.3)));
         }
         else {
             return zone.cloud().dynamicProvisioning()


### PR DESCRIPTION
…sters on-prem.

We don't have HW capacity on-prem to use 300 Gb disk (and probably not 16 Gb memory either), so go back to what we had before version 8.75