### PR TITLE
More user-friendly error message in Cloud setting

### DIFF
--- a/jdisc-cloud-aws/src/main/java/com/yahoo/jdisc/cloud/aws/VespaAwsCredentialsProvider.java
+++ b/jdisc-cloud-aws/src/main/java/com/yahoo/jdisc/cloud/aws/VespaAwsCredentialsProvider.java
@@ -39,7 +39,7 @@ public class VespaAwsCredentialsProvider implements AWSCredentialsProvider {
         try {
             credentials.set(readCredentials());
         } catch (Exception e) {
-            throw new RuntimeException("Unable to get credentials in " + credentialsPath.toString(), e);
+            throw new RuntimeException("Unable to get credentials. Please ensure cluster is configured as exclusive. See: https://cloud.vespa.ai/en/reference/services#nodes");
         }
     }
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
