### PR TITLE
Revert "switch to "go" version of vespa-start-services"

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -20,7 +20,6 @@ install_symlink(libexec/vespa/script-utils bin/vespa-get-cluster-state)
 install_symlink(libexec/vespa/script-utils bin/vespa-get-node-state)
 install_symlink(libexec/vespa/script-utils bin/vespa-set-node-state)
 install_symlink(libexec/vespa/script-utils bin/vespa-start-configserver)
-install_symlink(libexec/vespa/script-utils bin/vespa-start-services bin)
 
 install_symlink(libexec/vespa/script-utils bin/vespa-get-config)
 install_symlink(libexec/vespa/script-utils bin/vespa-verify-ranksetup)

--- a/vespabase/CMakeLists.txt
+++ b/vespabase/CMakeLists.txt
@@ -6,6 +6,7 @@ vespa_install_script(src/rhel-prestart.sh vespa-prestart.sh bin)
 vespa_install_script(src/common-env.sh common-env.sh libexec/vespa)
 vespa_install_script(src/start-vespa-base.sh start-vespa-base.sh libexec/vespa)
 vespa_install_script(src/stop-vespa-base.sh stop-vespa-base.sh libexec/vespa)
+vespa_install_script(src/vespa-start-services.sh vespa-start-services bin)
 vespa_install_script(src/vespa-stop-configserver.sh vespa-stop-configserver bin)
 vespa_install_script(src/vespa-stop-services.sh vespa-stop-services bin)
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#25676

Core dump test fails, could be related to setting of core dump size

FYI @tokle 