### PR TITLE
Support auto-resolving private key files based on token key ID

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/ToolInvocation.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/ToolInvocation.java
@@ -6,6 +6,7 @@ import org.apache.commons.cli.CommandLine;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author vekterli
@@ -16,5 +17,11 @@ public record ToolInvocation(CommandLine arguments,
                              PrintStream stdOut,
                              PrintStream stdError,
                              boolean debugMode) {
+
+    public void printIfDebug(Supplier<String> stringSupplier) {
+        if (debugMode) {
+            stdError.println(stringSupplier.get());
+        }
+    }
 
 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/CipherUtils.java
@@ -19,7 +19,7 @@ public class CipherUtils {
      *
      * @param input source stream to read from
      * @param output destination stream to write to
-     * @param cipher an {@link AeadCipher} created with for either encryption or decryption
+     * @param cipher an {@link AeadCipher} created for either encryption or decryption
      * @throws IOException if any file operation fails
      */
     public static void streamEncipher(InputStream input, OutputStream output, AeadCipher cipher) throws IOException {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ToolUtils.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/ToolUtils.java
@@ -2,14 +2,30 @@
 package com.yahoo.vespa.security.tool.crypto;
 
 import com.yahoo.security.KeyId;
+import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SealedSharedKey;
+import com.yahoo.vespa.security.tool.CliUtils;
+import com.yahoo.vespa.security.tool.ToolInvocation;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.interfaces.XECPrivateKey;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 /**
  * @author vekterli
  */
 public class ToolUtils {
+
+    static final String PRIVATE_KEY_FILE_OPTION = "private-key-file";
+    static final String PRIVATE_KEY_DIR_OPTION  = "private-key-dir";
+    static final String PRIVATE_KEY_DIR_ENV_VAR = "VESPA_CRYPTO_CLI_PRIVATE_KEY_DIR";
+
+    static final Pattern SAFE_KEY_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9_-]+$");
 
     static void verifyExpectedKeyId(SealedSharedKey sealedSharedKey, Optional<String> maybeKeyId) {
         if (maybeKeyId.isPresent()) {
@@ -19,6 +35,67 @@ public class ToolUtils {
                 throw new IllegalArgumentException("Key ID specified with --expected-key-id does not match key ID " +
                                                    "used when generating the supplied token");
             }
+        }
+    }
+
+    private static void verifyKeyIdIsPathSafe(KeyId keyId) {
+        String keyIdStr = keyId.asString();
+        if (!SAFE_KEY_ID_PATTERN.matcher(keyIdStr).matches()) {
+            throw new IllegalArgumentException("The token key ID is not comprised of path-safe characters; refusing " +
+                                               "to auto-deduce key file name");
+        }
+    }
+
+    private static void verifyPrivateKeyFileNotWorldReadable(Path keyPath) throws IOException {
+        var privKeyPerms = Files.getPosixFilePermissions(keyPath);
+        if (privKeyPerms.contains(PosixFilePermission.OTHERS_READ)) {
+            throw new IllegalArgumentException("Private key file '%s' is insecurely world-readable; refusing to read it"
+                                               .formatted(keyPath.toAbsolutePath()));
+        }
+    }
+
+    private static XECPrivateKey attemptResolvePrivateKeyFromDir(Path privKeyDirPath, KeyId tokenKeyId) throws IOException {
+        if (!Files.isDirectory(privKeyDirPath)) {
+            throw new IllegalArgumentException("'%s' is not a valid directory".formatted(privKeyDirPath.toAbsolutePath()));
+        }
+        verifyKeyIdIsPathSafe(tokenKeyId);
+        var keyPath = privKeyDirPath.resolve(tokenKeyId.asString() + ".key");
+        if (!Files.exists(keyPath)) {
+            // We've verified the key ID contents, so we know it's safe to print here
+            throw new IllegalArgumentException("Could not find a private key file matching token key ID '%s'"
+                                               .formatted(tokenKeyId.asString()));
+        }
+        verifyPrivateKeyFileNotWorldReadable(keyPath);
+        return KeyUtils.fromBase58EncodedX25519PrivateKey(Files.readString(keyPath).strip());
+    }
+
+    public static XECPrivateKey resolvePrivateKeyFromInvocation(ToolInvocation invocation, KeyId tokenKeyId) throws IOException {
+        var arguments = invocation.arguments();
+        var envVars   = invocation.envVars();
+
+        if (arguments.hasOption(PRIVATE_KEY_FILE_OPTION)) {
+            if (arguments.hasOption(PRIVATE_KEY_DIR_OPTION)) {
+                throw new IllegalArgumentException("--%s and --%s cannot be specified at the same time"
+                                                   .formatted(PRIVATE_KEY_FILE_OPTION, PRIVATE_KEY_DIR_OPTION));
+            }
+            var privKeyFilePath = Paths.get(arguments.getOptionValue(PRIVATE_KEY_FILE_OPTION));
+            invocation.printIfDebug(() -> "Using private key file '%s'".formatted(privKeyFilePath));
+            if (!Files.exists(privKeyFilePath)) {
+                throw new IllegalArgumentException("Specified private key file '%s' does not exist"
+                                                   .formatted(privKeyFilePath.toAbsolutePath()));
+            }
+            verifyPrivateKeyFileNotWorldReadable(privKeyFilePath);
+            return KeyUtils.fromBase58EncodedX25519PrivateKey(Files.readString(privKeyFilePath).strip());
+        } else if (arguments.hasOption(PRIVATE_KEY_DIR_OPTION) || envVars.containsKey(PRIVATE_KEY_DIR_ENV_VAR)) {
+            // Explicitly provided command line directory is preferred over env var, if set
+            var privKeyDirPath = Paths.get(arguments.hasOption(PRIVATE_KEY_DIR_OPTION)
+                                           ? arguments.getOptionValue(PRIVATE_KEY_DIR_OPTION)
+                                           : envVars.get(PRIVATE_KEY_DIR_ENV_VAR));
+            invocation.printIfDebug(() -> "Using private key lookup directory '%s'".formatted(privKeyDirPath));
+            return attemptResolvePrivateKeyFromDir(privKeyDirPath, tokenKeyId);
+        } else {
+            throw new IllegalArgumentException("No private key specified. Must specify either --%s or --%s"
+                                               .formatted(PRIVATE_KEY_FILE_OPTION, PRIVATE_KEY_DIR_OPTION));
         }
     }
 

--- a/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
@@ -5,6 +5,9 @@ given private key.
 
 To decrypt the contents of STDIN, specify an input file of '-' (without
 the quotes).
+ -d,--private-key-dir <arg>    Private key file directory used for
+                               automatically looking up private keys based
+                               on the key ID specified as part of a token.
  -e,--expected-key-id <arg>    Expected key ID in token. If this is not
                                provided, the key ID is not verified.
  -h,--help                     Show help

--- a/vespaclient-java/src/test/resources/expected-reseal-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-reseal-help-output.txt
@@ -2,6 +2,10 @@ usage: vespa-security reseal <token> <options>
 Reseals the input token for another recipient, allowing that recipient to
 decrypt the file that the input token was originally created for.
 Prints new token to STDOUT.
+ -d,--private-key-dir <arg>        Private key file directory used for
+                                   automatically looking up private keys
+                                   based on the key ID specified as part
+                                   of a token.
  -e,--expected-key-id <arg>        Expected key ID in token. If this is
                                    not provided, the key ID is not
                                    verified.


### PR DESCRIPTION
@bjorncs please review

Lets a user specify a private key directory either with a command line argument or via an environment variable. If a directory is provided, the private key to use will be attempted auto-resolved based on the key ID stored in the token. This only applies if the key ID is comprised exclusively of path-safe characters.

