### PR TITLE
Use ChaCha20-Poly1305 instead of AES-GCM for shared key-based crypto

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandler.java
@@ -186,7 +186,7 @@ public class CoredumpHandler {
 
     static OutputStream maybeWrapWithEncryption(OutputStream wrappedStream, Optional<SecretSharedKey> sharedCoreKey) {
         return sharedCoreKey
-                .map(key -> SharedKeyGenerator.makeAesGcmEncryptionCipher(key).wrapOutputStream(wrappedStream))
+                .map(key -> key.makeEncryptionCipher().wrapOutputStream(wrappedStream))
                 .orElse(wrappedStream);
     }
 

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -294,7 +294,7 @@ public class CoredumpHandlerTest {
         // We don't parse any of these fields in the test, so just use dummy contents.
         byte[] enc = bytesOf("hello world");
         byte[] ciphertext = bytesOf("imaginary ciphertext");
-        return new SecretSharedKey(secretKey, new SealedSharedKey(keyId, enc, ciphertext));
+        return new SecretSharedKey(secretKey, new SealedSharedKey(SealedSharedKey.CURRENT_TOKEN_VERSION, keyId, enc, ciphertext));
     }
 
 }

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/maintenance/coredump/CoredumpHandlerTest.java
@@ -202,7 +202,7 @@ public class CoredumpHandlerTest {
         assertFolderContents(coredumpDirectory, "metadata2.json", "dump_bash.core.431");
         CoreDumpMetadata expectedMetadata = new CoreDumpMetadata();
         if (encrypt)
-            expectedMetadata.setDecryptionToken("XWTN195KaZecNCloqRICq9YwxwWJEKGqyMYcTgHtwaZfnXtzHzd7bPrPPR60VdxxzA");
+            expectedMetadata.setDecryptionToken("131Q0MMF3hBuMVnXg1WnSFexZGrcwa9ZhfHlegLNwPIN6hQJnBxq5srLf3aZbYdlRVE");
 
         coredumpHandler.processAndReportSingleCoreDump(context, coredumpDirectory, Optional.empty());
         verify(coreCollector, never()).collect(any(), any());

--- a/security-utils/src/main/java/com/yahoo/security/ChaCha20Poly1305AeadBlockCipherAdapter.java
+++ b/security-utils/src/main/java/com/yahoo/security/ChaCha20Poly1305AeadBlockCipherAdapter.java
@@ -1,0 +1,84 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.security;
+
+import org.bouncycastle.crypto.BlockCipher;
+import org.bouncycastle.crypto.CipherParameters;
+import org.bouncycastle.crypto.DataLengthException;
+import org.bouncycastle.crypto.InvalidCipherTextException;
+import org.bouncycastle.crypto.modes.AEADBlockCipher;
+import org.bouncycastle.crypto.modes.ChaCha20Poly1305;
+
+/**
+ * Minimal adapter to make ChaCha20Poly1305 usable as an AEADBlockCipher (it's technically
+ * an AEAD stream cipher, but this is not exposed in the BouncyCastle type system).
+ *
+ * @author vekterli
+ */
+class ChaCha20Poly1305AeadBlockCipherAdapter implements AEADBlockCipher {
+
+    private final ChaCha20Poly1305 cipher;
+
+    ChaCha20Poly1305AeadBlockCipherAdapter(ChaCha20Poly1305 cipher) {
+        this.cipher = cipher;
+    }
+
+    @Override
+    public BlockCipher getUnderlyingCipher() {
+        return null;
+    }
+
+    @Override
+    public void init(boolean forEncryption, CipherParameters params) throws IllegalArgumentException {
+        cipher.init(forEncryption, params);
+    }
+
+    @Override
+    public String getAlgorithmName() {
+        return cipher.getAlgorithmName();
+    }
+
+    @Override
+    public void processAADByte(byte in) {
+        cipher.processAADByte(in);
+    }
+
+    @Override
+    public void processAADBytes(byte[] in, int inOff, int len) {
+        cipher.processAADBytes(in, inOff, len);
+    }
+
+    @Override
+    public int processByte(byte in, byte[] out, int outOff) throws DataLengthException {
+        return cipher.processByte(in, out, outOff);
+    }
+
+    @Override
+    public int processBytes(byte[] in, int inOff, int len, byte[] out, int outOff) throws DataLengthException {
+        return cipher.processBytes(in, inOff, len, out, outOff);
+    }
+
+    @Override
+    public int doFinal(byte[] out, int outOff) throws IllegalStateException, InvalidCipherTextException {
+        return cipher.doFinal(out, outOff);
+    }
+
+    @Override
+    public byte[] getMac() {
+        return cipher.getMac();
+    }
+
+    @Override
+    public int getUpdateOutputSize(int len) {
+        return cipher.getUpdateOutputSize(len);
+    }
+
+    @Override
+    public int getOutputSize(int len) {
+        return cipher.getOutputSize(len);
+    }
+
+    @Override
+    public void reset() {
+        cipher.reset();
+    }
+}

--- a/security-utils/src/main/java/com/yahoo/security/SharedKeyGenerator.java
+++ b/security-utils/src/main/java/com/yahoo/security/SharedKeyGenerator.java
@@ -7,6 +7,7 @@ import com.yahoo.security.hpke.Hpke;
 import com.yahoo.security.hpke.Kdf;
 import com.yahoo.security.hpke.Kem;
 import org.bouncycastle.crypto.engines.AESEngine;
+import org.bouncycastle.crypto.modes.ChaCha20Poly1305;
 import org.bouncycastle.crypto.modes.GCMBlockCipher;
 import org.bouncycastle.crypto.params.AEADParameters;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -20,6 +21,8 @@ import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.interfaces.XECPrivateKey;
 import java.security.interfaces.XECPublicKey;
+
+import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
 
 /**
  * Implements both the sender and receiver sides of a secure, anonymous one-way
@@ -40,9 +43,13 @@ import java.security.interfaces.XECPublicKey;
  */
 public class SharedKeyGenerator {
 
-    private static final int    AES_GCM_KEY_BITS      = 128;
-    private static final int    AES_GCM_AUTH_TAG_BITS = 128;
-    private static final String AES_GCM_ALGO_SPEC     = "AES/GCM/NoPadding";
+    private static final int AES_GCM_KEY_BITS      = 128;
+    private static final int AES_GCM_AUTH_TAG_BITS = 128;
+
+    private static final int CHACHA20_POLY1305_KEY_BITS       = 256;
+    private static final int CHACHA20_POLY1305_AUTH_TAG_BITS  = 128;
+    private static final byte[] CHACHA20_POLY1305_KDF_CONTEXT = toUtf8Bytes("ChaCha20Poly1305 key expansion");
+
     private static final byte[] EMPTY_BYTES           = new byte[0];
     private static final SecureRandom SHARED_CSPRNG   = new SecureRandom();
     // Since the HPKE ciphersuite is not provided in the token, we must be very explicit about what it always is
@@ -61,7 +68,7 @@ public class SharedKeyGenerator {
 
     public static SecretSharedKey generateForReceiverPublicKey(PublicKey receiverPublicKey, KeyId keyId) {
         var secretKey = generateRandomSecretAesKey();
-        return internalSealSecretKeyForReceiver(secretKey, receiverPublicKey, keyId);
+        return internalSealSecretKeyForReceiver(SealedSharedKey.CURRENT_TOKEN_VERSION, secretKey, receiverPublicKey, keyId);
     }
 
     public static SecretSharedKey fromSealedKey(SealedSharedKey sealedKey, PrivateKey receiverPrivateKey) {
@@ -71,13 +78,15 @@ public class SharedKeyGenerator {
     }
 
     public static SecretSharedKey reseal(SecretSharedKey secret, PublicKey receiverPublicKey, KeyId keyId) {
-        return internalSealSecretKeyForReceiver(secret.secretKey(), receiverPublicKey, keyId);
+        // The resealed token must inherit the token version of the original token, or the receiver will
+        // end up trying to decrypt with the wrong parameters and/or cipher.
+        return internalSealSecretKeyForReceiver(secret.sealedSharedKey().tokenVersion(), secret.secretKey(), receiverPublicKey, keyId);
     }
 
-    private static SecretSharedKey internalSealSecretKeyForReceiver(SecretKey secretKey, PublicKey receiverPublicKey, KeyId keyId) {
+    private static SecretSharedKey internalSealSecretKeyForReceiver(int tokenVersion, SecretKey secretKey, PublicKey receiverPublicKey, KeyId keyId) {
         // We protect the integrity of the key ID by passing it as AAD.
         var sealed = HPKE.sealBase((XECPublicKey) receiverPublicKey, EMPTY_BYTES, keyId.asBytes(), secretKey.getEncoded());
-        var sealedSharedKey = new SealedSharedKey(keyId, sealed.enc(), sealed.ciphertext());
+        var sealedSharedKey = new SealedSharedKey(tokenVersion, keyId, sealed.enc(), sealed.ciphertext());
         return new SecretSharedKey(secretKey, sealedSharedKey);
     }
 
@@ -88,6 +97,7 @@ public class SharedKeyGenerator {
     // token recipient (which would be the case if the IV were deterministically derived
     // from the recipient key and ephemeral ECDH public key), as that would preclude
     // support for delegated key forwarding.
+    // Both AES GCM and ChaCha20Poly1305 use a 96-bit user-supplied IV.
     private static final byte[] FIXED_96BIT_IV_FOR_SINGLE_USE_KEY = new byte[] {
             'h','e','r','e','B','d','r','a','g','o','n','s' // Nothing up my sleeve!
     };
@@ -100,12 +110,24 @@ public class SharedKeyGenerator {
         return AeadCipher.of(cipher);
     }
 
+    private static AeadCipher makeChaCha20Poly1305Cipher(SecretSharedKey secretSharedKey, boolean forEncryption) {
+        // ChaCha20Poly1305 uses 256-bit keys, but our shared secret keys are 128 bit.
+        // Deterministically derive a longer key from the existing key using a KDF.
+        var expandedKey = HKDF.unsaltedExtractedFrom(secretSharedKey.secretKey().getEncoded())
+                .expand(CHACHA20_POLY1305_KEY_BITS / 8, CHACHA20_POLY1305_KDF_CONTEXT);
+        var aeadParams = new AEADParameters(new KeyParameter(expandedKey), CHACHA20_POLY1305_AUTH_TAG_BITS,
+                                            FIXED_96BIT_IV_FOR_SINGLE_USE_KEY);
+        var cipher = new ChaCha20Poly1305();
+        cipher.init(forEncryption, aeadParams);
+        return AeadCipher.of(new ChaCha20Poly1305AeadBlockCipherAdapter(cipher));
+    }
+
     /**
      * Creates an AES-GCM cipher that can be used to encrypt arbitrary plaintext.
      *
      * The given secret key MUST NOT be used to encrypt more than one plaintext.
      */
-    public static AeadCipher makeAesGcmEncryptionCipher(SecretSharedKey secretSharedKey) {
+    static AeadCipher makeAesGcmEncryptionCipher(SecretSharedKey secretSharedKey) {
         return makeAesGcmCipher(secretSharedKey, true);
     }
 
@@ -113,8 +135,25 @@ public class SharedKeyGenerator {
      * Creates an AES-GCM cipher that can be used to decrypt ciphertext that was previously
      * encrypted with the given secret key.
      */
-    public static AeadCipher makeAesGcmDecryptionCipher(SecretSharedKey secretSharedKey) {
+    static AeadCipher makeAesGcmDecryptionCipher(SecretSharedKey secretSharedKey) {
         return makeAesGcmCipher(secretSharedKey, false);
+    }
+
+    /**
+     * Creates a ChaCha20-Poly1305 cipher that can be used to encrypt arbitrary plaintext.
+     *
+     * The given secret key MUST NOT be used to encrypt more than one plaintext.
+     */
+    static AeadCipher makeChaCha20Poly1305EncryptionCipher(SecretSharedKey secretSharedKey) {
+        return makeChaCha20Poly1305Cipher(secretSharedKey, true);
+    }
+
+    /**
+     * Creates a ChaCha20-Poly1305 cipher that can be used to decrypt ciphertext that was previously
+     * encrypted with the given secret key.
+     */
+    static AeadCipher makeChaCha20Poly1305DecryptionCipher(SecretSharedKey secretSharedKey) {
+        return makeChaCha20Poly1305Cipher(secretSharedKey, false);
     }
 
 }

--- a/security-utils/src/test/java/com/yahoo/security/SharedKeyTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/SharedKeyTest.java
@@ -59,20 +59,74 @@ public class SharedKeyTest {
     }
 
     @Test
-    void token_v1_representation_is_stable() {
+    void resealed_token_preserves_token_version_of_source_token() {
+        var originalPrivate = KeyUtils.fromBase58EncodedX25519PrivateKey("GFg54SaGNCmcSGufZCx68SKLGuAFrASoDeMk3t5AjU6L");
+        var v1Token         = "OntP9gRVAjXeZIr4zkYqRJFcnA993v7ZEE7VbcNs1NcR3HdE7Mpwlwi3r3anF1kVa5fn7O1CyeHQpBWpdayUTKkrtyFepG6WJrZdE";
+
+        var originalSealed = SealedSharedKey.fromTokenString(v1Token);
+        var originalSecret = SharedKeyGenerator.fromSealedKey(originalSealed, originalPrivate);
+
+        var secondaryReceiverKp = KeyUtils.generateX25519KeyPair();
+        var resealedShared = SharedKeyGenerator.reseal(originalSecret, secondaryReceiverKp.getPublic(), KEY_ID_2);
+
+        var theirSealed = SealedSharedKey.fromTokenString(resealedShared.sealedSharedKey().toTokenString());
+        assertEquals(1, theirSealed.tokenVersion());
+    }
+
+    @Test
+    void token_v1_representation_is_stable() throws IOException {
         var receiverPrivate = KeyUtils.fromBase58EncodedX25519PrivateKey("GFg54SaGNCmcSGufZCx68SKLGuAFrASoDeMk3t5AjU6L");
         var receiverPublic  = KeyUtils.fromBase58EncodedX25519PublicKey( "5drrkakYLjYSBpr5Haknh13EiCYL36ndMzK4gTJo6pwh");
         var keyId           = KeyId.ofString("my key ID");
 
-        // Token generated for the above receiver public key, with the below expected shared secret (in hex)
+        // V1 token generated for the above receiver public key, with the below expected shared secret (in hex)
         var publicToken = "OntP9gRVAjXeZIr4zkYqRJFcnA993v7ZEE7VbcNs1NcR3HdE7Mpwlwi3r3anF1kVa5fn7O1CyeHQpBWpdayUTKkrtyFepG6WJrZdE";
         var expectedSharedSecret = "1b33b4dcd6a94e5a4a1ee6d208197d01";
 
         var theirSealed = SealedSharedKey.fromTokenString(publicToken);
         var theirShared = SharedKeyGenerator.fromSealedKey(theirSealed, receiverPrivate);
 
+        assertEquals(1, theirSealed.tokenVersion());
         assertEquals(keyId, theirSealed.keyId());
         assertEquals(expectedSharedSecret, hex(theirShared.secretKey().getEncoded()));
+
+        // Encryption with v1 tokens must use AES-GCM 128
+        var plaintext = "it's Bocchi time";
+        var expectedCiphertext = "a2ba842b2e0769a4a2948c4236d4ae921f1dd05c2e094dcde9699eeefcc3d7ae";
+        byte[] ct = streamEncryptString(plaintext, theirShared);
+        assertEquals(expectedCiphertext, hex(ct));
+
+        // Decryption with v1 tokens must use AES-GCM 128
+        var decrypted = streamDecryptString(ct, theirShared);
+        assertEquals(plaintext, decrypted);
+    }
+
+    @Test
+    void token_v2_representation_is_stable() throws IOException {
+        var receiverPrivate = KeyUtils.fromBase58EncodedX25519PrivateKey("GFg54SaGNCmcSGufZCx68SKLGuAFrASoDeMk3t5AjU6L");
+        var receiverPublic  = KeyUtils.fromBase58EncodedX25519PublicKey( "5drrkakYLjYSBpr5Haknh13EiCYL36ndMzK4gTJo6pwh");
+        var keyId           = KeyId.ofString("my key ID");
+
+        // V2 token generated for the above receiver public key, with the below expected shared secret (in hex)
+        var publicToken = "mjA83HYuulZW5SWV8FKz4m3b3m9zU8mTrX9n6iY4wZaA6ZNr8WnBZwOU4KQqhPCORPlzSYk4svlonzPZIb3Bjbqr2ePYKLOpdGhCO";
+        var expectedSharedSecret = "205af82154690fd7b6d56a977563822c";
+
+        var theirSealed = SealedSharedKey.fromTokenString(publicToken);
+        var theirShared = SharedKeyGenerator.fromSealedKey(theirSealed, receiverPrivate);
+
+        assertEquals(2, theirSealed.tokenVersion());
+        assertEquals(keyId, theirSealed.keyId());
+        assertEquals(expectedSharedSecret, hex(theirShared.secretKey().getEncoded()));
+
+        // Encryption with v2 tokens must use ChaCha20-Poly1305
+        var plaintext = "it's Bocchi time";
+        var expectedCiphertext = "ea19dd0ac3ea6d76dc4e96430b0d5902a21cb3a27fa99490f4dcc391eaf5cec4";
+        byte[] ct = streamEncryptString(plaintext, theirShared);
+        assertEquals(expectedCiphertext, hex(ct));
+
+        // Decryption with v2 tokens must use ChaCha20-Poly1305
+        var decrypted = streamDecryptString(ct, theirShared);
+        assertEquals(plaintext, decrypted);
     }
 
     @Test
@@ -102,7 +156,7 @@ public class SharedKeyTest {
         var mySealed = myShared.sealedSharedKey();
         var badId    = KeyId.ofString("my key 2");
 
-        var tamperedShared = new SealedSharedKey(badId, mySealed.enc(), mySealed.ciphertext());
+        var tamperedShared = new SealedSharedKey(SealedSharedKey.CURRENT_TOKEN_VERSION, badId, mySealed.enc(), mySealed.ciphertext());
         // Should not be able to unseal the token since the AAD auth tag won't be correct
         assertThrows(RuntimeException.class, // TODO consider distinct exception class
                      () -> SharedKeyGenerator.fromSealedKey(tamperedShared, keyPair.getPrivate()));
@@ -130,7 +184,7 @@ public class SharedKeyTest {
         var myShared = SharedKeyGenerator.generateForReceiverPublicKey(keyPair.getPublic(), goodId);
 
         // token header is u8 version || u8 key id length || key id bytes ...
-        // Since the key ID is only 1 bytes long, patch it with a bad UTF-8 value
+        // Since the key ID is only 1 byte long, patch it with a bad UTF-8 value
         byte[] tokenBytes = Base62.codec().decode(myShared.sealedSharedKey().toTokenString());
         tokenBytes[2] = (byte)0xC0; // First part of a 2-byte continuation without trailing byte
         var patchedTokenStr = Base62.codec().encode(tokenBytes);
@@ -138,7 +192,7 @@ public class SharedKeyTest {
     }
 
     static byte[] streamEncryptString(String data, SecretSharedKey secretSharedKey) throws IOException {
-        var cipher = SharedKeyGenerator.makeAesGcmEncryptionCipher(secretSharedKey);
+        var cipher = secretSharedKey.makeEncryptionCipher();
         var outStream = new ByteArrayOutputStream();
         try (var cipherStream = cipher.wrapOutputStream(outStream)) {
             cipherStream.write(data.getBytes(StandardCharsets.UTF_8));
@@ -148,7 +202,7 @@ public class SharedKeyTest {
     }
 
     static String streamDecryptString(byte[] encrypted, SecretSharedKey secretSharedKey) throws IOException {
-        var cipher   = SharedKeyGenerator.makeAesGcmDecryptionCipher(secretSharedKey);
+        var cipher   = secretSharedKey.makeDecryptionCipher();
         var inStream = new ByteArrayInputStream(encrypted);
         var total    = ByteBuffer.allocate(encrypted.length); // Assume decrypted form can't be _longer_
         byte[] tmp   = new byte[8]; // short buf to test chunking
@@ -198,7 +252,7 @@ public class SharedKeyTest {
     }
 
     private static void doOutputStreamCipherDecrypt(SecretSharedKey myShared, byte[] encrypted) throws Exception {
-        var cipher = SharedKeyGenerator.makeAesGcmDecryptionCipher(myShared);
+        var cipher = myShared.makeDecryptionCipher();
         var outStream = new ByteArrayOutputStream();
         try (var cipherStream = cipher.wrapOutputStream(outStream)) {
             cipherStream.write(encrypted);

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
@@ -113,7 +113,7 @@ public class DecryptTool implements Tool {
             var privateKey   = ToolUtils.resolvePrivateKeyFromInvocation(invocation, sealedSharedKey.keyId(),
                                                                          !CliUtils.useStdIo(inputArg) && !CliUtils.useStdIo(outputArg));
             var secretShared = SharedKeyGenerator.fromSealedKey(sealedSharedKey, privateKey);
-            var cipher       = SharedKeyGenerator.makeAesGcmDecryptionCipher(secretShared);
+            var cipher       = secretShared.makeDecryptionCipher();
             boolean unZstd   = arguments.hasOption(ZSTD_DECOMPRESS_OPTION);
 
             try (var inStream  = CliUtils.inputStreamFromFileOrStream(inputArg, invocation.stdIn());

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/EncryptTool.java
@@ -87,7 +87,7 @@ public class EncryptTool implements Tool {
             var recipientPubKey = KeyUtils.fromBase58EncodedX25519PublicKey(CliUtils.optionOrThrow(arguments, RECIPIENT_PUBLIC_KEY_OPTION).strip());
             var keyId    = KeyId.ofString(CliUtils.optionOrThrow(arguments, KEY_ID_OPTION));
             var shared   = SharedKeyGenerator.generateForReceiverPublicKey(recipientPubKey, keyId);
-            var cipher   = SharedKeyGenerator.makeAesGcmEncryptionCipher(shared);
+            var cipher   = shared.makeEncryptionCipher();
             boolean zstd = arguments.hasOption(ZSTD_COMPRESS_OPTION);
 
             try (var inStream  = CliUtils.inputStreamFromFileOrStream(inputArg, invocation.stdIn());


### PR DESCRIPTION
@bjorncs please review
@tokle FYI

This is to get around the limitation where AES GCM can only produce a maximum of 64 GiB of ciphertext for a particular <key, IV> pair before its security properties break down. ChaCha20-Poly1305 does not have any practical limitations here.

ChaCha20-Poly1305 uses a 256-bit key whereas the shared key is 128 bits. A HKDF is used to internally expand the key material to 256 bits.

To let token based decryption be fully backwards compatible, introduce a token version 2. V1 tokens will be decrypted with AES-GCM 128, while V2 tokens use ChaCha20-Poly1305.

As a bonus, cryptographic operations will generally be _faster_ after this cipher change, as we use BouncyCastle ciphers and these do not use any native AES instructions. ChaCha20-Poly1305 is usually considerably faster when running without specialized hardware support. An ad-hoc experiment with a large ciphertext showed a near 70% performance increase over AES-GCM 128.
