### PR TITLE
Get systemctl service property silently

### DIFF
--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/systemd/SystemCtl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/systemd/SystemCtl.java
@@ -91,7 +91,7 @@ public class SystemCtl {
     public String getServiceProperty(TaskContext context, String unit, String property) {
         return newCommandLine(context)
                 .add("systemctl", "show", "--property", property, "--value", unit + ".service")
-                .execute()
+                .executeSilently()
                 .getOutput();
     }
 


### PR DESCRIPTION
This has no side effects, so no need to log it