### PR TITLE
Mock auth clients in tests

### DIFF
--- a/client/go/internal/cli/auth/auth0/auth0_test.go
+++ b/client/go/internal/cli/auth/auth0/auth0_test.go
@@ -21,7 +21,7 @@ func TestConfigWriting(t *testing.T) {
   "oauth-token-endpoint": "https://example.com/oauth/token"
 }`
 	httpClient.NextResponseString(200, flowConfigResponse)
-	client, err := newClient(&httpClient, configPath, "public", "http://example.com")
+	client, err := NewClient(&httpClient, Options{ConfigPath: configPath, SystemName: "public", SystemURL: "http://example.com"})
 	require.Nil(t, err)
 	assert.Equal(t, "https://example.com/api/v2/", client.Authenticator.Audience)
 	assert.Equal(t, "some-id", client.Authenticator.ClientID)
@@ -56,7 +56,7 @@ func TestConfigWriting(t *testing.T) {
 
 	// Switch to another system
 	httpClient.NextResponseString(200, flowConfigResponse)
-	client, err = newClient(&httpClient, configPath, "publiccd", "http://example.com")
+	client, err = NewClient(&httpClient, Options{ConfigPath: configPath, SystemName: "publiccd", SystemURL: "http://example.com"})
 	require.Nil(t, err)
 	creds2 := Credentials{
 		AccessToken: "another-token",

--- a/client/go/internal/cli/auth/zts/zts.go
+++ b/client/go/internal/cli/auth/zts/zts.go
@@ -21,7 +21,7 @@ type Client struct {
 }
 
 // NewClient creates a new client for an Athenz ZTS service located at serviceURL.
-func NewClient(serviceURL string, client util.HTTPClient) (*Client, error) {
+func NewClient(client util.HTTPClient, serviceURL string) (*Client, error) {
 	tokenURL, err := url.Parse(serviceURL)
 	if err != nil {
 		return nil, err

--- a/client/go/internal/cli/auth/zts/zts_test.go
+++ b/client/go/internal/cli/auth/zts/zts_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccessToken(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	client, err := NewClient("http://example.com", &httpClient)
+	client, err := NewClient(&httpClient, "http://example.com")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -490,7 +490,7 @@ func (c *Config) readAPIKey(cli *CLI, system vespa.System, tenantName string) ([
 		return nil, nil // Vespa Cloud CI only talks to data plane and does not have an API key
 	}
 	if !cli.isCI() {
-		client, err := auth0.New(c.authConfigPath(), system.Name, system.URL)
+		client, err := cli.auth0Factory(cli.httpClient, auth0.Options{ConfigPath: c.authConfigPath(), SystemName: system.Name, SystemURL: system.URL})
 		if err == nil && client.HasCredentials() {
 			return nil, nil // use Auth0
 		}

--- a/client/go/internal/cli/cmd/login.go
+++ b/client/go/internal/cli/cmd/login.go
@@ -35,7 +35,7 @@ func newLoginCmd(cli *CLI) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			a, err := auth0.New(cli.config.authConfigPath(), system.Name, system.URL)
+			a, err := auth0.NewClient(cli.httpClient, auth0.Options{ConfigPath: cli.config.authConfigPath(), SystemName: system.Name, SystemURL: system.URL})
 			if err != nil {
 				return err
 			}
@@ -68,16 +68,14 @@ func newLoginCmd(cli *CLI) *cobra.Command {
 				return fmt.Errorf("login error: %w", err)
 			}
 
-			log.Print("\n")
-			log.Println("Successfully logged in.")
-			log.Print("\n")
+			cli.printSuccess("Logged in")
 
 			// store the refresh token
 			secretsStore := &auth.Keyring{}
 			err = secretsStore.Set(auth.SecretsNamespace, system.Name, res.RefreshToken)
 			if err != nil {
 				// log the error but move on
-				log.Println("Could not store the refresh token locally, please expect to login again once your access token expired.")
+				cli.printWarning("Could not store the refresh token locally. You may need to login again once your access token expires")
 			}
 
 			creds := auth0.Credentials{

--- a/client/go/internal/cli/cmd/logout.go
+++ b/client/go/internal/cli/cmd/logout.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
 	"github.com/vespa-engine/vespa/client/go/internal/cli/auth/auth0"
 )
@@ -24,17 +22,14 @@ func newLogoutCmd(cli *CLI) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			a, err := auth0.New(cli.config.authConfigPath(), system.Name, system.URL)
+			a, err := auth0.NewClient(cli.httpClient, auth0.Options{ConfigPath: cli.config.authConfigPath(), SystemName: system.Name, SystemURL: system.URL})
 			if err != nil {
 				return err
 			}
 			if err := a.RemoveCredentials(); err != nil {
 				return err
 			}
-
-			log.Print("\n")
-			log.Println("Successfully logged out.")
-			log.Print("\n")
+			cli.printSuccess("Logged out")
 			return nil
 		},
 	}

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -43,7 +43,8 @@ type Service struct {
 	BaseURL    string
 	Name       string
 	TLSOptions TLSOptions
-	ztsClient  ztsClient
+
+	zts        zts
 	httpClient util.HTTPClient
 }
 
@@ -95,7 +96,7 @@ func (s *Service) Do(request *http.Request, timeout time.Duration) (*http.Respon
 		s.httpClient.UseCertificate([]tls.Certificate{s.TLSOptions.KeyPair})
 	}
 	if s.TLSOptions.AthenzDomain != "" {
-		accessToken, err := s.ztsClient.AccessToken(s.TLSOptions.AthenzDomain, s.TLSOptions.KeyPair)
+		accessToken, err := s.zts.AccessToken(s.TLSOptions.AthenzDomain, s.TLSOptions.KeyPair)
 		if err != nil {
 			return nil, err
 		}

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -164,6 +164,8 @@ func createCloudTarget(t *testing.T, url string, logWriter io.Writer) Target {
 
 	target, err := CloudTarget(
 		util.CreateClient(time.Second*10),
+		&mockZTS{},
+		&mockAuth0{},
 		APIOptions{APIKey: apiKey, System: PublicSystem},
 		CloudDeploymentOptions{
 			Deployment: Deployment{
@@ -179,7 +181,7 @@ func createCloudTarget(t *testing.T, url string, logWriter io.Writer) Target {
 	}
 	if ct, ok := target.(*cloudTarget); ok {
 		ct.apiOptions.System.URL = url
-		ct.ztsClient = &mockZTSClient{token: "foo bar"}
+		ct.zts = &mockZTS{token: "foo bar"}
 	} else {
 		t.Fatalf("Wrong target type %T", ct)
 	}
@@ -201,10 +203,14 @@ func assertServiceWait(t *testing.T, expectedStatus int, target Target, service 
 	assert.Equal(t, expectedStatus, status)
 }
 
-type mockZTSClient struct {
-	token string
-}
+type mockZTS struct{ token string }
 
-func (c *mockZTSClient) AccessToken(domain string, certificate tls.Certificate) (string, error) {
+func (c *mockZTS) AccessToken(domain string, certificate tls.Certificate) (string, error) {
 	return c.token, nil
 }
+
+type mockAuth0 struct{}
+
+func (a *mockAuth0) AccessToken() (string, error) { return "", nil }
+
+func (a *mockAuth0) HasCredentials() bool { return true }


### PR DESCRIPTION
Tests were making real requests to `/auth0/v1/device-flow-config`... And Auth0
client wasn't reusing connections since it used its own client instead of the
default CLI one.

@jonmv