### PR TITLE
Revert "Turn off logging for containers for some classes"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -25,6 +25,9 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
     }
 
     @Override
+    protected void doPrepare(DeployState deployState) { }
+
+    @Override
     public void getConfig(QrStartConfig.Builder builder) {
         super.getConfig(builder);
         builder.jvm.heapsize(128);

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -37,6 +37,9 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
     @Override
     protected Set<Path> unnecessaryPlatformBundles() { return UNNECESSARY_BUNDLES; }
 
+    @Override
+    protected void doPrepare(DeployState deployState) { }
+
     @Override protected boolean messageBusEnabled() { return false; }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -137,6 +137,9 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
     }
 
     @Override
+    protected void doPrepare(DeployState deployState) { }
+
+    @Override
     public void getConfig(MetricsNodesConfig.Builder builder) {
         builder.node.addAll(MetricsNodesConfigGenerator.generate(getContainers()));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminBuilderBase.java
@@ -21,8 +21,11 @@ import com.yahoo.vespa.model.admin.monitoring.builder.Metrics;
 import com.yahoo.vespa.model.admin.monitoring.builder.PredefinedMetricSets;
 import com.yahoo.vespa.model.admin.monitoring.builder.xml.MetricsBuilder;
 import org.w3c.dom.Element;
+
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainer.java
@@ -9,8 +9,11 @@ import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.search.config.QrStartConfig;
+import com.yahoo.vespa.model.LogctlSpec;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
+
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -38,6 +41,15 @@ public final class ApplicationContainer extends Container implements
         addComponent(new SimpleComponent("com.yahoo.container.jdisc.SystemInfoProvider"));
         addComponent(new SimpleComponent("com.yahoo.container.jdisc.ZoneInfoProvider"));
         addComponent(new SimpleComponent("com.yahoo.container.jdisc.ClusterInfoProvider"));
+    }
+
+    private List<LogctlSpec> logctlSpecs = List.of();
+    void setLogctlSpecs(List<LogctlSpec> logctlSpecs) {
+        this.logctlSpecs = logctlSpecs;
+    }
+    @Override
+    public List<LogctlSpec> getLogctlSpecs() {
+        return logctlSpecs;
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -124,12 +124,19 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
                 : defaultHeapSizePercentageOfTotalNodeMemory;
     }
 
+    private void wireLogctlSpecs() {
+        getAdmin().ifPresent(admin -> {
+            for (var c : getContainers()) {
+                c.setLogctlSpecs(admin.getLogctlSpecs());
+            }});
+    }
+
     @Override
     protected void doPrepare(DeployState deployState) {
-        super.doPrepare(deployState);
         addAndSendApplicationBundles(deployState);
         sendUserConfiguredFiles(deployState);
         createEndpointList(deployState);
+        wireLogctlSpecs();
     }
 
     private void addAndSendApplicationBundles(DeployState deployState) {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/Container.java
@@ -16,7 +16,6 @@ import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
-import com.yahoo.vespa.model.LogctlSpec;
 import com.yahoo.vespa.model.PortAllocBridge;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
 import com.yahoo.vespa.model.container.component.Component;
@@ -35,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -66,8 +64,6 @@ public abstract class Container extends AbstractService implements
 
     /** The cluster this container belongs to, or null if it is not added to any cluster */
     private ContainerCluster<?> owner = null;
-
-    private List<LogctlSpec> logctlSpecs = List.of();
 
     protected final TreeConfigProducer<?> parent;
     private final String name;
@@ -418,12 +414,5 @@ public abstract class Container extends AbstractService implements
     private static ContainerCluster containerClusterOrNull(AnyConfigProducer producer) {
         return producer instanceof ContainerCluster<?> ? (ContainerCluster<?>) producer : null;
     }
-
-    void setLogctlSpecs(List<LogctlSpec> logctlSpecs) {
-        this.logctlSpecs = logctlSpecs;
-    }
-
-    @Override
-    public List<LogctlSpec> getLogctlSpecs() { return logctlSpecs; }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -61,6 +61,7 @@ import com.yahoo.vespa.model.container.search.ContainerSearch;
 import com.yahoo.vespa.model.container.search.searchchain.SearchChains;
 import com.yahoo.vespa.model.content.Content;
 import com.yahoo.vespa.model.search.SearchCluster;
+
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -300,16 +301,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         doPrepare(deployState);
     }
 
