### PR TITLE
Add support for token resealing

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/Main.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/Main.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.security.tool.crypto.ConvertBaseTool;
 import com.yahoo.vespa.security.tool.crypto.DecryptTool;
 import com.yahoo.vespa.security.tool.crypto.EncryptTool;
 import com.yahoo.vespa.security.tool.crypto.KeygenTool;
+import com.yahoo.vespa.security.tool.crypto.ResealTool;
 import com.yahoo.vespa.security.tool.crypto.TokenInfoTool;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -47,7 +48,7 @@ public class Main {
 
     private static final List<Tool> TOOLS = List.of(
             new KeygenTool(), new EncryptTool(), new DecryptTool(), new TokenInfoTool(),
-            new ConvertBaseTool());
+            new ConvertBaseTool(), new ResealTool());
 
     private static Optional<Tool> toolFromCliArgs(String[] args) {
         if (args.length == 0) {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
@@ -46,7 +46,7 @@ public class EncryptTool implements Tool {
                     .longOpt(KEY_ID_OPTION)
                     .hasArg(true)
                     .required(false)
-                    .desc("Numeric ID of recipient key")
+                    .desc("ID of recipient key")
                     .build());
 
     @Override

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ResealTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ResealTool.java
@@ -1,0 +1,104 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.security.tool.crypto;
+
+import com.yahoo.security.KeyId;
+import com.yahoo.security.KeyUtils;
+import com.yahoo.security.SealedSharedKey;
+import com.yahoo.security.SharedKeyGenerator;
+import com.yahoo.vespa.security.tool.CliUtils;
+import com.yahoo.vespa.security.tool.Tool;
+import com.yahoo.vespa.security.tool.ToolDescription;
+import com.yahoo.vespa.security.tool.ToolInvocation;
+import org.apache.commons.cli.Option;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tooling for resealing a token for another recipient. This allows for delegating
+ * decryption to another party without having to reveal the private key of the original
+ * recipient.
+ *
+ * @author vekterli
+ */
+public class ResealTool implements Tool {
+
+    static final String PRIVATE_KEY_FILE_OPTION     = "private-key-file";
+    static final String EXPECTED_KEY_ID_OPTION      = "expected-key-id";
+    static final String RECIPIENT_KEY_ID_OPTION     = "key-id";
+    static final String RECIPIENT_PUBLIC_KEY_OPTION = "recipient-public-key";
+
+    private static final List<Option> OPTIONS = List.of(
+            Option.builder("k")
+                    .longOpt(PRIVATE_KEY_FILE_OPTION)
+                    .hasArg(true)
+                    .required(false)
+                    .desc("Private key file in Base58 encoded format")
+                    .build(),
+            Option.builder("e")
+                    .longOpt(EXPECTED_KEY_ID_OPTION)
+                    .hasArg(true)
+                    .required(false)
+                    .desc("Expected key ID in token. If this is not provided, the key ID is not verified.")
+                    .build(),
+            Option.builder("r")
+                    .longOpt(RECIPIENT_PUBLIC_KEY_OPTION)
+                    .hasArg(true)
+                    .required(false)
+                    .desc("Recipient X25519 public key in Base58 encoded format")
+                    .build(),
+            Option.builder("i")
+                    .longOpt(RECIPIENT_KEY_ID_OPTION)
+                    .hasArg(true)
+                    .required(false)
+                    .desc("ID of recipient key")
+                    .build());
+
+    @Override
+    public String name() {
+        return "reseal";
+    }
+
+    @Override
+    public ToolDescription description() {
+        return new ToolDescription(
+                "<token> <options>",
+                "Reseals the input token for another recipient, allowing that recipient to " +
+                "decrypt the file that the input token was originally created for.\n" +
+                "Prints new token to STDOUT.",
+                "Note: this is a BETA tool version; its interface may be changed at any time",
+                OPTIONS);
+    }
+
+    @Override
+    public int invoke(ToolInvocation invocation) {
+        try {
+            var arguments    = invocation.arguments();
+            var leftoverArgs = arguments.getArgs();
+            if (leftoverArgs.length != 1) {
+                throw new IllegalArgumentException("Expected exactly 1 token argument to re-seal");
+            }
+            var tokenString = leftoverArgs[0];
+            var maybeKeyId  = Optional.ofNullable(arguments.hasOption(EXPECTED_KEY_ID_OPTION)
+                                                  ? arguments.getOptionValue(EXPECTED_KEY_ID_OPTION)
+                                                  : null);
+            var sealedSharedKey = SealedSharedKey.fromTokenString(tokenString.strip());
+            ToolUtils.verifyExpectedKeyId(sealedSharedKey, maybeKeyId);
+
+            var recipientPubKey = KeyUtils.fromBase58EncodedX25519PublicKey(CliUtils.optionOrThrow(arguments, RECIPIENT_PUBLIC_KEY_OPTION).strip());
+            var recipientKeyId  = KeyId.ofString(CliUtils.optionOrThrow(arguments, RECIPIENT_KEY_ID_OPTION));
+            var privKeyPath     = Paths.get(CliUtils.optionOrThrow(arguments, PRIVATE_KEY_FILE_OPTION));
+            var privateKey      = KeyUtils.fromBase58EncodedX25519PrivateKey(Files.readString(privKeyPath).strip());
+            var secretShared    = SharedKeyGenerator.fromSealedKey(sealedSharedKey, privateKey);
+            var resealedShared  = SharedKeyGenerator.reseal(secretShared, recipientPubKey, recipientKeyId);
+
+            invocation.stdOut().println(resealedShared.sealedSharedKey().toTokenString());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return 0;
+    }
+}

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ToolUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ToolUtils.java
@@ -1,0 +1,25 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.security.tool.crypto;
+
+import com.yahoo.security.KeyId;
+import com.yahoo.security.SealedSharedKey;
+
+import java.util.Optional;
+
+/**
+ * @author vekterli
+ */
+public class ToolUtils {
+
+    static void verifyExpectedKeyId(SealedSharedKey sealedSharedKey, Optional<String> maybeKeyId) {
+        if (maybeKeyId.isPresent()) {
+            var myKeyId = KeyId.ofString(maybeKeyId.get());
+            if (!myKeyId.equals(sealedSharedKey.keyId())) {
+                // Don't include raw key bytes array verbatim in message (may contain control chars etc.)
+                throw new IllegalArgumentException("Key ID specified with --expected-key-id does not match key ID " +
+                                                   "used when generating the supplied token");
+            }
+        }
+    }
+
+}

--- a/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
@@ -5,18 +5,14 @@ given private key.
 
 To decrypt the contents of STDIN, specify an input file of '-' (without
 the quotes).
- -h,--help                               Show help
- -i,--key-id <arg>                       Numeric ID of recipient key. If
-                                         this is not provided, the key ID
-                                         stored as part of the token is
-                                         not verified.
- -k,--recipient-private-key-file <arg>   Recipient private key file in
-                                         Base58 encoded format
- -o,--output-file <arg>                  Output file for decrypted
-                                         plaintext. Specify '-' (without
-                                         the quotes) to write plaintext to
-                                         STDOUT instead of a file.
- -t,--token <arg>                        Token generated when the input
-                                         file was encrypted
+ -e,--expected-key-id <arg>    Expected key ID in token. If this is not
+                               provided, the key ID is not verified.
+ -h,--help                     Show help
+ -k,--private-key-file <arg>   Private key file in Base58 encoded format
+ -o,--output-file <arg>        Output file for decrypted plaintext.
+                               Specify '-' (without the quotes) to write
+                               plaintext to STDOUT instead of a file.
+ -t,--token <arg>              Token generated when the input file was
+                               encrypted
 Note: this is a BETA tool version; its interface may be changed at any
 time

--- a/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
@@ -7,7 +7,7 @@ kept secret.
 To encrypt the contents of STDIN, specify an input file of '-' (without
 the quotes).
  -h,--help                         Show help
- -i,--key-id <arg>                 Numeric ID of recipient key
+ -i,--key-id <arg>                 ID of recipient key
  -o,--output-file <arg>            Output file (will be truncated if it
                                    already exists)
  -r,--recipient-public-key <arg>   Recipient X25519 public key in Base58

--- a/vespaclient-java/src/test/resources/expected-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-help-output.txt
@@ -1,4 +1,5 @@
 usage: vespa-security <tool> [TOOL OPTIONS]
-Where <tool> is one of: keygen, encrypt, decrypt, token-info, convert-base
+Where <tool> is one of: keygen, encrypt, decrypt, token-info,
+convert-base, reseal
  -h,--help   Show help
 Invoke vespa-security <tool> --help for tool-specific help

--- a/vespaclient-java/src/test/resources/expected-reseal-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-reseal-help-output.txt
@@ -1,0 +1,15 @@
+usage: vespa-security reseal <token> <options>
+Reseals the input token for another recipient, allowing that recipient to
+decrypt the file that the input token was originally created for.
+Prints new token to STDOUT.
+ -e,--expected-key-id <arg>        Expected key ID in token. If this is
+                                   not provided, the key ID is not
+                                   verified.
+ -h,--help                         Show help
+ -i,--key-id <arg>                 ID of recipient key
+ -k,--private-key-file <arg>       Private key file in Base58 encoded
+                                   format
+ -r,--recipient-public-key <arg>   Recipient X25519 public key in Base58
+                                   encoded format
+Note: this is a BETA tool version; its interface may be changed at any
+time


### PR DESCRIPTION
@bjorncs please review

Adds underlying support—and tooling—for resealing a token for another recipient. This allows for delegating decryption to another party without having to reveal the private key of the original recipient (or having to send the raw underlying secret key over a potentially insecure channel). Key ID can/should change as part of this operation.

