### PR TITLE
Avoid flushing components in proton more than necessary.

### DIFF
--- a/searchcore/src/tests/proton/flushengine/prepare_restart_flush_strategy/prepare_restart_flush_strategy_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/prepare_restart_flush_strategy/prepare_restart_flush_strategy_test.cpp
@@ -1,9 +1,10 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include <vespa/vespalib/testkit/testapp.h>
 
-#include <vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h>
-#include <vespa/searchcore/proton/flushengine/flush_target_candidates.h>
+#include <vespa/searchcore/proton/flushengine/active_flush_stats.h>
 #include <vespa/searchcore/proton/flushengine/flush_target_candidate.h>
+#include <vespa/searchcore/proton/flushengine/flush_target_candidates.h>
+#include <vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h>
 #include <vespa/searchcore/proton/flushengine/tls_stats_map.h>
 #include <vespa/searchcore/proton/test/dummy_flush_handler.h>
 #include <vespa/searchcore/proton/test/dummy_flush_target.h>
@@ -220,7 +221,8 @@ struct FlushStrategyFixture
     {}
     FlushContext::List getFlushTargets(const FlushContext::List &targetList,
                                        const flushengine::TlsStatsMap &tlsStatsMap) const {
-        return strategy.getFlushTargets(targetList, tlsStatsMap);
+        flushengine::ActiveFlushStats active_flushes;
+        return strategy.getFlushTargets(targetList, tlsStatsMap, active_flushes);
     }
 };
 

--- a/searchcore/src/tests/proton/server/memoryflush/memoryflush_test.cpp
+++ b/searchcore/src/tests/proton/server/memoryflush/memoryflush_test.cpp
@@ -1,5 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/searchcore/proton/flushengine/active_flush_stats.h>
 #include <vespa/searchcore/proton/flushengine/flushcontext.h>
 #include <vespa/searchcore/proton/flushengine/tls_stats_map.h>
 #include <vespa/searchcore/proton/server/memoryflush.h>
@@ -52,19 +53,15 @@ public:
     bool needUrgentFlush() const override { return _urgentFlush; }
 };
 
-struct StringList : public std::vector<vespalib::string> {
-    StringList() : std::vector<vespalib::string>() {}
-    StringList &add(const vespalib::string &str) {
-        push_back(str);
-        return *this;
-    }
-};
+using StringList = std::vector<vespalib::string>;
 
 class ContextBuilder {
 private:
     FlushContext::List _list;
     IFlushHandler::SP  _handler;
     flushengine::TlsStatsMap::Map _map;
+    flushengine::ActiveFlushStats _active_flushes;
+
     void
     fixupMap(const vespalib::string &name, SerialNum lastSerial)
     {
@@ -92,10 +89,17 @@ public:
         FlushContext::SP ctx(new FlushContext(_handler, target, lastSerial));
         return add(ctx);
     }
+    ContextBuilder& active_flush(const vespalib::string& handler_name, vespalib::system_time start_time) {
+        _active_flushes.set_start_time(handler_name, start_time);
+        return *this;
+    }
     const FlushContext::List &list() const { return _list; }
     flushengine::TlsStatsMap tlsStats() const {
         flushengine::TlsStatsMap::Map map(_map);
         return flushengine::TlsStatsMap(std::move(map));
+    }
+    FlushContext::List flush_targets(const IFlushStrategy& strategy) const {
+        return strategy.getFlushTargets(list(), tlsStats(), _active_flushes);
     }
 };
 
@@ -103,14 +107,14 @@ using minutes = std::chrono::minutes;
 using seconds = std::chrono::seconds;
 
 ContextBuilder::ContextBuilder()
-    : _list(), _handler(new MyFlushHandler("myhandler"))
+    : _list(), _handler(new MyFlushHandler("myhandler")), _map(), _active_flushes()
 {}
 ContextBuilder::~ContextBuilder() = default;
 
 MyFlushTarget::SP
 createTargetM(const vespalib::string &name, MemoryGain memoryGain)
 {
-    return std::make_shared<MyFlushTarget>(name, memoryGain, DiskGain(),SerialNum(), system_time(), false);
+    return std::make_shared<MyFlushTarget>(name, memoryGain, DiskGain(), SerialNum(), system_time(), false);
 }
 
 MyFlushTarget::SP
