### PR TITLE
MERGEOK Revert "start wireguard earlier"

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeagent/NodeAgentImpl.java
@@ -483,8 +483,6 @@ public class NodeAgentImpl implements NodeAgent {
                 storageMaintainer.cleanDiskIfFull(context);
                 storageMaintainer.handleCoreDumpsForContainer(context, container, false);
 
-                wireguardTasks.forEach(task -> task.converge(context));
-
                 if (downloadImageIfNeeded(context, container)) {
                     context.log(logger, "Waiting for image to download " + context.node().wantedDockerImage().get().asString());
                     return;
@@ -500,6 +498,7 @@ public class NodeAgentImpl implements NodeAgent {
                 }
 
                 aclMaintainer.ifPresent(maintainer -> maintainer.converge(context));
+                wireguardTasks.forEach(task -> task.converge(context));
                 startServicesIfNeeded(context);
                 resumeNodeIfNeeded(context);
                 if (healthChecker.isPresent()) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#26318

Looks like one or more wireguard tasks depend on container running and will fail otherwise, preventing other tasks to be run?

[2023-03-07 05:48:06.979] INFO    node-admin       Container.com.yahoo.vespa.hosted.hostadmin.scheduler.TaskDriver	root>NodeAdminTask Executing task
[2023-03-07 05:48:07.040] ERROR   node-admin       Container.com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl
	cfg3: Unhandled exception, ignoring
	exception=
	java.lang.IllegalArgumentException: No running container found named 'cfg3'
	at com.yahoo.vespa.hosted.hostadmin.task.podman.Podman.lambda$requireRunning$15(Podman.java:394)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at com.yahoo.vespa.hosted.hostadmin.task.podman.Podman.requireRunning(Podman.java:393)
	at com.yahoo.vespa.hosted.hostadmin.task.podman.Podman.lambda$executeCommandInNetworkNamespace$16(Podman.java:399)
	at java.base/java.util.OptionalInt.orElseGet(OptionalInt.java:234)
	at com.yahoo.vespa.hosted.hostadmin.task.podman.Podman.executeCommandInNetworkNamespace(Podman.java:399)
	at com.yahoo.vespa.hosted.hostadmin.task.podman.Podman.executeInNetworkNamespace(Podman.java:268)
	at com.yahoo.vespa.hosted.node.admin.container.ContainerOperations.executeCommandInNetworkNamespace(ContainerOperations.java:80)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.ContainerWireguardMaintainer.executeCommand(ContainerWireguardMaintainer.java:41)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.ContainerWireguardMaintainer.executeCommand(ContainerWireguardMaintainer.java:23)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.WireguardMaintainer.isWireguardRunning(WireguardMaintainer.java:108)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.WireguardMaintainer.needsRestart(WireguardMaintainer.java:88)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.TenantHostWireguardTask.maintainWireguard(TenantHostWireguardTask.java:76)
	at com.yahoo.vespa.hosted.hostadmin.wireguard.CfgContainerWireguardTask.converge(CfgContainerWireguardTask.java:34)
	at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.lambda$doConverge$13(NodeAgentImpl.java:486)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.doConverge(NodeAgentImpl.java:486)
	at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.converge(NodeAgentImpl.java:438)
	at com.yahoo.vespa.hosted.node.admin.nodeagent.NodeAgentImpl.lambda$start$0(NodeAgentImpl.java:148)
	at java.base/java.lang.Thread.run(Thread.java:833)