### PR TITLE
Enable having lock free atomic<CompresssionConfig> and make its use i…

### DIFF
--- a/searchlib/src/tests/docstore/document_store/document_store_test.cpp
+++ b/searchlib/src/tests/docstore/document_store/document_store_test.cpp
@@ -91,7 +91,7 @@ vespalib::stringref S1("this is a string long enough to be compressed and is jus
                        "Adding some repeatble sequences like aaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbb to ensure compression"
                        "xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz");
 
-Value createValue(vespalib::stringref s, const CompressionConfig & cfg) {
+Value createValue(vespalib::stringref s, CompressionConfig cfg) {
     Value v(7);
     vespalib::DataBuffer input;
     input.writeBytes(s.data(), s.size());

--- a/searchlib/src/vespa/searchlib/docstore/chunk.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.cpp
@@ -58,12 +58,12 @@ Chunk::hasRoom(size_t len) const
 }
 
 size_t
-Chunk::getMaxPackSize(const CompressionConfig & compression) const {
+Chunk::getMaxPackSize(CompressionConfig compression) const {
     return _format->getMaxPackSize(compression);
 }
 
 void
-Chunk::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, const CompressionConfig & compression)
+Chunk::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, CompressionConfig compression)
 {
     _lastSerial = lastSerial;
     std::lock_guard guard(_lock);

--- a/searchlib/src/vespa/searchlib/docstore/chunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/chunk.h
@@ -97,8 +97,8 @@ public:
     size_t size() const;
     const LidList & getLids() const { return _lids; }
     LidList getUniqueLids() const;
-    size_t getMaxPackSize(const CompressionConfig & compression) const;
-    void pack(uint64_t lastSerial, vespalib::DataBuffer & buffer, const CompressionConfig & compression);
+    size_t getMaxPackSize(CompressionConfig compression) const;
+    void pack(uint64_t lastSerial, vespalib::DataBuffer & buffer, CompressionConfig compression);
     uint64_t getLastSerial() const { return _lastSerial; }
     uint32_t getId() const { return _id; }
     bool validSerial() const { return getLastSerial() != static_cast<uint64_t>(-1l); }

--- a/searchlib/src/vespa/searchlib/docstore/chunkformat.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/chunkformat.cpp
@@ -19,7 +19,7 @@ ChunkException::ChunkException(const vespalib::string & msg, vespalib::stringref
 }
 
 void
-ChunkFormat::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, const CompressionConfig & compression)
+ChunkFormat::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, CompressionConfig compression)
 {
     vespalib::nbostream & os = _dataBuf;
     os << lastSerial;
@@ -46,7 +46,7 @@ ChunkFormat::pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, const 
 }
 
 size_t
-ChunkFormat::getMaxPackSize(const CompressionConfig & compression) const
+ChunkFormat::getMaxPackSize(CompressionConfig compression) const
 {
     const size_t OVERHEAD(0);
     const size_t MINSIZE(1 + 1 + 4 + 4 + (includeSerializedSize() ? 4 : 0));  // version + type + real length + crc + lastserial

--- a/searchlib/src/vespa/searchlib/docstore/chunkformat.h
+++ b/searchlib/src/vespa/searchlib/docstore/chunkformat.h
@@ -31,7 +31,7 @@ public:
      * @param compressed The buffer where the serialized data shall be placed.
      * @param compression What kind of compression shall be employed.
      */
-    void pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, const CompressionConfig & compression);
+    void pack(uint64_t lastSerial, vespalib::DataBuffer & compressed, CompressionConfig compression);
     /**
      * Will deserialize and create a representation of the uncompressed data.
      * param buffer Pointer to the serialized data
@@ -45,7 +45,7 @@ public:
      * @param compression Compression config to be used.
      * @return maximum number of bytes a packet can take in serialized form.
      */
