### PR TITLE
Remove ControllerMaintainer logger

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintainer.java
@@ -21,8 +21,6 @@ import java.util.logging.Logger;
  */
 public abstract class ControllerMaintainer extends Maintainer {
 
-    protected static final Logger log = Logger.getLogger(ControllerMaintainer.class.getName());
-
     private final Controller controller;
 
     /** The systems in which this maintainer should run */


### PR DESCRIPTION
There is already one in the superclass and the ControllerMaintainer logger hid the name of the maintainer implementation.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
