### PR TITLE
Move $VESPA_HOME/tmp to $VESPA_HOME/var/tmp [run-systemtest]

### DIFF
--- a/config-proxy/src/main/sh/vespa-config-ctl.sh
+++ b/config-proxy/src/main/sh/vespa-config-ctl.sh
@@ -122,7 +122,7 @@ case $1 in
             java ${jvmopts} \
                 -XX:+ExitOnOutOfMemoryError $(getJavaOptionsIPV46) \
                 -Dproxyconfigsources="${configsources}" \
-                -Djava.io.tmpdir=${VESPA_HOME}/tmp \
+                -Djava.io.tmpdir=${VESPA_HOME}/var/tmp \
                 ${userargs} \
                 -XX:ActiveProcessorCount=2 \
                 -cp $cp com.yahoo.vespa.config.proxy.ProxyServer 19090

--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -182,7 +182,7 @@ vespa-run-as-vespa-user vespa-runserver -s ${VESPA_SERVICE_NAME} -r 30 -p $pidfi
         --add-opens=java.base/java.nio=ALL-UNNAMED \
         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
-	-Djava.io.tmpdir=${VESPA_HOME}/tmp \
+	-Djava.io.tmpdir=${VESPA_HOME}/var/tmp \
 	-Djava.library.path=${VESPA_HOME}/lib64 \
 	-Djava.security.properties=${VESPA_HOME}/conf/vespa/java.security.override \
 	-Djava.awt.headless=true \

--- a/container-disc/src/main/sh/vespa-start-container-daemon.sh
+++ b/container-disc/src/main/sh/vespa-start-container-daemon.sh
@@ -274,7 +274,7 @@ exec $numactlcmd $envcmd java \
         --add-opens=java.base/java.nio=ALL-UNNAMED \
         --add-opens=java.base/jdk.internal.loader=ALL-UNNAMED \
         --add-opens=java.base/sun.security.ssl=ALL-UNNAMED  \
