### PR TITLE
Make VespaMetrics a public interface. DefaultMetrics uses suffix enum sets for metric creation

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetrics.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/DefaultMetrics.java
@@ -4,11 +4,20 @@ package com.yahoo.vespa.model.admin.monitoring;
 
 import com.yahoo.metrics.ContainerMetrics;
 import com.yahoo.metrics.SearchNodeMetrics;
+import com.yahoo.metrics.Suffix;
+import com.yahoo.metrics.VespaMetrics;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static com.yahoo.metrics.Suffix.average;
+import static com.yahoo.metrics.Suffix.count;
+import static com.yahoo.metrics.Suffix.max;
+import static com.yahoo.metrics.Suffix.ninety_five_percentile;
+import static com.yahoo.metrics.Suffix.ninety_nine_percentile;
+import static com.yahoo.metrics.Suffix.sum;
 import static com.yahoo.vespa.model.admin.monitoring.DefaultVespaMetrics.defaultVespaMetricSet;
 
 /**
@@ -39,72 +48,53 @@ public class DefaultMetrics {
     }
 
     private static void addContainerMetrics(Set<Metric> metrics) {
-        metrics.add(new Metric(ContainerMetrics.HTTP_STATUS_1XX.rate()));
-        metrics.add(new Metric(ContainerMetrics.HTTP_STATUS_2XX.rate()));
-        metrics.add(new Metric(ContainerMetrics.HTTP_STATUS_3XX.rate()));
-        metrics.add(new Metric(ContainerMetrics.HTTP_STATUS_4XX.rate()));
-        metrics.add(new Metric(ContainerMetrics.HTTP_STATUS_5XX.rate()));
-        metrics.add(new Metric(ContainerMetrics.JDISC_GC_MS.average()));
-        metrics.add(new Metric(ContainerMetrics.MEM_HEAP_FREE.average()));
+        addMetric(metrics, ContainerMetrics.HTTP_STATUS_1XX.rate());
+        addMetric(metrics, ContainerMetrics.HTTP_STATUS_2XX.rate());
+        addMetric(metrics, ContainerMetrics.HTTP_STATUS_3XX.rate());
+        addMetric(metrics, ContainerMetrics.HTTP_STATUS_4XX.rate());
+        addMetric(metrics, ContainerMetrics.HTTP_STATUS_5XX.rate());
+        addMetric(metrics, ContainerMetrics.JDISC_GC_MS.average());
+        addMetric(metrics, ContainerMetrics.MEM_HEAP_FREE.average());
     }
 
     private static void addSearchChainMetrics(Set<Metric> metrics) {
-        metrics.add(new Metric(ContainerMetrics.QUERIES.rate()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.sum()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.count()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.max()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.ninety_five_percentile()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.ninety_nine_percentile()));
-        metrics.add(new Metric(ContainerMetrics.HITS_PER_QUERY.sum()));
-        metrics.add(new Metric(ContainerMetrics.HITS_PER_QUERY.count()));
-        metrics.add(new Metric(ContainerMetrics.HITS_PER_QUERY.max()));
-        metrics.add(new Metric(ContainerMetrics.TOTAL_HITS_PER_QUERY.sum()));
-        metrics.add(new Metric(ContainerMetrics.TOTAL_HITS_PER_QUERY.count()));
-        metrics.add(new Metric(ContainerMetrics.TOTAL_HITS_PER_QUERY.max()));
-        metrics.add(new Metric(ContainerMetrics.DEGRADED_QUERIES.rate()));
-        metrics.add(new Metric(ContainerMetrics.FAILED_QUERIES.rate()));
-        metrics.add(new Metric(ContainerMetrics.QUERY_LATENCY.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(ContainerMetrics.HITS_PER_QUERY.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(ContainerMetrics.TOTAL_HITS_PER_QUERY.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(ContainerMetrics.SERVER_ACTIVE_THREADS.average())); // TODO: Remove on Vespa 9. Use jdisc.thread_pool.active_threads.
+        addMetric(metrics, ContainerMetrics.QUERIES.rate());
+        addMetric(metrics, ContainerMetrics.QUERY_LATENCY, EnumSet.of(sum, count, max, ninety_five_percentile, ninety_nine_percentile, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, ContainerMetrics.HITS_PER_QUERY, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, ContainerMetrics.TOTAL_HITS_PER_QUERY, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, ContainerMetrics.DEGRADED_QUERIES.rate());
+        addMetric(metrics, ContainerMetrics.FAILED_QUERIES.rate());
+        addMetric(metrics, ContainerMetrics.SERVER_ACTIVE_THREADS.average()); // TODO: Remove on Vespa 9. Use jdisc.thread_pool.active_threads.
     }
 
     private static void addContentMetrics(Set<Metric> metrics) {
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_REQUESTED_DOCUMENTS.rate()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_LATENCY.sum()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_LATENCY.count()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_LATENCY.max()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_LATENCY.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_QUERY_LATENCY.sum()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_QUERY_LATENCY.count()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_QUERY_LATENCY.max()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_QUERY_LATENCY.average())); // TODO: Remove with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_REQUESTED_DOCUMENTS.rate());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_DOCSUM_LATENCY, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_SEARCH_PROTOCOL_QUERY_LATENCY, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
 
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_TOTAL.last()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_READY.last()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_ACTIVE.last()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DISK_USAGE.last()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MEMORY_USAGE_ALLOCATED_BYTES.last()));
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_TOTAL.last());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_READY.last());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DOCUMENTS_ACTIVE.last());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_DISK_USAGE.last());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MEMORY_USAGE_ALLOCATED_BYTES.last());
 
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_RESOURCE_USAGE_DISK.average()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_RESOURCE_USAGE_MEMORY.average()));
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_RESOURCE_USAGE_DISK.average());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_RESOURCE_USAGE_MEMORY.average());
 
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_DOCS_MATCHED.rate()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_DOCS_RERANKED.rate()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_SETUP_TIME.sum()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_SETUP_TIME.count()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_SETUP_TIME.max()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_SETUP_TIME.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_LATENCY.sum()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_LATENCY.count()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_LATENCY.max()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_LATENCY.average())); // TODO: Remove with Vespa 9
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_RERANK_TIME.sum()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_RERANK_TIME.count()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_RERANK_TIME.max()));
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_RERANK_TIME.average())); // TODO: Remove with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_DOCS_MATCHED.rate());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_DOCS_RERANKED.rate());
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_SETUP_TIME, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_QUERY_LATENCY, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_MATCHING_RANK_PROFILE_RERANK_TIME, EnumSet.of(sum, count, max, average)); // TODO: Remove average with Vespa 9
+        addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_TRANSACTIONLOG_DISK_USAGE.last());
+    }
 
-        metrics.add(new Metric(SearchNodeMetrics.CONTENT_PROTON_TRANSACTIONLOG_DISK_USAGE.last()));
+    private static void addMetric(Set<Metric> metrics, String nameWithSuffix) {
+        metrics.add(new Metric(nameWithSuffix));
+    }
+
+    private static void addMetric(Set<Metric> metrics, VespaMetrics metric, EnumSet<Suffix> suffixes) {
+        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
     }
 
     private DefaultMetrics() { }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/monitoring/VespaMetricSet.java
@@ -13,6 +13,7 @@ import com.yahoo.metrics.SlobrokMetrics;
 import com.yahoo.metrics.StorageMetrics;
 import com.yahoo.metrics.NodeAdminMetrics;
 import com.yahoo.metrics.Suffix;
+import com.yahoo.metrics.VespaMetrics;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -84,7 +85,7 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.JRT_TRANSPORT_SERVER_TLS_CONNECIONTS_ESTABLISHED.baseName());
         addMetric(metrics, ContainerMetrics.JRT_TRANSPORT_CLIENT_TLS_CONNECTIONS_ESTABLISHED.baseName());
         addMetric(metrics, ContainerMetrics.JRT_TRANSPORT_SERVER_UNENCRYPTED_CONNECTIONS_ESTABLISHED.baseName());
-        addMetric(metrics, ContainerMetrics. JRT_TRANSPORT_CLIENT_UNENCRYPTED_CONNECTIONS_ESTABLISHED. baseName());
+        addMetric(metrics, ContainerMetrics.JRT_TRANSPORT_CLIENT_UNENCRYPTED_CONNECTIONS_ESTABLISHED.baseName());
 
         // C++ TLS metrics
         addMetric(metrics, StorageMetrics.VDS_SERVER_NETWORK_TLS_HANDSHAKES_FAILED.count());
@@ -113,7 +114,7 @@ public class VespaMetricSet {
     }
 
     private static Set<Metric> getConfigServerMetrics() {
-        Set<Metric> metrics =new LinkedHashSet<>();
+        Set<Metric> metrics = new LinkedHashSet<>();
 
         addMetric(metrics, ConfigServerMetrics.REQUESTS.count());
         addMetric(metrics, ConfigServerMetrics.FAILED_REQUESTS.count());
@@ -140,9 +141,9 @@ public class VespaMetricSet {
 
         addMetric(metrics, ContainerMetrics.HANDLED_REQUESTS.count());
         addMetric(metrics, ContainerMetrics.HANDLED_LATENCY, EnumSet.of(sum, count, max));
-        
-        addMetric(metrics, ContainerMetrics.SERVER_NUM_OPEN_CONNECTIONS, EnumSet.of(max,last, average));
-        addMetric(metrics, ContainerMetrics.SERVER_NUM_CONNECTIONS, EnumSet.of(max,last, average));
+
+        addMetric(metrics, ContainerMetrics.SERVER_NUM_OPEN_CONNECTIONS, EnumSet.of(max, last, average));
+        addMetric(metrics, ContainerMetrics.SERVER_NUM_CONNECTIONS, EnumSet.of(max, last, average));
 
         addMetric(metrics, ContainerMetrics.SERVER_BYTES_RECEIVED, EnumSet.of(sum, count));
         addMetric(metrics, ContainerMetrics.SERVER_BYTES_SENT, EnumSet.of(sum, count));
@@ -187,7 +188,7 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.MEM_NATIVE_TOTAL.average());
         addMetric(metrics, ContainerMetrics.MEM_NATIVE_FREE.average());
         addMetric(metrics, ContainerMetrics.MEM_NATIVE_USED.average());
-                
+
         addMetric(metrics, ContainerMetrics.JDISC_MEMORY_MAPPINGS.max());
         addMetric(metrics, ContainerMetrics.JDISC_OPEN_FILE_DESCRIPTORS.max());
 
@@ -240,7 +241,7 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.JDISC_APPLICATION_FAILED_COMPONENT_GRAPHS.rate());
 
         addMetric(metrics, ContainerMetrics.JDISC_JVM.last());
-        
+
         // Deprecated metrics. TODO: Remove on Vespa 9.
         addMetric(metrics, ContainerMetrics.SERVER_REJECTED_REQUESTS, EnumSet.of(rate, count));             // TODO: Remove on Vespa 9. Use jdisc.thread_pool.rejected_tasks.
         addMetric(metrics, ContainerMetrics.SERVER_THREAD_POOL_SIZE, EnumSet.of(max, last));                // TODO: Remove on Vespa 9. Use jdisc.thread_pool.rejected_tasks.
@@ -264,7 +265,7 @@ public class VespaMetricSet {
         addMetric(metrics, ClusterControllerMetrics.CLUSTER_STATE_CHANGE_COUNT.baseName());
         addMetric(metrics, ClusterControllerMetrics.BUSY_TICK_TIME_MS, EnumSet.of(last, max, sum, count));
         addMetric(metrics, ClusterControllerMetrics.IDLE_TICK_TIME_MS, EnumSet.of(last, max, sum, count));
-        
+
         addMetric(metrics, ClusterControllerMetrics.WORK_MS, EnumSet.of(last, sum, count));
 
         addMetric(metrics, ClusterControllerMetrics.IS_MASTER.last());
@@ -278,7 +279,7 @@ public class VespaMetricSet {
         addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_MEMORY_LIMIT.last());
         addMetric(metrics, ClusterControllerMetrics.RESOURCE_USAGE_DISK_LIMIT.last());
         addMetric(metrics, ClusterControllerMetrics.REINDEXING_PROGRESS.last());
-        
+
         return metrics;
     }
 
@@ -321,7 +322,7 @@ public class VespaMetricSet {
         addMetric(metrics, ContainerMetrics.RELEVANCE_AT_1, EnumSet.of(sum, count));
         addMetric(metrics, ContainerMetrics.RELEVANCE_AT_3, EnumSet.of(sum, count));
         addMetric(metrics, ContainerMetrics.RELEVANCE_AT_10, EnumSet.of(sum, count));
-                
+
         // Errors from search container
         addMetric(metrics, ContainerMetrics.ERROR_TIMEOUT.rate());
         addMetric(metrics, ContainerMetrics.ERROR_BACKENDS_OOS.rate());
@@ -419,7 +420,7 @@ public class VespaMetricSet {
         addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_THREADING_SERVICE_SUMMARY_ACCEPTED.rate());
         addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_THREADING_SERVICE_SUMMARY_WAKEUPS.rate());
         addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_THREADING_SERVICE_SUMMARY_UTILIZATION, EnumSet.of(max, sum, count));
-        
+
         // lid space
         addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_READY_LID_SPACE_LID_BLOAT_FACTOR.average());
         addMetric(metrics, SearchNodeMetrics.CONTENT_PROTON_DOCUMENTDB_READY_LID_SPACE_LID_FRAGMENTATION_FACTOR.average());
@@ -616,6 +617,7 @@ public class VespaMetricSet {
 
         return metrics;
     }
+
     private static Set<Metric> getDistributorMetrics() {
         Set<Metric> metrics = new LinkedHashSet<>();
         addMetric(metrics, DistributorMetrics.VDS_IDEALSTATE_BUCKETS_RECHECKING.average());
@@ -709,37 +711,10 @@ public class VespaMetricSet {
         metrics.add(new Metric(nameWithSuffix));
     }
 
-    private static void addMetric(Set<Metric> metrics, ClusterControllerMetrics metric, EnumSet<Suffix> suffixes) {
+    private static void addMetric(Set<Metric> metrics, VespaMetrics metric, EnumSet<Suffix> suffixes) {
         suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
     }
 
-    private static void addMetric(Set<Metric> metrics, ContainerMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-
-    private static void addMetric(Set<Metric> metrics, SearchNodeMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-
-    private static void addMetric(Set<Metric> metrics, StorageMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-
-    private static void addMetric(Set<Metric> metrics, DistributorMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-    private static void addMetric(Set<Metric> metrics, SentinelMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-    private static void addMetric(Set<Metric> metrics, SlobrokMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-    private static void addMetric(Set<Metric> metrics, LogdMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
-    private static void addMetric(Set<Metric> metrics, ConfigServerMetrics metric, EnumSet<Suffix> suffixes) {
-        suffixes.forEach(suffix -> metrics.add(new Metric(metric.baseName() + "." + suffix.suffix())));
-    }
     private static void addMetric(Set<Metric> metrics, String metricName, Iterable<String> aggregateSuffices) {
         for (String suffix : aggregateSuffices) {
             metrics.add(new Metric(metricName + "." + suffix));

--- a/container-core/src/main/java/com/yahoo/metrics/VespaMetrics.java
+++ b/container-core/src/main/java/com/yahoo/metrics/VespaMetrics.java
@@ -3,7 +3,7 @@ package com.yahoo.metrics;
 /**
  * @author gjoranv
  */
-interface VespaMetrics {
+public interface VespaMetrics {
 
     String baseName();
     Unit unit();


### PR DESCRIPTION
Reference documentation generation will be easier when `VespaMetricSet.java` and `DefaultMetrics.java` are more alike
