### PR TITLE
Add JNA in lib/jars + export as packages from jdisc_core [run-systemtest]

### DIFF
--- a/container-dev/pom.xml
+++ b/container-dev/pom.xml
@@ -54,6 +54,10 @@
       <classifier>no_aop</classifier>
     </dependency>
     <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>
@@ -169,10 +173,6 @@
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-exec</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>net.java.dev.jna</groupId>
-          <artifactId>jna</artifactId>
         </exclusion>
         <exclusion>
           <groupId>net.openhft</groupId>

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -34,6 +34,10 @@
           <groupId>com.yahoo.vespa</groupId>
           <artifactId>airlift-zstd</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>net.java.dev.jna</groupId>
+          <artifactId>jna</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -195,7 +195,7 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <excludeTransitive>true</excludeTransitive>
+                            <excludeTransitive>false</excludeTransitive>
                             <stripVersion>true</stripVersion>
                             <outputDirectory>${project.build.directory}/dependency</outputDirectory>
                         </configuration>
@@ -227,6 +227,7 @@
                                 <argument>${project.build.directory}/dependency/slf4j-api.jar</argument>
                                 <argument>${project.build.directory}/dependency/slf4j-jdk14.jar</argument>
                                 <argument>${project.build.directory}/dependency/jcl-over-slf4j.jar</argument>
+                                <argument>${project.build.directory}/dependency/jna.jar</argument>
                                 <argument>${project.build.directory}/dependency/log4j-over-slf4j.jar</argument>
                                 <argument>${project.build.directory}/dependency/annotations.jar</argument>
                                 <argument>${project.build.directory}/dependency/config-lib.jar</argument>

--- a/model-integration/pom.xml
+++ b/model-integration/pom.xml
@@ -32,6 +32,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <!-- required for bundle-plugin to generate import-package statements for Java's standard library + misc 3party -->
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>jdisc_core</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>searchlib</artifactId>
       <version>${project.version}</version>
@@ -61,6 +68,11 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -76,7 +88,15 @@
            <groupId>com.google.code.gson</groupId>
            <artifactId>gson</artifactId>
          </exclusion>
-         </exclusions>
+         <exclusion>
+           <groupId>net.java.dev.jna</groupId>
+           <artifactId>jna</artifactId>
+         </exclusion>
+         <exclusion>
+           <groupId>org.slf4j</groupId>
+           <artifactId>slf4j-api</artifactId>
+         </exclusion>
+       </exclusions>
     </dependency>
 
     <dependency>

--- a/vespa-3party-jars/pom.xml
+++ b/vespa-3party-jars/pom.xml
@@ -29,6 +29,10 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/vespa-athenz/pom.xml
+++ b/vespa-athenz/pom.xml
@@ -41,6 +41,11 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- test -->
         <dependency>
@@ -118,6 +123,10 @@
                 <exclusion>
                     <groupId>junit</groupId>
                     <artifactId>junit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Jdisc-core will embed JNA. The JNA in lib/jars is used by fatjars only.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
