### PR TITLE
Revert "Use own zero node resources implementation"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceSnapshot.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/resource/ResourceSnapshot.java
@@ -20,13 +20,6 @@ import java.util.stream.Collectors;
  */
 public class ResourceSnapshot {
 
-    private static final NodeResources zero = new NodeResources(
-            0, 0, 0, 0,
-            NodeResources.DiskSpeed.any,
-            NodeResources.StorageType.any,
-            NodeResources.Architecture.any,
-            NodeResources.GpuResources.zero());
-
     private final ApplicationId applicationId;
     private final NodeResources resources;
     private final Instant timestamp;
@@ -60,7 +53,7 @@ public class ResourceSnapshot {
 
         var resources = nodes.stream()
                 .map(Node::resources)
-                .reduce(zero, ResourceSnapshot::addResources);
+                .reduce(NodeResources.zero(), ResourceSnapshot::addResources);
 
         return new ResourceSnapshot(applicationIds.iterator().next(), resources, timestamp, zoneId, versions.iterator().next());
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#26407

Reverting this makes unit tests successful again for controller-api. Might be because of changes in https://github.com/vespa-engine/vespa/pull/26406?