### PR TITLE
Expose SameElement query terms to ranking.

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -99,9 +99,9 @@ vespalib::string make_simple_stack_dump(const vespalib::string &field, const ves
 vespalib::string make_same_element_stack_dump(const vespalib::string &a1_term, const vespalib::string &f1_term)
 {
     QueryBuilder<ProtonNodeTypes> builder;
-    builder.addSameElement(2, "my");
-    builder.addStringTerm(a1_term, "a1", 1, search::query::Weight(1));
-    builder.addStringTerm(f1_term, "f1", 2, search::query::Weight(1));
+    builder.addSameElement(2, "my", 0, Weight(1));
+    builder.addStringTerm(a1_term, "a1", 1, Weight(1));
+    builder.addStringTerm(f1_term, "f1", 2, Weight(1));
     return StackDumpCreator::create(*builder.build());
 }
 

--- a/searchcore/src/tests/proton/matching/querynodes_test.cpp
+++ b/searchcore/src/tests/proton/matching/querynodes_test.cpp
@@ -214,7 +214,7 @@ public:
 
 using QB = QueryBuilder<ProtonNodeTypes>;
 struct Phrase { void addToBuilder(QB& b) { b.addPhrase(2, view, id, weight); }};
-struct SameElement { void addToBuilder(QB& b) { b.addSameElement(2, view); }};
+struct SameElement { void addToBuilder(QB& b) { b.addSameElement(2, view, id, weight); }};
 struct Near   { void addToBuilder(QB& b) { b.addNear(2, distance); } };
 struct ONear  { void addToBuilder(QB& b) { b.addONear(2, distance); } };
 struct Or     { void addToBuilder(QB& b) { b.addOr(2); } };
@@ -301,7 +301,7 @@ SearchIterator *getParent<SameElement>(SearchIterator *a, SearchIterator *b) {
     // we only check how many term/field combinations
     // are below the SameElement parent:
     // two terms searching in one index field
-    return new SameElementSearch(nullptr, std::move(children), true);
+    return new SameElementSearch(tmd, nullptr, std::move(children), true);
 }
 
 template <>

--- a/searchcore/src/tests/proton/matching/resolveviewvisitor_test.cpp
+++ b/searchcore/src/tests/proton/matching/resolveviewvisitor_test.cpp
@@ -136,18 +136,22 @@ TEST_F("require that equiv nodes resolve view from children", Fixture) {
     EXPECT_EQUAL(field2, base.field(1).field_name);
 }
 
-TEST_F("require that view is resolved for SameElement children", Fixture) {
+TEST_F("require that view is resolved for SameElement and its children", Fixture) {
     ViewResolver resolver;
     resolver.add(view, field1);
+    resolver.add("view2", field2);
 
     QueryBuilder<ProtonNodeTypes> builder;
-    builder.addSameElement(2, "");
+    ProtonSameElement &same_elem = builder.addSameElement(2, "view2", 13, weight);
     ProtonStringTerm &my_term = builder.addStringTerm(term, view, 42, weight);
     builder.addStringTerm(term, field2, 43, weight);
     Node::UP node = builder.build();
 
     ResolveViewVisitor visitor(resolver, f.index_environment);
     node->accept(visitor);
+
+    ASSERT_EQUAL(1u, same_elem.numFields());
+    EXPECT_EQUAL(field2, same_elem.field(0).field_name);
 
     ASSERT_EQUAL(1u, my_term.numFields());
     EXPECT_EQUAL(field1, my_term.field(0).field_name);

--- a/searchcore/src/tests/proton/matching/termdataextractor_test.cpp
+++ b/searchcore/src/tests/proton/matching/termdataextractor_test.cpp
@@ -130,11 +130,11 @@ TEST("requireThatNegativeTermsAreSkipped") {
     EXPECT_EQUAL(id[1], term_data[1]->getUniqueId());
 }
 
-TEST("requireThatSameElementIsSkipped")
+TEST("requireThatSameElementIsExtractedAsOneTerm")
 {
     QueryBuilder<ProtonNodeTypes> query_builder;
     query_builder.addAnd(2);
-    query_builder.addSameElement(2, field);
+    query_builder.addSameElement(2, field, id[3], Weight(7));
     query_builder.addStringTerm("term1", field, id[0], Weight(1));
     query_builder.addStringTerm("term2", field, id[1], Weight(1));
     query_builder.addStringTerm("term3", field, id[2], Weight(1));
@@ -142,9 +142,9 @@ TEST("requireThatSameElementIsSkipped")
 
     vector<const ITermData *> term_data;
     TermDataExtractor::extractTerms(*node, term_data);
-    EXPECT_EQUAL(1u, term_data.size());
-    ASSERT_TRUE(term_data.size() >= 1);
-    EXPECT_EQUAL(id[2], term_data[0]->getUniqueId());
+    ASSERT_EQUAL(2u, term_data.size());
+    EXPECT_EQUAL(id[3], term_data[0]->getUniqueId());
+    EXPECT_EQUAL(id[2], term_data[1]->getUniqueId());
 }
 
 }  // namespace

--- a/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
+++ b/searchcore/src/tests/proton/matching/unpacking_iterators_optimizer/unpacking_iterators_optimizer_test.cpp
@@ -99,7 +99,7 @@ void add_phrase(QueryBuilder<ProtonNodeTypes> &builder) {
 }
 
 void add_same_element(QueryBuilder<ProtonNodeTypes> &builder) {
-    builder.addSameElement(2, view);
+    builder.addSameElement(2, view, id, weight);
     {
         builder.addStringTerm("x", view, id, weight);
         builder.addStringTerm("y", view, id, weight);

--- a/searchcore/src/vespa/searchcore/proton/matching/docsum_matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/docsum_matcher.cpp
@@ -59,7 +59,8 @@ template<typename T>
 const T *as(const Blueprint &bp) { return dynamic_cast<const T *>(&bp); }
 
 void find_matching_elements(const std::vector<uint32_t> &docs, const SameElementBlueprint &same_element, MatchingElements &result) {
-    auto search = same_element.create_same_element_search(false);
+    search::fef::TermFieldMatchData dummy_tfmd;
+    auto search = same_element.create_same_element_search(dummy_tfmd, false);
     search->initRange(docs.front(), docs.back()+1);
     std::vector<uint32_t> matches;
     for (uint32_t i = 0; i < docs.size(); ++i) {

--- a/searchcore/src/vespa/searchcore/proton/matching/matchdatareservevisitor.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/matchdatareservevisitor.h
@@ -27,7 +27,6 @@ public:
         }
         n.allocateTerms(_mdl);
     }
-    void visit(ProtonNodeTypes::SameElement &) override { }
 
     MatchDataReserveVisitor(search::fef::MatchDataLayout &mdl) : _mdl(mdl) {}
 };

--- a/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/querynodes.h
@@ -114,12 +114,15 @@ using ProtonONear =       search::query::SimpleONear;
 using ProtonOr =          search::query::SimpleOr;
 using ProtonRank =        search::query::SimpleRank;
 using ProtonWeakAnd =     search::query::SimpleWeakAnd;
-using ProtonSameElement = search::query::SimpleSameElement;
 using ProtonTrue =        search::query::SimpleTrue;
 using ProtonFalse =       search::query::SimpleFalse;
 
 struct ProtonEquiv final : public ProtonTermBase<search::query::Equiv> {
     search::fef::MatchDataLayout children_mdl;
+    using ProtonTermBase::ProtonTermBase;
+};
+
+struct ProtonSameElement final : public ProtonTermBase<search::query::SameElement> {
     using ProtonTermBase::ProtonTermBase;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/matching/resolveviewvisitor.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/resolveviewvisitor.h
@@ -28,6 +28,11 @@ public:
         visitChildren(n);
         n.resolveFromChildren(n.getChildren());
     }
+
+    void visit(ProtonNodeTypes::SameElement &n) override {
+        visitChildren(n);
+        visitTerm(n);
+    }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.cpp
@@ -75,10 +75,10 @@ public:
 } // namespace proton::matching::<unnamed>
 
 SameElementBuilder::SameElementBuilder(const search::queryeval::IRequestContext &requestContext, ISearchContext &context,
-                                       const vespalib::string &struct_field_name, bool expensive)
+                                       const search::queryeval::FieldSpec &field, bool expensive)
     : _requestContext(requestContext),
       _context(context),
-      _result(std::make_unique<SameElementBlueprint>(struct_field_name, expensive))
+      _result(std::make_unique<SameElementBlueprint>(field, expensive))
 {
 }
 
@@ -92,7 +92,7 @@ SameElementBuilder::add_child(search::query::Node &node)
 Blueprint::UP
 SameElementBuilder::build()
 {
-    if (!_result || _result->terms().empty()) {
+    if (_result->terms().empty()) {
         return std::make_unique<EmptyBlueprint>();
     }
     return std::move(_result);

--- a/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.h
@@ -7,6 +7,8 @@
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/same_element_blueprint.h>
 
+namespace search::queryeval { class FieldSpec; }
+
 namespace proton::matching {
 
 class SameElementBuilder
@@ -17,7 +19,7 @@ private:
     std::unique_ptr<search::queryeval::SameElementBlueprint> _result;
 public:
     SameElementBuilder(const search::queryeval::IRequestContext &requestContext, ISearchContext &context,
-                       const vespalib::string &struct_field_name, bool expensive);
+                       const search::queryeval::FieldSpec &field, bool expensive);
     void add_child(search::query::Node &node);
     search::queryeval::Blueprint::UP build();
 };

--- a/searchcore/src/vespa/searchcore/proton/matching/termdataextractor.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/termdataextractor.cpp
@@ -39,7 +39,6 @@ public:
         _term_data.push_back(&n);
     }
 
-    virtual void visit(ProtonNodeTypes::SameElement &) override {}
 };
 }  // namespace
 

