### PR TITLE
Add tensor short form option to vespa-visit and vespa-get

### DIFF
--- a/document/src/main/java/com/yahoo/document/json/JsonWriter.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonWriter.java
@@ -93,6 +93,10 @@ public class JsonWriter implements DocumentWriter {
         this(createPrivateGenerator(out));
     }
 
+    public JsonWriter(OutputStream out, boolean tensorShortForm) {
+        this(createPrivateGenerator(out), tensorShortForm);
+    }
+
     private static JsonGenerator createPrivateGenerator(OutputStream out) {
         try {
             return jsonFactory.createGenerator(out);
@@ -265,15 +269,26 @@ public class JsonWriter implements DocumentWriter {
     /**
      * Utility method to easily serialize a single document.
      *
-     * @param document
-     *            the document to be serialized
+     * @param document the document to be serialized
+     * @param tensorShortForm whether tensors should be serialized in short form
+     * @return the input document serialised as UTF-8 encoded JSON
+     */
+    public static byte[] toByteArray(Document document, boolean tensorShortForm) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        JsonWriter writer = new JsonWriter(out, tensorShortForm);
+        writer.write(document);
+        return out.toByteArray();
+    }
+
+    /**
+     * Utility method to easily serialize a single document.
+     *
+     * @param document the document to be serialized
      * @return the input document serialised as UTF-8 encoded JSON
      */
     public static byte[] toByteArray(Document document) {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        JsonWriter writer = new JsonWriter(out);
-        writer.write(document);
-        return out.toByteArray();
+        // TODO Vespa 9: change tensorShortForm default to true
+        return toByteArray(document, false);
     }
 
     /**

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/ClientParameters.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/ClientParameters.java
@@ -37,13 +37,15 @@ public class ClientParameters {
     public final DocumentProtocol.Priority priority;
     // If full documents are printed, they will be printed as JSON (instead of XML)
     public final boolean jsonOutput;
+    // Output JSON tensors in short form
+    public final boolean tensorShortForm;
 
 
     private ClientParameters(
             boolean help, Iterator<String> documentIds, boolean printIdsOnly,
             String fieldSet, String route, String cluster, String configId,
             boolean showDocSize, double timeout, boolean noRetry, int traceLevel,
-            DocumentProtocol.Priority priority, boolean jsonOutput) {
+            DocumentProtocol.Priority priority, boolean jsonOutput, boolean tensorShortForm) {
 
         this.help = help;
         this.documentIds = documentIds;
@@ -58,6 +60,7 @@ public class ClientParameters {
         this.traceLevel = traceLevel;
         this.priority = priority;
         this.jsonOutput = jsonOutput;
+        this.tensorShortForm = tensorShortForm;
     }
 
     public static class Builder {
@@ -74,6 +77,7 @@ public class ClientParameters {
         private int traceLevel;
         private DocumentProtocol.Priority priority;
         private boolean jsonOutput;
+        private boolean tensorShortForm;
 
         public Builder setHelp(boolean help) {
             this.help = help;
@@ -140,10 +144,15 @@ public class ClientParameters {
             return this;
         }
 
+        public Builder setTensorShortForm(boolean tensorShortForm) {
+            this.tensorShortForm = tensorShortForm;
+            return this;
+        }
+
         public ClientParameters build() {
             return new ClientParameters(
                     help, documentIds, printIdsOnly, fieldSet, route, cluster, configId,
-                    showDocSize, timeout, noRetry, traceLevel, priority, jsonOutput);
+                    showDocSize, timeout, noRetry, traceLevel, priority, jsonOutput, tensorShortForm);
         }
     }
 

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
@@ -39,6 +39,7 @@ public class CommandLineOptions {
     public static final String PRIORITY_OPTION = "priority";
     public static final String JSONOUTPUT_OPTION = "jsonoutput";
     public static final String XMLOUTPUT_OPTION = "xmloutput";
+    public static final String TENSOR_SHORT_FORM_OPTION = "tensor-short-form";
 
     private final Options options = createOptions();
     private final InputStream stdIn;
@@ -131,6 +132,13 @@ public class CommandLineOptions {
                 .desc("XML output")
                 .longOpt(XMLOUTPUT_OPTION).build());
 
+        // TODO Vespa 9: replace with --tensor-long-form ?
+        options.addOption(Option.builder()
+                .longOpt(TENSOR_SHORT_FORM_OPTION)
+                .desc("Output JSON tensors in short form. Will be the default on Vespa 9")
+                .hasArg(false)
+                .build());
+
         return options;
     }
 
@@ -159,6 +167,7 @@ public class CommandLineOptions {
             boolean showDocSize = cl.hasOption(SHOWDOCSIZE_OPTION);
             boolean jsonOutput = cl.hasOption(JSONOUTPUT_OPTION);
             boolean xmlOutput = cl.hasOption(XMLOUTPUT_OPTION);
+            boolean tensorShortForm = cl.hasOption(TENSOR_SHORT_FORM_OPTION);
             int trace = getTrace(cl);
             DocumentProtocol.Priority priority = getPriority(cl);
             double timeout = getTimeout(cl);
@@ -209,6 +218,7 @@ public class CommandLineOptions {
                     .setPriority(priority)
                     .setTimeout(timeout)
                     .setJsonOutput(!xmlOutput)
+                    .setTensorShortForm(tensorShortForm)
                     .build();
         } catch (ParseException pe) {
             throw new IllegalArgumentException(pe.getMessage());

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/CommandLineOptions.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespaget;
 
-import com.yahoo.document.fieldset.AllFields;
 import com.yahoo.document.fieldset.DocumentOnly;
 import com.yahoo.document.fieldset.DocIdOnly;
 import com.yahoo.documentapi.messagebus.protocol.DocumentProtocol;
@@ -39,7 +38,7 @@ public class CommandLineOptions {
     public static final String PRIORITY_OPTION = "priority";
     public static final String JSONOUTPUT_OPTION = "jsonoutput";
     public static final String XMLOUTPUT_OPTION = "xmloutput";
-    public static final String TENSOR_SHORT_FORM_OPTION = "tensor-short-form";
+    public static final String SHORTTENSORS_OPTION = "shorttensors";
 
     private final Options options = createOptions();
     private final InputStream stdIn;
@@ -132,9 +131,9 @@ public class CommandLineOptions {
                 .desc("XML output")
                 .longOpt(XMLOUTPUT_OPTION).build());
 
-        // TODO Vespa 9: replace with --tensor-long-form ?
+        // TODO Vespa 9: replace with --longtensors ?
         options.addOption(Option.builder()
-                .longOpt(TENSOR_SHORT_FORM_OPTION)
+                .longOpt(SHORTTENSORS_OPTION)
                 .desc("Output JSON tensors in short form. Will be the default on Vespa 9")
                 .hasArg(false)
                 .build());
@@ -167,7 +166,7 @@ public class CommandLineOptions {
             boolean showDocSize = cl.hasOption(SHOWDOCSIZE_OPTION);
             boolean jsonOutput = cl.hasOption(JSONOUTPUT_OPTION);
             boolean xmlOutput = cl.hasOption(XMLOUTPUT_OPTION);
-            boolean tensorShortForm = cl.hasOption(TENSOR_SHORT_FORM_OPTION);
+            boolean shortTensors = cl.hasOption(SHORTTENSORS_OPTION);
             int trace = getTrace(cl);
             DocumentProtocol.Priority priority = getPriority(cl);
             double timeout = getTimeout(cl);
@@ -218,7 +217,7 @@ public class CommandLineOptions {
                     .setPriority(priority)
                     .setTimeout(timeout)
                     .setJsonOutput(!xmlOutput)
-                    .setTensorShortForm(tensorShortForm)
+                    .setTensorShortForm(shortTensors)
                     .build();
         } catch (ParseException pe) {
             throw new IllegalArgumentException(pe.getMessage());

--- a/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespaget/DocumentRetriever.java
@@ -168,7 +168,7 @@ public class DocumentRetriever {
             System.out.println(document.getId());
         } else {
             if (params.jsonOutput) {
-                System.out.print(Utf8.toString(JsonWriter.toByteArray(document)));
+                System.out.print(Utf8.toString(JsonWriter.toByteArray(document, params.tensorShortForm)));
             } else {
                 System.out.print(document.toXML("  "));
             }

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/StdOutVisitorHandler.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/StdOutVisitorHandler.java
@@ -40,25 +40,30 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
     private int processTimeMilliSecs;
     private PrintStream out;
     private final boolean jsonOutput;
+    private final boolean tensorShortForm;
 
     private VisitorDataHandler dataHandler;
 
     public StdOutVisitorHandler(boolean printIds, boolean indentXml,
                                 boolean showProgress, boolean showStatistics, boolean doStatistics,
-                                boolean abortOnClusterDown, int processtime, boolean jsonOutput)
+                                boolean abortOnClusterDown, int processtime, boolean jsonOutput,
+                                boolean tensorShortForm)
     {
-        this(printIds, indentXml, showProgress, showStatistics, doStatistics, abortOnClusterDown, processtime, jsonOutput, createStdOutPrintStream());
+        this(printIds, indentXml, showProgress, showStatistics, doStatistics, abortOnClusterDown, processtime,
+             jsonOutput, tensorShortForm, createStdOutPrintStream());
     }
 
     StdOutVisitorHandler(boolean printIds, boolean indentXml,
                          boolean showProgress, boolean showStatistics, boolean doStatistics,
-                         boolean abortOnClusterDown, int processtime, boolean jsonOutput, PrintStream out)
+                         boolean abortOnClusterDown, int processtime, boolean jsonOutput,
+                         boolean tensorShortForm, PrintStream out)
     {
         super(showProgress, showStatistics, abortOnClusterDown);
         this.printIds = printIds;
         this.indentXml = indentXml;
         this.processTimeMilliSecs = processtime;
         this.jsonOutput = jsonOutput;
+        this.tensorShortForm = tensorShortForm;
         this.out = out;
         this.dataHandler = new DataHandler(doStatistics);
     }
@@ -169,7 +174,7 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
 
         private void writeJsonDocument(Document doc) throws IOException {
             writeFeedStartOrRecordSeparator();
-            out.write(JsonWriter.toByteArray(doc));
+            out.write(JsonWriter.toByteArray(doc, tensorShortForm));
         }
 
         @Override

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -348,6 +348,13 @@ public class VdsVisit {
                         FixedBucketSpaces.defaultSpace(), FixedBucketSpaces.globalSpace(), FixedBucketSpaces.defaultSpace()))
                 .build());
 
+        // TODO Vespa 9 replace with --tensor-long-form ?
+        options.addOption(Option.builder()
+                .longOpt("tensor-short-form")
+                .desc("Output JSON tensors in short form. Will be the default on Vespa 9")
+                .hasArg(false)
+                .build());
+
         return options;
     }
 
@@ -363,6 +370,7 @@ public class VdsVisit {
         private int processTime = 0;
         private int fullTimeout = 7 * 24 * 60 * 60 * 1000;
         private boolean jsonOutput = false;
+        private boolean tensorShortForm = false; // TODO Vespa 9: change default to true
 
         public VisitorParameters getVisitorParameters() {
             return visitorParameters;
@@ -430,6 +438,14 @@ public class VdsVisit {
 
         public void setJsonOutput(boolean jsonOutput) {
             this.jsonOutput = jsonOutput;
+        }
+
+        public boolean tensorShortForm() {
+            return tensorShortForm;
+        }
+
+        public void setTensorShortForm(boolean tensorShortForm) {
+            this.tensorShortForm = tensorShortForm;
         }
     }
 
@@ -552,6 +568,9 @@ public class VdsVisit {
                 StaticThrottlePolicy throttlePolicy = new StaticThrottlePolicy();
                 throttlePolicy.setMaxPendingCount(((Number)line.getParsedOptionValue("maxpendingsuperbuckets")).intValue());
                 params.setThrottlePolicy(throttlePolicy);
+            }
+            if (line.hasOption("tensor-short-form")) {
+                allParams.setTensorShortForm(true);
             }
 
             boolean jsonOutput = line.hasOption("jsonoutput");
@@ -723,7 +742,8 @@ public class VdsVisit {
                 params.getStatisticsParts() != null,
                 params.getAbortOnClusterDown(),
                 params.getProcessTime(),
-                params.jsonOutput);
+                params.jsonOutput,
+                params.tensorShortForm);
 
         if (visitorParameters.getResumeFileName() != null) {
             handler.setProgressFileName(visitorParameters.getResumeFileName());

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -348,7 +348,7 @@ public class VdsVisit {
                         FixedBucketSpaces.defaultSpace(), FixedBucketSpaces.globalSpace(), FixedBucketSpaces.defaultSpace()))
                 .build());
 
-        // TODO Vespa 9 replace with --tensor-long-form ?
+        // TODO Vespa 9: replace with --tensor-long-form ?
         options.addOption(Option.builder()
                 .longOpt("tensor-short-form")
                 .desc("Output JSON tensors in short form. Will be the default on Vespa 9")

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -348,9 +348,9 @@ public class VdsVisit {
                         FixedBucketSpaces.defaultSpace(), FixedBucketSpaces.globalSpace(), FixedBucketSpaces.defaultSpace()))
                 .build());
 
-        // TODO Vespa 9: replace with --tensor-long-form ?
+        // TODO Vespa 9: replace with --longtensors ?
         options.addOption(Option.builder()
-                .longOpt("tensor-short-form")
+                .longOpt("shorttensors")
                 .desc("Output JSON tensors in short form. Will be the default on Vespa 9")
                 .hasArg(false)
                 .build());
@@ -569,7 +569,7 @@ public class VdsVisit {
                 throttlePolicy.setMaxPendingCount(((Number)line.getParsedOptionValue("maxpendingsuperbuckets")).intValue());
                 params.setThrottlePolicy(throttlePolicy);
             }
-            if (line.hasOption("tensor-short-form")) {
+            if (line.hasOption("shorttensors")) {
                 allParams.setTensorShortForm(true);
             }
 

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
@@ -71,7 +71,7 @@ public class CommandLineOptionsTest {
                 "--noretry",
                 "--trace", "1",
                 "--priority", Integer.toString(DocumentProtocol.Priority.HIGH_3.getValue()),
-                "--tensor-short-form",
+                "--shorttensors",
                 "id:1", "id:2"
         );
 

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/CommandLineOptionsTest.java
@@ -57,6 +57,7 @@ public class CommandLineOptionsTest {
         assertFalse(params.noRetry);
         assertEquals(0, params.traceLevel);
         assertEquals(DocumentProtocol.Priority.NORMAL_2, params.priority);
+        assertFalse(params.tensorShortForm); // TODO Vespa 9: change default to true
     }
 
     @Test
@@ -70,6 +71,7 @@ public class CommandLineOptionsTest {
                 "--noretry",
                 "--trace", "1",
                 "--priority", Integer.toString(DocumentProtocol.Priority.HIGH_3.getValue()),
+                "--tensor-short-form",
                 "id:1", "id:2"
         );
 
@@ -81,6 +83,7 @@ public class CommandLineOptionsTest {
         assertTrue(params.noRetry);
         assertEquals(1, params.traceLevel);
         assertEquals(DocumentProtocol.Priority.HIGH_3, params.priority);
+        assertTrue(params.tensorShortForm);
 
         Iterator<String> documentsIds = params.documentIds;
         assertEquals("id:1", documentsIds.next());

--- a/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespaget/DocumentRetrieverTest.java
@@ -240,7 +240,7 @@ public class DocumentRetrieverTest {
     }
 
     @Test
-    void testEmtpyClusterList() throws DocumentRetrieverException {
+    void testEmptyClusterList() throws DocumentRetrieverException {
         Throwable exception = assertThrows(DocumentRetrieverException.class, () -> {
 
             ClientParameters params = createParameters()

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
@@ -1,7 +1,18 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespavisit;
 
+import com.yahoo.document.Document;
+import com.yahoo.document.DocumentPut;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.TensorDataType;
+import com.yahoo.document.datatypes.TensorFieldValue;
+import com.yahoo.documentapi.AckToken;
+import com.yahoo.documentapi.VisitorControlSession;
 import com.yahoo.documentapi.VisitorDataHandler;
+import com.yahoo.documentapi.messagebus.protocol.PutDocumentMessage;
+import com.yahoo.tensor.Tensor;
+import com.yahoo.tensor.TensorType;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -9,6 +20,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author bjorncs
@@ -30,7 +42,7 @@ public class StdOutVisitorHandlerTest {
         initStdOutVisitorHandlerTest(jsonOutput);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         StdOutVisitorHandler visitorHandler =
-                new StdOutVisitorHandler(/*printIds*/true, false, false, false, false, false, 0, jsonOutput, new PrintStream(out, true));
+                new StdOutVisitorHandler(/*printIds*/true, false, false, false, false, false, 0, jsonOutput, false, new PrintStream(out, true));
         VisitorDataHandler dataHandler = visitorHandler.getDataHandler();
         dataHandler.onDone();
         String output = out.toString();
@@ -43,11 +55,49 @@ public class StdOutVisitorHandlerTest {
         initStdOutVisitorHandlerTest(jsonOutput);
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         StdOutVisitorHandler visitorHandler =
-                new StdOutVisitorHandler(/*printIds*/false, false, false, false, false, false, 0, jsonOutput, new PrintStream(out, true));
+                new StdOutVisitorHandler(/*printIds*/false, false, false, false, false, false, 0, jsonOutput, false, new PrintStream(out, true));
         VisitorDataHandler dataHandler = visitorHandler.getDataHandler();
         dataHandler.onDone();
         String expectedOutput = jsonOutput ? "[]" : "";
         String output = out.toString().trim();
         assertEquals(expectedOutput, output);
     }
+
+    void do_test_json_tensor_fields_can_be_output_in_short_or_long_form(boolean tensorShortForm, String expectedOutput) {
+        var docType = new DocumentType("foo");
+        docType.addField("bar", TensorDataType.getTensor(TensorType.fromSpec("tensor(x[3])")));
+        var doc = new Document(docType, "id:baz:foo::tensor-stuff");
+        doc.setFieldValue("bar", new TensorFieldValue(Tensor.from("tensor(x[3]):[1,2,3]")));
+        var putMsg = new PutDocumentMessage(new DocumentPut(doc));
+
+        var out = new ByteArrayOutputStream();
+        var visitorHandler = new StdOutVisitorHandler(/*printIds*/false, false, false, false, false, false,
+                                                      0, true, tensorShortForm, new PrintStream(out, true));
+        var dataHandler = visitorHandler.getDataHandler();
+        var controlSession = mock(VisitorControlSession.class);
+        var ackToken = mock(AckToken.class);
+        dataHandler.setSession(controlSession);
+        dataHandler.onMessage(putMsg, ackToken);
+        dataHandler.onDone();
+
+        String output = out.toString().trim();
+        assertEquals(expectedOutput, output);
+    }
+
+    @Test
+    void json_tensor_fields_can_be_output_in_long_form() {
+        var expectedOutput = """
+        [
+        {"id":"id:baz:foo::tensor-stuff","fields":{"bar":{"cells":[{"address":{"x":"0"},"value":1.0},{"address":{"x":"1"},"value":2.0},{"address":{"x":"2"},"value":3.0}]}}}]""";
+        do_test_json_tensor_fields_can_be_output_in_short_or_long_form(false, expectedOutput);
+    }
+
+    @Test
+    void json_tensor_fields_can_be_output_in_short_form() {
+        var expectedOutput = """
+        [
+        {"id":"id:baz:foo::tensor-stuff","fields":{"bar":{"type":"tensor(x[3])","values":[1.0,2.0,3.0]}}}]""";
+        do_test_json_tensor_fields_can_be_output_in_short_or_long_form(true, expectedOutput);
+    }
+
 }

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
@@ -140,7 +140,7 @@ public class VdsVisitTestCase {
                 "--abortonclusterdown",
                 "--visitremoves",
                 "--bucketspace", "outerspace",
-                "--tensor-short-form"
+                "--shorttensors"
         };
         VdsVisit.ArgumentParser parser = createMockArgumentParser();
         VdsVisit.VdsVisitParameters allParams = parser.parse(args);

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/VdsVisitTestCase.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,7 +139,8 @@ public class VdsVisitTestCase {
                 "--skipbucketsonfatalerrors",
                 "--abortonclusterdown",
                 "--visitremoves",
-                "--bucketspace", "outerspace"
+                "--bucketspace", "outerspace",
+                "--tensor-short-form"
         };
         VdsVisit.ArgumentParser parser = createMockArgumentParser();
         VdsVisit.VdsVisitParameters allParams = parser.parse(args);
