### PR TITLE
Revert "Delete file reference for application immediately after being…

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -875,12 +875,7 @@ public class SessionRepository {
         }
         ApplicationId applicationId = sessionZKClient.readApplicationId();
         log.log(Level.FINE, () -> "Creating local session for tenant '" + tenantName + "' with session id " + sessionId);
-        try {
-            createLocalSession(sessionDir, applicationId, sessionZKClient.readTags(), sessionId);
-        } finally {
-            log.log(Level.FINE, "Deleting file distribution reference " + fileReference + " for app package with session id " + sessionId);
-            fileDirectory.delete(fileReference, (reference) -> true); // Delete downloaded file reference, not needed anymore
-        }
+        createLocalSession(sessionDir, applicationId, sessionZKClient.readTags(), sessionId);
     }
 
     private Optional<Long> getActiveSessionId(ApplicationId applicationId) {


### PR DESCRIPTION
… copied"

The file reference will be downloaded anyway afterwards, since it is one of the file references in use by the active deployment. There is a maintainer that deletes unused file references after a while.