### PR TITLE
Allow handshake to go through as long as at least one policy matches

### DIFF
--- a/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/policy_checking_certificate_verifier.cpp
@@ -74,13 +74,15 @@ VerificationResult PolicyConfiguredCertificateVerifier::verify(const PeerCredent
         return VerificationResult::make_authorized_with_all_capabilities();
     }
     CapabilitySet caps;
+    bool matched_any_policy = false;
     for (const auto& policy : _authorized_peers.peer_policies()) {
         if (matches_all_policy_requirements(peer_creds, policy)) {
             caps.add_all(policy.granted_capabilities());
+            matched_any_policy = true;
         }
     }
-    if (!caps.empty()) {
-        return VerificationResult::make_authorized_with_capabilities(std::move(caps));
+    if (matched_any_policy) {
+        return VerificationResult::make_authorized_with_capabilities(caps);
     } else {
         return VerificationResult::make_not_authorized();
     }

--- a/vespalib/src/vespa/vespalib/net/tls/verification_result.cpp
+++ b/vespalib/src/vespa/vespalib/net/tls/verification_result.cpp
@@ -6,14 +6,18 @@
 
 namespace vespalib::net::tls {
 
-VerificationResult::VerificationResult() = default;
-
-VerificationResult::VerificationResult(CapabilitySet granted_capabilities)
-    : _granted_capabilities(std::move(granted_capabilities))
+VerificationResult::VerificationResult() noexcept
+    : _granted_capabilities(),
+      _authorized(false)
 {}
 
-VerificationResult::VerificationResult(const VerificationResult&) = default;
-VerificationResult& VerificationResult::operator=(const VerificationResult&) = default;
+VerificationResult::VerificationResult(bool authorized, CapabilitySet granted_capabilities) noexcept
+    : _granted_capabilities(granted_capabilities),
+      _authorized(authorized)
+{}
+
+VerificationResult::VerificationResult(const VerificationResult&) noexcept = default;
+VerificationResult& VerificationResult::operator=(const VerificationResult&) noexcept = default;
 VerificationResult::VerificationResult(VerificationResult&&) noexcept = default;
 VerificationResult& VerificationResult::operator=(VerificationResult&&) noexcept = default;
 VerificationResult::~VerificationResult() = default;
@@ -29,18 +33,18 @@ void VerificationResult::print(asciistream& os) const {
 }
 
 VerificationResult
-VerificationResult::make_authorized_with_capabilities(CapabilitySet granted_capabilities) {
-    return VerificationResult(std::move(granted_capabilities));
+VerificationResult::make_authorized_with_capabilities(CapabilitySet granted_capabilities) noexcept {
+    return {true, granted_capabilities};
 }
 
 VerificationResult
-VerificationResult::make_authorized_with_all_capabilities() {
-    return VerificationResult(CapabilitySet::make_with_all_capabilities());
+VerificationResult::make_authorized_with_all_capabilities() noexcept {
+    return {true, CapabilitySet::make_with_all_capabilities()};
 }
 
 VerificationResult
-VerificationResult::make_not_authorized() {
-    return {};
+VerificationResult::make_not_authorized() noexcept {
+    return {false, CapabilitySet::make_empty()};
 }
 
 asciistream& operator<<(asciistream& os, const VerificationResult& res) {

--- a/vespalib/src/vespa/vespalib/net/tls/verification_result.h
+++ b/vespalib/src/vespa/vespalib/net/tls/verification_result.h
@@ -16,22 +16,27 @@ namespace vespalib::net::tls {
  * This result contains the union set of all capabilities granted by the matching
  * authorization rules. If no rules matched, the set will be empty. The capability
  * set will also be empty for a default-constructed instance.
+ *
+ * It is possible for a VerificationResult to be successful but with an empty
+ * capability set. If capabilities are enforced, this will effectively only
+ * allow mTLS handshakes to go through, allowing rudimentary health checking.
  */
 class VerificationResult {
     CapabilitySet _granted_capabilities;
+    bool          _authorized;
 
-    explicit VerificationResult(CapabilitySet granted_capabilities);
+    VerificationResult(bool authorized, CapabilitySet granted_capabilities) noexcept;
 public:
-    VerificationResult();
-    VerificationResult(const VerificationResult&);
-    VerificationResult& operator=(const VerificationResult&);
+    VerificationResult() noexcept; // Unauthorized by default
+    VerificationResult(const VerificationResult&) noexcept;
+    VerificationResult& operator=(const VerificationResult&) noexcept;
     VerificationResult(VerificationResult&&) noexcept;
     VerificationResult& operator=(VerificationResult&&) noexcept;
     ~VerificationResult();
 
-    // Returns true iff at least one capability been granted.
+    // Returns true iff the peer matched at least one policy or authorization is not enforced.
     [[nodiscard]] bool success() const noexcept {
-        return !_granted_capabilities.empty();
+        return _authorized;
     }
 
     [[nodiscard]] const CapabilitySet& granted_capabilities() const noexcept {
@@ -40,9 +45,9 @@ public:
 
     void print(asciistream& os) const;
 
-    static VerificationResult make_authorized_with_capabilities(CapabilitySet granted_capabilities);
-    static VerificationResult make_authorized_with_all_capabilities();
-    static VerificationResult make_not_authorized();
+    static VerificationResult make_authorized_with_capabilities(CapabilitySet granted_capabilities) noexcept;
+    static VerificationResult make_authorized_with_all_capabilities() noexcept;
+    static VerificationResult make_not_authorized() noexcept;
 };
 
 asciistream& operator<<(asciistream&, const VerificationResult&);


### PR DESCRIPTION
@bjorncs please review

This avoids handshake failures even the resulting capability set is empty. If capabilities are enforced, this effectively only lets the peer check that connectivity works.

