### PR TITLE
remove complicated code trying to find a good hostname

### DIFF
--- a/client/go/internal/vespa/detect_hostname_test.go
+++ b/client/go/internal/vespa/detect_hostname_test.go
@@ -4,7 +4,6 @@ package vespa
 import (
 	"fmt"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,16 +17,7 @@ func TestDetectHostname(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "foo.bar", got)
 	os.Unsetenv("VESPA_HOSTNAME")
-	got, err = findOurHostnameFrom("bar.foo.123")
-	fmt.Fprintln(os.Stderr, "findOurHostname from bar.foo.123 returns:", got, "with error:", err)
+	got, _ = FindOurHostname()
 	assert.NotEqual(t, "", got)
-	parts := strings.Split(got, ".")
-	if len(parts) > 1 {
-		expanded, err2 := findOurHostnameFrom(parts[0])
-		fmt.Fprintln(os.Stderr, "findOurHostname from", parts[0], "returns:", expanded, "with error:", err2)
-		assert.Equal(t, got, expanded)
-	}
-	got, err = findOurHostnameFrom("")
-	assert.NotEqual(t, "", got)
-	fmt.Fprintln(os.Stderr, "findOurHostname('') returns:", got, "with error:", err)
+	fmt.Fprintln(os.Stderr, "FindOurHostname() returns:", got, "with error:", err)
 }


### PR DESCRIPTION
@aressem please review
@kkraune @hmusum FYI

this code was converted from shell scripts and c++ programs, but it is very eager to fall back on "localhost".

Falling back to "localhost" used to work pretty well (in ancient times), but now that doesn't work for starting configserver anymore, so just trusting "os.Hostname()" blindly is probably the best we can do.
