### PR TITLE
Make initialization of proton components more robust regarding resour…

### DIFF
--- a/searchcore/CMakeLists.txt
+++ b/searchcore/CMakeLists.txt
@@ -151,6 +151,7 @@ vespa_define_module(
     src/tests/proton/server/disk_mem_usage_metrics
     src/tests/proton/server/disk_mem_usage_sampler
     src/tests/proton/server/health_adapter
+    src/tests/proton/server/initialize_threads_calculator
     src/tests/proton/server/memory_flush_config_updater
     src/tests/proton/server/memoryflush
     src/tests/proton/server/shared_threading_service

--- a/searchcore/src/tests/proton/server/initialize_threads_calculator/CMakeLists.txt
+++ b/searchcore/src/tests/proton/server/initialize_threads_calculator/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchcore_initialize_threads_calculator_test_app TEST
+    SOURCES
+    initialize_threads_calculator_test.cpp
+    DEPENDS
+    searchcore_server
+    GTest::GTest
+)
+vespa_add_test(NAME searchcore_initialize_threads_calculator_test_app COMMAND searchcore_initialize_threads_calculator_test_app)

--- a/searchcore/src/tests/proton/server/initialize_threads_calculator/initialize_threads_calculator_test.cpp
+++ b/searchcore/src/tests/proton/server/initialize_threads_calculator/initialize_threads_calculator_test.cpp
@@ -1,0 +1,64 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchcore/proton/server/initialize_threads_calculator.h>
+#include <vespa/searchlib/test/directory_handler.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
+
+using namespace proton;
+using vespalib::ThreadStackExecutor;
+
+class InitializeThreadsCalculatorTest : public search::test::DirectoryHandler, public testing::Test {
+public:
+    InitializeThreadsCalculatorTest() : DirectoryHandler("tmp") {}
+};
+
+void
+expect_successful_init(uint32_t exp_threads)
+{
+    InitializeThreadsCalculator i("tmp", 9);
+    EXPECT_EQ(exp_threads, i.num_threads());
+    EXPECT_TRUE(i.threads().get() != nullptr);
+    EXPECT_EQ(exp_threads, dynamic_cast<const ThreadStackExecutor&>(*i.threads()).getNumThreads());
+    i.init_done();
+    EXPECT_TRUE(i.threads().get() == nullptr);
+}
+
+void
+expect_aborted_init(uint32_t exp_threads, uint32_t cfg_threads = 9)
+{
+    InitializeThreadsCalculator i("tmp", cfg_threads);
+    EXPECT_EQ(exp_threads, i.num_threads());
+    EXPECT_TRUE(i.threads().get() != nullptr);
+    EXPECT_EQ(exp_threads, dynamic_cast<const ThreadStackExecutor&>(*i.threads()).getNumThreads());
+}
+
+TEST_F(InitializeThreadsCalculatorTest, initialize_threads_unchanged_when_init_is_successful)
+{
+    expect_successful_init(9);
+    // The previous init was successful,
+    // so we still use the configured number of initialize threads.
+    expect_successful_init(9);
+}
+
+TEST_F(InitializeThreadsCalculatorTest, initialize_threads_cut_in_half_when_init_is_aborted)
+{
+    expect_aborted_init(9);
+    expect_aborted_init(4);
+    expect_aborted_init(2);
+    expect_aborted_init(1);
+    expect_aborted_init(1);
+}
+
+TEST_F(InitializeThreadsCalculatorTest, zero_initialize_threads_is_special)
+{
+    {
+        InitializeThreadsCalculator i("tmp", 0);
+        EXPECT_EQ(0, i.num_threads());
+        EXPECT_TRUE(i.threads().get() == nullptr);
+    }
+    expect_aborted_init(1, 0);
+    expect_aborted_init(1, 0);
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/server/CMakeLists.txt
@@ -57,6 +57,7 @@ vespa_add_library(searchcore_server STATIC
     hw_info_explorer.cpp
     idocumentdbowner.cpp
     ifeedview.cpp
+    initialize_threads_calculator.cpp
     ireplayconfig.cpp
     job_tracked_maintenance_job.cpp
     lid_space_compaction_handler.cpp

--- a/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.cpp
@@ -1,0 +1,70 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "initialize_threads_calculator.h"
+#include <vespa/vespalib/util/cpu_usage.h>
+#include <vespa/vespalib/util/size_literals.h>
+#include <vespa/vespalib/util/threadstackexecutor.h>
+#include <fstream>
+
+using vespalib::CpuUsage;
+using CpuCategory = vespalib::CpuUsage::Category;
+
+namespace {
+
+void
+write(const vespalib::string& path, uint32_t num_threads)
+{
+    std::ofstream file;
+    file.open(path);
+    file << num_threads;
+    file.close();
+}
+
+uint32_t
+read(const vespalib::string& path)
+{
+    std::ifstream file;
+    file.open(path);
+    uint32_t result;
+    file >> result;
+    file.close();
+    return result;
+}
+
+VESPA_THREAD_STACK_TAG(proton_initialize_executor)
+
+const vespalib::string file_name = "initialize-threads.txt";
+
+}
+
+namespace proton {
+
+InitializeThreadsCalculator::InitializeThreadsCalculator(const vespalib::string& base_dir,
+                                                         uint32_t configured_num_threads)
+    : _path(base_dir + "/" + file_name),
+      _num_threads(configured_num_threads),
+      _threads()
+{
+    if (std::filesystem::exists(_path)) {
+        _num_threads = read(_path.c_str());
+        _num_threads = std::max(1u, (_num_threads / 2));
+        std::filesystem::remove(_path);
+    }
+    write(_path.c_str(), _num_threads);
+    if (_num_threads > 0) {
+        _threads = std::make_shared<vespalib::ThreadStackExecutor>(_num_threads, 128_Ki,
+                                                                   CpuUsage::wrap(proton_initialize_executor, CpuCategory::SETUP));
+    }
+}
+
+InitializeThreadsCalculator::~InitializeThreadsCalculator() = default;
+
+void
+InitializeThreadsCalculator::init_done()
+{
+    std::filesystem::remove(_path);
+    _threads = InitializeThreads();
+}
+
+}
+

--- a/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.h
@@ -1,0 +1,36 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/threadexecutor.h>
+#include <filesystem>
+#include <memory>
+
+namespace proton {
+
+/**
+ * Class that is used to calculate the number of threads to use
+ * during the initialization of proton components.
+ *
+ * The number of threads is cut in half each time the initialization of proton components is aborted,
+ * e.g. due to running out of memory.
+ * This adjustment should ensure that we eventually are able to initialize and start proton.
+ */
+ class InitializeThreadsCalculator {
+ private:
+     using InitializeThreads = std::shared_ptr<vespalib::ThreadExecutor>;
+     std::filesystem::path _path;
+     uint32_t _num_threads;
+     InitializeThreads _threads;
+
+ public:
+     InitializeThreadsCalculator(const vespalib::string& base_dir,
+                                 uint32_t configured_num_threads);
+     ~InitializeThreadsCalculator();
+     uint32_t num_threads() const { return _num_threads; }
+     InitializeThreads threads() const { return _threads; }
+     void init_done();
+ };
+
+}


### PR DESCRIPTION
…ce usage.

With this change the number of initialize threads is cut in half each time the initialization of proton components is aborted, e.g. due to running out of memory. This adjustment should ensure that we eventually are able to initialize and start proton if we are very tight on resources.

@toregge please review
