### PR TITLE
Don't produce sentinel config from Host anymore

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/Host.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/Host.java
@@ -1,10 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model;
 
-import com.yahoo.cloud.config.SentinelConfig;
 import com.yahoo.config.model.producer.AnyConfigProducer;
 import com.yahoo.config.model.producer.TreeConfigProducer;
-
 import java.util.Objects;
 
 /**
@@ -13,9 +11,8 @@ import java.util.Objects;
  *
  * @author gjoranv
  */
-public final class Host extends TreeConfigProducer<AnyConfigProducer> implements SentinelConfig.Producer, Comparable<Host> {
+public final class Host extends TreeConfigProducer<AnyConfigProducer> implements Comparable<Host> {
 
-    private ConfigSentinel configSentinel = null;
     private final String hostname;
     private final boolean runsConfigServer;
 
@@ -56,19 +53,6 @@ public final class Host extends TreeConfigProducer<AnyConfigProducer> implements
     /** Returns the string representation of this Host object. */
     public String toString() {
         return "host '" + getHostname() + "'";
-    }
-
-    @Override
-    public void getConfig(SentinelConfig.Builder builder) {
-        // TODO (MAJOR_RELEASE): This shouldn't really be here, but we need to make sure users can upgrade if we change sentinel to use hosts/<hostname>/sentinel instead of hosts/<hostname>
-        // as config id. We should probably wait for a major release
-        if (configSentinel != null) {
-            configSentinel.getConfig(builder);
-        }
-    }
-
-    public void setConfigSentinel(ConfigSentinel configSentinel) {
-        this.configSentinel = configSentinel;
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/Admin.java
@@ -268,11 +268,9 @@ public class Admin extends TreeConfigProducer<AnyConfigProducer> implements Seri
         }
     }
 
-    private void addConfigSentinel(DeployState deployState, HostResource host)
-    {
+    private void addConfigSentinel(DeployState deployState, HostResource host) {
         ConfigSentinel configSentinel = new ConfigSentinel(host.getHost(), deployState.getProperties().applicationId(), deployState.zone());
         addAndInitializeService(deployState, host, configSentinel);
-        host.getHost().setConfigSentinel(configSentinel);
     }
 
     private void addLogForwarder(DeployState deployState, HostResource host) {

--- a/config-model/src/test/java/com/yahoo/config/model/deploy/SystemModelTestCase.java
+++ b/config-model/src/test/java/com/yahoo/config/model/deploy/SystemModelTestCase.java
@@ -81,7 +81,7 @@ public class SystemModelTestCase {
         // Verify configIds from vespaModel
         assertTrue(12 <= vespaModel.getConfigIds().size());
         String localhost = HostName.getLocalhost();
-        String localhostConfigId = "hosts/" + localhost;
+        String localhostConfigId = "hosts/" + localhost + "/sentinel";
         Set<String> configIds = vespaModel.getConfigIds();
         assertTrue(configIds.contains("client"));
         assertTrue(configIds.contains(localhostConfigId));

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/AdminTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/AdminTestCase.java
@@ -54,7 +54,7 @@ public class AdminTestCase {
         // Verify configIds
         Set<String> configIds = vespaModel.getConfigIds();
         String localhost = HostName.getLocalhost();
-        String localhostConfigId = "hosts/" + localhost;
+        String localhostConfigId = "hosts/" + localhost + "/sentinel";
         assertTrue(configIds.contains(localhostConfigId));
         assertTrue(configIds.contains("admin/logserver"));
         assertTrue(configIds.contains("admin/configservers/configserver.0"));
@@ -118,7 +118,7 @@ public class AdminTestCase {
         // Verify configIds
         Set<String> configIds = vespaModel.getConfigIds();
         String localhost = HostName.getLocalhost();
-        String localhostConfigId = "hosts/" + localhost;
+        String localhostConfigId = "hosts/" + localhost + "/sentinel";
         assertTrue(configIds.contains(localhostConfigId));
         assertTrue(configIds.contains("admin/logserver"));
         assertTrue(configIds.contains("admin/configservers/configserver.0"));
@@ -158,7 +158,7 @@ public class AdminTestCase {
                 .build();
         TestRoot root = new TestDriver().buildModel(state);
         String localhost = HostName.getLocalhost();
-        SentinelConfig config = root.getConfig(SentinelConfig.class, "hosts/" + localhost);
+        SentinelConfig config = root.getConfig(SentinelConfig.class, "hosts/" + localhost + "/sentinel");
         assertEquals("quux", config.application().tenant());
         assertEquals("foo", config.application().name());
         assertEquals("dev", config.application().environment());

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/DedicatedAdminV4Test.java
@@ -71,12 +71,12 @@ public class DedicatedAdminV4Test {
         VespaModel model = createModel(hosts, services);
         assertEquals(3, model.getHosts().size());
 
-        assertHostContainsServices(model, "hosts/myhost0", "slobrok", "logd",
+        assertHostContainsServices(model, "hosts/myhost0/sentinel", "slobrok", "logd",
                 METRICS_PROXY_CONTAINER.serviceName);
-        assertHostContainsServices(model, "hosts/myhost1", "slobrok", "logd",
+        assertHostContainsServices(model, "hosts/myhost1/sentinel", "slobrok", "logd",
                 METRICS_PROXY_CONTAINER.serviceName);
         // Note: A logserver container is always added on logserver host
-        assertHostContainsServices(model, "hosts/myhost2", "logserver", "logd",
+        assertHostContainsServices(model, "hosts/myhost2/sentinel", "logserver", "logd",
                 METRICS_PROXY_CONTAINER.serviceName, LOGSERVER_CONTAINER.serviceName);
 
         Monitoring monitoring = model.getAdmin().getMonitoring();
@@ -129,13 +129,13 @@ public class DedicatedAdminV4Test {
         assertEquals(4, model.getHosts().size());
 
         // 4 slobroks, 2 per cluster where possible
-        assertHostContainsServices(model, "hosts/myhost0", "slobrok", "logd", "logserver",
+        assertHostContainsServices(model, "hosts/myhost0/sentinel", "slobrok", "logd", "logserver",
                 METRICS_PROXY_CONTAINER.serviceName, CONTAINER.serviceName);
-        assertHostContainsServices(model, "hosts/myhost1", "slobrok", "logd",
+        assertHostContainsServices(model, "hosts/myhost1/sentinel", "slobrok", "logd",
                 METRICS_PROXY_CONTAINER.serviceName, CONTAINER.serviceName);
-        assertHostContainsServices(model, "hosts/myhost2", "slobrok", "logd",
+        assertHostContainsServices(model, "hosts/myhost2/sentinel", "slobrok", "logd",
                 METRICS_PROXY_CONTAINER.serviceName, CONTAINER.serviceName);
-        assertHostContainsServices(model, "hosts/myhost3", "slobrok", "logd",
+        assertHostContainsServices(model, "hosts/myhost3/sentinel", "slobrok", "logd",
                 METRICS_PROXY_CONTAINER.serviceName, CONTAINER.serviceName);
     }
 
@@ -154,12 +154,12 @@ public class DedicatedAdminV4Test {
         VespaModel model = createModel(hosts, services);
         assertEquals(3, model.getHosts().size());
 
-        assertHostContainsServices(model, "hosts/myhost0", "logd", "logforwarder", "slobrok",
+        assertHostContainsServices(model, "hosts/myhost0/sentinel", "logd", "logforwarder", "slobrok",
                 METRICS_PROXY_CONTAINER.serviceName);
-        assertHostContainsServices(model, "hosts/myhost1", "logd", "logforwarder", "slobrok",
+        assertHostContainsServices(model, "hosts/myhost1/sentinel", "logd", "logforwarder", "slobrok",
                 METRICS_PROXY_CONTAINER.serviceName);
         // Note: A logserver container is always added on logserver host
-        assertHostContainsServices(model, "hosts/myhost2", "logd", "logforwarder", "logserver",
+        assertHostContainsServices(model, "hosts/myhost2/sentinel", "logd", "logforwarder", "logserver",
                 METRICS_PROXY_CONTAINER.serviceName, LOGSERVER_CONTAINER.serviceName);
 
         Set<String> configIds = model.getConfigIds();
@@ -206,17 +206,17 @@ public class DedicatedAdminV4Test {
                 .properties(new TestProperties().setHostedVespa(true)));
         assertEquals(1, model.getHosts().size());
         // Should create a logserver container on the same node as logserver
-        assertHostContainsServices(model, "hosts/myhost0", "slobrok", "logd", "logserver",
+        assertHostContainsServices(model, "hosts/myhost0/sentinel", "slobrok", "logd", "logserver",
                 METRICS_PROXY_CONTAINER.serviceName, LOGSERVER_CONTAINER.serviceName);
     }
 
-    private Set<String> serviceNames(VespaModel model, String hostname) {
-        SentinelConfig config = model.getConfig(SentinelConfig.class, hostname);
+    private Set<String> serviceNames(VespaModel model, String sentinelConfigId) {
+        SentinelConfig config = model.getConfig(SentinelConfig.class, sentinelConfigId);
         return config.service().stream().map(SentinelConfig.Service::name).collect(Collectors.toSet());
     }
 
-    private void assertHostContainsServices(VespaModel model, String hostname, String... expectedServices) {
-        Set<String> serviceNames = serviceNames(model, hostname);
+    private void assertHostContainsServices(VespaModel model, String sentinelConfigId, String... expectedServices) {
+        Set<String> serviceNames = serviceNames(model, sentinelConfigId);
         assertEquals(expectedServices.length, serviceNames.size());
         for (String serviceName : expectedServices) {
             assertTrue(serviceNames.contains(serviceName));


### PR DESCRIPTION
Config id for sentinel now leads to config being produced by ConfigSentinel. This change is in model only, which is version-dependent, so should be safe (TM). See also https://github.com/vespa-engine/vespa/pull/26014