### PR TITLE
Use Principal::getName instead of toString() in run abort message

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -218,7 +218,7 @@ class JobControllerApiHandlerHelper {
         Cursor responseObject = slime.setObject();
         Optional<Run> run = jobs.last(id, type).flatMap(last -> jobs.active(last.id()));
         if (run.isPresent()) {
-            jobs.abort(run.get().id(), "aborted by " + request.getJDiscRequest().getUserPrincipal());
+            jobs.abort(run.get().id(), "aborted by " + request.getJDiscRequest().getUserPrincipal().getName());
             responseObject.setString("message", "Aborting " + run.get().id());
         }
         else


### PR DESCRIPTION
Currently logs
```
Aborting run: aborted by AthenzPrincipal{athenzIdentity=AthenzUser{userId=valerijf}}
```