### PR TITLE
Add range checks for BitVector setBits and clearBits member functions,

### DIFF
--- a/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/allocatedbitvector.cpp
@@ -69,7 +69,7 @@ AllocatedBitVector::AllocatedBitVector(Index numberOfElements, Index capacityBit
         if (minCount/8 == numberOfElements/8) {
             static_cast<Word *>(getStart())[numWords()-1] &= ~endBits(minCount);
         }
-        setBit(size()); // Guard bit
+        set_bit_no_range_check(size()); // Guard bit
     }
     updateCount();
 }
@@ -90,7 +90,7 @@ AllocatedBitVector::AllocatedBitVector(const BitVector & rhs, std::pair<Index, I
     _capacityBits = computeCapacity(_capacityBits, _alloc.size());
     memcpy(_alloc.get(),  rhs.getStart(), numBytes(size_capacity.first - rhs.getStartIndex()));
     init(_alloc.get(), 0, size_capacity.first);
-    setBit(size());
+    set_bit_no_range_check(size());
     updateCount();
 }
 

--- a/searchlib/src/vespa/searchlib/common/bitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/bitvector.cpp
@@ -9,8 +9,8 @@
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/objects/nbostream.h>
 #include <vespa/fastos/file.h>
-#include <stdlib.h>
 #include <cassert>
+#include <cstdlib>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.common.bitvector");

--- a/searchlib/src/vespa/searchlib/common/bitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/bitvector.cpp
@@ -376,7 +376,7 @@ void
 BitVector::consider_enable_range_check()
 {
     const char *env = getenv("VESPA_BITVECTOR_RANGE_CHECK");
-    if (env != nullptr && strcmp(env, "yes") == 0) {
+    if (env != nullptr && strcmp(env, "true") == 0) {
         _enable_range_check = true;
     }
 }

--- a/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/growablebitvector.cpp
@@ -28,7 +28,7 @@ GrowableBitVector::grow(BitWord::Index newSize, BitWord::Index newCapacity)
     if (newCapacity != self.capacity()) {
         auto tbv = std::make_unique<AllocatedBitVector>(newSize, newCapacity, self._alloc.get(), self.size(), &self._alloc);
         if (newSize > self.size()) {
-            tbv->clearBitAndMaintainCount(self.size());  // Clear old guard bit.
+            tbv->clear_bit_and_maintain_count_no_range_check(self.size());  // Clear old guard bit.
         }
         auto to_hold = std::make_unique<GenerationHeldAllocatedBitVector>(std::move(_stored));
         _self.store(tbv.get(), std::memory_order_release);

--- a/searchlib/src/vespa/searchlib/common/partialbitvector.cpp
+++ b/searchlib/src/vespa/searchlib/common/partialbitvector.cpp
@@ -26,7 +26,7 @@ PartialBitVector::PartialBitVector(const BitVector & org, Index start, Index end
     if (org.size() < end) {
         clearInterval(org.size(), end);
     }
-    setBit(size());
+    set_bit_no_range_check(size());
 }
 
 PartialBitVector::~PartialBitVector() = default;


### PR DESCRIPTION
enabled when VESPA_BITVECTOR_RANGE_CHECK environment variable is set to "yes".

@baldersheim : please review
@geirst : FYI