@@ -158,6 +160,7 @@ public class VdsVisitTestCase {
         assertEquals(123456789, params.getTimeoutMs());
         assertEquals(7 * 24 * 60 * 60 * 1000, allParams.getFullTimeout());
         assertEquals("kittens", allParams.getCluster());
+        assertTrue(allParams.tensorShortForm());
 
         assertTrue(params.getThrottlePolicy() instanceof StaticThrottlePolicy);
         assertEquals(3, ((StaticThrottlePolicy) params.getThrottlePolicy()).getMaxPendingCount());
@@ -200,6 +203,13 @@ public class VdsVisitTestCase {
     }
 
     private static String[] emptyArgList() { return new String[]{}; }
+
+    // TODO Vespa 9: change default from long to short
+    @Test
+    void tensor_output_format_is_long_by_default() throws Exception {
+        var allParams = createMockArgumentParser().parse(emptyArgList());
+        assertFalse(allParams.tensorShortForm());
+    }
 
     @Test
     void visitor_priority_is_low1_by_default() throws Exception {


### PR DESCRIPTION
@bjorncs please review
@jobergum FYI

Specified with `--tensor-short-form`. No single-char option alias, as short form output will be the default on Vespa 9 and we're running out of usable option characters for these tools anyway.

This resolves #23470

