### PR TITLE
Inline apache http client artifacts in container-apache-http-client-bundle

### DIFF
--- a/config-proxy/pom.xml
+++ b/config-proxy/pom.xml
@@ -52,6 +52,7 @@
       <groupId>com.yahoo.vespa</groupId>
       <artifactId>container-apache-http-client-bundle</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/container-apache-http-client-bundle/pom.xml
+++ b/container-apache-http-client-bundle/pom.xml
@@ -6,7 +6,7 @@
    http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>container-apache-http-client-bundle</artifactId>
-    <packaging>container-plugin</packaging>
+    <packaging>jar</packaging>
     <version>8-SNAPSHOT</version>
 
     <parent>
@@ -19,26 +19,6 @@
         <maven.javadoc.skip>true</maven.javadoc.skip> <!-- Javadoc plugin fails because of no source code in module -->
     </properties>
     <dependencies>
-        <!-- provided -->
-        <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>annotations</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <!-- Not directly used in this module, but needed to get Import-Packages for JDK packages it exports. -->
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>jdisc_core</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- compile -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -68,9 +48,72 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.yahoo.vespa</groupId>
-                <artifactId>bundle-plugin</artifactId>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
+                        <Export-Package>org.apache.hc.*;version=1.0.0;-noimport:=true,org.apache.http.*;version=1.0.0;-noimport:=true</Export-Package>
+                        <Embed-Dependency>*;scope=compile;type=!pom;inline=true</Embed-Dependency>
+                        <Import-Package>!javax.servlet,javax.*,org.slf4j,org.ietf.jgss</Import-Package>
+                        <Embed-Transitive>true</Embed-Transitive>
+                        <_nouses>true</_nouses>
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                    <attach>false</attach>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/async/methods/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/async/methods/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.async.methods;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/async/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/async/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.async;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/classic/methods/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/classic/methods/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.classic.methods;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/classic/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/classic/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.classic;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/config/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/config/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.config;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/entity/mime/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/entity/mime/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.entity.mime;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/entity/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/entity/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.entity;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/async/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/async/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.impl.async;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/classic/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/classic/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.impl.classic;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/io/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/io/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.impl.io;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/nio/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/nio/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.impl.nio;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/impl/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.impl;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/io/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/io/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.io;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/nio/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/nio/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.nio;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/protocol/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/protocol/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.protocol;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/routing/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/routing/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.routing;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/socket/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/socket/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.socket;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/ssl/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/client5/http/ssl/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.client5.http.ssl;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/concurrent/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/concurrent/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.concurrent;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/config/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/config/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.config;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/entity/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/entity/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.io.entity;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.io;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/support/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/io/support/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.io.support;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/message/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/message/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.message;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.nio;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/ssl/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/ssl/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.nio.ssl;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/support/classic/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/support/classic/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.nio.support.classic;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/support/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/nio/support/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.nio.support;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/protocol/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http/protocol/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http.protocol;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http2/config/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http2/config/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http2.config;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http2/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/http2/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.http2;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/net/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/net/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.net;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/reactor/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/reactor/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.reactor;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/util/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/hc/core5/util/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.hc.core5.util;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/annotation/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/annotation/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.annotation;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/auth/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/auth/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.auth;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/config/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/config/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client.config;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/entity/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/entity/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client.entity;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/methods/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/methods/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client.methods;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/protocol/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/protocol/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client.protocol;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/client/utils/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/client/utils/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.client.utils;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/config/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/config/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.config;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.conn;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/routing/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/routing/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.conn.routing;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/socket/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/socket/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.conn.socket;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/ssl/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/conn/ssl/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.conn.ssl;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/mime/content/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/mime/content/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.entity.mime.content;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/mime/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/mime/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.entity.mime;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/entity/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.entity;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/client/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/client/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.impl.client;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/conn/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/conn/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.impl.conn;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/io/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/io/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.impl.io;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/impl/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.impl;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/message/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/message/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.message;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/params/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/params/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.params;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/pool/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/pool/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.pool;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/protocol/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/protocol/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.protocol;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-apache-http-client-bundle/src/main/java/org/apache/http/util/package-info.java
+++ b/container-apache-http-client-bundle/src/main/java/org/apache/http/util/package-info.java
@@ -1,8 +1,0 @@
-// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @author bjorncs
- */
-@ExportPackage
-package org.apache.http.util;
-
-import com.yahoo.osgi.annotation.ExportPackage;

--- a/vespa-3party-jars/pom.xml
+++ b/vespa-3party-jars/pom.xml
@@ -26,6 +26,17 @@
             <type>pom</type>
         </dependency>
         <dependency>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>container-apache-http-client-bundle</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
@@ -58,6 +69,7 @@
                     <overWriteReleases>false</overWriteReleases>
                     <overWriteSnapshots>false</overWriteSnapshots>
                     <excludeTransitive>false</excludeTransitive>
+                    <excludeGroupIds>com.yahoo.vespa</excludeGroupIds>
                 </configuration>
             </plugin>
         </plugins>

--- a/vespaclient-java/pom.xml
+++ b/vespaclient-java/pom.xml
@@ -68,13 +68,11 @@
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
         </dependency>
-            <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-        </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
+            <groupId>com.yahoo.vespa</groupId>
+            <artifactId>container-apache-http-client-bundle</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
Allows container-apache-http-client-bundle to be used on classpath for classic fatjars. Since the bundle is now built with Felix's bundle plugin, there is no need to depend on jdisc_core or manually export through `@PublicApi` annotations.