### PR TITLE
Parse tensor JSON values at root

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/searcher/FieldCollapsingSearcher.java
@@ -89,7 +89,7 @@ public class FieldCollapsingSearcher extends Searcher {
 
         if (collapseField == null) return execution.search(query);
 
-        int collapseSize = query.properties().getInteger(collapsesize,defaultCollapseSize);
+        int collapseSize = query.properties().getInteger(collapsesize, defaultCollapseSize);
         query.properties().set(collapse, "0");
 
         int hitsToRequest = query.getHits() != 0 ? (int) Math.ceil((query.getOffset() + query.getHits() + 1) * extraFactor) : 0;

--- a/document/src/main/java/com/yahoo/document/json/JsonSerializationHelper.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonSerializationHelper.java
@@ -48,6 +48,7 @@ import java.util.Set;
  * @author Vegard Sjonfjell
  */
 public class JsonSerializationHelper {
+
     private final static Base64.Encoder base64Encoder = Base64.getEncoder(); // Important: _basic_ format
 
     static class JsonSerializationException extends RuntimeException {
@@ -97,14 +98,6 @@ public class JsonSerializationHelper {
             }
             generator.writeEndObject();
         });
-    }
-
-    private static void serializeTensorDimensions(JsonGenerator generator, Set<String> dimensions) throws IOException {
-        generator.writeArrayFieldStart(TensorReader.TENSOR_DIMENSIONS);
-        for (String dimension : dimensions) {
-            generator.writeString(dimension);
-        }
-        generator.writeEndArray();
     }
 
     static void serializeTensorCells(JsonGenerator generator, Tensor tensor) throws IOException {

--- a/document/src/main/java/com/yahoo/document/json/TokenBuffer.java
+++ b/document/src/main/java/com/yahoo/document/json/TokenBuffer.java
@@ -35,25 +35,31 @@ public class TokenBuffer {
     /** Returns whether any tokens are available in this */
     public boolean isEmpty() { return remaining() == 0; }
 
-    public JsonToken next() {
-        position++;
-        JsonToken token = currentToken();
-        updateNesting(token);
-        return token;
-    }
-
     public JsonToken previous() {
-        updateNestingGoingBackwards(currentToken());
+        updateNestingGoingBackwards(current());
         position--;
-        return currentToken();
+        return current();
     }
 
     /** Returns the current token without changing position, or null if none */
-    public JsonToken currentToken() {
+    public JsonToken current() {
         if (isEmpty()) return null;
         Token token = tokens.get(position);
         if (token == null) return null;
         return token.token;
+    }
+
+    public JsonToken next() {
+        position++;
+        JsonToken token = current();
+        updateNesting(token);
+        return token;
+    }
+
+    /** Returns a given number of tokens ahead, or null if none */
+    public JsonToken peek(int ahead) {
+        if (tokens.size() <= position + ahead) return null;
+        return tokens.get(position + ahead).token;
     }
 
     /** Returns the current token name without changing position, or null if none */
@@ -150,7 +156,7 @@ public class TokenBuffer {
         Token toReturn = null;
         Iterator<Token> i;
 
-        if (name.equals(currentName()) && currentToken().isScalarValue()) {
+        if (name.equals(currentName()) && current().isScalarValue()) {
             toReturn = tokens.get(position);
         } else {
             i = tokens.iterator();

--- a/document/src/main/java/com/yahoo/document/json/TokenBuffer.java
+++ b/document/src/main/java/com/yahoo/document/json/TokenBuffer.java
@@ -33,7 +33,7 @@ public class TokenBuffer {
     }
 
     /** Returns whether any tokens are available in this */
-    public boolean isEmpty() { return tokens.isEmpty(); }
+    public boolean isEmpty() { return remaining() == 0; }
 
     public JsonToken next() {
         position++;
@@ -42,7 +42,6 @@ public class TokenBuffer {
         return token;
     }
 
-    /** Goes one token back. Repeated calls to this method will *not* go back further. */
     public JsonToken previous() {
         updateNestingGoingBackwards(currentToken());
         position--;
@@ -51,7 +50,7 @@ public class TokenBuffer {
 
     /** Returns the current token without changing position, or null if none */
     public JsonToken currentToken() {
-        if (position >= tokens.size()) return null;
+        if (isEmpty()) return null;
         Token token = tokens.get(position);
         if (token == null) return null;
         return token.token;
@@ -59,7 +58,7 @@ public class TokenBuffer {
 
     /** Returns the current token name without changing position, or null if none */
     public String currentName() {
-        if (position >= tokens.size()) return null;
+        if (isEmpty()) return null;
         Token token = tokens.get(position);
         if (token == null) return null;
         return token.name;
@@ -67,13 +66,13 @@ public class TokenBuffer {
 
     /** Returns the current token text without changing position, or null if none */
     public String currentText() {
-        if (position >= tokens.size()) return null;
+        if (isEmpty()) return null;
         Token token = tokens.get(position);
         if (token == null) return null;
         return token.text;
     }
 
-    public int size() {
+    public int remaining() {
         return tokens.size() - position;
     }
 
@@ -91,7 +90,7 @@ public class TokenBuffer {
 
         Preconditions.checkArgument(first == firstToken,
                 "Expected %s, got %s.", firstToken.name(), t);
-        if (size() == 0) {
+        if (remaining() == 0) {
             updateNesting(t);
         }
         localNesting = storeAndPeekNesting(t, localNesting, tokens);
@@ -121,7 +120,6 @@ public class TokenBuffer {
         try {
             add(t, tokens.getCurrentName(), tokens.getText());
         } catch (IOException e) {
-            // TODO something sane
             throw new IllegalArgumentException(e);
         }
     }
@@ -130,7 +128,6 @@ public class TokenBuffer {
         try {
             return tokens.nextValue();
         } catch (IOException e) {
-            // TODO something sane
             throw new IllegalArgumentException(e);
         }
     }

--- a/document/src/main/java/com/yahoo/document/json/document/DocumentParser.java
+++ b/document/src/main/java/com/yahoo/document/json/document/DocumentParser.java
@@ -76,18 +76,10 @@ public class DocumentParser {
             throw new IllegalArgumentException("Could not read document, no document?");
         }
         switch (currentToken) {
-            case START_OBJECT:
-                indentLevel++;
-                break;
-            case END_OBJECT:
-                indentLevel--;
-                break;
-            case START_ARRAY:
-                indentLevel += 10000L;
-                break;
-            case END_ARRAY:
-                indentLevel -= 10000L;
-                break;
+            case START_OBJECT -> indentLevel++;
+            case END_OBJECT -> indentLevel--;
+            case START_ARRAY -> indentLevel += 10000L;
+            case END_ARRAY -> indentLevel -= 10000L;
         }
     }
 
@@ -133,18 +125,12 @@ public class DocumentParser {
     }
 
     private static DocumentOperationType operationNameToOperationType(String operationName) {
-        switch (operationName) {
-            case PUT:
-            case ID:
-                return DocumentOperationType.PUT;
-            case REMOVE:
-                return DocumentOperationType.REMOVE;
-            case UPDATE:
-                return DocumentOperationType.UPDATE;
-            default:
-                throw new IllegalArgumentException(
-                        "Got " + operationName + " as document operation, only \"put\", " +
-                                "\"remove\" and \"update\" are supported.");
-        }
+        return switch (operationName) {
+            case PUT, ID -> DocumentOperationType.PUT;
+            case REMOVE -> DocumentOperationType.REMOVE;
+            case UPDATE -> DocumentOperationType.UPDATE;
+            default -> throw new IllegalArgumentException("Got " + operationName + " as document operation, only \"put\", " +
+                                                          "\"remove\" and \"update\" are supported.");
+        };
     }
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/AddRemoveCreator.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/AddRemoveCreator.java
@@ -41,7 +41,7 @@ public class AddRemoveCreator {
         FieldUpdate singleUpdate;
         int initNesting = buffer.nesting();
 
-        Preconditions.checkState(buffer.currentToken().isStructStart(), "Expected start of composite, got %s", buffer.currentToken());
+        Preconditions.checkState(buffer.current().isStructStart(), "Expected start of composite, got %s", buffer.current());
         if (container instanceof CollectionFieldValue) {
             buffer.next();
             DataType valueType = ((CollectionFieldValue) container).getDataType().getNestedType();
@@ -58,8 +58,8 @@ public class AddRemoveCreator {
             } else {
                 List<FieldValue> arrayContents = new ArrayList<>();
                 ArrayReader.fillArrayUpdate(buffer, initNesting, valueType, arrayContents, ignoreUndefinedFields);
-                if (buffer.currentToken() != JsonToken.END_ARRAY) {
-                    throw new IllegalArgumentException("Expected END_ARRAY. Got '" + buffer.currentToken() + "'.");
+                if (buffer.current() != JsonToken.END_ARRAY) {
+                    throw new IllegalArgumentException("Expected END_ARRAY. Got '" + buffer.current() + "'.");
                 }
                 if (isRemove) {
                     singleUpdate = FieldUpdate.createRemoveAll(field, arrayContents);
@@ -72,7 +72,7 @@ public class AddRemoveCreator {
                     "Trying to add or remove from a field of a type the reader does not know how to handle: "
                             + container.getClass().getName());
         }
-        expectCompositeEnd(buffer.currentToken());
+        expectCompositeEnd(buffer.current());
         update.addAll(singleUpdate);
     }
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/ArrayReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/ArrayReader.java
@@ -18,7 +18,7 @@ public class ArrayReader {
     public static void fillArrayUpdate(TokenBuffer buffer, int initNesting, DataType valueType,
                                        List<FieldValue> arrayContents, boolean ignoreUndefinedFields) {
         while (buffer.nesting() >= initNesting) {
-            Preconditions.checkArgument(buffer.currentToken() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
+            Preconditions.checkArgument(buffer.current() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
             arrayContents.add(readSingleValue(buffer, valueType, ignoreUndefinedFields));
             buffer.next();
         }
@@ -27,10 +27,10 @@ public class ArrayReader {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public static void fillArray(TokenBuffer buffer, CollectionFieldValue parent, DataType valueType, boolean ignoreUndefinedFields) {
         int initNesting = buffer.nesting();
-        expectArrayStart(buffer.currentToken());
+        expectArrayStart(buffer.current());
         buffer.next();
         while (buffer.nesting() >= initNesting) {
-            Preconditions.checkArgument(buffer.currentToken() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
+            Preconditions.checkArgument(buffer.current() != JsonToken.VALUE_NULL, "Illegal null value for array entry");
             parent.add(readSingleValue(buffer, valueType, ignoreUndefinedFields));
             buffer.next();
         }

--- a/document/src/main/java/com/yahoo/document/json/readers/CompositeReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/CompositeReader.java
@@ -19,8 +19,8 @@ import static com.yahoo.document.json.readers.WeightedSetReader.fillWeightedSet;
 public class CompositeReader {
 
     public static boolean populateComposite(TokenBuffer buffer, FieldValue fieldValue, boolean ignoreUndefinedFields) {
-        boolean fullyApplied = populateComposite(buffer.currentToken(), buffer, fieldValue, ignoreUndefinedFields);
-        expectCompositeEnd(buffer.currentToken());
+        boolean fullyApplied = populateComposite(buffer.current(), buffer, fieldValue, ignoreUndefinedFields);
+        expectCompositeEnd(buffer.current());
         return fullyApplied;
     }
 

--- a/document/src/main/java/com/yahoo/document/json/readers/GeoPositionReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/GeoPositionReader.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.document.json.readers;
 
-import com.fasterxml.jackson.core.JsonToken;
 import com.yahoo.document.PositionDataType;
 import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.json.TokenBuffer;
@@ -16,7 +15,7 @@ public class GeoPositionReader {
     static void fillGeoPosition(TokenBuffer buffer, FieldValue positionFieldValue) {
         Double latitude = null;
         Double longitude = null;
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
             String curName = buffer.currentName();
@@ -32,7 +31,7 @@ public class GeoPositionReader {
                 throw new IllegalArgumentException("Unexpected attribute "+curName+" in geo position field");
             }
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         if (latitude == null) {
             throw new IllegalArgumentException("Missing 'lat' attribute in geo position field");
         }

--- a/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/JsonParserHelpers.java
@@ -5,6 +5,8 @@ package com.yahoo.document.json.readers;
 import com.fasterxml.jackson.core.JsonToken;
 import com.google.common.base.Preconditions;
 
+import java.util.Arrays;
+
 public class JsonParserHelpers {
 
     public static void expectArrayStart(JsonToken token) {
@@ -59,6 +61,11 @@ public class JsonParserHelpers {
         catch (IllegalStateException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    public static void expectOneOf(JsonToken token, JsonToken ... tokens) {
+        if (Arrays.stream(tokens).noneMatch(t -> t == token))
+            throw new IllegalArgumentException("Expected one of " + tokens + " but got " + token);
     }
 
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/MapReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/MapReader.java
@@ -32,7 +32,7 @@ public class MapReader {
     public static final String UPDATE_MATCH = "match";
 
     public static void fillMap(TokenBuffer buffer, MapFieldValue parent, boolean ignoreUndefinedFields) {
-        if (buffer.currentToken() == JsonToken.START_ARRAY) {
+        if (buffer.current() == JsonToken.START_ARRAY) {
             MapReader.fillMapFromArray(buffer, parent, ignoreUndefinedFields);
         } else {
             MapReader.fillMapFromObject(buffer, parent, ignoreUndefinedFields);
@@ -41,7 +41,7 @@ public class MapReader {
 
     @SuppressWarnings({ "rawtypes", "cast", "unchecked" })
     public static void fillMapFromArray(TokenBuffer buffer, MapFieldValue parent, boolean ignoreUndefinedFields) {
-        JsonToken token = buffer.currentToken();
+        JsonToken token = buffer.current();
         int initNesting = buffer.nesting();
         expectArrayStart(token);
         token = buffer.next();
@@ -70,7 +70,7 @@ public class MapReader {
 
     @SuppressWarnings({ "rawtypes", "cast", "unchecked" })
     public static void fillMapFromObject(TokenBuffer buffer, MapFieldValue parent, boolean ignoreUndefinedFields) {
-        JsonToken token = buffer.currentToken();
+        JsonToken token = buffer.current();
         int initNesting = buffer.nesting();
         expectObjectStart(token);
         token = buffer.next();

--- a/document/src/main/java/com/yahoo/document/json/readers/SingleValueReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/SingleValueReader.java
@@ -10,7 +10,6 @@ import com.yahoo.document.datatypes.FieldValue;
 import com.yahoo.document.json.TokenBuffer;
 import com.yahoo.document.update.ValueUpdate;
 
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -42,7 +41,7 @@ public class SingleValueReader {
     }
 
     public static FieldValue readSingleValue(TokenBuffer buffer, DataType expectedType, boolean ignoreUndefinedFields) {
-        if (buffer.currentToken().isScalarValue()) {
+        if (buffer.current().isScalarValue()) {
             return readAtomic(buffer.currentText(), expectedType);
         } else {
             FieldValue fieldValue = expectedType.createFieldValue();
@@ -54,7 +53,7 @@ public class SingleValueReader {
     @SuppressWarnings("rawtypes")
     public static ValueUpdate readSingleUpdate(TokenBuffer buffer, DataType expectedType, String action, boolean ignoreUndefinedFields) {
         return switch (action) {
-            case UPDATE_ASSIGN -> (buffer.currentToken() == JsonToken.VALUE_NULL)
+            case UPDATE_ASSIGN -> (buffer.current() == JsonToken.VALUE_NULL)
                                   ? ValueUpdate.createClear()
                                   : ValueUpdate.createAssign(readSingleValue(buffer, expectedType, ignoreUndefinedFields));
             // double is silly, but it's what is used internally anyway

--- a/document/src/main/java/com/yahoo/document/json/readers/StructReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/StructReader.java
@@ -36,7 +36,7 @@ public class StructReader {
             }
 
             try {
-                if (buffer.currentToken() != JsonToken.VALUE_NULL) {
+                if (buffer.current() != JsonToken.VALUE_NULL) {
                     FieldValue v = readSingleValue(buffer, field.getDataType(), ignoreUndefinedFields);
                     parent.setFieldValue(field, v);
                 }

--- a/document/src/main/java/com/yahoo/document/json/readers/TensorAddUpdateReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorAddUpdateReader.java
@@ -22,7 +22,7 @@ public class TensorAddUpdateReader {
     }
 
     public static TensorAddUpdate createTensorAddUpdate(TokenBuffer buffer, Field field) {
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         expectTensorTypeHasSparseDimensions(field);
 
         TensorDataType tensorDataType = (TensorDataType)field.getDataType();

--- a/document/src/main/java/com/yahoo/document/json/readers/TensorModifyUpdateReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorModifyUpdateReader.java
@@ -33,7 +33,7 @@ public class TensorModifyUpdateReader {
     public static TensorModifyUpdate createModifyUpdate(TokenBuffer buffer, Field field) {
         expectFieldIsOfTypeTensor(field);
         expectTensorTypeHasNoIndexedUnboundDimensions(field);
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
 
         ModifyUpdateResult result = createModifyUpdateResult(buffer, field);
         expectOperationSpecified(result.operation, field.getName());

--- a/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
@@ -14,6 +14,7 @@ import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
 
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
 
 import static com.yahoo.document.json.readers.JsonParserHelpers.*;
@@ -40,7 +41,7 @@ public class TensorReader {
         expectOneOf(buffer.currentToken(), JsonToken.START_OBJECT, JsonToken.START_ARRAY);
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
-            if (TENSOR_CELLS.equals(buffer.currentName()) && ! primitiveContent(new TokenBuffer(new ArrayDeque<>(buffer.rest())))) {
+            if (TENSOR_CELLS.equals(buffer.currentName()) && ! primitiveContent(new TokenBuffer(new ArrayList<>(buffer.rest())))) {
                 readTensorCells(buffer, builder);
             }
             else if (TENSOR_VALUES.equals(buffer.currentName()) && builder.type().dimensions().stream().allMatch(d -> d.isIndexed())) {

--- a/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorReader.java
@@ -4,18 +4,11 @@ package com.yahoo.document.json.readers;
 import com.fasterxml.jackson.core.JsonToken;
 import com.yahoo.document.datatypes.TensorFieldValue;
 import com.yahoo.document.json.TokenBuffer;
-import com.yahoo.document.select.parser.Token;
-import com.yahoo.slime.Inspector;
-import com.yahoo.slime.Type;
 import com.yahoo.tensor.IndexedTensor;
 import com.yahoo.tensor.MixedTensor;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
-
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Deque;
 
 import static com.yahoo.document.json.readers.JsonParserHelpers.*;
 import static com.yahoo.tensor.serialization.JsonFormat.decodeHexString;
@@ -38,10 +31,10 @@ public class TensorReader {
     // MUST be kept in sync with com.yahoo.tensor.serialization.JsonFormat.decode in vespajlib
     static void fillTensor(TokenBuffer buffer, TensorFieldValue tensorFieldValue) {
         Tensor.Builder builder = Tensor.Builder.of(tensorFieldValue.getDataType().getTensorType());
-        expectOneOf(buffer.currentToken(), JsonToken.START_OBJECT, JsonToken.START_ARRAY);
+        expectOneOf(buffer.current(), JsonToken.START_OBJECT, JsonToken.START_ARRAY);
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
-            if (TENSOR_CELLS.equals(buffer.currentName()) && ! primitiveContent(new TokenBuffer(new ArrayList<>(buffer.rest())))) {
+            if (TENSOR_CELLS.equals(buffer.currentName()) && ! primitiveContent(buffer)) {
                 readTensorCells(buffer, builder);
             }
             else if (TENSOR_VALUES.equals(buffer.currentName()) && builder.type().dimensions().stream().allMatch(d -> d.isIndexed())) {
@@ -56,15 +49,15 @@ public class TensorReader {
                 buffer.previous(); // ... and back up to the end of the enclosing block
             }
         }
-        expectOneOf(buffer.currentToken(), JsonToken.END_OBJECT, JsonToken.END_ARRAY);
+        expectOneOf(buffer.current(), JsonToken.END_OBJECT, JsonToken.END_ARRAY);
         tensorFieldValue.assign(builder.build());
     }
 
     static boolean primitiveContent(TokenBuffer buffer) {
-        JsonToken cellsValue = buffer.currentToken();
+        JsonToken cellsValue = buffer.current();
         if (cellsValue.isScalarValue()) return true;
         if (cellsValue == JsonToken.START_ARRAY) {
-            JsonToken firstArrayValue = buffer.next();
+            JsonToken firstArrayValue = buffer.peek(1);
             if (firstArrayValue == JsonToken.END_ARRAY) return false;
             if (firstArrayValue.isScalarValue()) return true;
         }
@@ -72,24 +65,24 @@ public class TensorReader {
     }
 
     static void readTensorCells(TokenBuffer buffer, Tensor.Builder builder) {
-        if (buffer.currentToken() == JsonToken.START_ARRAY) {
+        if (buffer.current() == JsonToken.START_ARRAY) {
             int initNesting = buffer.nesting();
             for (buffer.next(); buffer.nesting() >= initNesting; buffer.next())
                 readTensorCell(buffer, builder);
         }
-        else if (buffer.currentToken() == JsonToken.START_OBJECT) { // single dimension short form
+        else if (buffer.current() == JsonToken.START_OBJECT) { // single dimension short form
             int initNesting = buffer.nesting();
             for (buffer.next(); buffer.nesting() >= initNesting; buffer.next())
                 builder.cell(asAddress(buffer.currentName(), builder.type()), readDouble(buffer));
         }
         else {
-            throw new IllegalArgumentException("Expected 'cells' to contain an array or an object, but got " + buffer.currentToken());
+            throw new IllegalArgumentException("Expected 'cells' to contain an array or an object, but got " + buffer.current());
         }
-        expectCompositeEnd(buffer.currentToken());
+        expectCompositeEnd(buffer.current());
     }
 
     private static void readTensorCell(TokenBuffer buffer, Tensor.Builder builder) {
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
 
         TensorAddress address = null;
         Double value = null;
@@ -102,7 +95,7 @@ public class TensorReader {
                 value = readDouble(buffer);
             }
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         if (address == null)
             throw new IllegalArgumentException("Expected an object in a tensor 'cells' array to contain an 'address' field");
         if (value == null)
@@ -114,7 +107,7 @@ public class TensorReader {
         if ( ! (builder instanceof IndexedTensor.BoundBuilder indexedBuilder))
             throw new IllegalArgumentException("The 'values' field can only be used with dense tensors. " +
                                                "Use 'cells' or 'blocks' instead");
-        if (buffer.currentToken() == JsonToken.VALUE_STRING) {
+        if (buffer.current() == JsonToken.VALUE_STRING) {
             double[] decoded = decodeHexString(buffer.currentText(), builder.type().valueType());
             if (decoded.length == 0)
                 throw new IllegalArgumentException("The 'values' string does not contain any values");
@@ -130,19 +123,19 @@ public class TensorReader {
         }
         if (index == 0)
             throw new IllegalArgumentException("The 'values' array does not contain any values");
-        expectCompositeEnd(buffer.currentToken());
+        expectCompositeEnd(buffer.current());
     }
 
     static void readTensorBlocks(TokenBuffer buffer, Tensor.Builder builder) {
         if ( ! (builder instanceof MixedTensor.BoundBuilder mixedBuilder))
             throw new IllegalArgumentException("The 'blocks' field can only be used with mixed tensors with bound dimensions. " +
                                                "Use 'cells' or 'values' instead");
-        if (buffer.currentToken() == JsonToken.START_ARRAY) {
+        if (buffer.current() == JsonToken.START_ARRAY) {
             int initNesting = buffer.nesting();
             for (buffer.next(); buffer.nesting() >= initNesting; buffer.next())
                 readTensorBlock(buffer, mixedBuilder);
         }
-        else if (buffer.currentToken() == JsonToken.START_OBJECT) {
+        else if (buffer.current() == JsonToken.START_OBJECT) {
             int initNesting = buffer.nesting();
             for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
                 TensorAddress mappedAddress = asAddress(buffer.currentName(), builder.type().mappedSubtype());
@@ -152,14 +145,14 @@ public class TensorReader {
         }
         else {
             throw new IllegalArgumentException("Expected 'blocks' to contain an array or an object, but got " +
-                                               buffer.currentToken());
+                                               buffer.current());
         }
 
-        expectCompositeEnd(buffer.currentToken());
+        expectCompositeEnd(buffer.current());
     }
 
     private static void readTensorBlock(TokenBuffer buffer, MixedTensor.BoundBuilder mixedBuilder) {
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
 
         TensorAddress address = null;
         double[] values = null;
@@ -172,7 +165,7 @@ public class TensorReader {
             else if (TensorReader.TENSOR_VALUES.equals(currentName))
                 values = readValues(buffer, (int)mixedBuilder.denseSubspaceSize(), address, mixedBuilder.type());
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         if (address == null)
             throw new IllegalArgumentException("Expected a 'blocks' array object to contain an object 'address'");
         if (values == null)
@@ -194,12 +187,12 @@ public class TensorReader {
     }
 
     private static TensorAddress readAddress(TokenBuffer buffer, TensorType type) {
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         TensorAddress.Builder builder = new TensorAddress.Builder(type);
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next())
             builder.add(buffer.currentName(), buffer.currentText());
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         return builder.build();
     }
 
@@ -215,15 +208,15 @@ public class TensorReader {
     private static double[] readValues(TokenBuffer buffer, int size, TensorAddress address, TensorType type) {
         int index = 0;
         double[] values = new double[size];
-        if (buffer.currentToken() == JsonToken.VALUE_STRING) {
+        if (buffer.current() == JsonToken.VALUE_STRING) {
             values = decodeHexString(buffer.currentText(), type.valueType());
             index = values.length;
         } else {
-            expectArrayStart(buffer.currentToken());
+            expectArrayStart(buffer.current());
             int initNesting = buffer.nesting();
             for (buffer.next(); buffer.nesting() >= initNesting; buffer.next())
                 values[index++] = readDouble(buffer);
-            expectCompositeEnd(buffer.currentToken());
+            expectCompositeEnd(buffer.current());
         }
         if (index != size)
             throw new IllegalArgumentException((address != null ? "At " + address.toString(type) + ": " : "") +

--- a/document/src/main/java/com/yahoo/document/json/readers/TensorRemoveUpdateReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/TensorRemoveUpdateReader.java
@@ -26,7 +26,7 @@ public class TensorRemoveUpdateReader {
     public static final String TENSOR_ADDRESSES = "addresses";
 
     static TensorRemoveUpdate createTensorRemoveUpdate(TokenBuffer buffer, Field field) {
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         expectTensorTypeHasSparseDimensions(field);
 
         TensorDataType tensorDataType = (TensorDataType)field.getDataType();
@@ -59,11 +59,11 @@ public class TensorRemoveUpdateReader {
      */
     private static Tensor readRemoveUpdateTensor(TokenBuffer buffer, TensorType sparseType, TensorType originalType) {
         Tensor.Builder builder = null;
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
             if (TENSOR_ADDRESSES.equals(buffer.currentName())) {
-                expectArrayStart(buffer.currentToken());
+                expectArrayStart(buffer.current());
                 int nesting = buffer.nesting();
                 for (buffer.next(); buffer.nesting() >= nesting; buffer.next()) {
                     if (builder == null) {
@@ -74,10 +74,10 @@ public class TensorRemoveUpdateReader {
                         builder.cell(readTensorAddress(buffer, builder.type(), originalType), 1.0);
                     }
                 }
-                expectCompositeEnd(buffer.currentToken());
+                expectCompositeEnd(buffer.current());
             }
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         return (builder != null) ? builder.build() : Tensor.Builder.of(sparseType).build();
     }
 
@@ -88,7 +88,7 @@ public class TensorRemoveUpdateReader {
     private static Pair<TensorType, TensorAddress> readFirstTensorAddress(TokenBuffer buffer, TensorType sparseType, TensorType originalType) {
         var typeBuilder = new TensorType.Builder(sparseType.valueType());
         var rawAddress = new HashMap<String, String>();
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
             var elem = readRawElement(buffer, sparseType, originalType);
@@ -100,7 +100,7 @@ public class TensorRemoveUpdateReader {
                 throw new IllegalArgumentException(originalType + " does not contain dimension '" + elem.getFirst() + "'");
             }
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         var type = typeBuilder.build();
         var builder = new TensorAddress.Builder(type);
         rawAddress.forEach((dimension, label) -> builder.add(dimension, label));
@@ -119,13 +119,13 @@ public class TensorRemoveUpdateReader {
 
     private static TensorAddress readTensorAddress(TokenBuffer buffer, TensorType type, TensorType originalType) {
         TensorAddress.Builder builder = new TensorAddress.Builder(type);
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         int initNesting = buffer.nesting();
         for (buffer.next(); buffer.nesting() >= initNesting; buffer.next()) {
             var elem = readRawElement(buffer, type, originalType);
             builder.add(elem.getFirst(), elem.getSecond());
         }
-        expectObjectEnd(buffer.currentToken());
+        expectObjectEnd(buffer.current());
         return builder.build();
     }
 

--- a/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
@@ -235,7 +235,7 @@ public class VespaJsonDocumentReader {
                                  "Expected end of JSON struct (%s), got %s", expectedFinalToken, buffer.currentToken());
         Preconditions.checkState(buffer.nesting() == 0, "Nesting not zero at end of operation");
         Preconditions.checkState(buffer.next() == null, "Dangling data at end of operation");
-        Preconditions.checkState(buffer.size() == 0, "Dangling data at end of operation");
+        Preconditions.checkState(buffer.remaining() == 0, "Dangling data at end of operation");
     }
 
 }

--- a/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
@@ -96,13 +96,13 @@ public class VespaJsonDocumentReader {
     public boolean readUpdate(TokenBuffer buffer, DocumentUpdate update) {
         if (buffer.isEmpty())
             throw new IllegalArgumentException("Update of document " + update.getId() + " is missing a 'fields' map");
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         int localNesting = buffer.nesting();
 
         buffer.next();
         boolean fullyApplied = true;
         while (localNesting <= buffer.nesting()) {
-            expectObjectStart(buffer.currentToken());
+            expectObjectStart(buffer.current());
 
             String fieldName = buffer.currentName();
             try {
@@ -111,7 +111,7 @@ public class VespaJsonDocumentReader {
                 } else {
                     fullyApplied &= addFieldUpdates(update, buffer, fieldName);
                 }
-                expectObjectEnd(buffer.currentToken());
+                expectObjectEnd(buffer.current());
             }
             catch (IllegalArgumentException | IndexOutOfBoundsException e) {
                 throw new IllegalArgumentException("Error in '" + fieldName + "'", e);
@@ -211,7 +211,7 @@ public class VespaJsonDocumentReader {
     }
 
     private RemoveFieldPathUpdate readRemoveFieldPathUpdate(DocumentType documentType, String fieldPath, TokenBuffer buffer) {
-        expectScalarValue(buffer.currentToken());
+        expectScalarValue(buffer.current());
         return new RemoveFieldPathUpdate(documentType, fieldPath);
     }
 
@@ -231,8 +231,8 @@ public class VespaJsonDocumentReader {
     }
 
     private static void verifyEndState(TokenBuffer buffer, JsonToken expectedFinalToken) {
-        Preconditions.checkState(buffer.currentToken() == expectedFinalToken,
-                                 "Expected end of JSON struct (%s), got %s", expectedFinalToken, buffer.currentToken());
+        Preconditions.checkState(buffer.current() == expectedFinalToken,
+                                 "Expected end of JSON struct (%s), got %s", expectedFinalToken, buffer.current());
         Preconditions.checkState(buffer.nesting() == 0, "Nesting not zero at end of operation");
         Preconditions.checkState(buffer.next() == null, "Dangling data at end of operation");
         Preconditions.checkState(buffer.remaining() == 0, "Dangling data at end of operation");

--- a/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/VespaJsonDocumentReader.java
@@ -219,7 +219,7 @@ public class VespaJsonDocumentReader {
                                                                 TokenBuffer buffer, String fieldPathOperation) {
         AssignFieldPathUpdate fieldPathUpdate = new AssignFieldPathUpdate(documentType, fieldPath);
         String arithmeticSign = SingleValueReader.UPDATE_OPERATION_TO_ARITHMETIC_SIGN.get(fieldPathOperation);
-        double value = Double.valueOf(buffer.currentText());
+        double value = Double.parseDouble(buffer.currentText());
         String expression = String.format("$value %s %s", arithmeticSign, value);
         fieldPathUpdate.setExpression(expression);
         return fieldPathUpdate;

--- a/document/src/main/java/com/yahoo/document/json/readers/WeightedSetReader.java
+++ b/document/src/main/java/com/yahoo/document/json/readers/WeightedSetReader.java
@@ -13,7 +13,7 @@ public class WeightedSetReader {
 
     public static void fillWeightedSet(TokenBuffer buffer, DataType valueType, @SuppressWarnings("rawtypes") WeightedSet weightedSet) {
         int initNesting = buffer.nesting();
-        expectObjectStart(buffer.currentToken());
+        expectObjectStart(buffer.current());
         buffer.next();
         iterateThroughWeightedSet(buffer, initNesting, valueType, weightedSet);
     }


### PR DESCRIPTION
Our current tensor JSON formats require a "blocks", "cells" or "values" key at the root, containing values in various forms.

This adds support for skipping that extra level and adding content at the root, where the permissible content format depends on the tensor type, and matches the formats below "blocks", "cells" or "values" for the corresponding tensor types.