### PR TITLE
Add units to the global container metrics enum.

### DIFF
--- a/container-core/src/main/java/com/yahoo/metrics/ContainerMetrics.java
+++ b/container-core/src/main/java/com/yahoo/metrics/ContainerMetrics.java
@@ -5,18 +5,20 @@ package com.yahoo.metrics;
  */
 public enum ContainerMetrics {
 
-    HTTP_STATUS_1XX("http.status.1xx", "Number of responses with a 1xx status"),
-    HTTP_STATUS_2XX("http.status.2xx", "Number of responses with a 2xx status"),
-    HTTP_STATUS_3XX("http.status.3xx", "Number of responses with a 3xx status"),
-    HTTP_STATUS_4XX("http.status.4xx", "Number of responses with a 4xx status"),
-    HTTP_STATUS_5XX("http.status.5xx", "Number of responses with a 5xx status"),
-    JDISC_GC_MS("jdisc.gc.ms", "Time [ms] spent in garbage collection");
+    HTTP_STATUS_1XX("http.status.1xx", Unit.RESPONSE, "Number of responses with a 1xx status"),
+    HTTP_STATUS_2XX("http.status.2xx", Unit.RESPONSE, "Number of responses with a 2xx status"),
+    HTTP_STATUS_3XX("http.status.3xx", Unit.RESPONSE, "Number of responses with a 3xx status"),
+    HTTP_STATUS_4XX("http.status.4xx", Unit.RESPONSE, "Number of responses with a 4xx status"),
+    HTTP_STATUS_5XX("http.status.5xx", Unit.RESPONSE, "Number of responses with a 5xx status"),
+    JDISC_GC_MS("jdisc.gc.ms", Unit.MILLISECOND, "Time spent in garbage collection");
 
     private final String name;
+    private final Unit unit;
     private final String description;
 
-    ContainerMetrics(String name, String description) {
+    ContainerMetrics(String name, Unit unit, String description) {
         this.name = name;
+        this.unit = unit;
         this.description = description;
     }
 
@@ -25,7 +27,7 @@ public enum ContainerMetrics {
     }
 
     public String description() {
-        return description;
+        return description + " (unit: " + unit.shortName() + ")";
     }
 
     private String withSuffix(Suffix suffix) {

--- a/container-core/src/main/java/com/yahoo/metrics/Unit.java
+++ b/container-core/src/main/java/com/yahoo/metrics/Unit.java
@@ -1,0 +1,82 @@
+package com.yahoo.metrics;
+
+/**
+ * @author gjoranv
+ */
+public enum Unit {
+
+    BYTE(BaseUnit.BYTE),
+    DOCUMENT(BaseUnit.DOCUMENT),
+    DOCUMENT_PER_SECOND(BaseUnit.DOCUMENT, BaseUnit.SECOND),
+    FRACTION(BaseUnit.FRACTION),
+    HIT(BaseUnit.HIT),
+    HIT_PER_QUERY(BaseUnit.HIT, BaseUnit.QUERY),
+    MILLISECOND(BaseUnit.MILLISECOND),
+    OPERATION_PER_SECOND(BaseUnit.OPERATION, BaseUnit.SECOND),
+    QUERY(BaseUnit.QUERY),
+    QUERY_PER_SECOND(BaseUnit.QUERY, BaseUnit.SECOND),
+    RESPONSE(BaseUnit.RESPONSE),
+    RESPONSE_PER_SECOND(BaseUnit.RESPONSE, BaseUnit.SECOND),
+    SECOND(BaseUnit.SECOND),
+    THREAD(BaseUnit.THREAD);
+
+
+    private final BaseUnit unit;
+    private final BaseUnit perUnit;
+
+    Unit(BaseUnit unit) {
+        this(unit, null);
+    }
+
+    Unit(BaseUnit unit, BaseUnit perUnit) {
+        this.unit = unit;
+        this.perUnit = perUnit;
+    }
+
+    public String fullName() {
+        return perUnit == null ?
+                unit.fullName() :
+                unit.fullName() + "/" + perUnit.fullName();
+    }
+
+    public String shortName() {
+        return perUnit == null ?
+                unit.shortName :
+                unit.shortName + "/" + perUnit.shortName;
+    }
+
+    public enum BaseUnit {
+
+        BYTE("byte"),
+        DOCUMENT("document"),
+        FRACTION("fraction"),
+        HIT("hit"),
+        MILLISECOND("millisecond", "ms"),
+        OPERATION("operation"),
+        QUERY("query"),
+        RESPONSE("response"),
+        SECOND("second", "s"),
+        THREAD("thread");
+
+        private final String fullName;
+        private final String shortName;
+
+        BaseUnit(String fullName) {
+            this(fullName, fullName);
+        }
+
+        BaseUnit(String fullName, String shortName) {
+            this.fullName = fullName;
+            this.shortName = shortName;
+        }
+
+        public String fullName() {
+            return fullName;
+        }
+
+        public String shortName() {
+            return shortName;
+        }
+
+    }
+}


### PR DESCRIPTION
The units defined so far are base on https://github.com/DataDog/integrations-extras/blob/master/vespa/metadata.csv

A couple of good things with this:
1. We avoid using almost the same unit, e.g. "document" vs "documents"
2. The unit is automatically added to the description.

Note that it's usually with the 'rate' suffix/aggregator that we use "per second", so most metrics should be declared with unit 'document', 'operation' etc.
