### PR TITLE
Use vespa-pybind11-devel since the regular pybind11-devel has gone mi…

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -62,7 +62,7 @@ BuildRequires: gcc-toolset-11-libatomic-devel
 %endif
 BuildRequires: maven
 BuildRequires: maven-openjdk17
-BuildRequires: pybind11-devel
+BuildRequires: vespa-pybind11-devel
 BuildRequires: python3-pytest
 BuildRequires: python36-devel
 BuildRequires: glibc-langpack-en


### PR DESCRIPTION
…ssing.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
