### PR TITLE
Be explicit about lbound/ubound for bucket DB iteration and add lbound variant

### DIFF
--- a/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
+++ b/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
@@ -1697,7 +1697,7 @@ TopLevelBucketDBUpdaterTest::merge_bucket_lists(
     BucketDumper dumper_tmp(true);
     for (auto* s : distributor_stripes()) {
         auto& db = s->getBucketSpaceRepo().get(document::FixedBucketSpaces::default_space()).getBucketDatabase();
-        db.forEach(dumper_tmp);
+        db.for_each_upper_bound(dumper_tmp);
     }
 
     {
@@ -1717,7 +1717,7 @@ TopLevelBucketDBUpdaterTest::merge_bucket_lists(
     BucketDumper dumper(include_bucket_info);
     for (auto* s : distributor_stripes()) {
         auto& db = s->getBucketSpaceRepo().get(document::FixedBucketSpaces::default_space()).getBucketDatabase();
-        db.forEach(dumper);
+        db.for_each_upper_bound(dumper);
         db.clear();
     }
     return dumper.ost.str();

--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.cpp
@@ -151,9 +151,16 @@ BTreeBucketDatabase::process_update(const document::BucketId& bucket, EntryUpdat
 }
 
 // TODO need snapshot read with guarding
-// FIXME semantics of for-each in judy and bit tree DBs differ, former expects lbound, latter ubound..!
-// FIXME but bit-tree code says "lowerBound" in impl and "after" in declaration???
-void BTreeBucketDatabase::forEach(EntryProcessor& proc, const BucketId& after) const {
+void BTreeBucketDatabase::for_each_lower_bound(EntryProcessor& proc, const BucketId& at_or_after) const {
+    for (auto iter = _impl->lower_bound(at_or_after.toKey()); iter.valid(); ++iter) {
+        if (!proc.process(_impl->const_value_ref_from_valid_iterator(iter))) {
+            break;
+        }
+    }
+}
+
+// TODO need snapshot read with guarding
+void BTreeBucketDatabase::for_each_upper_bound(EntryProcessor& proc, const BucketId& after) const {
     for (auto iter = _impl->upper_bound(after.toKey()); iter.valid(); ++iter) {
         if (!proc.process(_impl->const_value_ref_from_valid_iterator(iter))) {
             break;

--- a/storage/src/vespa/storage/bucketdb/btree_bucket_database.h
+++ b/storage/src/vespa/storage/bucketdb/btree_bucket_database.h
@@ -44,7 +44,8 @@ public:
                 std::vector<Entry>& entries) const override;
     void update(const Entry& newEntry) override;
     void process_update(const document::BucketId& bucket, EntryUpdateProcessor &processor, bool create_if_nonexisting) override;
-    void forEach(EntryProcessor&, const document::BucketId& after) const override;
+    void for_each_lower_bound(EntryProcessor&, const document::BucketId& at_or_after) const override;
+    void for_each_upper_bound(EntryProcessor&, const document::BucketId& after) const override;
     Entry upperBound(const document::BucketId& value) const override;
     uint64_t size() const override;
     void clear() override;

--- a/storage/src/vespa/storage/bucketdb/bucketdatabase.h
+++ b/storage/src/vespa/storage/bucketdb/bucketdatabase.h
@@ -99,9 +99,15 @@ public:
 
     virtual void process_update(const document::BucketId& bucket, EntryUpdateProcessor &processor, bool create_if_nonexisting) = 0;
 
-    virtual void forEach(
-            EntryProcessor&,
-            const document::BucketId& after = document::BucketId()) const = 0;
+    virtual void for_each_lower_bound(EntryProcessor&, const document::BucketId& at_or_after) const = 0;
+    void for_each_lower_bound(EntryProcessor& proc) const {
+        for_each_lower_bound(proc, document::BucketId());
+    }
+
+    virtual void for_each_upper_bound(EntryProcessor&, const document::BucketId& after) const = 0;
+    void for_each_upper_bound(EntryProcessor& proc) const {
+        for_each_upper_bound(proc, document::BucketId());
+    }
 
     using TrailingInserter = bucketdb::TrailingInserter<Entry>;
     using Merger           = bucketdb::Merger<Entry>;

--- a/storage/src/vespa/storage/distributor/idealstatemanager.cpp
+++ b/storage/src/vespa/storage/distributor/idealstatemanager.cpp
@@ -265,7 +265,7 @@ IdealStateManager::getBucketStatus(
 void IdealStateManager::dump_bucket_space_db_status(document::BucketSpace bucket_space, std::ostream& out) const {
     StatusBucketVisitor proc(*this, bucket_space, out);
     auto& distributorBucketSpace = _op_ctx.bucket_space_repo().get(bucket_space);
-    distributorBucketSpace.getBucketDatabase().forEach(proc);
+    distributorBucketSpace.getBucketDatabase().for_each_upper_bound(proc);
 }
 
 void IdealStateManager::getBucketStatus(std::ostream& out) const {

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -388,23 +388,19 @@ VisitorOperation::pickBucketsToVisit(const std::vector<BucketDatabase::Entry>& b
 
     std::vector<document::BucketId> bucketVisitOrder;
 
-    for (uint32_t i = 0; i < buckets.size(); ++i) {
-        bucketVisitOrder.push_back(buckets[i].getBucketId());
+    for (const auto& bucket : buckets) {
+        bucketVisitOrder.push_back(bucket.getBucketId());
     }
 
     VisitorOrder bucketLessThan;
     std::sort(bucketVisitOrder.begin(), bucketVisitOrder.end(), bucketLessThan);
 
-    std::vector<document::BucketId>::const_iterator iter(bucketVisitOrder.begin());
-    std::vector<document::BucketId>::const_iterator end(bucketVisitOrder.end());
+    auto iter = bucketVisitOrder.begin();
+    auto end  = bucketVisitOrder.end();
     for (; iter != end; ++iter) {
-        if (bucketLessThan(*iter, _lastBucket) ||
-            *iter == _lastBucket)
-        {
-            LOG(spam,
-                "Skipping bucket %s because it is lower than or equal to progress bucket %s",
-                iter->toString().c_str(),
-                _lastBucket.toString().c_str());
+        if (bucketLessThan(*iter, _lastBucket) || *iter == _lastBucket) {
+            LOG(spam, "Skipping bucket %s because it is lower than or equal to progress bucket %s",
+                iter->toString().c_str(), _lastBucket.toString().c_str());
             continue;
         }
         LOG(spam, "Iterating: Found in db: %s", iter->toString().c_str());
@@ -460,11 +456,11 @@ getBucketIdAndLast(BucketDatabase& database,
 {
     if (!super.contains(last)) {
         NextEntryFinder proc(super);
-        database.forEach(proc, super);
+        database.for_each_upper_bound(proc, super);
         return proc._next;
     } else {
         NextEntryFinder proc(last);
-        database.forEach(proc, last);
+        database.for_each_upper_bound(proc, last);
         return proc._next;
     }
 }


### PR DESCRIPTION
@geirst please review

The DB API was rather coy about whether `forEach` had lower or upper bound semantics with regards to the bucket ID passed in as a starting point. Be explicit and add a lower-bound variant.