### PR TITLE
When resorting to paged structures you are will use all memory and more.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
@@ -62,9 +62,10 @@ MmapFileAllocator::alloc(size_t sz) const
     assert(ins_res.second);
     int retval = madvise(buf, sz, MADV_RANDOM);
     assert(retval == 0);
+    retval = madvise(buf, sz, MADV_DONTDUMP);
+    assert(retval == 0);
     return PtrAndSize(buf, sz);
 }
-
 
 void
 MmapFileAllocator::free(PtrAndSize alloc) const

--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
@@ -62,8 +62,10 @@ MmapFileAllocator::alloc(size_t sz) const
     assert(ins_res.second);
     int retval = madvise(buf, sz, MADV_RANDOM);
     assert(retval == 0);
+#ifdef __linux__
     retval = madvise(buf, sz, MADV_DONTDUMP);
     assert(retval == 0);
+#endif
     return PtrAndSize(buf, sz);
 }
 


### PR DESCRIPTION
That is too large to get in a coredump, so ignore it.

@vekterli @toregge @geirst PR