### PR TITLE
Add standalone runner script for vespa-crypto-cli

### DIFF
--- a/vespaclient-java/src/main/sh/vespa-crypto-cli-standalone.sh
+++ b/vespaclient-java/src/main/sh/vespa-crypto-cli-standalone.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env sh
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+# Resolve symlink (if any) and normalize path
+program=$(readlink -f "$0")
+program_dir=$(dirname "$program")
+jarfile=$(readlink -f "$program_dir"/../../../target/vespaclient-java-jar-with-dependencies.jar)
+
+if ! test -e "$jarfile"
+then
+    echo "No such file: '$jarfile'" >&2
+    exit 1
+fi
+
+exec java \
+-Djava.awt.headless=true \
+-Xms128m -Xmx2048m \
+-cp "$jarfile" com.yahoo.vespa.security.tool.Main "$@"


### PR DESCRIPTION
@bjorncs please review. The maybe-symlinked-relative-to-absolute-path™ resolving isn't beautiful, but I've tested it both with symlink and direct invocation on macOS and CentOS Stream 8 and it seems to do the job, at least.

Useful when the script is run in a context where `VESPA_HOME` is not set. Should work both if the script is invoked directly or through a symbolic link.
