### PR TITLE
proton metrics -> searchnode metrics

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/ApplicationRepository.java
@@ -69,9 +69,9 @@ import com.yahoo.vespa.config.server.http.SimpleHttpFetcher;
 import com.yahoo.vespa.config.server.http.TesterClient;
 import com.yahoo.vespa.config.server.http.v2.PrepareResult;
 import com.yahoo.vespa.config.server.http.v2.response.DeploymentMetricsResponse;
-import com.yahoo.vespa.config.server.http.v2.response.ProtonMetricsResponse;
+import com.yahoo.vespa.config.server.http.v2.response.SearchNodeMetricsResponse;
 import com.yahoo.vespa.config.server.metrics.DeploymentMetricsRetriever;
-import com.yahoo.vespa.config.server.metrics.ProtonMetricsRetriever;
+import com.yahoo.vespa.config.server.metrics.SearchNodeMetricsRetriever;
 import com.yahoo.vespa.config.server.provision.HostProvisionerProvider;
 import com.yahoo.vespa.config.server.session.LocalSession;
 import com.yahoo.vespa.config.server.session.PrepareParams;
@@ -943,14 +943,13 @@ public class ApplicationRepository implements com.yahoo.config.provision.Deploye
         return tenantRepository.getTenant(tenantName).getApplicationRepo().activeApplications();
     }
 
-    // ---------------- Proton Metrics V1 ------------------------------------------------------------------------
+    // ---------------- SearchNode Metrics ------------------------------------------------------------------------
 
