### PR TITLE
Revert "add more relevant information when messagebus fails to start"

### DIFF
--- a/jrt/pom.xml
+++ b/jrt/pom.xml
@@ -67,10 +67,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <forkCount>4</forkCount>
-          <redirectTestOutputToFile>false</redirectTestOutputToFile>
-          <systemPropertyVariables>
-            <java.util.logging.SimpleFormatter.format>%1$Ts.%1$TL [%4$s] %5$s {%3$s}%n</java.util.logging.SimpleFormatter.format>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/jrt/tests/com/yahoo/jrt/SlobrokTest.java
+++ b/jrt/tests/com/yahoo/jrt/SlobrokTest.java
@@ -111,7 +111,6 @@ public class SlobrokTest {
         assertTrue(mirror.updates() > 0);
 
         List<Entry> oneArr = mirror.lookup("*/*/*");
-        mirror.dumpState();
         assertTrue(oneArr.size() == 1);
         Mirror.Entry one = oneArr.get(0);
         assertTrue(one.equals(new Mirror.Entry(wantName, mySpec)));

--- a/messagebus/src/main/java/com/yahoo/messagebus/MessageBus.java
+++ b/messagebus/src/main/java/com/yahoo/messagebus/MessageBus.java
@@ -151,24 +151,18 @@ public class MessageBus implements ConfigHandler, NetworkOwner, MessageHandler, 
         this.net = net;
         net.attach(this);
         if ( ! net.net().waitUntilReady(180)) {
-            var failure = new IllegalStateException("Network failed to become ready in time.");
             try {
                 var tmp = net.net().getMirror();
                 var mirror = (com.yahoo.jrt.slobrok.api.Mirror) tmp;
-                mirror.dumpState();
-                if (mirror.ready()) {
-                    log.warning("location broker mirror is ready, but network is not");
-                } else if (mirror.getIterations() < 2) {
+                if (mirror.getIterations() < 2) {
                     Process.dumpThreads();
                     String fn = "var/crash/java_pid." + ProcessHandle.current().pid() + ".hprof";
                     Process.dumpHeap(Defaults.getDefaults().underVespaHome(fn), true);
-                } else {
-                    failure = new IllegalStateException("No answer from any service location broker, failing startup");
                 }
             } catch (Exception e) {
                 // ignore
             }
-            throw failure;
+            throw new IllegalStateException("Network failed to become ready in time.");
         }
 
         // Start messenger.


### PR DESCRIPTION
Reverts vespa-engine/vespa#25315
@arnej27959 PR

Started getting ConcurrentModificationException
```
[17:35:03.845] requireThatSyncSessionWorks(test.SyncSessionTest)  Time elapsed: 1.918 sec  <<< ERROR!
[17:35:03.845] com.yahoo.documentapi.DocumentAccessException: java.util.ConcurrentModificationException
[17:35:03.845] 	at com.yahoo.documentapi.messagebus.MessageBusDocumentAccess.<init>(MessageBusDocumentAccess.java:77)
[17:35:03.845] 	at com.yahoo.documentapi.messagebus.MessageBusDocumentAccess.<init>(MessageBusDocumentAccess.java:48)
[17:35:03.845] 	at com.yahoo.documentapi.DocumentAccess.createForNonContainer(DocumentAccess.java:64)
[17:35:03.845] 	at test.SyncSessionTest.<init>(SyncSessionTest.java:30)
[17:35:03.845] 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
[17:35:03.845] 	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
[17:35:03.845] 	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
[17:35:03.845] 	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
[17:35:03.845] 	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:250)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:260)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner$2.runReflectiveCall(BlockJUnit4ClassRunner.java:309)
[17:35:03.845] 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:306)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
[17:35:03.845] 	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
[17:35:03.845] 	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
[17:35:03.845] 	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
[17:35:03.845] 	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
[17:35:03.845] 	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
[17:35:03.845] 	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
[17:35:03.845] 	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
[17:35:03.845] 	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
[17:35:03.845] 	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
[17:35:03.845] 	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
[17:35:03.845] 	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
[17:35:03.845] 	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
[17:35:03.845] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[17:35:03.845] 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
[17:35:03.845] 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:35:03.845] 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
[17:35:03.845] 	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
[17:35:03.845] 	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
[17:35:03.845] 	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
[17:35:03.845] 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
[17:35:03.845] 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
[17:35:03.845] Caused by: java.util.ConcurrentModificationException
[17:35:03.845] 	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
[17:35:03.845] 	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
[17:35:03.845] 	at com.yahoo.jrt.slobrok.api.Mirror$EventLog.dump(Mirror.java:391)
[17:35:03.845] 	at com.yahoo.jrt.slobrok.api.Mirror.dumpState(Mirror.java:353)
[17:35:03.845] 	at com.yahoo.messagebus.network.rpc.RPCNetwork.waitUntilReady(RPCNetwork.java:162)
[17:35:03.845] 	at com.yahoo.messagebus.MessageBus.<init>(MessageBus.java:153)
[17:35:03.845] 	at com.yahoo.messagebus.MessageBus.<init>(MessageBus.java:131)
[17:35:03.845] 	at com.yahoo.messagebus.RPCMessageBus.<init>(RPCMessageBus.java:48)
[17:35:03.845] 	at com.yahoo.messagebus.RPCMessageBus.<init>(RPCMessageBus.java:44)
[17:35:03.845] 	at com.yahoo.documentapi.messagebus.MessageBusDocumentAccess.<init>(MessageBusDocumentAccess.java:72)
[17:35:03.845] 	... 36 more
```