### PR TITLE
Avoid mass pending GC on config enable edge [run-systemtest]

### DIFF
--- a/storage/src/tests/distributor/statecheckerstest.cpp
+++ b/storage/src/tests/distributor/statecheckerstest.cpp
@@ -1371,6 +1371,12 @@ std::string StateCheckersTest::testGarbageCollection(
         uint32_t checkInterval, uint32_t lastChangeTime,
         bool includePriority, bool includeSchedulingPri)
 {
+    GarbageCollectionStateChecker checker;
+    auto cfg = make_config();
+    cfg->setGarbageCollection("music", std::chrono::seconds(checkInterval));
+    cfg->setLastGarbageCollectionChangeTime(vespalib::steady_time(std::chrono::seconds(lastChangeTime)));
+    configure_stripe(cfg);
+    // Insert after stripe configuration to avoid GC timestamp being implicitly reset
     BucketDatabase::Entry e(document::BucketId(17, 0));
     e.getBucketInfo().addNode(BucketCopy(prevTimestamp, 0,
                                          api::BucketInfo(3,3,3)),
@@ -1378,11 +1384,6 @@ std::string StateCheckersTest::testGarbageCollection(
     e.getBucketInfo().setLastGarbageCollectionTime(prevTimestamp);
     getBucketDatabase().update(e);
 
-    GarbageCollectionStateChecker checker;
-    auto cfg = make_config();
-    cfg->setGarbageCollection("music", std::chrono::seconds(checkInterval));
-    cfg->setLastGarbageCollectionChangeTime(vespalib::steady_time(std::chrono::seconds(lastChangeTime)));
-    configure_stripe(cfg);
     NodeMaintenanceStatsTracker statsTracker;
     StateChecker::Context c(node_context(), operation_context(),
                             getDistributorBucketSpace(), statsTracker,

--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -132,6 +132,18 @@ struct TopLevelDistributorTest : Test, TopLevelDistributorTestUtil {
             EXPECT_EQ(stripe->non_activation_maintenance_is_inhibited(), inhibited);
         }
     }
+
+    void set_bucket_last_gc_time(const BucketId& bucket_id, uint32_t last_gc_time) {
+        auto db_entry = get_bucket(bucket_id);
+        db_entry->setLastGarbageCollectionTime(last_gc_time);
+        stripe_bucket_database(stripe_index_of_bucket(bucket_id)).update(db_entry);
+    }
+
+    uint32_t get_bucket_last_gc_time(const BucketId& bucket_id) const {
+        auto db_entry = get_bucket(bucket_id);
+        return db_entry->getLastGarbageCollectionTime();
+    }
+
 };
 
 TopLevelDistributorTest::TopLevelDistributorTest()
@@ -618,6 +630,71 @@ TEST_F(TopLevelDistributorTest, maintenance_safe_time_not_triggered_if_state_tra
     enable_distributor_cluster_state("storage:1 distributor:1", false);
     tick_distributor_and_stripes_n_times(1);
     ASSERT_NO_FATAL_FAILURE(assert_all_stripes_are_maintenance_inhibited(false));
+}
+
+/**
+ * If a system is running in a stable state with no GC enabled, per-bucket last GC timestamps
+ * in the DB will end up further and further in the past. If GC is then enabled in config,
+ * we must ensure that GC timestamps are reset to the current time to avoid suddenly ending
+ * up with _every single_ bucket having exceeded its GC deadline, causing pending GC en masse.
+ *
+ * Resetting is edge-triggered, so it should not happen if GC is enabled in both the old
+ * and new configs.
+ */
+TEST_F(TopLevelDistributorTest, gc_timestamps_reset_to_current_time_on_gc_enabled_edge) {
+    setup_distributor(Redundancy(2), NodeCount(2), "version:1 distributor:1 storage:2");
+    fake_clock().setAbsoluteTimeInSeconds(1234);
+
+    BucketId b1(16, 1);
+    BucketId b2(16, 2);
+    BucketId b3(16, 3);
+
+    add_nodes_to_stripe_bucket_db(b1, "0=1/1/1/t/a");
+    add_nodes_to_stripe_bucket_db(b2, "0=2/2/2/t/a");
+    add_nodes_to_stripe_bucket_db(b3, "0=3/3/3/t/a");
+
+    // Reconfigure GC interval from 0 (disabled) to 3600 (enabled).
+    auto cfg = current_distributor_config();
+    cfg.garbagecollection.interval = 3600;
+    cfg.garbagecollection.selectiontoremove = "true";
+    reconfigure(cfg);
+
+    // GC timestamps must be set to the current time to avoid a flood of GC ops caused by
+    // all buckets suddenly implicitly exceeding their GC deadline.
+    ASSERT_EQ(get_bucket_last_gc_time(b1), 1234);
+    ASSERT_EQ(get_bucket_last_gc_time(b2), 1234);
+    ASSERT_EQ(get_bucket_last_gc_time(b3), 1234);
+}
+
+TEST_F(TopLevelDistributorTest, gc_timestamps_not_reset_to_current_time_when_gc_enabled_in_old_and_new_configs) {
+    setup_distributor(Redundancy(2), NodeCount(2), "version:1 distributor:1 storage:2");
+    fake_clock().setAbsoluteTimeInSeconds(1234);
+
+    auto cfg = current_distributor_config();
+    cfg.garbagecollection.interval = 3600;
+    cfg.garbagecollection.selectiontoremove = "true";
+    reconfigure(cfg);
+
+    BucketId b1(16, 1);
+    BucketId b2(16, 2);
+    BucketId b3(16, 3);
+
+    add_nodes_to_stripe_bucket_db(b1, "0=1/1/1/t/a");
+    set_bucket_last_gc_time(b1, 1001);
+    add_nodes_to_stripe_bucket_db(b2, "0=2/2/2/t/a");
+    set_bucket_last_gc_time(b2, 1002);
+    add_nodes_to_stripe_bucket_db(b3, "0=3/3/3/t/a");
+    set_bucket_last_gc_time(b3, 1003);
+
+    // Change in GC interval, but no enabling-edge
+    cfg = current_distributor_config();
+    cfg.garbagecollection.interval = 1800;
+    reconfigure(cfg);
+
+    // No changes in GC time
+    ASSERT_EQ(get_bucket_last_gc_time(b1), 1001);
+    ASSERT_EQ(get_bucket_last_gc_time(b2), 1002);
+    ASSERT_EQ(get_bucket_last_gc_time(b3), 1003);
 }
 
 }

--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -650,8 +650,11 @@ TEST_F(TopLevelDistributorTest, gc_timestamps_reset_to_current_time_on_gc_enable
     BucketId b3(16, 3);
 
     add_nodes_to_stripe_bucket_db(b1, "0=1/1/1/t/a");
+    set_bucket_last_gc_time(b1, 100);
     add_nodes_to_stripe_bucket_db(b2, "0=2/2/2/t/a");
+    set_bucket_last_gc_time(b2, 101);
     add_nodes_to_stripe_bucket_db(b3, "0=3/3/3/t/a");
+    set_bucket_last_gc_time(b3, 102);
 
     // Reconfigure GC interval from 0 (disabled) to 3600 (enabled).
     auto cfg = current_distributor_config();

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -769,11 +769,26 @@ void DistributorStripe::mark_maintenance_tick_as_no_longer_inhibited() noexcept 
     _inhibited_maintenance_tick_count = 0;
 }
 
+namespace {
+
+bool config_change_has_gc_enable_edge(const DistributorConfiguration& old_config,
+                                      const DistributorConfiguration& new_config) noexcept {
+    return ((old_config.getGarbageCollectionInterval().count() == 0) &&
+            (new_config.getGarbageCollectionInterval().count() != 0));
+}
+
+}
+
 void
 DistributorStripe::update_total_distributor_config(std::shared_ptr<const DistributorConfiguration> config)
 {
+    auto old_config = std::move(_total_config);
     _total_config = std::move(config);
     propagate_config_snapshot_to_internal_components();
+    if (config_change_has_gc_enable_edge(*old_config, *_total_config)) {
+        LOG(debug, "GC has been enabled at reconfig edge; resetting last GC for all buckets to current time");
+        _bucketDBUpdater.reset_all_last_gc_timestamps_to_current_time();
+    }
 }
 
 void

--- a/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/stripe_bucket_db_updater.h
@@ -71,6 +71,8 @@ public:
     }
 
     OperationRoutingSnapshot read_snapshot_for_bucket(const document::Bucket&) const;
+
+    void reset_all_last_gc_timestamps_to_current_time();
 private:
     class MergeReplyGuard {
     public:


### PR DESCRIPTION
@geirst please review

If a system is running in a stable state with no GC enabled, per-bucket last GC timestamps in the DB will end up further and further in the past. If GC is then enabled in config, we must ensure that GC timestamps are reset to the current time to avoid suddenly ending up with _every single_ bucket having exceeded its GC deadline, causing pending GC _en masse_.

Resetting is edge-triggered, so it should not happen if GC is enabled in both the old and new configs.