-    protected void doPrepare(DeployState deployState) {
-        wireLogctlSpecs();
-    }
-
-    private void wireLogctlSpecs() {
-        getAdmin().ifPresent(admin -> {
-            for (var c : getContainers()) {
-                c.setLogctlSpecs(admin.getLogctlSpecs());
-            }});
-    }
+    protected abstract void doPrepare(DeployState deployState);
 
     public String getName() {
         return name;

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/AdminTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/AdminTestCase.java
@@ -17,22 +17,17 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.container.jdisc.config.HealthMonitorConfig;
 import com.yahoo.net.HostName;
 import com.yahoo.vespa.config.core.StateserverConfig;
-import com.yahoo.vespa.model.LogctlSpec;
 import com.yahoo.vespa.model.Service;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import org.junit.jupiter.api.Test;
-import java.util.List;
+
 import java.util.Set;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class AdminTestCase {
@@ -246,46 +241,6 @@ public class AdminTestCase {
         Set<String> configIds = vespaModel.getConfigIds();
         // 1 logforwarder on each host
         assertTrue(configIds.contains("hosts/myhost0/logforwarder"), configIds.toString());
-    }
-
-    @Test
-    void testDefaultLogCtlSpecs() {
-        String hosts = "<hosts>"
-                + "  <host name=\"myhost0\">"
-                + "    <alias>node0</alias>"
-                + "  </host>"
-                + "</hosts>";
-
-        String services = "<services>" +
-                "  <admin version='2.0'>" +
-                "    <adminserver hostalias='node0' />" +
-                "  </admin>" +
-                "  <container version=\"1.0\">" +
-                "    <nodes>" +
-                "      <node hostalias=\"node0\" />" +
-                "    </nodes>" +
-                "    <search/>" +
-                "    <document-api/>" +
-                "  </container>" +
-                "</services>";
-
-        VespaModel vespaModel = new VespaModelCreatorWithMockPkg(hosts, services).create();
-        List<LogctlSpec> logctlSpecs = vespaModel.getAdmin().getLogctlSpecs();
-        assertEquals(4, logctlSpecs.size());  // Default logctl specs
-        assertEquals(1, logctlSpecs
-                .stream()
-                .filter(l -> (l.componentSpec.equals("com.yahoo.vespa.spifly.repackaged.spifly.BaseActivator")
-                        && l.levelsModSpec.equals("fatal=on,error=on,warning=on,info=off,event=on,config=on,debug=off,spam=off"))).count());
-
-        String localhostConfigId = "hosts/myhost0";
-        SentinelConfig sentinelConfig = vespaModel.getConfig(SentinelConfig.class, localhostConfigId);
-        System.out.println(sentinelConfig);
-        assertEquals(4, getConfigForService("container", sentinelConfig).logctl().size());
-        assertEquals(4, getConfigForService("metricsproxy-container", sentinelConfig).logctl().size());
-    }
-
-    private SentinelConfig.Service getConfigForService(String serviceName, SentinelConfig config) {
-        return config.service().stream().filter(service -> service.name().equals(serviceName)).findFirst().get();
     }
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#26445

Logging is turned off for containers, but seeing lines like this in log (I haven't found where they are created):

[2023-03-16 11:02:20.860] INFO    container        stdout	.com.yahoo.vespa.spifly.repackaged.spifly.BaseActivator   ON  ON  ON  ON OFF  ON OFF OFF

Also seeing

1678964771.464928	ip-10-47-142-7.ec2.internal	361/16725	config-sentinel	sentinel.sentinel.logctl	error	waitpid() failed: Interrupted system call


and some tests that check output from some config verification script started failing, probably due to one of the above issues
