### PR TITLE
Reapply "Add missing writes to unified node path"

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -182,8 +182,8 @@ public class Nodes {
                 nodesToAdd.add(node);
             }
             NestedTransaction transaction = new NestedTransaction();
-            List<Node> resultingNodes = db.addNodesInState(IP.Config.verify(nodesToAdd, list(lock)), Node.State.provisioned, agent, transaction);
             db.removeNodes(nodesToRemove, transaction);
+            List<Node> resultingNodes = db.addNodesInState(IP.Config.verify(nodesToAdd, list(lock)), Node.State.provisioned, agent, transaction);
             transaction.commit();
             return resultingNodes;
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CachingCurator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CachingCurator.java
@@ -68,6 +68,11 @@ public class CachingCurator {
                      .toList();
     }
 
+    // TODO(mpolden): Remove this
+    public void deleteRecursively(Path path) {
+        curator.delete(path);
+    }
+
     /** Create a reentrant lock */
     public Lock lock(Path path, Duration timeout) {
         return curator.lock(path, timeout);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
@@ -115,7 +115,10 @@ public class CuratorDb {
                 throw new IllegalArgumentException(node + " is not in the " + expectedState + " state");
 
             node = node.with(node.history().recordStateTransition(null, expectedState, agent, clock.instant()));
-            curatorTransaction.add(CuratorOperations.create(toPath(node).getAbsolute(), nodeSerializer.toJson(node)));
+            // TODO(mpolden): Remove after migration to nodesPath
+            byte[] serialized = nodeSerializer.toJson(node);
+            curatorTransaction.add(CuratorOperations.create(toPath(node).getAbsolute(), serialized));
+            curatorTransaction.add(CuratorOperations.create(nodePath(node).getAbsolute(), serialized));
         }
 
         for (Node node : nodes)
@@ -136,7 +139,11 @@ public class CuratorDb {
         for (Node node : nodes) {
             Path path = toPath(node.state(), node.hostname());
             CuratorTransaction curatorTransaction = db.newCuratorTransactionIn(transaction);
+            // TODO(mpolden): Remove after migration to nodesPath
             curatorTransaction.add(CuratorOperations.delete(path.getAbsolute()));
+            if (db.exists(nodePath(node))) {
+                curatorTransaction.add(CuratorOperations.delete(nodePath(node).getAbsolute()));
+            }
         }
         nodes.forEach(node -> log.log(Level.INFO, "Removed node " + node.hostname() + " in state " + node.state()));
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
@@ -246,11 +246,7 @@ public class CuratorDb {
                                   .add(CuratorOperations.create(newNodePath, nodeData));
             }
         }
-        Path nodePath = nodePath(newNode);
-        if (db.exists(nodePath)) {
-            curatorTransaction.add(CuratorOperations.delete(nodePath.getAbsolute()));
-        }
-        curatorTransaction.add(CuratorOperations.create(nodePath.getAbsolute(), nodeData));
+        curatorTransaction.add(createOrSet(nodePath(newNode), nodeData));
     }
 
     private Status newNodeStatus(Node node, Node.State toState) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
@@ -93,6 +93,7 @@ public class CuratorDb {
 
     private void initZK() {
         db.create(root);
+        db.deleteRecursively(nodesPath); // TODO(mpolden): Remove before we start reading from this path
         db.create(nodesPath);
         // TODO(mpolden): Remove state paths after migration to nodesPath
         for (Node.State state : Node.State.values())


### PR DESCRIPTION
Since #25375 never deleted node objects from the new path, we have to GC all of
it. This is to ensure we don't have any stale node objects present when we start
reading from the new path.

@bratseth