### PR TITLE
Improve error message

### DIFF
--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -144,7 +144,7 @@ void ExternalOperationHandler::bounce_with_result(api::StorageCommand& cmd, cons
 void ExternalOperationHandler::bounce_with_feed_blocked(api::StorageCommand& cmd) {
     const auto& feed_block = _op_ctx.cluster_state_bundle().feed_block();
     bounce_with_result(cmd, api::ReturnCode(api::ReturnCode::NO_SPACE,
-                                            "External feed is blocked due to resource exhaustion: " +
+                                            "External feed is blocked due to resource exhaustion, see https://docs.vespa.ai/en/operations/feed-block.html: " +
                                                     feed_block->description()));
 }
 


### PR DESCRIPTION
- We need to improve the error message for full disk or memory.
- The information is already available in the message, but hard for users to translate into what it means: (0.767 > 0.750)
- Ideally, it should say something like "Resource _disk_ on node 0 is at _76.7%_, which is over the feed-block limit at _75%_, refer to https://docs.vespa.ai/en/operations/feed-block.html "

If we are OK with this, I can update code and tests (the change below is a dummy for now) - OK @geirst ?