### PR TITLE
trying to make an OnnxEvaluator with empty path would fail

### DIFF
--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluator.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluator.java
@@ -37,6 +37,9 @@ public class OnnxEvaluator {
             environment = OrtEnvironment.getEnvironment();
             session = environment.createSession(modelPath, options.getOptions());
         } catch (OrtException e) {
+            if (e.getCode() == OrtException.OrtErrorCode.ORT_NO_SUCHFILE) {
+                throw new IllegalArgumentException("No such file: "+modelPath);
+            }
             throw new RuntimeException("ONNX Runtime exception", e);
         }
     }
@@ -101,6 +104,11 @@ public class OnnxEvaluator {
         try {
             new OnnxEvaluator(modelPath);
             return true;
+        } catch (IllegalArgumentException e) {
+            if (e.getMessage().equals("No such file: ")) {
+                return true;
+            }
+            return false;
         } catch (UnsatisfiedLinkError | RuntimeException | NoClassDefFoundError e) {
             return false;
         }


### PR DESCRIPTION
currently, all the checks in unit tests with
`assumeTrue(OnnxEvaluator.isRuntimeAvailable());`
would always fail because of failure to load the "empty string".
After this change, it still fails, but adding `LD_LIBRARY_PATH=/opt/vespa-deps/lib64` makes unit tests run (and fail).