@@ -155,13 +159,11 @@ TEST(MemoryFlushTest, can_order_by_memory_gain)
       .add(createTargetM("t3", MemoryGain(15, 0)));
     { // target t4 has memoryGain >= maxMemoryGain
         MemoryFlush flush({1000, 20_Gi, 1.0, 20, 1.0, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
     { // trigger totalMemoryGain >= globalMaxMemory
         MemoryFlush flush({50, 20_Gi, 1.0, 1000, 1.0, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
 }
 
@@ -178,14 +180,12 @@ TEST(MemoryFlushTest, can_order_by_disk_gain_with_large_values)
     { // target t4 has diskGain > bloatValue
         // t4 gain: 55M / 100M = 0.55 -> bloat factor 0.54 to trigger
         MemoryFlush flush({1000, 20_Gi, 10.0, 1000, 0.54, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
     { // trigger totalDiskGain > totalBloatValue
         // total gain: 160M / 4 * 100M = 0.4 -> bloat factor 0.39 to trigger
         MemoryFlush flush({1000, 20_Gi, 0.39, 1000, 10.0, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
 }
 
@@ -201,14 +201,12 @@ TEST(MemoryFlushTest, can_order_by_disk_gain_with_small_values)
     { // target t4 has diskGain > bloatValue
         // t4 gain: 55 / 100M = 0.0000055 -> bloat factor 0.0000054 to trigger
         MemoryFlush flush({1000, 20_Gi, 10.0, 1000, 0.00000054, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
     { // trigger totalDiskGain > totalBloatValue
         // total gain: 160 / 100M = 0.0000016 -> bloat factor 0.0000015 to trigger
         MemoryFlush flush({1000, 20_Gi, 0.0000015, 1000, 10.0, minutes(1)});
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
 }
 
@@ -224,12 +222,11 @@ TEST(MemoryFlushTest, can_order_by_age)
 
     { // all targets have timeDiff >= maxTimeGain
         MemoryFlush flush({1000, 20_Gi, 1.0, 1000, 1.0, seconds(2)}, start);
-        assertOrder(StringList().add("t4").add("t3").add("t2").add("t1"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t3", "t2", "t1"}, cb.flush_targets(flush));
     }
     { // no targets have timeDiff >= maxTimeGain
         MemoryFlush flush({1000, 20_Gi, 1.0, 1000, 1.0, seconds(30)}, start);
-        assertOrder(StringList(), flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({}, cb.flush_targets(flush));
     }
 }
 
@@ -238,8 +235,8 @@ TEST(MemoryFlushTest, can_order_by_tls_size)
     system_time now(vespalib::system_clock::now());
     system_time start = now - seconds(20);
     ContextBuilder cb;
-    IFlushHandler::SP handler1(std::make_shared<MyFlushHandler>("handler1"));
-    IFlushHandler::SP handler2(std::make_shared<MyFlushHandler>("handler2"));
+    auto handler1 = std::make_shared<MyFlushHandler>("handler1");
+    auto handler2 = std::make_shared<MyFlushHandler>("handler2");
     cb.addTls("handler1", {20_Gi, 1001, 2000 });
     cb.addTls("handler2", { 5_Gi, 1001, 2000 });
     cb.add(std::make_shared<FlushContext>(handler1, createTargetT("t2", now - seconds(10), 1900), 2000)).
@@ -248,27 +245,52 @@ TEST(MemoryFlushTest, can_order_by_tls_size)
         add(std::make_shared<FlushContext>(handler2, createTargetT("t3", now - seconds(15), 1900), 2000));
     { // sum of tls sizes above limit, trigger sort order based on tls size
         MemoryFlush flush({1000, 3_Gi, 1.0, 1000, 1.0, seconds(2)}, start);
-        assertOrder(StringList().add("t4").add("t1").add("t2").add("t3"),
-                    flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t4", "t1", "t2", "t3"}, cb.flush_targets(flush));
     }
     { // sum of tls sizes below limit
         MemoryFlush flush({1000, 30_Gi, 1.0, 1000, 1.0, seconds(30)}, start);
-        assertOrder(StringList(), flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({}, cb.flush_targets(flush));
     }
+}
+
+TEST(MemoryFlushTest, order_by_tls_size_not_always_selected_when_active_flushes)
+{
+    system_time now = vespalib::system_clock::now();
+    system_time start = now - seconds(20);
+    ContextBuilder cb;
+    auto h1 = std::make_shared<MyFlushHandler>("h1");
+    constexpr uint64_t first_serial = 1001;
+    constexpr uint64_t last_serial = 2000;
+    cb.addTls("h1", {5_Gi, first_serial, last_serial});
+    cb.add(std::make_shared<FlushContext>(h1, createTargetT("t1", now - seconds(10), 1300), last_serial)).
+       add(std::make_shared<FlushContext>(h1, createTargetT("t2", now - seconds(5), 1500), last_serial));
+    MemoryFlush flush({1000, 4_Gi, 1.0, 1000, 1.0, seconds(60)}, start);
+
+    // Last flush time of both t1 and t2 are older than start of active flush -> triggers TLSSIZE.
+    cb.active_flush("h1", now - seconds(4));
+    assertOrder({"t1", "t2"}, cb.flush_targets(flush));
+
+    // Last flush time of only t1 is older than start of active flush -> triggers TLSSIZE.
+    cb.active_flush("h1", now - seconds(9));
+    assertOrder({"t1", "t2"}, cb.flush_targets(flush));
+
+    // Last flush time both t1 and t2 is newer than start of active flush -> don't use TLSSIZE.
+    cb.active_flush("h1", now - seconds(11));
+    assertOrder({}, cb.flush_targets(flush));
 }
 
 TEST(MemoryFlushTest, can_handle_large_serial_numbers_when_ordering_by_tls_size)
 {
     uint64_t uint32_max = std::numeric_limits<uint32_t>::max();
-    ContextBuilder builder;
+    ContextBuilder cb;
     SerialNum firstSerial = 10;
     SerialNum lastSerial = uint32_max + 10;
-    builder.addTls("myhandler", {uint32_max, firstSerial, lastSerial});
-    builder.add(createTargetT("t1", system_time(), uint32_max + 5), lastSerial);
-    builder.add(createTargetT("t2", system_time(), uint32_max - 5), lastSerial);
+    cb.addTls("myhandler", {uint32_max, firstSerial, lastSerial});
+    cb.add(createTargetT("t1", system_time(), uint32_max + 5), lastSerial);
+    cb.add(createTargetT("t2", system_time(), uint32_max - 5), lastSerial);
     uint64_t maxMemoryGain = 10;
     MemoryFlush flush({maxMemoryGain, 1000, 0, maxMemoryGain, 0, vespalib::duration(0)}, system_time());
-    assertOrder(StringList().add("t2").add("t1"), flush.getFlushTargets(builder.list(), builder.tlsStats()));
+    assertOrder({"t2", "t1"}, cb.flush_targets(flush));
 }
 
 TEST(MemoryFlushTest, order_type_is_preserved)
@@ -281,21 +303,21 @@ TEST(MemoryFlushTest, order_type_is_preserved)
         cb.add(createTargetT("t2", ts2, 5), 14)
           .add(createTargetD("t1", DiskGain(100 * milli, 80 * milli), 5));
         MemoryFlush flush({1000, 20_Gi, 1.0, 1000, 0.19, seconds(30)});
-        assertOrder(StringList().add("t1").add("t2"), flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t1", "t2"}, cb.flush_targets(flush));
     }
     { // DISKBLOAT VS MEMORY
         ContextBuilder cb;
         cb.add(createTargetD("t2", DiskGain(100 * milli, 80 * milli)))
           .add(createTargetM("t1", MemoryGain(100, 80)));
         MemoryFlush flush({1000, 20_Gi, 1.0, 20, 0.19, seconds(30)});
-        assertOrder(StringList().add("t1").add("t2"), flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t1", "t2"}, cb.flush_targets(flush));
     }
     { // urgent flush
         ContextBuilder cb;
         cb.add(createTargetF("t2", false))
           .add(createTargetF("t1", true));
         MemoryFlush flush({1000, 20_Gi, 1.0, 1000, 1.0, seconds(30)});
-        assertOrder(StringList().add("t1").add("t2"), flush.getFlushTargets(cb.list(), cb.tlsStats()));
+        assertOrder({"t1", "t2"}, cb.flush_targets(flush));
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(searchcore_flushengine STATIC
     SOURCES
+    active_flush_stats.cpp
     cachedflushtarget.cpp
     shrink_lid_space_flush_target.cpp
     flush_all_strategy.cpp

--- a/searchcore/src/vespa/searchcore/proton/flushengine/active_flush_stats.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/active_flush_stats.cpp
@@ -1,0 +1,40 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "active_flush_stats.h"
+#include <vespa/vespalib/stllike/hash_map.hpp>
+#include <vespa/vespalib/util/time.h>
+
+namespace proton::flushengine {
+
+ActiveFlushStats::ActiveFlushStats()
+    : _stats()
+{
+}
+
+void
+ActiveFlushStats::set_start_time(const vespalib::string& handler_name, vespalib::system_time start_time)
+{
+    auto itr = _stats.find(handler_name);
+    if (itr != _stats.end()) {
+        if (start_time < itr->second) {
+            itr->second = start_time;
+        }
+    } else {
+        _stats.insert(std::make_pair(handler_name, start_time));
+    }
+}
+
+ActiveFlushStats::OptionalTime
+ActiveFlushStats::oldest_start_time(const vespalib::string& handler_name) const
+{
+    auto itr = _stats.find(handler_name);
+    if (itr != _stats.end()) {
+        return OptionalTime(itr->second);
+    }
+    return std::nullopt;
+}
+
+}
+
+VESPALIB_HASH_MAP_INSTANTIATE(vespalib::string, vespalib::system_time);
+

--- a/searchcore/src/vespa/searchcore/proton/flushengine/active_flush_stats.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/active_flush_stats.h
@@ -1,0 +1,32 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/hash_map.h>
+#include <vespa/vespalib/util/time.h>
+#include <optional>
+
+namespace proton::flushengine {
+
+/**
+ * Tracks the oldest start time of active (ongoing) flushes in each flush handler.
+ */
+class ActiveFlushStats {
+public:
+    using OptionalTime = std::optional<vespalib::system_time>;
+
+private:
+    using StatsMap = vespalib::hash_map<vespalib::string, vespalib::system_time>;
+    StatsMap _stats;
+
+public:
+    ActiveFlushStats();
+    /**
+     * Set the start time for a flush in the given flush handler.
+     * A start time is only updated if it is older than the current oldest one.
+     */
+    void set_start_time(const vespalib::string& handler_name, vespalib::system_time start_time);
+    OptionalTime oldest_start_time(const vespalib::string& handler_name) const;
+};
+
+}
+

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_all_strategy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_all_strategy.cpp
@@ -36,10 +36,11 @@ FlushAllStrategy::FlushAllStrategy()
 
 FlushContext::List
 FlushAllStrategy::getFlushTargets(const FlushContext::List &targetList,
-                                  const flushengine::TlsStatsMap &) const
+                                  const flushengine::TlsStatsMap&,
+                                  const flushengine::ActiveFlushStats&) const
 {
     if (targetList.empty()) {
-        return FlushContext::List();
+        return {};
     }
     FlushContext::List fv(targetList);
     std::sort(fv.begin(), fv.end(), CompareTarget());

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flush_all_strategy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flush_all_strategy.h
@@ -16,7 +16,8 @@ public:
 
     FlushContext::List
     getFlushTargets(const FlushContext::List &targetList,
-                    const flushengine::TlsStatsMap &) const override;
+                    const flushengine::TlsStatsMap&,
+                    const flushengine::ActiveFlushStats&) const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.cpp
@@ -20,7 +20,13 @@ FlushContext::FlushContext(
 
 vespalib::string
 FlushContext::createName(const IFlushHandler & handler, const IFlushTarget & target) {
-    return (handler.getName() + "." + target.getName());
+    return create_name(handler.getName(), target.getName());
+}
+
+vespalib::string
+FlushContext::create_name(const vespalib::string& handler_name,
+                          const vespalib::string& target_name) {
+    return (handler_name + "." + target_name);
 }
 
 FlushContext::~FlushContext()

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushcontext.h
@@ -35,6 +35,12 @@ public:
     static vespalib::string createName(const IFlushHandler & handler, const IFlushTarget & target);
 
     /**
+     * Create a combined name of the handler name and the target name.
+     */
+    static vespalib::string create_name(const vespalib::string& handler_name,
+                                        const vespalib::string& target_name);
+
+    /**
      * Constructs a new instance of this class.
      *
      * @param handler The flush handler that contains the given target.

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -23,31 +23,33 @@ class FlushEngine final : public FastOS_Runnable
 public:
     class FlushMeta {
     public:
-        FlushMeta(const vespalib::string & name, uint32_t id);
+        FlushMeta(const vespalib::string& handler_name, const vespalib::string& target_name, uint32_t id);
         ~FlushMeta();
         const vespalib::string & getName() const { return _name; }
+        const vespalib::string& handler_name() const { return _handler_name; }
         vespalib::system_time getStart() const { return vespalib::system_clock::now() - std::chrono::duration_cast<vespalib::system_time::duration>(elapsed()); }
         vespalib::duration elapsed() const { return _timer.elapsed(); }
         uint32_t getId() const { return _id; }
         bool operator < (const FlushMeta & rhs) const { return _id < rhs._id; }
     private:
         vespalib::string  _name;
+        vespalib::string  _handler_name;
         vespalib::Timer   _timer;
         uint32_t          _id;
     };
-    typedef std::set<FlushMeta> FlushMetaSet;
+    using FlushMetaSet = std::set<FlushMeta>;
 private:
     using IFlushTarget = searchcorespi::IFlushTarget;
     struct FlushInfo : public FlushMeta
     {
         FlushInfo();
-        FlushInfo(uint32_t taskId, const IFlushTarget::SP &target, const vespalib::string &destination);
+        FlushInfo(uint32_t taskId, const vespalib::string& handler_name, const IFlushTarget::SP &target);
         ~FlushInfo();
 
         IFlushTarget::SP  _target;
     };
-    typedef std::map<uint32_t, FlushInfo> FlushMap;
-    typedef HandlerMap<IFlushHandler> FlushHandlerMap;
+    using FlushMap = std::map<uint32_t, FlushInfo>;
+    using FlushHandlerMap = HandlerMap<IFlushHandler>;
     bool                           _closed;
     const uint32_t                 _maxConcurrent;
     const vespalib::duration       _idleInterval;
@@ -89,8 +91,8 @@ public:
     /**
      * Convenience typedefs.
      */
-    typedef std::unique_ptr<FlushEngine> UP;
-    typedef std::shared_ptr<FlushEngine> SP;
+    using UP = std::unique_ptr<FlushEngine>;
+    using SP = std::shared_ptr<FlushEngine>;
 
     /**
      * Constructs a new instance of this class.

--- a/searchcore/src/vespa/searchcore/proton/flushengine/iflushstrategy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/iflushstrategy.h
@@ -6,7 +6,10 @@
 
 namespace proton {
 
-namespace flushengine { class TlsStatsMap; }
+namespace flushengine {
+class ActiveFlushStats;
+class TlsStatsMap;
+}
 
 /**
  * This class represents a strategy used by the FlushEngine to make decisions on
@@ -25,11 +28,13 @@ public:
      * Takes an input of targets that are candidates for flush and returns
      * a list of targets sorted according to priority strategy.
      * @param targetList The list of possible flush targets.
-     * @param lastSerial is the last serialnumber known by flushengine.
+     * @param tlsStatsMap Statistics per domain in the TLS. A domain matches a flush handler.
+     * @parma active_flushes Statistics of active (ongoing) flushes per flush handler.
      * @return A prioritized list of targets to flush.
      */
-    virtual FlushContext::List getFlushTargets(const FlushContext::List & targetList,
-                                               const flushengine::TlsStatsMap & tlsStatsMap) const = 0;
+    virtual FlushContext::List getFlushTargets(const FlushContext::List& targetList,
+                                               const flushengine::TlsStatsMap& tlsStatsMap,
+                                               const flushengine::ActiveFlushStats& active_flushes) const = 0;
 protected:
     IFlushStrategy() = default;
 };

--- a/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.cpp
@@ -153,7 +153,8 @@ findBestTargetsToFlushPerHandler(const FlushContextsMap &flushContextsPerHandler
 
 FlushContext::List
 PrepareRestartFlushStrategy::getFlushTargets(const FlushContext::List &targetList,
-                                             const flushengine::TlsStatsMap &tlsStatsMap) const
+                                             const flushengine::TlsStatsMap &tlsStatsMap,
+                                             const flushengine::ActiveFlushStats&) const
 {
     return flatten(findBestTargetsToFlushPerHandler(
             groupByFlushHandler(removeGCFlushTargets(targetList)),

--- a/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/prepare_restart_flush_strategy.h
@@ -36,8 +36,8 @@ public:
     PrepareRestartFlushStrategy(const Config &cfg);
 
     virtual FlushContext::List getFlushTargets(const FlushContext::List &targetList,
-                                               const flushengine::TlsStatsMap &
-                                               tlsStatsMap) const override;
+                                               const flushengine::TlsStatsMap &tlsStatsMap,
+                                               const flushengine::ActiveFlushStats&) const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/memoryflush.h
+++ b/searchcore/src/vespa/searchcore/proton/server/memoryflush.h
@@ -80,7 +80,8 @@ public:
 
     FlushContext::List
     getFlushTargets(const FlushContext::List &targetList,
-                    const flushengine::TlsStatsMap &tlsStatsMap) const override;
+                    const flushengine::TlsStatsMap &tlsStatsMap,
+                    const flushengine::ActiveFlushStats& active_flushes) const override;
 
     void setConfig(const Config &config);
     Config getConfig() const;

--- a/searchcore/src/vespa/searchcore/proton/server/simpleflush.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/simpleflush.cpp
@@ -13,10 +13,10 @@ SimpleFlush::SimpleFlush()
 }
 
 FlushContext::List
-SimpleFlush::getFlushTargets(const FlushContext::List &targetList,
-                             const flushengine::TlsStatsMap &tlsStatsMap) const
+SimpleFlush::getFlushTargets(const FlushContext::List& targetList,
+                             const flushengine::TlsStatsMap&,
+                             const flushengine::ActiveFlushStats&) const
 {
-    (void) tlsStatsMap;
     FlushContext::List fv(targetList);
     std::sort(fv.begin(), fv.end(), CompareTarget());
     return fv;

--- a/searchcore/src/vespa/searchcore/proton/server/simpleflush.h
+++ b/searchcore/src/vespa/searchcore/proton/server/simpleflush.h
@@ -21,8 +21,9 @@ public:
     SimpleFlush();
 
     // Implements IFlushStrategy
-    virtual FlushContext::List getFlushTargets(const FlushContext::List &targetList,
-                                               const flushengine::TlsStatsMap &tlsStatsMap) const override;
+    virtual FlushContext::List getFlushTargets(const FlushContext::List& targetList,
+                                               const flushengine::TlsStatsMap&,
+                                               const flushengine::ActiveFlushStats&) const override;
 
 };
 


### PR DESCRIPTION
Don't consider TLSSIZE ordering if there exists an active (ongoing) flush (for the same flush handler) that started before the last flush time of the flush target to evaluate. Instead we should wait for the active (ongoing) flush to be finished before doing another evaluation.

@baldersheim please review
@toregge FYI