### PR TITLE
Improve error response when trying to use an imported field in a condition

### DIFF
--- a/document/src/vespa/document/base/testdocrepo.cpp
+++ b/document/src/vespa/document/base/testdocrepo.cpp
@@ -58,6 +58,7 @@ DocumenttypesConfig TestDocRepo::getDefaultConfig() {
                      .addTensorField("sparse_xy_tensor", "tensor(x{},y{})")
                      .addTensorField("sparse_float_tensor", "tensor<float>(x{})")
                      .addTensorField("dense_tensor", "tensor(x[2])"))
+        .imported_field("my_imported_field")
         .doc_type.fieldsets["[document]"].fields.swap(documentfields);
 
     builder.document(type2_id, "testdoctype2",

--- a/storage/src/tests/persistence/testandsettest.cpp
+++ b/storage/src/tests/persistence/testandsettest.cpp
@@ -222,6 +222,18 @@ TEST_F(TestAndSetTest, invalid_document_selection_should_fail) {
     EXPECT_EQ("", dumpBucket(BUCKET_ID));
 }
 
+TEST_F(TestAndSetTest, document_selection_with_imported_field_should_fail_with_illegal_parameters) {
+    api::Timestamp timestamp = 0;
+    auto put = std::make_shared<api::PutCommand>(BUCKET, testDoc, timestamp);
+    put->setCondition(documentapi::TestAndSetCondition("testdoctype1.my_imported_field == null"));
+
+    ASSERT_EQ(fetchResult(asyncHandler->handlePut(*put, createTracker(put, BUCKET))),
+              api::ReturnCode(api::ReturnCode::Result::ILLEGAL_PARAMETERS,
+                              "Condition field 'my_imported_field' could not be found, or is an imported field. "
+                              "Imported fields are not supported in conditional mutations."));
+    EXPECT_EQ("", dumpBucket(BUCKET_ID));
+}
+
 TEST_F(TestAndSetTest, conditional_put_to_non_existing_document_should_fail) {
     // Conditionally replace nonexisting document
     // Fail since no document exists to match with test and set


### PR DESCRIPTION
@geirst please review
@jonmv FYI

We don't support using imported fields in conditional mutations, so catch attempts at doing this during the field enumeration that is done as part of the condition evaluation. Would previously get an internal error response with an ugly stack trace since the exception would propagate up to a generic exception-to-response handler.

Will now generate an `ILLEGAL_PARAMETERS` error response with a hopefully helpful error message.
