### PR TITLE
Keep the original task in a shared_ptr in the wrapping lambda and mak…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/scheduled_forward_executor.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/scheduled_forward_executor.cpp
@@ -24,8 +24,9 @@ IScheduledExecutor::Handle
 ScheduledForwardExecutor::scheduleAtFixedRate(Executor::Task::UP task,
                                               duration delay, duration interval)
 {
-    return _scheduler.scheduleAtFixedRate(makeLambdaTask([&, my_task = std::move(task)]() {
-        _executor.execute(makeLambdaTask([&]() {
+    std::shared_ptr<Executor::Task> my_task = std::move(task);
+    return _scheduler.scheduleAtFixedRate(makeLambdaTask([&, my_task = std::move(my_task)]() {
+        _executor.execute(makeLambdaTask([&, my_task]() {
             my_task->run();
         }));
     }), delay, interval);


### PR DESCRIPTION
…e a copy of it and pass to the actual task diaptch on another executor to ensure lifetime.

@geirst or @toregge PR