### PR TITLE
Fix C++ document selection regression where supertype in field expression would not match as expected

### DIFF
--- a/document/src/tests/documentselectparsertest.cpp
+++ b/document/src/tests/documentselectparsertest.cpp
@@ -673,8 +673,9 @@ TEST_F(DocumentSelectParserTest, operators_1)
     // Inherited doctypes
     PARSE("testdoctype2", *_doc[4], True);
     PARSE("testdoctype2", *_doc[3], False);
-    PARSE("testdoctype1", *_doc[4], False); // testdoctype2 inherits testdoctype1, but we use exact matching for types
-    PARSE("testdoctype1.headerval = 10", *_doc[4], Invalid);
+    PARSE("testdoctype1", *_doc[4], False); // testdoctype2 inherits testdoctype1, but we use exact matching for "standalone" doctype matches.
+    PARSE("testdoctype1.headerval = 10", *_doc[4], True); // But _field lookups_ use is-a type matching semantics.
+    PARSE("testdoctype2.headerval = 10", *_doc[4], True); // Exact type match with parent field also works transparently
 }
 
 TEST_F(DocumentSelectParserTest, operators_2)


### PR DESCRIPTION
@bratseth please review

A change between Vespa major versions 7 and 8 to use exact-matching for document types was implemented a tad too aggressively, as it should still be possible to match against supertypes in a document selection _field expression_.

Let type `B` inherit `A`, `A` have a field `foo`, and matching a document of type `B` with field `foo` present:

Prior to this fix:
 * `B.foo` _would_ match (exact type match and implicit supertype field resolving)
 * `A.foo` would _not_ match due to exact type mismatch

After this fix, both will match (as would generally be expected). This brings behavior in sync with the Java implementation.