### PR TITLE
Add utility wrapper around RE2 possible regex prefix match range (take 2)

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -386,3 +386,15 @@
    ...
    fun:_ZNK3re23RE25MatchERKNS_11StringPieceEmmNS0_6AnchorEPS1_i
 }
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Cond
+   ...
+   fun:_ZNK3re23RE218PossibleMatchRangeEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_i
+}
+{
+   RE2 sparse structures deliberately do not care about uninitialized memory (https://github.com/google/re2/issues/121)
+   Memcheck:Value8
+   ...
+   fun:_ZNK3re23RE218PossibleMatchRangeEPNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES7_i
+}

--- a/vespalib/src/tests/regex/regex.cpp
+++ b/vespalib/src/tests/regex/regex.cpp
@@ -150,4 +150,35 @@ TEST("Test that default constructed regex is invalid.") {
     ASSERT_FALSE(dummy.valid());
 }
 
+TEST("Can extract min/max prefix range from anchored regex") {
+    auto min_max = Regex::from_pattern("^.*").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "");
+    EXPECT_EQUAL(min_max.second, "\xf4\x8f\xbf\xc0"); // Highest possible Unicode char (U+10FFFF) as UTF-8, plus 1
+
+    min_max = Regex::from_pattern("^hello").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "hello");
+
+    min_max = Regex::from_pattern("^hello|^world").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "world");
+
+    min_max = Regex::from_pattern("(^hello|^world|^zoidberg)").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "zoidberg");
+
+    min_max = Regex::from_pattern("^hello (foo|bar|zoo)").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello bar");
+    EXPECT_EQUAL(min_max.second, "hello zoo");
+
+    min_max = Regex::from_pattern("^(hello|world)+").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "hello");
+    EXPECT_EQUAL(min_max.second, "worldwp");
+
+    // Bad regex; no range
+    min_max = Regex::from_pattern("*hello").possible_anchored_match_prefix_range();
+    EXPECT_EQUAL(min_max.first,  "");
+    EXPECT_EQUAL(min_max.second, "");
+}
+
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/vespalib/src/vespa/vespalib/regex/regex.cpp
+++ b/vespalib/src/vespa/vespalib/regex/regex.cpp
@@ -49,6 +49,16 @@ public:
         }
         return RE2::FullMatch(StringPiece(input.data(), input.size()), _regex);
     }
+
+    std::pair<std::string, std::string> possible_anchored_match_prefix_range() const {
+        constexpr int max_len = 128; // TODO determine a "reasonable" value. RE2 docs are not clear on this.
+        std::string min_prefix, max_prefix;
+
+        if (!_regex.PossibleMatchRange(&min_prefix, &max_prefix, max_len)) {
+            return {};
+        }
+        return {std::move(min_prefix), std::move(max_prefix)};
+    }
 };
 
 Regex Regex::from_pattern(std::string_view pattern, uint32_t opt_mask) {
@@ -74,6 +84,10 @@ bool Regex::partial_match(std::string_view input) const noexcept {
 
 bool Regex::full_match(std::string_view input) const noexcept {
     return _impl->full_match(input);
+}
+
+std::pair<std::string, std::string> Regex::possible_anchored_match_prefix_range() const {
+    return _impl->possible_anchored_match_prefix_range();
 }
 
 bool Regex::partial_match(std::string_view input, std::string_view pattern) noexcept {


### PR DESCRIPTION
@geirst please review

* ed1b065de64874981b4cdb23c239e7e07dc50d28 is the same as #26494, but squashed
* fe50c5095c7e6616571d36270e0b2189f7ec8730 adds the necessary Valgrind suppressions for RE2's (intentional) dancing around in the flowers of uninitialized memory
