### PR TITLE
Handle no traffic

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
@@ -225,15 +225,14 @@ public class ClusterModel {
             growthRateHeadroom = Math.min(growthRateHeadroom, 1 / queryFractionOfMax() + 0.1);
 
         // How much headroom is needed to handle sudden arrival of additional traffic due to another zone going down?
-        double maxTrafficShiftHeadroom = 10.0; // Cap to avoid extreme sizes from a current very small share
         double trafficShiftHeadroom;
         if (application.status().maxReadShare() == 0) // No traffic fraction data
             trafficShiftHeadroom = 2.0; // assume we currently get half of the global share of traffic
         else if (application.status().currentReadShare() == 0)
-            trafficShiftHeadroom = maxTrafficShiftHeadroom;
+            trafficShiftHeadroom = 1/application.status().maxReadShare();
         else
             trafficShiftHeadroom = application.status().maxReadShare() / application.status().currentReadShare();
-        trafficShiftHeadroom = Math.min(trafficShiftHeadroom, maxTrafficShiftHeadroom);
+        trafficShiftHeadroom = Math.min(trafficShiftHeadroom, 1/application.status().maxReadShare());
 
         // Assumptions: 1) Write load is not organic so we should not grow to handle more.
         //                 (TODO: But allow applications to set their target write rate and size for that)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -113,16 +113,16 @@ public class AutoscalingTest {
 
     @Test
     public void test_autoscaling_without_traffic() {
-        var min = new ClusterResources(1, 1, new NodeResources(2, 4, 10, 0.3));
-        var now = new ClusterResources(4, 1, new NodeResources(2, 16, 10, 0.3));
-        var max = new ClusterResources(4, 1, new NodeResources(3, 16, 50, 0.3));
+        var min = new ClusterResources(1, 1, new NodeResources(0.5, 4, 10, 0.3));
+        var now = new ClusterResources(4, 1, new NodeResources(8, 16, 10, 0.3));
+        var max = new ClusterResources(4, 1, new NodeResources(16, 32, 50, 0.3));
         var fixture = AutoscalingTester.fixture(min, now, max)
                                        .clusterType(ClusterSpec.Type.container)
                                        .awsProdSetup()
                                        .build();
         var duration = fixture.loader().addMeasurements(new Load(0.04, 0.39, 0.01), 20);
         fixture.tester().clock().advance(duration.negated());
-        fixture.loader().zeroTraffic(20);
+        fixture.loader().zeroTraffic(20, 1);
         fixture.tester().assertResources("Scaled down",
                                          2, 1, 2, 16, 10,
                                          fixture.autoscale());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Loader.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Loader.java
@@ -26,9 +26,12 @@ public class Loader {
     }
 
     /** Assign measured zero traffic in the same way as the system will. */
-    public Duration zeroTraffic(int measurements) {
+    public Duration zeroTraffic(int measurements, int prodRegions) {
         try (var lock = fixture.tester().nodeRepository().applications().lock(fixture.applicationId())) {
-            var statusWithZeroLoad = fixture.application().status().withCurrentReadShare(0).withMaxReadShare(1);
+            var statusWithZeroLoad = fixture.application().status()
+                                            .withCurrentReadShare(0)
+                                            // the line below from TrafficShareUpdater
+                                            .withMaxReadShare(prodRegions < 2 ? 1.0 : 1.0 / ( prodRegions - 1.0));
             fixture.tester().nodeRepository().applications().put(fixture.application().with(statusWithZeroLoad), lock);
         }
         return addQueryRateMeasurements(measurements, (n) -> 0.0);


### PR DESCRIPTION
Never assume we need more traffic shift headroom than 1/maxTrafficShare when we have a max traffic share measurement.
