### PR TITLE
Use system time duration in vespalog.

### DIFF
--- a/vespalog/src/vespa/log/internal.h
+++ b/vespalog/src/vespa/log/internal.h
@@ -22,7 +22,7 @@ public:
 };
 
 using system_time = std::chrono::system_clock::time_point;
-using duration = std::chrono::nanoseconds;
+using duration = system_time::duration;
 
 constexpr int64_t
 count_s(duration d) noexcept {


### PR DESCRIPTION
@baldersheim : please review
