### PR TITLE
Add metric tracking internal `StateManager` state propagation latency

### DIFF
--- a/storage/src/vespa/storage/storageserver/statemanager.h
+++ b/storage/src/vespa/storage/storageserver/statemanager.h
@@ -45,8 +45,11 @@ class StateManager : public NodeStateUpdater,
     using TimeStateCmdPair   = std::pair<framework::MilliSecTime, api::GetNodeStateCommand::SP>;
     using TimeSysStatePair   = std::pair<framework::MilliSecTime, std::shared_ptr<const ClusterStateBundle>>;
 
+    struct StateManagerMetrics;
+
     StorageComponent                          _component;
     metrics::MetricManager&                   _metricManager;
+    std::unique_ptr<StateManagerMetrics>      _metrics;
     mutable std::mutex                        _stateLock;
     std::condition_variable                   _stateCond;
     std::mutex                                _listenerLock;


### PR DESCRIPTION
@geirst please review

Adds a new top-level metric set with the single metric
```
vds.state_manager.invoke_state_listeners_latency
```
which tracks the latency for invoking the set of all state listeners.
