### PR TITLE
Make internal cluster/node state propagation noexcept

### DIFF
--- a/storage/src/tests/storageserver/statemanagertest.cpp
+++ b/storage/src/tests/storageserver/statemanagertest.cpp
@@ -163,7 +163,7 @@ struct MyStateListener : public StateListener {
         : updater(upd), current(*updater.getReportedNodeState()) {}
     ~MyStateListener() override = default;
 
-    void handleNewState() override {
+    void handleNewState() noexcept override {
         ost << current << " -> ";
         current = *updater.getReportedNodeState();
         ost << current << "\n";

--- a/storage/src/vespa/storage/common/nodestateupdater.h
+++ b/storage/src/vespa/storage/common/nodestateupdater.h
@@ -31,8 +31,8 @@ namespace storage {
 namespace lib { class ClusterStateBundle; }
 
 struct StateListener {
-    virtual ~StateListener() {}
-    virtual void handleNewState() = 0;
+    virtual ~StateListener() = default;
+    virtual void handleNewState() noexcept = 0;
 };
 
 struct NodeStateUpdater {

--- a/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.cpp
@@ -15,7 +15,7 @@ DistributorComponentRegisterImpl::DistributorComponentRegisterImpl()
 DistributorComponentRegisterImpl::~DistributorComponentRegisterImpl() = default;
 
 void
-DistributorComponentRegisterImpl::handleNewState()
+DistributorComponentRegisterImpl::handleNewState() noexcept
 {
     auto clusterStateBundle = getNodeStateUpdater().getClusterStateBundle();
     _clusterState = std::make_shared<lib::ClusterState>(*clusterStateBundle->getBaselineClusterState());

--- a/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.h
+++ b/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.h
@@ -42,7 +42,7 @@ public:
     void setDistributorConfig(const DistributorConfig&);
     void setVisitorConfig(const VisitorConfig&);
 private:
-    void handleNewState() override;
+    void handleNewState() noexcept override;
     void setNodeStateUpdater(NodeStateUpdater& updater) override;
 };
 

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -999,7 +999,7 @@ FileStorManager::propagateClusterStates()
 }
 
 void
-FileStorManager::handleNewState()
+FileStorManager::handleNewState() noexcept
 {
     propagateClusterStates();
     //TODO: Don't update if it isn't necessary (distributor-only change)

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -101,7 +101,7 @@ public:
     }
     ProviderErrorWrapper& error_wrapper() noexcept;
 
-    void handleNewState() override;
+    void handleNewState() noexcept override;
 
     // Must be called exactly once at startup _before_ storage chain is opened.
     // This function expects that no external messages may arrive prior to, or

--- a/storage/src/vespa/storage/storageserver/bouncer.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer.cpp
@@ -349,7 +349,7 @@ deriveNodeState(const lib::NodeState &reportedNodeState,
 }
 
 void
-Bouncer::handleNewState()
+Bouncer::handleNewState() noexcept
 {
     std::lock_guard lock(_lock);
     const auto reportedNodeState = *_component.getStateUpdater().getReportedNodeState();

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -74,7 +74,7 @@ private:
      */
     uint64_t extractMutationTimestampIfAny(const api::StorageMessage& msg);
     bool onDown(const std::shared_ptr<api::StorageMessage>&) override;
-    void handleNewState() override;
+    void handleNewState() noexcept override;
     const lib::NodeState &getDerivedNodeState(document::BucketSpace bucketSpace) const;
     void append_node_identity(std::ostream& target_stream) const;
 };


### PR DESCRIPTION
@geirst please review

It is not well defined what to do if an implementation of the propagation callback throws, so make it `noexcept` to core the process if it does happen.

