### PR TITLE
split AbstractConfigProducer

### DIFF
--- a/config-model/src/main/java/com/yahoo/config/model/ApplicationConfigProducerRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/ApplicationConfigProducerRoot.java
@@ -13,7 +13,8 @@ import com.yahoo.cloud.config.log.LogdConfig;
 import com.yahoo.component.Version;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.AnyConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.document.config.DocumenttypesConfig;
 import com.yahoo.document.config.DocumentmanagerConfig;
@@ -49,7 +50,7 @@ import java.util.Set;
  *
  * @author gjoranv
  */
-public class ApplicationConfigProducerRoot extends AbstractConfigProducer<AbstractConfigProducer<?>> implements CommonConfigsProducer {
+public class ApplicationConfigProducerRoot extends TreeConfigProducer<TreeConfigProducer<?>> implements CommonConfigsProducer {
 
     private final DocumentModel documentModel;
     private Routing routing = null;
@@ -68,7 +69,7 @@ public class ApplicationConfigProducerRoot extends AbstractConfigProducer<Abstra
      * @param name   the name, used as configId
      * @param documentModel DocumentModel to serve global document config from.
      */
-    public ApplicationConfigProducerRoot(AbstractConfigProducer parent, String name, DocumentModel documentModel, Version vespaVersion, ApplicationId applicationId) {
+    public ApplicationConfigProducerRoot(TreeConfigProducer parent, String name, DocumentModel documentModel, Version vespaVersion, ApplicationId applicationId) {
         super(parent, name);
         this.documentModel = documentModel;
         this.vespaVersion = vespaVersion;
@@ -120,8 +121,8 @@ public class ApplicationConfigProducerRoot extends AbstractConfigProducer<Abstra
      *
      * @param descendant The configProducer descendant to add
      */
-    // TODO: Make protected if this moves to the same package as AbstractConfigProducer
-    public void addDescendant(AbstractConfigProducer descendant) {
+    // TODO: Make protected if this moves to the same package as TreeConfigProducer
+    public void addDescendant(AnyConfigProducer descendant) {
         id2producer.put(descendant.getConfigId(), descendant);
     }
 

--- a/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
+++ b/config-model/src/main/java/com/yahoo/config/model/ConfigModelContext.java
@@ -5,7 +5,7 @@ import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.VespaModel;
 
 import java.util.stream.Stream;
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
  */
 public final class ConfigModelContext {
 
-    private final AbstractConfigProducer<?> parent;
+    private final TreeConfigProducer<?> parent;
     private final String producerId;
     private final DeployState deployState;
     private final VespaModel vespaModel;
@@ -29,7 +29,7 @@ public final class ConfigModelContext {
                                DeployState deployState,
                                VespaModel vespaModel,
                                ConfigModelRepoAdder configModelRepoAdder,
-                               AbstractConfigProducer<?> parent,
+                               TreeConfigProducer<?> parent,
                                String producerId) {
         this.applicationType = applicationType;
         this.deployState = deployState;
@@ -41,7 +41,7 @@ public final class ConfigModelContext {
 
     public ApplicationPackage getApplicationPackage() { return deployState.getApplicationPackage(); }
     public String getProducerId() { return producerId; }
-    public AbstractConfigProducer<?> getParentProducer() { return parent; }
+    public TreeConfigProducer<?> getParentProducer() { return parent; }
     public DeployLogger getDeployLogger() { return deployState.getDeployLogger(); }
     public DeployState getDeployState() { return deployState; }
     public ApplicationType getApplicationType() { return applicationType; }
@@ -53,7 +53,7 @@ public final class ConfigModelContext {
     public ConfigModelRepoAdder getConfigModelRepoAdder() { return configModelRepoAdder; }
 
     /** Create a new context with a different parent */
-    public ConfigModelContext withParent(AbstractConfigProducer<?> newParent) {
+    public ConfigModelContext withParent(TreeConfigProducer<?> newParent) {
         return ConfigModelContext.create(deployState, vespaModel, configModelRepoAdder, newParent, producerId);
     }
 
@@ -77,7 +77,7 @@ public final class ConfigModelContext {
     public static ConfigModelContext create(DeployState deployState,
                                             VespaModel vespaModel,
                                             ConfigModelRepoAdder configModelRepoAdder,
-                                            AbstractConfigProducer<?> parent,
+                                            TreeConfigProducer<?> parent,
                                             String producerId) {
         return new ConfigModelContext(ApplicationType.DEFAULT, deployState, vespaModel, configModelRepoAdder, parent, producerId);
     }
@@ -95,7 +95,7 @@ public final class ConfigModelContext {
                                             DeployState deployState,
                                             VespaModel vespaModel,
                                             ConfigModelRepoAdder configModelRepoAdder,
-                                            AbstractConfigProducer<?> parent,
+                                            TreeConfigProducer<?> parent,
                                             String producerId) {
         return new ConfigModelContext(applicationType, deployState, vespaModel, configModelRepoAdder, parent, producerId);
     }

--- a/config-model/src/main/java/com/yahoo/config/model/ConfigModelRepo.java
+++ b/config-model/src/main/java/com/yahoo/config/model/ConfigModelRepo.java
@@ -9,7 +9,7 @@ import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.graph.ModelGraphBuilder;
 import com.yahoo.config.model.graph.ModelNode;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.provision.HostsXmlProvisioner;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.VespaModel;
@@ -172,7 +172,7 @@ public class ConfigModelRepo implements ConfigModelRepoAdder, Serializable, Iter
                              ApplicationType applicationType,
                              DeployState deployState,
                              VespaModel vespaModel,
-                             AbstractConfigProducer parent,
+                             TreeConfigProducer parent,
                              List<Element> elements) {
         for (Element servicesElement : elements) {
             ConfigModel model = buildModel(node, applicationType, deployState, vespaModel, parent, servicesElement);
@@ -185,7 +185,7 @@ public class ConfigModelRepo implements ConfigModelRepoAdder, Serializable, Iter
                                    ApplicationType applicationType,
                                    DeployState deployState,
                                    VespaModel vespaModel,
-                                   AbstractConfigProducer parent,
+                                   TreeConfigProducer parent,
                                    Element servicesElement) {
         ConfigModelBuilder builder = node.builder;
         ConfigModelContext context = ConfigModelContext.create(applicationType, deployState, vespaModel, this, parent, getIdString(servicesElement));

--- a/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
+++ b/config-model/src/main/java/com/yahoo/config/model/admin/AdminModel.java
@@ -9,7 +9,7 @@ import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.admin.Admin;
 import com.yahoo.vespa.model.builder.xml.dom.DomAdminV2Builder;
 import com.yahoo.vespa.model.builder.xml.dom.DomAdminV4Builder;
@@ -80,7 +80,7 @@ public class AdminModel extends ConfigModel {
                 new BuilderV4().doBuild(model, adminElement, modelContext);
                 return;
             }
-            AbstractConfigProducer<?> parent = modelContext.getParentProducer();
+            TreeConfigProducer<?> parent = modelContext.getParentProducer();
             ModelContext.Properties properties = modelContext.getDeployState().getProperties();
             DomAdminV2Builder domBuilder = new DomAdminV2Builder(modelContext.getApplicationType(),
                                                                  properties.multitenant(),
@@ -109,7 +109,7 @@ public class AdminModel extends ConfigModel {
 
         @Override
         public void doBuild(AdminModel model, Element adminElement, ConfigModelContext modelContext) {
-            AbstractConfigProducer<?> parent = modelContext.getParentProducer();
+            TreeConfigProducer<?> parent = modelContext.getParentProducer();
             ModelContext.Properties properties = modelContext.getDeployState().getProperties();
             DomAdminV4Builder domBuilder = new DomAdminV4Builder(modelContext,
                                                                  properties.multitenant(),

--- a/config-model/src/main/java/com/yahoo/config/model/builder/xml/ConfigModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/config/model/builder/xml/ConfigModelBuilder.java
@@ -8,7 +8,7 @@ import com.yahoo.config.model.ConfigModelInstanceFactory;
 import com.yahoo.config.model.ConfigModelRepo;
 import com.yahoo.config.model.api.ConfigModelPlugin;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.VespaModel;
 import org.w3c.dom.Element;
 
@@ -55,7 +55,7 @@ public abstract class ConfigModelBuilder<MODEL extends ConfigModel> extends Abst
      * @param spec the XML element this is constructed from
      */
     public final MODEL build(DeployState deployState, VespaModel vespaModel, ConfigModelRepo configModelRepo,
-                             AbstractConfigProducer<?> parent, Element spec) {
+                             TreeConfigProducer<?> parent, Element spec) {
         ConfigModelContext context = ConfigModelContext.create(deployState, vespaModel, configModelRepo, parent, getIdString(spec));
         return build(new DefaultModelInstanceFactory(), spec, context);
     }

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducerRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AbstractConfigProducerRoot.java
@@ -15,7 +15,7 @@ import java.util.Optional;
  *
  * @author Tony Vaagenes
  */
-public abstract class AbstractConfigProducerRoot extends AbstractConfigProducer<AbstractConfigProducer<?>>
+public abstract class AbstractConfigProducerRoot extends TreeConfigProducer<TreeConfigProducer<?>>
         implements ConfigProducerRoot {
 
     /** The ConfigProducers contained in this model indexed by config id */

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AnyConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AnyConfigProducer.java
@@ -14,15 +14,11 @@ import com.yahoo.vespa.config.GenericConfig;
 import com.yahoo.vespa.model.ConfigProducer;
 import com.yahoo.vespa.model.HostSystem;
 import com.yahoo.vespa.model.Service;
-import com.yahoo.vespa.model.SimpleConfigProducer;
 import com.yahoo.vespa.model.admin.Admin;
 import com.yahoo.vespa.model.admin.monitoring.Monitoring;
-import com.yahoo.vespa.model.utils.FreezableMap;
-import java.io.PrintStream;
+
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -33,6 +29,7 @@ import java.util.logging.Logger;
  * Config producers constructs and returns config instances on request.
  *
  * @author gjoranv
+ * @author arnej
  */
 public abstract class AnyConfigProducer
         implements ConfigProducer, ConfigInstance.Producer, Serializable {
@@ -41,8 +38,6 @@ public abstract class AnyConfigProducer
     public static final Logger log = Logger.getLogger(AnyConfigProducer.class.getPackage().toString());
     private final String subId;
     private String configId = null;
-
-    private final List<Service> descendantServices = new ArrayList<>();
 
     private TreeConfigProducer parent = null;
 
@@ -90,14 +85,6 @@ public abstract class AnyConfigProducer
             throw new IllegalArgumentException("A subId might not contain '/' : '" + subId + "'");
         }
         this.subId = subId;
-    }
-
-    /**
-     * Helper to provide an error message on collisions of sub ids (ignore SimpleConfigProducer, use the parent in that case)
-     */
-    protected String errorMsgClassName() {
-        if (getClass().equals(SimpleConfigProducer.class)) return parent.getClass().getSimpleName();
-        return getClass().getSimpleName();
     }
 
     /**

--- a/config-model/src/main/java/com/yahoo/config/model/producer/AnyConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/AnyConfigProducer.java
@@ -34,34 +34,32 @@ import java.util.logging.Logger;
  *
  * @author gjoranv
  */
-public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProducer<?>>
+public abstract class AnyConfigProducer
         implements ConfigProducer, ConfigInstance.Producer, Serializable {
 
     private static final long serialVersionUID = 1L;
-    public static final Logger log = Logger.getLogger(AbstractConfigProducer.class.getPackage().toString());
+    public static final Logger log = Logger.getLogger(AnyConfigProducer.class.getPackage().toString());
     private final String subId;
     private String configId = null;
 
     private final List<Service> descendantServices = new ArrayList<>();
 
-    private AbstractConfigProducer parent = null;
+    private TreeConfigProducer parent = null;
 
     private UserConfigRepo userConfigs = new UserConfigRepo();
-
-    private final FreezableMap<String, CHILD> childrenBySubId = new FreezableMap<>(LinkedHashMap.class);
 
     protected static boolean stateIsHosted(DeployState deployState) {
         return (deployState != null) && deployState.isHosted();
     }
 
     /**
-     * Creates a new AbstractConfigProducer with the given parent and subId.
+     * Creates a new AnyConfigProducer with the given parent and subId.
      * This constructor will add the resulting producer to the children of parent.
      *
      * @param parent the parent of this ConfigProducer
      * @param subId  the fragment of the config id for the producer
      */
-    public AbstractConfigProducer(AbstractConfigProducer parent, String subId) {
+    public AnyConfigProducer(TreeConfigProducer parent, String subId) {
         this(subId);
         if (parent != null) {
             parent.addChild(this);
@@ -74,7 +72,7 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
             parent.removeChild(this);
     }
 
-    protected final void setParent(AbstractConfigProducer<?> parent) {
+    protected final void setParent(TreeConfigProducer parent) {
         this.parent = parent;
         computeConfigId();
     }
@@ -83,11 +81,11 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
 
     /**
      * Create an config producer with a configId only. Used e.g. to create root nodes, and producers
-     * that are given children after construction using {@link #addChild(AbstractConfigProducer)}.
+     * that are given parents after construction using {@link TreeConfigProducer#addChild(AnyConfigProducer)}.
      *
      * @param subId The sub configId. Note that this can be prefixed when calling addChild with this producer as arg.
      */
-    public AbstractConfigProducer(String subId) {
+    public AnyConfigProducer(String subId) {
         if (subId.indexOf('/') != -1) {
             throw new IllegalArgumentException("A subId might not contain '/' : '" + subId + "'");
         }
@@ -95,49 +93,9 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
     }
 
     /**
-     * Adds a child to this config producer.
-     *
-     * @param child the child config producer to add
-     */
-    protected void addChild(CHILD child) {
-        if (child == null) {
-            throw new IllegalArgumentException("Trying to add null child for: " + this);
-        }
-        if (child instanceof AbstractConfigProducerRoot) {
-            throw new IllegalArgumentException("Child cannot be a root node: " + child);
-        }
-
-        child.setParent(this);
-        if (childrenBySubId.get(child.getSubId()) != null) {
-            throw new IllegalArgumentException("Multiple services/instances of the id '" + child.getSubId() + "' under the service/instance " +
-                                               errorMsgClassName() + " '" + subId + "'. (This is commonly caused by service/node index " +
-                                               "collisions in the config.)." +
-                                               "\nExisting instance: " + childrenBySubId.get(child.getSubId()) +
-                                               "\nAttempted to add:  " + child);
-        }
-        childrenBySubId.put(child.getSubId(), child);
-
-        if (child instanceof Service) {
-            addDescendantService((Service)child);
-        }
-    }
-
-    public void removeChild(CHILD child) {
-        if (child.getParent() != this)
-            throw new IllegalArgumentException("Could not remove " + child  + ": Expected its parent to be " +
-                                               this + ", but was " + child.getParent());
-
-        if (child instanceof Service)
-            descendantServices.remove(child);
-
-        childrenBySubId.remove(child.getSubId());
-        child.setParent(null);
-    }
-
-    /**
      * Helper to provide an error message on collisions of sub ids (ignore SimpleConfigProducer, use the parent in that case)
      */
-    private String errorMsgClassName() {
+    protected String errorMsgClassName() {
         if (getClass().equals(SimpleConfigProducer.class)) return parent.getClass().getSimpleName();
         return getClass().getSimpleName();
     }
@@ -163,6 +121,10 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
         return configId;
     }
 
+    protected final String currentConfigId() {
+        return configId;
+    }
+
     /**
      * Sets the config id for this producer. Will also add this
      * service to the root node, so the new config id will be picked
@@ -175,30 +137,6 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
         if (!isVespa() && (getVespa() != null))
             getVespa().addDescendant(this);
     }
-
-    /** Returns this ConfigProducer's children (only 1st level) */
-    public Map<String, CHILD> getChildren() { return Collections.unmodifiableMap(childrenBySubId); }
-
-    @Beta
-    public <J extends AbstractConfigProducer<?>> List<J> getChildrenByTypeRecursive(Class<J> type) {
-        List<J> validChildren = new ArrayList<>();
-
-        if (this.getClass().equals(type)) {
-            validChildren.add(type.cast(this));
-        }
-
-        Map<String, ? extends AbstractConfigProducer<?>> children = this.getChildren();
-        for (AbstractConfigProducer<?> child : children.values()) {
-            validChildren.addAll(child.getChildrenByTypeRecursive(type));
-        }
-
-        return Collections.unmodifiableList(validChildren);
-    }
-
-    /** Returns a list of all the children of this who are instances of Service */
-    public List<Service> getDescendantServices() { return Collections.unmodifiableList(descendantServices); }
-
-    protected void addDescendantService(Service s) { descendantServices.add(s); }
 
     @Override
     public final boolean cascadeConfig(ConfigInstance.Builder builder) {
@@ -271,7 +209,11 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
      */
     private ApplicationConfigProducerRoot getVespa() {
         if (isRoot()) return null;
-        return isVespa() ? (ApplicationConfigProducerRoot)this : parent.getVespa();
+        if (isVespa()) {
+            return (ApplicationConfigProducerRoot)this;
+        } else {
+            return getParent().getVespa();
+        }
     }
 
     private boolean isRoot() {
@@ -279,19 +221,10 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
     }
 
     private boolean isVespa() {
-       return ((this instanceof ApplicationConfigProducerRoot) && parent.isRoot());
+        return ((this instanceof ApplicationConfigProducerRoot) && getParent().isRoot());
     }
 
-    public AbstractConfigProducer getParent() { return parent; }
-
-    public void dump(PrintStream out) {
-        for (ConfigProducer c : getChildren().values()) {
-            out.println("id: " + c.getConfigId());
-            if (c.getChildren().size() > 0) {
-                c.dump(out);
-            }
-        }
-    }
+    public AnyConfigProducer getParent() { return parent; }
 
     void setupConfigId(String parentConfigId) {
         if (this instanceof AbstractConfigProducerRoot) {
@@ -301,15 +234,6 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
             addConfigId(configId);
         }
         computeConfigId();
-        setupChildConfigIds(getConfigIdPrefix());
-    }
-
-    private String getConfigIdPrefix() {
-        if (this instanceof AbstractConfigProducerRoot || this instanceof ApplicationConfigProducerRoot) {
-            return "";
-        }
-        if (configId == null) return null;
-        return configId + "/";
     }
 
     private void computeConfigId() {
@@ -328,7 +252,7 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
         }
     }
 
-    private static ClassLoader findInheritedClassLoader(Class clazz, String producerName) {
+    protected static ClassLoader findInheritedClassLoader(Class clazz, String producerName) {
         Class<?>[] interfazes = clazz.getInterfaces();
         for (Class interfaze : interfazes) {
             if (producerName.equals(interfaze.getName())) {
@@ -341,51 +265,11 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
     }
 
     protected ClassLoader getConfigClassLoader(String producerName) {
-        ClassLoader classLoader = findInheritedClassLoader(getClass(), producerName);
-        if (classLoader != null)
-            return classLoader;
-
-        // TODO: Make logic correct, so that the deepest child will be the one winning.
-        for (AbstractConfigProducer child : childrenBySubId.values()) {
-            ClassLoader loader = child.getConfigClassLoader(producerName);
-            if (loader != null) {
-                return loader;
-            }
-        }
-        return null;
-    }
-
-    private void setupChildConfigIds(String currentConfigId) {
-        for (AbstractConfigProducer child : childrenBySubId.values()) {
-            child.setupConfigId(currentConfigId);
-        }
-    }
-
-    void aggregateDescendantServices() {
-        for (AbstractConfigProducer child : childrenBySubId.values()) {
-            child.aggregateDescendantServices();
-            descendantServices.addAll(child.descendantServices);
-        }
-    }
-
-    void freeze() {
-        childrenBySubId.freeze();
-        for (AbstractConfigProducer child : childrenBySubId.values()) {
-            child.freeze();
-        }
+        return findInheritedClassLoader(getClass(), producerName);
     }
 
     public void mergeUserConfigs(UserConfigRepo newRepo) {
         userConfigs.merge(newRepo);
-    }
-
-    @Override
-    public void validate() throws Exception {
-        assert (childrenBySubId.isFrozen());
-
-        for (AbstractConfigProducer<?> child : childrenBySubId.values()) {
-            child.validate();
-        }
     }
 
     // TODO: Make producers depend on AdminModel instead
@@ -401,4 +285,13 @@ public abstract class AbstractConfigProducer<CHILD extends AbstractConfigProduce
         }
         return null;
     }
+
+    // NOPs for all config producers without children; overridden in TreeConfigProducer
+    void aggregateDescendantServices() { }
+    public List<Service> getDescendantServices() { return List.of(); }
+    <J extends AnyConfigProducer> List<J> getChildrenByTypeRecursive(Class<J> type) { return List.of(); }
+    void freeze() { }
+    @Override
+    public void validate() throws Exception { }
+
 }

--- a/config-model/src/main/java/com/yahoo/config/model/producer/TreeConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/TreeConfigProducer.java
@@ -2,21 +2,10 @@
 package com.yahoo.config.model.producer;
 
 import com.yahoo.api.annotations.Beta;
-import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
-import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.subscription.ConfigInstanceUtil;
-import com.yahoo.vespa.config.ConfigDefinitionKey;
-import com.yahoo.vespa.config.ConfigPayload;
-import com.yahoo.vespa.config.ConfigPayloadBuilder;
-import com.yahoo.vespa.config.ConfigTransformer;
-import com.yahoo.vespa.config.GenericConfig;
 import com.yahoo.vespa.model.ConfigProducer;
-import com.yahoo.vespa.model.HostSystem;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.SimpleConfigProducer;
-import com.yahoo.vespa.model.admin.Admin;
-import com.yahoo.vespa.model.admin.monitoring.Monitoring;
 import com.yahoo.vespa.model.utils.FreezableMap;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -29,10 +18,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Superclass for all config producers with children.
+ * Superclass for all producers with children.
  * Config producers constructs and returns config instances on request.
  *
  * @author gjoranv
+ * @author arnej
  */
 public abstract class TreeConfigProducer<CHILD extends AnyConfigProducer>
     extends AnyConfigProducer
@@ -60,6 +50,14 @@ public abstract class TreeConfigProducer<CHILD extends AnyConfigProducer>
      */
     public TreeConfigProducer(String subId) {
         super(subId);
+    }
+
+    /**
+     * Helper to provide an error message on collisions of sub ids (ignore SimpleConfigProducer, use the parent in that case)
+     */
+    private String errorMsgClassName() {
+        if (getClass().equals(SimpleConfigProducer.class)) return getParent().getClass().getSimpleName();
+        return getClass().getSimpleName();
     }
 
     /**

--- a/config-model/src/main/java/com/yahoo/config/model/producer/TreeConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/TreeConfigProducer.java
@@ -1,0 +1,199 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.config.model.producer;
+
+import com.yahoo.api.annotations.Beta;
+import com.yahoo.config.ConfigInstance;
+import com.yahoo.config.model.ApplicationConfigProducerRoot;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.config.subscription.ConfigInstanceUtil;
+import com.yahoo.vespa.config.ConfigDefinitionKey;
+import com.yahoo.vespa.config.ConfigPayload;
+import com.yahoo.vespa.config.ConfigPayloadBuilder;
+import com.yahoo.vespa.config.ConfigTransformer;
+import com.yahoo.vespa.config.GenericConfig;
+import com.yahoo.vespa.model.ConfigProducer;
+import com.yahoo.vespa.model.HostSystem;
+import com.yahoo.vespa.model.Service;
+import com.yahoo.vespa.model.SimpleConfigProducer;
+import com.yahoo.vespa.model.admin.Admin;
+import com.yahoo.vespa.model.admin.monitoring.Monitoring;
+import com.yahoo.vespa.model.utils.FreezableMap;
+import java.io.PrintStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Superclass for all config producers with children.
+ * Config producers constructs and returns config instances on request.
+ *
+ * @author gjoranv
+ */
+public abstract class TreeConfigProducer<CHILD extends AnyConfigProducer>
+    extends AnyConfigProducer
+{
+    private static final long serialVersionUID = 1L;
+    private final List<Service> descendantServices = new ArrayList<>();
+    private final FreezableMap<String, CHILD> childrenBySubId = new FreezableMap<>(LinkedHashMap.class);
+
+    /**
+     * Creates a new TreeConfigProducer with the given parent and subId.
+     * This constructor will add the resulting producer to the children of parent.
+     *
+     * @param parent the parent of this ConfigProducer
+     * @param subId  the fragment of the config id for the producer
+     */
+    public TreeConfigProducer(TreeConfigProducer parent, String subId) {
+        super(parent, subId);
+    }
+
+    /**
+     * Create an config producer with a configId only. Used e.g. to create root nodes, and producers
+     * that are given children after construction using {@link #addChild(AnyConfigProducer)}.
+     *
+     * @param subId The sub configId. Note that this can be prefixed when calling addChild with this producer as arg.
+     */
+    public TreeConfigProducer(String subId) {
+        super(subId);
+    }
+
+    /**
+     * Adds a child to this config producer.
+     *
+     * @param child the child config producer to add
+     */
+    protected void addChild(CHILD child) {
+        if (child == null) {
+            throw new IllegalArgumentException("Trying to add null child for: " + this);
+        }
+        if (child instanceof AbstractConfigProducerRoot) {
+            throw new IllegalArgumentException("Child cannot be a root node: " + child);
+        }
+
+        child.setParent(this);
+        if (childrenBySubId.get(child.getSubId()) != null) {
+            throw new IllegalArgumentException("Multiple services/instances of the id '" + child.getSubId() + "' under the service/instance " +
+                                               errorMsgClassName() + " '" + getSubId() + "'. (This is commonly caused by service/node index " +
+                                               "collisions in the config.)." +
+                                               "\nExisting instance: " + childrenBySubId.get(child.getSubId()) +
+                                               "\nAttempted to add:  " + child);
+        }
+        childrenBySubId.put(child.getSubId(), child);
+
+        if (child instanceof Service) {
+            addDescendantService((Service)child);
+        }
+    }
+
+    public void removeChild(CHILD child) {
+        if (child.getParent() != this)
+            throw new IllegalArgumentException("Could not remove " + child  + ": Expected its parent to be " +
+                                               this + ", but was " + child.getParent());
+
+        if (child instanceof Service)
+            descendantServices.remove(child);
+
+        childrenBySubId.remove(child.getSubId());
+        child.setParent(null);
+    }
+
+    /** Returns this ConfigProducer's children (only 1st level) */
+    public Map<String, CHILD> getChildren() { return Collections.unmodifiableMap(childrenBySubId); }
+
+    @Beta
+    public <J extends AnyConfigProducer> List<J> getChildrenByTypeRecursive(Class<J> type) {
+        List<J> validChildren = new ArrayList<>();
+
+        if (this.getClass().equals(type)) {
+            validChildren.add(type.cast(this));
+        }
+
+        Map<String, CHILD> children = this.getChildren();
+        for (CHILD child : children.values()) {
+            validChildren.addAll(child.getChildrenByTypeRecursive(type));
+        }
+
+        return Collections.unmodifiableList(validChildren);
+    }
+
+    /** Returns a list of all the children of this who are instances of Service */
+    public List<Service> getDescendantServices() { return Collections.unmodifiableList(descendantServices); }
+
+    protected void addDescendantService(Service s) { descendantServices.add(s); }
+
+    public void dump(PrintStream out) {
+        for (ConfigProducer c : getChildren().values()) {
+            out.println("id: " + c.getConfigId());
+            if (c.getChildren().size() > 0) {
+                c.dump(out);
+            }
+        }
+    }
+
+    void setupConfigId(String parentConfigId) {
+        super.setupConfigId(parentConfigId);
+        setupChildConfigIds(getConfigIdPrefix());
+    }
+
+    String getConfigIdPrefix() {
+        if (this instanceof AbstractConfigProducerRoot || this instanceof ApplicationConfigProducerRoot) {
+            return "";
+        }
+        if (currentConfigId() == null) {
+            return null;
+        }
+        return getConfigId() + "/";
+    }
+
+    @Override
+    protected ClassLoader getConfigClassLoader(String producerName) {
+        ClassLoader classLoader = findInheritedClassLoader(getClass(), producerName);
+        if (classLoader != null)
+            return classLoader;
+
+        // TODO: Make logic correct, so that the deepest child will be the one winning.
+        for (AnyConfigProducer child : childrenBySubId.values()) {
+            ClassLoader loader = child.getConfigClassLoader(producerName);
+            if (loader != null) {
+                return loader;
+            }
+        }
+        return null;
+    }
+
+    private void setupChildConfigIds(String currentConfigId) {
+        for (AnyConfigProducer child : childrenBySubId.values()) {
+            child.setupConfigId(currentConfigId);
+        }
+    }
+
+    @Override
+    void aggregateDescendantServices() {
+        for (CHILD child : childrenBySubId.values()) {
+            child.aggregateDescendantServices();
+            descendantServices.addAll(child.getDescendantServices());
+        }
+    }
+
+    @Override
+    void freeze() {
+        childrenBySubId.freeze();
+        for (CHILD child : childrenBySubId.values()) {
+            child.freeze();
+        }
+    }
+
+    @Override
+    public void validate() throws Exception {
+        assert (childrenBySubId.isFrozen());
+        for (CHILD child : childrenBySubId.values()) {
+            child.validate();
+        }
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/config/model/producer/UserConfigRepo.java
+++ b/config-model/src/main/java/com/yahoo/config/model/producer/UserConfigRepo.java
@@ -28,7 +28,7 @@ public class UserConfigRepo {
     }
 
     /**
-     * Must copy the builder, because the merge method on {@link AbstractConfigProducer} might override the row's builders otherwise
+     * Must copy the builder, because the merge method on {@link TreeConfigProducer} might override the row's builders otherwise
      */
     private Map<ConfigDefinitionKey, ConfigPayloadBuilder> copyBuilders(Map<ConfigDefinitionKey, ConfigPayloadBuilder> source) {
         Map<ConfigDefinitionKey, ConfigPayloadBuilder> ret = new LinkedHashMap<>();

--- a/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
+++ b/config-model/src/main/java/com/yahoo/config/model/test/MockRoot.java
@@ -6,7 +6,8 @@ import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelRepo;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.AnyConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.vespa.model.ConfigProducer;
 import com.yahoo.vespa.model.HostSystem;
@@ -95,7 +96,7 @@ public class MockRoot extends AbstractConfigProducerRoot {
 
     public HostSystem hostSystem() { return hostSystem; }
 
-    public void addDescendant(String configId, AbstractConfigProducer<?> descendant) {
+    public void addDescendant(String configId, AnyConfigProducer descendant) {
         if (id2producer.containsKey(configId)) {
             throw new RuntimeException
                     ("Config ID '" + configId + "' cannot be reserved by an instance of class '" +
@@ -106,7 +107,7 @@ public class MockRoot extends AbstractConfigProducerRoot {
     }
 
     @Override
-    public void addChild(AbstractConfigProducer<?> abstractConfigProducer) {
+    public void addChild(TreeConfigProducer<?> abstractConfigProducer) {
         super.addChild(abstractConfigProducer);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/AbstractService.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model;
 import com.yahoo.config.model.api.PortInfo;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.defaults.Defaults;
 
 import java.util.Collection;
@@ -27,7 +27,7 @@ import static com.yahoo.text.Lowercase.toLowerCase;
  *
  * @author gjoranv
  */
-public abstract class AbstractService extends AbstractConfigProducer<AbstractConfigProducer<?>> implements Service {
+public abstract class AbstractService extends TreeConfigProducer<TreeConfigProducer<?>> implements Service {
 
     // The physical host this Service runs on.
     private HostResource hostResource = null;
@@ -78,13 +78,13 @@ public abstract class AbstractService extends AbstractConfigProducer<AbstractCon
 
     /**
      * Preferred constructor when building from XML. Use this if you are building
-     * in doBuild() in an AbstractConfigProducerBuilder.
+     * in doBuild() in an TreeConfigProducerBuilder.
      * build() will call initService() in that case, after setting hostalias and baseport.
      *
      * @param parent the parent config producer in the model tree
      * @param name   the name of this service
      */
-    public AbstractService(AbstractConfigProducer<?> parent, String name) {
+    public AbstractService(TreeConfigProducer<?> parent, String name) {
         super(parent, name);
         environmentVariables.put("VESPA_SILENCE_CORE_ON_OOM", true);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/Client.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/Client.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model;
 
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 /**
  * This is a placeholder config producer that makes global configuration available through a single identifier. This
@@ -10,7 +10,7 @@ import com.yahoo.config.model.producer.AbstractConfigProducer;
  *
  * @author Simon Thoresen Hult
  */
-public class Client extends AbstractConfigProducer {
+public class Client extends TreeConfigProducer {
 
     /**
      * Constructs a client config producer that is added as a child to
@@ -18,7 +18,7 @@ public class Client extends AbstractConfigProducer {
      *
      * @param parent The parent config producer.
      */
-    public Client(AbstractConfigProducer parent) {
+    public Client(TreeConfigProducer parent) {
         super(parent, "client");
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/ConfigProducerRoot.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/ConfigProducerRoot.java
@@ -2,7 +2,8 @@
 package com.yahoo.vespa.model;
 
 import com.yahoo.config.ConfigInstance;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.AnyConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.admin.Admin;
 
 import java.util.Set;
@@ -21,7 +22,7 @@ public interface ConfigProducerRoot extends ConfigProducer {
      * @param id string id of descendant
      * @param descendant the producer to add to this root node
      */
-    void addDescendant(String id, AbstractConfigProducer<?> descendant);
+    void addDescendant(String id, AnyConfigProducer descendant);
 
     /**
      * @return an unmodifiable copy of the set of configIds in this root.

--- a/config-model/src/main/java/com/yahoo/vespa/model/Host.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/Host.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model;
 
 import com.yahoo.cloud.config.SentinelConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 import java.util.Objects;
 
@@ -12,7 +12,7 @@ import java.util.Objects;
  *
  * @author gjoranv
  */
-public final class Host extends AbstractConfigProducer<AbstractConfigProducer<?>> implements SentinelConfig.Producer, Comparable<Host> {
+public final class Host extends TreeConfigProducer<TreeConfigProducer<?>> implements SentinelConfig.Producer, Comparable<Host> {
 
     private ConfigSentinel configSentinel = null;
     private final String hostname;
@@ -21,14 +21,14 @@ public final class Host extends AbstractConfigProducer<AbstractConfigProducer<?>
     /**
      * Constructs a new Host instance.
      *
-     * @param parent   parent AbstractConfigProducer in the config model.
+     * @param parent   parent TreeConfigProducer in the config model.
      * @param hostname hostname for this host.
      */
-    public Host(AbstractConfigProducer<?> parent, String hostname) {
+    public Host(TreeConfigProducer<?> parent, String hostname) {
         this(parent, hostname, false);
     }
 
-    private Host(AbstractConfigProducer<?> parent, String hostname, boolean runsConfigServer) {
+    private Host(TreeConfigProducer<?> parent, String hostname, boolean runsConfigServer) {
         super(parent, hostname);
         Objects.requireNonNull(hostname, "The host name of a host cannot be null");
         this.runsConfigServer = runsConfigServer;

--- a/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/HostSystem.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model;
 
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.api.HostProvisioner;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.Capacity;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
@@ -29,7 +29,7 @@ import static java.util.logging.Level.FINE;
  *
  * @author gjoranv
  */
-public class HostSystem extends AbstractConfigProducer<Host> {
+public class HostSystem extends TreeConfigProducer<Host> {
 
     private static final Logger log = Logger.getLogger(HostSystem.class.getName());
     private static final boolean doCheckIp;
@@ -45,7 +45,7 @@ public class HostSystem extends AbstractConfigProducer<Host> {
         doCheckIp = ! checkIpProperty.equalsIgnoreCase("false");
     }
 
-    public HostSystem(AbstractConfigProducer<?> parent, String name, HostProvisioner provisioner, DeployLogger deployLogger, boolean isHosted) {
+    public HostSystem(TreeConfigProducer<?> parent, String name, HostProvisioner provisioner, DeployLogger deployLogger, boolean isHosted) {
         super(parent, name);
         this.provisioner = provisioner;
         this.deployLogger = deployLogger;

--- a/config-model/src/main/java/com/yahoo/vespa/model/SimpleConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/SimpleConfigProducer.java
@@ -1,14 +1,14 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 /**
  * Some configuration level with no special handling of its own.
  *
  * @author arnej27959
  */
-public final class SimpleConfigProducer<T extends AbstractConfigProducer<?>> extends AbstractConfigProducer<T> {
+public final class SimpleConfigProducer<T extends TreeConfigProducer<?>> extends TreeConfigProducer<T> {
 
     private static final long serialVersionUID = 1L;
 
@@ -18,7 +18,7 @@ public final class SimpleConfigProducer<T extends AbstractConfigProducer<?>> ext
      * @param parent   parent ConfigProducer.
      * @param configId name of this instance
      */
-    public SimpleConfigProducer(AbstractConfigProducer<?> parent, String configId) {
+    public SimpleConfigProducer(TreeConfigProducer<?> parent, String configId) {
         super(parent, configId);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/VespaModel.java
@@ -23,7 +23,8 @@ import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.Provisioned;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.AnyConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.config.provision.AllocatedHosts;
@@ -591,7 +592,7 @@ public final class VespaModel extends AbstractConfigProducerRoot implements Mode
      * @param configId   the id to register with, not necessarily equal to descendant.getConfigId().
      * @param descendant The configProducer descendant to add
      */
-    public void addDescendant(String configId, AbstractConfigProducer<?> descendant) {
+    public void addDescendant(String configId, AnyConfigProducer descendant) {
         if (id2producer.containsKey(configId)) {
             throw new RuntimeException
                     ("Config ID '" + configId + "' cannot be reserved by an instance of class '" +

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -6,7 +6,7 @@ import com.yahoo.cloud.config.ZookeepersConfig;
 import com.yahoo.cloud.config.log.LogdConfig;
 import com.yahoo.config.model.ConfigModelContext.ApplicationType;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.ConfigProxy;
@@ -38,7 +38,7 @@ import static com.yahoo.vespa.model.admin.monitoring.MetricSet.empty;
  *
  * @author gjoranv
  */
-public class Admin extends AbstractConfigProducer<Admin> implements Serializable {
+public class Admin extends TreeConfigProducer<Admin> implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
@@ -87,7 +87,7 @@ public class Admin extends AbstractConfigProducer<Admin> implements Serializable
     private final FileDistributionConfigProducer fileDistribution;
     private final boolean multitenant;
 
-    public Admin(AbstractConfigProducer<?> parent,
+    public Admin(TreeConfigProducer<?> parent,
                  Monitoring monitoring,
                  Metrics metrics,
                  boolean multitenant,

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Configserver.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Configserver.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.admin;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 
@@ -23,7 +23,7 @@ public class Configserver extends AbstractService {
 
     private final int rpcPort;
 
-    public Configserver(AbstractConfigProducer parent, String name, int rpcPort) {
+    public Configserver(TreeConfigProducer parent, String name, int rpcPort) {
         super(parent, name);
         this.rpcPort = rpcPort;
         portsMeta.on(0).tag("rpc").tag("config");

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogForwarder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogForwarder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.admin;
 
 import com.yahoo.cloud.config.LogforwarderConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import java.util.Optional;
@@ -41,7 +41,7 @@ public class LogForwarder extends AbstractService implements LogforwarderConfig.
      * Creates a new LogForwarder instance.
      */
     // TODO: Use proper types?
-    public LogForwarder(AbstractConfigProducer parent, Config config) {
+    public LogForwarder(TreeConfigProducer parent, Config config) {
         super(parent, "logforwarder");
         this.config = config;
         setProp("clustertype", "hosts");

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Logserver.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Logserver.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.admin;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import java.util.Optional;
@@ -19,7 +19,7 @@ public class Logserver extends AbstractService {
     private static final String logArchiveDir = "$ROOT/logs/vespa/logarchive";
     private String compressionType = "gzip";
 
-    public Logserver(AbstractConfigProducer parent) {
+    public Logserver(TreeConfigProducer parent) {
         super(parent, "logserver");
         portsMeta.on(0).tag("logtp").tag("rpc");
         portsMeta.on(1).tag("unused");

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.admin;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.vespa.model.container.Container;
 import com.yahoo.vespa.model.container.component.AccessLogComponent;
@@ -17,7 +17,7 @@ import java.util.Optional;
  */
 public class LogserverContainer extends Container {
 
-    public LogserverContainer(AbstractConfigProducer<?> parent, DeployState deployState) {
+    public LogserverContainer(TreeConfigProducer<?> parent, DeployState deployState) {
         super(parent, "" + 0, 0, deployState);
         if (deployState.isHosted() && deployState.getProperties().applicationId().instance().isTester()) useDynamicPorts();
         LogserverContainerCluster cluster = (LogserverContainerCluster) parent;

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.admin;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
@@ -16,7 +16,7 @@ import java.util.Optional;
  */
 public class LogserverContainerCluster extends ContainerCluster<LogserverContainer> {
 
-    public LogserverContainerCluster(AbstractConfigProducer<?> parent, String name, DeployState deployState) {
+    public LogserverContainerCluster(TreeConfigProducer<?> parent, String name, DeployState deployState) {
         super(parent, name, name, deployState, true);
 
         addDefaultHandlersWithVip();

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/ModelConfigProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/ModelConfigProvider.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.admin;
 
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 /**
  * A config provider for the model config. The ModelConfig is a common config and produced by {@link ApplicationConfigProducerRoot} , this config
@@ -11,9 +11,9 @@ import com.yahoo.config.model.producer.AbstractConfigProducer;
  * @author gjoranv
  * @since 5.0.8
  */
-public class ModelConfigProvider extends AbstractConfigProducer {
+public class ModelConfigProvider extends TreeConfigProducer {
 
-    public ModelConfigProvider(AbstractConfigProducer<?> parent) {
+    public ModelConfigProvider(TreeConfigProducer<?> parent) {
         super(parent, "model");
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Slobrok.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Slobrok.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.admin;
 
 import com.yahoo.config.model.api.ModelContext;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.config.core.StateserverConfig;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
@@ -28,7 +28,7 @@ public class Slobrok extends AbstractService implements StateserverConfig.Produc
      * @param parent the parent ConfigProducer.
      * @param index  unique index for all slobroks
      */
-    public Slobrok(AbstractConfigProducer<?> parent, int index,
+    public Slobrok(TreeConfigProducer<?> parent, int index,
                    ModelContext.FeatureFlags featureFlags)
     {
         super(parent, "slobrok." + index);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerCluster.java
@@ -6,7 +6,7 @@ import com.yahoo.cloud.config.ZookeeperServerConfig;
 import com.yahoo.cloud.config.ZookeepersConfig;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.HostSpec;
 import com.yahoo.vespa.model.Service;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
  *
  * @author Ulf Lilleengen
  */
-public class ClusterControllerCluster extends AbstractConfigProducer<ClusterControllerContainerCluster> implements
+public class ClusterControllerCluster extends TreeConfigProducer<ClusterControllerContainerCluster> implements
         ZookeeperServerConfig.Producer,
         ZookeepersConfig.Producer {
 
@@ -35,7 +35,7 @@ public class ClusterControllerCluster extends AbstractConfigProducer<ClusterCont
     private ClusterControllerContainerCluster containerCluster = null;
     private final Set<String> previousHosts;
 
-    public ClusterControllerCluster(AbstractConfigProducer<?> parent, String subId, DeployState deployState) {
+    public ClusterControllerCluster(TreeConfigProducer<?> parent, String subId, DeployState deployState) {
         super(parent, subId);
         this.previousHosts = Collections.unmodifiableSet(deployState.getPreviousModel().stream()
                                                                     .map(Model::allocatedHosts)

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -6,7 +6,7 @@ import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
@@ -50,7 +50,7 @@ public class ClusterControllerContainer extends Container implements
 
     private final Set<String> bundles = new TreeSet<>(); // Ensure stable ordering
 
-    public ClusterControllerContainer(AbstractConfigProducer<?> parent,
+    public ClusterControllerContainer(TreeConfigProducer<?> parent,
                                       int index,
                                       boolean runStandaloneZooKeeper,
                                       DeployState deployState,

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.admin.clustercontroller;
 
 import com.yahoo.config.model.api.Reindexing;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
@@ -27,7 +27,7 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
     private final ReindexingContext reindexingContext;
 
     public ClusterControllerContainerCluster(
-            AbstractConfigProducer<?> parent, String subId, String name, DeployState deployState) {
+            TreeConfigProducer<?> parent, String subId, String name, DeployState deployState) {
         super(parent, subId, name, deployState, false);
         addDefaultHandlersWithVip();
         this.reindexingContext = createReindexingContext(deployState);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -24,7 +24,7 @@ import ai.vespa.metricsproxy.telegraf.Telegraf;
 import ai.vespa.metricsproxy.telegraf.TelegrafConfig;
 import ai.vespa.metricsproxy.telegraf.TelegrafRegistry;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.Zone;
@@ -92,10 +92,10 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         static final String LEGACY_APPLICATION = "app";        // app.instance
     }
 
-    private final AbstractConfigProducer<?> parent;
+    private final TreeConfigProducer<?> parent;
     private final ApplicationId applicationId;
 
-    public MetricsProxyContainerCluster(AbstractConfigProducer<?> parent, String name, DeployState deployState) {
+    public MetricsProxyContainerCluster(TreeConfigProducer<?> parent, String name, DeployState deployState) {
         super(parent, name, name, deployState, true);
         this.parent = parent;
         applicationId = deployState.getProperties().applicationId();

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/RankSetupValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/RankSetupValidator.java
@@ -6,7 +6,7 @@ import com.yahoo.collections.Pair;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.io.IOUtils;
 import com.yahoo.log.InvalidLogFormatException;
 import com.yahoo.log.LogMessage;
@@ -108,7 +108,7 @@ public class RankSetupValidator extends Validator {
         IOUtils.recursiveDeleteDir(dir);
     }
 
-    private void writeConfigs(String dir, AbstractConfigProducer<?> producer) throws IOException {
+    private void writeConfigs(String dir, TreeConfigProducer<?> producer) throws IOException {
         RankProfilesConfig.Builder rpcb = new RankProfilesConfig.Builder();
         ((RankProfilesConfig.Producer) producer).getConfig(rpcb);
         writeConfig(dir, RankProfilesConfig.getDefName() + ".cfg", rpcb.build());

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/VespaModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/VespaModelBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelRepo;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
 
 /**
@@ -14,7 +14,7 @@ import com.yahoo.config.model.ApplicationConfigProducerRoot;
  */
 public abstract class VespaModelBuilder {
 
-    public abstract ApplicationConfigProducerRoot getRoot(String name, DeployState deployState, AbstractConfigProducer parent);
+    public abstract ApplicationConfigProducerRoot getRoot(String name, DeployState deployState, TreeConfigProducer parent);
 
     /**
      * Processing that requires access across plugins
@@ -22,6 +22,6 @@ public abstract class VespaModelBuilder {
      * @param producerRoot the root producer.
      * @param configModelRepo a {@link com.yahoo.config.model.ConfigModelRepo instance}
      */
-    public abstract void postProc(DeployState deployState, AbstractConfigProducer producerRoot, ConfigModelRepo configModelRepo);
+    public abstract void postProc(DeployState deployState, TreeConfigProducer producerRoot, ConfigModelRepo configModelRepo);
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom;
 import com.yahoo.config.model.ConfigModelContext.ApplicationType;
 import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.container.logging.LevelsModSpec;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.Host;
@@ -47,7 +47,7 @@ public abstract class DomAdminBuilderBase extends VespaDomBuilder.DomConfigProdu
         this.configServerSpecs = configServerSpecs;
     }
 
-    List<Configserver> getConfigServersFromSpec(DeployState deployState, AbstractConfigProducer<?> parent) {
+    List<Configserver> getConfigServersFromSpec(DeployState deployState, TreeConfigProducer<?> parent) {
         List<Configserver> configservers = new ArrayList<>();
         for (ConfigServerSpec spec : configServerSpecs) {
             HostSystem hostSystem = parent.hostSystem();
@@ -63,7 +63,7 @@ public abstract class DomAdminBuilderBase extends VespaDomBuilder.DomConfigProdu
     }
 
     @Override
-    protected Admin doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element adminElement) {
+    protected Admin doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element adminElement) {
         Monitoring monitoring = getMonitoring(XML.getChild(adminElement,"monitoring"), deployState.isHosted());
         Metrics metrics = new MetricsBuilder(applicationType, PredefinedMetricSets.get())
                                   .buildMetrics(XML.getChild(adminElement, "metrics"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.api.ConfigServerSpec;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.SimpleConfigProducer;
 import com.yahoo.vespa.model.admin.Admin;
@@ -76,7 +76,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
     }
 
     private ClusterControllerContainerCluster addConfiguredClusterControllers(DeployState deployState,
-                                                                              AbstractConfigProducer<?> parent,
+                                                                              TreeConfigProducer<?> parent,
                                                                               Element admin) {
         Element controllersElements = XML.getChild(admin, "cluster-controllers");
         if (controllersElements == null) return null;
@@ -104,7 +104,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         return cluster;
     }
 
-    private List<Configserver> getConfigServers(DeployState deployState, AbstractConfigProducer<?> parent, Element adminE) {
+    private List<Configserver> getConfigServers(DeployState deployState, TreeConfigProducer<?> parent, Element adminE) {
         Element configserversE = XML.getChild(adminE, "configservers");
         if (configserversE == null) {
             Element adminserver = XML.getChild(adminE, "adminserver");
@@ -126,7 +126,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
     }
 
     /** Fallback when no config server is specified */
-    private List<Configserver> createSingleConfigServer(DeployState deployState, AbstractConfigProducer<?> parent) {
+    private List<Configserver> createSingleConfigServer(DeployState deployState, TreeConfigProducer<?> parent) {
         SimpleConfigProducer<?> configServers = new SimpleConfigProducer<>(parent, "configservers");
         Configserver configServer = new Configserver(configServers, "configserver", Configserver.defaultRpcPort);
         configServer.setHostResource(parent.hostSystem().getHost(Container.SINGLENODE_CONTAINER_SERVICESPEC));
@@ -134,14 +134,14 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         return List.of(configServer);
     }
 
-    private List<Slobrok> getSlobroks(DeployState deployState, AbstractConfigProducer<?> parent, Element slobroksE) {
+    private List<Slobrok> getSlobroks(DeployState deployState, TreeConfigProducer<?> parent, Element slobroksE) {
         List<Slobrok> slobroks = new ArrayList<>();
         if (slobroksE != null)
             slobroks = getExplicitSlobrokSetup(deployState, parent, slobroksE);
         return slobroks;
     }
 
-    private List<Slobrok> getExplicitSlobrokSetup(DeployState deployState, AbstractConfigProducer<?> parent, Element slobroksE) {
+    private List<Slobrok> getExplicitSlobrokSetup(DeployState deployState, TreeConfigProducer<?> parent, Element slobroksE) {
         List<Slobrok> slobroks = new ArrayList<>();
         int i = 0;
         for (Element e : XML.getChildren(slobroksE, "slobrok"))
@@ -154,7 +154,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         }
 
         @Override
-        protected Logserver doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element producerSpec) {
+        protected Logserver doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element producerSpec) {
             return new Logserver(parent);
         }
     }
@@ -173,7 +173,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         }
 
         @Override
-        protected Configserver doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element spec) {
+        protected Configserver doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element spec) {
             var configServer = new Configserver(parent, "configserver." + i, rpcPort);
             configServer.setProp("index", i);
             return configServer;
@@ -189,7 +189,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         }
 
         @Override
-        protected Slobrok doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element spec) {
+        protected Slobrok doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element spec) {
             return new Slobrok(parent, i, deployState.featureFlags());
         }
 
@@ -205,7 +205,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         }
 
         @Override
-        protected ClusterControllerContainer doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element spec) {
+        protected ClusterControllerContainer doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element spec) {
             return new ClusterControllerContainer(parent, i, runStandaloneZooKeeper, deployState, false);
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomClientProviderBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.Handler;
@@ -20,7 +20,7 @@ public class DomClientProviderBuilder extends DomHandlerBuilder {
     }
 
     @Override
-    protected Handler doBuild(DeployState deployState, AbstractConfigProducer parent, Element clientElement) {
+    protected Handler doBuild(DeployState deployState, TreeConfigProducer parent, Element clientElement) {
         Handler client = createHandler(clientElement);
 
         for (Element binding : XML.getChildren(clientElement, "binding"))

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomComponentBuilder.java
@@ -5,7 +5,7 @@ import com.yahoo.component.ComponentId;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.xml.BundleInstantiationSpecificationBuilder;
@@ -30,7 +30,7 @@ public class DomComponentBuilder extends VespaDomBuilder.DomConfigProducerBuilde
     }
 
     @Override
-    protected Component doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element spec) {
+    protected Component doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element spec) {
         Component component = buildComponent(spec);
         addChildren(deployState, ancestor, spec, component);
         return component;
@@ -43,13 +43,13 @@ public class DomComponentBuilder extends VespaDomBuilder.DomConfigProducerBuilde
         return new Component<Component<?, ?>, ComponentModel>(new ComponentModel(bundleSpec));
     }
 
-    public static void addChildren(DeployState deployState, AbstractConfigProducer ancestor, Element componentNode, Component<? super Component<?, ?>, ?> component) {
+    public static void addChildren(DeployState deployState, TreeConfigProducer ancestor, Element componentNode, Component<? super Component<?, ?>, ?> component) {
         for (Element childNode : XML.getChildren(componentNode, elementName)) {
             addAndInjectChild(deployState, ancestor, component, childNode);
         }
     }
 
-    private static void addAndInjectChild(DeployState deployState, AbstractConfigProducer ancestor, Component<? super Component<?, ?>, ?> component, Element childNode) {
+    private static void addAndInjectChild(DeployState deployState, TreeConfigProducer ancestor, Component<? super Component<?, ?>, ?> component, Element childNode) {
         Component<?, ?> child = new DomComponentBuilder(component.getComponentId()).build(deployState, ancestor, childNode);
         component.addComponent(child);
         component.inject(child);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomHandlerBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom;
 
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.text.XML;
@@ -48,7 +48,7 @@ public class DomHandlerBuilder extends VespaDomBuilder.DomConfigProducerBuilder<
     }
 
     @Override
-    protected Handler doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element handlerElement) {
+    protected Handler doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element handlerElement) {
         Handler handler = createHandler(handlerElement);
         OptionalInt port = portBindingOverride.isPresent() && deployState.isHosted() && deployState.featureFlags().useRestrictedDataPlaneBindings()
                 ? portBindingOverride

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomSearchTuningBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.text.XML;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.search.Tuning;
 import org.w3c.dom.Element;
 
@@ -15,7 +15,7 @@ import org.w3c.dom.Element;
 public class DomSearchTuningBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Tuning> {
 
     @Override
-    protected Tuning doBuild(DeployState deployState, AbstractConfigProducer parent, Element spec) {
+    protected Tuning doBuild(DeployState deployState, TreeConfigProducer parent, Element spec) {
         Tuning tuning = new Tuning(parent);
         for (Element e : XML.getChildren(spec)) {
             if (equals("searchnode", e))

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/LegacyConfigModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/LegacyConfigModelBuilder.java
@@ -5,7 +5,7 @@ import com.yahoo.config.model.ConfigModel;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.ConfigModelInstanceFactory;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import org.w3c.dom.Element;
 
 /**
@@ -23,7 +23,7 @@ public abstract class LegacyConfigModelBuilder<MODEL extends ConfigModel> extend
     @Override
     public MODEL build(ConfigModelInstanceFactory<MODEL> factory, Element spec, ConfigModelContext context) {
         VespaDomBuilder.DomSimpleConfigProducerBuilder builder = new VespaDomBuilder.DomSimpleConfigProducerBuilder(context.getProducerId());
-        AbstractConfigProducer producer = builder.build(context.getDeployState(), context.getParentProducer(), spec);
+        TreeConfigProducer producer = builder.build(context.getDeployState(), context.getParentProducer(), spec);
         return super.build(factory, spec, context.withParent(producer));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
@@ -7,7 +7,7 @@ import com.yahoo.config.model.ApplicationConfigProducerRoot;
 import com.yahoo.config.model.ConfigModelRepo;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.AbstractService;
@@ -61,7 +61,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
 
 
     @Override
-    public ApplicationConfigProducerRoot getRoot(String name, DeployState deployState, AbstractConfigProducer parent) {
+    public ApplicationConfigProducerRoot getRoot(String name, DeployState deployState, TreeConfigProducer parent) {
         try {
             return new DomRootBuilder(name).
                     build(deployState, parent, XmlHelper.getDocument(deployState.getApplicationPackage().getServices(), "services.xml")
@@ -83,12 +83,12 @@ public class VespaDomBuilder extends VespaModelBuilder {
      * Base class for builders of producers using DOM. The purpose is to always
      * include hostalias, baseport and user config overrides generically.
      *
-     * @param <T> an {@link com.yahoo.config.model.producer.AbstractConfigProducer}
+     * @param <T> an {@link com.yahoo.config.model.producer.TreeConfigProducer}
      */
-    public static abstract class DomConfigProducerBuilder<T extends AbstractConfigProducer<?>> {
+    public static abstract class DomConfigProducerBuilder<T extends TreeConfigProducer<?>> {
 
         // TODO: find good way to provide access to app package
-        public final T build(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        public final T build(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             T t = doBuild(deployState, ancestor, producerSpec);
 
             if (t instanceof AbstractService) {
@@ -100,9 +100,9 @@ public class VespaDomBuilder extends VespaModelBuilder {
             return t;
         }
 
-        protected abstract T doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec);
+        protected abstract T doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec);
 
-        private void initializeProducer(AbstractConfigProducer<?> child, DeployState deployState, Element producerSpec) {
+        private void initializeProducer(TreeConfigProducer<?> child, DeployState deployState, Element producerSpec) {
             UserConfigRepo userConfigs = UserConfigBuilder.build(producerSpec, deployState, deployState.getDeployLogger());
             // TODO: must be made to work:
             //userConfigs.applyWarnings(child);
@@ -183,7 +183,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
         }
 
         @Override
-        protected SimpleConfigProducer<?> doBuild(DeployState deployState, AbstractConfigProducer<?> parent,
+        protected SimpleConfigProducer<?> doBuild(DeployState deployState, TreeConfigProducer<?> parent,
                                                   Element producerSpec) {
             return new SimpleConfigProducer<>(parent, configId);
         }
@@ -200,7 +200,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
         }
 
         @Override
-        protected ApplicationConfigProducerRoot doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element producerSpec) {
+        protected ApplicationConfigProducerRoot doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element producerSpec) {
             ApplicationConfigProducerRoot root = new ApplicationConfigProducerRoot(parent,
                                                                                    name,
                                                                                    deployState.getDocumentModel(),
@@ -242,7 +242,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
      * @param root root config producer
      * @param configModelRepo a {@link ConfigModelRepo}
      */
-    public void postProc(DeployState deployState, AbstractConfigProducer root, ConfigModelRepo configModelRepo) {
+    public void postProc(DeployState deployState, TreeConfigProducer root, ConfigModelRepo configModelRepo) {
         setContentSearchClusterIndexes(configModelRepo);
         createDocprocMBusServersAndClients(configModelRepo);
         if (deployState.isHosted()) validateContainerClusterIds(configModelRepo);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/ChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/ChainsBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.text.XML;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.chain.Chain;
 import com.yahoo.vespa.model.container.component.chain.ChainedComponent;
 import org.w3c.dom.Element;
@@ -24,7 +24,7 @@ public class ChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends 
     private final Map<String, Class<? extends DomChainBuilderBase<? extends COMPONENT, ? extends CHAIN>>> chainType2BuilderClass;
 
     // NOTE: The chain type string (key in chainType2BuilderClass) must match the xml tag name for the chain.
-    public ChainsBuilder(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> chainsElems,
+    public ChainsBuilder(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> chainsElems,
                          Map<String, ComponentsBuilder.ComponentType<?>> outerComponentTypeByComponentName,
                          Map<String, Class<? extends DomChainBuilderBase<? extends COMPONENT, ? extends CHAIN>>> chainType2BuilderClass) {
 
@@ -36,7 +36,7 @@ public class ChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends 
         return Collections.unmodifiableCollection(chains);
     }
 
-    private void readChains(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> chainsElems,
+    private void readChains(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> chainsElems,
                             Map<String, ComponentsBuilder.ComponentType<?>> outerSearcherTypeByComponentName) {
 
         for (Map.Entry<String, Class<? extends DomChainBuilderBase<? extends COMPONENT, ? extends CHAIN>>>
@@ -49,7 +49,7 @@ public class ChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends 
         }
     }
 
-    private void readChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element chainElem,
+    private void readChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element chainElem,
                            Class<? extends DomChainBuilderBase<? extends COMPONENT, ? extends CHAIN>> builderClass,
                            Map<String, ComponentsBuilder.ComponentType<?>> outerSearcherTypeByComponentName) {
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/ComponentsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/ComponentsBuilder.java
@@ -5,7 +5,7 @@ import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.text.XML;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.docproc.DomDocumentProcessorBuilder;
@@ -73,7 +73,7 @@ public class ComponentsBuilder<T extends ChainedComponent<?>> {
      *                                          every component is a definition, not a reference.
      */
     ComponentsBuilder(DeployState deployState,
-                      AbstractConfigProducer<?> ancestor,
+                      TreeConfigProducer<?> ancestor,
                       Collection<ComponentType<T>> componentTypes,
                       List<Element> elementsContainingComponentElems,
                       Map<String, ComponentType<?>> outerComponentTypeByComponentName) {
@@ -81,7 +81,7 @@ public class ComponentsBuilder<T extends ChainedComponent<?>> {
         readComponents(deployState, ancestor, componentTypes, elementsContainingComponentElems, unmodifiable(outerComponentTypeByComponentName));
     }
 
-    private void readComponents(DeployState deployState, AbstractConfigProducer<?> ancestor,
+    private void readComponents(DeployState deployState, TreeConfigProducer<?> ancestor,
                                 Collection<ComponentType<T>> componentTypes,
                                 List<Element> elementsContainingComponentElems,
                                 Map<String, ComponentType<?>> outerComponentTypeByComponentName) {
@@ -95,7 +95,7 @@ public class ComponentsBuilder<T extends ChainedComponent<?>> {
         }
     }
 
-    private void readComponent(DeployState deployState, AbstractConfigProducer<?> ancestor,
+    private void readComponent(DeployState deployState, TreeConfigProducer<?> ancestor,
                                Element componentElement,
                                ComponentType<T> componentType,
                                Map<String, ComponentType<?>> outerComponentTypeByComponentName) {
@@ -119,7 +119,7 @@ public class ComponentsBuilder<T extends ChainedComponent<?>> {
         outerComponentReferences.add(componentSpecification);
     }
 
-    private void readComponentDefinition(DeployState deployState, AbstractConfigProducer<?> ancestor, Element componentElement, ComponentType<T> componentType) {
+    private void readComponentDefinition(DeployState deployState, TreeConfigProducer<?> ancestor, Element componentElement, ComponentType<T> componentType) {
         T component = componentType.createBuilder().build(deployState, ancestor, componentElement);
         componentDefinitions.add(component);
         updateComponentTypes(component.getComponentId(), componentType);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainBuilderBase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainBuilderBase.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains;
 
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.component.chain.Chain;
 import com.yahoo.vespa.model.container.component.chain.ChainedComponent;
@@ -28,7 +28,7 @@ public abstract class DomChainBuilderBase<COMPONENT extends ChainedComponent<?>,
         this.outerComponentTypeByComponentName = outerComponentTypeByComponentName;
     }
 
-    public final CHAIN doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+    public final CHAIN doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
         ComponentsBuilder<COMPONENT> componentsBuilder =
                 new ComponentsBuilder<>(deployState, ancestor, allowedComponentTypes, List.of(producerSpec), outerComponentTypeByComponentName);
         ChainSpecification specWithoutInnerComponents =
@@ -46,6 +46,6 @@ public abstract class DomChainBuilderBase<COMPONENT extends ChainedComponent<?>,
         }
     }
 
-    protected abstract CHAIN buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec,
+    protected abstract CHAIN buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec,
                                         ChainSpecification specWithoutInnerComponents);
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/DomChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
 import com.yahoo.vespa.model.container.component.chain.Chain;
@@ -31,10 +31,10 @@ class DomChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends Chai
         this.allowedComponentTypes = new ArrayList<>(allowedComponentTypes);
     }
 
-    protected abstract CHAINS newChainsInstance(AbstractConfigProducer<?> parent);
+    protected abstract CHAINS newChainsInstance(TreeConfigProducer<?> parent);
 
     @Override
-    protected final CHAINS doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element chainsElement) {
+    protected final CHAINS doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element chainsElement) {
         CHAINS chains = newChainsInstance(parent);
 
         List<Element> allChainElements = allChainElements(deployState, chainsElement);
@@ -56,12 +56,12 @@ class DomChainsBuilder<COMPONENT extends ChainedComponent<?>, CHAIN extends Chai
         return chainsElements;
     }
 
-    private ComponentsBuilder<COMPONENT> readOuterComponents(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> chainsElems) {
+    private ComponentsBuilder<COMPONENT> readOuterComponents(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> chainsElems) {
         return new ComponentsBuilder<>(deployState, ancestor, allowedComponentTypes, chainsElems, null);
     }
 
     protected abstract
-    ChainsBuilder<COMPONENT, CHAIN> readChains(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> allChainsElems,
+    ChainsBuilder<COMPONENT, CHAIN> readChains(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> allChainsElems,
                                                Map<String, ComponentsBuilder.ComponentType<?>> outerComponentTypeByComponentName);
 
     private void addOuterComponents(CHAINS chains, ComponentsBuilder<COMPONENT> outerComponentsBuilder) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DocprocChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DocprocChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.docproc;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
@@ -29,7 +29,7 @@ public class DocprocChainsBuilder extends ChainsBuilder<DocumentProcessor, Docpr
                 put("chain", DomDocprocChainBuilder.class);
             }});
 
-    public DocprocChainsBuilder(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> docprocChainsElements,
+    public DocprocChainsBuilder(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> docprocChainsElements,
                                 Map<String, ComponentsBuilder.ComponentType<?>> outerSearcherTypeByComponentName) {
         super(deployState, ancestor, docprocChainsElements, outerSearcherTypeByComponentName, chainType2builderClass);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.docproc;
 import com.yahoo.collections.Pair;
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
 import com.yahoo.vespa.model.container.docproc.DocprocChain;
@@ -25,7 +25,7 @@ public class DomDocprocChainBuilder extends DomChainBuilderBase<DocumentProcesso
     }
 
     @Override
-    protected DocprocChain buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec,
+    protected DocprocChain buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec,
                                       ChainSpecification specWithoutInnerComponents) {
         Map<Pair<String, String>, String> fieldNameSchemaMap = DocumentProcessorModelBuilder.parseFieldNameSchemaMap(producerSpec);
         return new DocprocChain(specWithoutInnerComponents, fieldNameSchemaMap);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocprocChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.docproc;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainsBuilder;
 import com.yahoo.vespa.model.container.docproc.DocprocChain;
@@ -24,12 +24,12 @@ public class DomDocprocChainsBuilder  extends DomChainsBuilder<DocumentProcessor
     }
 
     @Override
-    protected DocprocChains newChainsInstance(AbstractConfigProducer<?> parent) {
+    protected DocprocChains newChainsInstance(TreeConfigProducer<?> parent) {
         return new DocprocChains(parent, "docprocchains");
     }
 
     @Override
-    protected DocprocChainsBuilder readChains(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> docprocChainsElements,
+    protected DocprocChainsBuilder readChains(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> docprocChainsElements,
                                               Map<String, ComponentType<?>> outerComponentTypeByComponentName) {
         return new DocprocChainsBuilder(deployState, ancestor, docprocChainsElements, outerComponentTypeByComponentName);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocumentProcessorBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/docproc/DomDocumentProcessorBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.docproc;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.docproc.DocumentProcessor;
 import org.w3c.dom.Element;
@@ -15,7 +15,7 @@ import org.w3c.dom.Element;
 public class DomDocumentProcessorBuilder extends VespaDomBuilder.DomConfigProducerBuilder<DocumentProcessor> {
 
     @Override
-    protected DocumentProcessor doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element documentProcessorElement) {
+    protected DocumentProcessor doBuild(DeployState deployState, TreeConfigProducer ancestor, Element documentProcessorElement) {
         DocumentProcessorModelBuilder modelBuilder = new DocumentProcessorModelBuilder(documentProcessorElement);
         return new DocumentProcessor(modelBuilder.build());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.processing;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainsBuilder;
 import com.yahoo.vespa.model.container.processing.ProcessingChain;
@@ -24,12 +24,12 @@ public class DomProcessingBuilder extends DomChainsBuilder<Processor, Processing
     }
 
     @Override
-    protected ProcessingChains newChainsInstance(AbstractConfigProducer<?> parent) {
+    protected ProcessingChains newChainsInstance(TreeConfigProducer<?> parent) {
         return new ProcessingChains(parent, "processing");
     }
 
     @Override
-    protected ProcessingChainsBuilder readChains(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> processingChainsElements,
+    protected ProcessingChainsBuilder readChains(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> processingChainsElements,
                                                  Map<String, ComponentsBuilder.ComponentType<?>> outerComponentTypeByComponentName) {
         return new ProcessingChainsBuilder(deployState, ancestor, processingChainsElements, outerComponentTypeByComponentName);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingChainBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessingChainBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.processing;
 
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
 import com.yahoo.vespa.model.container.processing.ProcessingChain;
@@ -21,7 +21,7 @@ public class DomProcessingChainBuilder extends DomChainBuilderBase<Processor, Pr
         super(List.of(ComponentsBuilder.ComponentType.processor), outerComponentTypeByComponentName);
     }
 
-    protected ProcessingChain buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec,
+    protected ProcessingChain buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec,
                                          ChainSpecification specWithoutInnerComponents) {
         return new ProcessingChain(specWithoutInnerComponents);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessorBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/DomProcessorBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.processing;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainedComponentModelBuilder;
 import com.yahoo.vespa.model.container.processing.Processor;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import org.w3c.dom.Element;
 
@@ -17,7 +17,7 @@ import org.w3c.dom.Element;
 public class DomProcessorBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Processor> {
 
     @Override
-    protected Processor doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element processorElement) {
+    protected Processor doBuild(DeployState deployState, TreeConfigProducer ancestor, Element processorElement) {
         ChainedComponentModelBuilder modelBuilder = new ChainedComponentModelBuilder(processorElement);
         return new Processor(modelBuilder.build());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/ProcessingChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/processing/ProcessingChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.processing;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
@@ -29,7 +29,7 @@ public class ProcessingChainsBuilder extends ChainsBuilder<Processor, Processing
                 put("chain", DomProcessingChainBuilder.class);
             }});
 
-    public ProcessingChainsBuilder(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> processingChainsElements,
+    public ProcessingChainsBuilder(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> processingChainsElements,
                                    Map<String, ComponentsBuilder.ComponentType<?>> outerSearcherTypeByComponentName) {
         super(deployState, ancestor, processingChainsElements, outerSearcherTypeByComponentName, chainType2builderClass);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomFederationSearcherBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomFederationSearcherBuilder.java
@@ -8,7 +8,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.search.searchchain.model.federation.FederationOptions;
 import com.yahoo.search.searchchain.model.federation.FederationSearcherModel;
 import com.yahoo.text.XML;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.DomComponentBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.GenericChainedComponentModelBuilder;
@@ -75,14 +75,14 @@ public class DomFederationSearcherBuilder extends VespaDomBuilder.DomConfigProdu
     }
 
     @Override
-    protected FederationSearcher doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element searcherElement) {
+    protected FederationSearcher doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element searcherElement) {
         FederationSearcherModel model = new FederationSearcherModelBuilder(searcherElement).build();
         Optional<Component> targetSelector = buildTargetSelector(deployState, ancestor, searcherElement, model.getComponentId());
 
         return new FederationSearcher(model, targetSelector);
     }
 
-    private Optional<Component> buildTargetSelector(DeployState deployState, AbstractConfigProducer<?> ancestor, Element searcherElement, ComponentId namespace) {
+    private Optional<Component> buildTargetSelector(DeployState deployState, TreeConfigProducer<?> ancestor, Element searcherElement, ComponentId namespace) {
         Element targetSelectorElement = XML.getChild(searcherElement, "target-selector");
         if (targetSelectorElement == null)
             return Optional.empty();

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomProviderBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomProviderBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.search.searchchain.model.federation.FederationOptions;
 import com.yahoo.search.searchchain.model.federation.LocalProviderSpec;
 import com.yahoo.text.XML;
@@ -125,7 +125,7 @@ public class DomProviderBuilder extends DomGenericTargetBuilder<Provider> {
     }
 
     @Override
-    protected Provider buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element providerElement,
+    protected Provider buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element providerElement,
                                   ChainSpecification specWithoutInnerComponents) {
 
         ProviderReader providerReader = new ProviderReader(providerElement);
@@ -140,7 +140,7 @@ public class DomProviderBuilder extends DomGenericTargetBuilder<Provider> {
     }
 
 
-    private Collection<Source> buildSources(DeployState deployState, AbstractConfigProducer<?> ancestor, Element providerElement) {
+    private Collection<Source> buildSources(DeployState deployState, TreeConfigProducer<?> ancestor, Element providerElement) {
         List<Source> sources = new ArrayList<>();
         for (Element sourceElement : XML.getChildren(providerElement, "source")) {
             sources.add(new DomSourceBuilder(outerComponentTypeByComponentName).build(deployState, ancestor, sourceElement));

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChain;
@@ -24,7 +24,7 @@ public class DomSearchChainBuilder extends DomChainBuilderBase<Searcher<?>, Sear
                 outerSearcherTypeByComponentName);
     }
 
-    protected SearchChain buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec,
+    protected SearchChain buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec,
                                      ChainSpecification specWithoutInnerComponents) {
         return new SearchChain(specWithoutInnerComponents);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearchChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainsBuilder;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChain;
@@ -26,12 +26,12 @@ public class DomSearchChainsBuilder extends DomChainsBuilder<Searcher<?>, Search
     }
 
     @Override
-    protected SearchChains newChainsInstance(AbstractConfigProducer<?> parent) {
+    protected SearchChains newChainsInstance(TreeConfigProducer<?> parent) {
         return new SearchChains(parent, "searchchains");
     }
 
     @Override
-    protected SearchChainsBuilder readChains(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> searchChainsElements,
+    protected SearchChainsBuilder readChains(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> searchChainsElements,
                                              Map<String, ComponentType<?>> outerComponentTypeByComponentName) {
         return new SearchChainsBuilder(deployState, ancestor, searchChainsElements, outerComponentTypeByComponentName);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearcherBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSearcherBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.component.chain.model.ChainedComponentModel;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainedComponentModelBuilder;
 import com.yahoo.vespa.model.container.search.searchchain.Searcher;
@@ -16,7 +16,7 @@ import org.w3c.dom.Element;
 public class DomSearcherBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Searcher<?>> {
 
     @Override
-    protected Searcher<ChainedComponentModel> doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element searcherElement) {
+    protected Searcher<ChainedComponentModel> doBuild(DeployState deployState, TreeConfigProducer ancestor, Element searcherElement) {
         ChainedComponentModelBuilder modelBuilder = new ChainedComponentModelBuilder(searcherElement);
         return new Searcher<>(modelBuilder.build());
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSourceBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomSourceBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.container.search.searchchain.Source;
@@ -20,7 +20,7 @@ public class DomSourceBuilder extends DomGenericTargetBuilder<Source> {
         super(outerSearcherTypeByComponentName);
     }
 
-    protected Source buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec, ChainSpecification specWithoutInnerComponents) {
+    protected Source buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec, ChainSpecification specWithoutInnerComponents) {
         Source.GroupOption groupOption =
                 XmlHelper.isReference(producerSpec) ?
                         Source.GroupOption.participant :

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/SearchChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/SearchChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
@@ -30,7 +30,7 @@ public class SearchChainsBuilder extends ChainsBuilder<Searcher<?>, SearchChain>
                 put("provider", DomProviderBuilder.class);
             }});
 
-    public SearchChainsBuilder(DeployState deployState, AbstractConfigProducer<?> ancestor, List<Element> searchChainsElements,
+    public SearchChainsBuilder(DeployState deployState, TreeConfigProducer<?> ancestor, List<Element> searchChainsElements,
                                Map<String, ComponentsBuilder.ComponentType<?>> outerSearcherTypeByComponentName) {
         super(deployState, ancestor, searchChainsElements, outerSearcherTypeByComponentName, chainType2builderClass);
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -5,7 +5,7 @@ import com.yahoo.cloud.config.ZookeeperServerConfig;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.search.config.QrStartConfig;
@@ -28,11 +28,11 @@ public final class ApplicationContainer extends Container implements
 
     private final boolean isHostedVespa;
 
-    public ApplicationContainer(AbstractConfigProducer<?> parent, String name, int index, DeployState deployState) {
+    public ApplicationContainer(TreeConfigProducer<?> parent, String name, int index, DeployState deployState) {
         this(parent, name, false, index, deployState);
     }
 
-    public ApplicationContainer(AbstractConfigProducer<?> parent, String name, boolean retired, int index, DeployState deployState) {
+    public ApplicationContainer(TreeConfigProducer<?> parent, String name, boolean retired, int index, DeployState deployState) {
         super(parent, name, retired, index, deployState);
         this.isHostedVespa = deployState.isHosted();
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -13,7 +13,7 @@ import com.yahoo.config.model.api.ApplicationClusterInfo;
 import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.HostSpec;
@@ -97,7 +97,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
 
     private List<ApplicationClusterEndpoint> endpointList = List.of();
 
-    public ApplicationContainerCluster(AbstractConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState) {
+    public ApplicationContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState) {
         super(parent, configSubId, clusterId, deployState, true, 10);
         this.tlsClientAuthority = deployState.tlsClientAuthority();
         previousHosts = Collections.unmodifiableSet(deployState.getPreviousModel().stream()

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -10,7 +10,7 @@ import com.yahoo.config.docproc.DocprocConfig;
 import com.yahoo.config.docproc.SchemamappingConfig;
 import com.yahoo.config.model.ApplicationConfigProducerRoot;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.ComponentsConfig;
@@ -83,7 +83,7 @@ import static com.yahoo.vespa.model.container.component.chain.ProcessingHandler.
  * @author Tony Vaagenes
  */
 public abstract class ContainerCluster<CONTAINER extends Container>
-        extends AbstractConfigProducer<AbstractConfigProducer<?>>
+        extends TreeConfigProducer<TreeConfigProducer<?>>
         implements
         ComponentsConfig.Producer,
         JdiscBindingsConfig.Producer,
@@ -166,10 +166,10 @@ public abstract class ContainerCluster<CONTAINER extends Container>
     private boolean clientsLegacyMode;
     private List<Client> clients = List.of();
 
-    public ContainerCluster(AbstractConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity) {
+    public ContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity) {
         this(parent, configSubId, clusterId, deployState, zooKeeperLocalhostAffinity, 1);
     }
-    public ContainerCluster(AbstractConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity, int defaultPoolNumThreads) {
+    public ContainerCluster(TreeConfigProducer<?> parent, String configSubId, String clusterId, DeployState deployState, boolean zooKeeperLocalhostAffinity, int defaultPoolNumThreads) {
         super(parent, configSubId);
         this.name = clusterId;
         this.isHostedVespa = stateIsHosted(deployState);
@@ -422,13 +422,13 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         return Collections.unmodifiableCollection(allComponents);
     }
 
-    private void recursivelyFindAllComponents(Collection<Component<?, ?>> allComponents, AbstractConfigProducer<?> current) {
-        for (AbstractConfigProducer<?> child: current.getChildren().values()) {
+    private void recursivelyFindAllComponents(Collection<Component<?, ?>> allComponents, TreeConfigProducer<?> current) {
+        for (var child: current.getChildren().values()) {
             if (child instanceof Component)
                 allComponents.add((Component<?, ?>) child);
 
-            if (!(child instanceof Container))
-                recursivelyFindAllComponents(allComponents, child);
+            if (child instanceof TreeConfigProducer t && !(child instanceof Container))
+                recursivelyFindAllComponents(allComponents, t);
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/Component.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/Component.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.component;
 import com.yahoo.collections.Pair;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.osgi.provider.model.ComponentModel;
 
 import java.util.HashSet;
@@ -15,8 +15,8 @@ import java.util.Set;
  * @author gjoranv
  * @author Tony Vaagenes
  */
-public class Component<CHILD extends AbstractConfigProducer<?>, MODEL extends ComponentModel>
-        extends AbstractConfigProducer<CHILD> implements Comparable<Component<?, ?>> {
+public class Component<CHILD extends TreeConfigProducer<?>, MODEL extends ComponentModel>
+        extends TreeConfigProducer<CHILD> implements Comparable<Component<?, ?>> {
 
     public final MODEL model;
     final Set<Pair<String, Component>> injectedComponents = new LinkedHashSet<>();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/ComponentGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/ComponentGroup.java
@@ -1,14 +1,14 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.component;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 /**
  * @author Tony Vaagenes
  */
 public class ComponentGroup <CHILD extends Component<?, ?>> extends ConfigProducerGroup<CHILD> {
 
-    public ComponentGroup(AbstractConfigProducer parent, String subId) {
+    public ComponentGroup(TreeConfigProducer parent, String subId) {
         super(parent, subId);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConfigProducerGroup.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/ConfigProducerGroup.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.component;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -16,11 +16,11 @@ import java.util.Map;
  *
  * @author Tony Vaagenes
  */
-public class ConfigProducerGroup<CHILD extends AbstractConfigProducer<?>> extends AbstractConfigProducer<CHILD> {
+public class ConfigProducerGroup<CHILD extends TreeConfigProducer<?>> extends TreeConfigProducer<CHILD> {
 
     private final Map<ComponentId, CHILD> producerById = new LinkedHashMap<>();
 
-    public ConfigProducerGroup(AbstractConfigProducer parent, String subId) {
+    public ConfigProducerGroup(TreeConfigProducer parent, String subId) {
         super(parent, subId);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/SimpleComponent.java
@@ -3,14 +3,14 @@ package com.yahoo.vespa.model.container.component;
 
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 /**
  * A component that uses the class name as id, and resides in the container-disc bundle.
  *
  * @author gjoranv
  */
-public class SimpleComponent extends Component<AbstractConfigProducer<?>, ComponentModel> {
+public class SimpleComponent extends Component<TreeConfigProducer<?>, ComponentModel> {
 
     public SimpleComponent(ComponentModel model) {
         super(model);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chain.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chain.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.component.chain;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.chain.model.ChainSpecification;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.ComponentGroup;
 
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ import static com.yahoo.container.core.ChainsConfig.Chains.Type;
  * @author Tony Vaagenes
  * @author gjoranv
  */
-public class Chain<T extends ChainedComponent<?>> extends AbstractConfigProducer<AbstractConfigProducer<?>> {
+public class Chain<T extends ChainedComponent<?>> extends TreeConfigProducer<TreeConfigProducer<?>> {
 
     private final ComponentId componentId;
     private final ChainSpecification specWithoutInnerComponents;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ChainedComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/ChainedComponent.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.container.component.chain;
 
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.model.ChainedComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.Component;
 
 
@@ -13,7 +13,7 @@ import com.yahoo.vespa.model.container.component.Component;
  *
  * Base class for all ChainedComponent config producers.
  */
-public class ChainedComponent<T extends ChainedComponentModel> extends Component<AbstractConfigProducer<?>, T> {
+public class ChainedComponent<T extends ChainedComponentModel> extends Component<TreeConfigProducer<?>, T> {
 
     public ChainedComponent(T model) {
         super(model);
@@ -27,7 +27,7 @@ public class ChainedComponent<T extends ChainedComponentModel> extends Component
     }
 
     private ComponentId namespace() {
-        AbstractConfigProducer owner = getParent().getParent();
+        var owner = getParent().getParent();
         return (owner instanceof Chain) ?
                 ((Chain) owner).getGlobalComponentId() :
                 null;

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/component/chain/Chains.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.component.chain;
 import com.yahoo.component.chain.model.ChainsModel;
 import com.yahoo.component.provider.ComponentRegistry;
 import com.yahoo.container.core.ChainsConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.ComponentGroup;
 import com.yahoo.vespa.model.container.component.ConfigProducerGroup;
 
@@ -18,13 +18,13 @@ import java.util.Set;
  * @author gjoranv
  */
 public class Chains<CHAIN extends Chain<?>>
-        extends AbstractConfigProducer<AbstractConfigProducer<?>>
+        extends TreeConfigProducer<TreeConfigProducer<?>>
         implements ChainsConfig.Producer {
 
     private final ComponentGroup<ChainedComponent<?>> componentGroup;
     private final ConfigProducerGroup<CHAIN> chainGroup;
 
-    public Chains(AbstractConfigProducer parent, String subId) {
+    public Chains(TreeConfigProducer parent, String subId) {
         super(parent, subId);
         componentGroup = new ComponentGroup<>(this, "component");
         chainGroup = new ConfigProducerGroup<>(this, "chain");

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.configserver;
 import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.cloud.config.CuratorConfig;
 import com.yahoo.cloud.config.ZookeeperServerConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
@@ -25,7 +25,7 @@ import java.util.stream.IntStream;
  *
  * @author Ulf Lilleengen
  */
-public class ConfigserverCluster extends AbstractConfigProducer
+public class ConfigserverCluster extends TreeConfigProducer
         implements
         ConfigserverConfig.Producer,
         CuratorConfig.Producer,
@@ -36,7 +36,7 @@ public class ConfigserverCluster extends AbstractConfigProducer
     private final CloudConfigOptions options;
     private ContainerCluster<?> containerCluster;
 
-    public ConfigserverCluster(AbstractConfigProducer<?> parent, String subId, CloudConfigOptions options) {
+    public ConfigserverCluster(TreeConfigProducer<?> parent, String subId, CloudConfigOptions options) {
         super(parent, subId);
         this.options = options;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/docproc/DocprocChains.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.docproc;
 
 import com.yahoo.component.ComponentId;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.jdisc.config.SessionConfig;
 import com.yahoo.docproc.jdisc.observability.DocprocsStatusExtension;
@@ -25,7 +25,7 @@ public class DocprocChains extends Chains<DocprocChain> {
 
     private final ProcessingHandler<DocprocChains> docprocHandler;
 
-    public DocprocChains(AbstractConfigProducer<?> parent, String subId) {
+    public DocprocChains(TreeConfigProducer<?> parent, String subId) {
         super(parent, subId);
         docprocHandler = new ProcessingHandler<>(
                 this,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/FilterChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/FilterChains.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.http;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.component.chain.model.ChainSpecification;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.component.chain.Chains;
 
@@ -15,7 +15,7 @@ import java.util.Set;
  */
 public class FilterChains extends Chains<HttpFilterChain>  {
 
-    public FilterChains(AbstractConfigProducer<?> parent) {
+    public FilterChains(TreeConfigProducer<?> parent) {
         super(parent, "filters");
 
         addChild(new SimpleComponent("com.yahoo.container.http.filter.FilterChainRepository"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/Http.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/Http.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.http;
 
 import com.yahoo.component.provider.ComponentRegistry;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.jdisc.http.ServerConfig;
 import com.yahoo.vespa.model.container.component.chain.ChainedComponent;
 
@@ -17,7 +17,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author Tony Vaagenes
  * @author bjorncs
  */
-public class Http extends AbstractConfigProducer<AbstractConfigProducer<?>> implements ServerConfig.Producer {
+public class Http extends TreeConfigProducer<TreeConfigProducer<?>> implements ServerConfig.Producer {
 
     private final FilterChains filterChains;
     private final List<FilterBinding> bindings = new CopyOnWriteArrayList<>();

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.http.xml;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.builder.xml.dom.DomComponentBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
@@ -18,7 +18,7 @@ import org.w3c.dom.Element;
 public class FilterBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Filter> {
 
     @Override
-    protected Filter doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element filterElement) {
+    protected Filter doBuild(DeployState deployState, TreeConfigProducer ancestor, Element filterElement) {
         ChainedComponentModelBuilder modelBuilder = new ChainedComponentModelBuilder(filterElement);
         Filter filter =  new Filter(modelBuilder.build());
         DomComponentBuilder.addChildren(deployState, ancestor, filterElement, filter);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainBuilder.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.container.http.xml;
 
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.DomChainBuilderBase;
 import com.yahoo.vespa.model.container.http.Filter;
 import com.yahoo.vespa.model.container.http.HttpFilterChain;
@@ -27,7 +27,7 @@ public class FilterChainBuilder extends DomChainBuilderBase<Filter, HttpFilterCh
     }
 
     @Override
-    protected HttpFilterChain buildChain(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec, ChainSpecification specWithoutInnerComponents) {
+    protected HttpFilterChain buildChain(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec, ChainSpecification specWithoutInnerComponents) {
         return new HttpFilterChain(specWithoutInnerComponents, HttpFilterChain.Type.USER);
     }
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainsBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/FilterChainsBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.http.xml;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ChainsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder;
 import com.yahoo.vespa.model.builder.xml.dom.chains.ComponentsBuilder.ComponentType;
@@ -35,14 +35,14 @@ public class FilterChainsBuilder extends DomChainsBuilder<Filter, HttpFilterChai
     }
 
     @Override
-    protected FilterChains newChainsInstance(AbstractConfigProducer<?> parent) {
+    protected FilterChains newChainsInstance(TreeConfigProducer<?> parent) {
         return new FilterChains(parent);
     }
 
     @Override
     protected ChainsBuilder<Filter, HttpFilterChain> readChains(
             DeployState deployState,
-            AbstractConfigProducer<?> ancestor,
+            TreeConfigProducer<?> ancestor,
             List<Element> allChainsElems, Map<String, ComponentsBuilder.ComponentType<?>> outerComponentTypeByComponentName) {
 
         return new ChainsBuilder<>(deployState, ancestor, allChainsElems, outerComponentTypeByComponentName, chainType2BuilderClass);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/HttpBuilder.java
@@ -4,7 +4,8 @@ package com.yahoo.vespa.model.container.http.xml;
 import com.yahoo.component.ComponentSpecification;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.AnyConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.defaults.Defaults;
@@ -34,7 +35,7 @@ public class HttpBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Http> 
     static final List<String> VALID_FILTER_CHAIN_TAG_NAMES = List.of(REQUEST_CHAIN_TAG_NAME, RESPONSE_CHAIN_TAG_NAME);
 
     @Override
-    protected Http doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element spec) {
+    protected Http doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element spec) {
         FilterChains filterChains;
         List<FilterBinding> bindings = new ArrayList<>();
         AccessControl accessControl = null;
@@ -66,7 +67,7 @@ public class HttpBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Http> 
         return http;
     }
 
-    private AccessControl buildAccessControl(DeployState deployState, AbstractConfigProducer<?> ancestor, Element accessControlElem) {
+    private AccessControl buildAccessControl(DeployState deployState, TreeConfigProducer<?> ancestor, Element accessControlElem) {
         AthenzDomain domain = getAccessControlDomain(deployState, accessControlElem);
         AccessControl.Builder builder = new AccessControl.Builder(domain.value());
 
@@ -129,8 +130,8 @@ public class HttpBuilder extends VespaDomBuilder.DomConfigProducerBuilder<Http> 
         return tenantDomain != null ? tenantDomain : explicitDomain;
     }
 
-    private static Optional<ApplicationContainerCluster> getContainerCluster(AbstractConfigProducer<?> configProducer) {
-        AbstractConfigProducer<?> currentProducer = configProducer;
+    private static Optional<ApplicationContainerCluster> getContainerCluster(TreeConfigProducer<?> configProducer) {
+        AnyConfigProducer currentProducer = configProducer;
         while (! ApplicationContainerCluster.class.isAssignableFrom(currentProducer.getClass())) {
             currentProducer = currentProducer.getParent();
             if (currentProducer == null)

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyConnectorBuilder.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.http.xml;
 import com.yahoo.component.ComponentId;
 import com.yahoo.config.model.builder.xml.XmlHelper;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
@@ -26,7 +26,7 @@ import java.util.Optional;
 public class JettyConnectorBuilder extends VespaDomBuilder.DomConfigProducerBuilder<ConnectorFactory>  {
 
     @Override
-    protected ConnectorFactory doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element serverSpec) {
+    protected ConnectorFactory doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element serverSpec) {
         String name = XmlHelper.getIdString(serverSpec);
         int port = HttpBuilder.readPort(new ModelElement(serverSpec), deployState.isHosted());
         ConnectorFactory.Builder builder = new ConnectorFactory.Builder(name, port);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/http/xml/JettyHttpServerBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.http.xml;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.text.XML;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.ContainerCluster;
@@ -22,7 +22,7 @@ public class JettyHttpServerBuilder extends VespaDomBuilder.DomConfigProducerBui
     }
 
     @Override
-    protected JettyHttpServer doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element http) {
+    protected JettyHttpServer doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element http) {
         JettyHttpServer jettyHttpServer = new JettyHttpServer("jdisc-jetty", cluster, deployState);
         for (Element serverSpec: XML.getChildren(http, "server")) {
             ConnectorFactory connectorFactory = new JettyConnectorBuilder().build(deployState, ancestor, serverSpec);

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/processing/ProcessingChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/processing/ProcessingChains.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.processing;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.BindingPattern;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.component.chain.Chains;
@@ -16,7 +16,7 @@ public class ProcessingChains extends Chains<ProcessingChain> {
     public static final BindingPattern[] defaultBindings = new BindingPattern[]{SystemBindingPattern.fromHttpPath("/processing/*")};
 
 
-    public ProcessingChains(AbstractConfigProducer parent, String subId) {
+    public ProcessingChains(TreeConfigProducer parent, String subId) {
         super(parent, subId);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatcherComponent.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.config.search.DispatchNodesConfig;
@@ -15,7 +15,7 @@ import com.yahoo.vespa.model.search.IndexedSearchCluster;
  *
  * @author bratseth
  */
-public class DispatcherComponent extends Component<AbstractConfigProducer<?>, ComponentModel> implements
+public class DispatcherComponent extends Component<TreeConfigProducer<?>, ComponentModel> implements
         DispatchConfig.Producer,
         DispatchNodesConfig.Producer
 {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/SearchChains.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.container.search.searchchain;
 
 import com.yahoo.collections.CollectionUtil;
 import com.yahoo.component.provider.ComponentRegistry;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.chain.Chains;
 import com.yahoo.vespa.model.search.SearchCluster;
 import com.yahoo.vespa.model.container.search.searchchain.defaultsearchchains.LocalClustersCreator;
@@ -21,7 +21,7 @@ public class SearchChains extends Chains<SearchChain> {
 
     private final SourceGroupRegistry sourceGroups = new SourceGroupRegistry();
 
-    public SearchChains(AbstractConfigProducer<?> parent, String subId) {
+    public SearchChains(TreeConfigProducer<?> parent, String subId) {
         super(parent, subId);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/Searcher.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/Searcher.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.search.searchchain;
 
 import com.yahoo.component.chain.model.ChainedComponentModel;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.container.component.chain.ChainedComponent;
 
 /**
@@ -16,7 +16,7 @@ public class Searcher<T extends ChainedComponentModel> extends ChainedComponent<
     }
 
     protected SearchChains getSearchChains() {
-        AbstractConfigProducer ancestor = getParent();
+        var ancestor = getParent();
         while (!(ancestor instanceof SearchChains)) {
             ancestor = ancestor.getParent();
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/Source.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/searchchain/Source.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.container.search.searchchain;
 import com.yahoo.component.ComponentId;
 import com.yahoo.component.chain.model.ChainSpecification;
 import com.yahoo.search.searchchain.model.federation.FederationOptions;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 import java.util.Arrays;
 
@@ -41,7 +41,7 @@ public class Source extends GenericTarget {
     }
 
     public Provider getParentProvider() {
-        AbstractConfigProducer parent = getParent();
+        var parent = getParent();
         while (!(parent instanceof Provider)) {
             parent = parent.getParent();
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/AccessLogBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/AccessLogBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.xml;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.AccessLogComponent;
@@ -50,7 +50,7 @@ public class AccessLogBuilder {
         }
 
         @Override
-        protected AccessLogComponent doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element spec) {
+        protected AccessLogComponent doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element spec) {
             String fallback = deployState.featureFlags().logFileCompressionAlgorithm("zstd");
             return new AccessLogComponent(
                     accessLogType,

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -24,7 +24,7 @@ import com.yahoo.config.model.application.provider.IncludeDirs;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AthenzDomain;
 import com.yahoo.config.provision.AthenzService;
 import com.yahoo.config.provision.Capacity;
@@ -193,7 +193,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private ApplicationContainerCluster createContainerCluster(Element spec, ConfigModelContext modelContext) {
         return new VespaDomBuilder.DomConfigProducerBuilder<ApplicationContainerCluster>() {
             @Override
-            protected ApplicationContainerCluster doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+            protected ApplicationContainerCluster doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
                 return new ApplicationContainerCluster(ancestor, modelContext.getProducerId(),
                                                        modelContext.getProducerId(), deployState);
             }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerServiceBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerServiceBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.container.xml;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.container.ApplicationContainer;
 import org.w3c.dom.Element;
@@ -21,7 +21,7 @@ public class ContainerServiceBuilder extends VespaDomBuilder.DomConfigProducerBu
     }
 
     @Override
-    protected ApplicationContainer doBuild(DeployState deployState, AbstractConfigProducer<?> parent, Element nodeElem) {
+    protected ApplicationContainer doBuild(DeployState deployState, TreeConfigProducer<?> parent, Element nodeElem) {
         return new ApplicationContainer(parent, id, index, deployState);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/document/DocumentFactoryBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/document/DocumentFactoryBuilder.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.xml.document;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.text.XML;
@@ -30,7 +30,7 @@ public class DocumentFactoryBuilder {
             String pkg = clazz.substring(0, clazz.lastIndexOf('.'));
             String concDocFactory=pkg+"."+CONCRETE_DOC_FACTORY_CLASS;
             String bundle = e.getAttribute("bundle");
-            Component<AbstractConfigProducer<?>, ComponentModel> component = new Component<>(
+            Component<TreeConfigProducer<?>, ComponentModel> component = new Component<>(
                     new ComponentModel(BundleInstantiationSpecification.fromStrings(concDocFactory, concDocFactory, bundle)));
             if (!cluster.getComponentsMap().containsKey(component.getComponentId())) cluster.addComponent(component);
             types.put(type, concDocFactory);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ClusterControllerConfig.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.content;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.vespa.model.VespaModel;
@@ -16,7 +16,7 @@ import org.w3c.dom.Element;
  *
  * TODO: Author
  */
-public class ClusterControllerConfig extends AbstractConfigProducer<ClusterControllerConfig> implements FleetcontrollerConfig.Producer {
+public class ClusterControllerConfig extends TreeConfigProducer<ClusterControllerConfig> implements FleetcontrollerConfig.Producer {
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<ClusterControllerConfig> {
         private final String clusterName;
@@ -30,7 +30,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
         }
 
         @Override
-        protected ClusterControllerConfig doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected ClusterControllerConfig doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             ModelElement tuning = null;
 
             ModelElement clusterTuning = clusterElement.child("tuning");
@@ -75,7 +75,7 @@ public class ClusterControllerConfig extends AbstractConfigProducer<ClusterContr
     private final ResourceLimits resourceLimits;
 
     // TODO refactor; too many args
-    private ClusterControllerConfig(AbstractConfigProducer<?> parent,
+    private ClusterControllerConfig(TreeConfigProducer<?> parent,
                                     String clusterName,
                                     Duration initProgressTime,
                                     Duration transitionTime,

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Content.java
@@ -13,7 +13,7 @@ import com.yahoo.config.model.admin.AdminModel;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.SimpleConfigProducer;
@@ -290,7 +290,7 @@ public class Content extends ConfigModel {
                                                    ConfigModelContext modelContext,
                                                    ApplicationConfigProducerRoot root) {
             String indexerName = cluster.getIndexingClusterName();
-            AbstractConfigProducer<?> parent = root.getChildren().get(DOCPROC_RESERVED_NAME);
+            TreeConfigProducer<?> parent = root.getChildren().get(DOCPROC_RESERVED_NAME);
             if (parent == null)
                 parent = new SimpleConfigProducer(root, DOCPROC_RESERVED_NAME);
             ApplicationContainerCluster indexingCluster = new ApplicationContainerCluster(parent, "cluster." + indexerName, indexerName, modelContext.getDeployState());

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentNode.java
@@ -6,7 +6,7 @@ import com.yahoo.metrics.MetricsmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorCommunicationmanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.vespa.config.content.core.StorStatusConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
@@ -27,7 +27,7 @@ public abstract class ContentNode extends AbstractService
     private final int rpc_num_targets;
     private final int rpc_events_before_wakeup;
 
-    public ContentNode(ModelContext.FeatureFlags featureFlags, AbstractConfigProducer<?> parent, String clusterName, String rootDirectory, int distributionKey) {
+    public ContentNode(ModelContext.FeatureFlags featureFlags, TreeConfigProducer<?> parent, String clusterName, String rootDirectory, int distributionKey) {
         super(parent, "" + distributionKey);
         this.distributionKey = distributionKey;
         this.rootDirectory = rootDirectory;

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/ContentSearchCluster.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.content;
 
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.documentmodel.NewDocumentType;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.derived.SchemaInfo;
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * Encapsulates the various options for search in a content model.
  * Wraps a search cluster from com.yahoo.vespa.model.search.
  */
-public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> implements
+public class ContentSearchCluster extends TreeConfigProducer<SearchCluster> implements
         ProtonConfig.Producer,
         DispatchNodesConfig.Producer,
         DispatchConfig.Producer
@@ -94,7 +94,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
         }
 
         @Override
-        protected ContentSearchCluster doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected ContentSearchCluster doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             ModelElement clusterElem = new ModelElement(producerSpec);
             String clusterName = ContentCluster.getClusterId(clusterElem);
             Boolean flushOnShutdownElem = clusterElem.childAsBoolean("engine.proton.flush-on-shutdown");
@@ -195,7 +195,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
         }
     }
 
-    private ContentSearchCluster(AbstractConfigProducer<?> parent,
+    private ContentSearchCluster(TreeConfigProducer<?> parent,
                                  String clusterName,
                                  ModelContext.FeatureFlags featureFlags,
                                  Map<String, NewDocumentType> documentDefinitions,
@@ -267,7 +267,7 @@ public class ContentSearchCluster extends AbstractConfigProducer<SearchCluster> 
     }
 
     public void addSearchNode(DeployState deployState, ContentNode node, StorageGroup parentGroup, ModelElement element) {
-        AbstractConfigProducer<?> parent = hasIndexedCluster() ? getIndexed() : this;
+        TreeConfigProducer<?> parent = hasIndexedCluster() ? getIndexed() : this;
 
         NodeSpec spec = getNextSearchNodeSpec(parentGroup);
         SearchNode searchNode;

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/Distributor.java
@@ -5,7 +5,7 @@ import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.config.content.core.StorDistributormanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.content.engines.PersistenceEngine;
@@ -29,7 +29,7 @@ public class Distributor extends ContentNode implements StorDistributormanagerCo
         }
 
         @Override
-        protected Distributor doBuild(DeployState deployState, AbstractConfigProducer ancestor, Element producerSpec) {
+        protected Distributor doBuild(DeployState deployState, TreeConfigProducer ancestor, Element producerSpec) {
             return new Distributor(deployState.getProperties(), (DistributorCluster)ancestor, new ModelElement(producerSpec).integerAttribute("distribution-key"),
                                    clusterXml.integerAttribute("distributor-base-port"), persistenceProvider);
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -6,7 +6,7 @@ import com.yahoo.vespa.config.content.core.StorDistributormanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.document.select.DocumentSelector;
 import com.yahoo.document.select.parser.ParseException;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.metrics.MetricsmanagerConfig;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
@@ -18,7 +18,7 @@ import java.util.logging.Logger;
 /**
  * Generates distributor-specific configuration.
  */
-public class DistributorCluster extends AbstractConfigProducer<Distributor> implements
+public class DistributorCluster extends TreeConfigProducer<Distributor> implements
         StorDistributormanagerConfig.Producer,
         StorServerConfig.Producer,
         MetricsmanagerConfig.Producer {
@@ -86,7 +86,7 @@ public class DistributorCluster extends AbstractConfigProducer<Distributor> impl
         }
 
         @Override
-        protected DistributorCluster doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected DistributorCluster doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             final ModelElement clusterElement = new ModelElement(producerSpec);
             final ModelElement documentsNode = clusterElement.child("documents");
             final GcOptions gc = parseGcOptions(documentsNode);

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/StorageNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/StorageNode.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.content;
 
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.config.content.StorFilestorConfig;
 import com.yahoo.vespa.config.content.core.StorBucketmoverConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
@@ -32,7 +32,7 @@ public class StorageNode extends ContentNode implements StorServerConfig.Produce
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<StorageNode> {
 
         @Override
-        protected StorageNode doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected StorageNode doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             ModelElement e = new ModelElement(producerSpec);
             return new StorageNode(deployState.getProperties(), (StorageCluster)ancestor, e.doubleAttribute("capacity"), e.integerAttribute("distribution-key"), false);
         }
@@ -67,7 +67,7 @@ public class StorageNode extends ContentNode implements StorServerConfig.Produce
     public boolean isRetired() { return retired; }
 
     private boolean isProviderProton() {
-        for (AbstractConfigProducer<?> producer : getChildren().values()) {
+        for (TreeConfigProducer<?> producer : getChildren().values()) {
             if (producer instanceof ProtonProvider) {
                 return true;
             }
@@ -81,7 +81,7 @@ public class StorageNode extends ContentNode implements StorServerConfig.Produce
 
         builder.node_capacity(getCapacity());
 
-        for (AbstractConfigProducer<?> producer : getChildren().values()) {
+        for (TreeConfigProducer<?> producer : getChildren().values()) {
             ((PersistenceEngine)producer).getConfig(builder);
         }
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -5,7 +5,7 @@ import com.google.common.base.Preconditions;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
@@ -69,7 +69,7 @@ import java.util.logging.Level;
  * @author mostly somebody unknown
  * @author bratseth
  */
-public class ContentCluster extends AbstractConfigProducer<AbstractConfigProducer<?>> implements
+public class ContentCluster extends TreeConfigProducer<TreeConfigProducer<?>> implements
                                                            DistributionConfig.Producer,
                                                            StorDistributionConfig.Producer,
                                                            StorDistributormanagerConfig.Producer,
@@ -344,7 +344,7 @@ public class ContentCluster extends AbstractConfigProducer<AbstractConfigProduce
             return admin.getClusterControllers();
         }
 
-        private ClusterControllerContainerCluster createClusterControllers(AbstractConfigProducer<?> parent,
+        private ClusterControllerContainerCluster createClusterControllers(TreeConfigProducer<?> parent,
                                                                            Collection<HostResource> hosts,
                                                                            String name,
                                                                            boolean runStandaloneZooKeeper,
@@ -385,7 +385,7 @@ public class ContentCluster extends AbstractConfigProducer<AbstractConfigProduce
 
     }
 
-    private ContentCluster(AbstractConfigProducer<?> parent, String clusterId,
+    private ContentCluster(TreeConfigProducer<?> parent, String clusterId,
                            Map<String, NewDocumentType> documentDefinitions,
                            Set<NewDocumentType> globallyDistributedDocuments,
                            String routingSelection, Zone zone, boolean isHosted) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/engines/PersistenceEngine.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/engines/PersistenceEngine.java
@@ -3,15 +3,15 @@ package com.yahoo.vespa.model.content.engines;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
 import com.yahoo.vespa.model.content.StorageGroup;
 import com.yahoo.vespa.model.content.StorageNode;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
 
-public abstract class PersistenceEngine extends AbstractConfigProducer implements StorServerConfig.Producer {
+public abstract class PersistenceEngine extends TreeConfigProducer implements StorServerConfig.Producer {
 
-    public PersistenceEngine(AbstractConfigProducer parent, String name) {
+    public PersistenceEngine(TreeConfigProducer parent, String name) {
         super(parent, name);
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -9,7 +9,7 @@ import com.yahoo.vespa.config.content.StorFilestorConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
 import com.yahoo.vespa.config.content.PersistenceConfig;
 import com.yahoo.metrics.MetricsmanagerConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
 import com.yahoo.vespa.model.builder.xml.dom.ModelElement;
@@ -19,7 +19,7 @@ import org.w3c.dom.Element;
 /**
  * Represents configuration that is common to all storage nodes.
  */
-public class StorageCluster extends AbstractConfigProducer<StorageNode>
+public class StorageCluster extends TreeConfigProducer<StorageNode>
     implements StorServerConfig.Producer,
         StorBucketmoverConfig.Producer,
         StorIntegritycheckerConfig.Producer,
@@ -30,7 +30,7 @@ public class StorageCluster extends AbstractConfigProducer<StorageNode>
 {
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilder<StorageCluster> {
         @Override
-        protected StorageCluster doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected StorageCluster doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             final ModelElement clusterElem = new ModelElement(producerSpec);
             final ContentCluster cluster = (ContentCluster)ancestor;
 
@@ -51,7 +51,7 @@ public class StorageCluster extends AbstractConfigProducer<StorageNode>
     private final StorVisitorProducer storVisitorProducer;
     private final PersistenceProducer persistenceProducer;
 
-    StorageCluster(AbstractConfigProducer<?> parent,
+    StorageCluster(TreeConfigProducer<?> parent,
                    String clusterName,
                    FileStorProducer fileStorProducer,
                    IntegrityCheckerProducer integrityCheckerProducer,

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProducer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProducer.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.filedistribution;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.Host;
 
 import java.util.IdentityHashMap;
@@ -12,11 +12,11 @@ import java.util.Map;
  *
  * @author hmusum
  */
-public class FileDistributionConfigProducer extends AbstractConfigProducer<AbstractConfigProducer<?>> {
+public class FileDistributionConfigProducer extends TreeConfigProducer<TreeConfigProducer<?>> {
 
     private final Map<Host, FileDistributionConfigProvider> fileDistributionConfigProviders = new IdentityHashMap<>();
 
-    public FileDistributionConfigProducer(AbstractConfigProducer<?> parent) {
+    public FileDistributionConfigProducer(TreeConfigProducer<?> parent) {
         super(parent, "filedistribution");
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/FileDistributionConfigProvider.java
@@ -2,15 +2,15 @@
 package com.yahoo.vespa.model.filedistribution;
 
 import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.ConfigProxy;
 import com.yahoo.vespa.model.Host;
 
-public class FileDistributionConfigProvider extends AbstractConfigProducer<AbstractConfigProducer<?>> implements FiledistributorrpcConfig.Producer {
+public class FileDistributionConfigProvider extends TreeConfigProducer<TreeConfigProducer<?>> implements FiledistributorrpcConfig.Producer {
 
     private final Host host;
 
-    public FileDistributionConfigProvider(AbstractConfigProducer<?> parent, Host host) {
+    public FileDistributionConfigProvider(TreeConfigProducer<?> parent, Host host) {
         super(parent, host.getHostname());
         this.host = host;
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/package-info.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/package-info.java
@@ -8,18 +8,18 @@
     href="#plugin_loading">plugin loading</a> and currently
     instantiates one {@link com.yahoo.config.model.ApplicationConfigProducerRoot Vespa}
     object. VespaModel is the root node in a tree of {@link
-com.yahoo.config.model.producer.AbstractConfigProducer
-    AbstractConfigProducers} that is built from the structure of the
+com.yahoo.config.model.producer.TreeConfigProducer
+    TreeConfigProducers} that is built from the structure of the
     user's specification. In a future version, the VespaModel can
     contain multiple Vespa instances, each built from a separate user
     specification (currently called 'services.xml').
     </p>
 
-    <p>Each AbstractConfigProducer in the tree represents an actual
+    <p>Each TreeConfigProducer in the tree represents an actual
     service or another logical unit in the Vespa system. An example of
     a logical unit is a cluster that holds a set of services. Each
-    child class of {@link com.yahoo.config.model.producer.AbstractConfigProducer
-    AbstractConfigProducer} can contain hard-wired config that should
+    child class of {@link com.yahoo.config.model.producer.TreeConfigProducer
+    TreeConfigProducer} can contain hard-wired config that should
     be delivered to the Vespa unit it represents, and its children. It
     can also keep track of the status of the unit.
     </p>
@@ -83,7 +83,7 @@ com.yahoo.config.model.producer.AbstractConfigProducer
     could look like this:
     VespaModel.getConfig(builder, &quot;grandchild_0&quot;).
     This triggers a call to the {@link
-    com.yahoo.config.model.producer.AbstractConfigProducer#cascadeConfig(com.yahoo.config.ConfigInstance.Builder)}) AbstractConfigProducer.cascadeConfig} method for
+    com.yahoo.config.model.producer.TreeConfigProducer#cascadeConfig(com.yahoo.config.ConfigInstance.Builder)}) TreeConfigProducer.cascadeConfig} method for
     grandchild_0 which calls the same method in child_0, and finally
     in the VespaModel root node, where the {@link
     com.yahoo.vespa.model.VespaModel#getConfig(com.yahoo.config.ConfigInstance.Builder,String)
@@ -120,8 +120,8 @@ com.yahoo.config.model.builder.xml.ConfigModelBuilder ConfigModelBuilder}. The
     <ul>
 
     <li>The constructors of all child classes of {@link
-com.yahoo.config.model.producer.AbstractConfigProducer
-    AbstractConfigProducer} should throw a new 'RuntimeException' upon
+com.yahoo.config.model.producer.TreeConfigProducer
+    TreeConfigProducer} should throw a new 'RuntimeException' upon
     errors in xml or other initialization problems. This allows the
     exception to be nested upwards, adding valuable information from
     each level in the ConfigProducer tree to the error message output

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentDatabase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentDatabase.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.search;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.search.config.SchemaInfoConfig;
 import com.yahoo.schema.derived.DerivedConfiguration;
@@ -21,7 +21,7 @@ import com.yahoo.vespa.configdefinition.IlscriptsConfig;
  *
  * @author geirst
  */
-public class DocumentDatabase extends AbstractConfigProducer<DocumentDatabase> implements
+public class DocumentDatabase extends TreeConfigProducer<DocumentDatabase> implements
         IndexInfoConfig.Producer,
         IlscriptsConfig.Producer,
         AttributesConfig.Producer,
@@ -38,7 +38,7 @@ public class DocumentDatabase extends AbstractConfigProducer<DocumentDatabase> i
     private final String schemaName;
     private final DerivedConfiguration derivedCfg;
 
-    public DocumentDatabase(AbstractConfigProducer<?> parent, String schemaName, DerivedConfiguration derivedCfg) {
+    public DocumentDatabase(TreeConfigProducer<?> parent, String schemaName, DerivedConfiguration derivedCfg) {
         super(parent, schemaName);
         this.schemaName = schemaName;
         this.derivedCfg = derivedCfg;

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/IndexedSearchCluster.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.search;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.search.config.SchemaInfoConfig;
@@ -73,7 +73,7 @@ public class IndexedSearchCluster extends SearchCluster
         return routingSelector;
     }
 
-    public IndexedSearchCluster(AbstractConfigProducer<SearchCluster> parent, String clusterName, int index, ModelContext.FeatureFlags featureFlags) {
+    public IndexedSearchCluster(TreeConfigProducer<SearchCluster> parent, String clusterName, int index, ModelContext.FeatureFlags featureFlags) {
         super(parent, clusterName, index);
         documentDbsConfigProducer = new MultipleDocumentDatabasesConfigProducer(this, documentDbs);
         rootDispatch =  new DispatchGroup(this);
@@ -351,7 +351,7 @@ public class IndexedSearchCluster extends SearchCluster
      * which is the parent to this. This avoids building the config multiple times.
      */
     public static class MultipleDocumentDatabasesConfigProducer
-            extends AbstractConfigProducer<MultipleDocumentDatabasesConfigProducer>
+            extends TreeConfigProducer<MultipleDocumentDatabasesConfigProducer>
             implements AttributesConfig.Producer,
                        IndexInfoConfig.Producer,
                        IlscriptsConfig.Producer,
@@ -359,7 +359,7 @@ public class IndexedSearchCluster extends SearchCluster
                        RankProfilesConfig.Producer {
         private final List<DocumentDatabase> docDbs;
 
-        private MultipleDocumentDatabasesConfigProducer(AbstractConfigProducer<?> parent, List<DocumentDatabase> docDbs) {
+        private MultipleDocumentDatabasesConfigProducer(TreeConfigProducer<?> parent, List<DocumentDatabase> docDbs) {
             super(parent, "union");
             this.docDbs = docDbs;
         }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
@@ -9,7 +9,7 @@ import com.yahoo.vespa.config.search.RankProfilesConfig;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.vespa.configdefinition.IlscriptsConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -21,7 +21,7 @@ import java.util.Map;
  *
  * @author arnej27959
  */
-public abstract class SearchCluster extends AbstractConfigProducer<SearchCluster>
+public abstract class SearchCluster extends TreeConfigProducer<SearchCluster>
         implements
         DocumentdbInfoConfig.Producer,
         IndexInfoConfig.Producer,
@@ -34,7 +34,7 @@ public abstract class SearchCluster extends AbstractConfigProducer<SearchCluster
     private Double visibilityDelay = 0.0;
     private final Map<String, SchemaInfo> schemas = new LinkedHashMap<>();
 
-    public SearchCluster(AbstractConfigProducer<?> parent, String clusterName, int index) {
+    public SearchCluster(TreeConfigProducer<?> parent, String clusterName, int index) {
         super(parent, "cluster." + clusterName);
         this.clusterName = clusterName;
         this.index = index;

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchNode.java
@@ -4,7 +4,7 @@ package com.yahoo.vespa.model.search;
 import com.yahoo.cloud.config.filedistribution.FiledistributorrpcConfig;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.metrics.MetricsmanagerConfig;
 import com.yahoo.searchlib.TranslogserverConfig;
@@ -94,7 +94,7 @@ public class SearchNode extends AbstractService implements
         }
 
         @Override
-        protected SearchNode doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected SearchNode doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             return SearchNode.create(ancestor, name, contentNode.getDistributionKey(), nodeSpec, clusterName, contentNode,
                                      flushOnShutdown, tuning, resourceLimits, deployState.isHosted(),
                                      fractionOfMemoryReserved, deployState.featureFlags());
@@ -102,7 +102,7 @@ public class SearchNode extends AbstractService implements
 
     }
 
-    public static SearchNode create(AbstractConfigProducer<?> parent, String name, int distributionKey, NodeSpec nodeSpec,
+    public static SearchNode create(TreeConfigProducer<?> parent, String name, int distributionKey, NodeSpec nodeSpec,
                                     String clusterName, AbstractService serviceLayerService, boolean flushOnShutdown,
                                     Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                                     double fractionOfMemoryReserved, ModelContext.FeatureFlags featureFlags) {
@@ -117,7 +117,7 @@ public class SearchNode extends AbstractService implements
         return node;
     }
 
-    private SearchNode(AbstractConfigProducer<?> parent, String name, int distributionKey, NodeSpec nodeSpec,
+    private SearchNode(TreeConfigProducer<?> parent, String name, int distributionKey, NodeSpec nodeSpec,
                        String clusterName, AbstractService serviceLayerService, boolean flushOnShutdown,
                        Optional<Tuning> tuning, Optional<ResourceLimits> resourceLimits, boolean isHostedVespa,
                        double fractionOfMemoryReserved) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/StreamingSearchCluster.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.search;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.prelude.fastsearch.DocumentdbInfoConfig;
 import com.yahoo.schema.Schema;
 import com.yahoo.schema.derived.AttributeFields;
@@ -34,7 +34,7 @@ public class StreamingSearchCluster extends SearchCluster implements
     private final String docTypeName;
     private DerivedConfiguration derivedConfig = null;
 
-    public StreamingSearchCluster(AbstractConfigProducer<SearchCluster> parent,
+    public StreamingSearchCluster(TreeConfigProducer<SearchCluster> parent,
                                   String clusterName,
                                   int index,
                                   String docTypeName,
@@ -123,9 +123,9 @@ public class StreamingSearchCluster extends SearchCluster implements
             derivedConfig.getSummaries().getConfig(builder);
     }
 
-    private class AttributesProducer extends AbstractConfigProducer<AttributesProducer> implements AttributesConfig.Producer {
+    private class AttributesProducer extends TreeConfigProducer<AttributesProducer> implements AttributesConfig.Producer {
 
-        AttributesProducer(AbstractConfigProducer<?> parent, String docType) {
+        AttributesProducer(TreeConfigProducer<?> parent, String docType) {
             super(parent, docType);
         }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/TransactionLogServer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/TransactionLogServer.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.model.search;
 
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.searchlib.TranslogserverConfig;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
@@ -16,7 +16,7 @@ public class TransactionLogServer extends AbstractService  {
 
     private final Boolean useFsync;
 
-    public TransactionLogServer(AbstractConfigProducer<?> searchNode, String clusterName, Boolean useFsync) {
+    public TransactionLogServer(TreeConfigProducer<?> searchNode, String clusterName, Boolean useFsync) {
         super(searchNode, "transactionlogserver");
         portsMeta.on(0).tag("tls");
         this.useFsync = useFsync;
@@ -34,7 +34,7 @@ public class TransactionLogServer extends AbstractService  {
         }
 
         @Override
-        protected TransactionLogServer doBuild(DeployState deployState, AbstractConfigProducer<?> ancestor, Element producerSpec) {
+        protected TransactionLogServer doBuild(DeployState deployState, TreeConfigProducer<?> ancestor, Element producerSpec) {
             return new TransactionLogServer(ancestor, clusterName, useFsync);
         }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/Tuning.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.search;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.config.search.core.ProtonConfig;
 import com.yahoo.vespa.model.content.DispatchTuning;
 
@@ -13,7 +13,7 @@ import static com.yahoo.text.Lowercase.toLowerCase;
  *
  * @author geirst
  */
-public class Tuning extends AbstractConfigProducer<Tuning> implements ProtonConfig.Producer {
+public class Tuning extends TreeConfigProducer<Tuning> implements ProtonConfig.Producer {
 
     public static class SearchNode implements ProtonConfig.Producer {
 
@@ -396,7 +396,7 @@ public class Tuning extends AbstractConfigProducer<Tuning> implements ProtonConf
     public DispatchTuning dispatch = DispatchTuning.empty;
     public SearchNode searchNode;
 
-    public Tuning(AbstractConfigProducer<?> parent) {
+    public Tuning(TreeConfigProducer<?> parent) {
         super(parent, "tuning");
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/utils/FileSender.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/utils/FileSender.java
@@ -5,7 +5,7 @@ import com.yahoo.config.FileReference;
 import com.yahoo.config.ModelReference;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.application.api.FileRegistry;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.path.Path;
 import com.yahoo.vespa.config.ConfigDefinition;
@@ -40,7 +40,7 @@ public class FileSender implements Serializable {
     /**
      * Sends all user configured files for a producer to all given services.
      */
-    public <PRODUCER extends AbstractConfigProducer<?>> void sendUserConfiguredFiles(PRODUCER producer) {
+    public <PRODUCER extends TreeConfigProducer<?>> void sendUserConfiguredFiles(PRODUCER producer) {
         if (services.isEmpty()) return;
 
         UserConfigRepo userConfigs = producer.getUserConfigs();

--- a/config-model/src/test/java/com/yahoo/config/model/ConfigModelContextTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/ConfigModelContextTest.java
@@ -4,7 +4,7 @@ package com.yahoo.config.model;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.model.test.MockRoot;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ public class ConfigModelContextTest {
         ctx = ConfigModelContext.create(root.getDeployState(), null, null, root, id);
         assertEquals(id, ctx.getProducerId());
         assertEquals(root, ctx.getParentProducer());
-        AbstractConfigProducer newRoot = new MockRoot("bar");
+        TreeConfigProducer newRoot = new MockRoot("bar");
         ctx = ctx.withParent(newRoot);
         assertEquals(id, ctx.getProducerId());
         assertNotEquals(root, ctx.getParentProducer());

--- a/config-model/src/test/java/com/yahoo/config/model/producer/AbstractConfigProducerTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/producer/AbstractConfigProducerTest.java
@@ -41,7 +41,7 @@ public class AbstractConfigProducerTest {
         assertEquals(1337, config.logserver().rpcport());
     }
 
-    private static class MockLogdProducer extends AbstractConfigProducer implements LogdConfig.Producer {
+    private static class MockLogdProducer extends TreeConfigProducer implements LogdConfig.Producer {
 
         public MockLogdProducer(String subId) {
             super(subId);
@@ -53,7 +53,7 @@ public class AbstractConfigProducerTest {
         }
     }
 
-    private static abstract class MockLogdSuperClass extends AbstractConfigProducer implements LogdConfig.Producer {
+    private static abstract class MockLogdSuperClass extends TreeConfigProducer implements LogdConfig.Producer {
 
         public MockLogdSuperClass(String subId) {
             super(subId);

--- a/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/HostPortsTest.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.config.provision.NetworkPorts;
 
@@ -115,7 +115,7 @@ public class HostPortsTest {
     }
 
     private static class MockSlobrok extends AbstractService {
-        MockSlobrok(AbstractConfigProducer parent, int number) {
+        MockSlobrok(TreeConfigProducer parent, int number) {
             super(parent, "slobrok."+number);
         }
         @Override public int getPortCount() { return 1; }
@@ -133,7 +133,7 @@ public class HostPortsTest {
     private class TestService extends AbstractService {
         private final int portCount;
 
-        TestService(AbstractConfigProducer parent, int portCount) {
+        TestService(TreeConfigProducer parent, int portCount) {
             super(parent, "testService" + getCounter());
             this.portCount = portCount;
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/HostResourceTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/HostResourceTest.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.config.provision.ClusterMembership;
 import com.yahoo.config.provision.ClusterSpec;
@@ -65,7 +65,7 @@ public class HostResourceTest {
     private class TestService extends AbstractService {
         private final int portCount;
 
-        TestService(AbstractConfigProducer parent, int portCount) {
+        TestService(TreeConfigProducer parent, int portCount) {
             super(parent, "testService" + getCounter());
             this.portCount = portCount;
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ConfigValueChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ConfigValueChangeValidatorTest.java
@@ -7,7 +7,7 @@ import com.yahoo.config.ConfigInstance;
 import com.yahoo.test.RestartConfig;
 import com.yahoo.test.SimpletypesConfig;
 import com.yahoo.config.model.api.ConfigChangeAction;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.vespa.model.AbstractService;
@@ -229,7 +229,7 @@ public class ConfigValueChangeValidatorTest {
                 "</config>\n";
     }
 
-    private static MockRoot createRootWithChildren(AbstractConfigProducer<?>... children) {
+    private static MockRoot createRootWithChildren(TreeConfigProducer<?>... children) {
         MockRoot root = new MockRoot();
         List.of(children).forEach(root::addChild);
         root.freezeModelTopology();
@@ -252,7 +252,7 @@ public class ConfigValueChangeValidatorTest {
         @Override public void allocatePorts(int start, PortAllocBridge from) { }
     }
 
-    private static class SimpleConfigProducer extends AbstractConfigProducer<AbstractConfigProducer<?>>
+    private static class SimpleConfigProducer extends TreeConfigProducer<TreeConfigProducer<?>>
             implements RestartConfig.Producer {
         public final int value;
 
@@ -266,7 +266,7 @@ public class ConfigValueChangeValidatorTest {
             builder.value(value);
         }
 
-        public SimpleConfigProducer withChildren(AbstractConfigProducer<?>... producer) {
+        public SimpleConfigProducer withChildren(TreeConfigProducer<?>... producer) {
             List.of(producer).forEach(this::addChild);
             return this;
         }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/StartupCommandChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/StartupCommandChangeValidatorTest.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.application.validation.change;
 
 import com.yahoo.config.model.api.ConfigChangeAction;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.AbstractConfigProducerRoot;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.vespa.model.AbstractService;
@@ -52,7 +52,7 @@ public class StartupCommandChangeValidatorTest {
         return validator.findServicesWithChangedStartupCommand(currentModel, nextModel).toList();
     }
 
-    private static MockRoot createRootWithChildren(AbstractConfigProducer<?>... children) {
+    private static MockRoot createRootWithChildren(TreeConfigProducer<?>... children) {
         MockRoot root = new MockRoot();
         Arrays.asList(children).forEach(root::addChild);
         root.freezeModelTopology();

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomFederationSearcherBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/chains/search/DomFederationSearcherBuilderTest.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.builder.xml.dom.chains.search;
 
 import com.yahoo.config.model.builder.xml.test.DomBuilderTest;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.search.federation.FederationConfig;
 import com.yahoo.search.searchchain.model.federation.FederationSearcherModel;
 import com.yahoo.vespa.model.container.search.searchchain.FederationSearcher;
@@ -61,7 +61,7 @@ public class DomFederationSearcherBuilderTest extends DomBuilderTest {
 
         String targetSelectorId = "my-id@federation-id";
 
-        AbstractConfigProducer<?> targetSelector = searcher.getChildren().get(targetSelectorId);
+        TreeConfigProducer<?> targetSelector = searcher.getChildren().get(targetSelectorId);
         assertNotNull(targetSelector, "No target selector child found");
 
         FederationConfig.Builder builder = new FederationConfig.Builder();

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/ApiService.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/ApiService.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.test;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 
@@ -22,7 +22,7 @@ public class ApiService extends AbstractService implements com.yahoo.test.Standa
      * @param parent   The parent ConfigProducer.
      * @param name     Service name
      */
-    public ApiService(AbstractConfigProducer<?> parent, String name) {
+    public ApiService(TreeConfigProducer<?> parent, String name) {
         super(parent, name);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/DomTestServiceBuilder.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/DomTestServiceBuilder.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.test;
 
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.builder.xml.dom.VespaDomBuilder;
 import org.w3c.dom.Element;
 
@@ -20,7 +20,7 @@ public class DomTestServiceBuilder {
         }
 
         @Override
-        protected SimpleService doBuild(DeployState deployState, AbstractConfigProducer parent, Element spec) {
+        protected SimpleService doBuild(DeployState deployState, TreeConfigProducer parent, Element spec) {
             return new SimpleService(parent, "simpleservice." + i);
         }
     }
@@ -33,7 +33,7 @@ public class DomTestServiceBuilder {
         }
 
         @Override
-        protected ApiService doBuild(DeployState deployState, AbstractConfigProducer parent, Element spec) {
+        protected ApiService doBuild(DeployState deployState, TreeConfigProducer parent, Element spec) {
             return new ApiService(parent, "apiservice." + i);
         }
     }
@@ -46,7 +46,7 @@ public class DomTestServiceBuilder {
         }
 
         @Override
-        protected ParentService doBuild(DeployState deployState, AbstractConfigProducer parent, Element spec) {
+        protected ParentService doBuild(DeployState deployState, TreeConfigProducer parent, Element spec) {
             return new ParentService(parent, "parentservice." + i, spec);
         }
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
@@ -10,7 +10,7 @@ import com.yahoo.config.model.admin.AdminModel;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
@@ -165,7 +165,7 @@ public class ModelAmendingTestCase {
     /** To test that we can amend hosts with an additional service */
     private static class AmendedService extends AbstractService {
 
-        public AmendedService(AbstractConfigProducer parent) {
+        public AmendedService(TreeConfigProducer parent) {
             super(parent, "testservice");
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/ParentService.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/ParentService.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.test;
 
 import com.yahoo.test.StandardConfig.Builder;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 import org.w3c.dom.Element;
@@ -21,7 +21,7 @@ public class ParentService extends AbstractService implements com.yahoo.test.Sta
      * @param name       Service name
      * @param config     The xml config Element for this Service
      */
-    public ParentService(AbstractConfigProducer parent, String name,
+    public ParentService(TreeConfigProducer parent, String name,
                          Element config)
     {
         super(parent, name);

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/SimpleService.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/SimpleService.java
@@ -2,7 +2,7 @@
 package com.yahoo.vespa.model.test;
 
 import com.yahoo.test.StandardConfig.Builder;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.PortAllocBridge;
 
@@ -23,7 +23,7 @@ public class SimpleService extends AbstractService implements com.yahoo.test.Sta
      * @param parent     The parent ConfigProducer.
      * @param name       Service name
      */
-    public SimpleService(AbstractConfigProducer parent, String name) {
+    public SimpleService(TreeConfigProducer parent, String name) {
         super(parent, name);
         portsMeta.on(0).tag("base")
             .on(1).tag("base")

--- a/config-model/src/test/java/com/yahoo/vespa/model/utils/FileSenderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/utils/FileSenderTest.java
@@ -7,7 +7,7 @@ import com.yahoo.config.ModelReference;
 import com.yahoo.config.UrlReference;
 import com.yahoo.config.application.api.FileRegistry;
 import com.yahoo.config.model.application.provider.BaseDeployLogger;
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.config.model.test.MockRoot;
 import com.yahoo.vespa.config.ConfigDefinition;
@@ -250,7 +250,7 @@ public class FileSenderTest {
 
 
     private static class TestService extends AbstractService {
-        public TestService(AbstractConfigProducer<?> parent, String name) {
+        public TestService(TreeConfigProducer<?> parent, String name) {
             super(parent, name);
         }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/utils/internal/ReflectionUtilTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/utils/internal/ReflectionUtilTest.java
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.utils.internal;
 
-import com.yahoo.config.model.producer.AbstractConfigProducer;
+import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.test.ArraytypesConfig;
 import com.yahoo.config.ChangesRequiringRestart;
 import com.yahoo.config.ConfigInstance;
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class ReflectionUtilTest {
 
-    private static class SimpleProducer extends AbstractConfigProducer implements SimpletypesConfig.Producer {
-        SimpleProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+    private static class SimpleProducer extends TreeConfigProducer implements SimpletypesConfig.Producer {
+        SimpleProducer(TreeConfigProducer parent, String subId) { super(parent, subId); }
 
         @Override
         public void getConfig(SimpletypesConfig.Builder builder) { }
@@ -31,8 +31,8 @@ public class ReflectionUtilTest {
 
     private interface ProducerInterface extends SimpletypesConfig.Producer, ArraytypesConfig.Producer { }
 
-    private static class InterfaceImplementingProducer extends AbstractConfigProducer implements ProducerInterface {
-        InterfaceImplementingProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+    private static class InterfaceImplementingProducer extends TreeConfigProducer implements ProducerInterface {
+        InterfaceImplementingProducer(TreeConfigProducer parent, String subId) { super(parent, subId); }
 
         @Override
         public void getConfig(ArraytypesConfig.Builder builder) { }
@@ -40,14 +40,14 @@ public class ReflectionUtilTest {
         public void getConfig(SimpletypesConfig.Builder builder) { }
     }
 
-    private static abstract class MyAbstractProducer extends AbstractConfigProducer implements SimpletypesConfig.Producer {
-        MyAbstractProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+    private static abstract class MyAbstractProducer extends TreeConfigProducer implements SimpletypesConfig.Producer {
+        MyAbstractProducer(TreeConfigProducer parent, String subId) { super(parent, subId); }
         @Override
         public void getConfig(SimpletypesConfig.Builder builder) { }
     }
 
     private static class ConcreteProducer extends MyAbstractProducer {
-        ConcreteProducer(AbstractConfigProducer parent, String subId) { super(parent, subId); }
+        ConcreteProducer(TreeConfigProducer parent, String subId) { super(parent, subId); }
     }
 
     private static class RestartConfig extends ConfigInstance {


### PR DESCRIPTION
After trying (again) to figure out how AbstractConfigProducer is supposed to be used,
versus how it's actually mis-used, I've embarked on a quest to make things more sane.

As a first. step, this splits the class into a superclass "AnyConfigProducer" (without children)
and a subclass "TreeConfigProducer" (with just the support for having children).

@gjoranv please review
@bratseth please review
@hmusum FYI
