### PR TITLE
- Remove the explicit close method in SessionManager. Just do it in d…

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -126,16 +126,16 @@ struct EmptyRankingAssetsRepo : public proton::matching::IRankingAssetsRepo {
 //-----------------------------------------------------------------------------
 
 struct MyWorld {
-    Schema                  schema;
-    Properties              config;
-    FakeSearchContext       searchContext;
-    MockAttributeContext    attributeContext;
-    SessionManager::SP      sessionManager;
-    DocumentMetaStore       metaStore;
-    MatchingStats           matchingStats;
-    vespalib::TestClock     clock;
-    QueryLimiter            queryLimiter;
-    EmptyRankingAssetsRepo  constantValueRepo;
+    Schema                           schema;
+    Properties                       config;
+    FakeSearchContext                searchContext;
+    MockAttributeContext             attributeContext;
+    std::shared_ptr<SessionManager>  sessionManager;
+    DocumentMetaStore                metaStore;
+    MatchingStats                    matchingStats;
+    vespalib::TestClock              clock;
+    QueryLimiter                     queryLimiter;
+    EmptyRankingAssetsRepo           constantValueRepo;
 
     MyWorld();
     ~MyWorld();

--- a/searchcore/src/vespa/searchcore/proton/matching/sessionmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/sessionmanager.cpp
@@ -173,7 +173,11 @@ SessionManager::SessionManager(uint32_t maxSize)
       _search_map(std::make_unique<SearchSessionCache>()) {
 }
 
-SessionManager::~SessionManager() = default;
+SessionManager::~SessionManager() {
+    pruneTimedOutSessions(vespalib::steady_time::max());
+    assert(_grouping_cache->empty());
+    assert(_search_map->empty());
+}
 
 void SessionManager::insert(search::grouping::GroupingSession::UP session) {
     _grouping_cache->insert(std::move(session));
@@ -213,12 +217,6 @@ SessionManager::getSortedSearchSessionInfo() const
 void SessionManager::pruneTimedOutSessions(vespalib::steady_time currentTime) {
     _grouping_cache->pruneTimedOutSessions(currentTime);
     _search_map->pruneTimedOutSessions(currentTime);
-}
-
-void SessionManager::close() {
-    pruneTimedOutSessions(vespalib::steady_time::max());
-    assert(_grouping_cache->empty());
-    assert(_search_map->empty());
 }
 
 SessionManager::Stats SessionManager::getGroupingStats() {

--- a/searchcore/src/vespa/searchcore/proton/matching/sessionmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/sessionmanager.h
@@ -45,9 +45,6 @@ private:
     std::unique_ptr<SearchSessionCache> _search_map;
 
 public:
-    using UP = std::unique_ptr<SessionManager>;
-    using SP = std::shared_ptr<SessionManager>;
-
     SessionManager(uint32_t maxSizeGrouping);
     ~SessionManager();
 
@@ -62,7 +59,6 @@ public:
     std::vector<SearchSessionInfo> getSortedSearchSessionInfo() const;
 
     void pruneTimedOutSessions(vespalib::steady_time currentTime);
-    void close();
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -499,7 +499,7 @@ Proton::~Proton()
                                                 CpuUsage::wrap(proton_close_executor, CpuCategory::SETUP));
         closeDocumentDBs(closePool);
     }
-    _sessionManager->close();
+    _sessionManager.reset();
     _documentDBMap.clear();
     _persistenceEngine.reset();
     _tls.reset();


### PR DESCRIPTION
…estructor instead.

- Destruct instead of close. Works even if it has not been constructed.
- Minor code cleanup.

@geirst or @toregge PR