### PR TITLE
Support match:cased on index fields

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
@@ -189,9 +189,9 @@ public class IndexInfo extends Derived implements IndexInfoConfig.Producer {
     }
 
     private static boolean needLowerCase(ImmutableSDField field) {
-        return field.doesIndexing()
-                || field.doesLowerCasing()
-                || ((field.doesAttributing() || (field.getAttribute() != null))
+        return ( field.doesIndexing() && field.getMatching().getCase() != Case.CASED)
+               || field.doesLowerCasing()
+               || ((field.doesAttributing() || (field.getAttribute() != null))
                     && isAnyChildString(field.getDataType())
                     && field.getMatching().getCase().equals(Case.UNCASED));
     }

--- a/config-model/src/test/java/com/yahoo/schema/derived/CasedIndexTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/derived/CasedIndexTestCase.java
@@ -1,0 +1,48 @@
+package com.yahoo.schema.derived;
+
+import com.yahoo.schema.ApplicationBuilder;
+import com.yahoo.search.config.IndexInfoConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * @author bratseth
+ */
+public class CasedIndexTestCase {
+
+    @Test
+    public void testCasedIndexDeriving() throws Exception {
+        var b = new ApplicationBuilder();
+        b.addSchema("""
+                    schema test {
+                      document test {
+                        field a type string {
+                          indexing: summary | index
+                          match: cased
+                        }
+                      }
+                    }
+                    """);
+        var application = b.build(true);
+        var config = new DerivedConfiguration(application.schemas().get("test"), b.getRankProfileRegistry());
+        var indexInfo = config.getIndexInfo();
+        var indexInfoConfigBuilder = new IndexInfoConfig.Builder();
+        indexInfo.getConfig(indexInfoConfigBuilder);
+        assertFalse(commandsOf("test", "a", indexInfoConfigBuilder).contains("lowercase"));
+    }
+
+    private Set<String> commandsOf(String schema, String field, IndexInfoConfig.Builder indexInfoConfigBuilder) {
+        var schemaIndexInfo = indexInfoConfigBuilder.build().indexinfo().stream()
+                                                    .filter(c -> c.name().equals(schema))
+                                                    .findAny().get();
+        return schemaIndexInfo.command().stream()
+                              .filter(c -> c.indexname().equals(field))
+                              .map(c -> c.command())
+                              .collect(Collectors.toSet());
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/querytransform/VespaLowercasingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/querytransform/VespaLowercasingSearcher.java
@@ -38,9 +38,7 @@ public class VespaLowercasingSearcher extends LowercasingSearcher {
     public boolean shouldLowercase(String commonPath, WordItem word, IndexFacts.Session indexFacts) {
         if (word.isLowercased()) return false;
 
-        StringBuilder sb = new StringBuilder();
-        sb.append(commonPath).append(".").append(word.getIndexName());
-        return indexFacts.getIndex(sb.toString()).isLowercase();
+        return indexFacts.getIndex(commonPath + "." + word.getIndexName()).isLowercase();
     }
 
 }


### PR DESCRIPTION
This also requires using a tokenizer that returns cased tokens, but some have that ...