### PR TITLE
Reduce grace time before OS upgrade for new nodes

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
@@ -86,9 +86,7 @@ public class RetiringOsUpgrader implements OsUpgrader {
 
     /** The duration this leaves new nodes alone before scheduling any upgrade */
     private Duration gracePeriod() {
-        if (nodeRepository.zone().system().isCd()) return Duration.ofDays(1);
-        if (!nodeRepository.zone().environment().isProduction()) return Duration.ofDays(7);
-        return Duration.ofDays(30);
+        return Duration.ofDays(1);
     }
 
 }


### PR DESCRIPTION
Reduce from 30 to 1 days as 30 days leave too little time to complete global OS upgrade timely, when there are often a substantial fraction of new nodes in a zone (which is the case with autoscaling).

@mpolden fyi