### PR TITLE
libstdc++ 11 lacks stream operators for duration. Use same workaround

### DIFF
--- a/vespalib/src/vespa/vespalib/util/time.cpp
+++ b/vespalib/src/vespa/vespalib/util/time.cpp
@@ -93,9 +93,10 @@ Timer::waitAtLeast(duration dur, bool busyWait) {
 
 }
 
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+#if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000) || (!defined(_LIBCPP_VERSION) && defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12)
 
 // Temporary workaround until libc++ supports stream operators for duration
+// Temporary workaround while using libstdc++ 11
 
 #include <ostream>
 

--- a/vespalib/src/vespa/vespalib/util/time.h
+++ b/vespalib/src/vespa/vespalib/util/time.h
@@ -101,9 +101,10 @@ duration adjustTimeoutByHz(duration timeout, long hz);
 
 }
 
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000
+#if (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 160000) || (!defined(_LIBCPP_VERSION) && defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE < 12)
 
 // Temporary workaround until libc++ supports stream operators for duration
+// Temporary workaround while using libstdc++ 11
 
 #include <iosfwd>
 


### PR DESCRIPTION
as for old libc++ versions.

@baldersheim : please review
