### PR TITLE
Allow less vCPU in CD

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeResourceLimits.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeResourceLimits.java
@@ -62,7 +62,7 @@ public class NodeResourceLimits {
     }
 
     private double minAdvertisedVcpu(ClusterSpec cluster) {
-        if (zone().environment().isProduction() && nodeRepository.exclusiveAllocation(cluster)) return 2;
+        if (zone().environment().isProduction() && ! zone().system().isCd() && nodeRepository.exclusiveAllocation(cluster)) return 2;
         if (zone().environment().isProduction() && cluster.type().isContent()) return 1.0;
         if (zone().environment() == Environment.dev && ! nodeRepository.exclusiveAllocation(cluster)) return 0.1;
         if (cluster.type() == ClusterSpec.Type.admin) return 0.1;


### PR DESCRIPTION
As always, there's some app in CD that breaks the rule...
```
Redeploying vespa.canary-vespa7 failed, will retry
...
Caused by: java.lang.IllegalArgumentException: container cluster 'default': Min vcpu size is 0.50 but must be at least 2.00
...
```