### PR TITLE
- Remove cluster() from SystemInfo to only keep static information th…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -310,6 +310,7 @@ public abstract class Container extends AbstractService implements
                             .slobrokId(serviceSlobrokId()))
                 .filedistributor(filedistributorConfig())
                 .discriminator((clusterName != null ? clusterName + "." : "" ) + name)
+                .clustername(clusterName != null ? clusterName : "")
                 .nodeIndex(index)
                 .shutdown.dumpHeapOnTimeout(dumpHeapOnShutdownTimeout)
                          .timeout(shutdownTimeoutS);

--- a/container-core/src/main/resources/configdefinitions/container.qr.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr.def
@@ -23,6 +23,9 @@ rpc.slobrokId string default="" restart
 ## this string will be unique for every QRS in a Vespa application.
 discriminator string default="qrserver.0" restart
 
+## Cluster name
+clustername string default=""
+
 ## Index of this container inside the cluster. Guaranteed to be non-negative
 ## and unique for every container in a cluster, but not necessarily contiguous
 ## or starting from zero.

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/SystemInfoProvider.java
@@ -3,14 +3,12 @@ package com.yahoo.container.jdisc;
 
 import ai.vespa.cloud.ApplicationId;
 import ai.vespa.cloud.Cloud;
-import ai.vespa.cloud.Cluster;
 import ai.vespa.cloud.Environment;
 import ai.vespa.cloud.Node;
 import ai.vespa.cloud.SystemInfo;
 import ai.vespa.cloud.Zone;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.cloud.config.ApplicationIdConfig;
-import com.yahoo.cloud.config.ClusterInfoConfig;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.container.QrConfig;
@@ -29,14 +27,13 @@ public class SystemInfoProvider extends AbstractComponent implements Provider<Sy
     @Inject
     public SystemInfoProvider(ConfigserverConfig csConfig,
                               QrConfig qrConfig,
-                              ClusterInfoConfig ciConfig,
                               ApplicationIdConfig applicationIdConfig) {
         this.instance = new SystemInfo(new ApplicationId(applicationIdConfig.tenant(),
                                                          applicationIdConfig.application(),
                                                          applicationIdConfig.instance()),
                                        new Zone(Environment.valueOf(csConfig.environment()), csConfig.region()),
                                        new Cloud(csConfig.cloud()),
-                                       new Cluster(ciConfig.clusterId(), ciConfig.nodeCount(), ciConfig.nodeIndices()),
+                                       qrConfig.clustername(),
                                        new Node(qrConfig.nodeIndex()));
     }
 

--- a/hosted-zone-api/abi-spec.json
+++ b/hosted-zone-api/abi-spec.json
@@ -93,10 +93,10 @@
     "methods" : [
       "public void <init>(ai.vespa.cloud.ApplicationId, ai.vespa.cloud.Zone, ai.vespa.cloud.Cluster, ai.vespa.cloud.Node)",
       "public void <init>(ai.vespa.cloud.ApplicationId, ai.vespa.cloud.Zone, ai.vespa.cloud.Cloud, ai.vespa.cloud.Cluster, ai.vespa.cloud.Node)",
+      "public void <init>(ai.vespa.cloud.ApplicationId, ai.vespa.cloud.Zone, ai.vespa.cloud.Cloud, java.lang.String, ai.vespa.cloud.Node)",
       "public ai.vespa.cloud.ApplicationId application()",
       "public ai.vespa.cloud.Zone zone()",
       "public ai.vespa.cloud.Cloud cloud()",
-      "public ai.vespa.cloud.Cluster cluster()",
       "public java.lang.String clusterName()",
       "public ai.vespa.cloud.Node node()"
     ],

--- a/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
+++ b/hosted-zone-api/src/main/java/ai/vespa/cloud/SystemInfo.java
@@ -14,20 +14,24 @@ public class SystemInfo {
     private final ApplicationId application;
     private final Zone zone;
     private final Cloud cloud;
-    private final Cluster cluster;
+    private final String clusterName;
     private final Node node;
 
     // TODO: Remove on Vespa 9
     @Deprecated(forRemoval = true)
     public SystemInfo(ApplicationId application, Zone zone, Cluster cluster, Node node) {
-        this(application, zone, new Cloud(""), cluster, node);
+        this(application, zone, new Cloud(""), cluster.id(), node);
+    }
+    @Deprecated(forRemoval = true)
+    public SystemInfo(ApplicationId application, Zone zone, Cloud cloud, Cluster cluster, Node node) {
+        this(application, zone, cloud, cluster.id(), node);
     }
 
-    public SystemInfo(ApplicationId application, Zone zone, Cloud cloud, Cluster cluster, Node node) {
+    public SystemInfo(ApplicationId application, Zone zone, Cloud cloud, String clusterName, Node node) {
         this.application = Objects.requireNonNull(application, "Application cannot be null");
         this.zone = Objects.requireNonNull(zone, "Zone cannot be null");
         this.cloud = Objects.requireNonNull(cloud, "Cloud cannot be null");
-        this.cluster = Objects.requireNonNull(cluster, "Cluster cannot be null");
+        this.clusterName = Objects.requireNonNull(clusterName, "ClusterName cannot be null");
         this.node = Objects.requireNonNull(node, "Node cannot be null");
     }
 
@@ -42,17 +46,8 @@ public class SystemInfo {
         return cloud;
     }
 
-    /**
-     *  Returns the cluster this is part of
-     * @deprecated This will shortly be removed as it breaks the intention of SystemInfo
-     *             Use clusterName() as replacement for cluster().id().
-     *             If you need cluster size or node indices you should have Cluster injected directly.
-     */
-    @Deprecated(forRemoval = true)
-    public Cluster cluster() { return cluster; }
-
     /** Returns the name of the cluster it is running in */
-    public String clusterName() { return cluster.id(); }
+    public String clusterName() { return clusterName; }
 
     /** Returns the node this is running on */
     public Node node() { return node; }

--- a/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
+++ b/hosted-zone-api/src/test/java/ai/vespa/cloud/SystemInfoTest.java
@@ -19,15 +19,14 @@ public class SystemInfoTest {
         ApplicationId application = new ApplicationId("tenant1", "application1", "instance1");
         Zone zone = new Zone(Environment.dev, "us-west-1");
         Cloud cloud = new Cloud("aws");
-        Cluster cluster = new Cluster("clusterId", 1, List.of());
+        String cluster = "clusterName";
         Node node = new Node(0);
 
         SystemInfo info = new SystemInfo(application, zone, cloud, cluster, node);
         assertEquals(application, info.application());
         assertEquals(zone, info.zone());
         assertEquals(cloud, info.cloud());
-        assertEquals(cluster, info.cluster());
-        assertEquals(cluster.id(), info.clusterName());
+        assertEquals(cluster, info.clusterName());
         assertEquals(node, info.node());
     }
 


### PR DESCRIPTION
…ere.

- Instead provide only the cluster name.
- If you need cluster information have Cluster injected directly.

@bratseth @gjoranv @hakonhall PR
This is the second part of #24733
Do not merge until 8.79.16 or later has been released