### PR TITLE
Support Zstd (un)compression during crypto CLI encryption and decryption

### DIFF
--- a/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-decrypt-help-output.txt
@@ -21,5 +21,7 @@ the quotes).
                                plaintext to STDOUT instead of a file.
  -t,--token <arg>              Token generated when the input file was
                                encrypted
+ -z,--zstd-decompress          Decrypted data will be transparently
+                               Zstd-decompressed before being output.
 Note: this is a BETA tool version; its interface may be changed at any
 time

--- a/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
+++ b/vespaclient-java/src/test/resources/expected-encrypt-help-output.txt
@@ -12,5 +12,7 @@ the quotes).
                                    already exists)
  -r,--recipient-public-key <arg>   Recipient X25519 public key in Base58
                                    encoded format
+ -z,--zstd-compress                Input data will be transparently
+                                   Zstd-compressed before being encrypted.
 Note: this is a BETA tool version; its interface may be changed at any
 time


### PR DESCRIPTION
@bjorncs please review

Simplifies working with compressed plaintext, as it removes the need for piping via `unzstd` or using a temporary file.

