### PR TITLE
Add a `vespa.none` sentinel capability to C++ capability code

### DIFF
--- a/vespalib/src/tests/net/tls/capabilities/capabilities_test.cpp
+++ b/vespalib/src/tests/net/tls/capabilities/capabilities_test.cpp
@@ -38,6 +38,7 @@ TEST("CapabilitySet instances are equality comparable") {
 }
 
 TEST("Can get underlying name of all Capability instances") {
+    EXPECT_EQUAL(Capability::none().name(),                     "vespa.none"sv);
     EXPECT_EQUAL(Capability::content_storage_api().name(),      "vespa.content.storage_api"sv);
     EXPECT_EQUAL(Capability::content_document_api().name(),     "vespa.content.document_api"sv);
     EXPECT_EQUAL(Capability::content_search_api().name(),       "vespa.content.search_api"sv);
@@ -71,6 +72,7 @@ void check_capability_set_mapping(const std::string& name, CapabilitySet expecte
 }
 
 TEST("All known capabilities can be looked up by name") {
+    check_capability_mapping("vespa.none",                     Capability::none());
     check_capability_mapping("vespa.content.storage_api",      Capability::content_storage_api());
     check_capability_mapping("vespa.content.document_api",     Capability::content_document_api());
     check_capability_mapping("vespa.content.search_api",       Capability::content_search_api());
@@ -149,11 +151,14 @@ TEST("Default-constructed CapabilitySet has no capabilities") {
     EXPECT_EQUAL(caps.count(), 0u);
     EXPECT_TRUE(caps.empty());
     EXPECT_FALSE(caps.contains(Capability::content_storage_api()));
+    // "none" is a special sentinel, it does not imply an empty capability set
+    EXPECT_FALSE(caps.contains(Capability::none()));
 }
 
 TEST("CapabilitySet can be created with all capabilities") {
     auto caps = CapabilitySet::make_with_all_capabilities();
     EXPECT_EQUAL(caps.count(), CapabilitySet::max_count());
+    EXPECT_TRUE(caps.contains(Capability::none()));
     EXPECT_TRUE(caps.contains(Capability::content_storage_api()));
     EXPECT_TRUE(caps.contains(Capability::content_metrics_api()));
     // ... we just assume the rest are present as well.

--- a/vespalib/src/vespa/vespalib/net/tls/capability.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/capability.cpp
@@ -13,6 +13,7 @@ using namespace std::string_view_literals;
 
 // Important: must match 1-1 with CapabilityId values!
 constexpr std::array<std::string_view, Capability::max_value_count()> capability_names = {
+    "vespa.none"sv,
     "vespa.content.storage_api"sv,
     "vespa.content.document_api"sv,
     "vespa.content.search_api"sv,
@@ -39,6 +40,7 @@ string Capability::to_string() const {
 
 std::optional<Capability> Capability::find_capability(const string& cap_name) noexcept {
     static const hash_map<string, Capability> name_to_cap({
+        {"vespa.none",                                          none()},
         {"vespa.content.storage_api",                           content_storage_api()},
         {"vespa.content.document_api",                          content_document_api()},
         {"vespa.content.search_api",                            content_search_api()},

--- a/vespalib/src/vespa/vespalib/net/tls/capability.h
+++ b/vespalib/src/vespa/vespalib/net/tls/capability.h
@@ -25,7 +25,8 @@ private:
     // must be possible to change arbitrarily internally across versions.
     // Changes must be reflected in capabilities_test.cpp
     enum class Id : uint32_t {
-        ContentStorageApi = 0, // Must start at zero
+        None = 0, // Must start at zero
+        ContentStorageApi,
         ContentDocumentApi,
         ContentSearchApi,
         ContentProtonAdminApi,
@@ -70,6 +71,13 @@ public:
     string to_string() const;
 
     static std::optional<Capability> find_capability(const string& cap_name) noexcept;
+
+    // The "none" capability is a sentinel value to allow mTLS handshakes to go through
+    // but where no access is granted to any capability-checked API. Non-capability-checked
+    // APIs may still be accessed if this capability is granted.
+    constexpr static Capability none() noexcept {
+        return Capability(Id::None);
+    }
 
     constexpr static Capability content_storage_api() noexcept {
         return Capability(Id::ContentStorageApi);

--- a/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
@@ -61,7 +61,7 @@ public:
 
     ~PolicyConfiguredCertificateVerifier() override;
 
-    VerificationResult verify(const PeerCredentials& peer_creds) const override;
+    [[nodiscard]] VerificationResult verify(const PeerCredentials& peer_creds) const override;
 };
 
 PolicyConfiguredCertificateVerifier::PolicyConfiguredCertificateVerifier(AuthorizedPeers authorized_peers) noexcept


### PR DESCRIPTION
@bjorncs please review

Allows for configuring rules for peers that should pass mTLS handshakes but should not be able to access any capability-restricted APIs.

