### PR TITLE
if the Document to be processed is the wrong type, convert it

### DIFF
--- a/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
+++ b/docprocs/src/main/java/com/yahoo/docprocs/indexing/IndexingProcessor.java
@@ -107,6 +107,9 @@ public class IndexingProcessor extends DocumentProcessor {
         DocumentType wantType = docTypeMgr.getDocumentType(hadType.getName());
         Document prevDoc = prev.getDocument();
         if (hadType != wantType) {
+            // this happens when you have a concrete document; we need to
+            // convert back to a "normal" Document for indexing of complex structures
+            // to work properly.
             GrowableByteBuffer buffer = new GrowableByteBuffer(64 * 1024, 2.0f);
             DocumentSerializer serializer = DocumentSerializerFactory.createHead(buffer);
             serializer.write(prevDoc);


### PR DESCRIPTION
* this happens when you have a concrete document
* the indexing processor works better with the "normal" format, especially if there are any complex structure in the schema such as array<string> that needs processing
* convert to normal format by serializing and deserializing

@baldersheim please review
@bratseth FYI
