### PR TITLE
Revert "Don't attempt to lookup class in internal bundles if a bundle was exp…"

### DIFF
--- a/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
+++ b/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
@@ -62,11 +62,6 @@ public class OsgiImpl implements Osgi {
         if (bundle != null) {
             return resolveFromBundle(spec, bundle);
         } else {
-            if (jdiscOsgi.isFelixFramework() && ! spec.bundle.equals(spec.classId)) {
-                // Bundle was explicitly specified, but not found.
-                throw new IllegalArgumentException("Could not find bundle " + spec.bundle +
-                        ". " + bundleResolutionErrorMessage(spec.bundle));
-            }
             return resolveFromThisBundleOrSystemBundle(spec);
         }
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#25467

Config server does not start https://cd.screwdriver.cd/pipelines/6386/builds/840635/steps/verify-test-image :
```
06:08:00 [06:08:00.046] [2023-01-10 06:07:35.857] ERROR   configserver     Container.com.yahoo.jdisc.core.StandaloneMain	JDisc exiting: Throwable caught: \nexception=\njava.lang.IllegalArgumentException: Could not find bundle simplemetrics. Installed application bundles: [athenz-identity-provider-service version:8.109.1, config-model-fat version:8.109.1, configserver version:8.109.1, flags version:8.109.1, zookeeper-server version:8.109.1, http-client version:8.109.1, node-repository version:8.109.1, application-model version:8.109.1, orchestrator version:8.109.1, service-monitor version:8.109.1, configserver-flags version:8.109.1]\n\tat com.yahoo.osgi.OsgiImpl.resolveClass(OsgiImpl.java:68)\n\tat com.yahoo.container.di.Container.addNodes(Container.java:229)\n\tat com.yahoo.container.di.Container.createComponentGraph(Container.java:218)\n\tat com.yahoo.container.di.Container.waitForNewConfigGenAndCreateGraph(Container.java:135)\n\tat com.yahoo.container.di.Container.waitForNextGraphGeneration(Container.java:75)\n\tat com.yahoo.container.core.config.HandlersConfigurerDi.waitForNextGraphGeneration(HandlersConfigurerDi.java:155)\n\tat com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:78)\n\tat com.yahoo.container.core.config.HandlersConfigurerDi.<init>(HandlersConfigurerDi.java:64)\n\tat com.yahoo.container.jdisc.ConfiguredApplication.createConfigurer(ConfiguredApplication.java:407)\n\tat com.yahoo.container.jdisc.ConfiguredApplication.start(ConfiguredApplication.java:166)\n\tat com.yahoo.container.standalone.StandaloneContainerApplication.start(StandaloneContainerApplication.java:158)\n\tat com.yahoo.jdisc.core.ApplicationLoader.start(ApplicationLoader.java:157)\n\tat com.yahoo.jdisc.core.StandaloneMain.run(StandaloneMain.java:41)\n\tat com.yahoo.jdisc.core.StandaloneMain.main(StandaloneMain.java:33)\n
```