### PR TITLE
Use one MatchingElementsFields instance per summary class.

### DIFF
--- a/searchcore/src/tests/proton/docsummary/docsummary_test.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary_test.cpp
@@ -107,7 +107,10 @@ namespace proton {
 class MockDocsumFieldWriterFactory : public search::docsummary::IDocsumFieldWriterFactory
 {
 public:
-    std::unique_ptr<DocsumFieldWriter> create_docsum_field_writer(const vespalib::string&, const vespalib::string&, const vespalib::string&) override {
+    std::unique_ptr<DocsumFieldWriter> create_docsum_field_writer(const vespalib::string&,
+                                                                  const vespalib::string&,
+                                                                  const vespalib::string&,
+                                                                  std::shared_ptr<search::MatchingElementsFields>) override {
         return {};
     }
 

--- a/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer_factory.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/docsum_field_writer_factory.h
@@ -20,7 +20,6 @@ class DocsumFieldWriterFactory : public IDocsumFieldWriterFactory
     const IDocsumEnvironment& _env;
     const IQueryTermFilterFactory& _query_term_filter_factory;
 protected:
-    std::shared_ptr<MatchingElementsFields> _matching_elems_fields;
     const IDocsumEnvironment& getEnvironment() const noexcept { return _env; }
     bool has_attribute_manager() const noexcept;
 public:
@@ -28,7 +27,8 @@ public:
     ~DocsumFieldWriterFactory() override;
     std::unique_ptr<DocsumFieldWriter> create_docsum_field_writer(const vespalib::string& field_name,
                                                                   const vespalib::string& command,
-                                                                  const vespalib::string& source) override;
+                                                                  const vespalib::string& source,
+                                                                  std::shared_ptr<MatchingElementsFields> matching_elems_fields) override;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/i_docsum_field_writer_factory.h
+++ b/searchsummary/src/vespa/searchsummary/docsummary/i_docsum_field_writer_factory.h
@@ -5,6 +5,8 @@
 #include <memory>
 #include <vespa/vespalib/stllike/string.h>
 
+namespace search { class MatchingElementsFields; }
+
 namespace search::docsummary {
 
 class DocsumFieldWriter;
@@ -21,7 +23,8 @@ public:
      */
     virtual std::unique_ptr<DocsumFieldWriter> create_docsum_field_writer(const vespalib::string& field_name,
                                                                           const vespalib::string& command,
-                                                                          const vespalib::string& source) = 0;
+                                                                          const vespalib::string& source,
+                                                                          std::shared_ptr<MatchingElementsFields> matching_elems_fields) = 0;
 };
 
 }

--- a/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.cpp
+++ b/searchsummary/src/vespa/searchsummary/docsummary/resultconfig.cpp
@@ -5,6 +5,7 @@
 #include "docsum_field_writer_factory.h"
 #include "resultclass.h"
 #include <vespa/config-summary.h>
+#include <vespa/searchlib/common/matching_elements_fields.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 #include <atomic>
@@ -124,6 +125,7 @@ ResultConfig::readConfig(const SummaryConfig &cfg, const char *configId, IDocsum
             break;
         }
         resClass->set_omit_summary_features(cfg_class.omitsummaryfeatures);
+        auto matching_elems_fields = std::make_shared<MatchingElementsFields>();
         for (const auto & field : cfg_class.fields) {
             const char *fieldname = field.name.c_str();
             vespalib::string command = field.command;
@@ -134,7 +136,8 @@ ResultConfig::readConfig(const SummaryConfig &cfg, const char *configId, IDocsum
                 try {
                     docsum_field_writer = docsum_field_writer_factory.create_docsum_field_writer(fieldname,
                                                                                                  command,
-                                                                                                 source_name);
+                                                                                                 source_name,
+                                                                                                 matching_elems_fields);
                 } catch (const vespalib::IllegalArgumentException& ex) {
                     LOG(error, "Exception during setup of summary result class '%s': field='%s', command='%s', source='%s': %s",
                         cfg_class.name.c_str(), fieldname, command.c_str(), source_name.c_str(), ex.getMessage().c_str());

--- a/streamingvisitors/src/vespa/vsm/vsm/docsum_field_writer_factory.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/docsum_field_writer_factory.cpp
@@ -48,7 +48,8 @@ DocsumFieldWriterFactory::~DocsumFieldWriterFactory() = default;
 std::unique_ptr<DocsumFieldWriter>
 DocsumFieldWriterFactory::create_docsum_field_writer(const vespalib::string& field_name,
                                                      const vespalib::string& command,
-                                                     const vespalib::string& source)
+                                                     const vespalib::string& source,
+                                                     std::shared_ptr<MatchingElementsFields> matching_elems_fields)
 {
     std::unique_ptr<DocsumFieldWriter> fieldWriter;
     using namespace search::docsummary;
@@ -65,10 +66,10 @@ DocsumFieldWriterFactory::create_docsum_field_writer(const vespalib::string& fie
     } else if ((command == command::matched_attribute_elements_filter) ||
                (command == command::matched_elements_filter)) {
         vespalib::string source_field = source.empty() ? field_name : source;
-        populate_fields(*_matching_elems_fields, _vsm_fields_config, source_field);
-        fieldWriter = MatchedElementsFilterDFW::create(source_field, _matching_elems_fields);
+        populate_fields(*matching_elems_fields, _vsm_fields_config, source_field);
+        fieldWriter = MatchedElementsFilterDFW::create(source_field, matching_elems_fields);
     } else {
-        return search::docsummary::DocsumFieldWriterFactory::create_docsum_field_writer(field_name, command, source);
+        return search::docsummary::DocsumFieldWriterFactory::create_docsum_field_writer(field_name, command, source, matching_elems_fields);
     }
     return fieldWriter;
 }

--- a/streamingvisitors/src/vespa/vsm/vsm/docsum_field_writer_factory.h
+++ b/streamingvisitors/src/vespa/vsm/vsm/docsum_field_writer_factory.h
@@ -21,7 +21,8 @@ public:
     std::unique_ptr<search::docsummary::DocsumFieldWriter>
     create_docsum_field_writer(const vespalib::string& field_name,
                                const vespalib::string& command,
-                               const vespalib::string& source) override;
+                               const vespalib::string& source,
+                               std::shared_ptr<search::MatchingElementsFields> matching_elems_fields) override;
 };
 
 }


### PR DESCRIPTION
This avoids calculating MatchingElements for fields that exist in other summary classes.

@toregge please review