### PR TITLE
Handle unaligned read in PutDocumentMessage::getSequenceId() and

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/messages/putdocumentmessage.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/putdocumentmessage.cpp
@@ -38,7 +38,7 @@ PutDocumentMessage::hasSequenceId() const
 uint64_t
 PutDocumentMessage::getSequenceId() const
 {
-    return *reinterpret_cast<const uint64_t*>(_document->getId().getGlobalId().get());
+    return vespalib::Unaligned<uint64_t>::at(_document->getId().getGlobalId().get()).read();
 }
 
 uint32_t

--- a/documentapi/src/vespa/documentapi/messagebus/messages/updatedocumentmessage.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/updatedocumentmessage.cpp
@@ -41,7 +41,7 @@ UpdateDocumentMessage::hasSequenceId() const
 uint64_t
 UpdateDocumentMessage::getSequenceId() const
 {
-    return *reinterpret_cast<const uint64_t*>(_documentUpdate->getId().getGlobalId().get());
+    return vespalib::Unaligned<uint64_t>::at(_documentUpdate->getId().getGlobalId().get()).read();
 }
 
 uint32_t


### PR DESCRIPTION
UpdateDocumentMessage::getSequenceId() the same way as for RemoveDocumentMessage::getSequenceId().

@vekterli : please review
