### PR TITLE
fail on bad base64 POST data

### DIFF
--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -227,7 +227,12 @@ Client::run()
             const char* content = urlSource.content();
             std::string base64_decoded;
             if (_args->_usePostMode && _args->_base64Decode) {
-                base64_decoded = Base64::decode(content, cLen);
+                try {
+                    base64_decoded = Base64::decode(content, cLen);
+                } catch (...) {
+                    _status->SetError("POST request contains invalid base64 encoded data");
+                    break;
+                }
                 content = base64_decoded.c_str();
                 cLen = base64_decoded.size();
             }

--- a/fbench/src/fbench/client.cpp
+++ b/fbench/src/fbench/client.cpp
@@ -229,8 +229,10 @@ Client::run()
             if (_args->_usePostMode && _args->_base64Decode) {
                 try {
                     base64_decoded = Base64::decode(content, cLen);
-                } catch (...) {
-                    _status->SetError("POST request contains invalid base64 encoded data");
+                } catch (std::exception &e) {
+                    std::string msg = "POST request contains invalid base64 encoded data: ";
+                    msg.append(e.what());
+                    _status->SetError(msg.c_str());
                     break;
                 }
                 content = base64_decoded.c_str();


### PR DESCRIPTION
@balder please review

using existing error reporting framework rather than calling std::_Exit(1) directly from http client thread