### PR TITLE
Improve shared hosts resource tagging

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationId.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ApplicationId.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
  */
 public class ApplicationId implements Comparable<ApplicationId> {
 
-    static final Pattern namePattern = Pattern.compile("(?!\\.\\.)[a-zA-Z0-9_-]{1,256}");
+    static final Pattern namePattern = Pattern.compile("[a-zA-Z0-9_-]{1,256}");
 
     private static final ApplicationId global = new ApplicationId(TenantName.from("hosted-vespa"),
                                                                   ApplicationName.from("routing"),

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/ResourceTagger.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/aws/ResourceTagger.java
@@ -12,6 +12,9 @@ import java.util.Map;
  */
 public interface ResourceTagger {
 
+    ApplicationId INFRASTRUCTURE_APPLICATION = ApplicationId.from("hosted-vespa", "infrastructure", "default");
+
+
     /**
      * Returns number of tagged resources
      */

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/Node.java
@@ -66,6 +66,7 @@ public class Node {
     private final boolean down;
     private final Optional<TenantName> reservedTo;
     private final Optional<ApplicationId> exclusiveTo;
+    private final Optional<ClusterType> exclusiveToClusterType;
     private final Map<String, String> reports;
     private final List<Event> history;
     private final Set<String> ipAddresses;
@@ -83,7 +84,7 @@ public class Node {
                  long wantedRebootGeneration, int cost, int failCount, Optional<String> flavor, String clusterId,
                  ClusterType clusterType, String group, int index, boolean retired, boolean wantToRetire, boolean wantToDeprovision,
                  boolean wantToRebuild, boolean down, Optional<TenantName> reservedTo, Optional<ApplicationId> exclusiveTo,
-                 DockerImage wantedDockerImage, DockerImage currentDockerImage, Map<String, String> reports,
+                 DockerImage wantedDockerImage, DockerImage currentDockerImage, Optional<ClusterType> exclusiveToClusterType, Map<String, String> reports,
                  List<Event> history, Set<String> ipAddresses, Set<String> additionalIpAddresses,
                  Set<String> additionalHostnames, Optional<String> switchHostname,
                  Optional<String> modelName, Environment environment) {
@@ -118,6 +119,7 @@ public class Node {
         this.wantToRetire = wantToRetire;
         this.wantToDeprovision = wantToDeprovision;
         this.reservedTo = Objects.requireNonNull(reservedTo, "reservedTo must be non-null");
+        this.exclusiveToClusterType = Objects.requireNonNull(exclusiveToClusterType, "exclusiveToClusterType");
         this.exclusiveTo = Objects.requireNonNull(exclusiveTo, "exclusiveTo must be non-null");
         this.wantedDockerImage = Objects.requireNonNull(wantedDockerImage, "wantedDockerImage must be non-null");
         this.currentDockerImage = Objects.requireNonNull(currentDockerImage, "currentDockerImage must be non-null");
@@ -300,6 +302,9 @@ public class Node {
 
     /** The application this has been provisioned exclusively for, if any */
     public Optional<ApplicationId> exclusiveTo() { return exclusiveTo; }
+
+    /** The cluster type this has been provisioned exclusively for, if any */
+    public Optional<ClusterType> exclusiveToClusterType() { return exclusiveToClusterType; }
 
     /** Returns the reports of this node. Key is the report ID. Value is untyped, but is typically a JSON string */
     public Map<String, String> reports() {
@@ -487,6 +492,7 @@ public class Node {
         private boolean down = false;
         private Optional<TenantName> reservedTo = Optional.empty();
         private Optional<ApplicationId> exclusiveTo = Optional.empty();
+        private Optional<ClusterType> exclusiveToClusterType = Optional.empty();
         private Map<String, String> reports = Map.of();
         private List<Event> history = List.of();
         private Set<String> ipAddresses = Set.of();
@@ -535,6 +541,7 @@ public class Node {
             this.down = node.down;
             this.reservedTo = node.reservedTo;
             this.exclusiveTo = node.exclusiveTo;
+            this.exclusiveToClusterType = node.exclusiveToClusterType;
             this.reports = node.reports;
             this.history = node.history;
             this.ipAddresses = node.ipAddresses;
@@ -733,6 +740,11 @@ public class Node {
             return this;
         }
 
+        public Builder exclusiveToClusterType(ClusterType exclusiveToClusterType) {
+            this.exclusiveToClusterType = Optional.of(exclusiveToClusterType);
+            return this;
+        }
+
         public Builder history(List<Event> history) {
             this.history = history;
             return this;
@@ -779,7 +791,7 @@ public class Node {
                             suspendedSince, restartGeneration, wantedRestartGeneration, rebootGeneration,
                             wantedRebootGeneration, cost, failCount, flavor, clusterId, clusterType, group, index, retired,
                             wantToRetire, wantToDeprovision, wantToRebuild, down, reservedTo, exclusiveTo, wantedDockerImage,
-                            currentDockerImage, reports, history, ipAddresses, additionalIpAddresses,
+                            currentDockerImage, exclusiveToClusterType, reports, history, ipAddresses, additionalIpAddresses,
                             additionalHostnames, switchHostname, modelName, environment);
         }
 

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -517,6 +517,7 @@ public class NodeRepositoryNode {
                ", modelName='" + modelName + '\'' +
                ", reservedTo='" + reservedTo + '\'' +
                ", exclusiveTo='" + exclusiveTo + '\'' +
+               ", exclusiveToClusterType='" + exclusiveToClusterType + '\'' +
                ", switchHostname='" + switchHostname + '\'' +
                ", cloudAccount='" + cloudAccount + '\'' +
                 ", wireguardPubKey='" + wireguardPubKey + '\'' +

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/noderepository/NodeRepositoryNode.java
@@ -105,6 +105,8 @@ public class NodeRepositoryNode {
     private String reservedTo;
     @JsonProperty("exclusiveTo")
     private String exclusiveTo;
+    @JsonProperty("exclusiveToClusterType")
+    private String exclusiveToClusterType;
     @JsonProperty("switchHostname")
     private String switchHostname;
     @JsonProperty("cloudAccount")
@@ -433,6 +435,10 @@ public class NodeRepositoryNode {
     public String getExclusiveTo() { return exclusiveTo; }
 
     public void setExclusiveTo(String exclusiveTo) { this.exclusiveTo = exclusiveTo; }
+
+    public String getExclusiveToClusterType() { return exclusiveToClusterType; }
+
+    public void setExclusiveToClusterType(String exclusiveToClusterType) { this.exclusiveToClusterType = exclusiveToClusterType; }
 
     public String getSwitchHostname() {
         return switchHostname;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceTagMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/ResourceTagMaintainerTest.java
@@ -16,7 +16,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
-import static com.yahoo.vespa.hosted.controller.maintenance.ResourceTagMaintainer.SHARED_HOST_APPLICATION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
@@ -37,7 +36,8 @@ public class ResourceTagMaintainerTest {
         assertEquals(2, mockResourceTagger.getValues().size());
         Map<HostName, ApplicationId> applicationForHost = mockResourceTagger.getValues().get(ZoneId.from("prod.region-2"));
         assertEquals(ApplicationId.from("t1", "a1", "i1"), applicationForHost.get(HostName.of("parentHostA.prod.region-2")));
-        assertEquals(SHARED_HOST_APPLICATION, applicationForHost.get(HostName.of("parentHostB.prod.region-2")));
+        assertEquals(ApplicationId.from("hosted-vespa", "shared-host", "default"), applicationForHost.get(HostName.of("parentHostB.prod.region-2")));
+        assertEquals(ApplicationId.from("hosted-vespa", "shared-host", "admin"), applicationForHost.get(HostName.of("parentHostC.prod.region-2")));
     }
 
     private void setUpZones() {
@@ -67,7 +67,13 @@ public class ResourceTagMaintainerTest {
                         .type(NodeType.host)
                         .owner(ApplicationId.from(SystemApplication.TENANT.value(), "tenant-host", "default"))
                         .build();
-        tester.configServer().nodeRepository().putNodes(zone, List.of(hostA, nodeA, hostB));
+        var hostC = Node.builder()
+                .hostname(HostName.of("parentHostC." + zone.value()))
+                .type(NodeType.host)
+                .exclusiveToClusterType(Node.ClusterType.admin)
+                .owner(ApplicationId.from(SystemApplication.TENANT.value(), "tenant-host", "default"))
+                .build();
+        tester.configServer().nodeRepository().putNodes(zone, List.of(hostA, nodeA, hostB, hostC));
     }
 
 }


### PR DESCRIPTION
Must be merged with internal PR

Hosts that were exclusive to a cluster type will now we tagged with `hosted-vespa.shared-host.<cluster-type>` (previously `hosted-vespa.intrastructure.default`).