### PR TITLE
Just do nothing on-prem, as no access types are supported, but do not…

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
@@ -29,8 +29,6 @@ public class SharedLoadBalancerService implements LoadBalancerService {
 
     @Override
     public LoadBalancerInstance create(LoadBalancerSpec spec, boolean force) {
-        if (spec.settings().isPresent() && ! spec.settings().get().isDefault())
-            throw new IllegalArgumentException("custom zone endpoint settings are not supported with " + getClass());
         return new LoadBalancerInstance(Optional.of(DomainName.of(vipHostname)),
                                         Optional.empty(),
                                         Optional.empty(),


### PR DESCRIPTION
… kill wildcard use

@freva please review and merge. 

This allows someone with deployments in Yahoo and AWS to specify private endpoints with a wildcard setting, without killing new deployments to Yahoo. 