-    size_t getMaxPackSize(const CompressionConfig & compression) const;
+    size_t getMaxPackSize(CompressionConfig compression) const;
 protected:
     /**
      * Constructor used when deserializing

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -23,7 +23,7 @@ Compacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, const void *bu
     _ds.write(std::move(guard), fileId, lid, buffer, sz);
 }
 
-BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, const CompressionConfig & compression, LogDataStore & ds,
+BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, CompressionConfig compression, LogDataStore & ds,
                                  Executor & executor, const IBucketizer & bucketizer, FileId source, FileId destination) :
     _unSignificantBucketBits((maxSignificantBucketBits > 8) ? (maxSignificantBucketBits - 8) : 0),
     _sourceFileId(source),

--- a/searchlib/src/vespa/searchlib/docstore/compacter.h
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.h
@@ -35,7 +35,7 @@ class BucketCompacter : public IWriteData, public StoreByBucket::IWrite
     using Executor = vespalib::Executor;
 public:
     using FileId = FileChunk::FileId;
-    BucketCompacter(size_t maxSignificantBucketBits, const CompressionConfig & compression, LogDataStore & ds,
+    BucketCompacter(size_t maxSignificantBucketBits, CompressionConfig compression, LogDataStore & ds,
                     Executor & executor, const IBucketizer & bucketizer, FileId source, FileId destination);
     void write(LockGuard guard, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz) override ;
     void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz) override;

--- a/searchlib/src/vespa/searchlib/docstore/documentstore.h
+++ b/searchlib/src/vespa/searchlib/docstore/documentstore.h
@@ -31,13 +31,13 @@ public:
             _initialCacheEntries(0),
             _updateStrategy(INVALIDATE)
         { }
-        Config(const CompressionConfig & compression, size_t maxCacheBytes, size_t initialCacheEntries) :
+        Config(CompressionConfig compression, size_t maxCacheBytes, size_t initialCacheEntries) :
             _compression((maxCacheBytes != 0) ? compression : CompressionConfig::NONE),
             _maxCacheBytes(maxCacheBytes),
             _initialCacheEntries(initialCacheEntries),
             _updateStrategy(INVALIDATE)
         { }
-        const CompressionConfig & getCompression() const { return _compression; }
+        CompressionConfig getCompression() const { return _compression; }
         size_t getMaxCacheBytes()   const { return _maxCacheBytes; }
         size_t getInitialCacheEntries() const { return _initialCacheEntries; }
         Config & updateStrategy(UpdateStrategy strategy) { _updateStrategy = strategy; return *this; }

--- a/searchlib/src/vespa/searchlib/docstore/logdatastore.h
+++ b/searchlib/src/vespa/searchlib/docstore/logdatastore.h
@@ -58,7 +58,7 @@ public:
         uint32_t getMaxNumLids() const { return _maxNumLids; }
 
         bool crcOnReadDisabled() const { return _skipCrcOnRead; }
-        const CompressionConfig & compactCompression() const { return _compactCompression; }
+        CompressionConfig compactCompression() const { return _compactCompression; }
 
         const WriteableFileChunk::Config & getFileConfig() const { return _fileConfig; }
         Config & disableCrcOnRead(bool v) { _skipCrcOnRead = v; return *this;}

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
@@ -13,7 +13,7 @@ using document::BucketId;
 using vespalib::CpuUsage;
 using vespalib::makeLambdaTask;
 
-StoreByBucket::StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, const CompressionConfig & compression) noexcept
+StoreByBucket::StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, CompressionConfig compression) noexcept
     : _chunkSerial(0),
       _current(),
       _where(),

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.h
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.h
@@ -24,7 +24,7 @@ class StoreByBucket
     using ConstBufferRef = vespalib::ConstBufferRef;
     using CompressionConfig = vespalib::compression::CompressionConfig;
 public:
-    StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, const CompressionConfig & compression) noexcept;
+    StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, CompressionConfig compression) noexcept;
     //TODO Putting the below move constructor into cpp file fails for some unknown reason. Needs to be resolved.
     StoreByBucket(StoreByBucket &&) noexcept = default;
     StoreByBucket(const StoreByBucket &) = delete;

--- a/searchlib/src/vespa/searchlib/docstore/value.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/value.cpp
@@ -55,7 +55,7 @@ compact(size_t sz, vespalib::alloc::Alloc buf) {
 
 }
 void
-Value::set(vespalib::DataBuffer &&buf, ssize_t len, const CompressionConfig &compression) {
+Value::set(vespalib::DataBuffer &&buf, ssize_t len, CompressionConfig compression) {
     assert(len < std::numeric_limits<uint32_t>::max());
     //Underlying buffer must be identical to allow swap.
     vespalib::DataBuffer compressed(buf.getData(), 0u);

--- a/searchlib/src/vespa/searchlib/docstore/value.h
+++ b/searchlib/src/vespa/searchlib/docstore/value.h
@@ -35,7 +35,7 @@ public:
      * Compress buffer into temporary buffer and copy temporary buffer to
      * value along with compression config.
      */
