### PR TITLE
Remove unused variable in metrics manager test.

### DIFF
--- a/metrics/src/tests/metricmanagertest.cpp
+++ b/metrics/src/tests/metricmanagertest.cpp
@@ -742,8 +742,6 @@ namespace {
 
 struct MetricSnapshotTestFixture
 {
-    static const size_t DEFAULT_THREAD_STACK_SIZE = 256_Ki;
-
     MetricManagerTest& test;
     FastOS_ThreadPool pool;
     FakeTimer* timer;


### PR DESCRIPTION
@baldersheim : please review