--- a/searchlib/src/tests/features/prod_features.cpp
+++ b/searchlib/src/tests/features/prod_features.cpp
@@ -1717,6 +1717,17 @@ Test::testMatches()
         EXPECT_TRUE(ft.execute(RankResult().addScore("matches(foo,2)", 0)));
         EXPECT_TRUE(ft.execute(RankResult().addScore("matches(foo,3)", 0)));
     }
+    { // Test executor for virtual fields
+        FtFeatureTest ft(_factory, StringList().add("matches(foo)"));
+        ft.getIndexEnv().getBuilder().addField(FieldType::VIRTUAL, CollectionType::ARRAY, "foo");
+        ASSERT_TRUE(ft.getQueryEnv().getBuilder().add_virtual_node("foo") != nullptr); // query term 0 hits in foo
+        ASSERT_TRUE(ft.setup());
+
+        auto mdb = ft.createMatchDataBuilder();
+        mdb->setWeight("foo", 0, 100);
+        mdb->apply(1);
+        EXPECT_TRUE(ft.execute(RankResult().addScore("matches(foo)", 1)));
+    }
 }
 
 bool

--- a/searchlib/src/tests/query/customtypevisitor_test.cpp
+++ b/searchlib/src/tests/query/customtypevisitor_test.cpp
@@ -27,7 +27,7 @@ struct MyNear : Near { MyNear() : Near(1) {} };
 struct MyONear : ONear { MyONear() : ONear(1) {} };
 struct MyOr : Or {};
 struct MyPhrase : Phrase { MyPhrase() : Phrase("view", 0, Weight(42)) {} };
