### PR TITLE
Avoid presizing memory up front fro the BufferStates vector.

### DIFF
--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -912,8 +912,8 @@ AttributeTest::testSingle()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-post-int32", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(887756u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(656444u, ptr->getStatus().getUsed());
+            EXPECT_EQ(300092u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(68780u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<IntegerAttribute, AttributeVector::largeint_t, int32_t>(ptr, values);
         }
@@ -934,8 +934,8 @@ AttributeTest::testSingle()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-post-float", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(887756u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(656444u, ptr->getStatus().getUsed());
+            EXPECT_EQ(300092u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(68780u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<FloatingPointAttribute, double, float>(ptr, values);
         }
@@ -947,8 +947,8 @@ AttributeTest::testSingle()
         {
             AttributePtr ptr = createAttribute("sv-string", Config(BasicType::STRING, CollectionType::SINGLE));
             ptr->updateStat(true);
-            EXPECT_EQ(403552u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(328576u, ptr->getStatus().getUsed());
+            EXPECT_EQ(111520u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(36544u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<StringAttribute, string, string>(ptr, values);
         }
@@ -957,8 +957,8 @@ AttributeTest::testSingle()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-fs-string", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(902256u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(657088u, ptr->getStatus().getUsed());
+            EXPECT_EQ(317040u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(71872u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<StringAttribute, string, string>(ptr, values);
         }
@@ -1089,8 +1089,8 @@ AttributeTest::testArray()
         {
             AttributePtr ptr = createAttribute("a-int32", Config(BasicType::INT32, CollectionType::ARRAY));
             ptr->updateStat(true);
-            EXPECT_EQ(1474480u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(1462192u, ptr->getStatus().getUsed());
+            EXPECT_EQ(442288u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(430000u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
         }
@@ -1099,8 +1099,8 @@ AttributeTest::testArray()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("flags", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(1474480u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(1462192u, ptr->getStatus().getUsed());
+            EXPECT_EQ(442288u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(430000u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
         }
@@ -1109,8 +1109,8 @@ AttributeTest::testArray()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("a-fs-int32", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(2371884u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(2118656u, ptr->getStatus().getUsed());
+            EXPECT_EQ(752028u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(498800u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<IntegerAttribute, AttributeVector::largeint_t>(ptr, values);
         }
@@ -1128,8 +1128,8 @@ AttributeTest::testArray()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("a-fs-float", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(2371884u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(2118656u, ptr->getStatus().getUsed());
+            EXPECT_EQ(752028u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(498800u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<FloatingPointAttribute, double>(ptr, values);
         }
@@ -1140,8 +1140,8 @@ AttributeTest::testArray()
         {
             AttributePtr ptr = createAttribute("a-string", Config(BasicType::STRING, CollectionType::ARRAY));
             ptr->updateStat(true);
-            EXPECT_EQ(1865744u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(1790768u, ptr->getStatus().getUsed());
+            EXPECT_EQ(541520u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(466544u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<StringAttribute, string>(ptr, values);
         }
@@ -1150,8 +1150,8 @@ AttributeTest::testArray()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("afs-string", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(2386384u, ptr->getStatus().getAllocated());
-            EXPECT_EQ(2119300u, ptr->getStatus().getUsed());
+            EXPECT_EQ(768976u, ptr->getStatus().getAllocated());
+            EXPECT_EQ(501892u, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<StringAttribute, string>(ptr, values);
         }

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -462,8 +462,8 @@ TEST(MemoryIndexTest, require_that_num_docs_and_doc_id_limit_is_returned)
 
 TEST(MemoryIndexTest, require_that_we_understand_the_memory_footprint)
 {
-    constexpr size_t BASE_ALLOCATED = 1172040u;
-    constexpr size_t BASE_USED = 984116u;
+    constexpr size_t BASE_ALLOCATED = 289608u;
+    constexpr size_t BASE_USED = 101684u;
     {
         MySetup setup;
         Index index(setup);

--- a/searchlib/src/tests/predicate/document_features_store_test.cpp
+++ b/searchlib/src/tests/predicate/document_features_store_test.cpp
@@ -165,17 +165,17 @@ TEST("require that both features and ranges are removed by 'remove'") {
 
 TEST("require that both features and ranges counts towards memory usage") {
     DocumentFeaturesStore features_store(10);
-    EXPECT_EQUAL(328152u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(33672u, features_store.getMemoryUsage().usedBytes());
 
     PredicateTreeAnnotations annotations;
     annotations.features.push_back(PredicateHash::hash64("foo=100-199"));
     features_store.insert(annotations, doc_id);
-    EXPECT_EQUAL(328160u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(33680u, features_store.getMemoryUsage().usedBytes());
 
     annotations.features.clear();
     annotations.range_features.push_back({"foo", 100, 199});
     features_store.insert(annotations, doc_id + 1);
-    EXPECT_EQUAL(328256u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(33776u, features_store.getMemoryUsage().usedBytes());
 }
 
 TEST("require that DocumentFeaturesStore can be serialized") {
@@ -205,17 +205,17 @@ TEST("require that serialization cleans up wordstore") {
     PredicateTreeAnnotations annotations;
     annotations.range_features.push_back({"foo", 100, 199});
     features_store.insert(annotations, doc_id);
-    EXPECT_EQUAL(328248u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(33768u, features_store.getMemoryUsage().usedBytes());
     annotations.range_features.push_back({"bar", 100, 199});
     features_store.insert(annotations, doc_id + 1);
-    EXPECT_EQUAL(328636u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(34156u, features_store.getMemoryUsage().usedBytes());
     features_store.remove(doc_id + 1);
-    EXPECT_EQUAL(328588u, features_store.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(34108u, features_store.getMemoryUsage().usedBytes());
 
     vespalib::DataBuffer buffer;
     features_store.serialize(buffer);
     DocumentFeaturesStore features_store2(buffer);
-    EXPECT_EQUAL(328248u, features_store2.getMemoryUsage().usedBytes());
+    EXPECT_EQUAL(33768u, features_store2.getMemoryUsage().usedBytes());
 }
 
 

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.cpp
@@ -727,7 +727,6 @@ template <typename DataT>
 void
 PostingStore<DataT>::compact_worst_buffers(CompactionSpec compaction_spec, const CompactionStrategy& compaction_strategy)
 {
-
     auto compacting_buffers = this->start_compact_worst_buffers(compaction_spec, compaction_strategy);
     bool compact_btree_roots = false;
     auto filter = compacting_buffers->make_entry_ref_filter();

--- a/vespalib/src/tests/btree/btree_test.cpp
+++ b/vespalib/src/tests/btree/btree_test.cpp
@@ -1064,7 +1064,7 @@ adjustAllocatedBytes(size_t nodeCount, size_t nodeSize)
 
 TEST_F(BTreeTest, require_that_memory_usage_is_calculated)
 {
-    constexpr size_t BASE = 163912;
+    constexpr size_t BASE = 16744u;
     typedef BTreeNodeAllocator<int32_t, int8_t,
         btree::NoAggregated,
         MyTraits::INTERNAL_SLOTS, MyTraits::LEAF_SLOTS> NodeAllocator;

--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -210,16 +210,16 @@ INSTANTIATE_TEST_SUITE_P(NumberStoreFreeListsDisabledMultiTest,
 
 TEST_P(NumberStoreTest, control_static_sizes) {
 #ifdef _LIBCPP_VERSION
-    EXPECT_EQ(472u, sizeof(store));
-    EXPECT_EQ(296u, sizeof(NumberStoreTest::ArrayStoreType::DataStoreType));
+    EXPECT_EQ(520u, sizeof(store));
+    EXPECT_EQ(344u, sizeof(NumberStoreTest::ArrayStoreType::DataStoreType));
 #else
-    EXPECT_EQ(504u, sizeof(store));
-    EXPECT_EQ(328u, sizeof(NumberStoreTest::ArrayStoreType::DataStoreType));
+    EXPECT_EQ(552u, sizeof(store));
+    EXPECT_EQ(376u, sizeof(NumberStoreTest::ArrayStoreType::DataStoreType));
 #endif
     EXPECT_EQ(112u, sizeof(NumberStoreTest::ArrayStoreType::SmallBufferType));
     MemoryUsage usage = store.getMemoryUsage();
-    EXPECT_EQ(1312160u, usage.allocatedBytes());
-    EXPECT_EQ(1311232u, usage.usedBytes());
+    EXPECT_EQ(133088, usage.allocatedBytes());
+    EXPECT_EQ(132160u, usage.usedBytes());
 }
 
 TEST_P(NumberStoreTest, add_and_get_small_arrays_of_trivial_type)

--- a/vespalib/src/tests/datastore/datastore/datastore_test.cpp
+++ b/vespalib/src/tests/datastore/datastore/datastore_test.cpp
@@ -474,7 +474,7 @@ TEST(DataStoreTest, require_that_memory_stats_are_calculated)
 
 TEST(DataStoreTest, require_that_memory_usage_is_calculated)
 {
-    constexpr size_t BASE = 676;
+    constexpr size_t BASE = 244;
     MyStore s;
     MyRef r = s.addEntry(10);
     s.addEntry(20);
@@ -492,7 +492,7 @@ TEST(DataStoreTest, require_that_memory_usage_is_calculated)
 
 TEST(DataStoreTest, require_that_we_can_disable_elemement_hold_list)
 {
-    constexpr size_t BASE = 676;
+    constexpr size_t BASE = 244;
     MyStore s;
     MyRef r1 = s.addEntry(10);
     MyRef r2 = s.addEntry(20);
@@ -538,7 +538,7 @@ void assertGrowStats(GrowthStats expSizes,
 
 TEST(DataStoreTest, require_that_buffer_growth_works)
 {
-    constexpr size_t BASE = 41032u;
+    constexpr size_t BASE = 4456u;
     // Always switch to new buffer, min size 4
     assertGrowStats({ 4, 4, 4, 4, 8, 16, 16, 32, 64, 64 },
                     { 4 }, 20 + BASE, 4, 0);

--- a/vespalib/src/tests/datastore/unique_store/unique_store_test.cpp
+++ b/vespalib/src/tests/datastore/unique_store/unique_store_test.cpp
@@ -470,14 +470,14 @@ TEST_F(DoubleTest, nan_is_handled)
 }
 
 TEST_F(DoubleTest, control_memory_usage) {
-    EXPECT_EQ(464, sizeof(store));
+    EXPECT_EQ(512u, sizeof(store));
     EXPECT_EQ(144u, sizeof(BufferState));
-    EXPECT_EQ(163908u, store.get_values_memory_usage().allocatedBytes());
-    EXPECT_EQ(163892u, store.get_values_memory_usage().usedBytes());
-    EXPECT_EQ(262120u, store.get_dictionary_memory_usage().allocatedBytes());
-    EXPECT_EQ(164176u, store.get_dictionary_memory_usage().usedBytes());
-    EXPECT_EQ(426028u, store.getMemoryUsage().allocatedBytes());
-    EXPECT_EQ(328068u, store.getMemoryUsage().usedBytes());
+    EXPECT_EQ(16596u, store.get_values_memory_usage().allocatedBytes());
+    EXPECT_EQ(16580u, store.get_values_memory_usage().usedBytes());
+    EXPECT_EQ(114952, store.get_dictionary_memory_usage().allocatedBytes());
+    EXPECT_EQ(17008u, store.get_dictionary_memory_usage().usedBytes());
+    EXPECT_EQ(131548u, store.getMemoryUsage().allocatedBytes());
+    EXPECT_EQ(33588u, store.getMemoryUsage().usedBytes());
 }
                 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/datastore/buffer_free_list.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_free_list.cpp
@@ -52,5 +52,23 @@ BufferFreeList::disable()
     _free_list = nullptr;
 }
 
+void
+BufferFreeList::push_entry(EntryRef ref) {
+    if (empty()) {
+        attach();
+    }
+    _free_refs.push_back(ref);
+}
+EntryRef
+BufferFreeList::pop_entry() {
+    EntryRef ret = _free_refs.back();
+    _free_refs.pop_back();
+    if (empty()) {
+        detach();
+    }
+    _dead_elems.store(_dead_elems.load(std::memory_order_relaxed) - _array_size, std::memory_order_relaxed);
+    return ret;
+}
+
 }
 

--- a/vespalib/src/vespa/vespalib/datastore/buffer_free_list.h
+++ b/vespalib/src/vespa/vespalib/datastore/buffer_free_list.h
@@ -41,21 +41,8 @@ public:
     bool enabled() const { return _free_list != nullptr; }
     bool empty() const { return _free_refs.empty(); }
     uint32_t array_size() const { return _array_size; }
-    void push_entry(EntryRef ref) {
-        if (empty()) {
-            attach();
-        }
-        _free_refs.push_back(ref);
-    }
-    EntryRef pop_entry() {
-        EntryRef ret = _free_refs.back();
-        _free_refs.pop_back();
-        if (empty()) {
-            detach();
-        }
-        _dead_elems.store(_dead_elems.load(std::memory_order_relaxed) - _array_size, std::memory_order_relaxed);
-        return ret;
-    }
+    void push_entry(EntryRef ref);
+    EntryRef pop_entry();
 };
 
 }

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.h
@@ -75,7 +75,7 @@ public:
     uint32_t primary_buffer_id(uint32_t typeId) const { return _primary_buffer_ids[typeId]; }
     BufferState &getBufferState(uint32_t buffer_id) noexcept;
     const BufferAndMeta & getBufferMeta(uint32_t buffer_id) const { return _buffers[buffer_id]; }
-    uint32_t getNumBuffers() const { return _numBuffers; }
+    uint32_t getNumBuffers() noexcept { return _states.size(); }
 
     /**
      * Assign generation on data elements on hold lists added since the last time this function was called.
@@ -238,21 +238,21 @@ private:
 
     virtual void reclaim_all_entry_refs() = 0;
 
-    std::vector<BufferAndMeta>  _buffers; // For fast mapping with known types
+    std::vector<BufferAndMeta>    _buffers; // For fast mapping with known types
 
     // Provides a mapping from typeId -> primary buffer for that type.
     // The primary buffer is used for allocations of new element(s) if no available slots are found in free lists.
     std::vector<uint32_t>         _primary_buffer_ids;
 
-    std::vector<BufferState>      _states;
+    std::deque<BufferState>       _states;
     std::vector<BufferTypeBase *> _typeHandlers; // TypeId -> handler
     std::vector<FreeList>         _free_lists;
     mutable std::atomic<uint64_t> _compaction_count;
     vespalib::GenerationHolder    _genHolder;
     const uint32_t                _maxArrays;
     const uint32_t                _numBuffers;
-    const uint32_t                _offset_bits;
     uint32_t                      _hold_buffer_count;
+    const uint8_t                 _offset_bits;
     bool                          _freeListsEnabled;
     bool                          _initializing;
 };

--- a/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store.hpp
@@ -102,8 +102,8 @@ private:
     std::unique_ptr<CompactingBuffers> _compacting_buffers;
 
     void allocMapping() {
-        _mapping.resize(RefT::numBuffers());
         auto& data_store = _compacting_buffers->get_store();
+        _mapping.resize(data_store.getNumBuffers());
         for (const auto bufferId : _compacting_buffers->get_buffer_ids()) {
             BufferState &state = data_store.getBufferState(bufferId);
             _mapping[bufferId].resize(state.get_used_arrays());

--- a/vespalib/src/vespa/vespalib/datastore/unique_store_enumerator.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/unique_store_enumerator.hpp
@@ -42,8 +42,9 @@ template <typename RefT>
 void
 UniqueStoreEnumerator<RefT>::allocate_enum_values(DataStoreBase & store)
 {
-    _enumValues.resize(RefType::numBuffers());
-    for (uint32_t bufferId = 0; bufferId < RefType::numBuffers(); ++bufferId) {
+    size_t numBuffers = store.getNumBuffers();
+    _enumValues.resize(numBuffers);
+    for (uint32_t bufferId = 0; bufferId < numBuffers; ++bufferId) {
         const BufferState &state = store.getBufferState(bufferId);
         if (state.isActive()) {
             _enumValues[bufferId].resize(state.get_used_arrays());


### PR DESCRIPTION
@toregge and @geirst PR
Prior to this PR _states array was only accessed by write thread.
This PR uses a deque instead of a presized vector.
Currently not possible to grow with a vector due to BufferState exposes references to its internal member levaving it non-movable.