### PR TITLE
build: fix ldflags for override `version`

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -13,7 +13,7 @@ BIN ?= $(PREFIX)/bin
 SHARE ?= $(PREFIX)/share
 DIST ?= $(CURDIR)/dist
 
-GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/build.Version=$(VERSION)"
+GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/internal/cli/build.Version=$(VERSION)"
 GIT_ROOT := $(shell git rev-parse --show-toplevel)
 DIST_TARGETS := dist-mac dist-mac-arm64 dist-linux dist-linux-arm64 dist-win32 dist-win64
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

followup of https://github.com/vespa-engine/vespa/pull/25866
relates to https://github.com/Homebrew/homebrew-core/pull/122746