### PR TITLE
Reintroduce reversed form of vespalib::string equality comparison

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -654,7 +654,7 @@ template<uint32_t StackSize>
 small_string<StackSize>
 operator + (const char * a, const small_string<StackSize> & b);
 
-#if __cplusplus < 201709L
+#if __cplusplus < 201709L || (!defined(__clang__) && __GNUC__ == 13)
 template<typename T, uint32_t StackSize>
 bool
 operator == (const T& a, const small_string<StackSize>& b) noexcept


### PR DESCRIPTION
operators when compiling with gcc 13.

@baldersheim : please review
