### PR TITLE
Retire nodes on wrong parent host flavor

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -121,7 +121,6 @@ class NodeAllocation {
                 if ( candidate.state() == Node.State.active && allocation.removable()) continue; // don't accept; causes removal
                 if ( candidate.state() == Node.State.active && candidate.wantToFail()) continue; // don't accept; causes failing
                 if ( indexes.contains(membership.index())) continue; // duplicate index (just to be sure)
-                if ( requiredHostFlavor.isPresent() && ! candidate.parent.map(node -> node.flavor().name()).equals(requiredHostFlavor)) continue;
                 if ( candidate.parent.isPresent() && ! candidate.parent.get().cloudAccount().equals(requestedNodes.cloudAccount())) continue; // wrong account
 
                 boolean resizeable = requestedNodes.considerRetiring() && candidate.isResizable;
@@ -173,6 +172,7 @@ class NodeAllocation {
         if (candidate.wantToRetire()) return Retirement.hardRequest;
         if (candidate.preferToRetire() && candidate.replaceableBy(candidates)) return Retirement.softRequest;
         if (violatesExclusivity(candidate)) return Retirement.violatesExclusivity;
+        if (requiredHostFlavor.isPresent() && ! candidate.parent.map(node -> node.flavor().name()).equals(requiredHostFlavor)) return Retirement.violatesHostFlavor;
         return Retirement.none;
     }
 
@@ -486,6 +486,7 @@ class NodeAllocation {
         hardRequest("node is requested to retire"),
         softRequest("node is requested to retire (soft)"),
         violatesExclusivity("node violates host exclusivity"),
+        violatesHostFlavor("node violates host flavor"),
         none("");
 
         private final String description;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
@@ -284,7 +284,6 @@ public class DynamicProvisioningTest {
         hostProvisioner.overrideHostFlavor("x86");
         tester.activate(app, cluster, capacity);
         NodeList nodes = tester.nodeRepository().nodes().list();
-        nodes.forEach(n -> System.out.println(n.hostname() + " " + n.flavor().name()));
         assertEquals(4, nodes.owner(app).state(Node.State.active).size());
         assertEquals(Set.of("x86"), nodes.parentsOf(nodes.owner(app).state(Node.State.active)).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
 
@@ -292,18 +291,18 @@ public class DynamicProvisioningTest {
         flagSource.withStringFlag(PermanentFlags.HOST_FLAVOR.id(), "arm");
         tester.activate(app, cluster, capacity);
         nodes = tester.nodeRepository().nodes().list();
-        assertEquals(4, nodes.owner(app).state(Node.State.inactive).size());
-        assertEquals(4, nodes.owner(app).state(Node.State.active).size());
-        assertEquals(Set.of("x86"), nodes.parentsOf(tester.getNodes(app, Node.State.inactive)).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
-        assertEquals(Set.of("arm"), nodes.parentsOf(tester.getNodes(app, Node.State.active)).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
+        assertEquals(4, nodes.owner(app).state(Node.State.active).retired().size());
+        assertEquals(4, nodes.owner(app).state(Node.State.active).not().retired().size());
+        assertEquals(Set.of("x86"), nodes.parentsOf(tester.getNodes(app, Node.State.active).retired()).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
+        assertEquals(Set.of("arm"), nodes.parentsOf(tester.getNodes(app, Node.State.active).not().retired()).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
 
         flagSource.removeFlag(PermanentFlags.HOST_FLAVOR.id()); // Resetting flag does not moves the nodes back
         tester.activate(app, cluster, capacity);
         nodes = tester.nodeRepository().nodes().list();
-        assertEquals(4, nodes.owner(app).state(Node.State.inactive).size());
-        assertEquals(4, nodes.owner(app).state(Node.State.active).size());
-        assertEquals(Set.of("x86"), nodes.parentsOf(tester.getNodes(app, Node.State.inactive)).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
-        assertEquals(Set.of("arm"), nodes.parentsOf(tester.getNodes(app, Node.State.active)).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
+        assertEquals(4, nodes.owner(app).state(Node.State.active).retired().size());
+        assertEquals(4, nodes.owner(app).state(Node.State.active).not().retired().size());
+        assertEquals(Set.of("x86"), nodes.parentsOf(tester.getNodes(app, Node.State.active).retired()).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
+        assertEquals(Set.of("arm"), nodes.parentsOf(tester.getNodes(app, Node.State.active).not().retired()).stream().map(n -> n.flavor().name()).collect(Collectors.toSet()));
     }
 
     @Test


### PR DESCRIPTION
Nodes that run on host with the wrong flavor (due to feature flag change) should be retired and migrated instead of being immediately removed from the application.