### PR TITLE
Run unit tests as part of rpmbuild as this takes 2 minutes on Copr.

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -467,7 +467,6 @@ VERSION=%{version} CI=true make -C client/go install-all
 
 %check
 %if ! 0%{?installdir:1}
-%if 0%{?_run_unit_tests:1}
 %if 0%{?_java_home:1}
 export JAVA_HOME=%{?_java_home}
 %else
@@ -480,7 +479,6 @@ python3.9 -m pip install --user pytest
 export PYTHONPATH="$PYTHONPATH:/usr/local/lib/$(basename $(readlink -f $(which python3)))/site-packages"
 #%{?_use_mvn_wrapper:./mvnw}%{!?_use_mvn_wrapper:mvn} --batch-mode -nsu -T 1C -Dmaven.javadoc.skip=true test
 make test ARGS="--output-on-failure %{_smp_mflags}"
-%endif
 %endif
 
 %install

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -279,7 +279,6 @@ jobs:
                    --define="_topdir $WORKDIR/vespa-rpmbuild" \
                    --define "debug_package %{nil}" \
                    --define "_debugsource_template %{nil}" \
-                   --define "_run_unit_tests 1" \
                    --define '_cmake_extra_opts "-DDEFAULT_VESPA_CPU_ARCH_FLAGS=-msse3 -mcx16 -mtune=intel"' \
                    *.src.rpm
           rm -f *.src.rpm


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

If we really want to skip this can be done with ´rpmbuild --nocheck ...`, but this is not possible on Copr.