### PR TITLE
Revert "Read tags from deployment spec in package"

### DIFF
--- a/config-application-package/src/main/java/com/yahoo/config/application/XmlPreProcessor.java
+++ b/config-application-package/src/main/java/com/yahoo/config/application/XmlPreProcessor.java
@@ -43,6 +43,15 @@ public class XmlPreProcessor {
     private final Tags tags;
     private final List<PreProcessor> chain;
 
+    // TODO: Remove after November 2022
+    public XmlPreProcessor(File applicationDir,
+                           File xmlInput,
+                           InstanceName instance,
+                           Environment environment,
+                           RegionName region) throws IOException {
+        this(applicationDir, new FileReader(xmlInput), instance, environment, region, Tags.empty());
+    }
+
     public XmlPreProcessor(File applicationDir,
                            File xmlInput,
                            InstanceName instance,

--- a/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
+++ b/config-application-package/src/main/java/com/yahoo/config/model/application/provider/FilesApplicationPackage.java
@@ -11,10 +11,7 @@ import com.yahoo.config.application.api.ApplicationMetaData;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.ComponentInfo;
 import com.yahoo.config.application.api.DeployLogger;
-import com.yahoo.config.application.api.DeploymentInstanceSpec;
-import com.yahoo.config.application.api.DeploymentSpec;
 import com.yahoo.config.application.api.UnparsedConfigDefinition;
-import com.yahoo.config.application.api.xml.DeploymentSpecXmlReader;
 import com.yahoo.config.codegen.DefParser;
 import com.yahoo.config.model.application.AbstractApplicationPackage;
 import com.yahoo.config.provision.ApplicationId;
@@ -585,16 +582,12 @@ public class FilesApplicationPackage extends AbstractApplicationPackage {
     private void preprocessXML(File destination, File inputXml, Zone zone) throws IOException {
         if ( ! inputXml.exists()) return;
         try {
-            InstanceName instance = metaData.getApplicationId().instance();
             Document document = new XmlPreProcessor(appDir,
                                                     inputXml,
-                                                    instance,
+                                                    metaData.getApplicationId().instance(),
                                                     zone.environment(),
                                                     zone.region(),
-                                                    getDeployment().map(new DeploymentSpecXmlReader(false)::read)
-                                                                   .flatMap(spec -> spec.instance(instance))
-                                                                   .map(DeploymentInstanceSpec::tags)
-                                                                   .orElse(Tags.empty()))
+                                                    metaData.getTags())
                     .run();
 
             try (FileOutputStream outputStream = new FileOutputStream(destination)) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#25492

Breaks build (basic system test):

java.lang.NoClassDefFoundError: com/yahoo/config/application/api/xml/DeploymentSpecXmlReader