### PR TITLE
Revert "Skip fallback class resolution for explicit bundle 2 [run-systemtest]"

### DIFF
--- a/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
+++ b/container-core/src/main/java/com/yahoo/osgi/OsgiImpl.java
@@ -62,11 +62,6 @@ public class OsgiImpl implements Osgi {
         if (bundle != null) {
             return resolveFromBundle(spec, bundle);
         } else {
-            if (jdiscOsgi.isFelixFramework() && ! spec.bundle.equals(spec.classId)) {
-                // Bundle was explicitly specified, but not found.
-                throw new IllegalArgumentException("Could not find bundle " + spec.bundle + " to create a component with class '"
-                                                     + spec.classId.getName() + ". " + bundleResolutionErrorMessage(spec.bundle));
-            }
             return resolveFromThisBundleOrSystemBundle(spec);
         }
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#25475

Seems to break host-admin:

[2023-01-10 17:07:37.220] ERROR   node-admin       Container.com.yahoo.jdisc.core.StandaloneMain
	JDisc exiting: Throwable caught:
	exception=
	java.lang.IllegalArgumentException: Could not find bundle container-core to create a component with class 'com.yahoo.container.handler.LogHandler. Installed application bundles: [host-admin version:8.109.15, node-admin version:8.109.15, application-model version:8.109.15, gcp-secrets version:8.109.15, flags version:8.109.15, yahoo-configdefinitions version:8.109.15, vespa-ckms-provider version:8.109.15]