-    void set(vespalib::DataBuffer &&buf, ssize_t len, const CompressionConfig &compression);
+    void set(vespalib::DataBuffer &&buf, ssize_t len, CompressionConfig compression);
     // Keep buffer uncompressed
     void set(vespalib::DataBuffer &&buf, ssize_t len);
 

--- a/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/visitcache.cpp
@@ -84,7 +84,7 @@ CompressedBlobSet::CompressedBlobSet() :
 CompressedBlobSet::~CompressedBlobSet() = default;
 
 
-CompressedBlobSet::CompressedBlobSet(const CompressionConfig &compression, const BlobSet & uncompressed) :
+CompressedBlobSet::CompressedBlobSet(CompressionConfig compression, const BlobSet & uncompressed) :
     _compression(compression.type),
     _positions(uncompressed.getPositions()),
     _buffer()
@@ -144,27 +144,24 @@ bool
 VisitCache::BackingStore::read(const KeySet &key, CompressedBlobSet &blobs) const {
     VisitCollector collector;
     _backingStore.read(key.getKeys(), collector);
-    blobs = CompressedBlobSet(_compression, collector.getBlobSet());
+    blobs = CompressedBlobSet(_compression.load(std::memory_order_relaxed), collector.getBlobSet());
     return ! blobs.empty();
 }
 
 void
