### PR TITLE
Pass `stringref`s to Portal response rendering

### DIFF
--- a/vespalib/src/vespa/vespalib/portal/http_connection.cpp
+++ b/vespalib/src/vespa/vespalib/portal/http_connection.cpp
@@ -245,14 +245,16 @@ HttpConnection::handle_event(bool, bool)
 }
 
 void
-HttpConnection::respond_with_content(const vespalib::string &content_type,
-                                     const vespalib::string &content)
+HttpConnection::respond_with_content(vespalib::stringref content_type,
+                                     vespalib::stringref content)
 {
     {
         OutputWriter dst(_output, CHUNK_SIZE);
         dst.printf("HTTP/1.1 200 OK\r\n");
         dst.printf("Connection: close\r\n");
-        dst.printf("Content-Type: %s\r\n", content_type.c_str());
+        dst.printf("Content-Type: ");
+        dst.write(content_type.data(), content_type.size());
+        dst.printf("\r\n");
         dst.printf("Content-Length: %zu\r\n", content.size());
         emit_http_security_headers(dst);
         dst.printf("\r\n");
@@ -263,11 +265,13 @@ HttpConnection::respond_with_content(const vespalib::string &content_type,
 }
 
 void
-HttpConnection::respond_with_error(int code, const vespalib::string &msg)
+HttpConnection::respond_with_error(int code, vespalib::stringref msg)
 {
     {
         OutputWriter dst(_output, CHUNK_SIZE);
-        dst.printf("HTTP/1.1 %d %s\r\n", code, msg.c_str());
+        dst.printf("HTTP/1.1 %d ", code);
+        dst.write(msg.data(), msg.size());
+        dst.printf("\r\n");
         dst.printf("Connection: close\r\n");
         dst.printf("\r\n");
     }

--- a/vespalib/src/vespa/vespalib/portal/http_connection.h
+++ b/vespalib/src/vespa/vespalib/portal/http_connection.h
@@ -53,9 +53,9 @@ public:
     // Precondition: handshake must have been completed
     const net::ConnectionAuthContext &auth_context() const noexcept { return *_auth_ctx; }
 
-    void respond_with_content(const vespalib::string &content_type,
-                              const vespalib::string &content);
-    void respond_with_error(int code, const vespalib::string &msg);
+    void respond_with_content(vespalib::stringref content_type,
+                              vespalib::stringref content);
+    void respond_with_error(int code, const vespalib::stringref msg);
 };
 
 } // namespace vespalib::portal

--- a/vespalib/src/vespa/vespalib/portal/portal.cpp
+++ b/vespalib/src/vespa/vespalib/portal/portal.cpp
@@ -77,8 +77,8 @@ Portal::GetRequest::export_params() const
 }
 
 void
-Portal::GetRequest::respond_with_content(const vespalib::string &content_type,
-                                 const vespalib::string &content)
+Portal::GetRequest::respond_with_content(vespalib::stringref content_type,
+                                         vespalib::stringref content)
 {
     assert(active());
     _conn->respond_with_content(content_type, content);
@@ -86,7 +86,7 @@ Portal::GetRequest::respond_with_content(const vespalib::string &content_type,
 }
 
 void
-Portal::GetRequest::respond_with_error(int code, const vespalib::string &msg)
+Portal::GetRequest::respond_with_error(int code, vespalib::stringref msg)
 {
     assert(active());
     _conn->respond_with_error(code, msg);

--- a/vespalib/src/vespa/vespalib/portal/portal.h
+++ b/vespalib/src/vespa/vespalib/portal/portal.h
@@ -65,9 +65,9 @@ public:
         bool has_param(const vespalib::string &name) const;
         const vespalib::string &get_param(const vespalib::string &name) const;
         std::map<vespalib::string, vespalib::string> export_params() const;
-        void respond_with_content(const vespalib::string &content_type,
-                                  const vespalib::string &content);
-        void respond_with_error(int code, const vespalib::string &msg);
+        void respond_with_content(vespalib::stringref content_type,
+                                  vespalib::stringref content);
+        void respond_with_error(int code, vespalib::stringref msg);
         const net::ConnectionAuthContext &auth_context() const noexcept;
         ~GetRequest();
     };


### PR DESCRIPTION
@havardpe please review

Don't need to potentially instantiate temporaries since the data is always immediately committed to another buffer.
