### PR TITLE
Compute real resources correctly

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -5,6 +5,7 @@ import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.concurrent.maintenance.JobControl;
 import com.yahoo.config.provision.ApplicationTransaction;
+import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.NodeFlavors;
 import com.yahoo.config.provision.Zone;
@@ -189,6 +190,15 @@ public class NodeRepository extends AbstractComponent {
 
     /** The number of nodes we should ensure has free capacity for node failures whenever possible */
     public int spareCount() { return spareCount; }
+
+    /**
+     * Returns whether nodes are allocated exclusively in this instance given this cluster spec.
+     * Exclusive allocation requires that the wanted node resources matches the advertised resources of the node
+     * perfectly.
+     */
+    public boolean exclusiveAllocation(ClusterSpec clusterSpec) {
+        return clusterSpec.isExclusive() || zone().cloud().dynamicProvisioning();
+    }
 
     /**
      * Returns ACLs for the children of the given host.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocatableClusterResources.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocatableClusterResources.java
@@ -37,7 +37,7 @@ public class AllocatableClusterResources {
                                        NodeRepository nodeRepository) {
         this.nodes = requested.nodes();
         this.groups = requested.groups();
-        this.realResources = nodeRepository.resourcesCalculator().requestToReal(requested.nodeResources(), clusterSpec.isExclusive());
+        this.realResources = nodeRepository.resourcesCalculator().requestToReal(requested.nodeResources(), nodeRepository.exclusiveAllocation(clusterSpec));
         this.advertisedResources = requested.nodeResources();
         this.clusterSpec = clusterSpec;
         this.fulfilment = 1;
@@ -163,8 +163,8 @@ public class AllocatableClusterResources {
                                                              NodeList hosts,
                                                              NodeRepository nodeRepository) {
         var systemLimits = new NodeResourceLimits(nodeRepository);
-        boolean exclusive = clusterSpec.isExclusive();
-        if ( !clusterSpec.isExclusive() && !nodeRepository.zone().cloud().dynamicProvisioning()) {
+        boolean exclusive = nodeRepository.exclusiveAllocation(clusterSpec);
+        if (! exclusive) {
             // We decide resources: Add overhead to what we'll request (advertised) to make sure real becomes (at least) cappedNodeResources
             var advertisedResources = nodeRepository.resourcesCalculator().realToRequest(wantedResources.nodeResources(), exclusive);
             advertisedResources = systemLimits.enlargeToLegal(advertisedResources, clusterSpec.type(), exclusive); // Ask for something legal

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Autoscaler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/Autoscaler.java
@@ -76,8 +76,7 @@ public class Autoscaler {
 
         if (! worthRescaling(currentAllocation.realResources(), bestAllocation.get().realResources())) {
             if (bestAllocation.get().fulfilment() < 1)
-                return Advice.dontScale(Status.insufficient, "Configured limits prevents better scaling of this cluster"
-                + " (" + bestAllocation.get() + " real " + bestAllocation.get().realResources() + ")");
+                return Advice.dontScale(Status.insufficient, "Configured limits prevents better scaling of this cluster");
             else
                 return Advice.dontScale(Status.ideal, "Cluster is ideally scaled");
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
@@ -28,13 +28,13 @@ public interface HostResourcesCalculator {
      * Used with exclusive hosts:
      * Returns the lowest possible real resources we'll get if requesting the given advertised resources
      */
-    NodeResources requestToReal(NodeResources advertisedResources, boolean exclusive);
+    NodeResources requestToReal(NodeResources advertisedResources, boolean exclusiveAllocation);
 
     /**
      * Used with shared hosts:
      * Returns the advertised resources we need to request to be sure to get at least the given real resources.
      */
-    NodeResources realToRequest(NodeResources realResources, boolean exclusive);
+    NodeResources realToRequest(NodeResources realResources, boolean exclusiveAllocation);
 
     /**
      * Returns the disk space to reserve in base2 GB. This space is reserved for use by the host, e.g. for storing

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -123,9 +123,6 @@ public class AutoscalingTest {
         var duration = fixture.loader().addMeasurements(new Load(0.04, 0.39, 0.01), 20);
         fixture.tester().clock().advance(duration.negated());
         fixture.loader().zeroTraffic(20);
-
-        //System.out.println("Ideal         " + fixture.clusterModel().idealLoad());
-        //System.out.println("Adjustment to " + fixture.clusterModel().loadAdjustment());
         fixture.tester().assertResources("Scaled down",
                                          2, 1, 2, 16, 10,
                                          fixture.autoscale());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/awsnodes/AwsResourcesCalculator.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/awsnodes/AwsResourcesCalculator.java
@@ -20,6 +20,7 @@ public class AwsResourcesCalculator {
 
     /** The real resources of a child. */
     public NodeResources realResourcesOfChildContainer(NodeResources resources, VespaFlavor hostFlavor) {
+        // This must match realResourcesOfChildSaturatingHost() if exclusive is true, and vice versa
         boolean exclusive = saturates(hostFlavor, resources);
         return resources.withMemoryGb(resources.memoryGb() - memoryOverhead(hostFlavor, resources, false))
                         .withDiskGb(resources.diskGb() - diskOverhead(hostFlavor, resources, false, exclusive));


### PR DESCRIPTION
Computing worst case real resources on a host should not assume a larger than requested host may be used if the environment only allows exclusive allocation.
