### PR TITLE
Always retire arm64 hosts on OS upgrade

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
@@ -68,8 +68,10 @@ public class RebuildingOsUpgrader implements OsUpgrader {
     private List<Node> rebuildableHosts(OsVersionTarget target, NodeList allNodes, Instant now) {
         NodeList hostsOfTargetType = allNodes.nodeType(target.nodeType());
         if (softRebuild) {
-            // Soft rebuild is enabled so this should only act on hosts with remote storage
-            hostsOfTargetType = hostsOfTargetType.storageType(NodeResources.StorageType.remote);
+            // Soft rebuild is enabled so this should only act on hosts with remote storage and on x86-64
+            // TODO(mpolden): Rebuild arm64 hosts as well if image permissions can be fixed
+            hostsOfTargetType = hostsOfTargetType.matching(node -> node.resources().storageType() == NodeResources.StorageType.remote &&
+                                                                   node.resources().architecture() == NodeResources.Architecture.x86_64);
         }
         int rebuildLimit = rebuildLimit(target.nodeType(), hostsOfTargetType);
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
@@ -62,8 +62,9 @@ public class RetiringOsUpgrader implements OsUpgrader {
     private NodeList candidates(Instant instant, OsVersionTarget target, NodeList allNodes) {
         NodeList activeNodes = allNodes.state(Node.State.active).nodeType(target.nodeType());
         if (softRebuild) {
-            // Soft rebuild is enabled, so this should only act on hosts with local storage
-            activeNodes = activeNodes.storageType(NodeResources.StorageType.local);
+            // Soft rebuild is enabled, so this should only act on hosts with local storage, or non-x86-64
+            activeNodes = activeNodes.matching(node -> node.resources().storageType() == NodeResources.StorageType.local ||
+                                                       node.resources().architecture() != NodeResources.Architecture.x86_64);
         }
         if (activeNodes.isEmpty()) return NodeList.of();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
@@ -74,7 +74,6 @@ public class HostResumeProvisionerTest {
 
         Supplier<NodeList> provisioning = () -> tester.nodeRepository().nodes().list(Node.State.provisioned).nodeType(NodeType.host);
         assertEquals(1, provisioning.get().size());
-        provisioning.get().forEach(h -> System.out.println(h.hostname() + " " + h.ipConfig()));
         hostResumeProvisioner.maintain();
 
         assertTrue("No IP addresses written as DNS updates are failing",


### PR DESCRIPTION
Soft rebuild does not currently work for arm64 due to the way AMIs are shared
across accounts.

@freva