### PR TITLE
wait until we get config before hooking signals

### DIFF
--- a/configd/src/apps/sentinel/env.cpp
+++ b/configd/src/apps/sentinel/env.cpp
@@ -55,6 +55,8 @@ void Env::boot(const std::string &configId) {
     _cfgOwner.subscribe(configId, CONFIG_TIMEOUT_MS);
     _modelOwner.start(CONFIG_TIMEOUT_MS, true);
     // subscribe() should throw if something is not OK
+    vespalib::SignalHandler::TERM.hook();
+    vespalib::SignalHandler::INT.hook();
     Connectivity checker;
     for (int retry = 0; retry < maxConnectivityRetries; ++retry) {
         bool changed = _cfgOwner.checkForConfigUpdate();

--- a/configd/src/apps/sentinel/sentinel.cpp
+++ b/configd/src/apps/sentinel/sentinel.cpp
@@ -50,8 +50,6 @@ main(int argc, char **argv)
     EV_STARTED("config-sentinel");
 
     vespalib::SignalHandler::PIPE.ignore();
-    vespalib::SignalHandler::TERM.hook();
-    vespalib::SignalHandler::INT.hook();
     vespalib::SignalHandler::CHLD.hook();
 
     if (setenv("LC_ALL", "C", 1) != 0) {


### PR DESCRIPTION
@toregge please review

this makes "vespa-stop-services" fast when the sentinel is still waiting for its initial config
(no application, configserver not running, etc)
