### PR TITLE
Scale down slightly more aggressively

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
@@ -72,7 +72,6 @@ public class ClusterModel {
         this.scalingDuration = computeScalingDuration(cluster, clusterSpec);
         this.clusterTimeseries = metricsDb.getClusterTimeseries(application.id(), cluster.id());
         this.nodeTimeseries = new ClusterNodesTimeseries(scalingDuration(), cluster, nodes, metricsDb);
-        System.out.println("Scaling duration: " + scalingDuration + ", measurements per node: " + nodeTimeseries.measurementsPerNode());
     }
 
     ClusterModel(Zone zone,
@@ -101,7 +100,6 @@ public class ClusterModel {
 
     /** Returns the relative load adjustment that should be made to this cluster given available measurements. */
     public Load loadAdjustment() {
-        System.out.println("Node timeseries is empty: " + nodeTimeseries().isEmpty());
         if (nodeTimeseries().isEmpty()) return Load.one();
 
         Load adjustment = peakLoad().divide(idealLoad());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
@@ -72,6 +72,7 @@ public class ClusterModel {
         this.scalingDuration = computeScalingDuration(cluster, clusterSpec);
         this.clusterTimeseries = metricsDb.getClusterTimeseries(application.id(), cluster.id());
         this.nodeTimeseries = new ClusterNodesTimeseries(scalingDuration(), cluster, nodes, metricsDb);
+        System.out.println("Scaling duration: " + scalingDuration + ", measurements per node: " + nodeTimeseries.measurementsPerNode());
     }
 
     ClusterModel(Zone zone,
@@ -100,6 +101,7 @@ public class ClusterModel {
 
     /** Returns the relative load adjustment that should be made to this cluster given available measurements. */
     public Load loadAdjustment() {
+        System.out.println("Node timeseries is empty: " + nodeTimeseries().isEmpty());
         if (nodeTimeseries().isEmpty()) return Load.one();
 
         Load adjustment = peakLoad().divide(idealLoad());
@@ -111,7 +113,6 @@ public class ClusterModel {
     /** Are we in a position to make decisions to scale down at this point? */
     private boolean safeToScaleDown() {
         if (hasScaledIn(scalingDuration().multipliedBy(3))) return false;
-        if (nodeTimeseries().measurementsPerNode() < 4) return false;
         if (nodeTimeseries().nodesMeasured() != nodeCount()) return false;
         return true;
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/AutoscalingMaintainerTest.java
@@ -178,7 +178,11 @@ public class AutoscalingMaintainerTest {
         }
 
         assertEquals(Cluster.maxScalingEvents, tester.cluster(app1, cluster1).scalingEvents().size());
-        assertEquals("The latest rescaling is the last event stored",
+
+        // Complete last event
+        tester.addMeasurements(0.1f, 0.1f, 0.1f, 20, 1, app1);
+        tester.maintainer().maintain();
+        assertEquals("Last event is completed",
                      tester.clock().instant(),
                      tester.cluster(app1, cluster1).scalingEvents().get(Cluster.maxScalingEvents - 1).completion().get());
     }


### PR DESCRIPTION
Don't require a minimum number of measurements as we might not be able to ever collect them fast enough within the scaling window.
