### PR TITLE
Use BouncyCastle 1.72 everywhere

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -565,8 +565,25 @@
             </dependency>
             <dependency>
                 <groupId>com.yahoo.athenz</groupId>
+                <artifactId>athenz-cert-refresher</artifactId>
+                <version>${athenz.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.yahoo.athenz</groupId>
                 <artifactId>athenz-zms-java-client</artifactId>
                 <version>${athenz.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.yahoo.athenz</groupId>
@@ -577,6 +594,12 @@
                 <groupId>com.yahoo.athenz</groupId>
                 <artifactId>athenz-zts-java-client</artifactId>
                 <version>${athenz.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.bouncycastle</groupId>
+                        <artifactId>bcpkix-jdk15on</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>


### PR DESCRIPTION
BouncyCastle introduced new artifact ids after increasing JDK requirement (5 => 8)

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
