### PR TITLE
Retrieve execution value explicitly by '_'

### DIFF
--- a/docprocs/src/test/cfg/ilscripts.cfg
+++ b/docprocs/src/test/cfg/ilscripts.cfg
@@ -9,5 +9,5 @@ ilscript[0].content[0] "input artist | attribute artist"
 ilscript[0].content[1] "input title | attribute title"
 ilscript[0].content[2] "input song | attribute song"
 ilscript[0].content[4] "input artist . " ".  input title | index combined"
-ilscript[0].content[5] "(input artist || "") . " ".  (input title || "") | index combinedWithFallback"
+ilscript[0].content[5] "(input artist || "") . " " .  (input title || "") | index combinedWithFallback"
 

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionValueExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ExecutionValueExpression.java
@@ -1,0 +1,54 @@
+package com.yahoo.vespa.indexinglanguage.expressions;
+
+import com.yahoo.document.DataType;
+import com.yahoo.document.DocumentType;
+import com.yahoo.document.FieldPath;
+import com.yahoo.vespa.objects.ObjectOperation;
+import com.yahoo.vespa.objects.ObjectPredicate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Returns the current execution value, that is the value passed to this expression.
+ * Referring to this explicitly is useful e.g to concatenate it to some other string:
+ * ... | input foo . " " . _ | ...
+ *
+ * @author bratseth
+ */
+public final class ExecutionValueExpression extends Expression {
+
+    public ExecutionValueExpression() {
+        super(null);
+    }
+
+    @Override
+    protected void doExecute(ExecutionContext context) {
+        // Noop: Set the output execution value to the current execution value
+    }
+
+    @Override
+    protected void doVerify(VerificationContext context) {}
+
+    @Override
+    public DataType createdOutputType() {
+        return UnresolvedDataType.INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+        return "_";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof ExecutionValueExpression;
+    }
+
+    @Override
+    public int hashCode() {
+        return 9875876;
+    }
+
+}

--- a/indexinglanguage/src/main/javacc/IndexingParser.jj
+++ b/indexinglanguage/src/main/javacc/IndexingParser.jj
@@ -205,6 +205,7 @@ TOKEN :
     <ZCURVE: "zcurve"> |
     <TRUE: "true" > |
     <FALSE: "false" > |
+    <UNDERSCORE: "_"> |
     <IDENTIFIER: ["a"-"z","A"-"Z", "_"] (["a"-"z","A"-"Z","0"-"9","_","-"])*>
 }
 
@@ -343,6 +344,7 @@ Expression value() :
       val = trimExp()               |
       val = literalBoolExp()        |
       val = zcurveExp()             |
+      val = executionValueExp()     |
       ( <LPAREN> val = statement() <RPAREN> { val = new ParenthesisExpression(val); } ) )
     { return val; }
 }
@@ -750,6 +752,12 @@ Expression zcurveExp() : { }
 {
     ( <ZCURVE> )
     { return new ZCurveExpression(); }
+}
+
+Expression executionValueExp() : { }
+{
+    ( <UNDERSCORE> )
+    { return new ExecutionValueExpression(); }
 }
 
 String identifier() :


### PR DESCRIPTION
With multiple embeddings per document it might be useful to be able to prepend each string to be embedded by some context, e.g the title. Currently there is no way to do that (as far as I know) because it requires referring to the execution value (passed from the previous expression in the indexing statement) explicitly.

This adds a new expression which is simply '_' which returns the current context value, such that one can say e.g

`input myTextArray | for_each { input title . " " . _ } | embed | attribute 'mySparseTensor' `

I think this is needed at the top level in any case, but for nested expressions it would also be nice to be able to name the expression value explicitly to be able to say

`input myTextArray | for_each text { input title . " " . text } | embed | attribute 'mySparseTensor' `

but I'm not doing that right now.