### PR TITLE
move vespa-logctl invocation

### DIFF
--- a/client/go/script-utils/configserver/env.go
+++ b/client/go/script-utils/configserver/env.go
@@ -28,5 +28,4 @@ func exportSettings(vespaHome string) {
 	os.Setenv(envvars.STANDALONE_JDISC_DEPLOYMENT_PROFILE, "configserver")
 	os.Setenv(envvars.MALLOC_ARENA_MAX, "1")
 	util.OptionallyReduceTimerFrequency()
-	util.TuneLogging(SERVICE_NAME, "com.google.api.client.http.HttpTransport", "config=off")
 }

--- a/client/go/script-utils/configserver/start.go
+++ b/client/go/script-utils/configserver/start.go
@@ -46,6 +46,7 @@ func JustStartConfigserver() int {
 	vespaHome := commonPreChecks()
 	vespa.CheckCorrectUser()
 	util.TuneResourceLimits()
+	util.TuneLogging(SERVICE_NAME, "com.google.api.client.http.HttpTransport", "config=off")
 	exportSettings(vespaHome)
 	removeStaleZkLocks(vespaHome)
 	c := jvm.NewStandaloneContainer(SERVICE_NAME)


### PR DESCRIPTION
* this needs to be done after we have switched to the correct user, otherwise we end up with a vespa.log file owned by root and startup fails when we try to chown it later.

@hmusum or @baldersheim please review and merge
