### PR TITLE
Extract virtual fields in the index environment.

### DIFF
--- a/searchlib/src/vespa/searchcommon/common/datatype.cpp
+++ b/searchlib/src/vespa/searchcommon/common/datatype.cpp
@@ -25,6 +25,7 @@ dataTypeFromName(vespalib::stringref name) {
     else if (name == "BOOLEANTREE") { return DataType::BOOLEANTREE; }
     else if (name == "TENSOR") { return DataType::TENSOR; }
     else if (name == "REFERENCE") { return DataType::REFERENCE; }
+    else if (name == "COMBINED") { return DataType::COMBINED; }
     else {
         throw InvalidConfigException("Illegal enum value '" + name + "'");
     }
@@ -44,7 +45,8 @@ const char *datatype_str[] = { "BOOL",
                                "FEATURE_NOTUSED",
                                "BOOLEANTREE",
                                "TENSOR",
-                               "REFERENCE"};
+                               "REFERENCE",
+                               "COMBINED"};
 
 vespalib::string
 getTypeName(DataType type) {

--- a/searchlib/src/vespa/searchcommon/common/datatype.h
+++ b/searchlib/src/vespa/searchcommon/common/datatype.h
@@ -24,13 +24,15 @@ enum class DataType {
     //FEATURE = 11,
     BOOLEANTREE = 12,
     TENSOR = 13,
-    REFERENCE = 14
+    REFERENCE = 14,
+    COMBINED = 15
 };
 
 /**
  * Collection type for a field.
  **/
-enum class CollectionType { SINGLE = 0,
+enum class CollectionType {
+    SINGLE = 0,
     ARRAY = 1,
     WEIGHTEDSET = 2
 };

--- a/searchlib/src/vespa/searchlib/fef/fieldtype.h
+++ b/searchlib/src/vespa/searchlib/fef/fieldtype.h
@@ -10,7 +10,8 @@ namespace search::fef {
 enum class FieldType {
     INDEX = 1,
     ATTRIBUTE = 2,
-    HIDDEN_ATTRIBUTE = 3
+    HIDDEN_ATTRIBUTE = 3,
+    VIRTUAL = 4
 };
 
 }


### PR DESCRIPTION
Fields that are represented by a set of attributes in the backend are considered virtual fields. Currently, this is map or array of struct fields (from the SD file) with struct-field attributes.

@havardpe please review