### PR TITLE
Revert "Export refcount package"

### DIFF
--- a/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
+++ b/jdisc_core/src/main/java/com/yahoo/jdisc/core/ExportPackages.java
@@ -53,7 +53,6 @@ public class ExportPackages {
            .append("com.yahoo.jdisc.handler, ")
            .append("com.yahoo.jdisc.service, ")
            .append("com.yahoo.jdisc.statistics, ")
-           .append("com.yahoo.jdisc.refcount, ")
 
            .append("javax.inject;version=1.0.0, ")  // TODO Vespa 9: remove. Included in guice, but not exported. Needed by container-jersey.
            .append("org.aopalliance.intercept, ")


### PR DESCRIPTION
Reverts vespa-engine/vespa#26216

Broke the build and unable to follow instructions in ExportPackagesIT for how to update list of exported packages