### PR TITLE
Jonmv/more synch in config sub unit test

### DIFF
--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
@@ -5,6 +5,7 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.vespa.config.ConfigKey;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Config source as a programmatically built set of {@link com.yahoo.config.ConfigInstance}s
@@ -14,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ConfigSet implements ConfigSource {
 
     private final Map<ConfigKey<?>, ConfigInstance.Builder> configs = new ConcurrentHashMap<>();
-    private long generation = 1;
+    private final AtomicLong generation = new AtomicLong(1);
 
     /**
      * Inserts a new builder in this set. If an existing entry exists, it is overwritten.
@@ -30,7 +31,7 @@ public class ConfigSet implements ConfigSource {
     }
 
     public void incrementGeneration() {
-        ++generation;
+        generation.incrementAndGet();
     }
 
     /**
@@ -53,7 +54,7 @@ public class ConfigSet implements ConfigSource {
         return configs.containsKey(key);
     }
 
-    public long generation() { return generation; }
+    public long generation() { return generation.get(); }
 
     @Override
     public String toString() {

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Vegard Havdal
  */
 public class ConfigSet implements ConfigSource {
+
     private final Map<ConfigKey<?>, ConfigInstance.Builder> configs = new ConcurrentHashMap<>();
 
     /**
@@ -23,7 +24,6 @@ public class ConfigSet implements ConfigSource {
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void addBuilder(String configId, ConfigInstance.Builder builder) {
         Class<?> configClass = builder.getClass().getDeclaringClass();
-        //System.out.println("Declaring class for builder " + builder + " is " + configClass);
         ConfigKey<?> key = new ConfigKey(configClass, configId);
         configs.put(key, builder);
     }
@@ -56,4 +56,5 @@ public class ConfigSet implements ConfigSource {
         }
         return sb.toString();
     }
+
 }

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSet.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ConfigSet implements ConfigSource {
 
     private final Map<ConfigKey<?>, ConfigInstance.Builder> configs = new ConcurrentHashMap<>();
+    private long generation = 1;
 
     /**
      * Inserts a new builder in this set. If an existing entry exists, it is overwritten.
@@ -26,6 +27,10 @@ public class ConfigSet implements ConfigSource {
         Class<?> configClass = builder.getClass().getDeclaringClass();
         ConfigKey<?> key = new ConfigKey(configClass, configId);
         configs.put(key, builder);
+    }
+
+    public void incrementGeneration() {
+        ++generation;
     }
 
     /**
@@ -47,6 +52,8 @@ public class ConfigSet implements ConfigSource {
     public boolean contains(ConfigKey<?> key) {
         return configs.containsKey(key);
     }
+
+    public long generation() { return generation; }
 
     @Override
     public String toString() {

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSourceSet.java
@@ -58,7 +58,7 @@ public class ConfigSourceSet implements ConfigSource {
      * @param address  Connection endpoint on the format "tcp/host:port".
      */
     public ConfigSourceSet(String address) {
-        this(new String[] {address});
+        this(new String[] { address });
     }
 
     /**

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -407,15 +407,6 @@ public class ConfigSubscriber implements AutoCloseable {
         }
     }
 
-    /**
-     * The source used by this subscriber.
-     *
-     * @return the {@link ConfigSource} used by this subscriber
-     */
-    public ConfigSource getSource() {
-        return source;
-    }
-
     public boolean isClosed() {
         synchronized (monitor) {
             return state == State.CLOSED;

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigSubscriber.java
@@ -395,18 +395,6 @@ public class ConfigSubscriber implements AutoCloseable {
         }
     }
 
-    /**
-     * Sets all subscriptions under this subscriber to have the given generation. This is intended for testing, to emulate a
-     * reload-config operation.
-     *
-     * @param generation a generation number
-     */
-    public void reload(long generation) {
-        for (ConfigHandle<?> h : subscriptionHandles) {
-            h.subscription().reload(generation);
-        }
-    }
-
     public boolean isClosed() {
         synchronized (monitor) {
             return state == State.CLOSED;

--- a/config/src/main/java/com/yahoo/config/subscription/ConfigURI.java
+++ b/config/src/main/java/com/yahoo/config/subscription/ConfigURI.java
@@ -12,8 +12,8 @@ import java.io.File;
  */
 public class ConfigURI {
 
-    private String configId;
-    private ConfigSource source;
+    private final String configId;
+    private final ConfigSource source;
 
     private ConfigURI(String configId, ConfigSource source) {
         this.configId = configId;

--- a/config/src/main/java/com/yahoo/config/subscription/DirSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/DirSource.java
@@ -5,18 +5,20 @@ import java.io.File;
 
 /**
  * Source specifying config from a local directory
+ *
  * @author Vegard Havdal
  */
 public class DirSource implements ConfigSource {
+
     private final File dir;
 
     public DirSource(File dir) {
-        if (!dir.isDirectory()) throw new IllegalArgumentException("Not a directory: "+dir);
+        if ( ! dir.isDirectory()) throw new IllegalArgumentException("Not a directory: " + dir);
         this.dir = dir;
     }
 
-    public File getDir() {
-        return dir;
+    public File get(String name) {
+        return new File(dir, name);
     }
 
 }

--- a/config/src/main/java/com/yahoo/config/subscription/DirSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/DirSource.java
@@ -17,8 +17,8 @@ public class DirSource implements ConfigSource {
         this.dir = dir;
     }
 
-    public File get(String name) {
-        return new File(dir, name);
+    public FileSource get(String name) {
+        return new FileSource(new File(dir, name));
     }
 
 }

--- a/config/src/main/java/com/yahoo/config/subscription/FileSource.java
+++ b/config/src/main/java/com/yahoo/config/subscription/FileSource.java
@@ -11,14 +11,22 @@ import java.io.File;
 public class FileSource implements ConfigSource {
 
     private final File file;
+    private long generation;
+    private long timestamp;
 
     public FileSource(File file) {
-        if ( ! file.isFile()) throw new IllegalArgumentException("Not an ordinary file: "+file);
+        if ( ! file.isFile()) throw new IllegalArgumentException("Not an ordinary file: " + file);
         this.file = file;
+        this.timestamp = file.lastModified();
+        this.generation = 1;
     }
 
     public File getFile() {
         return file;
+    }
+
+    public long generation() {
+        return timestamp != (timestamp = file.lastModified()) ? ++generation : generation;
     }
 
 }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
@@ -18,11 +18,10 @@ public class ConfigSetSubscription<T extends ConfigInstance> extends ConfigSubsc
     private final ConfigSet set;
     private final ConfigKey<T> subKey;
 
-    ConfigSetSubscription(ConfigKey<T> key, ConfigSource cset) {
+    ConfigSetSubscription(ConfigKey<T> key, ConfigSet cset) {
         super(key);
-        if (!(cset instanceof ConfigSet)) throw new IllegalArgumentException("Source is not a ConfigSet: " + cset);
-        this.set = (ConfigSet) cset;
-        subKey = new ConfigKey<>(configClass, key.getConfigId());
+        this.set = cset;
+        this.subKey = new ConfigKey<>(configClass, key.getConfigId());
         if (!set.contains(subKey)) {
             throw new IllegalArgumentException("The given ConfigSet " + set + " does not contain a config for " + subKey);
         }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSetSubscription.java
@@ -29,9 +29,10 @@ public class ConfigSetSubscription<T extends ConfigInstance> extends ConfigSubsc
     }
 
     private boolean hasConfigChanged() {
-        T myInstance = getNewInstance();
         if (generation != (generation = set.generation())) {
-            setConfigAndGeneration(generation, false, myInstance, PayloadChecksums.empty());
+            T myInstance = getNewInstance();
+            if ( ! myInstance.equals(getConfigState().getConfig())) setConfig(generation, false, myInstance, PayloadChecksums.empty());
+            else setConfigAndGeneration(generation, false, myInstance, PayloadChecksums.empty());
             return true;
         }
         return false;

--- a/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/ConfigSubscription.java
@@ -121,7 +121,7 @@ public abstract class ConfigSubscription<T extends ConfigInstance> {
         if (source instanceof FileSource || configId.startsWith("file:")) return getFileSub(key, source);
         if (source instanceof DirSource || configId.startsWith("dir:")) return getDirFileSub(key, source);
         if (source instanceof JarSource || configId.startsWith("jar:")) return getJarSub(key, source);
-        if (source instanceof ConfigSet) return new ConfigSetSubscription<>(key, source);
+        if (source instanceof ConfigSet cset) return new ConfigSetSubscription<>(key, cset);
         if (source instanceof ConfigSourceSet) {
             JRTConfigRequester requester = requesters.getRequester((ConfigSourceSet) source, timingValues);
             return new JRTConfigSubscription<>(key, requester, timingValues);
@@ -132,13 +132,12 @@ public abstract class ConfigSubscription<T extends ConfigInstance> {
     private static <T extends ConfigInstance> JarConfigSubscription<T> getJarSub(ConfigKey<T> key, ConfigSource source) {
         String jarName;
         String path = "config/";
-        if (source instanceof JarSource) {
-            JarSource js = (JarSource) source;
+        if (source instanceof JarSource js) {
             jarName = js.getJarFile().getName();
             if (js.getPath() != null) path = js.getPath();
         } else {
-            jarName = key.getConfigId().replace("jar:", "").replaceFirst("\\!/.*", "");
-            if (key.getConfigId().contains("!/")) path = key.getConfigId().replaceFirst(".*\\!/", "");
+            jarName = key.getConfigId().replace("jar:", "").replaceFirst("!/.*", "");
+            if (key.getConfigId().contains("!/")) path = key.getConfigId().replaceFirst(".*!/", "");
         }
         return new JarConfigSubscription<>(key, jarName, path);
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -187,11 +187,6 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
         return requester;
     }
 
-    @Override
-    public void reload(long generation) {
-        log.log(FINE, "reload() is without effect on a JRTConfigSubscription.");
-    }
-
     void setLastCallBackOKTS(Instant lastCallBackOKTS) {
         this.lastOK = lastCallBackOKTS;
     }

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JRTConfigSubscription.java
@@ -17,7 +17,6 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import static com.yahoo.vespa.config.PayloadChecksum.Type.MD5;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 
@@ -86,7 +85,7 @@ public class JRTConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
         // These flags may have been left true from a previous call, since ConfigSubscriber's nextConfig
         // not necessarily returned true and reset the flags then
         ConfigState<T> configState = getConfigState();
-        return configState.isGenerationChanged() || configState.isConfigChanged() || hasException();
+        return configState.hasGenerationChanged() || configState.hasConfigChanged() || hasException();
     }
 
     /**

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
@@ -40,8 +40,7 @@ public class JarConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     @Override
     public boolean nextConfig(long timeout) {
         if (checkReloaded()) {
-            // Not supporting changing the payload for jar
-            return true;
+            throw new UnsupportedOperationException();
         }
         if (zipEntry == null) {
             // First time polled

--- a/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/JarConfigSubscription.java
@@ -39,9 +39,6 @@ public class JarConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
 
     @Override
     public boolean nextConfig(long timeout) {
-        if (checkReloaded()) {
-            throw new UnsupportedOperationException();
-        }
         if (zipEntry == null) {
             // First time polled
             JarFile jarFile;

--- a/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
@@ -29,9 +29,6 @@ public class RawConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
 
     @Override
     public boolean nextConfig(long timeout) {
-        if (checkReloaded()) {
-            throw new UnsupportedOperationException();
-        }
         if (payload == null) {
             payload = inputPayload;
             ConfigPayload configPayload = new CfgConfigPayloadBuilder().deserialize(Arrays.asList(payload.split("\n")));

--- a/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
+++ b/config/src/main/java/com/yahoo/config/subscription/impl/RawConfigSubscription.java
@@ -30,7 +30,7 @@ public class RawConfigSubscription<T extends ConfigInstance> extends ConfigSubsc
     @Override
     public boolean nextConfig(long timeout) {
         if (checkReloaded()) {
-            return true;
+            throw new UnsupportedOperationException();
         }
         if (payload == null) {
             payload = inputPayload;

--- a/config/src/main/java/com/yahoo/config/subscription/package-info.java
+++ b/config/src/main/java/com/yahoo/config/subscription/package-info.java
@@ -1,8 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+/** Classes for subscribing to Vespa config. */
 @ExportPackage
-/**
- * Classes for subscribing to Vespa config.
- */
 package com.yahoo.config.subscription;
 
 import com.yahoo.osgi.annotation.ExportPackage;

--- a/config/src/main/java/com/yahoo/vespa/config/TimingValues.java
+++ b/config/src/main/java/com/yahoo/vespa/config/TimingValues.java
@@ -9,6 +9,7 @@ import java.util.Random;
  * @author Gunnar Gauslaa Bergem
  */
 public class TimingValues {
+
     public static final long defaultNextConfigTimeout = 1000;
     // See getters below for an explanation of how these values are used and interpreted
     // All time values in milliseconds.
@@ -131,6 +132,5 @@ public class TimingValues {
                + ", fixedDelay=" + fixedDelay
                + ", rand=" + rand + "]";
     }
-
 
 }

--- a/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
@@ -92,6 +92,7 @@ public class ConfigSetSubscriptionTest {
         a0builder.message("A new message, 0").times(880);
         a1builder.message("A new message, 1").times(890);
         barBuilder.stringVal("new StringVal");
+        myConfigs.incrementGeneration();
         assertTrue(subscriber.nextConfig(0, false));
         assertTrue(hA0.isChanged());
         assertTrue(hA1.isChanged());
@@ -105,7 +106,7 @@ public class ConfigSetSubscriptionTest {
 
         // Reconfigure only one
         a0builder.message("Another new message, 0").times(8800);
-        subscriber.reload(2);
+        myConfigs.incrementGeneration();
         assertTrue(subscriber.nextConfig(0, false));
         assertTrue(hA0.isChanged());
         assertFalse(hA1.isChanged());
@@ -119,7 +120,7 @@ public class ConfigSetSubscriptionTest {
 
         //Reconfigure only one, and only one field on the builder
         a1builder.message("Yet another message, 1");
-        subscriber.reload(3);
+        myConfigs.incrementGeneration();
         assertTrue(subscriber.nextConfig(0, false));
         assertFalse(hA0.isChanged());
         assertTrue(hA1.isChanged());
@@ -151,9 +152,9 @@ public class ConfigSetSubscriptionTest {
 
         //Reconfigure two times in a row
         a0builder.message("A new message, 2");
-        subscriber.reload(1);
+        myConfigs.incrementGeneration();
         a0builder.message("An even newer message, 3");
-        subscriber.reload(2);
+        myConfigs.incrementGeneration();
 
         // Should pick up the last one
         assertTrue(subscriber.nextConfig(0, false));

--- a/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/ConfigSetSubscriptionTest.java
@@ -92,7 +92,6 @@ public class ConfigSetSubscriptionTest {
         a0builder.message("A new message, 0").times(880);
         a1builder.message("A new message, 1").times(890);
         barBuilder.stringVal("new StringVal");
-        subscriber.reload(1);
         assertTrue(subscriber.nextConfig(0, false));
         assertTrue(hA0.isChanged());
         assertTrue(hA1.isChanged());

--- a/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
@@ -2,6 +2,7 @@
 package com.yahoo.config.subscription.impl;
 
 import com.yahoo.config.subscription.DirSource;
+import com.yahoo.config.subscription.FileSource;
 import com.yahoo.foo.SimpletypesConfig;
 import com.yahoo.foo.TestReferenceConfig;
 import com.yahoo.vespa.config.ConfigKey;
@@ -42,7 +43,7 @@ public class FileConfigSubscriptionTest {
         writeConfig("intval", "23");
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                TEST_TYPES_FILE);
+                new FileSource(TEST_TYPES_FILE));
         assertTrue(sub.nextConfig(1000));
         assertEquals(23, sub.getConfigState().getConfig().intval());
         Thread.sleep(1000);
@@ -56,7 +57,7 @@ public class FileConfigSubscriptionTest {
         writeConfig("intval", "23");
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                TEST_TYPES_FILE);
+                new FileSource(TEST_TYPES_FILE));
         assertTrue(sub.nextConfig(1000));
         assertEquals(23, sub.getConfigState().getConfig().intval());
         writeConfig("intval", "33");
@@ -64,31 +65,31 @@ public class FileConfigSubscriptionTest {
         assertTrue(sub.nextConfig(1000));
         ConfigSubscription.ConfigState<SimpletypesConfig> configState = sub.getConfigState();
         assertEquals(33, configState.getConfig().intval());
-        assertTrue(configState.isConfigChanged());
-        assertTrue(configState.isGenerationChanged());
+        assertTrue(configState.hasConfigChanged());
+        assertTrue(configState.hasGenerationChanged());
 
         assertTrue(sub.isConfigChangedAndReset(7L));
         assertSame(configState, sub.getConfigState());
-        assertTrue(configState.isConfigChanged());
-        assertTrue(configState.isGenerationChanged());
+        assertTrue(configState.hasConfigChanged());
+        assertTrue(configState.hasGenerationChanged());
         assertTrue(sub.isConfigChangedAndReset(1L));
         assertNotSame(configState, sub.getConfigState());
         configState = sub.getConfigState();
-        assertFalse(configState.isConfigChanged());
-        assertFalse(configState.isGenerationChanged());
+        assertFalse(configState.hasConfigChanged());
+        assertFalse(configState.hasGenerationChanged());
 
         sub.reload(2);
         assertTrue(sub.nextConfig(1000));
         configState = sub.getConfigState();
         assertEquals(33, configState.getConfig().intval());
-        assertFalse(configState.isConfigChanged());
-        assertTrue(configState.isGenerationChanged());
+        assertFalse(configState.hasConfigChanged());
+        assertTrue(configState.hasGenerationChanged());
 
         assertFalse(sub.isConfigChangedAndReset(2L));
         assertNotSame(configState, sub.getConfigState());
         configState = sub.getConfigState();
-        assertFalse(configState.isConfigChanged());
-        assertFalse(configState.isGenerationChanged());
+        assertFalse(configState.hasConfigChanged());
+        assertFalse(configState.hasGenerationChanged());
     }
 
     @Test
@@ -110,9 +111,9 @@ public class FileConfigSubscriptionTest {
         writeConfig("intval", "23");
         ConfigSubscription<SimpletypesConfig> sub = new FileConfigSubscription<>(
                 new ConfigKey<>(SimpletypesConfig.class, ""),
-                TEST_TYPES_FILE);
-        sub.reload(1);
+                new FileSource(TEST_TYPES_FILE));
         Files.delete(TEST_TYPES_FILE.toPath()); // delete file so the below statement throws exception
         sub.nextConfig(0);
     }
+
 }

--- a/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
+++ b/config/src/test/java/com/yahoo/config/subscription/impl/FileConfigSubscriptionTest.java
@@ -25,7 +25,9 @@ import static org.junit.Assert.assertTrue;
  * @author Ulf Lilleengen
  */
 public class FileConfigSubscriptionTest {
+
     private File TEST_TYPES_FILE;
+    private long timestamp = System.currentTimeMillis();
 
     @Before
     public void setUp() throws IOException {
@@ -36,6 +38,11 @@ public class FileConfigSubscriptionTest {
         FileWriter writer = new FileWriter(TEST_TYPES_FILE);
         writer.write(field + " " + value);
         writer.close();
+        incrementTimestamp();
+    }
+
+    private void incrementTimestamp() {
+        TEST_TYPES_FILE.setLastModified(timestamp += 1000);
     }
 
     @Test
@@ -61,7 +68,6 @@ public class FileConfigSubscriptionTest {
         assertTrue(sub.nextConfig(1000));
         assertEquals(23, sub.getConfigState().getConfig().intval());
         writeConfig("intval", "33");
-        sub.reload(1);
         assertTrue(sub.nextConfig(1000));
         ConfigSubscription.ConfigState<SimpletypesConfig> configState = sub.getConfigState();
         assertEquals(33, configState.getConfig().intval());
@@ -72,20 +78,20 @@ public class FileConfigSubscriptionTest {
         assertSame(configState, sub.getConfigState());
         assertTrue(configState.hasConfigChanged());
         assertTrue(configState.hasGenerationChanged());
-        assertTrue(sub.isConfigChangedAndReset(1L));
+        assertTrue(sub.isConfigChangedAndReset(2L));
         assertNotSame(configState, sub.getConfigState());
         configState = sub.getConfigState();
         assertFalse(configState.hasConfigChanged());
         assertFalse(configState.hasGenerationChanged());
 
-        sub.reload(2);
+        incrementTimestamp();
         assertTrue(sub.nextConfig(1000));
         configState = sub.getConfigState();
         assertEquals(33, configState.getConfig().intval());
         assertFalse(configState.hasConfigChanged());
         assertTrue(configState.hasGenerationChanged());
 
-        assertFalse(sub.isConfigChangedAndReset(2L));
+        assertFalse(sub.isConfigChangedAndReset(3L));
         assertNotSame(configState, sub.getConfigState());
         configState = sub.getConfigState();
         assertFalse(configState.hasConfigChanged());

--- a/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
+++ b/container-core/src/main/java/com/yahoo/container/core/config/HandlersConfigurerDi.java
@@ -137,10 +137,6 @@ public class HandlersConfigurerDi {
         });
     }
 
-    public void reloadConfig(long generation) {
-        container.reloadConfig(generation);
-    }
-
     public <T> T getComponent(Class<T> componentClass) {
         return currentGraph.getInstance(componentClass);
     }

--- a/container-core/src/main/java/com/yahoo/container/di/CloudSubscriberFactory.java
+++ b/container-core/src/main/java/com/yahoo/container/di/CloudSubscriberFactory.java
@@ -8,13 +8,8 @@ import com.yahoo.container.di.config.Subscriber;
 import com.yahoo.container.di.config.SubscriberFactory;
 import com.yahoo.vespa.config.ConfigKey;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.WeakHashMap;
 
 /**
  * @author Tony Vaagenes
@@ -23,9 +18,6 @@ import java.util.WeakHashMap;
 public class CloudSubscriberFactory implements SubscriberFactory {
 
     private final ConfigSource configSource;
-    private final Map<CloudSubscriber, Integer> activeSubscribers = new WeakHashMap<>();
-
-    private Optional<Long> testGeneration = Optional.empty();
 
     public CloudSubscriberFactory(ConfigSource configSource) {
         this.configSource = configSource;
@@ -39,21 +31,8 @@ public class CloudSubscriberFactory implements SubscriberFactory {
             ConfigKey<ConfigInstance> invariant = (ConfigKey<ConfigInstance>) key;
             subscriptionKeys.add(invariant);
         }
-        CloudSubscriber subscriber = new CloudSubscriber(name, configSource, subscriptionKeys);
 
-        testGeneration.ifPresent(subscriber.getSubscriber()::reload); // TODO: test specific code, remove
-        activeSubscribers.put(subscriber, 0);
-
-        return subscriber;
-    }
-
-    //TODO: test specific code, remove
-    @Override
-    public void reloadActiveSubscribers(long generation) {
-        testGeneration = Optional.of(generation);
-
-        List<CloudSubscriber> subscribers = new ArrayList<>(activeSubscribers.keySet());
-        subscribers.forEach(s -> s.getSubscriber().reload(generation));
+        return new CloudSubscriber(name, configSource, subscriptionKeys);
     }
 
     public static class Provider implements com.google.inject.Provider<SubscriberFactory> {

--- a/container-core/src/main/java/com/yahoo/container/di/Container.java
+++ b/container-core/src/main/java/com/yahoo/container/di/Container.java
@@ -284,11 +284,6 @@ public class Container {
         retriever.shutdown();
     }
 
-    // Reload config manually, when subscribing to non-configserver sources
-    public void reloadConfig(long generation) {
-        subscriberFactory.reloadActiveSubscribers(generation);
-    }
-
     public static <T extends ConfigInstance> T getConfig(ConfigKey<T> key,
                                                          Map<ConfigKey<? extends ConfigInstance>, ConfigInstance> configs) {
         ConfigInstance inst = configs.get(key);

--- a/container-core/src/main/java/com/yahoo/container/di/config/SubscriberFactory.java
+++ b/container-core/src/main/java/com/yahoo/container/di/config/SubscriberFactory.java
@@ -15,6 +15,5 @@ import java.util.Set;
 public interface SubscriberFactory {
 
     Subscriber getSubscriber(Set<? extends ConfigKey<?>> configKeys, String name);
-    void reloadActiveSubscribers(long generation);
 
 }

--- a/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
@@ -39,7 +39,7 @@ public class ConfigRetrieverTest {
 
     @BeforeEach
     public void setup() {
-        dirConfigSource = new DirConfigSource(tmpDir, "ConfigRetrieverTest-");
+        dirConfigSource = new DirConfigSource(tmpDir);
     }
 
     @AfterEach
@@ -109,11 +109,10 @@ public class ConfigRetrieverTest {
 
     private ConfigRetriever createConfigRetriever() {
         String configId = dirConfigSource.configId();
-        CloudSubscriberFactory subscriberFactory = new CloudSubscriberFactory(dirConfigSource.configSource());
         Set<ConfigKey<? extends ConfigInstance>> keys = new HashSet<>();
         keys.add(new ConfigKey<>(Bootstrap1Config.class, configId));
         keys.add(new ConfigKey<>(Bootstrap2Config.class, configId));
-        return new ConfigRetriever(keys, subscriberFactory);
+        return new ConfigRetriever(keys, new CloudSubscriberFactory(null));
     }
 
     private void writeConfig(String name, String contents) {

--- a/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
@@ -107,10 +107,11 @@ public class ConfigRetrieverTest {
         Set<ConfigKey<? extends ConfigInstance>> keys = new HashSet<>();
         keys.add(new ConfigKey<>(Bootstrap1Config.class, configId));
         keys.add(new ConfigKey<>(Bootstrap2Config.class, configId));
-        return new ConfigRetriever(keys, new CloudSubscriberFactory(null));
+        return new ConfigRetriever(keys, new CloudSubscriberFactory(dirConfigSource.source()));
     }
 
     private void writeConfig(String name, String contents) {
         dirConfigSource.writeConfig(name, contents);
     }
+
 }

--- a/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ConfigRetrieverTest.java
@@ -42,11 +42,6 @@ public class ConfigRetrieverTest {
         dirConfigSource = new DirConfigSource(tmpDir);
     }
 
-    @AfterEach
-    public void cleanup() {
-        dirConfigSource.cleanup();
-    }
-
     @Test
     void require_that_bootstrap_configs_come_first() {
         writeConfigs();

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -280,7 +280,7 @@ public class ContainerTest extends ContainerTestBase {
     }
 
     @Test
-    void providers_are_destructed() {
+    void providers_are_destroyed() {
         writeBootstrapConfigs("id1", DestructableProvider.class);
 
         ComponentDeconstructor deconstructor = (generation, components, bundles) -> {

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -128,12 +128,12 @@ public class ContainerTest extends ContainerTestBase {
         DestructableComponent componentToDestruct = oldGraph.getInstance(DestructableComponent.class);
 
         writeBootstrapConfigs("id2", DestructableComponent.class);
-        container.reloadConfig(2);
+        dirConfigSource.incrementGeneration();
         getNewComponentGraph(container, oldGraph);
         assertTrue(componentToDestruct.deconstructed);
     }
 
-    @Disabled  // because logAndDie is impossible(?) to verify programmatically
+    @Disabled("because logAndDie is impossible(?) to verify programmatically")
     @Test
     void manually_verify_what_happens_when_first_graph_contains_component_that_throws_exception_in_ctor() {
         writeBootstrapConfigs("thrower", ComponentThrowingExceptionInConstructor.class);
@@ -261,7 +261,7 @@ public class ContainerTest extends ContainerTestBase {
         container.reloadConfig(2);
 
         assertThrows(IllegalArgumentException.class,
-                () -> getNewComponentGraph(container, currentGraph));
+                     () -> getNewComponentGraph(container, currentGraph));
 
         ExecutorService exec = Executors.newFixedThreadPool(1);
         Future<ComponentGraph> newGraph = exec.submit(() -> getNewComponentGraph(container, currentGraph));

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -250,7 +250,7 @@ public class ContainerTest extends ContainerTestBase {
         }
     }
 
-    @RepeatedTest(100)
+    @Test
     void getNewComponentGraph_hangs_waiting_for_valid_config_after_invalid_config() throws Exception {
         dirConfigSource.writeConfig("test", "stringVal \"original\"");
         writeBootstrapConfigs("myId", ComponentTakingConfig.class);

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
@@ -38,7 +38,7 @@ public class ContainerTestBase {
 
     protected Container newContainer(DirConfigSource dirConfigSource,
                                      ComponentDeconstructor deconstructor) {
-        return new Container(new CloudSubscriberFactory(null),
+        return new Container(new CloudSubscriberFactory(dirConfigSource.source()),
                              dirConfigSource.configId(),
                              deconstructor,
                              osgi);

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
@@ -31,7 +31,7 @@ public class ContainerTestBase {
 
     @BeforeEach
     public void setup() {
-        dirConfigSource = new DirConfigSource(tmpDir, "ContainerTest-");
+        dirConfigSource = new DirConfigSource(tmpDir);
         componentGraph = new ComponentGraph(0);
         osgi = new TestOsgi(BundleTestUtil.testBundles());
     }
@@ -43,8 +43,8 @@ public class ContainerTestBase {
 
 
     protected Container newContainer(DirConfigSource dirConfigSource,
-                                            ComponentDeconstructor deconstructor) {
-        return new Container(new CloudSubscriberFactory(dirConfigSource.configSource),
+                                     ComponentDeconstructor deconstructor) {
+        return new Container(new CloudSubscriberFactory(null),
                              dirConfigSource.configId(),
                              deconstructor,
                              osgi);

--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTestBase.java
@@ -36,12 +36,6 @@ public class ContainerTestBase {
         osgi = new TestOsgi(BundleTestUtil.testBundles());
     }
 
-    @AfterEach
-    public void cleanup() {
-        dirConfigSource.cleanup();
-    }
-
-
     protected Container newContainer(DirConfigSource dirConfigSource,
                                      ComponentDeconstructor deconstructor) {
         return new Container(new CloudSubscriberFactory(null),

--- a/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
+++ b/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
@@ -3,12 +3,15 @@ package com.yahoo.container.di;
 
 import com.yahoo.config.subscription.ConfigSource;
 import com.yahoo.config.subscription.ConfigSourceSet;
+import com.yahoo.config.subscription.DirSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Random;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -27,32 +30,20 @@ public class DirConfigSource {
     }
 
     public void writeConfig(String name, String contents) {
-        File file = new File(tempFolder, name + ".cfg");
-        if (!file.exists()) {
-            try {
-                file.createNewFile();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        try {
+            Files.writeString(tempFolder.toPath().resolve(name + ".cfg"), contents + "\n", UTF_8);
         }
-
-        printFile(file, contents + "\n");
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     public String configId() {
         return "dir:" + tempFolder.getPath();
     }
 
-    public void cleanup() {
-        tempFolder.delete();
-    }
-
-    private static void printFile(File f, String content) {
-        try (OutputStream out = new FileOutputStream(f)) {
-            out.write(content.getBytes(UTF_8));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public ConfigSource source() {
+        return new DirSource(tempFolder);
     }
 
 }

--- a/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
+++ b/container-core/src/test/java/com/yahoo/container/di/DirConfigSource.java
@@ -8,7 +8,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * @author Tony Vaagenes
@@ -18,11 +21,9 @@ import java.util.Random;
 public class DirConfigSource {
 
     private final File tempFolder;
-    public final ConfigSource configSource;
 
-    public DirConfigSource(File tmpDir, String testSourcePrefix) {
+    public DirConfigSource(File tmpDir) {
         this.tempFolder = tmpDir;
-        this.configSource = new ConfigSourceSet(testSourcePrefix + new Random().nextLong());
     }
 
     public void writeConfig(String name, String contents) {
@@ -42,17 +43,13 @@ public class DirConfigSource {
         return "dir:" + tempFolder.getPath();
     }
 
-    public ConfigSource configSource() {
-        return configSource;
-    }
-
     public void cleanup() {
         tempFolder.delete();
     }
 
     private static void printFile(File f, String content) {
         try (OutputStream out = new FileOutputStream(f)) {
-            out.write(content.getBytes("UTF-8"));
+            out.write(content.getBytes(UTF_8));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeMetricsTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/SslHandshakeMetricsTest.java
@@ -166,22 +166,19 @@ class SslHandshakeMetricsTest {
             String expectedExceptionSubstring) throws IOException {
         List<String> protocols = protocolOverride != null ? List.of(protocolOverride) : null;
         List<String> ciphers = cipherOverride != null ? List.of(cipherOverride) : null;
-        for (int i = 0; i < 100; i++) {
-            try (var client = new SimpleHttpClient(sslContext, protocols, ciphers, testDriver.server().getListenPort(), false)) {
-                client.get("/status.html");
-                fail("SSLHandshakeException expected");
-            } catch (SSLHandshakeException e) {
-                assertTrue(e.getMessage().contains(expectedExceptionSubstring), e.getMessage());
-                return; // OK!
-            } catch (SocketException | SSLException e) {
-                // This exception is thrown if Apache httpclient's write thread detects the handshake failure before the read thread.
-                log.log(Level.WARNING, "Client failed to get a proper TLS handshake response: " + e.getMessage(), e);
-                // Only ignore a subset of exceptions
-                assertTrue(   e.getMessage().contains("readHandshakeRecord")
-                           || e.getMessage().contains("Broken pipe")
-                           || e.getMessage().contains("Connection reset by peer"),
-                              e.getMessage());
-            }
+        try (var client = new SimpleHttpClient(sslContext, protocols, ciphers, testDriver.server().getListenPort(), false)) {
+            client.get("/status.html");
+            fail("SSLHandshakeException expected");
+        } catch (SSLHandshakeException e) {
+            assertTrue(e.getMessage().contains(expectedExceptionSubstring), e.getMessage());
+        } catch (SocketException | SSLException e) {
+            // This exception is thrown if Apache httpclient's write thread detects the handshake failure before the read thread.
+            log.log(Level.WARNING, "Client failed to get a proper TLS handshake response: " + e.getMessage(), e);
+            // Only ignore a subset of exceptions
+            assertTrue(   e.getMessage().contains("readHandshakeRecord")
+                          || e.getMessage().contains("Broken pipe")
+                          || e.getMessage().contains("Connection reset by peer"),
+                          e.getMessage());
         }
     }
 

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ContainerThreadFactory.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ContainerThreadFactory.java
@@ -3,7 +3,6 @@ package com.yahoo.container.jdisc;
 
 import com.yahoo.container.jdisc.metric.MetricConsumerProvider;
 import com.yahoo.jdisc.application.ContainerThread;
-import com.yahoo.jdisc.application.MetricConsumer;
 
 import java.util.concurrent.ThreadFactory;
 
@@ -15,14 +14,7 @@ public class ContainerThreadFactory implements ThreadFactory {
     private final ThreadFactory delegate;
 
     public ContainerThreadFactory(MetricConsumerProvider metricConsumerProvider) {
-        metricConsumerProvider.getClass(); // throws NullPointerException
-        delegate = new ContainerThread.Factory(new com.google.inject.Provider<MetricConsumer>() {
-
-            @Override
-            public MetricConsumer get() {
-                return metricConsumerProvider.newInstance();
-            }
-        });
+        delegate = new ContainerThread.Factory(metricConsumerProvider::newInstance);
     }
 
     @Override

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricProvider.java
@@ -17,13 +17,7 @@ public final class MetricProvider implements Provider<Metric> {
     private final Metric metric;
 
     public MetricProvider(MetricConsumerProvider provider) {
-        metric = new com.yahoo.jdisc.application.MetricProvider(new com.google.inject.Provider<MetricConsumer>() {
-
-            @Override
-            public MetricConsumer get() {
-                return provider.newInstance();
-            }
-        }).get();
+        metric = new com.yahoo.jdisc.application.MetricProvider(provider::newInstance).get();
     }
 
     @Override

--- a/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/JSONSearchHandlerTestCase.java
@@ -71,7 +71,7 @@ public class JSONSearchHandlerTestCase {
         IOUtils.copyDirectory(new File(testDir), cfgDir, 1); // make configs active
         generateComponentsConfigForActive();
 
-        configurer = new HandlersConfigurerTestWrapper(new Container(), configId);
+        configurer = new HandlersConfigurerTestWrapper(new Container(), cfgDir);
         searchHandler = (SearchHandler)configurer.getRequestHandlerRegistry().getComponent(SearchHandler.class.getName());
         driver = new RequestHandlerTestDriver(searchHandler);
     }

--- a/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTest.java
+++ b/container-search/src/test/java/com/yahoo/search/handler/SearchHandlerTest.java
@@ -61,12 +61,11 @@ public class SearchHandlerTest {
     public void startUp() throws IOException {
         File cfgDir = newFolder(tempfolder, "SearchHandlerTestCase");
         tempDir = cfgDir.getAbsolutePath();
-        String configId = "dir:" + tempDir;
 
         IOUtils.copyDirectory(new File(testDir), cfgDir, 1); // make configs active
         generateComponentsConfigForActive();
 
-        configurer = new HandlersConfigurerTestWrapper(new Container(), configId);
+        configurer = new HandlersConfigurerTestWrapper(new Container(), cfgDir);
         searchHandler = (SearchHandler)configurer.getRequestHandlerRegistry().getComponent(SearchHandler.class.getName());
         metric = (MockMetric) searchHandler.metric();
         driver = new RequestHandlerTestDriver(searchHandler);

--- a/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileIntegrationTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/query/profile/config/test/QueryProfileIntegrationTestCase.java
@@ -16,6 +16,8 @@ import com.yahoo.search.result.Hit;
 import com.yahoo.search.searchchain.Execution;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -33,10 +35,9 @@ public class QueryProfileIntegrationTestCase {
 
     @Test
     void testUntyped() {
-        String configId = "dir:src/test/java/com/yahoo/search/query/profile/config/test/untyped";
-        System.setProperty("config.id", configId);
+        File cfgDir = new File("src/test/java/com/yahoo/search/query/profile/config/test/untyped");
         Container container = new Container();
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(container, configId);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(container, cfgDir);
         SearchHandler searchHandler = (SearchHandler) configurer.getRequestHandlerRegistry().getComponent(SearchHandler.class.getName());
 
         // Should get "default" query profile containing the "test" search chain containing the "test" searcher
@@ -76,10 +77,9 @@ public class QueryProfileIntegrationTestCase {
 
     @Test
     void testTyped() {
-        String configId = "dir:src/test/java/com/yahoo/search/query/profile/config/test/typed";
-        System.setProperty("config.id", configId);
+        File cfgDir = new File("src/test/java/com/yahoo/search/query/profile/config/test/typed");
         Container container = new Container();
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(container, configId);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(container, cfgDir);
         SearchHandler searchHandler = (SearchHandler) configurer.getRequestHandlerRegistry().getComponent(SearchHandler.class.getName());
 
         // Should get "default" query profile containing the "test" search chain containing the "test" searcher

--- a/container-search/src/test/java/com/yahoo/search/searchchain/config/test/DependencyConfigTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchchain/config/test/DependencyConfigTestCase.java
@@ -48,8 +48,7 @@ public class DependencyConfigTestCase {
     }
 
     public static void setUp() {
-        String configId = "dir:" + root;
-        configurer = new HandlersConfigurerTestWrapper(configId);
+        configurer = new HandlersConfigurerTestWrapper(new File(root));
         registry=((SearchHandler) configurer.getRequestHandlerRegistry().getComponent("com.yahoo.search.handler.SearchHandler")).getSearchChainRegistry();
     }
 

--- a/container-search/src/test/java/com/yahoo/search/searchchain/config/test/SearchChainConfigurerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/searchchain/config/test/SearchChainConfigurerTestCase.java
@@ -76,7 +76,7 @@ public class SearchChainConfigurerTestCase {
 
     @Test
     synchronized void testConfiguration() {
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper("dir:" + testDir);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(new File(testDir));
 
         SearchChain simple = getSearchChainRegistryFrom(configurer).getComponent("simple");
         assertNotNull(simple);
@@ -125,7 +125,7 @@ public class SearchChainConfigurerTestCase {
 
     @Test
     void testConfigurableSearcher() {
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper("dir:" + testDir);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(new File(testDir));
 
         SearchChain configurable = getSearchChainRegistryFrom(configurer).getComponent("configurable");
         assertNotNull(configurable);
@@ -157,7 +157,7 @@ public class SearchChainConfigurerTestCase {
         printFile(new File(cfgDir + "/int.cfg"), "intVal 16\n");
         printFile(new File(cfgDir + "/string.cfg"), "stringVal \"testSearcherConfigUpdate\"\n");
 
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper("dir:" + cfgDir);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(cfgDir);
         SearcherRegistry searchers = getSearchChainRegistryFrom(configurer).getSearcherRegistry();
         assertEquals(3, searchers.getComponentCount());
 
@@ -209,7 +209,7 @@ public class SearchChainConfigurerTestCase {
         copyFile(testDir + "container-http.cfg", cfgDir +  "/container-http.cfg");
         createComponentsConfig(testDir + "chainsConfigUpdate_1.cfg", testDir + "handlers.cfg", cfgDir +  "/components.cfg");
 
-        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper("dir:" + cfgDir);
+        HandlersConfigurerTestWrapper configurer = new HandlersConfigurerTestWrapper(cfgDir);
 
         SearchChainRegistry scReg = getSearchChainRegistryFrom(configurer);
         SearcherRegistry searchers = scReg.getSearcherRegistry();

--- a/jdisc_core/src/main/java/com/yahoo/jdisc/application/MetricImpl.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/application/MetricImpl.java
@@ -45,11 +45,7 @@ class MetricImpl implements Metric {
     }
 
     private MetricConsumer currentConsumer() {
-        Thread thread = Thread.currentThread();
-        if (thread instanceof ContainerThread) {
-            return ((ContainerThread)thread).consumer();
-        }
-        return consumer.get();
+        return (Thread.currentThread() instanceof ContainerThread thread) ? thread.consumer() : consumer.get();
     }
 
     private static class LocalConsumer extends ThreadLocal<MetricConsumer> {
@@ -65,4 +61,5 @@ class MetricImpl implements Metric {
             return factory.get();
         }
     }
+
 }

--- a/messagebus/abi-spec.json
+++ b/messagebus/abi-spec.json
@@ -43,7 +43,6 @@
       "public void <init>(java.lang.String, com.yahoo.messagebus.ConfigHandler)",
       "public void <init>(com.yahoo.config.subscription.ConfigURI, com.yahoo.messagebus.ConfigHandler)",
       "public void <init>(com.yahoo.messagebus.MessagebusConfig, com.yahoo.messagebus.ConfigHandler)",
-      "public void reload(long)",
       "public void subscribe()",
       "public void configure(com.yahoo.messagebus.MessagebusConfig)",
       "public void shutdown()",

--- a/messagebus/src/main/java/com/yahoo/messagebus/ConfigAgent.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/ConfigAgent.java
@@ -55,16 +55,6 @@ public class ConfigAgent implements ConfigSubscriber.SingleSubscriber<Messagebus
     }
 
     /**
-     * Force reload config. Only necessary for testing or if subscribing to
-     * config using files.
-     */
-    public void reload(long generation) {
-        if (subscriber != null) {
-            subscriber.reload(generation);
-        }
-    }
-
-    /**
      * Start listening for config updates. This method will not return until the handler has been configured at least
      * once unless an exception is thrown.
      */

--- a/messagebus/src/test/java/com/yahoo/messagebus/ConfigAgentTestCase.java
+++ b/messagebus/src/test/java/com/yahoo/messagebus/ConfigAgentTestCase.java
@@ -5,20 +5,17 @@ import com.yahoo.config.subscription.ConfigSet;
 import com.yahoo.config.subscription.ConfigURI;
 import com.yahoo.messagebus.routing.RoutingSpec;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Simon Thoresen Hult
  */
 public class ConfigAgentTestCase {
-
-    @TempDir
-    public File tmpFolder;
 
     @Test
     void testRoutingConfig() throws InterruptedException {
@@ -38,13 +35,15 @@ public class ConfigAgentTestCase {
 
         handler.reset();
         set.addBuilder("test", writeHalf());
-        assertTrue(handler.await(120, TimeUnit.SECONDS));
+        set.incrementGeneration();
+        assertTrue(handler.await(5, TimeUnit.SECONDS));
         assertTrue(testHalf(handler.spec));
         assertFalse(testFull(handler.spec));
 
         handler.reset();
         set.addBuilder("test", writeFull());
-        assertTrue(handler.await(120, TimeUnit.SECONDS));
+        set.incrementGeneration();
+        assertTrue(handler.await(5, TimeUnit.SECONDS));
         assertTrue(testFull(handler.spec));
         assertFalse(testHalf(handler.spec));
     }
@@ -186,4 +185,5 @@ public class ConfigAgentTestCase {
             return spec != null;
         }
     }
+
 }

--- a/routing-generator/pom.xml
+++ b/routing-generator/pom.xml
@@ -18,8 +18,8 @@
     <dependencies>
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/RoutingGeneratorTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/RoutingGeneratorTest.java
@@ -6,28 +6,31 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.subscription.ConfigSet;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.config.ConfigKey;
-import org.junit.Test;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author mpolden
  */
 public class RoutingGeneratorTest {
 
-    @Test(timeout = 2000)
+    @Test()
+    @Timeout(5)
     public void config_subscription() {
         RouterMock router = new RouterMock();
         RoutingGenerator generator = new RoutingGenerator(new ConfigSetMock(), router, new ManualClock());
         try {
             router.awaitLoad();
-            assertNotNull("Router loads table", router.currentTable);
-            assertEquals("Routing generator and router has same table",
-                         generator.routingTable().get(),
-                         router.currentTable);
+            assertNotNull(router.currentTable, "Router loads table");
+            assertEquals(generator.routingTable().get(),
+                         router.currentTable,
+                         "Routing generator and router has same table");
         } finally {
             generator.deconstruct();
         }
@@ -65,6 +68,7 @@ public class RoutingGeneratorTest {
 
         @Override
         public ConfigInstance.Builder get(ConfigKey<?> key) {
+            incrementGeneration();
             if (++attempt <= 5) {
                 throw new RuntimeException("Failed to get config on attempt " + attempt);
             }

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/RoutingTableTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/RoutingTableTest.java
@@ -10,20 +10,21 @@ import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.vespa.hosted.routing.RoutingTable.Endpoint;
 import com.yahoo.vespa.hosted.routing.RoutingTable.Real;
 import com.yahoo.vespa.hosted.routing.RoutingTable.Target;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * @author mpolden
  */
-public class RoutingTableTest {
+class RoutingTableTest {
 
     @Test
-    public void translate_from_lb_services_config() {
+    void translate_from_lb_services_config() {
         RoutingTable expected = new RoutingTable(Map.of(
                 new Endpoint("beta.music.vespa.us-north-1.vespa.oath.cloud", RoutingMethod.sharedLayer4),
                 Target.create(ApplicationId.from("vespa", "music", "beta"),

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxHealthClientTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxHealthClientTest.java
@@ -2,12 +2,13 @@
 package com.yahoo.vespa.hosted.routing.nginx;
 
 import com.yahoo.vespa.hosted.routing.mock.HttpClientMock;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Paths;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author oyving

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxMetricsReporterTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxMetricsReporterTest.java
@@ -12,7 +12,8 @@ import com.yahoo.vespa.hosted.routing.RoutingTable.Endpoint;
 import com.yahoo.vespa.hosted.routing.RoutingTable.Target;
 import com.yahoo.vespa.hosted.routing.mock.HealthStatusMock;
 import com.yahoo.vespa.hosted.routing.status.ServerGroup;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -25,8 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author mortent

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/nginx/NginxTest.java
@@ -15,7 +15,8 @@ import com.yahoo.vespa.hosted.routing.TestUtil;
 import com.yahoo.vespa.hosted.routing.mock.RoutingStatusMock;
 import com.yahoo.yolean.Exceptions;
 import com.yahoo.yolean.concurrent.Sleeper;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -29,9 +30,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author mpolden
@@ -125,7 +126,7 @@ public class NginxTest {
         }
 
         public NginxTester assertMetric(String name, double expected) {
-            assertEquals("Metric " + name + " has expected value", expected, metric.metrics().get(name).get(Map.of()), Double.MIN_VALUE);
+            assertEquals(expected, metric.metrics().get(name).get(Map.of()), Double.MIN_VALUE, "Metric " + name + " has expected value");
             return this;
         }
 
@@ -138,7 +139,7 @@ public class NginxTest {
 
         public NginxTester assertTemporaryConfigRemoved(boolean removed) {
             Path path = NginxPath.temporaryConfig.in(fileSystem);
-            assertEquals(path + (removed ? " does not exist" : " exists"), removed, !Files.exists(path));
+            assertEquals(removed, !Files.exists(path), path + (removed ? " does not exist" : " exists"));
             return this;
         }
 
@@ -163,8 +164,7 @@ public class NginxTest {
             if (loaded) {
                 assertEquals(reloadCommand, processExecuter.history().get(processExecuter.history().size() - 1));
             } else {
-                assertTrue("Config is not loaded",
-                           processExecuter.history.stream().noneMatch(command -> command.equals(reloadCommand)));
+                assertTrue(processExecuter.history.stream().noneMatch(command -> command.equals(reloadCommand)), "Config is not loaded");
             }
             return this;
         }

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/restapi/AkamaiHandlerTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/restapi/AkamaiHandlerTest.java
@@ -16,15 +16,16 @@ import com.yahoo.vespa.hosted.routing.mock.RoutingStatusMock;
 import com.yahoo.vespa.hosted.routing.status.HealthStatus;
 import com.yahoo.vespa.hosted.routing.status.ServerGroup;
 import com.yahoo.yolean.Exceptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author oyving
@@ -89,7 +90,7 @@ public class AkamaiHandlerTest {
         String responseBody = out.toString();
 
         String expected = "\"message\":\"" + message + "\"";
-        assertTrue("Contains expected message", responseBody.contains(expected));
+        assertTrue(responseBody.contains(expected), "Contains expected message");
     }
 
     private static RoutingTable makeRoutingTable() {

--- a/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/status/RoutingStatusClientTest.java
+++ b/routing-generator/src/test/java/com/yahoo/vespa/hosted/routing/status/RoutingStatusClientTest.java
@@ -3,14 +3,14 @@ package com.yahoo.vespa.hosted.routing.status;
 
 import com.yahoo.vespa.hosted.routing.mock.HttpClientMock;
 import com.yahoo.vespa.hosted.routing.mock.HttpClientMock.JsonResponse;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author mpolden

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
@@ -88,10 +88,6 @@ public class StandaloneSubscriberFactory implements SubscriberFactory {
         return new StandaloneSubscriber((Set<ConfigKey<ConfigInstance>>) configKeys);
     }
 
-    public void reloadActiveSubscribers(long generation) {
-        throw new RuntimeException("unsupported");
-    }
-
     private static ConfigInstance.Builder newBuilderInstance(ConfigKey<ConfigInstance> key) {
         try {
             return builderClass(key).getDeclaredConstructor().newInstance();


### PR DESCRIPTION
@bjorncs or @baldersheim or @hmusum  please review.

I'm not super-happy about this. I think the `ConfigSubscription` is weird, and way too hard to please. It seems some of its subclasses were wrong before, in certain scenarios, and they still are; e.g., I worked around that by adding some "atomicity guarantee" to the config effectively served by the `DirConfigSource` in container-core tests. I also imitated the `JRTConfigSubscription` in the `ConfigSetSubscription` for no good reason, other than to avoid warning bonanza—the state induced by running the different code paths is identical. 

At least the `reloadConfig` wiring is gone now, and replaced with a notion of a "generation" on those test config sources (file, set) that has to be manually incremented—better explicit and dumb, than magical and wrong. 