### PR TITLE
Add a trace if the global filter matches everything.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -293,9 +293,12 @@ Query::handle_global_filter(Blueprint& blueprint, uint32_t docid_limit,
                                                      estimated_hit_ratio, global_filter_upper_limit));
         }
         global_filter = GlobalFilter::create(blueprint, docid_limit, thread_bundle);
+        if (!global_filter->is_active() && trace && trace->shouldTrace(5)) {
+            trace->addEvent(5, "Global filter matches everything");
+        }
     } else {
         if (trace && trace->shouldTrace(5)) {
-            trace->addEvent(5, vespalib::make_string("Create match all global filter (estimated_hit_ratio (%f) > upper_limit (%f))",
+            trace->addEvent(5, vespalib::make_string("Create match everything global filter (estimated_hit_ratio (%f) > upper_limit (%f))",
                                                      estimated_hit_ratio, global_filter_upper_limit));
         }
         global_filter = GlobalFilter::create();


### PR DESCRIPTION
This case enables an optimization to search the HNSW index without using the filter at all.

@havardpe please review