### PR TITLE
Add container DocumentAPI capability to `vespa.container_node`

### DIFF
--- a/vespalib/src/vespa/vespalib/net/tls/capability_set.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/capability_set.cpp
@@ -65,6 +65,7 @@ CapabilitySet CapabilitySet::content_node() noexcept {
 
 CapabilitySet CapabilitySet::container_node() noexcept {
     return CapabilitySet::of({Capability::content_document_api(),
+                              Capability::container_document_api(),
                               Capability::content_search_api()})
             .union_of(shared_app_node_capabilities());
 }


### PR DESCRIPTION
@bjorncs please review.

Brings C++ in line with Java capability set.

