### PR TITLE
Split up DynamicProvisioningMaintainer

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -55,7 +55,7 @@ public class PermanentFlags {
             "Specifies the resources that ought to be immediately available for additional cluster " +
                     "allocations.  If the resources are not available, additional hosts will be provisioned. " +
                     "Only applies to dynamically provisioned zones.",
-            "Takes effect on next iteration of DynamicProvisioningMaintainer.");
+            "Takes effect on next iteration of HostCapacityMaintainer.");
 
     public static final UnboundIntFlag REBOOT_INTERVAL_IN_DAYS = defineIntFlag(
             "reboot-interval-in-days", 15,
@@ -67,7 +67,7 @@ public class PermanentFlags {
             "shared-host", SharedHost.createDisabled(), SharedHost.class,
             "Specifies whether shared hosts can be provisioned, and if so, the advertised " +
                     "node resources of the host, the maximum number of containers, etc.",
-            "Takes effect on next iteration of DynamicProvisioningMaintainer.");
+            "Takes effect on next iteration of HostCapacityMaintainer.");
 
     public static final UnboundStringFlag HOST_FLAVOR = defineStringFlag(
             "host-flavor", "",

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacer.java
@@ -1,0 +1,56 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.jdisc.Metric;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeMutex;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Rebuilds hosts by replacing the root disk (only supports hosts with remote storage).
+ *
+ * @author mpolden
+ */
+public class DiskReplacer extends NodeRepositoryMaintainer {
+
+    private static final Logger log = Logger.getLogger(DiskReplacer.class.getName());
+
+    private final HostProvisioner hostProvisioner;
+
+    DiskReplacer(NodeRepository nodeRepository, Duration interval, Metric metric, HostProvisioner hostProvisioner) {
+        super(nodeRepository, interval, metric);
+        this.hostProvisioner = hostProvisioner;
+    }
+
+    @Override
+    protected double maintain() {
+        NodeList nodes = nodeRepository().nodes().list().rebuilding(true);
+        int failures = 0;
+        for (var host : nodes) {
+            Optional<NodeMutex> optionalMutex = nodeRepository().nodes().lockAndGet(host, Duration.ofSeconds(10));
+            if (optionalMutex.isEmpty()) continue;
+            try (NodeMutex mutex = optionalMutex.get()) {
+                // Re-check flag while holding lock
+                host = mutex.node();
+                if (!host.status().wantToRebuild()) {
+                    continue;
+                }
+                Node updatedNode = hostProvisioner.replaceRootDisk(host);
+                if (!updatedNode.status().wantToRebuild()) {
+                    nodeRepository().nodes().write(updatedNode, mutex);
+                }
+            } catch (RuntimeException e) {
+                failures++;
+                log.log(Level.WARNING, "Failed to rebuild " + host.hostname() + ", will retry in " + interval(), e);
+            }
+        }
+        return this.asSuccessFactor(nodes.size(), failures);
+    }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ExpeditedChangeApplicationMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ExpeditedChangeApplicationMaintainer.java
@@ -107,12 +107,10 @@ public class ExpeditedChangeApplicationMaintainer extends ApplicationMaintainer 
 
     /** Returns whether to expedite changes performed by agent */
     private boolean expediteChangeBy(Agent agent) {
-        switch (agent) {
-            case operator:
-            case RebuildingOsUpgrader:
-            case HostEncrypter: return true;
-        }
-        return false;
+        return switch (agent) {
+            case operator, HostEncrypter, HostResumeProvisioner, RebuildingOsUpgrader -> true;
+            default -> false;
+        };
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
@@ -104,9 +104,9 @@ public class HostCapacityMaintainer extends NodeRepositoryMaintainer {
 
                     // Retire the host to parked if possible, otherwise move it straight to parked
                     if (EnumSet.of(Node.State.reserved, Node.State.active, Node.State.inactive).contains(host.state())) {
-                        Node retiredHost = host.withWantToRetire(true, true, Agent.DynamicProvisioningMaintainer, nodeRepository().clock().instant());
+                        Node retiredHost = host.withWantToRetire(true, true, Agent.HostCapacityMaintainer, nodeRepository().clock().instant());
                         nodeRepository().nodes().write(retiredHost, mutex);
-                    } else nodeRepository().nodes().park(host.hostname(), true, Agent.DynamicProvisioningMaintainer, "Parked for removal");
+                    } else nodeRepository().nodes().park(host.hostname(), true, Agent.HostCapacityMaintainer, "Parked for removal");
                 } catch (UncheckedTimeoutException e) {
                     log.log(Level.WARNING, "Failed to mark " + host.hostname() +
                             " for deprovisioning: Failed to get lock on node, will retry later");
@@ -226,7 +226,7 @@ public class HostCapacityMaintainer extends NodeRepositoryMaintainer {
                                            osVersion, HostSharing.shared, Optional.empty(), nodeRepository().zone().cloud().account(),
                                            provisionedHosts -> {
                                                hosts.addAll(provisionedHosts.stream().map(ProvisionedHost::generateHost).toList());
-                                               nodeRepository().nodes().addNodes(hosts, Agent.DynamicProvisioningMaintainer);
+                                               nodeRepository().nodes().addNodes(hosts, Agent.HostCapacityMaintainer);
                                            });
             return hosts;
         } catch (NodeAllocationException | IllegalArgumentException | IllegalStateException e) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisioner.java
@@ -1,0 +1,57 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.jdisc.Metric;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+
+import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author freva
+ */
+public class HostDeprovisioner extends NodeRepositoryMaintainer {
+
+    private static final Logger log = Logger.getLogger(HostDeprovisioner.class.getName());
+
+    private final HostProvisioner hostProvisioner;
+
+    HostDeprovisioner(NodeRepository nodeRepository, Duration interval, Metric metric, HostProvisioner hostProvisioner) {
+        super(nodeRepository, interval, metric);
+        this.hostProvisioner = hostProvisioner;
+    }
+
+    @Override
+    protected double maintain() {
+        NodeList allNodes = nodeRepository().nodes().list();
+        NodeList hosts = allNodes.parents().matching(HostCapacityMaintainer::canDeprovision);
+
+        int failures = 0;
+        for (Node host : hosts) {
+            // This shouldn't be possible since failed, parked, and wantToDeprovision should be recursive
+            if (!allNodes.childrenOf(host).stream().allMatch(HostCapacityMaintainer::canDeprovision))
+                continue;
+
+            try {
+                // Technically we should do this under application lock, but
+                // * HostProvisioner::deprovision may take some time since we are waiting for request(s) against
+                //   the cloud provider
+                // * Because the application lock is shared between all hosts of the same type we want to avoid
+                //   holding it over longer periods
+                // * We are about to remove these hosts anyway, so only reason we'd want to hold the lock is
+                //   if we want to support aborting deprovision if operator manually intervenes
+                hostProvisioner.deprovision(host);
+                nodeRepository().nodes().removeRecursively(host, true);
+            } catch (RuntimeException e) {
+                failures++;
+                log.log(Level.WARNING, "Failed to deprovision " + host.hostname() + ", will retry in " + interval(), e);
+            }
+        }
+        return asSuccessFactor(hosts.size(), failures);
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostDeprovisioner.java
@@ -12,6 +12,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
+ * Deprovisions hosts that are no longer needed in dynamically provisioned systems.
+ *
  * @author freva
  */
 public class HostDeprovisioner extends NodeRepositoryMaintainer {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisioner.java
@@ -65,9 +65,8 @@ public class HostResumeProvisioner extends NodeRepositoryMaintainer {
                 failures++;
                 log.log(Level.SEVERE, "Failed to provision " + host.hostname() + " with " + children.size()  +
                                       " children, failing out the host recursively", e);
-                // Fail out as operator to force a quick redeployment
                 nodeRepository().nodes().failOrMarkRecursively(
-                        host.hostname(), Agent.operator, "Failed by HostProvisioner due to provisioning failure");
+                        host.hostname(), Agent.HostResumeProvisioner, "Failed by HostResumeProvisioner due to provisioning failure");
             } catch (RuntimeException e) {
                 if (e.getCause() instanceof NamingException)
                     log.log(Level.INFO, "Could not provision " + host.hostname() + ", will retry in " + interval() + ": " + Exceptions.toMessageString(e));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisioner.java
@@ -1,0 +1,89 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.jdisc.Metric;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.node.IP;
+import com.yahoo.vespa.hosted.provision.provisioning.FatalProvisioningException;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+import com.yahoo.yolean.Exceptions;
+
+import javax.naming.NamingException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * @author freva
+ * @author mpolden
+ */
+public class HostResumeProvisioner extends NodeRepositoryMaintainer {
+
+    private static final Logger log = Logger.getLogger(HostResumeProvisioner.class.getName());
+
+    private final HostProvisioner hostProvisioner;
+
+    HostResumeProvisioner(NodeRepository nodeRepository, Duration interval, Metric metric, HostProvisioner hostProvisioner) {
+        super(nodeRepository, interval, metric);
+        this.hostProvisioner = hostProvisioner;
+    }
+
+    @Override
+    protected double maintain() {
+        NodeList allNodes = nodeRepository().nodes().list();
+        Map<String, Set<Node>> nodesByProvisionedParentHostname =
+                allNodes.nodeType(NodeType.tenant, NodeType.config, NodeType.controller)
+                     .asList()
+                     .stream()
+                     .filter(node -> node.parentHostname().isPresent())
+                     .collect(Collectors.groupingBy(node -> node.parentHostname().get(), Collectors.toSet()));
+
+        NodeList hosts = allNodes.state(Node.State.provisioned).nodeType(NodeType.host, NodeType.confighost, NodeType.controllerhost);
+        int failures = 0;
+        for (Node host : hosts) {
+            Set<Node> children = nodesByProvisionedParentHostname.getOrDefault(host.hostname(), Set.of());
+            try {
+                try (var lock = nodeRepository().nodes().lockUnallocated()) {
+                    List<Node> updatedNodes = hostProvisioner.provision(host, children);
+                    verifyDns(updatedNodes);
+                    nodeRepository().nodes().write(updatedNodes, lock);
+                }
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                log.log(Level.INFO, "Could not provision " + host.hostname() + " with " + children.size() + " children, will retry in " +
+                                    interval() + ": " + Exceptions.toMessageString(e));
+            } catch (FatalProvisioningException e) {
+                failures++;
+                log.log(Level.SEVERE, "Failed to provision " + host.hostname() + " with " + children.size()  +
+                                      " children, failing out the host recursively", e);
+                // Fail out as operator to force a quick redeployment
+                nodeRepository().nodes().failOrMarkRecursively(
+                        host.hostname(), Agent.DynamicProvisioningMaintainer, "Failed by HostProvisioner due to provisioning failure");
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof NamingException)
+                    log.log(Level.INFO, "Could not provision " + host.hostname() + ", will retry in " + interval() + ": " + Exceptions.toMessageString(e));
+                else {
+                    failures++;
+                    log.log(Level.WARNING, "Failed to provision " + host.hostname() + ", will retry in " + interval(), e);
+                }
+            }
+        }
+        return asSuccessFactor(hosts.size(), failures);
+    }
+
+    /** Verify DNS configuration of given nodes */
+    private void verifyDns(List<Node> nodes) {
+        for (var node : nodes) {
+            for (var ipAddress : node.ipConfig().primary()) {
+                IP.verifyDns(node.hostname(), ipAddress, nodeRepository().nameResolver());
+            }
+        }
+    }
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -71,6 +71,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         provisionServiceProvider.getHostProvisioner()
                                 .map(hostProvisioner -> List.of(
                                         new DynamicProvisioningMaintainer(nodeRepository, defaults.dynamicProvisionerInterval, hostProvisioner, flagSource, metric),
+                                        new HostResumeProvisioner(nodeRepository, defaults.hostResumeProvisionerInterval, metric, hostProvisioner),
                                         new HostRetirer(nodeRepository, defaults.hostRetirerInterval, metric, hostProvisioner),
                                         new DiskReplacer(nodeRepository, defaults.diskReplacerInterval, metric, hostProvisioner)))
                                 .ifPresent(maintainers::addAll);
@@ -112,6 +113,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         private final Duration infrastructureProvisionInterval;
         private final Duration loadBalancerExpirerInterval;
         private final Duration dynamicProvisionerInterval;
+        private final Duration hostResumeProvisionerInterval;
         private final Duration diskReplacerInterval;
         private final Duration osUpgradeActivatorInterval;
         private final Duration rebalancerInterval;
@@ -126,6 +128,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         DefaultTimes(Zone zone, Deployer deployer) {
             autoscalingInterval = Duration.ofMinutes(5);
             dynamicProvisionerInterval = Duration.ofMinutes(3);
+            hostResumeProvisionerInterval = Duration.ofMinutes(3);
             diskReplacerInterval = Duration.ofMinutes(3);
             failedExpirerInterval = Duration.ofMinutes(10);
             failGrace = Duration.ofMinutes(20);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -70,7 +70,8 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
                                 .ifPresent(maintainers::add);
         provisionServiceProvider.getHostProvisioner()
                                 .map(hostProvisioner -> List.of(
-                                        new DynamicProvisioningMaintainer(nodeRepository, defaults.dynamicProvisionerInterval, hostProvisioner, flagSource, metric),
+                                        new HostCapacityMaintainer(nodeRepository, defaults.dynamicProvisionerInterval, hostProvisioner, flagSource, metric),
+                                        new HostDeprovisioner(nodeRepository, defaults.hostDeprovisionerInterval, metric, hostProvisioner),
                                         new HostResumeProvisioner(nodeRepository, defaults.hostResumeProvisionerInterval, metric, hostProvisioner),
                                         new HostRetirer(nodeRepository, defaults.hostRetirerInterval, metric, hostProvisioner),
                                         new DiskReplacer(nodeRepository, defaults.diskReplacerInterval, metric, hostProvisioner)))
@@ -113,6 +114,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         private final Duration infrastructureProvisionInterval;
         private final Duration loadBalancerExpirerInterval;
         private final Duration dynamicProvisionerInterval;
+        private final Duration hostDeprovisionerInterval;
         private final Duration hostResumeProvisionerInterval;
         private final Duration diskReplacerInterval;
         private final Duration osUpgradeActivatorInterval;
@@ -128,6 +130,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         DefaultTimes(Zone zone, Deployer deployer) {
             autoscalingInterval = Duration.ofMinutes(5);
             dynamicProvisionerInterval = Duration.ofMinutes(3);
+            hostDeprovisionerInterval = Duration.ofMinutes(3);
             hostResumeProvisionerInterval = Duration.ofMinutes(3);
             diskReplacerInterval = Duration.ofMinutes(3);
             failedExpirerInterval = Duration.ofMinutes(10);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintenance.java
@@ -69,11 +69,11 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
                                 .map(lbService -> new LoadBalancerExpirer(nodeRepository, defaults.loadBalancerExpirerInterval, lbService, metric))
                                 .ifPresent(maintainers::add);
         provisionServiceProvider.getHostProvisioner()
-                                .map(hostProvisioner -> new DynamicProvisioningMaintainer(nodeRepository, defaults.dynamicProvisionerInterval, hostProvisioner, flagSource, metric))
-                                .ifPresent(maintainers::add);
-        provisionServiceProvider.getHostProvisioner()
-                                .map(hostProvisioner -> new HostRetirer(nodeRepository, defaults.hostRetirerInterval, metric, hostProvisioner))
-                                .ifPresent(maintainers::add);
+                                .map(hostProvisioner -> List.of(
+                                        new DynamicProvisioningMaintainer(nodeRepository, defaults.dynamicProvisionerInterval, hostProvisioner, flagSource, metric),
+                                        new HostRetirer(nodeRepository, defaults.hostRetirerInterval, metric, hostProvisioner),
+                                        new DiskReplacer(nodeRepository, defaults.diskReplacerInterval, metric, hostProvisioner)))
+                                .ifPresent(maintainers::addAll);
         // The DuperModel is filled with infrastructure applications by the infrastructure provisioner, so explicitly run that now
         infrastructureProvisioner.maintainButThrowOnException();
     }
@@ -112,6 +112,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         private final Duration infrastructureProvisionInterval;
         private final Duration loadBalancerExpirerInterval;
         private final Duration dynamicProvisionerInterval;
+        private final Duration diskReplacerInterval;
         private final Duration osUpgradeActivatorInterval;
         private final Duration rebalancerInterval;
         private final Duration nodeMetricsCollectionInterval;
@@ -125,6 +126,7 @@ public class NodeRepositoryMaintenance extends AbstractComponent {
         DefaultTimes(Zone zone, Deployer deployer) {
             autoscalingInterval = Duration.ofMinutes(5);
             dynamicProvisionerInterval = Duration.ofMinutes(3);
+            diskReplacerInterval = Duration.ofMinutes(3);
             failedExpirerInterval = Duration.ofMinutes(10);
             failGrace = Duration.ofMinutes(20);
             infrastructureProvisionInterval = Duration.ofMinutes(3);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
@@ -23,6 +23,7 @@ public enum Agent {
     ReservationExpirer,
     ParkedExpirer,
     HostCapacityMaintainer,
+    HostResumeProvisioner,
     RetiringOsUpgrader,
     RebuildingOsUpgrader,
     SpareCapacityMaintainer,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Agent.java
@@ -22,7 +22,7 @@ public enum Agent {
     ProvisionedExpirer,
     ReservationExpirer,
     ParkedExpirer,
-    DynamicProvisioningMaintainer,
+    HostCapacityMaintainer,
     RetiringOsUpgrader,
     RebuildingOsUpgrader,
     SpareCapacityMaintainer,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -467,7 +467,8 @@ public class NodeSerializer {
             case "application" : return Agent.application;
             case "system" : return Agent.system;
             case "DirtyExpirer" : return Agent.DirtyExpirer;
-            case "DynamicProvisioningMaintainer" : return Agent.DynamicProvisioningMaintainer;
+            case "DynamicProvisioningMaintainer":
+            case "HostCapacityMaintainer": return Agent.HostCapacityMaintainer;
             case "FailedExpirer" : return Agent.FailedExpirer;
             case "InactiveExpirer" : return Agent.InactiveExpirer;
             case "NodeFailer" : return Agent.NodeFailer;
@@ -490,7 +491,7 @@ public class NodeSerializer {
             case application : return "application";
             case system : return "system";
             case DirtyExpirer : return "DirtyExpirer";
-            case DynamicProvisioningMaintainer : return "DynamicProvisioningMaintainer";
+            case HostCapacityMaintainer: return "DynamicProvisioningMaintainer";
             case FailedExpirer : return "FailedExpirer";
             case InactiveExpirer : return "InactiveExpirer";
             case NodeFailer : return "NodeFailer";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -410,131 +410,129 @@ public class NodeSerializer {
     
     /** Returns the event type, or null if this event type should be ignored */
     private History.Event.Type eventTypeFromString(String eventTypeString) {
-        switch (eventTypeString) {
-            case "provisioned" : return History.Event.Type.provisioned;
-            case "deprovisioned" : return History.Event.Type.deprovisioned;
-            case "readied" : return History.Event.Type.readied;
-            case "reserved" : return History.Event.Type.reserved;
-            case "activated" : return History.Event.Type.activated;
-            case "wantToRetire": return History.Event.Type.wantToRetire;
-            case "wantToFail": return History.Event.Type.wantToFail;
-            case "retired" : return History.Event.Type.retired;
-            case "deactivated" : return History.Event.Type.deactivated;
-            case "parked" : return History.Event.Type.parked;
-            case "failed" : return History.Event.Type.failed;
-            case "deallocated" : return History.Event.Type.deallocated;
-            case "down" : return History.Event.Type.down;
-            case "up" : return History.Event.Type.up;
-            case "resized" : return History.Event.Type.resized;
-            case "rebooted" : return History.Event.Type.rebooted;
-            case "osUpgraded" : return History.Event.Type.osUpgraded;
-            case "firmwareVerified" : return History.Event.Type.firmwareVerified;
-            case "breakfixed" : return History.Event.Type.breakfixed;
-            case "preferToRetire" : return History.Event.Type.preferToRetire;
-        }
-        throw new IllegalArgumentException("Unknown node event type '" + eventTypeString + "'");
+        return switch (eventTypeString) {
+            case "provisioned" -> History.Event.Type.provisioned;
+            case "deprovisioned" -> History.Event.Type.deprovisioned;
+            case "readied" -> History.Event.Type.readied;
+            case "reserved" -> History.Event.Type.reserved;
+            case "activated" -> History.Event.Type.activated;
+            case "wantToRetire" -> History.Event.Type.wantToRetire;
+            case "wantToFail" -> History.Event.Type.wantToFail;
+            case "retired" -> History.Event.Type.retired;
+            case "deactivated" -> History.Event.Type.deactivated;
+            case "parked" -> History.Event.Type.parked;
+            case "failed" -> History.Event.Type.failed;
+            case "deallocated" -> History.Event.Type.deallocated;
+            case "down" -> History.Event.Type.down;
+            case "up" -> History.Event.Type.up;
+            case "resized" -> History.Event.Type.resized;
+            case "rebooted" -> History.Event.Type.rebooted;
+            case "osUpgraded" -> History.Event.Type.osUpgraded;
+            case "firmwareVerified" -> History.Event.Type.firmwareVerified;
+            case "breakfixed" -> History.Event.Type.breakfixed;
+            case "preferToRetire" -> History.Event.Type.preferToRetire;
+            default -> throw new IllegalArgumentException("Unknown node event type '" + eventTypeString + "'");
+        };
     }
 
     private String toString(History.Event.Type nodeEventType) {
-        switch (nodeEventType) {
-            case provisioned : return "provisioned";
-            case deprovisioned : return "deprovisioned";
-            case readied : return "readied";
-            case reserved : return "reserved";
-            case activated : return "activated";
-            case wantToRetire: return "wantToRetire";
-            case wantToFail: return "wantToFail";
-            case retired : return "retired";
-            case deactivated : return "deactivated";
-            case parked : return "parked";
-            case failed : return "failed";
-            case deallocated : return "deallocated";
-            case down : return "down";
-            case up : return "up";
-            case resized: return "resized";
-            case rebooted: return "rebooted";
-            case osUpgraded: return "osUpgraded";
-            case firmwareVerified: return "firmwareVerified";
-            case breakfixed: return "breakfixed";
-            case preferToRetire: return "preferToRetire";
-        }
-        throw new IllegalArgumentException("Serialized form of '" + nodeEventType + "' not defined");
+        return switch (nodeEventType) {
+            case provisioned -> "provisioned";
+            case deprovisioned -> "deprovisioned";
+            case readied -> "readied";
+            case reserved -> "reserved";
+            case activated -> "activated";
+            case wantToRetire -> "wantToRetire";
+            case wantToFail -> "wantToFail";
+            case retired -> "retired";
+            case deactivated -> "deactivated";
+            case parked -> "parked";
+            case failed -> "failed";
+            case deallocated -> "deallocated";
+            case down -> "down";
+            case up -> "up";
+            case resized -> "resized";
+            case rebooted -> "rebooted";
+            case osUpgraded -> "osUpgraded";
+            case firmwareVerified -> "firmwareVerified";
+            case breakfixed -> "breakfixed";
+            case preferToRetire -> "preferToRetire";
+        };
     }
 
     private Agent eventAgentFromSlime(Inspector eventAgentField) {
-        switch (eventAgentField.asString()) {
-            case "operator" : return Agent.operator;
-            case "application" : return Agent.application;
-            case "system" : return Agent.system;
-            case "DirtyExpirer" : return Agent.DirtyExpirer;
-            case "DynamicProvisioningMaintainer":
-            case "HostCapacityMaintainer": return Agent.HostCapacityMaintainer;
-            case "FailedExpirer" : return Agent.FailedExpirer;
-            case "InactiveExpirer" : return Agent.InactiveExpirer;
-            case "NodeFailer" : return Agent.NodeFailer;
-            case "NodeHealthTracker" : return Agent.NodeHealthTracker;
-            case "ProvisionedExpirer" : return Agent.ProvisionedExpirer;
-            case "Rebalancer" : return Agent.Rebalancer;
-            case "ReservationExpirer" : return Agent.ReservationExpirer;
-            case "RetiringUpgrader" : return Agent.RetiringOsUpgrader;
-            case "RebuildingOsUpgrader" : return Agent.RebuildingOsUpgrader;
-            case "SpareCapacityMaintainer": return Agent.SpareCapacityMaintainer;
-            case "SwitchRebalancer": return Agent.SwitchRebalancer;
-            case "HostEncrypter": return Agent.HostEncrypter;
-            case "ParkedExpirer": return Agent.ParkedExpirer;
-        }
-        throw new IllegalArgumentException("Unknown node event agent '" + eventAgentField.asString() + "'");
+        return switch (eventAgentField.asString()) {
+            case "operator" -> Agent.operator;
+            case "application" -> Agent.application;
+            case "system" -> Agent.system;
+            case "DirtyExpirer" -> Agent.DirtyExpirer;
+            case "DynamicProvisioningMaintainer", "HostCapacityMaintainer" -> Agent.HostCapacityMaintainer;
+            case "HostResumeProvisioner" -> Agent.HostResumeProvisioner;
+            case "FailedExpirer" -> Agent.FailedExpirer;
+            case "InactiveExpirer" -> Agent.InactiveExpirer;
+            case "NodeFailer" -> Agent.NodeFailer;
+            case "NodeHealthTracker" -> Agent.NodeHealthTracker;
+            case "ProvisionedExpirer" -> Agent.ProvisionedExpirer;
+            case "Rebalancer" -> Agent.Rebalancer;
+            case "ReservationExpirer" -> Agent.ReservationExpirer;
+            case "RetiringUpgrader" -> Agent.RetiringOsUpgrader;
+            case "RebuildingOsUpgrader" -> Agent.RebuildingOsUpgrader;
+            case "SpareCapacityMaintainer" -> Agent.SpareCapacityMaintainer;
+            case "SwitchRebalancer" -> Agent.SwitchRebalancer;
+            case "HostEncrypter" -> Agent.HostEncrypter;
+            case "ParkedExpirer" -> Agent.ParkedExpirer;
+            default -> throw new IllegalArgumentException("Unknown node event agent '" + eventAgentField.asString() + "'");
+        };
     }
     private String toString(Agent agent) {
-        switch (agent) {
-            case operator : return "operator";
-            case application : return "application";
-            case system : return "system";
-            case DirtyExpirer : return "DirtyExpirer";
-            case HostCapacityMaintainer: return "DynamicProvisioningMaintainer";
-            case FailedExpirer : return "FailedExpirer";
-            case InactiveExpirer : return "InactiveExpirer";
-            case NodeFailer : return "NodeFailer";
-            case NodeHealthTracker: return "NodeHealthTracker";
-            case ProvisionedExpirer : return "ProvisionedExpirer";
-            case Rebalancer : return "Rebalancer";
-            case ReservationExpirer : return "ReservationExpirer";
-            case RetiringOsUpgrader: return "RetiringUpgrader";
-            case RebuildingOsUpgrader: return "RebuildingOsUpgrader";
-            case SpareCapacityMaintainer: return "SpareCapacityMaintainer";
-            case SwitchRebalancer: return "SwitchRebalancer";
-            case HostEncrypter: return "HostEncrypter";
-            case ParkedExpirer: return "ParkedExpirer";
-        }
-        throw new IllegalArgumentException("Serialized form of '" + agent + "' not defined");
+        return switch (agent) {
+            case operator -> "operator";
+            case application -> "application";
+            case system -> "system";
+            case DirtyExpirer -> "DirtyExpirer";
+            case HostCapacityMaintainer -> "DynamicProvisioningMaintainer";
+            case HostResumeProvisioner -> "HostResumeProvisioner";
+            case FailedExpirer -> "FailedExpirer";
+            case InactiveExpirer -> "InactiveExpirer";
+            case NodeFailer -> "NodeFailer";
+            case NodeHealthTracker -> "NodeHealthTracker";
+            case ProvisionedExpirer -> "ProvisionedExpirer";
+            case Rebalancer -> "Rebalancer";
+            case ReservationExpirer -> "ReservationExpirer";
+            case RetiringOsUpgrader -> "RetiringUpgrader";
+            case RebuildingOsUpgrader -> "RebuildingOsUpgrader";
+            case SpareCapacityMaintainer -> "SpareCapacityMaintainer";
+            case SwitchRebalancer -> "SwitchRebalancer";
+            case HostEncrypter -> "HostEncrypter";
+            case ParkedExpirer -> "ParkedExpirer";
+        };
     }
 
     static NodeType nodeTypeFromString(String typeString) {
-        switch (typeString) {
-            case "tenant": return NodeType.tenant;
-            case "host": return NodeType.host;
-            case "proxy": return NodeType.proxy;
-            case "proxyhost": return NodeType.proxyhost;
-            case "config": return NodeType.config;
-            case "confighost": return NodeType.confighost;
-            case "controller": return NodeType.controller;
-            case "controllerhost": return NodeType.controllerhost;
-            default : throw new IllegalArgumentException("Unknown node type '" + typeString + "'");
-        }
+        return switch (typeString) {
+            case "tenant" -> NodeType.tenant;
+            case "host" -> NodeType.host;
+            case "proxy" -> NodeType.proxy;
+            case "proxyhost" -> NodeType.proxyhost;
+            case "config" -> NodeType.config;
+            case "confighost" -> NodeType.confighost;
+            case "controller" -> NodeType.controller;
+            case "controllerhost" -> NodeType.controllerhost;
+            default -> throw new IllegalArgumentException("Unknown node type '" + typeString + "'");
+        };
     }
 
     static String toString(NodeType type) {
-        switch (type) {
-            case tenant: return "tenant";
-            case host: return "host";
-            case proxy: return "proxy";
-            case proxyhost: return "proxyhost";
-            case config: return "config";
-            case confighost: return "confighost";
-            case controller: return "controller";
-            case controllerhost: return "controllerhost";
-        }
-        throw new IllegalArgumentException("Serialized form of '" + type + "' not defined");
+        return switch (type) {
+            case tenant -> "tenant";
+            case host -> "host";
+            case proxy -> "proxy";
+            case proxyhost -> "proxyhost";
+            case config -> "config";
+            case confighost -> "confighost";
+            case controller -> "controller";
+            case controllerhost -> "controllerhost";
+        };
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -129,7 +129,7 @@ public class GroupPreparer {
                 } catch (NodeAllocationException e) {
                     // Mark the nodes that were written to ZK in the consumer for deprovisioning. While these hosts do
                     // not exist, we cannot remove them from ZK here because other nodes may already have been
-                    // allocated on them, so let DynamicProvisioningMaintainer deal with it
+                    // allocated on them, so let HostDeprovisioner deal with it
                     hosts.forEach(host -> nodeRepository.nodes().deprovision(host.hostname(), Agent.system, nodeRepository.clock().instant()));
                     throw e;
                 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -143,8 +143,8 @@ public class MockHostProvisioner implements HostProvisioner {
         return this;
     }
 
-    public MockHostProvisioner completeRebuildOf(Node host) {
-        rebuildsCompleted.add(host.hostname());
+    public MockHostProvisioner completeRebuildOf(String hostname) {
+        rebuildsCompleted.add(hostname);
         return this;
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -70,7 +70,7 @@ public class MockHostProvisioner implements HostProvisioner {
                                                                    .orElseThrow(() -> new NodeAllocationException("No host flavor matches " + resources, true)));
         List<ProvisionedHost> hosts = new ArrayList<>();
         for (int index : provisionIndices) {
-            String hostHostname = hostType == NodeType.host ? "hostname" + index : hostType.name() + index;
+            String hostHostname = hostType == NodeType.host ? "host" + index : hostType.name() + index;
             hosts.add(new ProvisionedHost("id-of-" + hostType.name() + index,
                                           hostHostname,
                                           hostFlavor,
@@ -173,11 +173,11 @@ public class MockHostProvisioner implements HostProvisioner {
     }
 
     private List<Address> createAddressesForHost(NodeType hostType, Flavor flavor, int hostIndex) {
-        long numAddresses = Math.max(1, Math.round(flavor.resources().bandwidthGbps()));
-        return IntStream.range(0, (int) numAddresses)
+        long numAddresses = Math.max(2, Math.round(flavor.resources().bandwidthGbps()));
+        return IntStream.range(1, (int) numAddresses)
                         .mapToObj(i -> {
                             String hostname = hostType == NodeType.host
-                                    ? "nodename" + hostIndex + "_" + i
+                                    ? "host" + hostIndex + "-" + i
                                     : hostType.childNodeType().name() + i;
                             return new Address(hostname);
                         })

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingIntegrationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingIntegrationTest.java
@@ -33,7 +33,7 @@ public class AutoscalingIntegrationTest {
         Autoscaler autoscaler = new Autoscaler(fixture.tester().nodeRepository());
 
         // The metrics response (below) hardcodes these hostnames:
-        assertEquals(Set.of("node-1-of-host-1.yahoo.com", "node-1-of-host-10.yahoo.com"), fixture.nodes().hostnames());
+        assertEquals(Set.of("host-1-1.yahoo.com", "host-10-1.yahoo.com"), fixture.nodes().hostnames());
 
         for (int i = 0; i < 1000; i++) {
             fixture.tester().clock().advance(Duration.ofSeconds(10));
@@ -58,7 +58,7 @@ public class AutoscalingIntegrationTest {
                 "{\n" +
                 "  \"nodes\": [\n" +
                 "    {\n" +
-                "      \"hostname\": \"node-1-of-host-1.yahoo.com\",\n" +
+                "      \"hostname\": \"host-1-1.yahoo.com\",\n" +
                 "      \"role\": \"role0\",\n" +
                 "      \"node\": {\n" +
                 "        \"timestamp\": [now],\n" +
@@ -77,7 +77,7 @@ public class AutoscalingIntegrationTest {
                 "      }\n" +
                 "    },\n" +
                 "    {\n" +
-                "      \"hostname\": \"node-1-of-host-10.yahoo.com\",\n" +
+                "      \"hostname\": \"host-10-1.yahoo.com\",\n" +
                 "      \"role\": \"role1\",\n" +
                 "      \"node\": {\n" +
                 "        \"timestamp\": [now],\n" +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DiskReplacerTest.java
@@ -1,0 +1,42 @@
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
+import com.yahoo.vespa.hosted.provision.testutils.MockHostProvisioner;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author mpolden
+ */
+public class DiskReplacerTest {
+
+    private final ProvisioningTester tester = new ProvisioningTester.Builder().build();
+    private final MockHostProvisioner hostProvisioner = new MockHostProvisioner(List.of());
+    private final DiskReplacer diskReplacer = new DiskReplacer(tester.nodeRepository(), Duration.ofDays(1), new TestMetric(), hostProvisioner);
+
+    @Test
+    public void rebuild_host() {
+        tester.makeReadyHosts(2, new NodeResources(1, 1, 1, 1, NodeResources.DiskSpeed.fast, NodeResources.StorageType.remote)).activateTenantHosts();
+
+        // No rebuilds in initial run
+        diskReplacer.maintain();
+        assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
+
+        // Host starts rebuilding
+        tester.nodeRepository().nodes().rebuild("host-1.yahoo.com", true, Agent.RebuildingOsUpgrader,
+                tester.nodeRepository().clock().instant());
+        diskReplacer.maintain();
+        assertEquals(1, tester.nodeRepository().nodes().list().rebuilding(true).size());
+
+        // Rebuild completes
+        hostProvisioner.completeRebuildOf("host-1.yahoo.com");
+        diskReplacer.maintain();
+        assertEquals(0, tester.nodeRepository().nodes().list().rebuilding(true).size());
+    }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/DynamicProvisioningMaintainerTest.java
@@ -612,30 +612,6 @@ public class DynamicProvisioningMaintainerTest {
         }
     }
 
-    @Test
-    public void rebuild_host() {
-        var tester = new DynamicProvisioningTester();
-        Node host1 = tester.addNode("host1", Optional.empty(), NodeType.host, Node.State.active);
-        Node host11 = tester.addNode("host1-1", Optional.of("host1"), NodeType.tenant, Node.State.parked, DynamicProvisioningTester.tenantApp);
-        Node host2 = tester.addNode("host2", Optional.empty(), NodeType.host, Node.State.active);
-        Node host21 = tester.addNode("host2-1", Optional.of("host2"), NodeType.tenant, Node.State.parked, DynamicProvisioningTester.tenantApp);
-
-        // No rebuilds in initial run
-        tester.maintainer.maintain();
-        assertEquals(0, tester.nodeRepository.nodes().list().rebuilding(true).size());
-
-        // Host starts rebuilding
-        tester.nodeRepository.nodes().rebuild(host1.hostname(), true, Agent.RebuildingOsUpgrader,
-                                              tester.nodeRepository.clock().instant());
-        tester.maintainer.maintain();
-        assertEquals(1, tester.nodeRepository.nodes().list().rebuilding(true).size());
-
-        // Rebuild completes
-        tester.hostProvisioner.completeRebuildOf(host1);
-        tester.maintainer.maintain();
-        assertEquals(0, tester.nodeRepository.nodes().list().rebuilding(true).size());
-    }
-
     private void provisionHostsIn(CloudAccount cloudAccount, int count, DynamicProvisioningTester tester) {
         tester.maintainer.maintain();
         List<String> provisionedHostnames = tester.hostProvisioner.provisionedHosts().stream()

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
@@ -442,12 +442,11 @@ public class HostCapacityMaintainerTest {
         // to parked
         int removedIndex = nodeToRemove.get().allocation().get().membership().index();
         tester.nodeRepository().nodes().setRemovable(configSrvApp, List.of(nodeToRemove.get()), true);
+        tester.nodeRepository().nodes().setRemovable(hostApp, List.of(hostToRemove.get()), true);
         tester.prepareAndActivateInfraApplication(configSrvApp, hostType.childNodeType());
-        assertSame("Node moves to expected state", Node.State.parked, nodeToRemove.get().state());
+        tester.prepareAndActivateInfraApplication(hostApp, hostType);
         assertEquals(2, tester.nodeRepository().nodes().list().nodeType(hostType.childNodeType()).state(Node.State.active).size());
-
-        // Host is parked (done by DynamicProvisioningMaintainer in a real system)
-        tester.nodeRepository().nodes().deallocate(hostToRemove.get(), Agent.system, getClass().getSimpleName());
+        assertSame("Node moves to expected state", Node.State.parked, nodeToRemove.get().state());
         assertSame("Host moves to parked", Node.State.parked, hostToRemove.get().state());
 
         // deprovisioning host cannot be unparked

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
@@ -1,0 +1,107 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.maintenance;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.Capacity;
+import com.yahoo.config.provision.Cloud;
+import com.yahoo.config.provision.ClusterResources;
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Environment;
+import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.config.provision.NodeType;
+import com.yahoo.config.provision.RegionName;
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.config.provision.Zone;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.node.IP;
+import com.yahoo.vespa.hosted.provision.provisioning.FlavorConfigBuilder;
+import com.yahoo.vespa.hosted.provision.provisioning.ProvisioningTester;
+import com.yahoo.vespa.hosted.provision.testutils.MockHostProvisioner;
+import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author freva
+ */
+public class HostResumeProvisionerTest {
+
+    private final List<Flavor> flavors = FlavorConfigBuilder.createDummies("default").getFlavors();
+    private final MockNameResolver nameResolver = new MockNameResolver();
+    private final MockHostProvisioner hostProvisioner = new MockHostProvisioner(flavors, nameResolver, 0);
+    private final ProvisioningTester tester = new ProvisioningTester.Builder()
+            .zone(new Zone(Cloud.builder().dynamicProvisioning(true).build(), SystemName.defaultSystem(), Environment.dev, RegionName.defaultName()))
+            .hostProvisioner(hostProvisioner)
+            .nameResolver(nameResolver)
+            .flavors(flavors)
+            .build();
+    private final HostResumeProvisioner hostResumeProvisioner = new HostResumeProvisioner(tester.nodeRepository(), Duration.ofDays(1), new TestMetric(), hostProvisioner);
+
+    @Test
+    public void delegates_to_host_provisioner_and_writes_back_result() {
+        deployApplication();
+
+        Node host = tester.nodeRepository().nodes().node("host100").orElseThrow();
+        Node node = tester.nodeRepository().nodes().node("host100-1").orElseThrow();
+        assertTrue("No IP addresses assigned",
+                Stream.of(host, node).map(n -> n.ipConfig().primary()).allMatch(Set::isEmpty));
+
+        Node hostNew = host.with(host.ipConfig().withPrimary(Set.of("::100:0")).withPool(host.ipConfig().pool().withIpAddresses(Set.of("::100:1", "::100:2"))));
+        Node nodeNew = node.with(IP.Config.ofEmptyPool(Set.of("::100:1")));
+
+        hostResumeProvisioner.maintain();
+        assertEquals(hostNew.ipConfig(), tester.nodeRepository().nodes().node("host100").get().ipConfig());
+        assertEquals(nodeNew.ipConfig(), tester.nodeRepository().nodes().node("host100-1").get().ipConfig());
+    }
+
+    @Test
+    public void defer_writing_ip_addresses_until_dns_resolves() {
+        deployApplication();
+        hostProvisioner.with(MockHostProvisioner.Behaviour.failDnsUpdate);
+
+        Supplier<NodeList> provisioning = () -> tester.nodeRepository().nodes().list(Node.State.provisioned).nodeType(NodeType.host);
+        assertEquals(1, provisioning.get().size());
+        provisioning.get().forEach(h -> System.out.println(h.hostname() + " " + h.ipConfig()));
+        hostResumeProvisioner.maintain();
+
+        assertTrue("No IP addresses written as DNS updates are failing",
+                provisioning.get().stream().allMatch(host -> host.ipConfig().pool().ipSet().isEmpty()));
+
+        hostProvisioner.without(MockHostProvisioner.Behaviour.failDnsUpdate);
+        hostResumeProvisioner.maintain();
+        provisioning.get().forEach(h -> System.out.println(h.hostname() + " " + h.ipConfig()));
+        assertTrue("IP addresses written as DNS updates are succeeding",
+                provisioning.get().stream().noneMatch(host -> host.ipConfig().pool().ipSet().isEmpty()));
+    }
+
+    @Test
+    public void correctly_fails_if_irrecoverable_failure() {
+        deployApplication();
+        hostProvisioner.with(MockHostProvisioner.Behaviour.failProvisioning);
+
+        Node host = tester.nodeRepository().nodes().node("host100").orElseThrow();
+        Node node = tester.nodeRepository().nodes().node("host100-1").orElseThrow();
+        assertTrue("No IP addresses assigned",
+                Stream.of(host, node).map(n -> n.ipConfig().primary()).allMatch(Set::isEmpty));
+
+        hostResumeProvisioner.maintain();
+        assertEquals(Set.of("host100", "host100-1"), tester.nodeRepository().nodes().list(Node.State.failed).hostnames());
+    }
+
+    private void deployApplication() {
+        ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("cluster1")).vespaVersion(Version.fromString("7")).build();
+        Capacity capacity = Capacity.from(new ClusterResources(1, 1, new NodeResources(1, 30, 20, 3)));
+        tester.prepare(ProvisioningTester.applicationId(), cluster, capacity);
+        assertEquals(2, tester.nodeRepository().nodes().list().size());
+    }
+}

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -23,9 +23,9 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static com.yahoo.vespa.hosted.provision.node.Report.Type.HARD_FAIL;
 import static org.junit.Assert.assertEquals;
@@ -647,9 +647,9 @@ public class NodeFailerTest {
                 .entrySet().stream()
                 .filter(entry -> entry.getValue().size() == n)
                 .map(Map.Entry::getKey)
-                .flatMap(parentHost -> Stream.of(parentHost.get()))
+                .flatMap(Optional::stream)
                 .filter(node -> ! exceptSet.contains(node))
-                .findFirst()
+                .min(Comparator.naturalOrder())
                 .orElseThrow();
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RebalancerTest.java
@@ -96,7 +96,7 @@ public class RebalancerTest {
         tester.maintain();
         assertTrue("Want to retire is reset", tester.getNodes(Node.State.active).stream().noneMatch(node -> node.status().wantToRetire()));
         assertEquals("Reserved node was moved to dirty", 2, tester.getNodes(Node.State.dirty).size());
-        String reservedHostname = tester.getNodes(Node.State.dirty).first().get().hostname();
+        String reservedHostname = tester.getNodes(Node.State.dirty).owner(memoryApp).first().get().hostname();
         tester.nodeRepository().nodes().setReady(reservedHostname, Agent.system, "Cleanup");
         tester.nodeRepository().nodes().removeRecursively(reservedHostname);
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -225,7 +225,7 @@ public class RetiredExpirerTest {
         assertEquals(1, parked.size());
         assertEquals(2, tester.nodeRepository().nodes().list(Node.State.active).nodeType(NodeType.config).size());
 
-        // Node is removed by DynamicProvisioningMaintainer (depending on its host), and these events should not affect
+        // Node is removed by HostDeprovisioner (depending on its host), and these events should not affect
         // the 2 active config servers.
         retiredNode = parked.first().get();
         nodeRepository.nodes().removeRecursively(retiredNode, true);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
@@ -340,8 +340,8 @@ public class DynamicAllocationTest {
         tester.activate(application, hosts);
 
         NodeList activeNodes = tester.nodeRepository().nodes().list().owner(application);
-        assertEquals(Set.of("127.0.127.13", "::d"), activeNodes.asList().get(0).ipConfig().primary());
-        assertEquals(Set.of("127.0.127.2", "::2"), activeNodes.asList().get(1).ipConfig().primary());
+        assertEquals(Set.of("127.0.127.2", "::2"), activeNodes.asList().get(0).ipConfig().primary());
+        assertEquals(Set.of("127.0.127.13", "::d"), activeNodes.asList().get(1).ipConfig().primary());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTest.java
@@ -99,7 +99,8 @@ public class ProvisioningTest {
 
         // remove nodes before deploying
         SystemState state5 = prepare(application1, 2, 2, 3, 3, defaultResources, tester);
-        HostSpec removed = tester.removeOne(state5.allHosts);
+        HostSpec removed = tester.removeOne(state5.content0);
+        state5.allHosts.remove(removed);
         tester.activate(application1, state5.allHosts);
         assertEquals(removed.hostname(),
                      tester.nodeRepository().nodes().list(Node.State.inactive).owner(application1).first().get().hostname());
@@ -1102,11 +1103,11 @@ public class ProvisioningTest {
 
     private static class SystemState {
 
-        private Set<HostSpec> allHosts;
-        private Set<HostSpec> container0;
-        private Set<HostSpec> container1;
-        private Set<HostSpec> content0;
-        private Set<HostSpec> content1;
+        private final Set<HostSpec> allHosts;
+        private final Set<HostSpec> container0;
+        private final Set<HostSpec> container1;
+        private final Set<HostSpec> content0;
+        private final Set<HostSpec> content1;
 
         public SystemState(Set<HostSpec> allHosts,
                            Set<HostSpec> container1,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -421,6 +421,7 @@ public class ProvisioningTester {
             }
 
             String hostname = nodeNamer.apply(nextHost);
+            String[] hostnameParts = hostname.split("\\.", 2);
             String ipv4 = String.format("127.0.%d.%d", nextIP / 256, nextIP % 256);
             String ipv6 = String.format("::%x", nextIP);
 
@@ -432,13 +433,14 @@ public class ProvisioningTester {
             Set<String> ipAddressPool = new LinkedHashSet<>();
             for (int poolIp = 1; poolIp <= ipAddressPoolSize; poolIp++) {
                 nextIP++;
+                String nodeHostname = hostnameParts[0] + "-" + poolIp + (hostnameParts.length > 1 ? "." + hostnameParts[1] : "");
                 String ipv6Addr = String.format("::%x", nextIP);
                 ipAddressPool.add(ipv6Addr);
-                nameResolver.addRecord(String.format("node-%d-of-%s", poolIp, hostname), ipv6Addr);
+                nameResolver.addRecord(nodeHostname, ipv6Addr);
                 if (dualStack) {
                     String ipv4Addr = String.format("127.0.%d.%d", (127 + (nextIP / 256)), nextIP % 256);
                     ipAddressPool.add(ipv4Addr);
-                    nameResolver.addRecord(String.format("node-%d-of-%s", poolIp, hostname), ipv4Addr);
+                    nameResolver.addRecord(nodeHostname, ipv4Addr);
                 }
             }
             Node.Builder builder = Node.create(hostname, new IP.Config(hostIps, ipAddressPool), hostname, flavor, type);


### PR DESCRIPTION
Splits up the old `DynamicProvisioningMaintainer` into 4 maintainers:
* `HostCapacityMaintainer`: Is tasked with provisioning new hosts if required per `preprovsion-capacity` feature flag and mark excess hosts as `wantToDeprovsion`
* `HostResumeProvisioner`: Resumes provisioning of hosts in `provisioned`
* `HostDeprovisioner`: Deprovisions and removes from node-repo host's that have finished retiring. TODO: These should go via `dirty` so that host-admin gets a chance to sync logs to archive.
* `DiskReplacer`: Replaces root disk on hosts that `wantToRebuild`

By splitting it up into separate maintainers it should make things happen quicker, we no longer need to wait for provisioning of preprovision capacity to deprovision excess host. Additionally, the actual deprovisioning no longer holds any locks.