### PR TITLE
Revert "remove complicated code trying to find a good hostname"

### DIFF
--- a/client/go/internal/vespa/detect_hostname.go
+++ b/client/go/internal/vespa/detect_hostname.go
@@ -4,10 +4,14 @@
 package vespa
 
 import (
+	"fmt"
 	"net"
 	"os"
+	"strings"
 
 	"github.com/vespa-engine/vespa/client/go/internal/admin/envvars"
+	"github.com/vespa-engine/vespa/client/go/internal/admin/trace"
+	"github.com/vespa-engine/vespa/client/go/internal/util"
 )
 
 // detect if this host is IPv6-only, in which case we want to pass
@@ -52,8 +56,76 @@ func FindOurHostname() (string, error) {
 	if err != nil {
 		name = "localhost"
 	}
+	name, err = findOurHostnameFrom(name)
 	if err == nil {
 		os.Setenv(envvars.VESPA_HOSTNAME, name)
 	}
 	return name, err
+}
+
+func validateHostname(name string) bool {
+	ipAddrs, _ := net.LookupIP(name)
+	trace.Debug("lookupIP", name, "=>", ipAddrs)
+	if len(ipAddrs) < 1 {
+		return false
+	}
+	myIpAddresses := make(map[string]bool)
+	interfaceAddrs, _ := net.InterfaceAddrs()
+	for _, ifAddr := range interfaceAddrs {
+		// note: ifAddr.String() is typically "127.0.0.1/8"
+		if ipnet, ok := ifAddr.(*net.IPNet); ok {
+			myIpAddresses[ipnet.IP.String()] = true
+		}
+	}
+	trace.Debug("validate with interfaces =>", myIpAddresses)
+	someGood := false
+	for _, addr := range ipAddrs {
+		if len(myIpAddresses) == 0 {
+			// no validation possible, assume OK
+			return true
+		}
+		if myIpAddresses[addr.String()] {
+			someGood = true
+		} else {
+			return false
+		}
+	}
+	return someGood
+}
+
+func goodHostname(name string) (result string, good bool) {
+	result = strings.TrimSpace(name)
+	result = strings.TrimSuffix(result, ".")
+	if name != result {
+		trace.Trace("trimmed hostname", name, "=>", result)
+	}
+	good = strings.Contains(result, ".") && validateHostname(result)
+	trace.Debug("hostname:", result, "good =>", good)
+	return
+}
+
+func findOurHostnameFrom(name string) (string, error) {
+	trimmed, good := goodHostname(name)
+	if good {
+		return trimmed, nil
+	}
+	backticks := util.BackTicksIgnoreStderr
+	out, err := backticks.Run("vespa-detect-hostname")
+	if err != nil {
+		out, err = backticks.Run("hostname", "-f")
+	}
+	if err != nil {
+		out, err = backticks.Run("hostname")
+	}
+	alternate, good := goodHostname(out)
+	if err == nil && good {
+		return alternate, nil
+	}
+	if validateHostname(trimmed) {
+		return trimmed, nil
+	}
+	if validateHostname(alternate) {
+		return alternate, nil
+	}
+	return "localhost", fmt.Errorf("fallback to localhost [os.Hostname was '%s']", name)
 }

--- a/client/go/internal/vespa/detect_hostname_test.go
+++ b/client/go/internal/vespa/detect_hostname_test.go
@@ -4,6 +4,7 @@ package vespa
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,16 @@ func TestDetectHostname(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "foo.bar", got)
 	os.Unsetenv("VESPA_HOSTNAME")
-	got, _ = FindOurHostname()
+	got, err = findOurHostnameFrom("bar.foo.123")
+	fmt.Fprintln(os.Stderr, "findOurHostname from bar.foo.123 returns:", got, "with error:", err)
 	assert.NotEqual(t, "", got)
-	fmt.Fprintln(os.Stderr, "FindOurHostname() returns:", got, "with error:", err)
+	parts := strings.Split(got, ".")
+	if len(parts) > 1 {
+		expanded, err2 := findOurHostnameFrom(parts[0])
+		fmt.Fprintln(os.Stderr, "findOurHostname from", parts[0], "returns:", expanded, "with error:", err2)
+		assert.Equal(t, got, expanded)
+	}
+	got, err = findOurHostnameFrom("")
+	assert.NotEqual(t, "", got)
+	fmt.Fprintln(os.Stderr, "findOurHostname('') returns:", got, "with error:", err)
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#26151

This broke the system testing:
```
bash-4.4$ hostname
vespa-test-cfg-0
bash-4.4$ hostname -f
vespa-test-cfg-0.vespa-test-cfg.1037047-system-test-opensource.svc.cluster.local
```

From log :
```
1677492256.410213	vespa-test-cfg-0	998	-	stderr	warning	only these hosts should run a config server: [vespa-test-cfg-0.vespa-test-cfg.1037047-system-test-opensource.svc.cluster.local vespa-test-cfg-1.vespa-test-cfg.1037047-system-test-opensource.svc.cluster.local vespa-test-cfg-2.vespa-test-cfg.1037047-system-test-opensource.svc.cluster.local]
this host [vespa-test-cfg-0] should not run a config server
```