### PR TITLE
Revert "open port for wireguard in acl"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
@@ -86,12 +86,10 @@ public record NodeAcl(Node node,
                 // - port 19070 (RPC) from all tenant nodes (and their hosts, in case traffic is NAT-ed via parent)
                 // - port 19070 (RPC) from all proxy nodes (and their hosts, in case traffic is NAT-ed via parent)
                 // - port 4443 from the world
-                // - port 51820 from the world (WireGuard)
                 trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.host, NodeType.tenant,
                                                                      NodeType.proxyhost, NodeType.proxy),
                                                    RPC_PORTS));
                 trustedPorts.add(4443);
-                trustedPorts.add(51820);
             }
             case proxy -> {
                 // Proxy nodes trust:

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
@@ -109,7 +109,7 @@ public class AclProvisioningTest {
                            TrustedNode.of(configNodes)),
                    Set.of("10.2.3.0/24", "10.4.5.0/24"),
                    List.of(nodeAcl));
-        assertEquals(Set.of(22, 4443, 51820), nodeAcl.trustedPorts());
+        assertEquals(Set.of(22, 4443), nodeAcl.trustedPorts());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-config-server.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-config-server.json
@@ -274,10 +274,6 @@
     {
       "port": 4443,
       "trustedBy": "cfg1.yahoo.com"
-    },
-    {
-      "port":51820,
-      "trustedBy":"cfg1.yahoo.com"
     }
   ]
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#24718

This doesn't do the trick, we need UDP not tcp ... 🤦‍♂️ 