### PR TITLE
Disable more warnings when using gcc 13.

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -86,9 +86,10 @@ else()
 endif()
 
 # Disable dangling reference and overloaded virtual warnings when using gcc 13
+# Disable stringop-oveflow and array-bounds warning when using gcc 13.
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "13")
-    set(CXX_SPECIFIC_WARN_OPTS "${CXX_SPECIFIC_WARN_OPTS} -Wno-dangling-reference -Wno-overloaded-virtual")
+    set(CXX_SPECIFIC_WARN_OPTS "${CXX_SPECIFIC_WARN_OPTS} -Wno-dangling-reference -Wno-overloaded-virtual -Wno-stringop-overflow -Wno-array-bounds")
   endif()
 endif()
 


### PR DESCRIPTION
@baldersheim : please review

With gcc 13, the following test program `badwarn.cpp` fails to compile:
```
#include <vector>
struct S { };
struct W : public std::vector<S*> { ~W(); };
void badwarn() { S s; W w; w.push_back(&s); W w2(w); }
```

Trying the command
```
g++ -O1 -Wall -c badwarn.cpp
```
gives the following output:
```
In file included from /usr/include/c++/13/vector:62,
                 from badwarn.cpp:1:
In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = S* const; _Up = S*; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = S* const*; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = S* const*; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
    inlined from ‘static _ForwardIterator std::__uninitialized_copy<true>::__uninit_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, std::vector<S*> >; _ForwardIterator = S**]’ at /usr/include/c++/13/bits/stl_uninitialized.h:147:27,
    inlined from ‘_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _ForwardIterator = S**]’ at /usr/include/c++/13/bits/stl_uninitialized.h:185:15,
    inlined from ‘_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, allocator<_Tp>&) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _ForwardIterator = S**; _Tp = S*]’ at /usr/include/c++/13/bits/stl_uninitialized.h:373:37,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:601:31,
    inlined from ‘W::W(const W&)’ at badwarn.cpp:3:8,
    inlined from ‘void badwarn()’ at badwarn.cpp:4:51:
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ forming offset 8 is out of the bounds [0, 8] [-Warray-bounds=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

and turning off `-Wall`
```
g++ -O1 -c badwarn.cpp
```

doesn't help much:
```
In file included from /usr/include/c++/13/vector:62,
                 from badwarn.cpp:1:
In static member function ‘static _Up* std::__copy_move<_IsMove, true, std::random_access_iterator_tag>::__copy_m(_Tp*, _Tp*, _Up*) [with _Tp = S* const; _Up = S*; bool _IsMove = false]’,
    inlined from ‘_OI std::__copy_move_a2(_II, _II, _OI) [with bool _IsMove = false; _II = S* const*; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:506:30,
    inlined from ‘_OI std::__copy_move_a1(_II, _II, _OI) [with bool _IsMove = false; _II = S* const*; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:533:42,
    inlined from ‘_OI std::__copy_move_a(_II, _II, _OI) [with bool _IsMove = false; _II = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:540:31,
    inlined from ‘_OI std::copy(_II, _II, _OI) [with _II = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _OI = S**]’ at /usr/include/c++/13/bits/stl_algobase.h:633:7,
    inlined from ‘static _ForwardIterator std::__uninitialized_copy<true>::__uninit_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, std::vector<S*> >; _ForwardIterator = S**]’ at /usr/include/c++/13/bits/stl_uninitialized.h:147:27,
    inlined from ‘_ForwardIterator std::uninitialized_copy(_InputIterator, _InputIterator, _ForwardIterator) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _ForwardIterator = S**]’ at /usr/include/c++/13/bits/stl_uninitialized.h:185:15,
    inlined from ‘_ForwardIterator std::__uninitialized_copy_a(_InputIterator, _InputIterator, _ForwardIterator, allocator<_Tp>&) [with _InputIterator = __gnu_cxx::__normal_iterator<S* const*, vector<S*> >; _ForwardIterator = S**; _Tp = S*]’ at /usr/include/c++/13/bits/stl_uninitialized.h:373:37,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:601:31,
    inlined from ‘W::W(const W&)’ at badwarn.cpp:3:8,
    inlined from ‘void badwarn()’ at badwarn.cpp:4:51:
/usr/include/c++/13/bits/stl_algobase.h:437:30: warning: ‘void* __builtin_memmove(void*, const void*, long unsigned int)’ writing between 9 and 9223372036854775807 bytes into a region of size 8 overflows the destination [-Wstringop-overflow=]
  437 |             __builtin_memmove(__result, __first, sizeof(_Tp) * _Num);
      |             ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/13/x86_64-redhat-linux/bits/c++allocator.h:33,
                 from /usr/include/c++/13/bits/allocator.h:46,
                 from /usr/include/c++/13/vector:63:
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = S*]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_Tp1> >::allocate(allocator_type&, size_type) [with _Tp = S*]’ at /usr/include/c++/13/bits/alloc_traits.h:482:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:378:33,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:395:44,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:332:26,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = S*; _Alloc = std::allocator<S*>]’ at /usr/include/c++/13/bits/stl_vector.h:598:61,
    inlined from ‘W::W(const W&)’ at badwarn.cpp:3:8,
    inlined from ‘void badwarn()’ at badwarn.cpp:4:51:
/usr/include/c++/13/bits/new_allocator.h:147:55: note: destination object of size 8 allocated by ‘operator new’
  147 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                       ^
```

