### PR TITLE
Enable the report-cores-via-cfg flag by default

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -421,7 +421,7 @@ public class Flags {
             "Takes effect immediately");
 
     public static final UnboundBooleanFlag REPORT_CORES_VIA_CFG = defineFeatureFlag(
-            "report-cores-via-cfg", false,
+            "report-cores-via-cfg", true,
             List.of("hakonhall"), "2022-11-01", "2022-12-01",
             "If true, report core dumps to the config server instead of directly to the panic app.",
             "Takes effect on the next tick.",

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileDeleter.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileDeleter.java
@@ -26,7 +26,7 @@ public class FileDeleter {
     public boolean converge(TaskContext context) {
         boolean deleted = uncheck(() -> Files.deleteIfExists(path));
         if (deleted) {
-            context.recordSystemModification(logger, "Deleted file or directory " + path);
+            context.recordSystemModification(logger, "Deleted " + path);
         }
 
         return deleted;

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileMover.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileMover.java
@@ -1,0 +1,55 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.task.util.file;
+
+import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
+
+import java.nio.file.CopyOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static com.yahoo.yolean.Exceptions.uncheck;
+
+/**
+ * Utility for idempotent move of (any type of) file.
+ *
+ * @author hakonhall
+ */
+public class FileMover {
+    private static final Logger logger = Logger.getLogger(FileMover.class.getName());
+
+    private final Path source;
+    private final Path destination;
+    private final Set<CopyOption> moveOptions = new HashSet<>();
+
+    public FileMover(Path source, Path destination) {
+        this.source = source;
+        this.destination = destination;
+    }
+
+    public FileMover replaceExisting() {
+        moveOptions.add(StandardCopyOption.REPLACE_EXISTING);
+        return this;
+    }
+
+    public FileMover atomic() {
+        moveOptions.add(StandardCopyOption.ATOMIC_MOVE);
+        return this;
+    }
+
+    /**
+     * Move file.
+     *
+     * @return false if the source doesn't exist while the destination do.
+     * @see Files#move(Path, Path, CopyOption...) Files.move()
+     */
+    public boolean converge(TaskContext context) {
+        if (!Files.exists(source) && Files.exists(destination)) return false;
+        uncheck(() -> Files.move(source, destination, moveOptions.toArray(CopyOption[]::new)));
+        context.recordSystemModification(logger, "Moved " + source + " to " + destination);
+        return true;
+    }
+}

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -77,7 +77,7 @@ public class CoredumpHandlerTest {
         createFileAged(crashPath.resolve("bash.core.431"), Duration.ZERO);
 
         assertFolderContents(crashPath, "bash.core.431");
-        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(crashPath, processingDir);
+        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(context, crashPath, processingDir);
         assertEquals(Optional.empty(), enqueuedPath);
 
         // bash.core.431 finished writing... and 2 more have since been written
@@ -86,7 +86,7 @@ public class CoredumpHandlerTest {
         createFileAged(crashPath.resolve("vespa-slobrok.core.673"), Duration.ofMinutes(5));
 
         when(coredumpIdSupplier.get()).thenReturn("id-123").thenReturn("id-321");
-        enqueuedPath = coredumpHandler.enqueueCoredump(crashPath, processingDir);
+        enqueuedPath = coredumpHandler.enqueueCoredump(context, crashPath, processingDir);
         assertEquals(Optional.of(processingDir.resolve("id-123")), enqueuedPath);
         assertFolderContents(crashPath, "bash.core.431", "vespa-slobrok.core.673");
         assertFolderContents(processingDir, "id-123");
@@ -94,7 +94,7 @@ public class CoredumpHandlerTest {
         verify(coredumpIdSupplier, times(1)).get();
 
         // Enqueue another
-        enqueuedPath = coredumpHandler.enqueueCoredump(crashPath, processingDir);
+        enqueuedPath = coredumpHandler.enqueueCoredump(context, crashPath, processingDir);
         assertEquals(Optional.of(processingDir.resolve("id-321")), enqueuedPath);
         assertFolderContents(crashPath, "bash.core.431");
         assertFolderContents(processingDir, "id-123", "id-321");
@@ -116,7 +116,7 @@ public class CoredumpHandlerTest {
         createFileAged(crashPath.resolve("hs_err_pid2421.log"), Duration.ofSeconds(550));
 
         when(coredumpIdSupplier.get()).thenReturn("id-123").thenReturn("id-321");
-        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(crashPath, processingDir);
+        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(context, crashPath, processingDir);
         assertEquals(Optional.of(processingDir.resolve("id-123")), enqueuedPath);
         assertFolderContents(crashPath, "hs_err_pid69.log", "java.core.69");
         assertFolderContents(processingDir, "id-123");
@@ -128,7 +128,7 @@ public class CoredumpHandlerTest {
         ContainerPath processingDir = context.paths().of("/some/other/processing");
 
         // Initially there are no core dumps
-        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(containerCrashPath, processingDir);
+        Optional<ContainerPath> enqueuedPath = coredumpHandler.enqueueCoredump(context, containerCrashPath, processingDir);
         assertEquals(Optional.empty(), enqueuedPath);
 
         // 3 core dumps occur
@@ -138,11 +138,11 @@ public class CoredumpHandlerTest {
         createFileAged(containerCrashPath.resolve("vespa-slobrok.core.673"), Duration.ofMinutes(5));
 
         when(coredumpIdSupplier.get()).thenReturn("id-123");
-        enqueuedPath = coredumpHandler.getCoredumpToProcess(containerCrashPath, processingDir);
+        enqueuedPath = coredumpHandler.getCoredumpToProcess(context, containerCrashPath, processingDir);
         assertEquals(Optional.of(processingDir.resolve("id-123")), enqueuedPath);
 
         // Running this again wont enqueue new core dumps as we are still processing the one enqueued previously
-        enqueuedPath = coredumpHandler.getCoredumpToProcess(containerCrashPath, processingDir);
+        enqueuedPath = coredumpHandler.getCoredumpToProcess(context, containerCrashPath, processingDir);
         assertEquals(Optional.of(processingDir.resolve("id-123")), enqueuedPath);
         verify(coredumpIdSupplier, times(1)).get();
     }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileMoverTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/task/util/file/FileMoverTest.java
@@ -1,0 +1,73 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.node.admin.task.util.file;
+
+import com.yahoo.vespa.hosted.node.admin.component.TaskContext;
+import com.yahoo.vespa.test.file.TestFileSystem;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.FileSystem;
+import java.nio.file.NoSuchFileException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author hakonhall
+ */
+class FileMoverTest {
+    private final FileSystem fileSystem = TestFileSystem.create();
+    private final TaskContext context = mock(TaskContext.class);
+    private final UnixPath source = new UnixPath(fileSystem.getPath("/from/source"));
+    private final UnixPath destination = new UnixPath(fileSystem.getPath("/to/destination"));
+    private final FileMover mover = new FileMover(source.toPath(), destination.toPath());
+
+    @Test
+    void movingRegularFile() {
+        assertConvergeThrows(() -> mover.converge(context), NoSuchFileException.class, "/from/source");
+
+        source.createParents().writeUtf8File("content");
+        assertConvergeThrows(() -> mover.converge(context), NoSuchFileException.class, "/to/destination");
+
+        destination.createParents();
+        assertTrue(mover.converge(context));
+        assertFalse(source.exists());
+        assertTrue(destination.exists());
+        assertEquals("content", destination.readUtf8File());
+
+        assertFalse(mover.converge(context));
+
+        source.writeUtf8File("content 2");
+        assertConvergeThrows(() -> mover.converge(context), FileAlreadyExistsException.class, "/to/destination");
+
+        mover.replaceExisting();
+        assertTrue(mover.converge(context));
+
+        source.writeUtf8File("content 3");
+        destination.deleteIfExists();
+        destination.createDirectory();
+        assertTrue(mover.converge(context));
+    }
+
+    private void assertConvergeThrows(Runnable runnable, Class<?> expectedRootExceptionClass, String expectedMessage) {
+        try {
+            runnable.run();
+            fail();
+        } catch (Throwable t) {
+            Throwable rootCause = t;
+            do {
+                Throwable cause = rootCause.getCause();
+                if (cause == null) break;
+                rootCause = cause;
+            } while (true);
+
+            assertTrue(expectedRootExceptionClass.isInstance(rootCause), "Unexpected root cause: " + rootCause);
+            assertEquals(expectedMessage, rootCause.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
AND log progress of core dump processing.
