### PR TITLE
Expose from/to visitor timestamps in Document V1 API

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1231,6 +1231,9 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
 
         getProperty(request, FROM_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setFromTimestamp);
         getProperty(request, TO_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setToTimestamp);
+        if (Long.compareUnsigned(parameters.getFromTimestamp(), parameters.getToTimestamp()) > 0) {
+            throw new IllegalArgumentException("toTimestamp must be greater than, or equal to, fromTimestamp");
+        }
 
         StorageCluster storageCluster = resolveCluster(cluster, clusters);
         parameters.setRoute(storageCluster.name());

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -171,6 +171,8 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
     private static final String SLICES = "slices";
     private static final String SLICE_ID = "sliceId";
     private static final String DRY_RUN = "dryRun";
+    private static final String FROM_TIMESTAMP = "fromTimestamp";
+    private static final String TO_TIMESTAMP = "toTimestamp";
 
     private final Clock clock;
     private final Duration handlerTimeout;
@@ -1226,6 +1228,9 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
 
         getProperty(request, CONTINUATION).map(ProgressToken::fromSerializedString).ifPresent(parameters::setResumeToken);
         parameters.setPriority(DocumentProtocol.Priority.NORMAL_4);
+
+        getProperty(request, FROM_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setFromTimestamp);
+        getProperty(request, TO_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setToTimestamp);
 
         StorageCluster storageCluster = resolveCluster(cluster, clusters);
         parameters.setRoute(storageCluster.name());

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -504,6 +504,15 @@ public class DocumentV1ApiTest {
                        "}", response.readAll());
         assertEquals(200, response.getStatus());
 
+        // GET with from timestamp > to timestamp is an error
+        access.expect(parameters -> { fail("unreachable"); });
+        response = driver.sendRequest("http://localhost/document/v1/?cluster=content&fromTimestamp=100&toTimestamp=99");
+        assertSameJson("{" +
+                "  \"pathId\": \"/document/v1/\"," +
+                "  \"message\": \"toTimestamp must be greater than, or equal to, fromTimestamp\"" +
+                "}", response.readAll());
+        assertEquals(400, response.getStatus());
+
         // GET with full document ID is a document get operation which returns 404 when no document is found
         access.session.expect((id, parameters) -> {
             assertEquals(doc1.getId(), id);

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -223,6 +223,8 @@ public class DocumentV1ApiTest {
             assertEquals("(all the things)", parameters.getDocumentSelection());
             assertEquals(6000, parameters.getSessionTimeoutMs());
             assertEquals(9, parameters.getTraceLevel());
+            assertEquals(1_000_000, parameters.getFromTimestamp());
+            assertEquals(2_000_000, parameters.getToTimestamp());
             // Put some documents in the response
             parameters.getLocalDataHandler().onMessage(new PutDocumentMessage(new DocumentPut(doc1)), tokens.get(0));
             parameters.getLocalDataHandler().onMessage(new PutDocumentMessage(new DocumentPut(doc2)), tokens.get(1));
@@ -234,7 +236,7 @@ public class DocumentV1ApiTest {
             parameters.getControlHandler().onDone(VisitorControlHandler.CompletionCode.TIMEOUT, "timeout is OK");
         });
         response = driver.sendRequest("http://localhost/document/v1?cluster=content&bucketSpace=default&wantedDocumentCount=1025&concurrency=123" +
-                                      "&selection=all%20the%20things&fieldSet=[id]&timeout=6&tracelevel=9");
+                                      "&selection=all%20the%20things&fieldSet=[id]&timeout=6&tracelevel=9&fromTimestamp=1000000&toTimestamp=2000000");
         assertSameJson("""
                        {
                          "pathId": "/document/v1",
@@ -284,6 +286,8 @@ public class DocumentV1ApiTest {
             assertEquals(6000, parameters.getTimeoutMs());
             assertEquals(4, parameters.getSlices());
             assertEquals(1, parameters.getSliceId());
+            assertEquals(0, parameters.getFromTimestamp()); // not set; 0 is default
+            assertEquals(0, parameters.getToTimestamp()); // not set; 0 is default
             // Put some documents in the response
             parameters.getLocalDataHandler().onMessage(new PutDocumentMessage(new DocumentPut(doc1)), tokens.get(0));
             parameters.getLocalDataHandler().onMessage(new PutDocumentMessage(new DocumentPut(doc2)), tokens.get(1));


### PR DESCRIPTION
@jonmv please review.

This directly mirrors `vespa-visit` (and the underlying `VisitorParameters`) in being in microseconds from UTC epoch. It can be argued whether this should be in _seconds_, as Vespa timestamps operations with wall-clock second time combined with a synthetic microsecond counter. But since the existing APIs use microseconds, I'm leaving this as micros as well to keep things consistent.
