### PR TITLE
Revert "Disallow incremental non-exclusive container allocation"

### DIFF
--- a/container-core/src/main/java/com/yahoo/metrics/ContainerMetrics.java
+++ b/container-core/src/main/java/com/yahoo/metrics/ContainerMetrics.java
@@ -122,7 +122,7 @@ public enum ContainerMetrics implements VespaMetrics {
     QUERIES("queries", Unit.OPERATION, "Query volume"),
     QUERY_CONTAINER_LATENCY("query_container_latency", Unit.MILLISECOND, "The query execution time consumed in the container"),
     QUERY_LATENCY("query_latency", Unit.MILLISECOND, "The overall query latency as seen by the container"),
-    QUERY_TIMEOUT("query_timeout", Unit.MILLISECOND, "The amount of time allowed for query execution, from the client"),
+    QUERY_TIMEOUT("query_timeout", Unit.MILLISECOND, "The amount of time allowed for query execytion, from the client"),
     FAILED_QUERIES("failed_queries", Unit.OPERATION, "The number of failed queries"),
     DEGRADED_QUERIES("degraded_queries", Unit.OPERATION, "The number of degraded queries, e.g. due to some conent nodes not responding in time"),
     HITS_PER_QUERY("hits_per_query", Unit.HIT_PER_QUERY, "The number of hits returned"),

--- a/container-core/src/main/java/com/yahoo/processing/request/Properties.java
+++ b/container-core/src/main/java/com/yahoo/processing/request/Properties.java
@@ -265,7 +265,7 @@ public class Properties implements Cloneable {
 
     /**
      * Sets all properties having this name as a compound prefix to null.
-     * I.e. clearAll("a") will clear the value of "a" and "a.b" but not "ab".
+     * I.e clearAll("a") will clear the value of "a" and "a.b" but not "ab".
      *
      * @param name    the compound prefix of the properties to clear
      * @throws RuntimeException if no instance in the chain accepted this name-value pair

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -205,7 +205,7 @@ public class NodeRepository extends AbstractComponent {
      */
     public boolean exclusiveAllocation(ClusterSpec clusterSpec) {
         return clusterSpec.isExclusive() ||
-               ( clusterSpec.type().isContainer() && zone.system().isPublic() && !zone.environment().isTest() ) ||
+               ( clusterSpec.type().isContainer() && zone.system().isPublic() &&  !zone.environment().isTest() ) ||
                ( !zone().cloud().allowHostSharing() && !sharedHosts.value().isEnabled(clusterSpec.type().name()));
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -47,7 +47,7 @@ public class MockHostProvisioner implements HostProvisioner {
 
     private int deprovisionedHosts = 0;
     private EnumSet<Behaviour> behaviours = EnumSet.noneOf(Behaviour.class);
-    private final Map<ClusterSpec.Type, Flavor> hostFlavors = new HashMap<>();
+    private Map<ClusterSpec.Type, Flavor> hostFlavors = new HashMap<>();
 
     public MockHostProvisioner(List<Flavor> flavors, MockNameResolver nameResolver, int memoryTaxGb) {
         this.flavors = List.copyOf(flavors);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -97,10 +97,10 @@ public class MockNodeRepository extends NodeRepository {
         defaultCloudAccount = zone.cloud().account();
 
         curator.setZooKeeperEnsembleConnectionSpec("cfg1:1234,cfg2:1234,cfg3:1234");
-        populate(zone);
+        populate();
     }
 
-    private void populate(Zone zone) {
+    private void populate() {
         NodeRepositoryProvisioner provisioner = new NodeRepositoryProvisioner(this, Zone.defaultZone(), new MockProvisionServiceProvider());
         List<Node> nodes = new ArrayList<>();
 
@@ -202,26 +202,16 @@ public class MockNodeRepository extends NodeRepository {
                                             .vespaVersion("6.42")
                                             .loadBalancerSettings(new ZoneEndpoint(false, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "arne"))))
                                             .build();
-        ClusterResources min, max;
-        if (zone.system().isPublic()) { // resources must match one of the flavors used in this mock ("large"), since this is a container cluster
-            min = new ClusterResources(2, 1, new NodeResources(4, 32, 1600, 1));
-            max = new ClusterResources(8, 2, new NodeResources(8, 64, 3200, 1));
-        }
-        else { // resources must fit on actually provisioned hosts
-            min = new ClusterResources(2, 1, new NodeResources(2, 8, 50, 1));
-            max = new ClusterResources(8, 2, new NodeResources(4, 16, 1000, 1));
-        }
-
         activate(provisioner.prepare(app1Id,
                                      cluster1Id,
-                                     Capacity.from(min,
-                                                   max,
+                                     Capacity.from(new ClusterResources(2, 1, new NodeResources(2, 8, 50, 1)),
+                                                   new ClusterResources(8, 2, new NodeResources(4, 16, 1000, 1)),
                                                    IntRange.empty(),
                                                    false,
                                                    true,
                                                    Optional.empty(),
                                                    ClusterInfo.empty()),
-                                     null), app1Id, provisioner);
+                                null), app1Id, provisioner);
         Application app1 = applications().get(app1Id).get();
         Cluster cluster1 = app1.cluster(cluster1Id.id()).get();
         cluster1 = cluster1.withSuggested(new Autoscaling(Autoscaling.Status.unavailable,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockProvisionServiceProvider.java
@@ -50,5 +50,4 @@ public class MockProvisionServiceProvider implements ProvisionServiceProvider {
     public HostResourcesCalculator getHostResourcesCalculator() {
         return hostResourcesCalculator;
     }
-
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainerTest.java
@@ -376,8 +376,8 @@ public class HostCapacityMaintainerTest {
 
         // Provision config servers
         for (int i = 0; i < provisionedHosts.size(); i++) {
-            tester.makeReadyChildren(1, i + 1, new NodeResources(1.0, 30, 20, 0.3), hostType.childNodeType(),
-                                     provisionedHosts.get(i).hostname(), (nodeIndex) -> "cfg" + nodeIndex);
+            tester.makeReadyChildren(1, i + 1, new NodeResources(1.5, 8, 50, 0.3), hostType.childNodeType(),
+                    provisionedHosts.get(i).hostname(), (nodeIndex) -> "cfg" + nodeIndex);
         }
         tester.prepareAndActivateInfraApplication(configSrvApp, hostType.childNodeType());
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
@@ -9,7 +9,6 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.Flavor;
 import com.yahoo.config.provision.HostSpec;
-import com.yahoo.config.provision.NodeAllocationException;
 import com.yahoo.config.provision.NodeFlavors;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeResources.Architecture;
@@ -29,11 +28,9 @@ import com.yahoo.vespa.hosted.provision.testutils.MockHostProvisioner;
 import com.yahoo.vespa.hosted.provision.testutils.MockNameResolver;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -53,25 +50,6 @@ import static org.junit.Assert.fail;
 public class DynamicProvisioningTest {
 
     private final MockNameResolver nameResolver = new MockNameResolver().mockAnyLookup();
-
-    @Test
-    public void test_provisioning_containers_wont_use_shared_hosts_on_public() {
-        var resources = new NodeResources(2.7, 9, 17, 0.1);
-        var now = new ClusterResources(2, 1, resources);
-        try {
-            var fixture = DynamicProvisioningTester.fixture()
-                                                   .awsProdSetup(true)
-                                                   .clusterType(ClusterSpec.Type.container)
-                                                   .initialResources(Optional.of(now))
-                                                   .capacity(Capacity.from(now))
-                                                   .hostCount(2)
-                                                   .build();
-        }
-        catch (NodeAllocationException e) {
-            assertTrue("Contains 'No host flavor matches': " + e.getMessage(),
-                       e.getMessage().contains("No host flavor matches"));
-        }
-    }
 
     @Test
     public void dynamically_provision_with_empty_node_repo() {
@@ -139,7 +117,7 @@ public class DynamicProvisioningTest {
 
     @Test
     public void avoids_allocating_to_empty_hosts() {
-        var tester = tester(true);
+        var tester = tester(false);
         tester.makeReadyHosts(6, new NodeResources(12, 12, 200, 12));
         tester.activateTenantHosts();
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -90,16 +90,16 @@ public class ProvisioningTester {
     private int nextIP = 0;
 
     private ProvisioningTester(Curator curator,
-                               NodeFlavors nodeFlavors,
-                               HostResourcesCalculator resourcesCalculator,
-                               Zone zone,
-                               NameResolver nameResolver,
-                               DockerImage containerImage,
-                               Orchestrator orchestrator,
-                               HostProvisioner hostProvisioner,
-                               LoadBalancerServiceMock loadBalancerService,
-                               FlagSource flagSource,
-                               int spareCount) {
+                              NodeFlavors nodeFlavors,
+                              HostResourcesCalculator resourcesCalculator,
+                              Zone zone,
+                              NameResolver nameResolver,
+                              DockerImage containerImage,
+                              Orchestrator orchestrator,
+                              HostProvisioner hostProvisioner,
+                              LoadBalancerServiceMock loadBalancerService,
+                              FlagSource flagSource,
+                              int spareCount) {
         this.curator = curator;
         this.nodeFlavors = nodeFlavors;
         this.clock = new ManualClock();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
@@ -368,12 +368,12 @@ public class VirtualNodeProvisioningTest {
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
         tester.makeReadyHosts(4, hostResources).activateTenantHosts();
         ApplicationId application1 = ProvisioningTester.applicationId("app1");
-        prepareAndActivate(application1, ClusterSpec.Type.content, 2, true, hostResources, tester);
+        prepareAndActivate(application1, 2, true, nodeResources, tester);
         assertEquals(Set.of("host-1.yahoo.com", "host-2.yahoo.com"),
                      hostsOf(tester.getNodes(application1, Node.State.active)));
 
         ApplicationId application2 = ProvisioningTester.applicationId("app2");
-        prepareAndActivate(application2, ClusterSpec.Type.content, 2, false, nodeResources, tester);
+        prepareAndActivate(application2, 2, false, nodeResources, tester);
         assertEquals("Application is assigned to separate hosts",
                      Set.of("host-3.yahoo.com", "host-4.yahoo.com"),
                      hostsOf(tester.getNodes(application2, Node.State.active)));
@@ -383,15 +383,16 @@ public class VirtualNodeProvisioningTest {
     @Test
     public void application_deployment_with_exclusive_app_last() {
         NodeResources hostResources = new NodeResources(10, 40, 1000, 10);
+        NodeResources nodeResources = new NodeResources(2, 4, 100, 1);
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
         tester.makeReadyHosts(4, hostResources).activateTenantHosts();
         ApplicationId application1 = ProvisioningTester.applicationId("app1");
-        prepareAndActivate(application1, 2, false, hostResources, tester);
+        prepareAndActivate(application1, 2, false, nodeResources, tester);
         assertEquals(Set.of("host-1.yahoo.com", "host-2.yahoo.com"),
                      hostsOf(tester.getNodes(application1, Node.State.active)));
 
         ApplicationId application2 = ProvisioningTester.applicationId("app2");
-        prepareAndActivate(application2, ClusterSpec.Type.content, 2, true, hostResources, tester);
+        prepareAndActivate(application2, 2, true, nodeResources, tester);
         assertEquals("Application is assigned to separate hosts",
                      Set.of("host-3.yahoo.com", "host-4.yahoo.com"),
                      hostsOf(tester.getNodes(application2, Node.State.active)));
@@ -401,23 +402,57 @@ public class VirtualNodeProvisioningTest {
     @Test
     public void application_deployment_change_to_exclusive_and_back() {
         NodeResources hostResources = new NodeResources(10, 40, 1000, 10);
+        NodeResources nodeResources = new NodeResources(2, 4, 100, 1);
         ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
         tester.makeReadyHosts(4, hostResources).activateTenantHosts();
 
         ApplicationId application1 = ProvisioningTester.applicationId();
-        prepareAndActivate(application1, ClusterSpec.Type.content, 2, false, hostResources, tester);
+        prepareAndActivate(application1, 2, false, nodeResources, tester);
         for (Node node : tester.getNodes(application1, Node.State.active))
             assertFalse(node.allocation().get().membership().cluster().isExclusive());
 
-        prepareAndActivate(application1, ClusterSpec.Type.content, 2, true,  hostResources, tester);
+        prepareAndActivate(application1, 2, true,  nodeResources, tester);
         assertEquals(Set.of("host-1.yahoo.com", "host-2.yahoo.com"), hostsOf(tester.getNodes(application1, Node.State.active)));
         for (Node node : tester.getNodes(application1, Node.State.active))
             assertTrue(node.allocation().get().membership().cluster().isExclusive());
 
-        prepareAndActivate(application1, ClusterSpec.Type.content, 2, false, hostResources, tester);
+        prepareAndActivate(application1, 2, false, nodeResources, tester);
         assertEquals(Set.of("host-1.yahoo.com", "host-2.yahoo.com"), hostsOf(tester.getNodes(application1, Node.State.active)));
         for (Node node : tester.getNodes(application1, Node.State.active))
             assertFalse(node.allocation().get().membership().cluster().isExclusive());
+    }
+
+    /** Non-exclusive app first, then an exclusive: Should give the same result as above */
+    @Test
+    public void application_deployment_with_exclusive_app_causing_allocation_failure() {
+        ApplicationId application1 = ApplicationId.from("tenant1", "app1", "default");
+        ApplicationId application2 = ApplicationId.from("tenant2", "app2", "default");
+        ApplicationId application3 = ApplicationId.from("tenant1", "app3", "default");
+        NodeResources hostResources = new NodeResources(10, 40, 1000, 10);
+        NodeResources nodeResources = new NodeResources(2, 4, 100, 1);
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(new Zone(Environment.prod, RegionName.from("us-east"))).build();
+        tester.makeReadyHosts(4, hostResources).activateTenantHosts();
+
+        prepareAndActivate(application1, 2, true, nodeResources, tester);
+        assertEquals(Set.of("host-1.yahoo.com", "host-2.yahoo.com"),
+                     hostsOf(tester.getNodes(application1, Node.State.active)));
+
+        try {
+            prepareAndActivate(application2, 3, false, nodeResources, tester);
+            fail("Expected allocation failure");
+        }
+        catch (Exception e) {
+            assertEquals("No room for 3 nodes as 2 of 4 hosts are exclusive",
+                         "Could not satisfy request for 3 nodes with " +
+                         "[vcpu: 2.0, memory: 4.0 Gb, disk 100.0 Gb, bandwidth: 1.0 Gbps, architecture: x86_64] " +
+                         "in tenant2.app2 container cluster 'my-container' 6.39: " +
+                         "Node allocation failure on group 0: " +
+                         "Not enough suitable nodes available due to host exclusivity constraints",
+                         e.getMessage());
+        }
+
+        // Adding 3 nodes of another application for the same tenant works
+        prepareAndActivate(application3, 2, true, nodeResources, tester);
     }
 
     @Test
@@ -636,12 +671,8 @@ public class VirtualNodeProvisioningTest {
     }
 
     private void prepareAndActivate(ApplicationId application, int nodeCount, boolean exclusive, NodeResources resources, ProvisioningTester tester) {
-        prepareAndActivate(application, ClusterSpec.Type.container, nodeCount, exclusive, resources, tester);
-    }
-
-    private void prepareAndActivate(ApplicationId application, ClusterSpec.Type clusterType, int nodeCount, boolean exclusive, NodeResources resources, ProvisioningTester tester) {
         Set<HostSpec> hosts = new HashSet<>(tester.prepare(application,
-                                                           ClusterSpec.request(clusterType, ClusterSpec.Id.from("my-container")).vespaVersion("6.39").exclusive(exclusive).build(),
+                                                           ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("my-container")).vespaVersion("6.39").exclusive(exclusive).build(),
                                                            Capacity.from(new ClusterResources(nodeCount, 1, resources), false, true)));
         tester.activate(application, hosts);
     }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveApiTest.java
@@ -16,7 +16,7 @@ import java.io.IOException;
  * 
  * Note: This class is referenced from our operations documentation and must not be renamed/moved without updating that.
  * 
- * @author freva
+ * @author bratseth
  */
 public class ArchiveApiTest {
 
@@ -54,6 +54,7 @@ public class ArchiveApiTest {
         tester.assertResponse(new Request("http://localhost:8080/nodes/v2/archive/account/777888999000", new byte[0], Request.Method.DELETE), "{\"message\":\"Removed archive URI for 777888999000\"}");
         tester.assertPartialResponse(new Request("http://localhost:8080/nodes/v2/node/dockerhost2.yahoo.com"), "archiveUri", false);
     }
+
 
     private void assertFile(Request request, String file) throws IOException {
         tester.assertFile(request, file);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersV1ApiTest.java
@@ -22,8 +22,7 @@ public class LoadBalancersV1ApiTest {
 
     @After
     public void closeTester() {
-        if (tester != null)
-            tester.close();
+        tester.close();
     }
 
     @Test


### PR DESCRIPTION
Reverts vespa-engine/vespa#26509

Cause of VESPA-26275:
```
22 205830 cfg2     I Retiring active child node cfg3.prod.cd-aws-us-east-1a.vespa.aws.oath.cloud allocated to hosted-vespa.zone-config-servers as 'admin/zone-config-servers/0/0/stateful' because node violates host exclusivity
22 205830 cfg2     I Retiring active child node cfg2.prod.cd-aws-us-east-1a.vespa.aws.oath.cloud allocated to hosted-vespa.zone-config-servers as 'admin/zone-config-servers/0/1/stateful' because node violates host exclusivity
```