### PR TITLE
Make attribute collection spec serial num optional. Pass reconfig

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/attribute/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/attribute/CMakeLists.txt
@@ -12,6 +12,7 @@ vespa_add_library(searchcore_attribute STATIC
     attribute_initializer_result.cpp
     attribute_manager_explorer.cpp
     attribute_manager_initializer.cpp
+    attribute_manager_reconfig.cpp
     attribute_populator.cpp
     attribute_spec.cpp
     attribute_transient_memory_calculator.cpp

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec.cpp
@@ -4,7 +4,7 @@
 
 namespace proton {
 
-AttributeCollectionSpec::AttributeCollectionSpec(AttributeList && attributes, uint32_t docIdLimit, SerialNum currentSerialNum)
+AttributeCollectionSpec::AttributeCollectionSpec(AttributeList && attributes, uint32_t docIdLimit, std::optional<SerialNum> currentSerialNum)
     : _attributes(std::move(attributes)),
       _docIdLimit(docIdLimit),
       _currentSerialNum(currentSerialNum)

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec.h
@@ -4,6 +4,7 @@
 
 #include "attribute_spec.h"
 #include <vespa/searchlib/common/serialnum.h>
+#include <optional>
 #include <vector>
 
 namespace proton {
@@ -21,10 +22,10 @@ private:
 
     AttributeList _attributes;
     uint32_t      _docIdLimit;
-    SerialNum     _currentSerialNum;
+    std::optional<SerialNum> _currentSerialNum;
 
 public:
-    AttributeCollectionSpec(AttributeList && attributes, uint32_t docIdLimit, SerialNum currentSerialNum);
+    AttributeCollectionSpec(AttributeList && attributes, uint32_t docIdLimit, std::optional<SerialNum> currentSerialNum);
     ~AttributeCollectionSpec();
     const AttributeList &getAttributes() const {
         return _attributes;
@@ -35,7 +36,7 @@ public:
     uint32_t getDocIdLimit() const {
         return _docIdLimit;
     }
-    SerialNum getCurrentSerialNum() const {
+    const std::optional<SerialNum>& getCurrentSerialNum() const noexcept {
         return _currentSerialNum;
     }
     bool hasAttribute(const vespalib::string &name) const;

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.cpp
@@ -20,7 +20,7 @@ AttributeCollectionSpecFactory::~AttributeCollectionSpecFactory() = default;
 std::unique_ptr<AttributeCollectionSpec>
 AttributeCollectionSpecFactory::create(const AttributesConfig &attrCfg,
                                        uint32_t docIdLimit,
-                                       search::SerialNum serialNum) const
+                                       std::optional<search::SerialNum> serialNum) const
 {
     AttributeCollectionSpec::AttributeList attrs;
     // Amortize memory spike cost over N docs

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_collection_spec_factory.h
@@ -5,6 +5,7 @@
 #include "attribute_collection_spec.h"
 #include <vespa/searchcore/proton/common/alloc_strategy.h>
 #include <vespa/searchlib/common/serialnum.h>
+#include <optional>
 
 namespace vespa::config::search::internal { class InternalAttributesType; };
 
@@ -26,7 +27,7 @@ public:
     AttributeCollectionSpecFactory(const AllocStrategy& alloc_strategy, bool fastAccessOnly);
     ~AttributeCollectionSpecFactory();
 
-    std::unique_ptr<AttributeCollectionSpec> create(const AttributesConfig &attrCfg, uint32_t docIdLimit, search::SerialNum serialNum) const;
+    std::unique_ptr<AttributeCollectionSpec> create(const AttributesConfig &attrCfg, uint32_t docIdLimit, std::optional<search::SerialNum> serialNum) const;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_factory.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_factory.cpp
@@ -19,9 +19,11 @@ AttributeFactory::create(const vespalib::string &name, const search::attribute::
 }
 
 void
-AttributeFactory::setupEmpty(const AttributeVector::SP &vec, search::SerialNum serialNum) const
+AttributeFactory::setupEmpty(const AttributeVector::SP &vec, std::optional<search::SerialNum> serialNum) const
 {
-    vec->setCreateSerialNum(serialNum);
+    if (serialNum.has_value()) {
+        vec->setCreateSerialNum(serialNum.value());
+    }
     vec->addReservedDoc();
 }
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_factory.h
@@ -16,7 +16,7 @@ public:
     AttributeFactory();
 
     AttributeVectorSP create(const vespalib::string &name, const search::attribute::Config &cfg) const override;
-    void setupEmpty(const AttributeVectorSP &vec, search::SerialNum serialNum) const override;
+    void setupEmpty(const AttributeVectorSP &vec, std::optional<search::SerialNum> serialNum) const override;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.cpp
@@ -209,11 +209,12 @@ void
 AttributeInitializer::setupEmptyAttribute(AttributeVectorSP &attr, search::SerialNum serialNum,
                                           const AttributeHeader &header) const
 {
-    if (header.getCreateSerialNum() > _currentSerialNum) {
-        logAttributeTooNew(header, _currentSerialNum);
+    assert(_currentSerialNum.has_value());
+    if (header.getCreateSerialNum() > _currentSerialNum.value()) {
+        logAttributeTooNew(header, _currentSerialNum.value());
     }
-    if (serialNum < _currentSerialNum) {
-        logAttributeTooOld(header, serialNum, _currentSerialNum);
+    if (serialNum < _currentSerialNum.value()) {
+        logAttributeTooOld(header, serialNum, _currentSerialNum.value());
     }
     if (!headerTypeOK(header, attr->getConfig())) {
         logAttributeWrongType(attr, header);
@@ -234,7 +235,7 @@ AttributeInitializer::createAndSetupEmptyAttribute() const
 AttributeInitializer::AttributeInitializer(const std::shared_ptr<AttributeDirectory> &attrDir,
                                            const vespalib::string &documentSubDbName,
                                            AttributeSpec && spec,
-                                           uint64_t currentSerialNum,
+                                           std::optional<uint64_t> currentSerialNum,
                                            const IAttributeFactory &factory,
                                            vespalib::Executor& shared_executor)
     : _attrDir(attrDir),
@@ -246,7 +247,9 @@ AttributeInitializer::AttributeInitializer(const std::shared_ptr<AttributeDirect
       _header(),
       _header_ok(false)
 {
-    readHeader();
+    if (_currentSerialNum.has_value()) {
+        readHeader();
+    }
 }
 
 AttributeInitializer::~AttributeInitializer() = default;

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_initializer.h
@@ -6,6 +6,7 @@
 #include "attribute_initializer_result.h"
 #include <vespa/vespalib/stllike/string.h>
 #include <vespa/searchlib/common/serialnum.h>
+#include <optional>
 
 namespace search::attribute { class AttributeHeader; }
 namespace vespalib { class Executor; }
@@ -28,7 +29,7 @@ private:
     std::shared_ptr<AttributeDirectory> _attrDir;
     const vespalib::string          _documentSubDbName;
     const AttributeSpec             _spec;
-    const uint64_t                  _currentSerialNum;
+    const std::optional<uint64_t>   _currentSerialNum;
     const IAttributeFactory        &_factory;
     vespalib::Executor             &_shared_executor;
     std::unique_ptr<const search::attribute::AttributeHeader> _header;
@@ -47,12 +48,12 @@ private:
 
 public:
     AttributeInitializer(const std::shared_ptr<AttributeDirectory> &attrDir, const vespalib::string &documentSubDbName,
-                         AttributeSpec && spec, uint64_t currentSerialNum, const IAttributeFactory &factory,
+                         AttributeSpec && spec, std::optional<uint64_t> currentSerialNum, const IAttributeFactory &factory,
                          vespalib::Executor& shared_executor);
     ~AttributeInitializer();
 
     AttributeInitializerResult init() const;
-    uint64_t getCurrentSerialNum() const { return _currentSerialNum; }
+    const std::optional<uint64_t>& getCurrentSerialNum() const noexcept { return _currentSerialNum; }
     size_t get_transient_memory_usage() const;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_initializer.cpp
@@ -86,7 +86,7 @@ void
 AttributeManagerInitializerTask::run()
 {
     _attrMgr->addExtraAttribute(_documentMetaStore);
-    _attrMgr->addInitializedAttributes(_attributesResult.get());
+    _attrMgr->addInitializedAttributes(_attributesResult.get(), std::nullopt, std::nullopt);
     _attrMgr->pruneRemovedFields(_configSerialNum);
     _promise.set_value();
 }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_reconfig.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_reconfig.cpp
@@ -1,0 +1,28 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "attribute_manager_reconfig.h"
+#include "attributemanager.h"
+#include "sequential_attributes_initializer.h"
+#include <cassert>
+
+namespace proton {
+
+AttributeManagerReconfig::AttributeManagerReconfig(std::shared_ptr<AttributeManager> mgr,
+                             std::unique_ptr<SequentialAttributesInitializer> initializer)
+    : _mgr(std::move(mgr)),
+      _initializer(std::move(initializer))
+{
+}
+
+AttributeManagerReconfig::~AttributeManagerReconfig() = default;
+
+std::shared_ptr<AttributeManager>
+AttributeManagerReconfig::create(std::optional<uint32_t> docid_limit, std::optional<search::SerialNum> serial_num)
+{
+    assert(_mgr);
+    _mgr->addInitializedAttributes(_initializer->getInitializedAttributes(), docid_limit, serial_num);
+    return std::move(_mgr);
+}
+
+
+}

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_reconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_manager_reconfig.h
@@ -1,0 +1,28 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include <vespa/searchlib/common/serialnum.h>
+#include <memory>
+#include <optional>
+
+namespace proton {
+
+class AttributeManager;
+class SequentialAttributesInitializer;
+
+/**
+ * Class representing the result of the prepare step of an AttributeManager
+ * reconfig.
+ */
+class AttributeManagerReconfig {
+    std::shared_ptr<AttributeManager>                _mgr;
+    std::unique_ptr<SequentialAttributesInitializer> _initializer;
+public:
+    AttributeManagerReconfig(std::shared_ptr<AttributeManager> mgr,
+                             std::unique_ptr<SequentialAttributesInitializer> initializer);
+    ~AttributeManagerReconfig();
+    std::shared_ptr<AttributeManager> create(std::optional<uint32_t> docid_limit, std::optional<search::SerialNum> serial_num);
+};
+
+}

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
@@ -123,7 +123,7 @@ public:
 
     AttributeVectorSP addAttribute(AttributeSpec && spec, uint64_t serialNum);
 
-    void addInitializedAttributes(const std::vector<AttributeInitializerResult> &attributes);
+    void addInitializedAttributes(const std::vector<AttributeInitializerResult> &attributes, std::optional<uint32_t> docid_limit, std::optional<SerialNum> serial_num);
 
     void addExtraAttribute(const AttributeVectorSP &attribute);
 
@@ -151,6 +151,7 @@ public:
 
     // Implements proton::IAttributeManager
 
+    std::unique_ptr<AttributeManagerReconfig> prepare_create(Spec && spec) const override;
     proton::IAttributeManager::SP create(Spec && spec) const override;
 
     std::vector<IFlushTargetSP> getFlushTargets() const override;

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributes_initializer_base.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributes_initializer_base.cpp
@@ -8,7 +8,7 @@ namespace proton {
 
 void
 AttributesInitializerBase::considerPadAttribute(search::AttributeVector &attribute,
-                                                search::SerialNum currentSerialNum,
+                                                std::optional<search::SerialNum> currentSerialNum,
                                                 uint32_t newDocIdLimit)
 {
     /*
@@ -32,7 +32,8 @@ AttributesInitializerBase::considerPadAttribute(search::AttributeVector &attribu
      * 1, since a replay of a non-corrupted transaction log should
      * grow the attribute as needed.
      */
-    if (attribute.getStatus().getLastSyncToken() < currentSerialNum) {
+    if (!currentSerialNum.has_value() ||
+        attribute.getStatus().getLastSyncToken() < currentSerialNum.value()) {
         AttributeManager::padAttribute(attribute, newDocIdLimit);
         attribute.commit();
         assert(newDocIdLimit <= attribute.getNumDocs());

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributes_initializer_base.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributes_initializer_base.h
@@ -21,7 +21,7 @@ protected:
 
 public:
     static void considerPadAttribute(search::AttributeVector &attribute,
-                                     search::SerialNum currentSerialNum,
+                                     std::optional<search::SerialNum> currentSerialNum,
                                      uint32_t newDocIdLimit);
 
     AttributesInitializerBase();

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.cpp
@@ -77,6 +77,12 @@ FilterAttributeManager::createContext() const {
     throw vespalib::IllegalArgumentException("Not implemented");
 }
 
+std::unique_ptr<AttributeManagerReconfig>
+FilterAttributeManager::prepare_create(AttributeCollectionSpec&&) const
+{
+    throw vespalib::IllegalArgumentException("Not implemented");
+}
+
 IAttributeManager::SP
 FilterAttributeManager::create(AttributeCollectionSpec &&) const {
     throw vespalib::IllegalArgumentException("Not implemented");

--- a/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/filter_attribute_manager.h
@@ -38,6 +38,7 @@ public:
     std::unique_ptr<search::attribute::AttributeReadGuard> getAttributeReadGuard(const vespalib::string &name, bool stableEnumGuard) const override;
 
     // Implements proton::IAttributeManager
+    std::unique_ptr<AttributeManagerReconfig> prepare_create(AttributeCollectionSpec&& spec) const override;
     IAttributeManager::SP create(AttributeCollectionSpec &&) const override;
     std::vector<searchcorespi::IFlushTarget::SP> getFlushTargets() const override;
     search::SerialNum getOldestFlushedSerialNumber() const override;

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_factory.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_factory.h
@@ -5,6 +5,7 @@
 #include <vespa/searchlib/common/serialnum.h>
 #include <vespa/vespalib/stllike/string.h>
 #include <memory>
+#include <optional>
 
 namespace search { class AttributeVector; }
 namespace search::attribute { class Config; }
@@ -23,7 +24,7 @@ struct IAttributeFactory
     virtual AttributeVectorSP create(const vespalib::string &name,
                                      const search::attribute::Config &cfg) const = 0;
     virtual void setupEmpty(const AttributeVectorSP &vec,
-                            search::SerialNum serialNum) const = 0;
+                            std::optional<search::SerialNum> serialNum) const = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/i_attribute_manager.h
@@ -21,6 +21,7 @@ namespace vespalib {
 
 namespace proton {
 
+class AttributeManagerReconfig;
 class ImportedAttributesRepo;
 
 /**
@@ -35,6 +36,8 @@ struct IAttributeManager : public search::IAttributeManager
     using OnDone = std::shared_ptr<vespalib::IDestructorCallback>;
     using IAttributeFunctor = search::attribute::IAttributeFunctor;
     using IConstAttributeFunctor = search::attribute::IConstAttributeFunctor;
+
+    virtual std::unique_ptr<AttributeManagerReconfig> prepare_create(AttributeCollectionSpec&& spec) const = 0;
 
     /**
      * Create a new attribute manager based on the content of the current one and

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
@@ -102,7 +102,7 @@ FastAccessDocSubDB::setupAttributeManager(AttributeManager::SP attrMgrResult)
 
 
 std::unique_ptr<AttributeCollectionSpec>
-FastAccessDocSubDB::createAttributeSpec(const AttributesConfig &attrCfg, const AllocStrategy& alloc_strategy, SerialNum serialNum) const
+FastAccessDocSubDB::createAttributeSpec(const AttributesConfig &attrCfg, const AllocStrategy& alloc_strategy, std::optional<SerialNum> serialNum) const
 {
     uint32_t docIdLimit(_dms->getCommittedDocIdLimit());
     AttributeCollectionSpecFactory factory(alloc_strategy, _fastAccessAttributesOnly);
@@ -270,7 +270,7 @@ FastAccessDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const
         std::unique_ptr<AttributeCollectionSpec> attrSpec =
             createAttributeSpec(newConfigSnapshot.getAttributesConfig(), alloc_strategy, serialNum);
         IReprocessingInitializer::UP initializer =
-            _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, std::move(*attrSpec), prepared_reconfig);
+            _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, std::move(*attrSpec), prepared_reconfig, serialNum);
         if (initializer->hasReprocessors()) {
             tasks.push_back(IReprocessingTask::SP(createReprocessingTask(*initializer,
                     newConfigSnapshot.getDocumentTypeRepoSP()).release()));

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.h
@@ -91,7 +91,7 @@ protected:
     std::shared_ptr<search::attribute::Interlock> _attribute_interlock;
     DocIdLimit           _docIdLimit;
 
-    std::unique_ptr<AttributeCollectionSpec> createAttributeSpec(const AttributesConfig &attrCfg, const AllocStrategy& alloc_strategy, SerialNum serialNum) const;
+    std::unique_ptr<AttributeCollectionSpec> createAttributeSpec(const AttributesConfig &attrCfg, const AllocStrategy& alloc_strategy, std::optional<SerialNum> serialNum) const;
     AttributeManager::SP getAndResetInitAttributeManager();
     virtual IFlushTargetList getFlushTargetsInternal() override;
     void reconfigureAttributeMetrics(const IAttributeManager &newMgr, const IAttributeManager &oldMgr);

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb_configurer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb_configurer.h
@@ -38,7 +38,8 @@ public:
     IReprocessingInitializer::UP reconfigure(const DocumentDBConfig &newConfig,
                                              const DocumentDBConfig &oldConfig,
                                              AttributeCollectionSpec && attrSpec,
-                                             const DocumentSubDBReconfig& prepared_reconfig);
+                                             const DocumentSubDBReconfig& prepared_reconfig,
+                                             search::SerialNum serial_num);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/searchable_doc_subdb_configurer.h
@@ -84,7 +84,8 @@ public:
                      const DocumentDBConfig &oldConfig,
                      const ReconfigParams &params,
                      IDocumentDBReferenceResolver &resolver,
-                     const DocumentSubDBReconfig& prepared_reconfig);
+                     const DocumentSubDBReconfig& prepared_reconfig,
+                     search::SerialNum serial_num);
 
     IReprocessingInitializer::UP
     reconfigure(const DocumentDBConfig &newConfig,
@@ -92,7 +93,8 @@ public:
                 AttributeCollectionSpec && attrSpec,
                 const ReconfigParams &params,
                 IDocumentDBReferenceResolver &resolver,
-                const DocumentSubDBReconfig& prepared_reconfig);
+                const DocumentSubDBReconfig& prepared_reconfig,
+                search::SerialNum serial_num);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -154,7 +154,7 @@ SearchableDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const
         std::unique_ptr<AttributeCollectionSpec> attrSpec =
             createAttributeSpec(newConfigSnapshot.getAttributesConfig(), alloc_strategy, serialNum);
         IReprocessingInitializer::UP initializer =
-            _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, std::move(*attrSpec), params, resolver, prepared_reconfig);
+            _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, std::move(*attrSpec), params, resolver, prepared_reconfig, serialNum);
         if (initializer && initializer->hasReprocessors()) {
             tasks.emplace_back(createReprocessingTask(*initializer, newConfigSnapshot.getDocumentTypeRepoSP()));
         }
@@ -163,7 +163,7 @@ SearchableDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const
             reconfigureAttributeMetrics(*newMgr, *oldMgr);
         }
     } else {
-        _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, params, resolver, prepared_reconfig);
+        _configurer.reconfigure(newConfigSnapshot, oldConfigSnapshot, params, resolver, prepared_reconfig, serialNum);
     }
     syncViews();
     return tasks;

--- a/searchcore/src/vespa/searchcore/proton/test/mock_attribute_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_attribute_manager.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/searchcore/proton/attribute/i_attribute_manager.h>
+#include <vespa/searchcore/proton/attribute/attribute_manager_reconfig.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 #include <vespa/searchlib/test/mock_attribute_manager.h>
 #include <vespa/vespalib/util/hdr_abort.h>
@@ -48,6 +49,9 @@ public:
     }
     search::attribute::IAttributeContext::UP createContext() const override {
         return _mock.createContext();
+    }
+    std::unique_ptr<AttributeManagerReconfig> prepare_create(AttributeCollectionSpec&&) const override {
+        return {};
     }
     IAttributeManager::SP create(AttributeCollectionSpec &&) const override {
         return IAttributeManager::SP();


### PR DESCRIPTION
serial num explicitly to various reconfigure member functions since it might not be available from attribute collection spec.

@geirst : please review
