### PR TITLE
Revert "Noop update default of reboot-interval-in-days to 15"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -70,7 +70,7 @@ public class PermanentFlags {
             "Takes effect on next iteration of HostCapacityMaintainer.");
 
     public static final UnboundIntFlag REBOOT_INTERVAL_IN_DAYS = defineIntFlag(
-            "reboot-interval-in-days", 15,
+            "reboot-interval-in-days", 30,
             "No reboots are scheduled 0x-1x reboot intervals after the previous reboot, while reboot is " +
                     "scheduled evenly distributed in the 1x-2x range (and naturally guaranteed at the 2x boundary).",
             "Takes effect on next run of NodeRebooter");


### PR DESCRIPTION
Reverts vespa-engine/vespa#16016

We are now running `podman version 4.2.0` that have the fix for the issue that made us reduce the default reboot interval