### PR TITLE
Suppress stringop-overflow= warning for document::select::ResultSet

### DIFF
--- a/document/src/vespa/document/select/resultset.cpp
+++ b/document/src/vespa/document/select/resultset.cpp
@@ -19,7 +19,12 @@ ResultSet::preCalc()
     uint32_t range = illegalMask();
     _ands.resize(range * range);
     _ors.resize(range * range);
+#pragma GCC diagnostic push
+#if !defined(__clang__) && __GNUC__ == 13
+#pragma GCC diagnostic ignored "-Wstringop-overflow="
+#endif
     _nots.resize(range);
+#pragma GCC diagnostic pop
     for (ResultSet lset; lset.pcvalid(); lset.pcnext()) {
         for (ResultSet rset; rset.pcvalid(); rset.pcnext()) {
             ResultSet myand;


### PR DESCRIPTION
when compiling with gcc 13.

@baldersheim : please review
