### PR TITLE
Add a metric query_timeout with same naming, unit as query_latency.

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -327,6 +327,11 @@ public class VespaMetricSet {
         metrics.add(new Metric("query_latency.count"));
         metrics.add(new Metric("query_latency.95percentile"));
         metrics.add(new Metric("query_latency.99percentile"));
+        metrics.add(new Metric("query_timeout.max"));
+        metrics.add(new Metric("query_timeout.sum"));
+        metrics.add(new Metric("query_timeout.count"));
+        metrics.add(new Metric("query_timeout.95percentile"));
+        metrics.add(new Metric("query_timeout.99percentile"));
         metrics.add(new Metric("failed_queries.rate"));
         metrics.add(new Metric("degraded_queries.rate"));
         metrics.add(new Metric("hits_per_query.max"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -327,6 +327,7 @@ public class VespaMetricSet {
         metrics.add(new Metric("query_latency.count"));
         metrics.add(new Metric("query_latency.95percentile"));
         metrics.add(new Metric("query_latency.99percentile"));
+        metrics.add(new Metric("query_timeout.min"));
         metrics.add(new Metric("query_timeout.max"));
         metrics.add(new Metric("query_timeout.sum"));
         metrics.add(new Metric("query_timeout.count"));

--- a/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/statistics/StatisticsSearcher.java
@@ -63,6 +63,7 @@ public class StatisticsSearcher extends Searcher {
     private static final String FAILED_QUERIES_METRIC = "failed_queries";
     private static final String MEAN_QUERY_LATENCY_METRIC = "mean_query_latency";
     private static final String QUERY_LATENCY_METRIC = "query_latency";
+    private static final String QUERY_TIMEOUT_METRIC = "query_timeout";
     private static final String QUERY_HIT_OFFSET_METRIC = "query_hit_offset";
     private static final String QUERIES_METRIC = "queries";
     private static final String PEAK_QPS_METRIC = "peak_qps";
@@ -125,6 +126,7 @@ public class StatisticsSearcher extends Searcher {
         this.peakQpsReporter = new PeakQpsReporter();
         this.metric = metric;
 
+        metricReceiver.declareGauge(QUERY_TIMEOUT_METRIC, Optional.empty(), new MetricSettings.Builder().histogram(true).build());
         metricReceiver.declareGauge(QUERY_LATENCY_METRIC, Optional.empty(), new MetricSettings.Builder().histogram(true).build());
         metricReceiver.declareGauge(HITS_PER_QUERY_METRIC, Optional.empty(), new MetricSettings.Builder().histogram(true).build());
         metricReceiver.declareGauge(TOTALHITS_PER_QUERY_METRIC, Optional.empty(), new MetricSettings.Builder().histogram(true).build());
@@ -223,6 +225,7 @@ public class StatisticsSearcher extends Searcher {
         logQuery(query);
         long start_ns = getStartNanoTime(query);
         qps(metricContext);
+        metric.set(QUERY_TIMEOUT_METRIC, query.getTimeout(), metricContext);
         Result result;
         //handle exceptions thrown below in searchers
         try {


### PR DESCRIPTION
This tracks the timeout given to the query.

@bjorncs PR
@yngveaasheim FYI