### PR TITLE
Limit use of [[maybe_unused]] attribute when using gcc 11.

### DIFF
--- a/fnet/src/tests/frt/method_pt/method_pt.cpp
+++ b/fnet/src/tests/frt/method_pt/method_pt.cpp
@@ -52,7 +52,11 @@ public:
 
 //-------------------------------------------------------------
 
+#if defined(__clang__) || __GNUC__ >= 12
 #define UNUSED_MEMBER [[maybe_unused]]
+#else
+#define UNUSED_MEMBER
+#endif
 
 class ComplexA
 {

--- a/vespamalloc/src/vespamalloc/malloc/overload.h
+++ b/vespamalloc/src/vespamalloc/malloc/overload.h
@@ -15,7 +15,10 @@ public:
         vespamalloc::createAllocator();
     }
 private:
-    [[maybe_unused]] unsigned _initialized;
+#if defined(__clang__) || __GNUC__ >= 12
+    [[maybe_unused]]
+#endif
+    unsigned _initialized;
 };
 
 static CreateAllocator _CreateAllocator __attribute__ ((init_priority (543)));


### PR DESCRIPTION
@baldersheim : please review
