### PR TITLE
Rethrow exception when building config if file reference does not exist

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
@@ -10,7 +10,6 @@ import com.yahoo.slime.ArrayTraverser;
 import com.yahoo.slime.Inspector;
 import com.yahoo.slime.ObjectTraverser;
 import com.yahoo.slime.Type;
-
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -21,7 +20,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.logging.Logger;
@@ -60,6 +58,8 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
         stack.push(new NamedBuilder(rootBuilder));
         try {
             handleValue(payload.getSlime().get());
+        } catch (FileReferenceDoesNotExistException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Not able to create config builder for payload '" + payload.toString() + "'", e);
         }

--- a/config/src/main/java/com/yahoo/vespa/config/FileReferenceDoesNotExistException.java
+++ b/config/src/main/java/com/yahoo/vespa/config/FileReferenceDoesNotExistException.java
@@ -1,5 +1,5 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-package com.yahoo.filedistribution.fileacquirer;
+package com.yahoo.vespa.config;
 
 /**
  * @author Tony Vaagenes
@@ -8,7 +8,7 @@ public class FileReferenceDoesNotExistException extends RuntimeException {
 
     public final String fileReference;
 
-    FileReferenceDoesNotExistException(String fileReference) {
+    public FileReferenceDoesNotExistException(String fileReference) {
         super("Could not retrieve file with file reference '" + fileReference + "'");
         this.fileReference = fileReference;
     }

--- a/fileacquirer/abi-spec.json
+++ b/fileacquirer/abi-spec.json
@@ -25,17 +25,6 @@
     ],
     "fields" : [ ]
   },
-  "com.yahoo.filedistribution.fileacquirer.FileReferenceDoesNotExistException" : {
-    "superClass" : "java.lang.RuntimeException",
-    "interfaces" : [ ],
-    "attributes" : [
-      "public"
-    ],
-    "methods" : [ ],
-    "fields" : [
-      "public final java.lang.String fileReference"
-    ]
-  },
   "com.yahoo.filedistribution.fileacquirer.MockFileAcquirer" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirer.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirer.java
@@ -2,6 +2,7 @@
 package com.yahoo.filedistribution.fileacquirer;
 
 import com.yahoo.config.FileReference;
+import com.yahoo.vespa.config.FileReferenceDoesNotExistException;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerImpl.java
@@ -2,18 +2,23 @@
 package com.yahoo.filedistribution.fileacquirer;
 
 import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
-import com.yahoo.config.subscription.ConfigSubscriber;
 import com.yahoo.config.FileReference;
-import com.yahoo.jrt.*;
-
+import com.yahoo.config.subscription.ConfigSubscriber;
+import com.yahoo.jrt.ErrorCode;
+import com.yahoo.jrt.Request;
+import com.yahoo.jrt.Spec;
+import com.yahoo.jrt.StringValue;
+import com.yahoo.jrt.Supervisor;
+import com.yahoo.jrt.Target;
+import com.yahoo.jrt.Transport;
+import com.yahoo.vespa.config.FileReferenceDoesNotExistException;
+import java.io.File;
 import java.time.Duration;
-import java.util.logging.Level;
-
-import java.util.logging.Logger;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.concurrent.TimeUnit;
-import java.io.File;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Retrieves the path to a file or directory on the local file system

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/MockFileAcquirer.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/MockFileAcquirer.java
@@ -2,6 +2,7 @@
 package com.yahoo.filedistribution.fileacquirer;
 
 import com.yahoo.config.FileReference;
+import com.yahoo.vespa.config.FileReferenceDoesNotExistException;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;

--- a/fileacquirer/src/test/java/MockFileAcquirerTest.java
+++ b/fileacquirer/src/test/java/MockFileAcquirerTest.java
@@ -1,11 +1,11 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
 import com.yahoo.config.FileReference;
 import com.yahoo.filedistribution.fileacquirer.FileAcquirer;
-import com.yahoo.filedistribution.fileacquirer.FileReferenceDoesNotExistException;
 import com.yahoo.filedistribution.fileacquirer.MockFileAcquirer;
 import com.yahoo.filedistribution.fileacquirer.TimeoutException;
+import com.yahoo.vespa.config.FileReferenceDoesNotExistException;
 import org.junit.Test;
-
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.util.HashMap;


### PR DESCRIPTION
Makes it easier to see that it is file distribution and not config that is the problem. I am not sure why fileacquirer is public API,  might need to keep this API unchanged if that is correct/important.