### PR TITLE
Do not deprovision on deallocate

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -324,7 +324,7 @@ public class Nodes {
 
     public Node deallocate(Node node, Agent agent, String reason, NestedTransaction transaction) {
         if (parkOnDeallocationOf(node, agent)) {
-            return park(node.hostname(), true, agent, reason, transaction);
+            return park(node.hostname(), false, agent, reason, transaction);
         } else {
             Node.State toState = Node.State.dirty;
             if (node.state() == Node.State.parked) {


### PR DESCRIPTION
Setting this to `false` means that `wantToRetire` & `wantToDeprovision` will not be touched when moving this node to `parked`.

Fixes VESPA-25087.