### PR TITLE
stop using fastos thread

### DIFF
--- a/slobrok/src/tests/mirrorapi/mirrorapi.cpp
+++ b/slobrok/src/tests/mirrorapi/mirrorapi.cpp
@@ -9,6 +9,7 @@
 #include <vespa/fnet/frt/target.h>
 #include <vespa/fnet/transport.h>
 #include <thread>
+#include <vespa/fastos/thread.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("mirrorapi_test");

--- a/vespalib/src/tests/thread/thread_test.cpp
+++ b/vespalib/src/tests/thread/thread_test.cpp
@@ -50,7 +50,7 @@ TEST("stop before start") {
         thread.start();
         thread.join();
     }
-    EXPECT_TRUE(agent.started);
+    EXPECT_TRUE(!agent.started);
     EXPECT_EQUAL(0, agent.loopCnt);
 }
 

--- a/vespalib/src/vespa/vespalib/util/thread.h
+++ b/vespalib/src/vespa/vespalib/util/thread.h
@@ -5,8 +5,8 @@
 #include "gate.h"
 #include "runnable.h"
 #include "active.h"
-#include <vespa/fastos/thread.h>
 #include <atomic>
+#include <thread>
 
 namespace vespalib {
 
@@ -17,29 +17,18 @@ class Thread : public Active
 {
 private:
     using init_fun_t = Runnable::init_fun_t;
-    enum { STACK_SIZE = 256*1024 };
     static __thread Thread *_currentThread;
 
-    struct Proxy : FastOS_Runnable {
-        Thread         &thread;
-        Runnable       &runnable;
-        init_fun_t      init_fun;
-        vespalib::Gate  start;
-        vespalib::Gate  started;
-        bool            cancel;
-
-        Proxy(Thread &parent, Runnable &target, init_fun_t init_fun_in);
-        ~Proxy() override;
-
-        void Run(FastOS_ThreadInterface *thisThread, void *arguments) override;
-    };
-
-    Proxy                   _proxy;
-    FastOS_ThreadPool       _pool;
+    Runnable               &_runnable;
+    init_fun_t              _init_fun;
+    vespalib::Gate          _start;
     std::mutex              _lock;
     std::condition_variable _cond;
     std::atomic<bool>       _stopped;
     bool                    _woken;
+    std::jthread            _thread;
+
+    void run();
 
 public:
     Thread(Runnable &runnable, init_fun_t init_fun_in);
@@ -56,4 +45,3 @@ public:
 };
 
 } // namespace vespalib
-


### PR DESCRIPTION
combine cancel with stop such that cancel means stopped before started and therefore never run.

drop the started sync point since there is no state we need to pass from the thread to the starter of the thread.

@baldersheim please review
