### PR TITLE
Resolve config when we discover a new config generation is active

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
@@ -152,12 +152,12 @@ class GetConfigProcessor implements Runnable {
 
         delayed.ifPresent(d -> {
             GetConfigContext context = d.context();
-            rpcServer.delayResponse(request, context);
-            if (rpcServer.hasNewerGeneration(context.applicationId(), d.generation())) {
+            if (rpcServer.hasNewerGeneration(context.applicationId(), d.generation()))
                 // This will ensure that if the config activation train left the station while I was boarding,
                 // we will resolve config again with new generation
                 resolveConfig(request);
-            }
+            else
+                rpcServer.delayResponse(request, context);
         });
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/GetConfigProcessor.java
@@ -155,8 +155,8 @@ class GetConfigProcessor implements Runnable {
             rpcServer.delayResponse(request, context);
             if (rpcServer.hasNewerGeneration(context.applicationId(), d.generation())) {
                 // This will ensure that if the config activation train left the station while I was boarding,
-                // another train will immediately be scheduled.
-                rpcServer.configActivated(context.applicationId());
+                // we will resolve config again with new generation
+                resolveConfig(request);
             }
         });
     }


### PR DESCRIPTION
Calling configActivated() will end up in going through all delayed responses, putting them on a queue and wait for configs to be resolved. This happens with the same executor that call configActivated() so it might end up in a deadlock when all threads have been used. Resolving config immediately instead should avoid this.

@arnej27959 I think you were involved making the original change, please review