### PR TITLE
Various improvements to avoid excessive scaling

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsV2MetricsFetcher.java
@@ -63,7 +63,7 @@ public class MetricsV2MetricsFetcher extends AbstractComponent implements Metric
             // Collector 'autoscaling' defined in com.yahoo.vespa.model.admin.monitoring.MetricConsumer
             String url = "http://" + metricsV2Container.get().hostname() + ":" + 4080 + apiPath + "?consumer=autoscaling";
             return httpClient.get(url)
-                             .thenApply(response -> new MetricsResponse(response, applicationNodes, nodeRepository));
+                             .thenApply(response -> new MetricsResponse(response, applicationNodes));
         }
     }
 


### PR DESCRIPTION
- Don't scale if there are provisioned nodes
- Don't scale if less than 5 minutes since last time
- Metrics are stable unless the cluster is actually retiring
