### PR TITLE
Improve key version handling

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/DecryptionTokenResealer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/controller/DecryptionTokenResealer.java
@@ -29,11 +29,16 @@ class DecryptionTokenResealer {
         if (!expectedKeyName.equals(keyName)) {
             throw new IllegalArgumentException("Token is not generated for the expected key");
         }
+        int keyVersion;
         try {
-            return Integer.parseUnsignedInt(components[1]);
+            keyVersion = Integer.parseInt(components[1]);
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Key version is not a valid unsigned integer");
+            throw new IllegalArgumentException("Key version is not a valid integer");
         }
+        if (keyVersion < 0) {
+            throw new IllegalArgumentException("Key version is out of range");
+        }
+        return keyVersion;
     }
 
     /**

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/ControllerApiTest.java
@@ -282,12 +282,17 @@ public class ControllerApiTest extends ControllerContainerTest {
         tester.assertResponse(
                 () -> operatorRequest("http://localhost:8080/controller/v1/access/cores/reseal",
                         requestJsonOf(createResealingRequestData("a-really-cool-key.123asdf")), Request.Method.POST),
-                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Key version is not a valid unsigned integer\"}",
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Key version is not a valid integer\"}",
                 400);
         tester.assertResponse(
                 () -> operatorRequest("http://localhost:8080/controller/v1/access/cores/reseal",
                         requestJsonOf(createResealingRequestData("a-really-cool-key.-123")), Request.Method.POST),
-                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Key version is not a valid unsigned integer\"}",
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Key version is out of range\"}",
+                400);
+        tester.assertResponse(
+                () -> operatorRequest("http://localhost:8080/controller/v1/access/cores/reseal",
+                        requestJsonOf(createResealingRequestData("a-really-cool-key.%d".formatted((long)Integer.MAX_VALUE + 1))), Request.Method.POST),
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Key version is not a valid integer\"}",
                 400);
     }
 


### PR DESCRIPTION
@bjorncs please review.

Now properly ensures only non-negative key version values. This shouldn't matter in practice, but good to keep value ranges within "expected" bounds.
