### PR TITLE
Add a "null-rendering" option to `vespa-visit`

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/StdOutVisitorHandler.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/StdOutVisitorHandler.java
@@ -55,6 +55,7 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
         OutputFormat outputFormat  = OutputFormat.JSON;
         boolean tensorShortForm    = false; // TODO Vespa 9: change default to true
         boolean tensorDirectValues = false; // TODO Vespa 9: change default to true
+        boolean nullRender         = false;
 
         boolean usesJson() {
             return outputFormat == OutputFormat.JSON || outputFormat == OutputFormat.JSONL;
@@ -157,6 +158,9 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
         @Override
         public void onDocument(Document doc, long timestamp) {
             try {
+                if (params.nullRender) {
+                    return;
+                }
                 if (lastLineIsProgress) {
                     System.err.print('\r');
                 }
@@ -187,6 +191,9 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
         @Override
         public void onRemove(DocumentId docId) {
             try {
+                if (params.nullRender) {
+                    return;
+                }
                 if (lastLineIsProgress) {
                     System.err.print('\r');
                 }
@@ -263,7 +270,7 @@ public class StdOutVisitorHandler extends VdsVisitHandler {
 
         @Override
         public synchronized void onDone() {
-            if ((params.outputFormat == OutputFormat.JSON) && !params.printIds) {
+            if ((params.outputFormat == OutputFormat.JSON) && !params.printIds && !params.nullRender) {
                 if (first) {
                     out.print('[');
                 }

--- a/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespavisit/VdsVisit.java
@@ -381,6 +381,13 @@ public class VdsVisit {
                 .type(Number.class)
                 .build());
 
+        options.addOption(Option.builder()
+                .longOpt("nullrender")
+                .desc("Process documents, but do not render any output. Overrides all other output options. " +
+                      "Used to benchmark whether document rendering is the bottleneck when processing documents.")
+                .hasArg(false)
+                .build());
+
         return options;
     }
 
@@ -399,6 +406,7 @@ public class VdsVisit {
         private boolean jsonLinesOutput = false;
         private boolean tensorShortForm = false; // TODO Vespa 9: change default to true
         private boolean tensorDirectValues = false; // TODO Vespa 9: change default to true
+        private boolean nullRender = false;
         private int slices = 1;
         private int sliceId = 0;
 
@@ -506,6 +514,14 @@ public class VdsVisit {
 
         public void setTensorDirectValues(boolean tensorDirectValues) {
             this.tensorDirectValues = tensorDirectValues;
+        }
+
+        public boolean nullRender() {
+            return nullRender;
+        }
+
+        public void setNullRender(boolean nullRender) {
+            this.nullRender = nullRender;
         }
 
         public int slices() {
@@ -659,6 +675,9 @@ public class VdsVisit {
             }
             if (line.hasOption("tensorvalues")) {
                 allParams.setTensorDirectValues(true);
+            }
+            if (line.hasOption("nullrender")) {
+                allParams.setNullRender(true);
             }
             if (line.hasOption("slices") != line.hasOption("sliceid")) {
                 throw new IllegalArgumentException("Both --slices and --sliceid must be specified when visiting with slicing");
@@ -848,6 +867,7 @@ public class VdsVisit {
         handlerParams.outputFormat         = params.stdOutHandlerOutputFormat();
         handlerParams.tensorShortForm      = params.tensorShortForm();
         handlerParams.tensorDirectValues   = params.tensorDirectValues();
+        handlerParams.nullRender           = params.nullRender();
         handler = new StdOutVisitorHandler(handlerParams);
 
         if (visitorParameters.getResumeFileName() != null) {

--- a/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespavisit/StdOutVisitorHandlerTest.java
@@ -156,4 +156,27 @@ public class StdOutVisitorHandlerTest {
         }
     }
 
+    @Test
+    void nothing_is_rendered_if_null_render_option_is_specified() {
+        var docType = new DocumentType("foo");
+        docType.addField("bar", DataType.STRING);
+
+        var params = createHandlerParams(true, true, true);
+        params.nullRender = true;
+
+        var out            = new ByteArrayOutputStream();
+        var visitorHandler = new StdOutVisitorHandler(params, new PrintStream(out, true));
+        var dataHandler    = visitorHandler.getDataHandler();
+        var controlSession = mock(VisitorControlSession.class);
+        dataHandler.setSession(controlSession);
+
+        dataHandler.onMessage(createPutWithDocAndValue(docType, "id:baz:foo::1", "fluffy\nbunnies"),  mock(AckToken.class));
+        dataHandler.onMessage(createRemoveForDoc("id:baz:foo::2"),                                    mock(AckToken.class));
+        dataHandler.onMessage(createPutWithDocAndValue(docType, "id:baz:foo::3", "\r\ncool fox\r\n"), mock(AckToken.class));
+        dataHandler.onDone();
+
+        String output = out.toString().trim();
+        assertEquals("", output);
+    }
+
 }


### PR DESCRIPTION
@bjorncs please review
@kkraune FYI

This makes it easy to benchmark whether document rendering is a bottleneck when visiting. For instance, large floating point tensor fields are notoriously expensive to render as JSON.

This is more accurate than just redirecting the visit output to `/dev/null` as that still requires documents to be rendered before being evicted into the void.

