### PR TITLE
Use BouncyCastle AES GCM cipher and I/O streams instead of JCA

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
@@ -29,7 +29,6 @@ import com.yahoo.vespa.hosted.node.admin.task.util.file.MakeDirectory;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.UnixPath;
 import com.yahoo.vespa.hosted.node.admin.task.util.fs.ContainerPath;
 
-import javax.crypto.CipherOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -49,7 +48,6 @@ import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.nameEndsWith;
 import static com.yahoo.vespa.hosted.node.admin.task.util.file.FileFinder.nameMatches;
@@ -275,7 +273,7 @@ public class CoredumpHandler {
 
     static OutputStream maybeWrapWithEncryption(OutputStream wrappedStream, Optional<SecretSharedKey> sharedCoreKey) {
         return sharedCoreKey
-                .map(key -> (OutputStream)new CipherOutputStream(wrappedStream, SharedKeyGenerator.makeAesGcmEncryptionCipher(key)))
+                .map(key -> SharedKeyGenerator.makeAesGcmEncryptionCipher(key).wrapOutputStream(wrappedStream))
                 .orElse(wrappedStream);
     }
 

--- a/security-utils/src/main/java/com/yahoo/security/AeadCipher.java
+++ b/security-utils/src/main/java/com/yahoo/security/AeadCipher.java
@@ -1,0 +1,44 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security;
+
+import org.bouncycastle.crypto.io.CipherInputStream;
+import org.bouncycastle.crypto.io.CipherOutputStream;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * AEAD cipher wrapper to hide the underlying crypto provider used.
+ *
+ * @author vekterli
+ */
+public class AeadCipher {
+
+    private final AEADBlockCipher cipher;
+
+    private AeadCipher(AEADBlockCipher cipher) {
+        this.cipher = cipher;
+    }
+
+    static AeadCipher of(AEADBlockCipher cipher) {
+        return new AeadCipher(cipher);
+    }
+
+    /**
+     * Returns a wrapping <code>OutputStream</code> that, depending on the cipher mode, either
+     * encrypts or decrypts all data that is written to it before passing it on to <code>out</code>.
+     */
+    public OutputStream wrapOutputStream(OutputStream out) {
+        return new CipherOutputStream(out, cipher);
+    }
+
+    /**
+     * Returns a wrapping <code>InputStream</code> that, depending on the cipher mode, either
+     * encrypts or decrypts all data that is read from the underlying input stream.
+     */
+    public InputStream wrapInputStream(InputStream in) {
+        return new CipherInputStream(in, cipher);
+    }
+
+}

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
@@ -1,8 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.security.tool.crypto;
 
-import javax.crypto.Cipher;
-import javax.crypto.CipherOutputStream;
+import com.yahoo.security.AeadCipher;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -19,11 +19,11 @@ public class CipherUtils {
      *
      * @param input source stream to read from
      * @param output destination stream to write to
-     * @param cipher a Cipher in either ENCRYPT or DECRYPT mode
+     * @param cipher an {@link AeadCipher} created with for either encryption or decryption
      * @throws IOException if any file operation fails
      */
-    public static void streamEncipher(InputStream input, OutputStream output, Cipher cipher) throws IOException {
-        try (var cipherStream = new CipherOutputStream(output, cipher)) {
+    public static void streamEncipher(InputStream input, OutputStream output, AeadCipher cipher) throws IOException {
+        try (var cipherStream = cipher.wrapOutputStream(output)) {
             input.transferTo(cipherStream);
             cipherStream.flush();
         }


### PR DESCRIPTION
@bjorncs please review

This resolves two issues:
 * `javax.crypto.OutputCipherStream` swallows MAC tag mismatch exceptions when the stream is closed, which means that corruptions (intentional or not) are not caught. This is documented behavior, but still very surprising and a rather questionable default. BC's interchangeable `CipherOutputStream` throws as expected. To avoid regressions, add an explicit test that both ciphertext and MAC tag corruptions are propagated.
 * The default-provided `AES/GCM/NoPadding` `Cipher` instance will not emit decrypted plaintext per `update()` chunk, but buffer everything until `doFinal()` is invoked when the stream is closed. This means that decrypting very large ciphertexts can blow up memory usage since internal output buffers are reallocated and increased per iteration...! Instead use an explicit BC `GCMBlockCipher` which has the expected behavior (and actually lets cipher streams, well, _stream_). Add an `AeadCipher` abstraction to avoid leaking BC APIs outside the security module.

