### PR TITLE
Move synchronous policy init inside lock [run-systemtest]

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/policies/asyncinitializationpolicy.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/policies/asyncinitializationpolicy.cpp
@@ -71,12 +71,12 @@ currentPolicyInitError(vespalib::stringref error) {
 void
 AsyncInitializationPolicy::select(mbus::RoutingContext& context)
 {
-    if (_syncInit && _state != State::DONE) {
-        initSynchronous();
-    }
-
     {
         std::lock_guard lock(_lock);
+
+        if (_syncInit && _state != State::DONE) {
+            initSynchronous();
+        }
 
         if (_state == State::NOT_STARTED || _state == State::FAILED) {
             // Only 1 task may be queued to the executor at any point in time.


### PR DESCRIPTION
@geirst please review
@toregge FYI

Avoids a race when multiple threads try to synchronously initialize a MessageBus policy.

This resolves a TSan warning.

