### PR TITLE
Log warning when deprecated jvm options used [run-systemtest]

### DIFF
--- a/config-model/src/main/resources/schema/common.rnc
+++ b/config-model/src/main/resources/schema/common.rnc
@@ -1,8 +1,8 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 service.attlist &= attribute hostalias { xsd:NCName }
 service.attlist &= attribute baseport { xsd:unsignedShort }?
-service.attlist &= attribute jvm-options { text }?
-service.attlist &= attribute jvm-gc-options { text }?
+service.attlist &= attribute jvm-options { text }? # Remove in Vespa 9
+service.attlist &= attribute jvm-gc-options { text }? # Remove in Vespa 9
 # preload is for internal use only
 service.attlist &= attribute preload { text }?
 

--- a/config-model/src/main/resources/schema/containercluster.rnc
+++ b/config-model/src/main/resources/schema/containercluster.rnc
@@ -274,10 +274,10 @@ HttpClientApi = element http-client-api {
 # NODES:
 
 NodesOfContainerCluster = element nodes {
-    attribute jvm-options { text }? &
-    attribute jvm-gc-options { text }? &
+    attribute jvm-options { text }? & # Remove in Vespa 9
+    attribute jvm-gc-options { text }? & # Remove in Vespa 9
     attribute preload { text }? &
-    attribute allocated-memory { text }? &
+    attribute allocated-memory { text }? &  # Remove in Vespa 9
     attribute cpu-socket-affinity { xsd:boolean }? &
     element jvm {
         attribute options { text }? &


### PR DESCRIPTION
Log when jvm-gc-options or allocated-memory attributes are used in node element. Deprecate and tell that these will be removed in Vespa 9.