### PR TITLE
- HashMap over TreeMap when order des not matter.

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -29,7 +29,6 @@ import com.yahoo.yolean.Exceptions;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -306,7 +305,7 @@ public class ClusterSearcher extends Searcher {
             Set<String> sources = query.getModel().getSources();
             return (sources == null || sources.isEmpty())
                     ? schemas
-                    : new HashSet<>(indexFacts.newSession(sources, Collections.emptyList(), schemas).documentTypes());
+                    : new HashSet<>(indexFacts.newSession(sources, Set.of(), schemas).documentTypes());
         } else {
             return filterValidDocumentTypes(restrict);
         }

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/CustomParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/CustomParser.java
@@ -6,7 +6,6 @@ import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.query.Item;
 import com.yahoo.search.query.parser.Parser;
 
-import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -23,7 +22,7 @@ public interface CustomParser extends Parser {
                        Set<String> toSearch, IndexFacts indexFacts, String defaultIndexName) {
         if (indexFacts == null)
             indexFacts = new IndexFacts();
-        return parse(queryToParse, filterToParse, parsingLanguage, indexFacts.newSession(toSearch, Collections.emptySet()), defaultIndexName);
+        return parse(queryToParse, filterToParse, parsingLanguage, indexFacts.newSession(toSearch, Set.of()), defaultIndexName);
     }
 
     Item parse(String queryToParse, String filterToParse, Language parsingLanguage,

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/Tokenizer.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/Tokenizer.java
@@ -8,7 +8,6 @@ import com.yahoo.prelude.Index;
 import com.yahoo.prelude.IndexFacts;
 import com.yahoo.prelude.query.Substring;
 
-import java.util.Collections;
 import java.util.List;
 
 import static com.yahoo.prelude.query.parser.Token.Kind.*;
@@ -63,7 +62,7 @@ public final class Tokenizer {
      * @return a read-only list of tokens. This list can only be used by this thread
      */
     public List<Token> tokenize(String string) {
-        return tokenize(string, new IndexFacts().newSession(Collections.emptySet(), Collections.emptySet()));
+        return tokenize(string, new IndexFacts().newSession());
     }
 
     /**
@@ -171,13 +170,10 @@ public final class Tokenizer {
         // this is a heuristic to check whether we probably have reached the end of an URL element
         for (int i = tokens.size() - 1; i >= 0; --i) {
             switch (tokens.get(i).kind) {
-                case COLON:
-                    if (i == indexLastExplicitlyChangedAt) return false;
-                    break;
-                case SPACE:
-                    return true;
-                default:
-                    // do nothing
+                case COLON -> { if (i == indexLastExplicitlyChangedAt) return false; }
+                case SPACE -> { return true; }
+                default -> { }
+                // do nothing
             }
         }
         // really not sure whether we should choose false instead, on cause of the guard at

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/TokenizerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/TokenizerTestCase.java
@@ -13,7 +13,6 @@ import com.yahoo.prelude.query.parser.Tokenizer;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static com.yahoo.prelude.query.parser.Token.Kind.COLON;
@@ -29,7 +28,9 @@ import static com.yahoo.prelude.query.parser.Token.Kind.SPACE;
 import static com.yahoo.prelude.query.parser.Token.Kind.STAR;
 import static com.yahoo.prelude.query.parser.Token.Kind.UNDERSCORE;
 import static com.yahoo.prelude.query.parser.Token.Kind.WORD;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the tokenizer
@@ -283,7 +284,7 @@ public class TokenizerTestCase {
         sd.addIndex(index2);
 
         IndexFacts facts = new IndexFacts(new IndexModel(sd));
-        IndexFacts.Session session = facts.newSession(Collections.emptySet(), Collections.emptySet());
+        IndexFacts.Session session = facts.newSession();
         Tokenizer tokenizer = new Tokenizer(new SimpleLinguistics());
         List<?> tokens = tokenizer.tokenize("normal a:b (normal testexact1:/,%#%&+-+ ) testexact2:ho_/&%&/()/aa*::*& b:c", "default", session);
         // tokenizer.print();
@@ -328,7 +329,7 @@ public class TokenizerTestCase {
 
         IndexFacts facts = new IndexFacts(new IndexModel(sd));
         Tokenizer tokenizer = new Tokenizer(new SimpleLinguistics());
-        IndexFacts.Session session = facts.newSession(Collections.emptySet(), Collections.emptySet());
+        IndexFacts.Session session = facts.newSession();
         List<?> tokens = tokenizer.tokenize("normal a:b (normal testexact1:/,%#%&+-+ ) testexact2:ho_/&%&/()/aa*::*&", session);
         assertEquals(new Token(WORD, "normal"), tokens.get(0));
         assertEquals(new Token(SPACE, " "), tokens.get(1));
@@ -365,7 +366,7 @@ public class TokenizerTestCase {
 
         IndexFacts facts = new IndexFacts(new IndexModel(sd));
         Tokenizer tokenizer = new Tokenizer(new SimpleLinguistics());
-        IndexFacts.Session session = facts.newSession(Collections.emptySet(), Collections.emptySet());
+        IndexFacts.Session session = facts.newSession();
         List<?> tokens = tokenizer.tokenize("normal a:b (normal testexact1:/,%#%&+-+ ) testexact2:ho_/&%&/()/aa*::*", session);
         assertEquals(new Token(WORD, "normal"), tokens.get(0));
         assertEquals(new Token(SPACE, " "), tokens.get(1));
@@ -402,7 +403,7 @@ public class TokenizerTestCase {
 
         IndexFacts facts = new IndexFacts(new IndexModel(sd));
         Tokenizer tokenizer = new Tokenizer(new SimpleLinguistics());
-        IndexFacts.Session session = facts.newSession(Collections.emptySet(), Collections.emptySet());
+        IndexFacts.Session session = facts.newSession();
         List<?> tokens = tokenizer.tokenize("normal a:b (normal testexact1:!/%#%&+-+ ) testexact2:ho_/&%&/()/aa*::*&b:", session);
         assertEquals(new Token(WORD, "normal"), tokens.get(0));
         assertEquals(new Token(SPACE, " "), tokens.get(1));
@@ -439,7 +440,7 @@ public class TokenizerTestCase {
         sd.addIndex(index2);
 
         IndexFacts indexFacts = new IndexFacts(new IndexModel(sd));
-        IndexFacts.Session facts = indexFacts.newSession(Collections.emptySet(), Collections.emptySet());
+        IndexFacts.Session facts = indexFacts.newSession();
 
         Tokenizer tokenizer = new Tokenizer(new SimpleLinguistics());
         List<?> tokens = tokenizer.tokenize("normal a:b (normal testexact1:foo) testexact2:bar", facts);

--- a/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/IndexFactsTestCase.java
@@ -15,8 +15,12 @@ import org.junit.jupiter.api.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests using synthetic index names for IndexFacts class.
@@ -180,7 +184,7 @@ public class IndexFactsTestCase {
         query.getModel().getSources().add("one");
         query.getModel().getRestrict().add("two");
 
-        IndexFacts.Session indexFacts = createIndexFacts().newSession(List.of("clusterOne"), List.of());
+        IndexFacts.Session indexFacts = createIndexFacts().newSession(List.of("clusterOne"), Set.of());
         assertTrue(indexFacts.isIndex("a"));
         assertFalse(indexFacts.isIndex("b"));
         assertTrue(indexFacts.isIndex("d"));


### PR DESCRIPTION
- Avoid creating mutable maps when not necessary.
- Moderize iteration for readability.
- Unify on Set.of instead of Collections.emptySet.

@bratseth PR