### PR TITLE
Don't attempt to lookup class in internal bundles if a bundle was exp…

### DIFF
--- a/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
+++ b/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
@@ -62,6 +62,11 @@ public class OsgiImpl implements Osgi {
         if (bundle != null) {
             return resolveFromBundle(spec, bundle);
         } else {
+            if (jdiscOsgi.isFelixFramework() && ! spec.bundle.equals(spec.classId)) {
+                // Bundle was explicitly specified, but not found.
+                throw new IllegalArgumentException("Could not find bundle " + spec.bundle +
+                        ". " + bundleResolutionErrorMessage(spec.bundle));
+            }
             return resolveFromThisBundleOrSystemBundle(spec);
         }
     }


### PR DESCRIPTION
…licitly specified.

This is the part of #25443 that skips class lookup in internal bundles. After #25465, it should at least get further in the build pipeline.

