### PR TITLE
Suppress array bounds warnings on gcc 13 for shared string repo.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/shared_string_repo.h
+++ b/vespalib/src/vespa/vespalib/util/shared_string_repo.h
@@ -216,7 +216,7 @@ private:
         uint32_t direct_id = try_make_direct_id(str);
         if (direct_id >= ID_BIAS) {
 #pragma GCC diagnostic push
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 12
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 12
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
             uint64_t full_hash = XXH3_64bits(str.data(), str.size());


### PR DESCRIPTION
@baldersheim : please review