-        -Djava.io.tmpdir="${VESPA_HOME}/tmp" \
+        -Djava.io.tmpdir="${VESPA_HOME}/var/tmp" \
         -Djava.library.path="${VESPA_HOME}/lib64" \
         -Djava.security.properties=${VESPA_HOME}/conf/vespa/java.security.override \
         -Djava.awt.headless=true \

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -692,8 +692,6 @@ fi
 %{_prefix}/sbin
 %{_prefix}/share
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp/vespa
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/crash
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa
@@ -708,6 +706,8 @@ fi
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa/tmp
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/jdisc_container
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/run
+%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp
+%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp/vespa
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/application
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/vespa/bundlecache

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -551,6 +551,7 @@ cp %{buildroot}/%{_prefix}/etc/systemd/system/vespa-configserver.service %{build
 %endif
 
 ln -s /usr/lib/jvm/jre-17-openjdk %{buildroot}/%{_prefix}/jdk
+ln -s %{_prefix}/var/tmp %{buildroot}/%{_prefix}/tmp
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -690,9 +691,9 @@ fi
 %{_prefix}/man
 %{_prefix}/sbin
 %{_prefix}/share
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/tmp
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/tmp/vespa
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var
+%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp
+%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/tmp/vespa
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/crash
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/db/vespa

--- a/logserver/bin/logserver-start.sh
+++ b/logserver/bin/logserver-start.sh
@@ -81,7 +81,7 @@ cd ${VESPA_HOME} || { echo "Cannot cd to ${VESPA_HOME}" 1>&2; exit 1; }
 
 heap_min=32
 heap_max=256
-addopts="-server -Xms${heap_min}m -Xmx${heap_max}m -XX:+PreserveFramePointer $(get_jvm_hugepage_settings $heap_max) -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=448 -XX:MaxJavaStackTraceDepth=1000 -XX:ActiveProcessorCount=2 -XX:-OmitStackTraceInFastThrow -Djava.io.tmpdir=${VESPA_HOME}/tmp"
+addopts="-server -Xms${heap_min}m -Xmx${heap_max}m -XX:+PreserveFramePointer $(get_jvm_hugepage_settings $heap_max) -XX:CompressedClassSpaceSize=32m -XX:MaxDirectMemorySize=32m -XX:ThreadStackSize=448 -XX:MaxJavaStackTraceDepth=1000 -XX:ActiveProcessorCount=2 -XX:-OmitStackTraceInFastThrow -Djava.io.tmpdir=${VESPA_HOME}/var/tmp"
 
 oomopt="-XX:+ExitOnOutOfMemoryError"
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImpl.java
@@ -98,7 +98,7 @@ public class VespaServiceDumperImpl implements VespaServiceDumper {
             handleFailure(context, request, startedAt, "No artifacts requested");
             return;
         }
-        ContainerPath directory = context.paths().underVespaHome("tmp/vespa-service-dump-" + request.getCreatedMillisOrNull());
+        ContainerPath directory = context.paths().underVespaHome("var/tmp/vespa-service-dump-" + request.getCreatedMillisOrNull());
         UnixPath unixPathDirectory = new UnixPath(directory);
         try {
             context.log(log, Level.INFO,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImplTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/servicedump/VespaServiceDumperImplTest.java
@@ -44,7 +44,7 @@ class VespaServiceDumperImplTest {
     private static final String HOSTNAME = "host-1.domain.tld";
 
     private final FileSystem fileSystem = TestFileSystem.create();
-    private final Path tmpDirectory = fileSystem.getPath("/data/vespa/storage/host-1/opt/vespa/tmp");
+    private final Path tmpDirectory = fileSystem.getPath("/data/vespa/storage/host-1/opt/vespa/var/tmp");
 
     @BeforeEach
     void create_tmp_directory() throws IOException {
@@ -84,11 +84,11 @@ class VespaServiceDumperImplTest {
         verify(operations).executeCommandInContainer(
                 context, context.users().vespa(), "/opt/vespa/libexec/vespa/find-pid", "default/container.1");
         verify(operations).executeCommandInContainer(
-                context, context.users().vespa(), "perf", "record", "-g", "--output=/opt/vespa/tmp/vespa-service-dump-1600000000000/perf-record.bin",
+                context, context.users().vespa(), "perf", "record", "-g", "--output=/opt/vespa/var/tmp/vespa-service-dump-1600000000000/perf-record.bin",
                 "--pid=12345", "sleep", "45");
         verify(operations).executeCommandInContainer(
-                context, context.users().vespa(), "bash", "-c", "perf report --input=/opt/vespa/tmp/vespa-service-dump-1600000000000/perf-record.bin" +
-                        " > /opt/vespa/tmp/vespa-service-dump-1600000000000/perf-report.txt");
+                context, context.users().vespa(), "bash", "-c", "perf report --input=/opt/vespa/var/tmp/vespa-service-dump-1600000000000/perf-record.bin" +
+                        " > /opt/vespa/var/tmp/vespa-service-dump-1600000000000/perf-report.txt");
 
         String expectedJson = "{\"createdMillis\":1600000000000,\"startedAt\":1600001000000,\"completedAt\":1600001000000," +
                 "\"location\":\"s3://uri-1/tenant1/service-dump/default-container-1-1600000000000/\"," +
@@ -127,7 +127,7 @@ class VespaServiceDumperImplTest {
                 context, context.users().vespa(), "/opt/vespa/libexec/vespa/find-pid", "default/container.1");
         verify(operations).executeCommandInContainer(
                 context, context.users().vespa(), "jcmd", "12345", "JFR.start", "name=host-admin", "path-to-gc-roots=true", "settings=profile",
-                "filename=/opt/vespa/tmp/vespa-service-dump-1600000000000/recording.jfr", "duration=30s");
+                "filename=/opt/vespa/var/tmp/vespa-service-dump-1600000000000/recording.jfr", "duration=30s");
         verify(operations).executeCommandInContainer(context, context.users().vespa(), "jcmd", "12345", "JFR.check", "name=host-admin");
 
         String expectedJson = "{\"createdMillis\":1600000000000,\"startedAt\":1600001000000," +

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneContainerApplication.java
@@ -67,7 +67,7 @@ public class StandaloneContainerApplication implements Application {
     public static final Named APPLICATION_PATH_NAME = Names.named(APPLICATION_LOCATION_INSTALL_VARIABLE);
     public static final Named CONFIG_MODEL_REPO_NAME = Names.named("ConfigModelRepo");
 
-    private static final String DEFAULT_TMP_BASE_DIR = Defaults.getDefaults().underVespaHome("tmp");
+    private static final String DEFAULT_TMP_BASE_DIR = Defaults.getDefaults().underVespaHome("var/tmp");
     private static final String TMP_DIR_NAME = "standalone_container";
 
     private static final StaticConfigDefinitionRepo configDefinitionRepo = new StaticConfigDefinitionRepo();

--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -125,8 +125,6 @@ fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/access
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/configserver
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/search
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/crash
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa
@@ -141,6 +139,8 @@ fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/search
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa/tmp
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/jdisc_container
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/run
+fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp
+fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/application
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/vespa/bundlecache

--- a/vespabase/src/rhel-prestart.sh
+++ b/vespabase/src/rhel-prestart.sh
@@ -124,9 +124,9 @@ fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/access
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/configserver
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  logs/vespa/search
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  tmp
-fixdir ${VESPA_USER} ${VESPA_GROUP}   755  tmp/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var
+fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp
+fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/tmp/vespa
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/crash
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db
 fixdir ${VESPA_USER} ${VESPA_GROUP}   755  var/db/vespa


### PR DESCRIPTION
Prepare to support immutable container image where only var and logs directories must be writable. Create symlink from old tmp directory to $VESPA_HOME/var/tmp

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
