### PR TITLE
Add utility wrapper around RE2 possible regex prefix match range

### DIFF
--- a/vespalib/src/tests/regex/regex.cpp
+++ b/vespalib/src/tests/regex/regex.cpp
@@ -174,6 +174,11 @@ TEST("Can extract min/max prefix range from anchored regex") {
     min_max = Regex::from_pattern("^(hello|world)+").possible_anchored_match_prefix_range();
     EXPECT_EQUAL(min_max.first,  "hello");
     EXPECT_EQUAL(min_max.second, "worldwp");
+
+    // Bad regex; no range
+    min_max = Regex::from_pattern("*hello").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "");
+    EXPECT_EQUAL(min_max.second, "");
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/tests/regex/regex.cpp
+++ b/vespalib/src/tests/regex/regex.cpp
@@ -150,4 +150,30 @@ TEST("Test that default constructed regex is invalid.") {
     ASSERT_FALSE(dummy.valid());
 }
 
+TEST("Can extract min/max prefix range from anchored regex") {
+    auto min_max = Regex::from_pattern("^.*").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "");
+    EXPECT_EQUAL(min_max.second, "\xf4\x8f\xbf\xc0"); // Highest possible Unicode char (U+10FFFF) as UTF-8, plus 1
+
+    min_max = Regex::from_pattern("^hello").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "hello");
+
+    min_max = Regex::from_pattern("^hello|^world").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "world");
+
+    min_max = Regex::from_pattern("(^hello|^world|^zoidberg)").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "zoidberg");
+
+    min_max = Regex::from_pattern("^hello (foo|bar|zoo)").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello bar");
+    EXPECT_EQUAL(min_max.second, "hello zoo");
+
+    min_max = Regex::from_pattern("^(hello|world)+").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "worldwp");
+}
+
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/regex/regex.cpp
+++ b/vespalib/src/vespa/vespalib/regex/regex.cpp
@@ -49,6 +49,16 @@ public:
         }
         return RE2::FullMatch(StringPiece(input.data(), input.size()), _regex);
     }
+
+    std::pair<std::string, std::string> possible_anchored_match_prefix_range() const {
+        constexpr int max_len = 128; // TODO determine a "reasonable" value. RE2 docs are not clear on this.
+        std::string min_prefix, max_prefix;
+
+        if (!_regex.PossibleMatchRange(&min_prefix, &max_prefix, max_len)) {
+            return {};
+        }
+        return {std::move(min_prefix), std::move(max_prefix)};
+    }
 };
 
 Regex Regex::from_pattern(std::string_view pattern, uint32_t opt_mask) {
@@ -74,6 +84,10 @@ bool Regex::partial_match(std::string_view input) const noexcept {
 
 bool Regex::full_match(std::string_view input) const noexcept {
     return _impl->full_match(input);
+}
+
+std::pair<std::string, std::string> Regex::possible_anchored_match_prefix_range() const {
+    return _impl->possible_anchored_match_prefix_range();
 }
 
 bool Regex::partial_match(std::string_view input, std::string_view pattern) noexcept {


### PR DESCRIPTION
@geirst please review

For a strictly _start-anchored_ regex, this provides a lower/upper bound pair that constrains the possible prefix range that may contain a string matching the regex.