-VisitCache::BackingStore::reconfigure(const CompressionConfig &compression) {
-    if (compression != _compression) {
-        // Need proper synchronization
-        _compression = compression;
-    }
+VisitCache::BackingStore::reconfigure(CompressionConfig compression) {
+    _compression.store(compression, std::memory_order_relaxed);
 }
 
 
-VisitCache::VisitCache(IDataStore &store, size_t cacheSize, const CompressionConfig &compression) :
+VisitCache::VisitCache(IDataStore &store, size_t cacheSize, CompressionConfig compression) :
     _store(store, compression),
     _cache(std::make_unique<Cache>(_store, cacheSize))
 {
 }
 
 void
-VisitCache::reconfigure(size_t cacheSize, const CompressionConfig &compression) {
+VisitCache::reconfigure(size_t cacheSize, CompressionConfig compression) {
     _store.reconfigure(compression);
     _cache->setCapacityBytes(cacheSize);
 }

--- a/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
+++ b/searchlib/src/vespa/searchlib/docstore/writeablefilechunk.h
@@ -26,12 +26,12 @@ public:
         using CompressionConfig = vespalib::compression::CompressionConfig;
         Config() : Config({CompressionConfig::LZ4, 9, 60}, 0x10000) { }
 
-        Config(const CompressionConfig &compression, size_t maxChunkBytes)
+        Config(CompressionConfig compression, size_t maxChunkBytes)
             : _compression(compression),
               _maxChunkBytes(maxChunkBytes)
         { }
 
-        const CompressionConfig & getCompression() const { return _compression; }
+        CompressionConfig getCompression() const { return _compression; }
         size_t getMaxChunkBytes() const { return _maxChunkBytes; }
         bool operator == (const Config & rhs) const {
             return (_compression == rhs._compression) && (_maxChunkBytes == rhs._maxChunkBytes);

--- a/vespalib/src/tests/compression/compression_test.cpp
+++ b/vespalib/src/tests/compression/compression_test.cpp
@@ -67,6 +67,11 @@ TEST("requiret that zstd compression/decompression works") {
     EXPECT_EQUAL(_G_compressableText, vespalib::string(decompress.data(), decompress.size()));
 }
 
+TEST("require that CompressionConfig is Atomic") {
+    EXPECT_EQUAL(8u, sizeof(CompressionConfig));
+    EXPECT_TRUE(std::atomic<CompressionConfig>::is_always_lock_free);
+}
+
 TEST_MAIN() {
     TEST_RUN_ALL();
 }

--- a/vespalib/src/vespa/vespalib/util/compressionconfig.h
+++ b/vespalib/src/vespa/vespalib/util/compressionconfig.h
@@ -9,7 +9,7 @@
 namespace vespalib::compression {
 
 struct CompressionConfig {
-    enum Type {
+    enum Type : uint8_t {
         NONE = 0,
         NONE_MULTI = 1,
         HISTORIC_2 = 2,
@@ -21,15 +21,15 @@ struct CompressionConfig {
     };
 
     CompressionConfig() noexcept
-        : type(NONE), compressionLevel(0), threshold(90), minSize(0) {}
+        : CompressionConfig(NONE, 0, 90) {}
     CompressionConfig(Type t) noexcept
-        : type(t), compressionLevel(9), threshold(90), minSize(0) {}
+        : CompressionConfig(t, 9, 90) {}
 
     CompressionConfig(Type t, uint8_t level, uint8_t minRes) noexcept
-        : type(t), compressionLevel(level), threshold(minRes), minSize(0) {}
+        : CompressionConfig(t, level, minRes, 0) {}
 
     CompressionConfig(Type t, uint8_t lvl, uint8_t minRes, size_t minSz) noexcept
-        : type(t), compressionLevel(lvl), threshold(minRes), minSize(minSz) {}
+        : minSize(minSz), type(t), compressionLevel(lvl), threshold(minRes) {}
 
     bool operator==(const CompressionConfig& o) const {
         return (type == o.type
@@ -66,10 +66,10 @@ struct CompressionConfig {
     }
     bool useCompression() const { return isCompressed(type); }
 
-    Type type;
-    uint8_t compressionLevel;
-    uint8_t threshold;
-    size_t minSize;
+    uint32_t minSize;
+    Type     type;
+    uint8_t  compressionLevel;
+    uint8_t  threshold;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/util/compressor.cpp
+++ b/vespalib/src/vespa/vespalib/util/compressor.cpp
@@ -15,7 +15,7 @@ namespace vespalib::compression {
 namespace {
 
 template <typename F>
-void with_compressor(const CompressionConfig::Type &type, F &&f) {
+void with_compressor(CompressionConfig::Type type, F &&f) {
     switch (type) {
     case CompressionConfig::LZ4:
     {
@@ -40,7 +40,7 @@ void with_compressor(const CompressionConfig::Type &type, F &&f) {
 //-----------------------------------------------------------------------------
 
 CompressionConfig::Type
-compress(ICompressor & compressor, const CompressionConfig & compression, const ConstBufferRef & org, DataBuffer & dest)
+compress(ICompressor & compressor, CompressionConfig compression, const ConstBufferRef & org, DataBuffer & dest)
 {
     CompressionConfig::Type type(CompressionConfig::NONE);
     dest.ensureFree(compressor.adjustProcessLen(0, org.size()));
@@ -55,7 +55,7 @@ compress(ICompressor & compressor, const CompressionConfig & compression, const 
 }
 
 CompressionConfig::Type
-docompress(const CompressionConfig & compression, const ConstBufferRef & org, DataBuffer & dest)
+docompress(CompressionConfig compression, const ConstBufferRef & org, DataBuffer & dest)
 {
     switch (compression.type) {
     case CompressionConfig::LZ4:
@@ -80,8 +80,9 @@ CompressionConfig::Type
 compress(CompressionConfig::Type compression, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap) {
     return compress(CompressionConfig(compression), org, dest, allowSwap);
 }
+
 CompressionConfig::Type
-compress(const CompressionConfig & compression, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap)
+compress(CompressionConfig compression, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap)
 {
     CompressionConfig::Type type(CompressionConfig::NONE);
     if (org.size() >= compression.minSize) {
@@ -124,7 +125,7 @@ decompress(ICompressor & decompressor, size_t uncompressedLen, const ConstBuffer
 }
 
 void
-decompress(const CompressionConfig::Type & type, size_t uncompressedLen, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap)
+decompress(CompressionConfig::Type type, size_t uncompressedLen, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap)
 {
     switch (type) {
     case CompressionConfig::LZ4:
@@ -169,7 +170,7 @@ size_t computeMaxCompressedsize(CompressionConfig::Type type, size_t payloadSize
 
 //-----------------------------------------------------------------------------
 
-Compress::Compress(const CompressionConfig &config,
+Compress::Compress(CompressionConfig config,
                    const char *uncompressed_data, size_t uncompressed_size)
     : _space(),
       _type(CompressionConfig::NONE),
@@ -194,7 +195,7 @@ Compress::Compress(const CompressionConfig &config,
     }
 }
 
-Decompress::Decompress(const CompressionConfig::Type &type, size_t uncompressed_size,
+Decompress::Decompress(CompressionConfig::Type type, size_t uncompressed_size,
                        const char *compressed_data, size_t compressed_size)
     : _space(),
       _data(compressed_data),

--- a/vespalib/src/vespa/vespalib/util/compressor.h
+++ b/vespalib/src/vespa/vespalib/util/compressor.h
@@ -13,7 +13,7 @@ class ICompressor
 {
 public:
     virtual ~ICompressor() { }
-    virtual bool process(const CompressionConfig& config, const void * input, size_t inputLen, void * output, size_t & outputLen) = 0;
+    virtual bool process(CompressionConfig config, const void * input, size_t inputLen, void * output, size_t & outputLen) = 0;
     virtual bool unprocess(const void * input, size_t inputLen, void * output, size_t & outputLen) = 0;
     virtual size_t adjustProcessLen(uint16_t options, size_t len)   const = 0;
 };
@@ -28,7 +28,7 @@ public:
  * @param allowSwap will tell it the data must be appended or if it can be swapped in if it is uncompressable or config is NONE.
  */
 CompressionConfig::Type compress(CompressionConfig::Type compression, const ConstBufferRef & org, DataBuffer & dest, bool allowSwap);
-CompressionConfig::Type compress(const CompressionConfig & compression, const vespalib::ConstBufferRef & org, vespalib::DataBuffer & dest, bool allowSwap);
+CompressionConfig::Type compress(CompressionConfig compression, const vespalib::ConstBufferRef & org, vespalib::DataBuffer & dest, bool allowSwap);
 
 /**
  * Will try to decompress a buffer according to the config.
@@ -41,7 +41,7 @@ CompressionConfig::Type compress(const CompressionConfig & compression, const ve
  *             Then it will be swapped in.
  * @param allowSwap will tell it the data must be appended or if it can be swapped in if compression type is NONE.
  */
-void decompress(const CompressionConfig::Type & compression, size_t uncompressedLen, const vespalib::ConstBufferRef & org, vespalib::DataBuffer & dest, bool allowSwap);
+void decompress(CompressionConfig::Type compression, size_t uncompressedLen, const vespalib::ConstBufferRef & org, vespalib::DataBuffer & dest, bool allowSwap);
 
 size_t computeMaxCompressedsize(CompressionConfig::Type type, size_t uncompressedSize);
 
@@ -53,14 +53,13 @@ size_t computeMaxCompressedsize(CompressionConfig::Type type, size_t uncompresse
  **/
 class Compress {
 private:
-    alloc::Alloc _space;
+    alloc::Alloc            _space;
     CompressionConfig::Type _type;
-    const char *_data;
-    size_t _size;
+    const char             *_data;
+    size_t                  _size;
 public:
-    Compress(const CompressionConfig &config,
-             const char *uncompressed_data, size_t uncompressed_size);
-    const CompressionConfig::Type &type() const { return _type; }
+    Compress(CompressionConfig config, const char *uncompressed_data, size_t uncompressed_size);
+    CompressionConfig::Type type() const { return _type; }
     const char *data() const { return _data; }
     size_t size() const { return _size; }
 };
@@ -72,10 +71,10 @@ public:
 class Decompress {
 private:
     alloc::Alloc _space;
-    const char *_data;
-    size_t _size;
+    const char  *_data;
+    size_t       _size;
 public:
-    Decompress(const CompressionConfig::Type &type, size_t uncompressed_size,
+    Decompress(CompressionConfig::Type type, size_t uncompressed_size,
                const char *compressed_data, size_t compressed_size);
     const char *data() const { return _data; }
     size_t size() const { return _size; }

--- a/vespalib/src/vespa/vespalib/util/lz4compressor.cpp
+++ b/vespalib/src/vespa/vespalib/util/lz4compressor.cpp
@@ -13,7 +13,7 @@ namespace vespalib::compression {
 size_t LZ4Compressor::adjustProcessLen(uint16_t, size_t len)   const { return LZ4_compressBound(len); }
 
 bool
-LZ4Compressor::process(const CompressionConfig& config, const void * inputV, size_t inputLen, void * outputV, size_t & outputLenV)
+LZ4Compressor::process(CompressionConfig config, const void * inputV, size_t inputLen, void * outputV, size_t & outputLenV)
 {
     const char * input(static_cast<const char *>(inputV));
     char * output(static_cast<char *>(outputV));

--- a/vespalib/src/vespa/vespalib/util/lz4compressor.h
+++ b/vespalib/src/vespa/vespalib/util/lz4compressor.h
@@ -8,7 +8,7 @@ namespace vespalib::compression {
 class LZ4Compressor : public ICompressor
 {
 public:
-    bool process(const CompressionConfig& config, const void * input, size_t inputLen, void * output, size_t & outputLen) override;
+    bool process(CompressionConfig config, const void * input, size_t inputLen, void * output, size_t & outputLen) override;
     bool unprocess(const void * input, size_t inputLen, void * output, size_t & outputLen) override;
     size_t adjustProcessLen(uint16_t options, size_t len)   const override;
 };

--- a/vespalib/src/vespa/vespalib/util/zstdcompressor.cpp
+++ b/vespalib/src/vespa/vespalib/util/zstdcompressor.cpp
@@ -36,7 +36,7 @@ thread_local std::unique_ptr<DecompressContext> _tlDecompressState;
 size_t ZStdCompressor::adjustProcessLen(uint16_t, size_t len)   const { return ZSTD_compressBound(len); }
 
 bool
-ZStdCompressor::process(const CompressionConfig& config, const void * inputV, size_t inputLen, void * outputV, size_t & outputLenV)
+ZStdCompressor::process(CompressionConfig config, const void * inputV, size_t inputLen, void * outputV, size_t & outputLenV)
 {
     size_t maxOutputLen = ZSTD_compressBound(inputLen);
     if ( ! _tlCompressState) {

--- a/vespalib/src/vespa/vespalib/util/zstdcompressor.h
+++ b/vespalib/src/vespa/vespalib/util/zstdcompressor.h
@@ -8,7 +8,7 @@ namespace vespalib::compression {
 class ZStdCompressor : public ICompressor
 {
 public:
-    bool process(const CompressionConfig& config, const void * input, size_t inputLen, void * output, size_t & outputLen) override;
+    bool process(CompressionConfig config, const void * input, size_t inputLen, void * output, size_t & outputLen) override;
     bool unprocess(const void * input, size_t inputLen, void * output, size_t & outputLen) override;
     size_t adjustProcessLen(uint16_t options, size_t len)   const override;
 };


### PR DESCRIPTION
…n documentstore thread safe.

@toregge PR