### PR TITLE
Predict best case overhead during autoscaling

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -976,16 +976,9 @@ public class YqlParserTestCase {
         assertEquals(4, terms.size());
         for (IndexedItem term : terms) {
             switch (term.getIndexedString()) {
-                case "a":
-                case "c":
-                    assertFalse(((Item) term).isRanked());
-                    break;
-                case "b":
-                case "d":
-                    assertTrue(((Item) term).isRanked());
-                    break;
-                default:
-                    fail();
+                case "a", "c" -> assertFalse(((Item) term).isRanked());
+                case "b", "d" -> assertTrue(((Item) term).isRanked());
+                default -> fail();
             }
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/EmptyProvisionServiceProvider.java
@@ -41,10 +41,10 @@ public class EmptyProvisionServiceProvider implements ProvisionServiceProvider {
         public NodeResources advertisedResourcesOf(Flavor flavor) { return flavor.resources(); }
 
         @Override
-        public NodeResources requestToReal(NodeResources resources, boolean exclusive) { return resources; }
+        public NodeResources requestToReal(NodeResources resources, boolean exclusive, boolean bestCase) { return resources; }
 
         @Override
-        public NodeResources realToRequest(NodeResources resources, boolean exclusive) { return resources; }
+        public NodeResources realToRequest(NodeResources resources, boolean exclusive, boolean bestCase) { return resources; }
 
         @Override
         public long reservedDiskSpaceInBase2Gb(NodeType nodeType, boolean sharedHost) { return 0; }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostResourcesCalculator.java
@@ -28,13 +28,13 @@ public interface HostResourcesCalculator {
      * Used with exclusive hosts:
      * Returns the lowest possible real resources we'll get if requesting the given advertised resources
      */
-    NodeResources requestToReal(NodeResources advertisedResources, boolean exclusiveAllocation);
+    NodeResources requestToReal(NodeResources advertisedResources, boolean exclusiveAllocation, boolean bestCase);
 
     /**
      * Used with shared hosts:
      * Returns the advertised resources we need to request to be sure to get at least the given real resources.
      */
-    NodeResources realToRequest(NodeResources realResources, boolean exclusiveAllocation);
+    NodeResources realToRequest(NodeResources realResources, boolean exclusiveAllocation, boolean bestCase);
 
     /**
      * Returns the disk space to reserve in base2 GB. This space is reserved for use by the host, e.g. for storing

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingTester.java
@@ -234,12 +234,12 @@ class AutoscalingTester {
         }
 
         @Override
-        public NodeResources requestToReal(NodeResources resources, boolean exclusive) {
+        public NodeResources requestToReal(NodeResources resources, boolean exclusive, boolean bestCase) {
             return resources.withMemoryGb(resources.memoryGb());
         }
 
         @Override
-        public NodeResources realToRequest(NodeResources resources, boolean exclusive) {
+        public NodeResources realToRequest(NodeResources resources, boolean exclusive, boolean bestCase) {
             return resources.withMemoryGb(resources.memoryGb());
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingUsingBcpGroupInfoTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingUsingBcpGroupInfoTest.java
@@ -27,15 +27,15 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.1, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 4.0,  7.6, 37.8,
+                                         9, 1, 3.6,  6.1, 25.3,
                                          fixture.autoscale());
 
-        // Higher query rate (mem and disk changes are due to being assigned larger hosts where we get less overhead share
+        // Higher query rate
         fixture.tester().clock().advance(Duration.ofDays(2));
         fixture.store(new BcpGroupInfo(200, 1.1, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 8.0,  7.4, 32.8,
+                                         9, 1, 7.1,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Higher headroom
@@ -43,7 +43,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.3, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         9, 1, 4.2,  6.6, 33.1,
+                                         9, 1, 4.2,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Higher per query cost
@@ -51,7 +51,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.1, 0.45));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         9, 1, 5.4,  6.6, 33.1,
+                                         9, 1, 5.4,  6.1, 25.3,
                                          fixture.autoscale());
     }
 
@@ -72,15 +72,15 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.1, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         3, 3, 10.5,  42.3, 187.0,
+                                         3, 3, 10.5,  41.0, 168.9,
                                          fixture.autoscale());
 
-        // Higher query rate (mem and disk changes are due to being assigned larger hosts where we get less overhead share
+        // Higher query rate
         fixture.tester().clock().advance(Duration.ofDays(2));
         fixture.store(new BcpGroupInfo(200, 1.1, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         3, 3, 20.9,  42.3, 178.0,
+                                         3, 3, 20.9,  41.0, 168.9,
                                          fixture.autoscale());
 
         // Higher headroom
@@ -88,7 +88,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.3, 0.3));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         3, 3, 12.4,  42.3, 187.0,
+                                         3, 3, 12.4,  41.0, 168.9,
                                          fixture.autoscale());
 
         // Higher per query cost
@@ -96,7 +96,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(100, 1.1, 0.45));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         3, 3, 15.7,  42.3, 187.0,
+                                         3, 3, 15.7,  41.0, 168.9,
                                          fixture.autoscale());
     }
 
@@ -151,7 +151,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.store(new BcpGroupInfo(200, 1.3, 0.45));
         fixture.loader().addCpuMeasurements(0.7f, 10);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 14.2,  7.4, 32.8,
+                                         8, 1, 14.2,  7.0, 29.0,
                                          fixture.autoscale());
 
         // Some local traffic
@@ -161,7 +161,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration1.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 10.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 6.9,  7.6, 37.8,
+                                         8, 1, 6.9,  7.0, 29.0,
                                          fixture.autoscale());
 
         // Enough local traffic to get half the votes
@@ -171,7 +171,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration2.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 50.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         7, 1, 3.5,  8.9, 55.5,
+                                         9, 1, 2.7,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Mostly local
@@ -181,7 +181,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration3.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 90.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         7, 1, 2.7,  8.9, 55.5,
+                                         9, 1, 2.1,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Local only
@@ -191,7 +191,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration4.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 100.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         7, 1, 2.6,  8.9, 55.5,
+                                         9, 1, 2.0,  6.1, 25.3,
                                          fixture.autoscale());
 
         // No group info, should be the same as the above
@@ -201,7 +201,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration5.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 100.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         7, 1, 2.6,  8.9, 55.5,
+                                         9, 1, 2.0,  6.1, 25.3,
                                          fixture.autoscale());
 
         // 40 query rate, no group info (for reference to the below)
@@ -211,7 +211,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration6.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 40.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         6, 1, 2.2,  10.6, 66.5,
+                                         9, 1, 1.4,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Local query rate is too low but global is even lower so disregard it, giving the same as above
@@ -221,7 +221,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration7.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 40.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         6, 1, 2.2,  10.6, 66.5,
+                                         9, 1, 1.4,  6.1, 25.3,
                                          fixture.autoscale());
 
         // Local query rate is too low to be fully confident, and so is global but as it is slightly larger, incorporate it slightly
@@ -231,7 +231,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration8.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 40.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         7, 1, 2.2,  8.9, 55.5,
+                                         9, 1, 1.8,  6.1, 25.3,
                                          fixture.autoscale());
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/awsnodes/AwsHostResourcesCalculatorImpl.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/awsnodes/AwsHostResourcesCalculatorImpl.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision.autoscale.awsnodes;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.Nodelike;
@@ -44,45 +43,35 @@ public class AwsHostResourcesCalculatorImpl implements HostResourcesCalculator {
     }
 
     @Override
-    public NodeResources requestToReal(NodeResources advertisedResources, boolean exclusive) {
-        // Only consider exactly matched flavors if any to avoid concluding we have slightly too little resources
-        // on an exactly matched flavor if we move from exclusive to shared hosts
-        List<VespaFlavor> consideredFlavors = flavorsCompatibleWithAdvertised(advertisedResources, true);
-        if (consideredFlavors.isEmpty())
-            consideredFlavors = flavorsCompatibleWithAdvertised(advertisedResources, false);
-
+    public NodeResources requestToReal(NodeResources advertisedResources, boolean exclusive, boolean bestCase) {
+        var consideredFlavors = consideredFlavorsGivenAdvertised(advertisedResources);
         double memoryOverhead = consideredFlavors.stream()
                                                  .mapToDouble(flavor -> resourcesCalculator.memoryOverhead(flavor, advertisedResources, false))
-                                                 .max().orElse(0);
+                                                 .reduce(bestCase ? Double::min : Double::max).orElse(0);
         double diskOverhead   = consideredFlavors.stream()
                                                  .mapToDouble(flavor -> resourcesCalculator.diskOverhead(flavor, advertisedResources, false, exclusive))
-                                                 .max().orElse(0);
+                                                 .reduce(bestCase ? Double::min : Double::max).orElse(0);
         return advertisedResources.withMemoryGb(advertisedResources.memoryGb() - memoryOverhead)
                                   .withDiskGb(advertisedResources.diskGb() - diskOverhead);
     }
 
     @Override
-    public NodeResources realToRequest(NodeResources realResources, boolean exclusive) {
-        // Only consider exactly matched flavors if any to avoid concluding we have slightly too little resources
-        // on an exactly matched flavor if we move from exclusive to shared hosts
-        List<VespaFlavor> consideredFlavors = flavorsCompatibleWithReal(realResources, true);
-        if (consideredFlavors.isEmpty())
-            consideredFlavors = flavorsCompatibleWithReal(realResources, false);
-        double worstMemoryOverhead = 0;
-        double worstDiskOverhead = 0;
-        for (VespaFlavor flavor : consideredFlavors) {
+    public NodeResources realToRequest(NodeResources realResources, boolean exclusive, boolean bestCase) {
+        double chosenMemoryOverhead = bestCase ? Integer.MAX_VALUE : 0;
+        double chosenDiskOverhead = bestCase ? Integer.MAX_VALUE : 0;
+        for (VespaFlavor flavor : consideredFlavorsGivenReal(realResources)) {
             double memoryOverhead = resourcesCalculator.memoryOverhead(flavor, realResources, true);
             double diskOverhead = resourcesCalculator.diskOverhead(flavor, realResources, true, exclusive);
             NodeResources advertised = realResources.withMemoryGb(realResources.memoryGb() + memoryOverhead)
                                                     .withDiskGb(realResources.diskGb() + diskOverhead);
             if ( ! flavor.advertisedResources().satisfies(advertised)) continue;
-            if (memoryOverhead > worstMemoryOverhead)
-                worstMemoryOverhead = memoryOverhead;
-            if (diskOverhead > worstDiskOverhead)
-                worstDiskOverhead = diskOverhead;
+            if (bestCase ? memoryOverhead < chosenMemoryOverhead : memoryOverhead > chosenDiskOverhead)
+                chosenMemoryOverhead = memoryOverhead;
+            if (bestCase ? diskOverhead < chosenDiskOverhead : diskOverhead > chosenDiskOverhead)
+                chosenDiskOverhead = diskOverhead;
         }
-        return realResources.withMemoryGb(realResources.memoryGb() + worstMemoryOverhead)
-                            .withDiskGb(realResources.diskGb() + worstDiskOverhead);
+        return realResources.withMemoryGb(realResources.memoryGb() + chosenMemoryOverhead)
+                            .withDiskGb(realResources.diskGb() + chosenDiskOverhead);
     }
 
     @Override
@@ -90,13 +79,47 @@ public class AwsHostResourcesCalculatorImpl implements HostResourcesCalculator {
         return 1;
     }
 
+    private List<VespaFlavor> consideredFlavorsGivenReal(NodeResources realResources) {
+        // Only consider exactly matched flavors if any to avoid concluding we have slightly too little resources
+        // on an exactly matched flavor if we move from exclusive to shared hosts
+        List<VespaFlavor> consideredFlavors = flavorsCompatibleWithReal(realResources, true);
+        if ( ! consideredFlavors.isEmpty()) return consideredFlavors;
+
+        // If both are applicable we prefer local storage
+        if (realResources.storageType() == NodeResources.StorageType.any)
+            consideredFlavors = flavorsCompatibleWithReal(realResources.with(NodeResources.StorageType.local), false);
+        if ( ! consideredFlavors.isEmpty()) return consideredFlavors;
+
+        return flavorsCompatibleWithReal(realResources, false);
+    }
+
+    private List<VespaFlavor> consideredFlavorsGivenAdvertised(NodeResources advertisedResources) {
+        // Only consider exactly matched flavors if any to avoid concluding we have slightly too little resources
+        // on an exactly matched flavor if we move from exclusive to shared hosts
+        List<VespaFlavor> consideredFlavors = flavorsCompatibleWithAdvertised(advertisedResources, true);
+        if ( ! consideredFlavors.isEmpty()) return consideredFlavors;
+
+        // If both are applicable we prefer local storage
+        if (advertisedResources.storageType() == NodeResources.StorageType.any)
+            consideredFlavors = flavorsCompatibleWithAdvertised(advertisedResources.with(NodeResources.StorageType.local), false);
+        if ( ! consideredFlavors.isEmpty()) return consideredFlavors;
+
+        return flavorsCompatibleWithAdvertised(advertisedResources, false);
+    }
+
     /** Returns the flavors of hosts which are eligible and matches the given advertised resources */
     private List<VespaFlavor> flavorsCompatibleWithAdvertised(NodeResources advertisedResources, boolean exactOnly) {
         return flavors.values().stream()
                       .filter(flavor -> exactOnly
-                                        ? flavor.advertisedResources().equalsWhereSpecified(advertisedResources)
+                                        ? equals(flavor.advertisedResources(), advertisedResources)
                                         : flavor.advertisedResources().satisfies(advertisedResources))
                       .toList();
+    }
+
+    private boolean equals(NodeResources hostResources, NodeResources advertisedResources) {
+        if (hostResources.storageType() == NodeResources.StorageType.remote)
+            hostResources = hostResources.withDiskGb(advertisedResources.diskGb());
+        return hostResources.equalsWhereSpecified(advertisedResources);
     }
 
     /** Returns the flavors of hosts which are eligible and matches the given real resources */

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -773,13 +773,13 @@ public class ProvisioningTester {
         }
 
         @Override
-        public NodeResources requestToReal(NodeResources resources, boolean exclusive) {
+        public NodeResources requestToReal(NodeResources resources, boolean exclusive, boolean bestCase) {
             return resources.withMemoryGb(resources.memoryGb() - memoryTaxGb)
                             .withDiskGb(resources.diskGb() - ( resources.storageType() == local ? localDiskTax : 0) );
         }
 
         @Override
-        public NodeResources realToRequest(NodeResources resources, boolean exclusive) {
+        public NodeResources realToRequest(NodeResources resources, boolean exclusive, boolean bestCase) {
             return resources.withMemoryGb(resources.memoryGb() + memoryTaxGb)
                             .withDiskGb(resources.diskGb() + ( resources.storageType() == local ? localDiskTax : 0) );
         }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningCompleteHostCalculatorTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningCompleteHostCalculatorTest.java
@@ -62,8 +62,8 @@ public class VirtualNodeProvisioningCompleteHostCalculatorTest {
         Flavor hostFlavor = new Flavor(new NodeResources(20, 40, 1000, 4));
         var calculator = new CompleteResourcesCalculator(hostFlavor);
         var originalReal = new NodeResources(0.7, 6.0, 12.9, 1.0);
-        var realToRequest = calculator.realToRequest(originalReal, false);
-        var requestToReal = calculator.requestToReal(realToRequest, false);
+        var realToRequest = calculator.realToRequest(originalReal, false, false);
+        var requestToReal = calculator.requestToReal(realToRequest, false, false);
         var realResourcesOf = calculator.realResourcesOf(realToRequest);
         assertEquals(originalReal, requestToReal);
         assertEquals(originalReal, realResourcesOf);
@@ -93,7 +93,7 @@ public class VirtualNodeProvisioningCompleteHostCalculatorTest {
         }
 
         @Override
-        public NodeResources requestToReal(NodeResources advertisedResources, boolean exclusive) {
+        public NodeResources requestToReal(NodeResources advertisedResources, boolean exclusive, boolean bestCase) {
             double memoryOverhead = memoryOverhead(advertisedResourcesOf(hostFlavor).memoryGb(), advertisedResources, false);
             double diskOverhead = diskOverhead(advertisedResourcesOf(hostFlavor).diskGb(), advertisedResources, false);
             return advertisedResources.withMemoryGb(advertisedResources.memoryGb() - memoryOverhead)
@@ -108,7 +108,7 @@ public class VirtualNodeProvisioningCompleteHostCalculatorTest {
         }
 
         @Override
-        public NodeResources realToRequest(NodeResources realResources, boolean exclusive) {
+        public NodeResources realToRequest(NodeResources realResources, boolean exclusive, boolean bestCase) {
             double memoryOverhead = memoryOverhead(advertisedResourcesOf(hostFlavor).memoryGb(), realResources, true);
             double diskOverhead = diskOverhead(advertisedResourcesOf(hostFlavor).diskGb(), realResources, true);
             return realResources.withMemoryGb(realResources.memoryGb() + memoryOverhead)


### PR DESCRIPTION
Predicting worst case has the unavoidable consequence that we will conclude we cannot fulfill requested resources in the case where there are no resource ranges (only node count ranges), or where they are too narrow, and thus refrain from scaling down when we should.

Instead, mostly predict the best case and let the ideal < 1 headroom absorb the deficiency in what we are actually allocated.

This is as complex as this logic will ever become and there will definitely never be any need to refine further :relaxed:
