### PR TITLE
Reduce log level for container env and args

### DIFF
--- a/client/go/internal/admin/jvm/container.go
+++ b/client/go/internal/admin/jvm/container.go
@@ -68,8 +68,8 @@ func (cb *containerBase) Exec() {
 	if cb.propsFile != "" {
 		writeEnvAsProperties(p.EffectiveEnv(), cb.propsFile)
 	}
-	trace.Info("starting container; env:", readableEnv(p.Env))
-	trace.Info("starting container; exec:", argv)
+	trace.Debug("starting container; env:", readableEnv(p.Env))
+	trace.Debug("starting container; exec:", argv)
 	err := p.Run()
 	util.JustExitWith(err)
 }


### PR DESCRIPTION
Trying to reduce log lines at startup, I guess this was used when developing startup script and is not needed anymore @arnej27959  please review
@kkraune FYI