### PR TITLE
Explicit equals and hash code

### DIFF
--- a/security-utils/src/main/java/com/yahoo/security/SealedSharedKey.java
+++ b/security-utils/src/main/java/com/yahoo/security/SealedSharedKey.java
@@ -2,6 +2,10 @@
 package com.yahoo.security;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+
+import static com.yahoo.security.ArrayUtils.hex;
 
 /**
  * A SealedSharedKey represents the public part of a secure one-way ephemeral key exchange.
@@ -95,6 +99,37 @@ public record SealedSharedKey(int version, KeyId keyId, byte[] enc, byte[] ciphe
         if (tokenString.length() > MAX_TOKEN_STRING_LENGTH) {
             throw new IllegalArgumentException("Token string is too long to possibly be a valid token");
         }
+    }
+
+    // Friendlier toString() with hex dump of enc/ciphertext fields
+    @Override
+    public String toString() {
+        return "SealedSharedKey{" +
+                "version=" + version +
+                ", keyId=" + keyId +
+                ", enc=" + hex(enc) +
+                ", ciphertext=" + hex(ciphertext) +
+                '}';
+    }
+
+    // Explicitly generated equals() and hashCode() to use _contents_ of
+    // enc/ciphertext arrays, and not just their refs.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SealedSharedKey that = (SealedSharedKey) o;
+        return version == that.version && keyId.equals(that.keyId) &&
+                Arrays.equals(enc, that.enc) &&
+                Arrays.equals(ciphertext, that.ciphertext);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(version, keyId);
+        result = 31 * result + Arrays.hashCode(enc);
+        result = 31 * result + Arrays.hashCode(ciphertext);
+        return result;
     }
 
 }

--- a/security-utils/src/test/java/com/yahoo/security/SharedKeyTest.java
+++ b/security-utils/src/test/java/com/yahoo/security/SharedKeyTest.java
@@ -14,12 +14,32 @@ import java.util.Optional;
 import static com.yahoo.security.ArrayUtils.hex;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SharedKeyTest {
 
     private static final KeyId KEY_ID_1 = KeyId.ofString("1");
     private static final KeyId KEY_ID_2 = KeyId.ofString("2");
+
+    @Test
+    void sealed_shared_key_uses_enc_and_ciphertext_contents_for_equals_and_hash_code() {
+        var tokenStr1 = "2qW20eDfgCxDVTJfLPzihhqV4i1Ma6QrvjdoU24Csf6W0iKbYmezchhxIGeI39WcHYDvbah5tfLoYZ69ofW40zy59Nm91tavFsA";
+        var tokenStr2 = "mjA83HYuulZW5SWV8FKz4m3b3m9zU8mTrX9n6iY4wZaA6ZNr8WnBZwOU4KQqhPCORPlzSYk4svlonzPZIb3Bjbqr2ePYKLOpdGhCO";
+        var token1a = SealedSharedKey.fromTokenString(tokenStr1);
+        var token1b = SealedSharedKey.fromTokenString(tokenStr1);
+        var token2a = SealedSharedKey.fromTokenString(tokenStr2);
+        var token2b = SealedSharedKey.fromTokenString(tokenStr2);
+        assertEquals(token1a, token1a); // trivial
+        assertEquals(token1a, token1b); // needs deep compare for array contents
+        assertEquals(token1b, token1a);
+        assertEquals(token2a, token2b);
+        assertNotEquals(token1a, token2a);
+
+        assertEquals(token1a.hashCode(), token1b.hashCode());
+        assertEquals(token2a.hashCode(), token2b.hashCode());
+        assertNotEquals(token1a.hashCode(), token2a.hashCode()); // ... with a very high probability
+    }
 
     @Test
     void generated_secret_key_is_128_bit_aes() {

--- a/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespa/security/tool/crypto/DecryptTool.java
@@ -146,7 +146,7 @@ public class DecryptTool implements Tool {
 
     private static SecretSharedKey secretFromInteractiveResealing(ToolInvocation invocation, String inputArg,
                                                                   String outputArg, SealedSharedKey sealedSharedKey) throws IOException {
-        if (!CliUtils.useStdIo(outputArg) || !CliUtils.useStdIo(inputArg)) {
+        if (CliUtils.useStdIo(outputArg) || CliUtils.useStdIo(inputArg)) {
             throw new IllegalArgumentException("Interactive token resealing not available with redirected I/O");
         }
         var session = SharedKeyResealingSession.newEphemeralSession();


### PR DESCRIPTION
@bjorncs please review. Also contains a tiny fix for `vespa-crypto-cli` detection of redirected I/O.
