### PR TITLE
Stop using diff in checkfmt target

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -135,7 +135,7 @@ test: ci
 	TMPDIR=`/bin/pwd`/mytmp go test ./...
 
 checkfmt:
-	@bash -c "diff --line-format='%L' <(echo -n) <(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }
+	@sh -c "test -z $$(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }
 
 fmt:
 	gofmt -w .


### PR DESCRIPTION
Should fix build on macOS Ventura.

Fixes #24860

@ean