### PR TITLE
We dont use the xxhash commandline tools so only require xxhash-libs.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -205,7 +205,6 @@ BuildRequires: perf
 %if 0%{?amzn2022}
 Requires: vespa-xxhash >= 0.8.1
 %else
-Requires: xxhash
 Requires: xxhash-libs >= 0.8.1
 %endif
 Requires: gdb


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
