### PR TITLE
Defer MBus DestinationSession registration during content node init [run-systemtest]

### DIFF
--- a/messagebus/src/vespa/messagebus/destinationsession.h
+++ b/messagebus/src/vespa/messagebus/destinationsession.h
@@ -22,6 +22,8 @@ private:
     MessageBus      &_mbus;
     string           _name;
     IMessageHandler &_msgHandler;
+    bool             _session_registered;
+    bool             _broadcast_name;
 
     /**
      * This constructor is package private since only MessageBus is supposed to
@@ -36,13 +38,20 @@ public:
     /**
      * Convenience typedef for an auto pointer to a DestinationSession object.
      */
-    typedef std::unique_ptr<DestinationSession> UP;
+    using UP = std::unique_ptr<DestinationSession>;
 
     /**
      * The destructor untangles from messagebus. After this method returns,
      * messagebus will not invoke any handlers associated with this session.
      */
-    virtual ~DestinationSession();
+    ~DestinationSession() override;
+
+    /**
+     * If a session was created with defer_registered(true) as part of its parameters,
+     * it can be subsequently registered at most once. The session will not be visible
+     * for incoming messages until that point in time.
+     */
+    void register_session_deferred();
 
     /**
      * This method unregisters this session from message bus, effectively

--- a/messagebus/src/vespa/messagebus/destinationsessionparams.cpp
+++ b/messagebus/src/vespa/messagebus/destinationsessionparams.cpp
@@ -6,6 +6,7 @@ namespace mbus {
 DestinationSessionParams::DestinationSessionParams() :
     _name("destination"),
     _broadcastName(true),
+    _defer_registration(false),
     _handler(nullptr)
 { }
 

--- a/messagebus/src/vespa/messagebus/destinationsessionparams.h
+++ b/messagebus/src/vespa/messagebus/destinationsessionparams.h
@@ -18,6 +18,7 @@ class DestinationSessionParams {
 private:
     string           _name;
     bool             _broadcastName;
+    bool             _defer_registration;
     IMessageHandler *_handler;
 
 public:
@@ -48,6 +49,8 @@ public:
      */
     bool getBroadcastName() const { return _broadcastName; }
 
+    [[nodiscard]] bool defer_registration() const noexcept { return _defer_registration; }
+
     /**
      * Sets whether or not to broadcast the name of this session on the network.
      *
@@ -55,6 +58,11 @@ public:
      * @return This, to allow chaining.
      */
     DestinationSessionParams &setBroadcastName(bool broadcastName) { _broadcastName = broadcastName; return *this; }
+
+    DestinationSessionParams& defer_registration(bool defer) noexcept {
+        _defer_registration = defer;
+        return *this;
+    }
 
     /**
      * Returns the handler to receive incoming messages. If you call this method without first assigning a

--- a/messagebus/src/vespa/messagebus/imessagehandler.h
+++ b/messagebus/src/vespa/messagebus/imessagehandler.h
@@ -20,7 +20,7 @@ protected:
 public:
     IMessageHandler(const IMessageHandler &) = delete;
     IMessageHandler & operator = (const IMessageHandler &) = delete;
-    virtual ~IMessageHandler() {}
+    virtual ~IMessageHandler() = default;
 
     /**
      * This method is invoked by messagebus to deliver a Message.

--- a/messagebus/src/vespa/messagebus/messagebus.cpp
+++ b/messagebus/src/vespa/messagebus/messagebus.cpp
@@ -225,11 +225,24 @@ MessageBus::createDestinationSession(const DestinationSessionParams &params)
 {
     std::lock_guard guard(_lock);
     DestinationSession::UP ret(new DestinationSession(*this, params));
-    _sessions[params.getName()] = ret.get();
-    if (params.getBroadcastName()) {
-        _network.registerSession(params.getName());
+    if (!params.defer_registration()) {
+        _sessions[params.getName()] = ret.get();
+        if (params.getBroadcastName()) {
+            _network.registerSession(params.getName());
+        }
     }
     return ret;
+}
+
+void
+MessageBus::register_session(IMessageHandler& session, const string& session_name, bool broadcast_name)
+{
+    std::lock_guard guard(_lock);
+    assert(!_sessions.contains(session_name));
+    _sessions[session_name] = &session;
+    if (broadcast_name) {
+        _network.registerSession(session_name);
+    }
 }
 
 void

--- a/messagebus/src/vespa/messagebus/messagebus.h
+++ b/messagebus/src/vespa/messagebus/messagebus.h
@@ -171,6 +171,12 @@ public:
     DestinationSession::UP createDestinationSession(const DestinationSessionParams &params);
 
     /**
+     * Register a session; used by session instances that are created with deferred registration.
+     * Don't use this directly.
+     */
+    void register_session(IMessageHandler& session, const string& session_name, bool broadcast_name);
+
+    /**
      * Unregister a session. This method is invoked by session destructors to ensure that no more Message objects are
      * delivered and that the session name is removed from the network naming service. The sync method can be invoked
      * after invoking this one to ensure that no callbacks are active.


### PR DESCRIPTION
@geirst please review
@toregge FYI

Creating a `DestinationSession` that is immediately registered as available for business means we may theoretically start receiving messages over the session even before the call returns to the caller. Either way there would be no memory barrier that ensures that `_messageBusSession` would be fully visible to the MessageBus threads (since it's written after return).

To avoid this sneaky scenario, defer registration (and thus introduce a barrier) until _after_ we've initialized our internal member variables.

This addresses a TSan warning.
