### PR TITLE
Handle archive URI without tenant name dir

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManager.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManager.java
@@ -13,7 +13,6 @@ import com.yahoo.vespa.hosted.provision.persistence.CuratorDb;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.logging.Logger;
 
 /**
  * Thread safe class to get and set archive URI for given account and tenants.
@@ -22,7 +21,6 @@ import java.util.logging.Logger;
  */
 public class ArchiveUriManager {
 
-    private static final Logger log = Logger.getLogger(ArchiveUriManager.class.getName());
     private static final Duration cacheTtl = Duration.ofMinutes(1);
 
     private final CuratorDb db;
@@ -48,7 +46,14 @@ public class ArchiveUriManager {
                 archiveUris.get().accountArchiveUris().get(node.cloudAccount()) :
                 archiveUris.get().tenantArchiveUris().get(app.tenant()))
                 .map(uri -> {
+                    // TODO (freva): Remove when all URIs dont have tenant name in them anymore
+                    String tenantSuffix = app.tenant().value() + "/";
+                    if (uri.endsWith(tenantSuffix)) return uri.substring(0, uri.length() - tenantSuffix.length());
+                    return uri;
+                })
+                .map(uri -> {
                     StringBuilder sb = new StringBuilder(100).append(uri)
+                            .append(app.tenant().value()).append('/')
                             .append(app.application().value()).append('/')
                             .append(app.instance().value()).append('/')
                             .append(node.allocation().get().membership().cluster().id().value()).append('/');

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManager.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManager.java
@@ -47,8 +47,8 @@ public class ArchiveUriManager {
                 archiveUris.get().tenantArchiveUris().get(app.tenant()))
                 .map(uri -> {
                     // TODO (freva): Remove when all URIs dont have tenant name in them anymore
-                    String tenantSuffix = app.tenant().value() + "/";
-                    if (uri.endsWith(tenantSuffix)) return uri.substring(0, uri.length() - tenantSuffix.length());
+                    String tenantSuffix = "/" + app.tenant().value() + "/";
+                    if (uri.endsWith(tenantSuffix)) return uri.substring(0, uri.length() - tenantSuffix.length() + 1);
                     return uri;
                 })
                 .map(uri -> {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManagerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManagerTest.java
@@ -65,8 +65,11 @@ public class ArchiveUriManagerTest {
         ApplicationId app1 = ApplicationId.from("vespa", "music", "main");
         ArchiveUriManager archiveUriManager = new ProvisioningTester.Builder().build().nodeRepository().archiveUriManager();
         archiveUriManager.setArchiveUri(app1.tenant(), Optional.of("scheme://tenant-bucket/vespa"));
-
         assertEquals("scheme://tenant-bucket/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, null)).get());
+
+        // Archive URI ends with the tenant name
+        archiveUriManager.setArchiveUri(app1.tenant(), Optional.of("scheme://tenant-vespa/"));
+        assertEquals("scheme://tenant-vespa/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, null)).get());
     }
 
     private Node createNode(ApplicationId appId, CloudAccount account) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManagerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/archive/ArchiveUriManagerTest.java
@@ -54,10 +54,19 @@ public class ArchiveUriManagerTest {
         assertFalse(archiveUriManager.archiveUriFor(createNode(null, account1)).isPresent()); // URI set for this account, but not allocated
         assertFalse(archiveUriManager.archiveUriFor(createNode(null, account2)).isPresent()); // Not allocated
         assertFalse(archiveUriManager.archiveUriFor(createNode(app2, null)).isPresent()); // No URI set for this tenant or account
-        assertEquals("scheme://tenant-bucket/dir/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, null)).get());
-        assertEquals("scheme://account-bucket/dir/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, account1)).get()); // Account has precedence
+        assertEquals("scheme://tenant-bucket/dir/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, null)).get());
+        assertEquals("scheme://account-bucket/dir/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, account1)).get()); // Account has precedence
         assertFalse(archiveUriManager.archiveUriFor(createNode(app1, account2)).isPresent()); // URI set for this tenant, but is ignored because enclave account
-        assertEquals("scheme://tenant-bucket/dir/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, accountSystem)).get()); // URI for tenant because non-enclave acocunt
+        assertEquals("scheme://tenant-bucket/dir/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, accountSystem)).get()); // URI for tenant because non-enclave acocunt
+    }
+
+    @Test
+    public void handles_uri_with_tenant_name() {
+        ApplicationId app1 = ApplicationId.from("vespa", "music", "main");
+        ArchiveUriManager archiveUriManager = new ProvisioningTester.Builder().build().nodeRepository().archiveUriManager();
+        archiveUriManager.setArchiveUri(app1.tenant(), Optional.of("scheme://tenant-bucket/vespa"));
+
+        assertEquals("scheme://tenant-bucket/vespa/music/main/default/h432a/", archiveUriManager.archiveUriFor(createNode(app1, null)).get());
     }
 
     private Node createNode(ApplicationId appId, CloudAccount account) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveApiTest.java
@@ -45,8 +45,8 @@ public class ArchiveApiTest {
                 "{\"message\":\"Updated archive URI for 777888999000\"}");
 
 
-        tester.assertPartialResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "\"archiveUri\":\"ftp://host/dir/application3/instance3/id3/host4/\"", true);
-        tester.assertPartialResponse(new Request("http://localhost:8080/nodes/v2/node/dockerhost2.yahoo.com"), "\"archiveUri\":\"s3://acc-bucket/zoneapp/zoneapp/node-admin/dockerhost2/\"", true);
+        tester.assertPartialResponse(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "\"archiveUri\":\"ftp://host/dir/tenant3/application3/instance3/id3/host4/\"", true);
+        tester.assertPartialResponse(new Request("http://localhost:8080/nodes/v2/node/dockerhost2.yahoo.com"), "\"archiveUri\":\"s3://acc-bucket/zoneapp/zoneapp/zoneapp/node-admin/dockerhost2/\"", true);
         assertFile(new Request("http://localhost:8080/nodes/v2/archive"), "archives.json");
 
         tester.assertResponse(new Request("http://localhost:8080/nodes/v2/archive/tenant/tenant3", new byte[0], Request.Method.DELETE), "{\"message\":\"Removed archive URI for tenant3\"}");


### PR DESCRIPTION
This is basically no-op change to make the API forward compatible with a change in a future version where controller will stop including tenant name in archive URI for tenant archive URIs.
Currently it looks like this:
```
{
    "archives": [
        {
            "tenant": "hosted-vespa",
            "uri": "s3://vespa-cloud-data-dev.aws-us-east-1c-275525/hosted-vespa/"
        },
        {
            "tenant": "vespa",
            "uri": "s3://vespa-cloud-data-dev.aws-us-east-1c-275525/vespa/"
        },
        {
            "account": "892075328880",
            "uri": "s3://vespa-archive-892075328880-dev.aws-use-1c-mwktci/"
        }
    ]
}
```
I want it to get to
```
{
    "archives": [
        {
            "tenant": "hosted-vespa",
            "uri": "s3://vespa-cloud-data-dev.aws-us-east-1c-275525/"
        },
        {
            "tenant": "vespa",
            "uri": "s3://vespa-cloud-data-dev.aws-us-east-1c-275525/"
        },
        {
            "account": "892075328880",
            "uri": "s3://vespa-archive-892075328880-dev.aws-use-1c-mwktci/"
        }
    ]
}
```