### PR TITLE
Skip auditing when bumping vespa-cli formula

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -33,7 +33,7 @@ all: test checkfmt install
 #
 # $ make dist-homebrew
 --dist-homebrew: dist-version
-	brew bump-formula-pr --version $(VERSION) --no-browse vespa-cli
+	brew bump-formula-pr --version $(VERSION) --no-audit --no-browse vespa-cli
 
 dist-homebrew:
 	go run cond_make.go --dist-homebrew


### PR DESCRIPTION
`publish-cli-release` currently fails with

```
09:05:33 vespa-cli:
09:05:33   * Stable: version 8.116.26 is redundant with version scanned from URL
09:05:33 Error: 1 problem in 1 formula detected
09:05:33 Error: `brew audit` failed! 
```

We haven't changed anything in the formula itself, so just skip auditing for
now.

@aressem