### PR TITLE
Revert "Use the forward scheduler in proton also for disk-mem-util-sampler""

### DIFF
--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchcore/proton/common/hw_info.h>
-#include <vespa/searchcore/proton/common/scheduledexecutor.h>
 #include <vespa/searchcore/proton/common/i_transient_resource_usage_provider.h>
 #include <vespa/searchcore/proton/server/disk_mem_usage_sampler.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
@@ -40,22 +39,19 @@ public:
 
 struct DiskMemUsageSamplerTest : public ::testing::Test {
     Transport transport;
-    ScheduledExecutor executor;
     std::unique_ptr<DiskMemUsageSampler> sampler;
     DiskMemUsageSamplerTest()
         : transport(),
-          executor(transport.transport()),
-          sampler(std::make_unique<DiskMemUsageSampler>(".", make_hw_info()))
+          sampler(std::make_unique<DiskMemUsageSampler>(transport.transport(), ".", DiskMemUsageSampler::Config(0.8, 0.8, 50ms, make_hw_info())))
     {
-        sampler->setConfig(DiskMemUsageSampler::Config(0.8, 0.8, 50ms, make_hw_info()), executor);
         sampler->add_transient_usage_provider(std::make_shared<MyProvider>(50, 200));
         sampler->add_transient_usage_provider(std::make_shared<MyProvider>(100, 150));
     }
-    ~DiskMemUsageSamplerTest();
+    ~DiskMemUsageSamplerTest() {
+        sampler.reset();
+    }
     const DiskMemUsageFilter& filter() const { return sampler->writeFilter(); }
 };
-
-DiskMemUsageSamplerTest::~DiskMemUsageSamplerTest() = default;
 
 TEST_F(DiskMemUsageSamplerTest, resource_usage_is_sampled)
 {

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -2,14 +2,17 @@
 
 #pragma once
 
+#include <vespa/vespalib/util/time.h>
 #include "disk_mem_usage_filter.h"
-#include <vespa/searchcore/proton/common/i_scheduled_executor.h>
+
+class FNET_Transport;
 
 namespace vespalib { class IDestructorCallback; }
 
 namespace proton {
 
 class ITransientResourceUsageProvider;
+class ScheduledExecutor;
 
 /*
  * Class to sample disk and memory usage used for filtering write operations.
@@ -19,6 +22,7 @@ class DiskMemUsageSampler {
     std::filesystem::path  _path;
     vespalib::duration     _sampleInterval;
     vespalib::steady_time  _lastSampleTime;
+    std::unique_ptr<ScheduledExecutor> _periodicTimer;
     std::mutex             _lock;
     std::unique_ptr<vespalib::IDestructorCallback> _periodicHandle;
     std::vector<std::shared_ptr<const ITransientResourceUsageProvider>> _transient_usage_providers;
@@ -37,7 +41,8 @@ public:
             : filterConfig(),
               sampleInterval(60s),
               hwInfo()
-        { }
+        {
+        }
 
         Config(double memoryLimit_in,
                double diskLimit_in,
@@ -46,19 +51,23 @@ public:
             : filterConfig(memoryLimit_in, diskLimit_in),
               sampleInterval(sampleInterval_in),
               hwInfo(hwInfo_in)
-        { }
+        {
+        }
     };
 
-    DiskMemUsageSampler(const std::string &path_in, const HwInfo &config);
-    ~DiskMemUsageSampler();
-    void close();
+    DiskMemUsageSampler(FNET_Transport & transport,
+                        const std::string &path_in,
+                        const Config &config);
 
-    void setConfig(const Config &config, IScheduledExecutor & executor);
+    ~DiskMemUsageSampler();
+
+    void setConfig(const Config &config);
 
     const DiskMemUsageFilter &writeFilter() const { return _filter; }
     IDiskMemUsageNotifier &notifier() { return _filter; }
     void add_transient_usage_provider(std::shared_ptr<const ITransientResourceUsageProvider> provider);
     void remove_transient_usage_provider(std::shared_ptr<const ITransientResourceUsageProvider> provider);
 };
+
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenancecontroller.h
@@ -25,7 +25,7 @@ namespace searchcorespi::index {
 namespace proton {
 
 class MaintenanceJobRunner;
-class IScheduledExecutor;
+class ScheduledExecutor;
 
 /**
  * Class that controls the bucket moving between ready and notready sub databases
@@ -81,17 +81,17 @@ private:
     using Guard = std::lock_guard<Mutex>;
     using TaskHandle = std::unique_ptr<vespalib::IDestructorCallback>;
 
-    ISyncableThreadService              &_masterThread;
-    vespalib::MonitoredRefCount         &_refCount;
-    MaintenanceDocumentSubDB             _readySubDB;
-    MaintenanceDocumentSubDB             _remSubDB;
-    MaintenanceDocumentSubDB             _notReadySubDB;
-    std::unique_ptr<IScheduledExecutor>  _periodicTimer;
-    std::vector<TaskHandle>              _periodicTaskHandles;
-    State                                _state;
-    const DocTypeName                   &_docTypeName;
-    JobList                              _jobs;
-    mutable Mutex                        _jobsLock;
+    ISyncableThreadService           &_masterThread;
+    vespalib::MonitoredRefCount      &_refCount;
+    MaintenanceDocumentSubDB          _readySubDB;
+    MaintenanceDocumentSubDB          _remSubDB;
+    MaintenanceDocumentSubDB          _notReadySubDB;
+    std::unique_ptr<ScheduledExecutor>  _periodicTimer;
+    std::vector<TaskHandle>           _periodicTaskHandles;
+    State                             _state;
+    const DocTypeName                &_docTypeName;
+    JobList                           _jobs;
+    mutable Mutex                     _jobsLock;
 
     void addJobsToPeriodicTimer();
     void restart();


### PR DESCRIPTION
Reverts vespa-engine/vespa#25229

Unit test that seems to be related failing when building:

12:19:30 The following tests FAILED:
12:19:30 	361 - searchcore_disk_mem_usage_sampler_test_app (Failed)
12:19:30 Errors while running CTest
12:19:30 make[1]: *** [Makefile:112: test] Error 8
12:19:30 make[1]: Leaving directory '/sd/workspace/src/git.ouryahoo.com/vespa/vespa'