-    public ProtonMetricsResponse getProtonMetrics(ApplicationId applicationId) {
+    public SearchNodeMetricsResponse getProtonMetrics(ApplicationId applicationId) {
         Application application = getApplication(applicationId);
-        ProtonMetricsRetriever protonMetricsRetriever = new ProtonMetricsRetriever();
-        return protonMetricsRetriever.getMetrics(application);
+        SearchNodeMetricsRetriever searchNodeMetricsRetriever = new SearchNodeMetricsRetriever();
+        return searchNodeMetricsRetriever.getMetrics(application);
     }
-
 
     // ---------------- Deployment Metrics V1 ------------------------------------------------------------------------
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SearchNodeMetricsResponse.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/response/SearchNodeMetricsResponse.java
@@ -4,15 +4,15 @@ package com.yahoo.vespa.config.server.http.v2.response;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
-import com.yahoo.vespa.config.server.metrics.ProtonMetricsAggregator;
+import com.yahoo.vespa.config.server.metrics.SearchNodeMetricsAggregator;
 import java.util.Map;
 
 /**
  * @author akvalsvik
  */
-public class ProtonMetricsResponse extends SlimeJsonResponse {
+public class SearchNodeMetricsResponse extends SlimeJsonResponse {
 
-    public ProtonMetricsResponse(ApplicationId applicationId, Map<String, ProtonMetricsAggregator> aggregatedProtonMetrics) {
+    public SearchNodeMetricsResponse(ApplicationId applicationId, Map<String, SearchNodeMetricsAggregator> aggregatedProtonMetrics) {
         Cursor application = slime.setObject();
         application.setString("applicationId", applicationId.serializedForm());
 
@@ -22,7 +22,7 @@ public class ProtonMetricsResponse extends SlimeJsonResponse {
             Cursor cluster = clusters.addObject();
             cluster.setString("clusterId", entry.getKey());
 
-            ProtonMetricsAggregator aggregator = entry.getValue();
+            SearchNodeMetricsAggregator aggregator = entry.getValue();
             Cursor metrics = cluster.setObject("metrics");
             metrics.setDouble("documentsActiveCount", aggregator.aggregateDocumentActiveCount());
             metrics.setDouble("documentsReadyCount", aggregator.aggregateDocumentReadyCount());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintainer.java
@@ -13,15 +13,12 @@ import com.yahoo.vespa.curator.Curator;
 import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.vespa.flags.ListFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
-
 import java.time.Clock;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * A maintainer is some job which runs at a fixed interval to perform some maintenance task in the config server.

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterInfo.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterInfo.java
@@ -32,8 +32,7 @@ public class ClusterInfo {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof ClusterInfo)) return false;
-        ClusterInfo other = (ClusterInfo) o;
+        if (!(o instanceof ClusterInfo other)) return false;
         return clusterId.equals(other.clusterId) && clusterType.equals(other.clusterType);
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterProtonMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/ClusterProtonMetricsRetriever.java
@@ -34,8 +34,8 @@ public class ClusterProtonMetricsRetriever {
             .build();
 
 
-    public Map<String, ProtonMetricsAggregator> requestMetricsGroupedByCluster(Collection<URI> hosts) {
-        Map<String, ProtonMetricsAggregator> clusterMetricsMap = new ConcurrentHashMap<>();
+    public Map<String, SearchNodeMetricsAggregator> requestMetricsGroupedByCluster(Collection<URI> hosts) {
+        Map<String, SearchNodeMetricsAggregator> clusterMetricsMap = new ConcurrentHashMap<>();
         for (URI uri : hosts) {
             addMetricsFromHost(uri, clusterMetricsMap);
         }
@@ -62,7 +62,7 @@ public class ClusterProtonMetricsRetriever {
         return clusterMetricsMap;
     }
 
-    private static void addMetricsFromHost(URI hostURI, Map<String, ProtonMetricsAggregator> clusterMetricsMap) {
+    private static void addMetricsFromHost(URI hostURI, Map<String, SearchNodeMetricsAggregator> clusterMetricsMap) {
         Slime hostResponseBody = doMetricsRequest(hostURI);
         Cursor error = hostResponseBody.get().field("error_message");
 
@@ -76,10 +76,10 @@ public class ClusterProtonMetricsRetriever {
         );
     }
 
-    private static void parseNode(Inspector node, Map<String, ProtonMetricsAggregator> clusterMetricsMap) {
+    private static void parseNode(Inspector node, Map<String, SearchNodeMetricsAggregator> clusterMetricsMap) {
         String nodeRole = node.field("role").asString();
         if(nodeRole.contains("content")) {
-            ProtonMetricsAggregator aggregator = new ProtonMetricsAggregator();
+            SearchNodeMetricsAggregator aggregator = new SearchNodeMetricsAggregator();
             clusterMetricsMap.put(nodeRole, aggregator);
             node.field("services").traverse((ArrayTraverser) (i, servicesInspector) ->
                     addServicesToAggregator(servicesInspector, aggregator)
@@ -87,13 +87,13 @@ public class ClusterProtonMetricsRetriever {
         }
     }
 
-    private static void addServicesToAggregator(Inspector services, ProtonMetricsAggregator aggregator) {
+    private static void addServicesToAggregator(Inspector services, SearchNodeMetricsAggregator aggregator) {
         services.field("metrics").traverse((ArrayTraverser) (i, metricsInspector) ->
                 addMetricsToAggregator(metricsInspector, aggregator)
         );
     }
 
-    private static void addMetricsToAggregator(Inspector metrics, ProtonMetricsAggregator aggregator) {
+    private static void addMetricsToAggregator(Inspector metrics, SearchNodeMetricsAggregator aggregator) {
         aggregator.addAll(metrics.field("values"));
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/DeploymentMetricsRetriever.java
@@ -5,11 +5,9 @@ import com.yahoo.config.model.api.HostInfo;
 import com.yahoo.config.model.api.ServiceInfo;
 import com.yahoo.vespa.config.server.application.Application;
 import com.yahoo.vespa.config.server.http.v2.response.DeploymentMetricsResponse;
-
 import java.net.URI;
 import java.util.Collection;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Finds all hosts we want to fetch metrics for, generates the appropriate URIs

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/SearchNodeMetricsAggregator.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/metrics/SearchNodeMetricsAggregator.java
@@ -3,7 +3,7 @@ package com.yahoo.vespa.config.server.metrics;
 
 import com.yahoo.slime.Inspector;
 
-public class ProtonMetricsAggregator {
+public class SearchNodeMetricsAggregator {
 
     private static final String DOCUMENT_ACTIVE = "content.proton.documentdb.documents.active.last";
     private static final String DOCUMENT_READY = "content.proton.documentdb.documents.ready.last";
@@ -20,7 +20,7 @@ public class ProtonMetricsAggregator {
     private final AverageMetric resourceDiskUsageAverage = new AverageMetric();
     private final AverageMetric resourceMemoryUsageAverage = new AverageMetric();
 
-    public synchronized ProtonMetricsAggregator addAll(Inspector metric) {
+    public synchronized SearchNodeMetricsAggregator addAll(Inspector metric) {
         if (metric.field(DOCUMENT_ACTIVE).valid()) addDocumentActiveCount(metric.field(DOCUMENT_ACTIVE).asDouble());
         if (metric.field(DOCUMENT_READY).valid()) addDocumentReadyCount(metric.field(DOCUMENT_READY).asDouble());
         if (metric.field(DOCUMENT_TOTAL).valid()) addDocumentTotalCount(metric.field(DOCUMENT_TOTAL).asDouble());
@@ -30,7 +30,7 @@ public class ProtonMetricsAggregator {
         return this;
     }
 
-    public ProtonMetricsAggregator addAll(ProtonMetricsAggregator aggregator) {
+    public SearchNodeMetricsAggregator addAll(SearchNodeMetricsAggregator aggregator) {
         this.documentActiveCount += aggregator.aggregateDocumentActiveCount();
         this.documentReadyCount += aggregator.aggregateDocumentReadyCount();
         this.documentTotalCount += aggregator.aggregateDocumentTotalCount();
@@ -40,45 +40,45 @@ public class ProtonMetricsAggregator {
         return this;
     }
 
-    public ProtonMetricsAggregator addResourceDiskUsageAverage(ProtonMetricsAggregator aggregator) {
+    public SearchNodeMetricsAggregator addResourceDiskUsageAverage(SearchNodeMetricsAggregator aggregator) {
         this.resourceDiskUsageAverage.averageCount += aggregator.resourceDiskUsageAverage.averageCount;
         this.resourceDiskUsageAverage.averageSum += aggregator.resourceDiskUsageAverage.averageSum;
         return this;
     }
 
-    public ProtonMetricsAggregator addResourceMemoryUsageAverage(ProtonMetricsAggregator aggregator) {
+    public SearchNodeMetricsAggregator addResourceMemoryUsageAverage(SearchNodeMetricsAggregator aggregator) {
         this.resourceMemoryUsageAverage.averageCount += aggregator.resourceMemoryUsageAverage.averageCount;
         this.resourceMemoryUsageAverage.averageSum += aggregator.resourceMemoryUsageAverage.averageSum;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addDocumentActiveCount(double documentActiveCount) {
+    public synchronized SearchNodeMetricsAggregator addDocumentActiveCount(double documentActiveCount) {
         this.documentActiveCount += documentActiveCount;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addDocumentReadyCount(double documentReadyCount) {
+    public synchronized SearchNodeMetricsAggregator addDocumentReadyCount(double documentReadyCount) {
         this.documentReadyCount += documentReadyCount;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addDocumentTotalCount(double documentTotalCount) {
+    public synchronized SearchNodeMetricsAggregator addDocumentTotalCount(double documentTotalCount) {
         this.documentTotalCount += documentTotalCount;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addDocumentDiskUsage(double documentDiskUsage) {
+    public synchronized SearchNodeMetricsAggregator addDocumentDiskUsage(double documentDiskUsage) {
         this.documentDiskUsage += documentDiskUsage;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addResourceDiskUsageAverage(double resourceDiskUsageAverage) {
+    public synchronized SearchNodeMetricsAggregator addResourceDiskUsageAverage(double resourceDiskUsageAverage) {
         this.resourceDiskUsageAverage.averageCount++;
         this.resourceDiskUsageAverage.averageSum += resourceDiskUsageAverage;
         return this;
     }
 
-    public synchronized ProtonMetricsAggregator addResourceMemoryUsageAverage(double resourceMemoryUsageAverage) {
+    public synchronized SearchNodeMetricsAggregator addResourceMemoryUsageAverage(double resourceMemoryUsageAverage) {
         this.resourceMemoryUsageAverage.averageCount++;
         this.resourceMemoryUsageAverage.averageSum += resourceMemoryUsageAverage;
         return this;

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/ClusterSearchNodeMetricsRetrieverTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/ClusterSearchNodeMetricsRetrieverTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,7 +19,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static org.junit.Assert.assertEquals;
 
-public class ClusterProtonMetricsRetrieverTest {
+public class ClusterSearchNodeMetricsRetrieverTest {
 
     @Rule
     public final WireMockRule wireMock = new WireMockRule(options().dynamicPort(), true);
@@ -44,10 +43,10 @@ public class ClusterProtonMetricsRetrieverTest {
 
         String expectedClusterNameContent = "content/content/0/0";
         String expectedClusterNameMusic = "content/music/0/0";
-        Map<String, ProtonMetricsAggregator> aggregatorMap = new ClusterProtonMetricsRetriever().requestMetricsGroupedByCluster(hosts);
+        Map<String, SearchNodeMetricsAggregator> aggregatorMap = new ClusterProtonMetricsRetriever().requestMetricsGroupedByCluster(hosts);
 
         compareAggregators(
-                new ProtonMetricsAggregator()
+                new SearchNodeMetricsAggregator()
                 .addDocumentReadyCount(1275)
                 .addDocumentActiveCount(1275)
                 .addDocumentTotalCount(1275)
@@ -58,7 +57,7 @@ public class ClusterProtonMetricsRetrieverTest {
         );
 
         compareAggregators(
-                new ProtonMetricsAggregator()
+                new SearchNodeMetricsAggregator()
                 .addDocumentReadyCount(3008)
                 .addDocumentActiveCount(3008)
                 .addDocumentTotalCount(3008)
@@ -78,7 +77,7 @@ public class ClusterProtonMetricsRetrieverTest {
     // Same tolerance value as used internally in MetricsAggregator.isZero
     private static final double metricsTolerance = 0.001;
 
-    private void compareAggregators(ProtonMetricsAggregator expected, ProtonMetricsAggregator actual) {
+    private void compareAggregators(SearchNodeMetricsAggregator expected, SearchNodeMetricsAggregator actual) {
         assertEquals(expected.aggregateDocumentDiskUsage(), actual.aggregateDocumentDiskUsage(), metricsTolerance);
     }
 

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/SearchNodeMetricsRetrieverTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/metrics/SearchNodeMetricsRetrieverTest.java
@@ -23,16 +23,16 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
-public class ProtonMetricsRetrieverTest {
+public class SearchNodeMetricsRetrieverTest {
 
     @Test
     public void getMetrics()  {
-        ProtonMetricsRetrieverTest.MockModel mockModel = new MockModel(mockHosts());
-        ProtonMetricsRetrieverTest.MockProtonMetricsRetriever mockMetricsRetriever = new MockProtonMetricsRetriever();
+        SearchNodeMetricsRetrieverTest.MockModel mockModel = new MockModel(mockHosts());
+        SearchNodeMetricsRetrieverTest.MockProtonMetricsRetriever mockMetricsRetriever = new MockProtonMetricsRetriever();
         Application application = new Application(mockModel, null, 0,
                                                   null, null, ApplicationId.fromSerializedForm("tenant:app:instance"));
 
-        ProtonMetricsRetriever clusterMetricsRetriever = new ProtonMetricsRetriever(mockMetricsRetriever);
+        SearchNodeMetricsRetriever clusterMetricsRetriever = new SearchNodeMetricsRetriever(mockMetricsRetriever);
         clusterMetricsRetriever.getMetrics(application);
 
         assertEquals(1, mockMetricsRetriever.hosts.size()); // Verify that logserver was ignored
@@ -58,12 +58,12 @@ public class ProtonMetricsRetrieverTest {
         Collection<URI> hosts = new ArrayList<>();
 
         @Override
-        public Map<String, ProtonMetricsAggregator> requestMetricsGroupedByCluster(Collection<URI> hosts) {
+        public Map<String, SearchNodeMetricsAggregator> requestMetricsGroupedByCluster(Collection<URI> hosts) {
             this.hosts = hosts;
 
             return Map.of(
                     ("content_cluster_id"),
-                    new ProtonMetricsAggregator()
+                    new SearchNodeMetricsAggregator()
             );
         }
     }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/application/v4/model/SearchNodeMetrics.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/application/v4/model/SearchNodeMetrics.java
@@ -10,11 +10,11 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class ProtonMetrics {
+public class SearchNodeMetrics {
 
     private static final ObjectMapper jsonMapper = new ObjectMapper();
 
-    private static final Logger logger = Logger.getLogger(ProtonMetrics.class.getName());
+    private static final Logger logger = Logger.getLogger(SearchNodeMetrics.class.getName());
 
     public static final String DOCUMENTS_ACTIVE_COUNT = "documentsActiveCount";
     public static final String DOCUMENTS_READY_COUNT = "documentsReadyCount";
@@ -26,7 +26,7 @@ public class ProtonMetrics {
     private final String clusterId;
     private final Map<String, Double> metrics;
 
-    public ProtonMetrics(String clusterId) {
+    public SearchNodeMetrics(String clusterId) {
         this.clusterId = clusterId;
         metrics = new HashMap<>();
     }
@@ -45,7 +45,7 @@ public class ProtonMetrics {
 
     public double resourceMemoryUsageAverage() { return metrics.get(RESOURCE_MEMORY_USAGE_AVERAGE); }
 
-    public ProtonMetrics addMetric(String name, double value) {
+    public SearchNodeMetrics addMetric(String name, double value) {
         metrics.put(name, value);
         return this;
     }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/ConfigServer.java
@@ -13,7 +13,7 @@ import com.yahoo.vespa.flags.json.FlagData;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.ClusterMetrics;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.DeploymentData;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.EndpointStatus;
-import com.yahoo.vespa.hosted.controller.api.application.v4.model.ProtonMetrics;
+import com.yahoo.vespa.hosted.controller.api.application.v4.model.SearchNodeMetrics;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.LogEntry;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.TestReport;
@@ -71,7 +71,7 @@ public interface ConfigServer {
 
     /**
      * Gets the contents of a file inside the current application package for a given deployment. If the path is to
-     * a directly, a JSON list with URLs to contents is returned.
+     * a directory, a JSON list with URLs to contents is returned.
      *
      * @param deployment deployment to get application package content for
      * @param path path within package to get
@@ -81,7 +81,7 @@ public interface ConfigServer {
 
     List<ClusterMetrics> getDeploymentMetrics(DeploymentId deployment);
 
-    List<ProtonMetrics> getProtonMetrics(DeploymentId deployment);
+    List<SearchNodeMetrics> getSearchNodeMetrics(DeploymentId deployment);
 
     List<String> getContentClusters(DeploymentId deployment);
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/ConfigServerMock.java
@@ -6,7 +6,6 @@ import ai.vespa.http.HttpURL.Path;
 import ai.vespa.http.HttpURL.Query;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.Version;
-import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterResources;
@@ -22,12 +21,11 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.ZoneEndpoint.AllowedUrn;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
 import com.yahoo.config.provision.zone.ZoneId;
-import com.yahoo.rdl.UUID;
 import com.yahoo.vespa.flags.json.FlagData;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.ClusterMetrics;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.DeploymentData;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.EndpointStatus;
-import com.yahoo.vespa.hosted.controller.api.application.v4.model.ProtonMetrics;
+import com.yahoo.vespa.hosted.controller.api.application.v4.model.SearchNodeMetrics;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.integration.LogEntry;
 import com.yahoo.vespa.hosted.controller.api.integration.configserver.ApplicationReindexing;
@@ -70,7 +68,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -106,7 +103,7 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     private final Map<DeploymentId, TestReport> testReport = new HashMap<>();
     private final Map<DeploymentId, CloudAccount> cloudAccounts = new HashMap<>();
     private final Map<DeploymentId, List<X509Certificate>> additionalCertificates = new HashMap<>();
-    private List<ProtonMetrics> protonMetrics;
+    private List<SearchNodeMetrics> searchnodeMetrics;
 
     private Version lastPrepareVersion = null;
     private Consumer<ApplicationId> prepareException = null;
@@ -310,8 +307,8 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
         this.clusterMetrics.put(deployment, clusterMetrics);
     }
 
-    public void setProtonMetrics(List<ProtonMetrics> protonMetrics) {
-        this.protonMetrics = protonMetrics;
+    public void setProtonMetrics(List<SearchNodeMetrics> searchnodeMetrics) {
+        this.searchnodeMetrics = searchnodeMetrics;
     }
 
     public void deferLoadBalancerProvisioningIn(Set<Environment> environments) {
@@ -511,8 +508,8 @@ public class ConfigServerMock extends AbstractComponent implements ConfigServer 
     }
 
     @Override
-    public List<ProtonMetrics> getProtonMetrics(DeploymentId deployment) {
-        return this.protonMetrics;
+    public List<SearchNodeMetrics> getSearchNodeMetrics(DeploymentId deployment) {
+        return this.searchnodeMetrics;
     }
 
     @Override

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -31,7 +31,7 @@ import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.LockedTenant;
 import com.yahoo.vespa.hosted.controller.api.application.v4.EnvironmentResource;
-import com.yahoo.vespa.hosted.controller.api.application.v4.model.ProtonMetrics;
+import com.yahoo.vespa.hosted.controller.api.application.v4.model.SearchNodeMetrics;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
 import com.yahoo.vespa.hosted.controller.api.identifiers.Property;
 import com.yahoo.vespa.hosted.controller.api.identifiers.PropertyId;
@@ -1860,20 +1860,20 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
     private void updateMetrics() {
         tester.serviceRegistry().configServerMock().setProtonMetrics(List.of(
-                (new ProtonMetrics("content/doc/"))
-                        .addMetric(ProtonMetrics.DOCUMENTS_ACTIVE_COUNT, 11430)
-                        .addMetric(ProtonMetrics.DOCUMENTS_READY_COUNT, 11430)
-                        .addMetric(ProtonMetrics.DOCUMENTS_TOTAL_COUNT, 11430)
-                        .addMetric(ProtonMetrics.DOCUMENT_DISK_USAGE, 44021)
-                        .addMetric(ProtonMetrics.RESOURCE_DISK_USAGE_AVERAGE, 0.0168421)
-                        .addMetric(ProtonMetrics.RESOURCE_MEMORY_USAGE_AVERAGE, 0.103482),
-                (new ProtonMetrics("content/music/"))
-                        .addMetric(ProtonMetrics.DOCUMENTS_ACTIVE_COUNT, 32210)
-                        .addMetric(ProtonMetrics.DOCUMENTS_READY_COUNT, 32000)
-                        .addMetric(ProtonMetrics.DOCUMENTS_TOTAL_COUNT, 32210)
-                        .addMetric(ProtonMetrics.DOCUMENT_DISK_USAGE, 90113)
-                        .addMetric(ProtonMetrics.RESOURCE_DISK_USAGE_AVERAGE, 0.23912)
-                        .addMetric(ProtonMetrics.RESOURCE_MEMORY_USAGE_AVERAGE, 0.00912)
+                (new SearchNodeMetrics("content/doc/"))
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_ACTIVE_COUNT, 11430)
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_READY_COUNT, 11430)
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_TOTAL_COUNT, 11430)
+                        .addMetric(SearchNodeMetrics.DOCUMENT_DISK_USAGE, 44021)
+                        .addMetric(SearchNodeMetrics.RESOURCE_DISK_USAGE_AVERAGE, 0.0168421)
+                        .addMetric(SearchNodeMetrics.RESOURCE_MEMORY_USAGE_AVERAGE, 0.103482),
+                (new SearchNodeMetrics("content/music/"))
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_ACTIVE_COUNT, 32210)
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_READY_COUNT, 32000)
+                        .addMetric(SearchNodeMetrics.DOCUMENTS_TOTAL_COUNT, 32210)
+                        .addMetric(SearchNodeMetrics.DOCUMENT_DISK_USAGE, 90113)
+                        .addMetric(SearchNodeMetrics.RESOURCE_DISK_USAGE_AVERAGE, 0.23912)
+                        .addMetric(SearchNodeMetrics.RESOURCE_MEMORY_USAGE_AVERAGE, 0.00912)
         ));
     }
 


### PR DESCRIPTION
Use name of service and add API that does not use the generic /metrics path for searchnode metrics
