### PR TITLE
Disable ZooKeeper snapshot compression by default

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -44,7 +44,8 @@ server[].retired bool default=false
 trustEmptySnapshot bool default=true
 
 dynamicReconfiguration bool default=false
-snapshotMethod string default="gz"
+# Set the snapshot compression method: "gz" for GZIP or "snappy" for Snappy. Any other value disables compression.
+snapshotMethod string default=""
 
 # Uses default Vespa mTLS config if empty string
 vespaTlsConfigFile string default=""


### PR DESCRIPTION
This gives the best write performance overall, especially for large snapshots (>1GB).

@hmusum