### PR TITLE
Add capability checking to state API handlers

### DIFF
--- a/storage/src/tests/storageserver/statereportertest.cpp
+++ b/storage/src/tests/storageserver/statereportertest.cpp
@@ -193,7 +193,7 @@ TEST_F(StateReporterTest, report_health) {
     for (int i=0; i<stateCount; i++) {
         _node->getStateUpdater().setCurrentNodeState(nodeStates[i]);
         std::ostringstream ost;
-        _stateReporter->reportStatus(ost, path);
+        ASSERT_TRUE(_stateReporter->reportStatus(ost, path));
         std::string jsonData = ost.str();
         ASSERT_NODE_STATUS(jsonData, codes[i], messages[i]);
     }

--- a/storage/src/vespa/storageframework/generic/status/statusreportermap.h
+++ b/storage/src/vespa/storageframework/generic/status/statusreportermap.h
@@ -14,7 +14,7 @@ namespace storage::framework {
 struct StatusReporter;
 
 struct StatusReporterMap {
-    virtual ~StatusReporterMap() {}
+    virtual ~StatusReporterMap() = default;
 
     virtual const StatusReporter* getStatusReporter(vespalib::stringref id) = 0;
 

--- a/vespalib/src/vespa/vespalib/net/http/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/net/http/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(vespalib_vespalib_net_http OBJECT
     component_config_producer.cpp
     generic_state_handler.cpp
     http_server.cpp
+    json_get_handler.cpp
     json_handler_repo.cpp
     simple_component_config_producer.cpp
     simple_health_producer.cpp

--- a/vespalib/src/vespa/vespalib/net/http/generic_state_handler.h
+++ b/vespalib/src/vespa/vespalib/net/http/generic_state_handler.h
@@ -23,9 +23,10 @@ private:
 
 public:
     GenericStateHandler(const vespalib::string &root_path, const StateExplorer &state);
-    virtual vespalib::string get(const vespalib::string &host,
-                                 const vespalib::string &path,
-                                 const std::map<vespalib::string,vespalib::string> &params) const override;
+    Response get(const vespalib::string &host,
+                 const vespalib::string &path,
+                 const std::map<vespalib::string,vespalib::string> &params,
+                 const net::ConnectionAuthContext &auth_ctx) const override;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/http_server.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/http_server.cpp
@@ -2,17 +2,18 @@
 
 #include "http_server.h"
 #include <vespa/vespalib/net/crypto_engine.h>
+#include <vespa/vespalib/net/connection_auth_context.h>
 
 namespace vespalib {
 
 void
 HttpServer::get(Portal::GetRequest req)
 {
-    vespalib::string json_result = _handler_repo.get(req.get_host(), req.get_path(), req.export_params());
-    if (json_result.empty()) {
-        req.respond_with_error(404, "Not Found");
+    auto response = _handler_repo.get(req.get_host(), req.get_path(), req.export_params(), req.auth_context());
+    if (response.failed()) {
+        req.respond_with_error(response.status_code(), response.status_message());
     } else {
-        req.respond_with_content("application/json", json_result);
+        req.respond_with_content("application/json", response.payload());
     }
 }
 

--- a/vespalib/src/vespa/vespalib/net/http/json_get_handler.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/json_get_handler.cpp
@@ -1,0 +1,42 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "json_get_handler.h"
+
+namespace vespalib {
+
+JsonGetHandler::Response::Response(int status_code, vespalib::string status_or_payload)
+    : _status_code(status_code),
+      _status_or_payload(std::move(status_or_payload))
+{}
+
+JsonGetHandler::Response::Response()
+    : _status_code(500),
+      _status_or_payload("Internal Server Error")
+{}
+
+JsonGetHandler::Response::~Response() = default;
+
+JsonGetHandler::Response::Response(const Response&) = default;
+JsonGetHandler::Response& JsonGetHandler::Response::operator=(const Response&) = default;
+JsonGetHandler::Response::Response(Response&&) noexcept = default;
+JsonGetHandler::Response& JsonGetHandler::Response::operator=(Response&&) noexcept = default;
+
+JsonGetHandler::Response
+JsonGetHandler::Response::make_ok_with_json(vespalib::string json)
+{
+    return {200, std::move(json)};
+}
+
+JsonGetHandler::Response
+JsonGetHandler::Response::make_failure(int status_code, vespalib::string status_message)
+{
+    return {status_code, std::move(status_message)};
+}
+
+JsonGetHandler::Response
+JsonGetHandler::Response::make_not_found()
+{
+    return {404, "Not Found"};
+}
+
+}

--- a/vespalib/src/vespa/vespalib/net/http/json_get_handler.h
+++ b/vespalib/src/vespa/vespalib/net/http/json_get_handler.h
@@ -5,13 +5,52 @@
 #include <vespa/vespalib/stllike/string.h>
 #include <map>
 
+namespace vespalib::net { class ConnectionAuthContext; }
+
 namespace vespalib {
 
 struct JsonGetHandler {
-    virtual vespalib::string get(const vespalib::string &host,
-                                 const vespalib::string &path,
-                                 const std::map<vespalib::string,vespalib::string> &params) const = 0;
-    virtual ~JsonGetHandler() {}
+    class Response {
+        int              _status_code;
+        vespalib::string _status_or_payload;
+
+        Response(int status_code, vespalib::string status_or_payload);
+    public:
+        Response(); // By default, 500 Internal Server Error
+        ~Response();
+        Response(const Response&);
+        Response& operator=(const Response&);
+        Response(Response&&) noexcept;
+        Response& operator=(Response&&) noexcept;
+
+        [[nodiscard]] int status_code() const noexcept { return _status_code; }
+        [[nodiscard]] bool ok() const noexcept { return _status_code == 200; }
+        [[nodiscard]] bool failed() const noexcept { return _status_code != 200; }
+        [[nodiscard]] vespalib::stringref status_message() const noexcept {
+            if (_status_code == 200) {
+                return "OK";
+            } else {
+                return _status_or_payload;
+            }
+        }
+        [[nodiscard]] vespalib::stringref payload() const noexcept {
+            if (_status_code == 200) {
+                return _status_or_payload;
+            } else {
+                return {};
+            }
+        }
+
+        [[nodiscard]] static Response make_ok_with_json(vespalib::string json);
+        [[nodiscard]] static Response make_failure(int status_code, vespalib::string status_message);
+        [[nodiscard]] static Response make_not_found();
+    };
+
+    virtual Response get(const vespalib::string &host,
+                         const vespalib::string &path,
+                         const std::map<vespalib::string,vespalib::string> &params,
+                         const net::ConnectionAuthContext &auth_ctx) const = 0;
+    virtual ~JsonGetHandler() = default;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/json_handler_repo.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/json_handler_repo.cpp
@@ -74,18 +74,19 @@ JsonHandlerRepo::get_root_resources() const
     return result;
 }
 
-vespalib::string
+JsonGetHandler::Response
 JsonHandlerRepo::get(const vespalib::string &host,
                      const vespalib::string &path,
-                     const std::map<vespalib::string,vespalib::string> &params) const
+                     const std::map<vespalib::string,vespalib::string> &params,
+                     const net::ConnectionAuthContext &auth_ctx) const
 {
     std::lock_guard<std::mutex> guard(_state->lock);
     for (const auto &hook: _state->hooks) {
         if (path.find(hook.path_prefix) == 0) {
-            return hook.handler->get(host, path, params);
+            return hook.handler->get(host, path, params, auth_ctx);
         }
     }
-    return "";
+    return Response::make_not_found();
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/json_handler_repo.h
+++ b/vespalib/src/vespa/vespalib/net/http/json_handler_repo.h
@@ -79,12 +79,13 @@ private:
 
 public:
     JsonHandlerRepo();
-    ~JsonHandlerRepo();
+    ~JsonHandlerRepo() override;
     Token::UP bind(vespalib::stringref path_prefix, const JsonGetHandler &get_handler);
     Token::UP add_root_resource(vespalib::stringref path);
     [[nodiscard]] std::vector<vespalib::string> get_root_resources() const;
-    [[nodiscard]] vespalib::string get(const vespalib::string &host, const vespalib::string &path,
-                                       const std::map<vespalib::string,vespalib::string> &params) const override;
+    [[nodiscard]] Response get(const vespalib::string &host, const vespalib::string &path,
+                               const std::map<vespalib::string,vespalib::string> &params,
+                               const net::ConnectionAuthContext &auth_ctx) const override;
 };
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/state_api.h
+++ b/vespalib/src/vespa/vespalib/net/http/state_api.h
@@ -30,9 +30,10 @@ public:
              MetricsProducer &mp,
              ComponentConfigProducer &ccp);
     ~StateApi() override;
-    vespalib::string get(const vespalib::string &host,
-                         const vespalib::string &path,
-                         const std::map<vespalib::string,vespalib::string> &params) const override;
+    Response get(const vespalib::string &host,
+                 const vespalib::string &path,
+                 const std::map<vespalib::string,vespalib::string> &params,
+                 const net::ConnectionAuthContext &auth_ctx) const override;
     JsonHandlerRepo &repo() { return _handler_repo; }
 };
 

--- a/vespalib/src/vespa/vespalib/portal/portal.h
+++ b/vespalib/src/vespa/vespalib/portal/portal.h
@@ -83,7 +83,7 @@ private:
         vespalib::string prefix;
         GetHandler *handler;
         BindState(uint64_t handle_in, vespalib::string prefix_in, GetHandler &handler_in) noexcept
-            : handle(handle_in), prefix(prefix_in), handler(&handler_in) {}
+            : handle(handle_in), prefix(std::move(prefix_in)), handler(&handler_in) {}
         bool operator<(const BindState &rhs) const {
             if (prefix.size() == rhs.prefix.size()) {
                 return (handle > rhs.handle);


### PR DESCRIPTION
@bjorncs and @havardpe please review.

This covers both the entry points from the `storagenode` and `searchnode` HTTP servers, though the former is mostly in the name of legacy support.

Ideally, capability checking would exist as a property of the HTTP server (Portal) bindings, but the abstractions for the JSON request handling are sufficiently leaky that it ended up making more sense to push things further down the hierarchy. It's always a good thing to move away from using strings with implicit semantics as return types anyway.

The `searchnode` state API handler mapping supports fine grained capabilities. The legacy `storagenode` state API forwarding does not—it uses a sledgehammer that expects the union of all possible API capability requirements.
