### PR TITLE
Limit use of [[maybe_unused]] attribute when using gcc 11.

### DIFF
--- a/fnet/src/tests/frt/method_pt/method_pt.cpp
+++ b/fnet/src/tests/frt/method_pt/method_pt.cpp
@@ -52,7 +52,11 @@ public:
 
 //-------------------------------------------------------------
 
+#if defined(__clang__) || __GNUC__ >= 12
 #define UNUSED_MEMBER [[maybe_unused]]
+#else
+#define UNUSED_MEMBER
+#endif
 
 class ComplexA
 {


### PR DESCRIPTION
@baldersheim : please review

This is the first part of #26495
