### PR TITLE
Use a thread executor to fire off subcribes to multiple keys concurre…

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/di/CloudSubscriber.java
+++ b/container-core/src/main/java/com/yahoo/container/di/CloudSubscriber.java
@@ -54,7 +54,7 @@ public class CloudSubscriber  implements Subscriber {
         return generation;
     }
 
-    //mapValues returns a view,, so we need to force evaluation of it here to prevent deferred evaluation.
+    //mapValues returns a view, so we need to force evaluation of it here to prevent deferred evaluation.
     @Override
     public Map<ConfigKey<ConfigInstance>, ConfigInstance> config() {
         Map<ConfigKey<ConfigInstance>, ConfigInstance> ret = new HashMap<>();

--- a/container-core/src/main/java/com/yahoo/container/di/config/SubscriberFactory.java
+++ b/container-core/src/main/java/com/yahoo/container/di/config/SubscriberFactory.java
@@ -16,5 +16,5 @@ public interface SubscriberFactory {
 
     Subscriber getSubscriber(Set<? extends ConfigKey<?>> configKeys, String name);
     void reloadActiveSubscribers(long generation);
-
+    void close();
 }

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -452,6 +452,7 @@ public final class ConfiguredApplication implements Application {
         startAndStopServers(List.of());
         startAndRemoveClients(List.of());
         activateContainer(null, () -> log.info("Last active container generation has terminated"));
+        subscriberFactory.close();
         nonTerminatedContainerTracker.arriveAndAwaitAdvance();
     }
 

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/StandaloneSubscriberFactory.java
@@ -126,4 +126,5 @@ public class StandaloneSubscriberFactory implements SubscriberFactory {
     private static Class<ConfigInstance> configClass(ConfigBuilder builder) {
         return (Class<ConfigInstance>) builder.getClass().getEnclosingClass();
     }
+    @Override public void close() {}
 }


### PR DESCRIPTION
…ntly.

@gjoranv or @bjorncs PR
This cuts 4-7s from startup of all containers, metricsproxy, clustercontroller, container.
This should also cut similar amount from all our system tests.