### PR TITLE
Reduce vespa-zkctl log spam

### DIFF
--- a/zookeeper-command-line-client/src/main/resources/log4j-vespa.properties
+++ b/zookeeper-command-line-client/src/main/resources/log4j-vespa.properties
@@ -1,7 +1,0 @@
-log4j.rootLogger=debug,console
-
-# console is set to be a ConsoleAppender using a PatternLayout
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=[%-5p] %m%n
-log4j.appender.console.threshold=warn

--- a/zookeeper-command-line-client/src/main/resources/logback-vespa.xml
+++ b/zookeeper-command-line-client/src/main/resources/logback-vespa.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>[%-5p] %m%n</pattern>
+    </encoder>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>warn</level>
+    </filter>
+  </appender>
+  <root level="debug">
+    <appender-ref ref="console"/>
+  </root>
+</configuration>

--- a/zookeeper-command-line-client/src/main/sh/vespa-zkcli
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkcli
@@ -78,5 +78,5 @@ export ROOT
 # END environment bootstrap section
 
 java -cp ${VESPA_HOME}/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
-     -Dlog4j.configuration="log4j-vespa.properties" -Xms32m -Xmx512m \
+     -Dlogback.configurationFile="logback-vespa.xml" -Xms32m -Xmx512m \
      com.yahoo.vespa.zookeeper.cli.Main "$@"

--- a/zookeeper-command-line-client/src/main/sh/vespa-zkflw
+++ b/zookeeper-command-line-client/src/main/sh/vespa-zkflw
@@ -78,5 +78,5 @@ export ROOT
 # END environment bootstrap section
 
 java -cp ${VESPA_HOME}/lib/jars/zookeeper-command-line-client-jar-with-dependencies.jar \
-     -Dlog4j.configuration="log4j-vespa.properties" -Xms32m -Xmx512m \
+     -Dlogback.configurationFile="logback-vespa.xml" -Xms32m -Xmx512m \
      com.yahoo.vespa.zookeeper.cli.FourLetterWordMain "$@"


### PR DESCRIPTION
In #20594 we switched to log4j-over-slf4j to get rid of log4j. This changed the
underlying logging implementation to Logback, which must be configured in a
different way.

@hmusum