### PR TITLE
Avoid duplicate reindexing notification

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ApplicationReindexing.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ApplicationReindexing.java
@@ -54,8 +54,6 @@ public class ApplicationReindexing {
 
     public static class Cluster {
 
-        public static final ApplicationReindexing.Cluster EMPTY = new ApplicationReindexing.Cluster(Map.of(), Map.of());
-
         private final Map<String, Long> pending;
         private final Map<String, Status> ready;
 


### PR DESCRIPTION
`clusterMetrics` may contain multiple objects per cluster, e.g.
```
"clusters": [
    {
        "clusterId": "music",
        "clusterType": "admin",
        "metrics": {
            "memoryUtil": 0.0155702581008,
            "memoryFeedBlockLimit": 0.8,
            "diskUtil": 0.0010475161206,
            "diskFeedBlockLimit": 0.75
        }
    },
    {
        "clusterId": "music",
        "clusterType": "content",
        "metrics": {
            "documentCount": 253813
        }
    }
]
```
so iterate over `applicatonReindexing` clusters separately to avoid duplicates.