### PR TITLE
we need onnxruntime for some tests

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -36,6 +36,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.yahoo.vespa</groupId>
+      <artifactId>container-onnxruntime</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
without this, maven will skip the onnx-related tests, and intellij will give NoClassDefFoundError

@gjoranv please review
@mpolden FYI
