### PR TITLE
Allow cloud-account on child nodes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -118,7 +118,6 @@ public final class Node implements Nodelike {
             if (!ipConfig.pool().ipSet().isEmpty()) throw new IllegalArgumentException("A child node cannot have an IP address pool");
             if (modelName.isPresent()) throw new IllegalArgumentException("A child node cannot have model name set");
             if (switchHostname.isPresent()) throw new IllegalArgumentException("A child node cannot have switch hostname set");
-            if (!cloudAccount.isEmpty()) throw new IllegalArgumentException("A child node cannot have cloud account set");
         }
 
         if (type != NodeType.host && reservedTo.isPresent())


### PR DESCRIPTION
Had to revert #24757 since we need to first allow setting cloud-account on child nodes, then after all the config servers have upgraded to this version (i.e. in the next release), we can start writing the cloud-account field.