### PR TITLE
make clang happy

### DIFF
--- a/vespalib/src/tests/coro/waiting_for/waiting_for_test.cpp
+++ b/vespalib/src/tests/coro/waiting_for/waiting_for_test.cpp
@@ -47,7 +47,7 @@ Lazy<int> wait_for_value(Service &service) {
 template <typename T>
 Lazy<T> wait_for_fun(auto &&fun) {
     T result = co_await wait_for<T>(fun);
-    co_return std::move(result);
+    co_return result;
 }
 
 TEST(WaitingForTest, wait_for_external_async_int) {

--- a/vespalib/src/vespa/vespalib/coro/async_crypto_socket.cpp
+++ b/vespalib/src/vespa/vespalib/coro/async_crypto_socket.cpp
@@ -221,7 +221,7 @@ Lazy<AsyncCryptoSocket::UP> accept_maybe_tls(AsyncIo &async, AbstractTlsCryptoEn
     } else {
         auto plain_socket = std::make_unique<SnoopedRawSocket>(async, std::move(handle));
         plain_socket->inject_data(buf, snooped);
-        co_return std::move(plain_socket);
+        co_return plain_socket;
     }
 }
 


### PR DESCRIPTION
Avoid checking thread id more than once in coroutines, since clang will assume it cannot change. Also set return values from the outside of the coroutine instead of trying to infer it from the inside.

Fixed a race in async_run fuctions ('this' is not safe to use after giving the coroutine away). This goes for all compilers.

Minor fix to io_uring connect to avoid returning valid non-connected socket if connect was called after AsyncIo shutdown.

Stop using std::move when co_returning local move-only values. clang 15 likes this, but it might not make all compilers more happy...

@geirst please review