### PR TITLE
Use var/zookeeper/conf for zookeeper server and client config [run-systemtest]

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -2,7 +2,7 @@
 namespace=cloud.config
 
 # Vespa home is prepended if the file is relative
-zooKeeperConfigFile string default="conf/zookeeper/zookeeper.cfg"
+zooKeeperConfigFile string default="var/zookeeper/conf/zookeeper.cfg"
 
 # For more info about the values below, see ZooKeeper documentation
 

--- a/configserver/CMakeLists.txt
+++ b/configserver/CMakeLists.txt
@@ -23,6 +23,6 @@ install_symlink(lib/jars/application-model-jar-with-dependencies.jar conf/config
 install_symlink(lib/jars/node-repository-jar-with-dependencies.jar conf/configserver-app/components/node-repository.jar)
 install_symlink(lib/jars/zookeeper-server-jar-with-dependencies.jar conf/configserver-app/components/zookeeper-server.jar)
 install_symlink(conf/configserver-app/components lib/jars/config-models)
-install(DIRECTORY DESTINATION conf/zookeeper)
 install(DIRECTORY DESTINATION var/zookeeper)
+install(DIRECTORY DESTINATION var/zookeeper/conf)
 install(DIRECTORY DESTINATION logs/vespa/configserver)

--- a/configserver/src/main/sh/start-configserver
+++ b/configserver/src/main/sh/start-configserver
@@ -99,9 +99,9 @@ fixddir () {
     chmod 755 $1
 }
 
-fixddir ${VESPA_HOME}/conf/zookeeper
-fixfile ${VESPA_HOME}/conf/zookeeper/zookeeper.cfg
 fixddir ${VESPA_HOME}/var/zookeeper
+fixddir ${VESPA_HOME}/var/zookeeper/conf
+fixfile ${VESPA_HOME}/var/zookeeper/conf/zookeeper.cfg
 fixfile ${VESPA_HOME}/var/zookeeper/myid
 fixddir ${VESPA_HOME}/var/zookeeper/version-2
 

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -636,7 +636,7 @@ fi
 %dir %{_prefix}/conf/logd
 %dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/conf/telegraf
 %dir %{_prefix}/conf/vespa
-%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/conf/zookeeper
+%dir %attr(-,%{_vespa_user},%{_vespa_group}) %{_prefix}/var/zookeeper/conf
 %dir %{_prefix}/etc
 %{_prefix}/etc/systemd
 %{_prefix}/etc/vespa

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -61,7 +61,7 @@ import java.util.logging.Logger;
 public class Curator extends AbstractComponent implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(Curator.class.getName());
-    private static final File ZK_CLIENT_CONFIG_FILE = new File(Defaults.getDefaults().underVespaHome("conf/zookeeper/zookeeper-client.cfg"));
+    private static final File ZK_CLIENT_CONFIG_FILE = new File(Defaults.getDefaults().underVespaHome("var/zookeeper/conf/zookeeper-client.cfg"));
 
     // Note that session timeout has min and max values are related to tickTime defined by server, see zookeeper-server.def
     static final Duration DEFAULT_ZK_SESSION_TIMEOUT = Duration.ofSeconds(120);

--- a/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
+++ b/zookeeper-server/zookeeper-server-common/src/main/java/com/yahoo/vespa/zookeeper/Configurator.java
@@ -6,8 +6,6 @@ import com.yahoo.security.tls.ConfigFileBasedTlsContext;
 import com.yahoo.security.tls.MixedMode;
 import com.yahoo.security.tls.TlsContext;
 import com.yahoo.security.tls.TransportSecurityUtils;
-import com.yahoo.vespa.defaults.Defaults;
-
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -161,10 +159,7 @@ public class Configurator {
 
     Path makeAbsolutePath(String filename) {
         Path path = Paths.get(filename);
-        if (path.isAbsolute())
-            return path;
-        else
-            return Paths.get(getDefaults().underVespaHome(filename));
+        return path.isAbsolute() ? path : Paths.get(getDefaults().underVespaHome(filename));
     }
 
     private interface TlsConfig {


### PR DESCRIPTION
Avoid using read-only conf/ directory for config files written when starting zookeeper
