### PR TITLE
Set cloud account on child nodes as well

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -118,7 +118,6 @@ public final class Node implements Nodelike {
             if (!ipConfig.pool().ipSet().isEmpty()) throw new IllegalArgumentException("A child node cannot have an IP address pool");
             if (modelName.isPresent()) throw new IllegalArgumentException("A child node cannot have model name set");
             if (switchHostname.isPresent()) throw new IllegalArgumentException("A child node cannot have switch hostname set");
-            if (!cloudAccount.isEmpty()) throw new IllegalArgumentException("A child node cannot have cloud account set");
         }
 
         if (type != NodeType.host && reservedTo.isPresent())

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.hosted.provision.provisioning;
 
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationTransaction;
+import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Flavor;
@@ -88,7 +89,8 @@ class Activator {
 
         NodeList activeToRemove = oldActive.matching(node ->  ! hostnames.contains(node.hostname()));
         remove(activeToRemove, transaction); // TODO: Pass activation time in this call and next line
-        nodeRepository.nodes().activate(newActive.asList(), transaction.nested()); // activate also continued active to update node state
+        // TODO (freva): Replace .mapToList(...) with .asList() after 8.80
+        nodeRepository.nodes().activate(newActive.mapToList(node -> fixCloudAccount(node, allNodes)), transaction.nested()); // activate also continued active to update node state
 
         rememberResourceChange(transaction, generation, activationTime,
                                oldActive.not().retired(),
@@ -246,6 +248,16 @@ class Activator {
             if (host.hostname().equals(hostname))
                 return host;
         return null;
+    }
+
+    private Node fixCloudAccount(Node node, NodeList allNodes) {
+        // Existing nodes do not have cloudAccount set, copy the one from parent
+        CloudAccount cloudAccount = allNodes.parentOf(node).map(Node::cloudAccount).orElseGet(node::cloudAccount);
+        return new Node(node.id(), node.ipConfig(), node.hostname(),
+                node.parentHostname(), node.flavor(), node.status(), node.state(), node.allocation(), node.history(),
+                node.type(), node.reports(), node.modelName(), node.reservedTo(),
+                node.exclusiveToApplicationId(), node.exclusiveToClusterType(), node.switchHostname(),
+                node.trustedCertificates(), cloudAccount);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
@@ -430,7 +430,9 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
                                      resources.with(parent.get().resources().diskSpeed())
                                               .with(parent.get().resources().storageType())
                                               .with(parent.get().resources().architecture()),
-                                     NodeType.tenant).build();
+                                     NodeType.tenant)
+                            .cloudAccount(parent.get().cloudAccount())
+                            .build();
             return new ConcreteNodeCandidate(node, freeParentCapacity, parent, violatesSpares, exclusiveSwitch, isSurplus, isNew, isResizable);
 
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisionedHost.java
@@ -74,7 +74,9 @@ public class ProvisionedHost {
 
     /** Generate {@link Node} instance representing the node running on this physical host */
     public Node generateNode() {
-        return Node.reserve(Set.of(), nodeHostname(), hostHostname, nodeResources, hostType.childNodeType()).build();
+        return Node.reserve(Set.of(), nodeHostname(), hostHostname, nodeResources, hostType.childNodeType())
+                .cloudAccount(cloudAccount)
+                .build();
     }
 
     public String getId() { return id; }


### PR DESCRIPTION
To be able to show in the Console that a node is running on a host that is in an external account without having to look up the host.