### PR TITLE
Have to switch to python39-pybind11-devel. pybind11-devel has been re…

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -404,7 +404,7 @@ Requires: %{name}-base-libs = %{version}-%{release}
 Requires: %{name}-libs = %{version}-%{release}
 %if 0%{?el8}
 %if 0%{?_centos_stream}
-BuildRequires: python39
+Requires: python39
 %else
 Requires: python36
 %endif

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -403,7 +403,11 @@ Summary: Vespa - The open big data serving engine - ann-benchmark
 Requires: %{name}-base-libs = %{version}-%{release}
 Requires: %{name}-libs = %{version}-%{release}
 %if 0%{?el8}
+%if 0%{?_centos_stream}
+BuildRequires: python39
+%else
 Requires: python36
+%endif
 %endif
 %if 0%{?el9}
 Requires: python3

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -52,19 +52,21 @@ BuildRequires: gcc-toolset-11-gcc-c++
 BuildRequires: gcc-toolset-11-binutils
 BuildRequires: gcc-toolset-11-libasan-devel
 BuildRequires: gcc-toolset-11-libatomic-devel
+BuildRequires: python39-pybind11-devel
+BuildRequires: python39-devel
 %define _devtoolset_enable /opt/rh/gcc-toolset-11/enable
 %else
 BuildRequires: gcc-toolset-11-gcc-c++
 BuildRequires: gcc-toolset-11-binutils
 BuildRequires: gcc-toolset-11-libasan-devel
 BuildRequires: gcc-toolset-11-libatomic-devel
+BuildRequires: pybind11-devel
+BuildRequires: python36-devel
 %define _devtoolset_enable /opt/rh/gcc-toolset-11/enable
 %endif
 BuildRequires: maven
 BuildRequires: maven-openjdk17
 BuildRequires: python3-pytest
-BuildRequires: python39-pybind11-devel
-BuildRequires: python39-devel
 BuildRequires: glibc-langpack-en
 %endif
 %if 0%{?el9}

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -62,9 +62,9 @@ BuildRequires: gcc-toolset-11-libatomic-devel
 %endif
 BuildRequires: maven
 BuildRequires: maven-openjdk17
-BuildRequires: pybind11-devel
 BuildRequires: python3-pytest
-BuildRequires: python36-devel
+BuildRequires: python39-pybind11-devel
+BuildRequires: python39-devel
 BuildRequires: glibc-langpack-en
 %endif
 %if 0%{?el9}


### PR DESCRIPTION
…moved from EPEL and not added to powertools for EL8.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
