### PR TITLE
Always propagate the document type to the internal StructFieldValue.

### DIFF
--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -86,6 +86,7 @@ VespaDocumentDeserializer::readDocument(Document &value) {
         value.getFields().reset();
     }
     value.setRepo(_repo.getDocumentTypeRepo());
+    value.getFields().setDocumentType(value.getType());
 
     FixedTypeRepo repo(_repo.getDocumentTypeRepo(), value.getType());
     VarScope<FixedTypeRepo> repo_scope(_repo, repo);


### PR DESCRIPTION
After deserialization of an empty document the internal StructFieldValue would not have the document type. Then, if a StringFieldValue of that empty document was updated (e.g. by an AssignValueUpdate), later lazy deserialization of its annotations would crash as the document type was not present.

@toregge please review
@baldersheim FYI