-struct MySameElement : SameElement { MySameElement() : SameElement("view") {} };
+struct MySameElement : SameElement { MySameElement() : SameElement("view", 0, Weight(42)) {} };
 struct MyRank : Rank {};
 struct MyNumberTerm : InitTerm<NumberTerm>  {};
 struct MyLocationTerm : InitTerm<LocationTerm> {};

--- a/searchlib/src/tests/query/query_visitor_test.cpp
+++ b/searchlib/src/tests/query/query_visitor_test.cpp
@@ -68,7 +68,7 @@ TEST("requireThatAllNodesCanBeVisited") {
     checkVisit<ONear>(new SimpleONear(0));
     checkVisit<Or>(new SimpleOr);
     checkVisit<Phrase>(new SimplePhrase("field", 0, Weight(42)));
-    checkVisit<SameElement>(new SimpleSameElement("field"));
+    checkVisit<SameElement>(new SimpleSameElement("field", 0, Weight(42)));
     checkVisit<WeightedSetTerm>(new SimpleWeightedSetTerm(0, "field", 0, Weight(42)));
     checkVisit<DotProduct>(new SimpleDotProduct(0, "field", 0, Weight(42)));
     checkVisit<WandTerm>(new SimpleWandTerm(0, "field", 0, Weight(42), 57, 67, 77.7));

--- a/searchlib/src/tests/query/querybuilder_test.cpp
+++ b/searchlib/src/tests/query/querybuilder_test.cpp
@@ -105,7 +105,7 @@ Node::UP createQueryTree() {
             n.addTerm(str[2], weight[2]);
         }
         builder.addRegExpTerm(str[5], view[5], id[5], weight[5]);
-        builder.addSameElement(3, view[4]);
+        builder.addSameElement(3, view[4], id[4], weight[4]);
         {
             builder.addStringTerm(str[4], view[4], id[4], weight[5]);
             builder.addStringTerm(str[5], view[5], id[5], weight[6]);
@@ -381,7 +381,7 @@ struct MyONear : ONear { MyONear(size_t dist) : ONear(dist) {} };
 struct MyWeakAnd : WeakAnd { MyWeakAnd(uint32_t minHits, const vespalib::string & v) : WeakAnd(minHits, v) {} };
 struct MyOr : Or {};
 struct MyPhrase : Phrase { MyPhrase(const string &f, int32_t i, Weight w) : Phrase(f, i, w) {}};
-struct MySameElement : SameElement { MySameElement(const string &f) : SameElement(f) {}};
+struct MySameElement : SameElement { MySameElement(const string &f, int32_t i, Weight w) : SameElement(f, i, w) {}};
 
 struct MyWeightedSetTerm : WeightedSetTerm {
     MyWeightedSetTerm(uint32_t n, const string &f, int32_t i, Weight w) : WeightedSetTerm(n, f, i, w) {}

--- a/searchlib/src/tests/query/streaming_query_test.cpp
+++ b/searchlib/src/tests/query/streaming_query_test.cpp
@@ -734,7 +734,7 @@ namespace {
 }
 TEST("testSameElementEvaluate") {
     QueryBuilder<SimpleQueryNodeTypes> builder;
-    builder.addSameElement(3, "field");
+    builder.addSameElement(3, "field", 0, Weight(0));
     {
         builder.addStringTerm("a", "f1", 0, Weight(0));
         builder.addStringTerm("b", "f2", 1, Weight(0));

--- a/searchlib/src/tests/query/templatetermvisitor_test.cpp
+++ b/searchlib/src/tests/query/templatetermvisitor_test.cpp
@@ -71,12 +71,12 @@ void Test::requireThatAllTermsCanBeVisited() {
     EXPECT_TRUE(checkVisit<SimplePredicateQuery>());
     EXPECT_TRUE(checkVisit<SimpleRegExpTerm>());
     EXPECT_TRUE(checkVisit(new SimplePhrase("field", 0, Weight(0))));
+    EXPECT_TRUE(checkVisit(new SimpleSameElement("foo", 0, Weight(0))));
     EXPECT_TRUE(!checkVisit(new SimpleAnd));
     EXPECT_TRUE(!checkVisit(new SimpleAndNot));
     EXPECT_TRUE(!checkVisit(new SimpleEquiv(17, Weight(100))));
     EXPECT_TRUE(!checkVisit(new SimpleNear(2)));
     EXPECT_TRUE(!checkVisit(new SimpleONear(2)));
-    EXPECT_TRUE(!checkVisit(new SimpleSameElement("foo")));
     EXPECT_TRUE(!checkVisit(new SimpleOr));
     EXPECT_TRUE(!checkVisit(new SimpleRank));
 }
@@ -84,4 +84,3 @@ void Test::requireThatAllTermsCanBeVisited() {
 }  // namespace
 
 TEST_APPHOOK(Test);
-#include <vespa/vespalib/testkit/testapp.h>

--- a/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
+++ b/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
@@ -306,8 +306,9 @@ struct ParallelWeakAndAdapter {
 
 // enable Make-ing same element
 struct SameElementAdapter {
+    FieldSpec field;
     SameElementBlueprint blueprint;
-    SameElementAdapter() : blueprint("foo", false) {}
+    SameElementAdapter() : field("foo", 5, 11), blueprint(field, false) {}
     void addChild(std::unique_ptr<Blueprint> child) {
         auto child_field = blueprint.getNextChildField("foo", 3);
         auto term = std::make_unique<LeafProxy>(child_field, std::move(child));

--- a/searchlib/src/vespa/searchlib/fef/parameterdescriptions.h
+++ b/searchlib/src/vespa/searchlib/fef/parameterdescriptions.h
@@ -68,7 +68,8 @@ private:
         return (normalTypesMask()        |
                 asMask(DataType::BOOLEANTREE) |
                 asMask(DataType::TENSOR)      |
-                asMask(DataType::REFERENCE));
+                asMask(DataType::REFERENCE) |
+                asMask(DataType::COMBINED));
     }
     ParameterDataTypeSet(uint32_t typeMask)
         : _typeMask(typeMask)

--- a/searchlib/src/vespa/searchlib/fef/test/queryenvironmentbuilder.cpp
+++ b/searchlib/src/vespa/searchlib/fef/test/queryenvironmentbuilder.cpp
@@ -52,10 +52,26 @@ QueryEnvironmentBuilder::addAttributeNode(const vespalib::string &attrName)
     if (info == nullptr || info->type() != FieldType::ATTRIBUTE) {
         return nullptr;
     }
+    return add_node(*info);
+}
+
+SimpleTermData *
+QueryEnvironmentBuilder::add_virtual_node(const vespalib::string &virtual_field)
+{
+    const auto *info = _queryEnv.getIndexEnv()->getFieldByName(virtual_field);
+    if (info == nullptr || info->type() != FieldType::VIRTUAL) {
+        return nullptr;
+    }
+    return add_node(*info);
+}
+
+SimpleTermData *
+QueryEnvironmentBuilder::add_node(const FieldInfo &info)
+{
     _queryEnv.getTerms().push_back(SimpleTermData());
     SimpleTermData &td = _queryEnv.getTerms().back();
     td.setWeight(search::query::Weight(100));
-    SimpleTermFieldData &tfd = td.addField(info->id());
+    SimpleTermFieldData &tfd = td.addField(info.id());
     tfd.setHandle(_layout.allocTermField(tfd.getFieldId()));
     return &td;
 }

--- a/searchlib/src/vespa/searchlib/fef/test/queryenvironmentbuilder.h
+++ b/searchlib/src/vespa/searchlib/fef/test/queryenvironmentbuilder.h
@@ -45,6 +45,11 @@ public:
      */
     SimpleTermData *addAttributeNode(const vespalib::string & attrName);
 
+    /**
+     * Add a term node searching in the given virtual field.
+     */
+    SimpleTermData *add_virtual_node(const vespalib::string &virtual_field);
+
     /** Returns a reference to the query environment of this. */
     QueryEnvironment &getQueryEnv() { return _queryEnv; }
 
@@ -62,6 +67,7 @@ public:
 private:
     QueryEnvironmentBuilder(const QueryEnvironmentBuilder &);             // hide
     QueryEnvironmentBuilder & operator=(const QueryEnvironmentBuilder &); // hide
+    SimpleTermData *add_node(const FieldInfo &info);
 
 private:
     QueryEnvironment &_queryEnv;

--- a/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/intermediatenodes.h
@@ -107,18 +107,17 @@ private:
     bool _expensive;
 };
 
-class SameElement : public QueryNodeMixin<SameElement, Intermediate> {
+class SameElement : public QueryNodeMixin<SameElement, Intermediate>, public Term {
 public:
-    SameElement(const vespalib::string &view) : _view(view), _expensive(false) {}
+    SameElement(const vespalib::string &view, int32_t id, Weight weight)
+        : Term(view, id, weight), _expensive(false) {}
     virtual ~SameElement() = 0;
-    const vespalib::string & getView() const { return _view; }
     SameElement &set_expensive(bool value) {
         _expensive = value;
         return *this;
     }
     bool is_expensive() const { return _expensive; }
 private:
-    vespalib::string _view;
     bool _expensive;
 };
 

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -129,8 +129,8 @@ typename NodeTypes::Phrase *createPhrase(vespalib::stringref view, int32_t id, W
     return new typename NodeTypes::Phrase(view, id, weight);
 }
 template <class NodeTypes>
-typename NodeTypes::SameElement *createSameElement(vespalib::stringref view) {
-    return new typename NodeTypes::SameElement(view);
+typename NodeTypes::SameElement *createSameElement(vespalib::stringref view, int32_t id, Weight weight) {
+    return new typename NodeTypes::SameElement(view, id, weight);
 }
 template <class NodeTypes>
 typename NodeTypes::WeightedSetTerm *createWeightedSetTerm(uint32_t num_terms, vespalib::stringref view, int32_t id, Weight weight) {
@@ -271,8 +271,8 @@ public:
         setWeightOverride(weight);
         return node;
     }
-    typename NodeTypes::SameElement &addSameElement(int child_count, stringref view) {
-        return addIntermediate(createSameElement<NodeTypes>(view), child_count);
+    typename NodeTypes::SameElement &addSameElement(int child_count, stringref view, int32_t id, Weight weight) {
+        return addIntermediate(createSameElement<NodeTypes>(view, id, weight), child_count);
     }
     typename NodeTypes::WeightedSetTerm &addWeightedSetTerm( int child_count, stringref view, int32_t id, Weight weight) {
         adjustWeight(weight);

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -74,7 +74,8 @@ private:
     }
 
     void visit(SameElement &node) override {
-        _builder.addSameElement(node.getChildren().size(), node.getView()).set_expensive(node.is_expensive());
+        _builder.addSameElement(node.getChildren().size(), node.getView(),
+                                node.getId(), node.getWeight()).set_expensive(node.is_expensive());
         visitNodes(node.getChildren());
     }
 

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -54,7 +54,8 @@ struct SimplePhrase : Phrase {
 };
 
 struct SimpleSameElement : SameElement {
-    SimpleSameElement(vespalib::stringref view) : SameElement(view) {}
+    SimpleSameElement(vespalib::stringref view, int32_t id, Weight weight)
+        : SameElement(view, id, weight) {}
     ~SimpleSameElement() override;
 };
 struct SimpleWeightedSetTerm : WeightedSetTerm {

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -110,7 +110,9 @@ private:
             pureTermView = view;
         } else if (type == ParseItem::ITEM_SAME_ELEMENT) {
             vespalib::stringref view = queryStack.getIndexName();
-            builder.addSameElement(arity, view);
+            int32_t id = queryStack.getUniqueId();
+            Weight weight = queryStack.GetWeight();
+            builder.addSameElement(arity, view, id, weight);
             pureTermView = view;
         } else if (type == ParseItem::ITEM_WEIGHTED_SET) {
             vespalib::stringref view = queryStack.getIndexName();

--- a/searchlib/src/vespa/searchlib/query/tree/templatetermvisitor.h
+++ b/searchlib/src/vespa/searchlib/query/tree/templatetermvisitor.h
@@ -53,6 +53,11 @@ class TemplateTermVisitor : public CustomTypeTermVisitor<NodeTypes> {
     // term's children, unless this member function is overridden
     // to do so.
     void visit(typename NodeTypes::WandTerm &n) override { myVisit(n); }
+
+    // SameElement have children. This visitor will not visit the
+    // term's children, unless this member function is overridden
+    // to do so.
+    void visit(typename NodeTypes::SameElement &n) override { myVisit(n); }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -13,12 +13,12 @@
 
 namespace search::queryeval {
 
-SameElementBlueprint::SameElementBlueprint(const vespalib::string &field_name_in, bool expensive)
-    : ComplexLeafBlueprint(FieldSpecBaseList()),
+SameElementBlueprint::SameElementBlueprint(const FieldSpec &field, bool expensive)
+    : ComplexLeafBlueprint(field),
       _estimate(),
       _layout(),
       _terms(),
-      _field_name(field_name_in)
+      _field_name(field.getName())
 {
     if (expensive) {
         set_cost_tier(State::COST_TIER_EXPENSIVE);
@@ -64,7 +64,7 @@ SameElementBlueprint::fetchPostings(const ExecuteInfo &execInfo)
 }
 
 std::unique_ptr<SameElementSearch>
-SameElementBlueprint::create_same_element_search(bool strict) const
+SameElementBlueprint::create_same_element_search(search::fef::TermFieldMatchData& tfmd, bool strict) const
 {
     fef::MatchDataLayout my_layout = _layout;
     fef::MatchData::UP md = my_layout.createMatchData();
@@ -79,15 +79,14 @@ SameElementBlueprint::create_same_element_search(bool strict) const
             children[i] = std::make_unique<attribute::SearchContextElementIterator>(std::move(child), *context);
         }
     }
-    return std::make_unique<SameElementSearch>(std::move(md), std::move(children), strict);
+    return std::make_unique<SameElementSearch>(tfmd, std::move(md), std::move(children), strict);
 }
 
 SearchIterator::UP
 SameElementBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const
 {
-    (void) tfmda;
-    assert(!tfmda.valid());
-    return create_same_element_search(strict);
+    assert(tfmda.size() == 1);
+    return create_same_element_search(*tfmda[0], strict);
 }
 
 SearchIterator::UP

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -20,7 +20,7 @@ private:
     vespalib::string           _field_name;
 
 public:
-    SameElementBlueprint(const vespalib::string &field_name_in, bool expensive);
+    SameElementBlueprint(const FieldSpec &field, bool expensive);
     SameElementBlueprint(const SameElementBlueprint &) = delete;
     SameElementBlueprint &operator=(const SameElementBlueprint &) = delete;
     ~SameElementBlueprint() override;
@@ -37,7 +37,7 @@ public:
     void optimize_self() override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
 
-    std::unique_ptr<SameElementSearch> create_same_element_search(bool strict) const;
+    std::unique_ptr<SameElementSearch> create_same_element_search(search::fef::TermFieldMatchData& tfmd, bool strict) const;
     SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda,
                                       bool strict) const override;
     SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_search.cpp
@@ -39,13 +39,16 @@ SameElementSearch::check_element_match(uint32_t docid)
     return !_matchingElements.empty();
 }
 
-SameElementSearch::SameElementSearch(fef::MatchData::UP md,
+SameElementSearch::SameElementSearch(fef::TermFieldMatchData &tfmd,
+                                     fef::MatchData::UP md,
                                      std::vector<ElementIterator::UP> children,
                                      bool strict)
-    : _md(std::move(md)),
+    : _tfmd(tfmd),
+      _md(std::move(md)),
       _children(std::move(children)),
       _strict(strict)
 {
+    _tfmd.reset(0);
     assert(!_children.empty());
 }
 
@@ -73,6 +76,12 @@ SameElementSearch::doSeek(uint32_t docid) {
         }
         setAtEnd();
     }
+}
+
+void
+SameElementSearch::doUnpack(uint32_t docid)
+{
+    _tfmd.resetOnlyDocId(docid);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_search.h
@@ -21,6 +21,7 @@ class SameElementSearch : public SearchIterator
 private:
     using It = fef::TermFieldMatchData::PositionsIterator;
 
+    fef::TermFieldMatchData         &_tfmd;
     fef::MatchData::UP               _md;
     std::vector<ElementIterator::UP> _children;
     std::vector<uint32_t>            _matchingElements;
@@ -31,12 +32,13 @@ private:
     bool check_element_match(uint32_t docid);
 
 public:
-    SameElementSearch(fef::MatchData::UP md,
+    SameElementSearch(fef::TermFieldMatchData &tfmd,
+                      fef::MatchData::UP md,
                       std::vector<ElementIterator::UP> children,
                       bool strict);
     void initRange(uint32_t begin_id, uint32_t end_id) override;
     void doSeek(uint32_t docid) override;
-    void doUnpack(uint32_t) override {}
+    void doUnpack(uint32_t docid) override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     const std::vector<ElementIterator::UP> &children() const { return _children; }
 

--- a/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
+++ b/streamingvisitors/src/tests/matching_elements_filler/matching_elements_filler_test.cpp
@@ -102,7 +102,7 @@ struct MyQueryBuilder : public search::query::QueryBuilder<search::query::Simple
         }
     }
     void make_same_element(vespalib::string field, BoundTerm term1, int32_t id1, BoundTerm term2, int32_t id2) {
-        addSameElement(2, field);
+        addSameElement(2, field, 0, Weight(0));
         add_term(term1, id1);
         add_term(term2, id2);
     }


### PR DESCRIPTION
A TermFieldMatchData is allocated per SameElement term, and this is used to signal matching docids in doUnpack() on the SameElement search iterator. This allows using the matches() rank feature on a field (virtual) that is searched using a SameElement term.

@havardpe please review