### PR TITLE
Don't always prefer local disk in autoscaling

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocatableClusterResources.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocatableClusterResources.java
@@ -132,10 +132,6 @@ public class AllocatableClusterResources {
         if (this.fulfilment < 1 || other.fulfilment < 1) // always fulfil as much as possible
             return this.fulfilment > other.fulfilment;
 
-        if (clusterSpec.type().isContent() // always prefer local storage on content nodes
-            && this.realResources.storageType() != other.realResources().nodeResources().storageType())
-            return this.realResources.storageType() == NodeResources.StorageType.local;
-
         return this.cost() < other.cost(); // otherwise, prefer lower cost
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTest.java
@@ -305,29 +305,6 @@ public class AutoscalingTest {
     }
 
     @Test
-    public void content_prefers_local_disk_when_no_local_match() {
-        var resources = new ClusterResources( 2, 1, new NodeResources(3, 100, 50, 1));
-        var local  = new NodeResources(3, 100,  75, 1, fast, StorageType.local);
-        var remote = new NodeResources(3, 100,  50, 1, fast, StorageType.remote);
-        var fixture = AutoscalingTester.fixture()
-                                       .dynamicProvisioning(true)
-                                       .clusterType(ClusterSpec.Type.content)
-                                       .hostFlavors(local, remote)
-                                       .capacity(Capacity.from(resources))
-                                       .initialResources(Optional.of(new ClusterResources(3, 1, resources.nodeResources())))
-                                       .build();
-
-        fixture.tester().clock().advance(Duration.ofDays(2));
-        fixture.loader().applyLoad(new Load(0.01, 0.01, 0.01), 120);
-        Autoscaler.Advice suggestion = fixture.suggest();
-        fixture.tester().assertResources("Always prefers local disk for content",
-                                         2, 1, 3.0,  100.0, 75.0,
-                                         suggestion);
-        assertEquals("Always prefers local disk for content",
-                     StorageType.local, suggestion.target().get().nodeResources().storageType());
-    }
-
-    @Test
     public void suggestions_ignores_limits() {
         ClusterResources min = new ClusterResources( 2, 1, new NodeResources(1, 1, 1, 1));
         var fixture = AutoscalingTester.fixture().hostCount(20).capacity(Capacity.from(min, min)).build();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
@@ -442,35 +442,6 @@ public class DynamicProvisioningTest {
                            app1, cluster1);
     }
 
-    @Test
-    public void test_any_disk_prefers_local_for_content() {
-        int memoryTax = 3;
-        int localDiskTax = 55;
-        // Disk tax is not included in flavor resources but memory tax is
-        List<Flavor> flavors = List.of(new Flavor("2x",  new NodeResources(2, 20 - memoryTax, 200, 0.1, fast, local)),
-                                       new Flavor("4x",  new NodeResources(4, 40 - memoryTax, 400, 0.1, fast, local)),
-                                       new Flavor("2xl", new NodeResources(2, 20 - memoryTax, 200, 0.1, fast, remote)),
-                                       new Flavor("4xl", new NodeResources(4, 40 - memoryTax, 400, 0.1, fast, remote)));
-
-        ProvisioningTester tester = new ProvisioningTester.Builder().zone(zone)
-                                                                    .flavors(flavors)
-                                                                    .hostProvisioner(new MockHostProvisioner(flavors, memoryTax))
-                                                                    .nameResolver(nameResolver)
-                                                                    .resourcesCalculator(memoryTax, localDiskTax)
-                                                                    .build();
-
-        tester.activateTenantHosts();
-
-        ApplicationId app1 = ProvisioningTester.applicationId("app1");
-        ClusterSpec cluster1 = ClusterSpec.request(ClusterSpec.Type.content, new ClusterSpec.Id("cluster1")).vespaVersion("7").build();
-
-        tester.activate(app1, cluster1, Capacity.from(resources(4, 2, 2, 10, 200, fast, StorageType.any),
-                                                      resources(6, 3, 3, 25, 400, fast, StorageType.any)));
-        tester.assertNodes("'any' selects a flavor with local storage",
-                           6, 2, 2, 20, 200, fast, local,
-                           app1, cluster1);
-    }
-
     private void prepareAndActivate(ApplicationId application, ClusterSpec clusterSpec, int nodes, int groups, NodeResources resources) {
         List<HostSpec> prepared = tester.prepare(application, clusterSpec, nodes, groups, resources);
         NodeList provisionedHosts = tester.nodeRepository().nodes().list(Node.State.provisioned).nodeType(NodeType.host);


### PR DESCRIPTION
We still prefer local disk when there is an exact match and that is enough.
