### PR TITLE
Reduce log level for some loggers

### DIFF
--- a/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
@@ -2,6 +2,7 @@
 package com.yahoo.log;
 
 import java.io.UnsupportedEncodingException;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.StreamHandler;
@@ -47,10 +48,10 @@ class VespaLogHandler extends StreamHandler {
      */
     @Override
     public synchronized void publish(LogRecord record) {
-        Level level = record.getLevel();
-        String component = record.getLoggerName();
+        String loggerName = record.getLoggerName();
+        Level level = possiblyReduceLogLevel(loggerName, record.getLevel());
 
-        LevelController ctrl = getLevelControl(component);
+        LevelController ctrl = getLevelControl(loggerName);
         if (!ctrl.shouldLog(level)) {
             return;
         }
@@ -73,12 +74,28 @@ class VespaLogHandler extends StreamHandler {
         closeFileTarget();
     }
 
+    // Reduce log level from info level to fine level for some loggers
+    private Level possiblyReduceLogLevel(String loggerName, Level level) {
+        if (loggerName == null)
+            return level;
+
+        if (Set.of("com.yahoo.vespa.spifly.repackaged.spifly.BaseActivator",
+                   "org.eclipse.jetty.server.Server",
+                   "org.eclipse.jetty.server.handler.ContextHandler",
+                   "org.eclipse.jetty.server.AbstractConnector")
+               .contains(loggerName)
+                && level == Level.INFO)
+            return Level.FINE;
+
+        return level;
+    }
+
     LevelController getLevelControl(String component) {
         return repo.getLevelController(component);
     }
 
     /**
-     * Initalize the handler.  The main invariant is that
+     * Initialize the handler.  The main invariant is that
      * outputStream is always set to something valid when this method
      * returns.
      */

--- a/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
+++ b/vespalog/src/main/java/com/yahoo/log/VespaLogHandler.java
@@ -14,6 +14,13 @@ import java.util.logging.StreamHandler;
 @SuppressWarnings("deprecation")
 class VespaLogHandler extends StreamHandler {
 
+    // Reduce log level from info level to fine level for some loggers
+    private static final Set<String> loggersWithReducedLogLevel =
+            Set.of("com.yahoo.vespa.spifly.repackaged.spifly.BaseActivator",
+                   "org.eclipse.jetty.server.Server",
+                   "org.eclipse.jetty.server.handler.ContextHandler",
+                   "org.eclipse.jetty.server.AbstractConnector");
+
     private final LogTarget logTarget;
     private final String serviceName;
     private final String appPrefix;
@@ -74,20 +81,10 @@ class VespaLogHandler extends StreamHandler {
         closeFileTarget();
     }
 
-    // Reduce log level from info level to fine level for some loggers
-    private Level possiblyReduceLogLevel(String loggerName, Level level) {
-        if (loggerName == null)
-            return level;
+    private static Level possiblyReduceLogLevel(String loggerName, Level level) {
+        if (loggerName == null) return level;
 
-        if (Set.of("com.yahoo.vespa.spifly.repackaged.spifly.BaseActivator",
-                   "org.eclipse.jetty.server.Server",
-                   "org.eclipse.jetty.server.handler.ContextHandler",
-                   "org.eclipse.jetty.server.AbstractConnector")
-               .contains(loggerName)
-                && level == Level.INFO)
-            return Level.FINE;
-
-        return level;
+        return (loggersWithReducedLogLevel.contains(loggerName) && level == Level.INFO) ? Level.FINE : level;
     }
 
     LevelController getLevelControl(String component) {


### PR DESCRIPTION
This is needed to reduce log level for standalone containers, where setting log level cannot be done by config sentinel (since these containers are not started by config sentinel).