### PR TITLE
Revert "Use new location for ZooKeeper TLS config file [run-systemtest]"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -82,7 +82,7 @@ public class ConfigserverCluster extends AbstractConfigProducer
             builder.clientPort(options.zookeeperClientPort().get());
         }
         if (options.hostedVespa().orElse(false)) {
-            builder.vespaTlsConfigFile(Defaults.getDefaults().underVespaHome("var/zookeeper/conf/tls.conf.json"));
+            builder.vespaTlsConfigFile(Defaults.getDefaults().underVespaHome("conf/zookeeper/tls.conf.json"));
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/NodeResourcesTuning.java
@@ -22,7 +22,7 @@ public class NodeResourcesTuning implements ProtonConfig.Producer {
     private final static double TLS_SIZE_FRACTION = 0.02;
     final static long MB = 1024 * 1024;
     public final static long GB = MB * 1024;
-    // This is an approximate number based on observation of a node using 33G memory with 765M docs
+    // This is an approximate number base on observation of a node using 33G memory with 765M docs
     private final static long MEMORY_COST_PER_DOCUMENT_STORE_ONLY = 46L;
     private final NodeResources resources;
     private final int threadsPerSearch;

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/ConfigserverClusterTest.java
@@ -41,7 +41,7 @@ public class ConfigserverClusterTest {
         assertZookeeperServerProperty(config.server(), ZookeeperServerConfig.Server::hostname, "localhost");
         assertZookeeperServerProperty(config.server(), ZookeeperServerConfig.Server::id, 0);
         assertEquals(0, config.myid());
-        assertEquals("/opt/vespa/var/zookeeper/conf/tls.conf.json", config.vespaTlsConfigFile());
+        assertEquals("/opt/vespa/conf/zookeeper/tls.conf.json", config.vespaTlsConfigFile());
     }
 
     @Test
@@ -52,7 +52,7 @@ public class ConfigserverClusterTest {
         assertZookeeperServerProperty(config.server(), ZookeeperServerConfig.Server::id, 0, 1, 2);
         assertEquals(1, config.myid());
         assertEquals("gz", config.snapshotMethod());
-        assertEquals("/opt/vespa/var/zookeeper/conf/tls.conf.json", config.vespaTlsConfigFile());
+        assertEquals("/opt/vespa/conf/zookeeper/tls.conf.json", config.vespaTlsConfigFile());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class ConfigserverClusterTest {
         assertZookeeperServerProperty(config.server(), ZookeeperServerConfig.Server::hostname, "cfg1", "localhost", "cfg3");
         assertZookeeperServerProperty(config.server(), ZookeeperServerConfig.Server::id, 4, 2, 3);
         assertEquals(2, config.myid());
-        assertEquals("/opt/vespa/var/zookeeper/conf/tls.conf.json", config.vespaTlsConfigFile());
+        assertEquals("/opt/vespa/conf/zookeeper/tls.conf.json", config.vespaTlsConfigFile());
     }
 
     @Test


### PR DESCRIPTION
Reverts vespa-engine/vespa#24976

Please review only, merge if the original PR breaks something