### PR TITLE
Use timed waits on persistence queue condition variable

### DIFF
--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -1054,7 +1054,7 @@ FileStorHandlerImpl::Stripe::waitUntilNoLocks() const
 {
     std::unique_lock guard(*_lock);
     while (!_lockedBuckets.empty()) {
-        _cond->wait(guard);
+        _cond->wait_for(guard, 100ms);
     }
 }
 
@@ -1062,7 +1062,7 @@ void
 FileStorHandlerImpl::Stripe::waitInactive(const AbortBucketOperationsCommand& cmd) const {
     std::unique_lock guard(*_lock);
     while (hasActive(guard, cmd)) {
-        _cond->wait(guard);
+        _cond->wait_for(guard, 100ms);
     }
 }
 


### PR DESCRIPTION
@toregge please review
@baldersheim FYI

This is a pragmatic workaround for our current optimistic signalling mechanisms seemingly being susceptible to lost wakeups under certain conditions. We should redesign how persistence queue signalling works on a more fundamental level to avoid this scenario altogether, but for now this will at least remove the possibility that a thread may be stalled if the persistence queues are completely quiescent over longer periods of time.

