### PR TITLE
Revert "Limit max inflight from outside apache client"

### DIFF
--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/StaticThrottler.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/StaticThrottler.java
@@ -21,8 +21,8 @@ public class StaticThrottler implements Throttler {
     private final AtomicLong targetX10;
 
     public StaticThrottler(FeedClientBuilderImpl builder) {
-        minInflight = min(16L, builder.maxStreamsPerConnection) * builder.connectionsPerEndpoint * builder.endpoints.size();
-        maxInflight = (long) builder.maxStreamsPerConnection * builder.connectionsPerEndpoint * builder.endpoints.size();
+        minInflight = 16L * builder.connectionsPerEndpoint * builder.endpoints.size();
+        maxInflight = 256 * minInflight; // 4096 max streams per connection on the server side.
         targetX10 = new AtomicLong(10 * maxInflight); // 10x the actual value to allow for smaller updates.
     }
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#25193

Feeding in integration tests seems to have gotten about 10 times slower with this, some integration tests fail due to this