### PR TITLE
Backport visit slicing to `vespa-visit` CLI tool

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/VisitorParameters.java
@@ -313,6 +313,10 @@ public class VisitorParameters extends Parameters {
         sb.append("  Max total hits:     ").append(maxTotalHits).append('\n');
         sb.append("  Max buckets:        ").append(maxBucketsPerVisitor).append('\n');
         sb.append("  Priority:           ").append(getPriority().toString()).append('\n');
+        if (slices > 1) {
+            sb.append("  Slice ID:           %d\n".formatted(sliceId));
+            sb.append("  Slice count:        %d\n".formatted(slices));
+        }
         sb.append(')');
 
         return sb.toString();


### PR DESCRIPTION
@bjorncs please review

Allows for efficient parallelization across multiple visitor instances, mirroring the existing support in Document V1.

Also clean up some legacy option value parsing code. Note: changing the parsed type for `maxtotalhits` from `int` to `long` is intentional; the internal limit is already a `long` and a cluster may have a lot more than `INT32_MAX` documents.
