### PR TITLE
Add query trace parameters for profiling backend query evaluation.

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -5698,6 +5698,7 @@
       "public void setTimestamps(boolean)",
       "public boolean getQuery()",
       "public void setQuery(boolean)",
+      "public com.yahoo.search.query.profiling.Profiling getProfiling()",
       "public void trace(java.lang.String, int)",
       "public void trace(java.lang.Object, int)",
       "public void trace(java.lang.String, boolean, int)",
@@ -5716,7 +5717,8 @@
       "public static final java.lang.String EXPLAIN_LEVEL",
       "public static final java.lang.String PROFILE_DEPTH",
       "public static final java.lang.String TIMESTAMPS",
-      "public static final java.lang.String QUERY"
+      "public static final java.lang.String QUERY",
+      "public static final java.lang.String PROFILING"
     ]
   },
   "com.yahoo.search.query.UniqueRequestId" : {
@@ -6678,6 +6680,52 @@
       "public static com.yahoo.search.query.profile.types.TensorFieldType fromTypeString(java.lang.String)"
     ],
     "fields" : [ ]
+  },
+  "com.yahoo.search.query.profiling.Profiling" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [
+      "java.lang.Cloneable"
+    ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>()",
+      "public static com.yahoo.search.query.profile.types.QueryProfileType getArgumentType()",
+      "public com.yahoo.search.query.profiling.ProfilingParams getMatching()",
+      "public com.yahoo.search.query.profiling.ProfilingParams getFirstPhaseRanking()",
+      "public com.yahoo.search.query.profiling.ProfilingParams getSecondPhaseRanking()",
+      "public com.yahoo.search.query.profiling.ProfilingParams clone()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()",
+      "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields" : [
+      "public static final java.lang.String MATCHING",
+      "public static final java.lang.String FIRST_PHASE_RANKING",
+      "public static final java.lang.String SECOND_PHASE_RANKING"
+    ]
+  },
+  "com.yahoo.search.query.profiling.ProfilingParams" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public"
+    ],
+    "methods" : [
+      "public void <init>()",
+      "public static com.yahoo.search.query.profile.types.QueryProfileType getArgumentType()",
+      "public int getDepth()",
+      "public void setDepth(int)",
+      "public com.yahoo.search.query.profiling.ProfilingParams clone()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()",
+      "public bridge synthetic java.lang.Object clone()"
+    ],
+    "fields" : [
+      "public static final java.lang.String PROFILING_PARAMS",
+      "public static final java.lang.String DEPTH"
+    ]
   },
   "com.yahoo.search.query.properties.CloneHelper" : {
     "superClass" : "com.yahoo.processing.request.CloneHelper",

--- a/container-search/src/main/java/com/yahoo/search/query/profiling/Profiling.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profiling/Profiling.java
@@ -1,0 +1,75 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.query.profiling;
+
+import com.yahoo.search.query.Trace;
+import com.yahoo.search.query.profile.types.FieldDescription;
+import com.yahoo.search.query.profile.types.QueryProfileFieldType;
+import com.yahoo.search.query.profile.types.QueryProfileType;
+
+import java.util.Objects;
+
+/**
+ * Contains settings for different parts of the backend query evaluation that should be profiled.
+ *
+ * @author geirst
+ */
+public class Profiling implements Cloneable {
+
+    public static final String MATCHING = "matching";
+    public static final String FIRST_PHASE_RANKING = "firstPhaseRanking";
+    public static final String SECOND_PHASE_RANKING = "secondPhaseRanking";
+
+    private static final QueryProfileType argumentType;
+
+    static {
+        argumentType = new QueryProfileType(Trace.PROFILING);
+        argumentType.setStrict(true);
+        argumentType.setBuiltin(true);
+        argumentType.addField(new FieldDescription(MATCHING, new QueryProfileFieldType(ProfilingParams.getArgumentType())));
+        argumentType.addField(new FieldDescription(FIRST_PHASE_RANKING, new QueryProfileFieldType(ProfilingParams.getArgumentType())));
+        argumentType.addField(new FieldDescription(SECOND_PHASE_RANKING, new QueryProfileFieldType(ProfilingParams.getArgumentType())));
+        argumentType.freeze();
+    }
+
+    public static QueryProfileType getArgumentType() { return argumentType; }
+
+    private ProfilingParams matching = new ProfilingParams();
+    private ProfilingParams firstPhaseRanking = new ProfilingParams();
+    private ProfilingParams secondPhaseRanking = new ProfilingParams();
+
+    public ProfilingParams getMatching() {
+        return matching;
+    }
+
+    public ProfilingParams getFirstPhaseRanking() {
+        return firstPhaseRanking;
+    }
+
+    public ProfilingParams getSecondPhaseRanking() {
+        return secondPhaseRanking;
+    }
+
+    @Override
+    public ProfilingParams clone() {
+        try {
+            return (ProfilingParams) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException("Someone inserted a non-cloneable superclass", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Profiling profiling = (Profiling) o;
+        return Objects.equals(matching, profiling.matching) &&
+                Objects.equals(firstPhaseRanking, profiling.firstPhaseRanking) &&
+                Objects.equals(secondPhaseRanking, profiling.secondPhaseRanking);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(matching, firstPhaseRanking, secondPhaseRanking);
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/query/profiling/ProfilingParams.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profiling/ProfilingParams.java
@@ -1,0 +1,62 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.search.query.profiling;
+
+import com.yahoo.search.query.profile.types.FieldDescription;
+import com.yahoo.search.query.profile.types.QueryProfileType;
+
+import java.util.Objects;
+
+/**
+ * Contains parameters for a part of the backend query evaluation that should be profiled.
+ *
+ * @author geirst
+ */
+public class ProfilingParams {
+
+    public static final String PROFILING_PARAMS = "profilingParams";
+    public static final String DEPTH = "depth";
+
+    private static final QueryProfileType argumentType;
+
+    static {
+        argumentType = new QueryProfileType(PROFILING_PARAMS);
+        argumentType.setStrict(true);
+        argumentType.setBuiltin(true);
+        argumentType.addField(new FieldDescription(DEPTH, "integer"));
+        argumentType.freeze();
+    }
+
+    public static QueryProfileType getArgumentType() { return argumentType; }
+
+    private int depth = 0;
+
+    public int getDepth() {
+        return depth;
+    }
+
+    public void setDepth(int value) {
+        depth = value;
+    }
+
+    @Override
+    public ProfilingParams clone() {
+        try {
+            return (ProfilingParams) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new RuntimeException("Someone inserted a non-cloneable superclass", e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProfilingParams that = (ProfilingParams) o;
+        return Objects.equals(depth, that.depth);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(depth);
+    }
+}

--- a/container-search/src/main/java/com/yahoo/search/query/profiling/package-info.java
+++ b/container-search/src/main/java/com/yahoo/search/query/profiling/package-info.java
@@ -1,0 +1,7 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+@ExportPackage
+@PublicApi
+package com.yahoo.search.query.profiling;
+
+import com.yahoo.api.annotations.PublicApi;
+import com.yahoo.osgi.annotation.ExportPackage;

--- a/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
+++ b/container-search/src/main/java/com/yahoo/search/query/properties/QueryProperties.java
@@ -16,6 +16,8 @@ import com.yahoo.search.query.profile.compiled.CompiledQueryProfileRegistry;
 import com.yahoo.search.query.profile.types.ConversionContext;
 import com.yahoo.search.query.profile.types.FieldDescription;
 import com.yahoo.search.query.profile.types.QueryProfileType;
+import com.yahoo.search.query.profiling.Profiling;
+import com.yahoo.search.query.profiling.ProfilingParams;
 import com.yahoo.search.query.ranking.Diversity;
 import com.yahoo.search.query.ranking.MatchPhase;
 import com.yahoo.search.query.ranking.Matching;
@@ -322,6 +324,15 @@ public class QueryProperties extends Properties {
                 if (key.last().equals(Trace.QUERY))
                     query.getTrace().setQuery(asBoolean(value, true));
             }
+            else if ((key.size() == 4) &&
+                    key.get(0).equals(Trace.TRACE) &&
+                    key.get(1).equals(Trace.PROFILING) &&
+                    key.get(3).equals(ProfilingParams.DEPTH)) {
+                var params = getProfilingParams(query.getTrace().getProfiling(), key.get(2));
+                if (params != null) {
+                    params.setDepth(asInteger(value, 0));
+                }
+            }
             else if (key.first().equals(Select.SELECT)) {
                 if (key.size() == 1) {
                     query.getSelect().setGroupingExpressionString(asString(value, ""));
@@ -362,6 +373,17 @@ public class QueryProperties extends Properties {
             else
                 throw new IllegalInputException("Could not set '" + key + "' to '" + value + "'", e);
         }
+    }
+
+    private static ProfilingParams getProfilingParams(Profiling prof, String name) {
+        if (name.equals(Profiling.MATCHING)) {
+            return prof.getMatching();
+        } else if (name.equals(Profiling.FIRST_PHASE_RANKING)) {
+            return prof.getFirstPhaseRanking();
+        } else if (name.equals(Profiling.SECOND_PHASE_RANKING)) {
+            return prof.getSecondPhaseRanking();
+        }
+        return null;
     }
 
     @Override

--- a/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/test/QueryTestCase.java
@@ -597,9 +597,24 @@ public class QueryTestCase {
     }
 
     @Test
-    void testProfilingDepth() {
+    void profile_depth_sets_default_profiling_parameters() {
         Query q = new Query("?query=foo&trace.profileDepth=2");
         assertEquals(2, q.getTrace().getProfileDepth());
+        assertEquals(2, q.getTrace().getProfiling().getMatching().getDepth());
+        assertEquals(2, q.getTrace().getProfiling().getFirstPhaseRanking().getDepth());
+        assertEquals(2, q.getTrace().getProfiling().getSecondPhaseRanking().getDepth());
+    }
+
+    @Test
+    void profiling_parameters_are_resolved() {
+        var q = new Query("?query=foo&" +
+                "trace.profiling.matching.depth=3&" +
+                "trace.profiling.firstPhaseRanking.depth=5&" +
+                "trace.profiling.secondPhaseRanking.depth=-7");
+        assertEquals(0, q.getTrace().getProfileDepth());
+        assertEquals(3, q.getTrace().getProfiling().getMatching().getDepth());
+        assertEquals(5, q.getTrace().getProfiling().getFirstPhaseRanking().getDepth());
+        assertEquals(-7, q.getTrace().getProfiling().getSecondPhaseRanking().getDepth());
     }
 
     @Test


### PR DESCRIPTION
With this change, profiling of matching, first-phase ranking, and second-phase ranking can be tuned separately.

@bratseth please review
@havardpe FYI