### PR TITLE
Remove out of range search::BitVector::setBit() in unit test.

### DIFF
--- a/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
+++ b/searchlib/src/tests/attribute/tensorattribute/tensorattribute_test.cpp
@@ -1271,7 +1271,6 @@ TEST_F("NN blueprint handles weak filter (pre-filtering)", NearestNeighborBluepr
     filter->setBit(5);
     filter->setBit(7);
     filter->setBit(9);
-    filter->setBit(11);
     filter->invalidateCachedCount();
     auto weak_filter = GlobalFilter::create(std::move(filter));
     bp->set_global_filter(*weak_filter, 0.6);


### PR DESCRIPTION
@geirst : please review
