### PR TITLE
Encapsulate key identifier in own object

### DIFF
--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.maintenance.coredump;
 
+import com.yahoo.security.KeyId;
 import com.yahoo.security.SealedSharedKey;
 import com.yahoo.security.SecretSharedKey;
 import com.yahoo.test.ManualClock;
@@ -303,7 +304,7 @@ public class CoredumpHandlerTest {
     private static SecretSharedKey makeFixedSecretSharedKey() {
         byte[] keyBytes = bytesOf("very secret yes!"); // 128 bits
         var secretKey = new SecretKeySpec(keyBytes, "AES");
-        byte[] keyId = bytesOf("the shiniest key");
+        var keyId = KeyId.ofString("the shiniest key");
         // We don't parse any of these fields in the test, so just use dummy contents.
         byte[] enc = bytesOf("hello world");
         byte[] ciphertext = bytesOf("imaginary ciphertext");

--- a/security-utils/src/main/java/com/yahoo/security/KeyId.java
+++ b/security-utils/src/main/java/com/yahoo/security/KeyId.java
@@ -1,0 +1,89 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.yahoo.security.ArrayUtils.fromUtf8Bytes;
+import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
+
+/**
+ * Represents a named key ID comprising an arbitrary (but length-limited)
+ * sequence of valid UTF-8 bytes.
+ *
+ * @author vekterli
+ */
+public class KeyId {
+
+    // Max length MUST be possible to fit in an unsigned byte; see SealedSharedKey token encoding/decoding.
+    public static final int MAX_KEY_ID_UTF8_LENGTH = 255;
+
+    private final byte[] keyIdBytes;
+
+    private KeyId(byte[] keyIdBytes) {
+        if (keyIdBytes.length > MAX_KEY_ID_UTF8_LENGTH) {
+            throw new IllegalArgumentException("Key ID is too large to be encoded (max is %d, got %d)"
+                                               .formatted(MAX_KEY_ID_UTF8_LENGTH, keyIdBytes.length));
+        }
+        verifyByteStringRoundtripsAsValidUtf8(keyIdBytes);
+        this.keyIdBytes = keyIdBytes;
+    }
+
+    /**
+     * Construct a KeyId containing the given sequence of bytes.
+     *
+     * @param keyIdBytes array of valid UTF-8 bytes. May be zero-length, but not null.
+     *                   Note: to avoid accidental mutations, the key bytes are deep-copied.
+     * @return a new KeyId instance
+     */
+    public static KeyId ofBytes(byte[] keyIdBytes) {
+        Objects.requireNonNull(keyIdBytes);
+        return new KeyId(keyIdBytes.clone());
+    }
+
+    /**
+     * Construct a KeyId containing the UTF-8 byte representation of the given string.
+     *
+     * @param keyId a string whose UTF-8 byte representation will be the key ID. May be
+     *              zero-length but not null.
+     * @return a new KeyId instance
+     */
+    public static KeyId ofString(String keyId) {
+        Objects.requireNonNull(keyId);
+        return new KeyId(toUtf8Bytes(keyId));
+    }
+
+    /**
+     * @return the raw backing byte array. <strong>Must therefore not be mutated.</strong>
+     */
+    public byte[] asBytes() { return keyIdBytes; }
+
+    public String asString() { return fromUtf8Bytes(keyIdBytes); }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        KeyId keyId = (KeyId) o;
+        return Arrays.equals(keyIdBytes, keyId.keyIdBytes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(keyIdBytes);
+    }
+
+    @Override
+    public String toString() {
+        return "KeyId(%s)".formatted(asString());
+    }
+
+    private static void verifyByteStringRoundtripsAsValidUtf8(byte[] byteStr) {
+        String asStr   = fromUtf8Bytes(byteStr); // Replaces bad chars with a placeholder
+        byte[] asBytes = toUtf8Bytes(asStr);
+        if (!Arrays.equals(byteStr, asBytes)) {
+            throw new IllegalArgumentException("Key ID is not valid normalized UTF-8");
+        }
+    }
+
+}

--- a/security-utils/src/main/java/com/yahoo/security/KeyId.java
+++ b/security-utils/src/main/java/com/yahoo/security/KeyId.java
@@ -38,7 +38,7 @@ public class KeyId {
      */
     public static KeyId ofBytes(byte[] keyIdBytes) {
         Objects.requireNonNull(keyIdBytes);
-        return new KeyId(keyIdBytes.clone());
+        return new KeyId(Arrays.copyOf(keyIdBytes, keyIdBytes.length));
     }
 
     /**

--- a/security-utils/src/main/java/com/yahoo/security/SharedKeyGenerator.java
+++ b/security-utils/src/main/java/com/yahoo/security/SharedKeyGenerator.java
@@ -60,17 +60,17 @@ public class SharedKeyGenerator {
         }
     }
 
-    public static SecretSharedKey generateForReceiverPublicKey(PublicKey receiverPublicKey, byte[] keyId) {
+    public static SecretSharedKey generateForReceiverPublicKey(PublicKey receiverPublicKey, KeyId keyId) {
         var secretKey = generateRandomSecretAesKey();
         // We protect the integrity of the key ID by passing it as AAD.
-        var sealed = HPKE.sealBase((XECPublicKey) receiverPublicKey, EMPTY_BYTES, keyId, secretKey.getEncoded());
+        var sealed = HPKE.sealBase((XECPublicKey) receiverPublicKey, EMPTY_BYTES, keyId.asBytes(), secretKey.getEncoded());
         var sealedSharedKey = new SealedSharedKey(keyId, sealed.enc(), sealed.ciphertext());
         return new SecretSharedKey(secretKey, sealedSharedKey);
     }
 
     public static SecretSharedKey fromSealedKey(SealedSharedKey sealedKey, PrivateKey receiverPrivateKey) {
         byte[] secretKeyBytes = HPKE.openBase(sealedKey.enc(), (XECPrivateKey) receiverPrivateKey,
-                                              EMPTY_BYTES, sealedKey.keyId(), sealedKey.ciphertext());
+                                              EMPTY_BYTES, sealedKey.keyId().asBytes(), sealedKey.ciphertext());
         return new SecretSharedKey(new SecretKeySpec(secretKeyBytes, "AES"), sealedKey);
     }
 

--- a/security-utils/src/test/java/com/yahoo/security/KeyIdTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/KeyIdTest.java
@@ -52,7 +52,7 @@ public class KeyIdTest {
     @Test
     void key_id_bytes_are_deep_copied_when_constructed_from_raw_byte_array() {
         byte[] keyBytes = new byte[]{'f','o','o'};
-        byte[] expected = keyBytes.clone();
+        byte[] expected = Arrays.copyOf(keyBytes, keyBytes.length);
         var id = KeyId.ofBytes(keyBytes);
         keyBytes[0] = 'b';
         assertArrayEquals(expected, id.asBytes());

--- a/security-utils/src/test/java/com/yahoo/security/KeyIdTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/KeyIdTest.java
@@ -1,0 +1,82 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author vekterli
+ */
+public class KeyIdTest {
+
+    @Test
+    void equality_predicated_on_key_id_byte_string() {
+        var id0s = KeyId.ofString("");
+        var id1s = KeyId.ofString("1");
+        var id2s = KeyId.ofString("12");
+        assertEquals(id0s, id0s);
+        assertEquals(id1s, id1s);
+        assertEquals(id2s, id2s);
+        assertNotEquals(id0s, id1s);
+        assertNotEquals(id1s, id0s);
+        assertNotEquals(id1s, id2s);
+        assertNotEquals(id0s, id2s);
+        var id0b = KeyId.ofBytes(new byte[0]);
+        var id1b = KeyId.ofBytes(new byte[]{ '1' });
+        var id2b = KeyId.ofBytes(new byte[]{ '1', '2' });
+        assertEquals(id0s, id0b);
+        assertEquals(id1s, id1b);
+        assertEquals(id2s, id2b);
+    }
+
+    @Test
+    void accessors_return_expected_values() {
+        byte[] fooBytes = new byte[]{'f','o','o'};
+        byte[] barBytes = new byte[]{'b','a','r'};
+
+        var id1 = KeyId.ofString("foo");
+        assertEquals("foo", id1.asString());
+        assertArrayEquals(fooBytes, id1.asBytes());
+
+        var id2 = KeyId.ofBytes(barBytes);
+        assertEquals("bar", id2.asString());
+        assertArrayEquals(barBytes, id2.asBytes());
+    }
+
+    @Test
+    void key_id_bytes_are_deep_copied_when_constructed_from_raw_byte_array() {
+        byte[] keyBytes = new byte[]{'f','o','o'};
+        byte[] expected = keyBytes.clone();
+        var id = KeyId.ofBytes(keyBytes);
+        keyBytes[0] = 'b';
+        assertArrayEquals(expected, id.asBytes());
+    }
+
+    @Test
+    void can_construct_largest_possible_key_id() {
+        byte[] okIdBytes = new byte[KeyId.MAX_KEY_ID_UTF8_LENGTH];
+        Arrays.fill(okIdBytes, (byte)'A');
+        var okId = KeyId.ofBytes(okIdBytes);
+        assertArrayEquals(okIdBytes, okId.asBytes());
+    }
+
+    @Test
+    void too_big_key_id_throws() {
+        byte[] tooBigIdBytes = new byte[KeyId.MAX_KEY_ID_UTF8_LENGTH + 1];
+        Arrays.fill(tooBigIdBytes, (byte)'A');
+        assertThrows(IllegalArgumentException.class, () -> KeyId.ofBytes(tooBigIdBytes));
+    }
+
+    @Test
+    void malformed_utf8_key_id_is_rejected_on_construction() {
+        byte[] malformedIdBytes = new byte[]{ (byte)0xC0 }; // First part of a 2-byte continuation without trailing byte
+        assertThrows(IllegalArgumentException.class, () -> KeyId.ofBytes(malformedIdBytes));
+    }
+
+}

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.security.tool.crypto;
 
+import com.yahoo.security.KeyId;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SealedSharedKey;
 import com.yahoo.security.SharedKeyGenerator;
@@ -95,8 +96,8 @@ public class DecryptTool implements Tool {
             var tokenString = CliUtils.optionOrThrow(arguments, TOKEN_OPTION);
             var sealedSharedKey = SealedSharedKey.fromTokenString(tokenString.strip());
             if (maybeKeyId.isPresent()) {
-                byte[] myKeyIdBytes = toUtf8Bytes(maybeKeyId.get());
-                if (!Arrays.equals(myKeyIdBytes, sealedSharedKey.keyId())) {
+                var myKeyId = KeyId.ofString(maybeKeyId.get());
+                if (!myKeyId.equals(sealedSharedKey.keyId())) {
                     // Don't include raw key bytes array verbatim in message (may contain control chars etc).
                     throw new IllegalArgumentException("Key ID specified with --key-id does not match key ID " +
                                                        "used when generating the supplied token");

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.security.tool.crypto;
 
+import com.yahoo.security.KeyId;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SharedKeyGenerator;
 import com.yahoo.vespa.security.tool.CliUtils;
@@ -79,7 +80,7 @@ public class EncryptTool implements Tool {
             var outputPath = Paths.get(CliUtils.optionOrThrow(arguments, OUTPUT_FILE_OPTION));
 
             var recipientPubKey = KeyUtils.fromBase64EncodedX25519PublicKey(CliUtils.optionOrThrow(arguments, RECIPIENT_PUBLIC_KEY_OPTION).strip());
-            var keyId  = toUtf8Bytes(CliUtils.optionOrThrow(arguments, KEY_ID_OPTION));
+            var keyId  = KeyId.ofString(CliUtils.optionOrThrow(arguments, KEY_ID_OPTION));
             var shared = SharedKeyGenerator.generateForReceiverPublicKey(recipientPubKey, keyId);
             var cipher = SharedKeyGenerator.makeAesGcmEncryptionCipher(shared);
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/TokenInfoTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/TokenInfoTool.java
@@ -47,7 +47,7 @@ public class TokenInfoTool implements Tool {
         var stdOut = invocation.stdOut();
 
         stdOut.format("Version:         %d\n", token.tokenVersion());
-        stdOut.format("Key ID:          %s (%s)\n", StringUtilities.escape(fromUtf8Bytes(token.keyId())), hex(token.keyId()));
+        stdOut.format("Key ID:          %s (%s)\n", StringUtilities.escape(token.keyId().asString()), hex(token.keyId().asBytes()));
         stdOut.format("HPKE enc:        %s\n", hex(token.enc()));
         stdOut.format("HPKE ciphertext: %s\n", hex(token.ciphertext()));
 


### PR DESCRIPTION
@bjorncs please review.

Enforces invariants and avoids having to pass raw byte arrays around.

