### PR TITLE
Ensure that explicit flag value is always preferred

### DIFF
--- a/client/go/internal/cli/cmd/config.go
+++ b/client/go/internal/cli/cmd/config.go
@@ -544,12 +544,12 @@ func (c *Config) list(includeUnset bool) []string {
 }
 
 // flagValue returns the set value and default value of the named flag.
-func (c *Config) flagValue(name string) (string, string) {
+func (c *Config) flagValue(name string) (string, string, bool) {
 	f, ok := c.flags[name]
 	if !ok {
-		return "", ""
+		return "", "", ok
 	}
-	return f.Value.String(), f.DefValue
+	return f.Value.String(), f.DefValue, f.Changed
 }
 
 // getNonEmpty returns value of given option, if that value is non-empty
@@ -564,9 +564,9 @@ func (c *Config) getNonEmpty(option string) (string, bool) {
 // get returns the value associated with option, from the most preferred source in the following order: flag > local
 // config > global config.
 func (c *Config) get(option string) (string, bool) {
-	flagValue, flagDefault := c.flagValue(option)
+	flagValue, flagDefault, changed := c.flagValue(option)
 	// explicit flag value always takes precedence over everything else
-	if flagValue != flagDefault {
+	if changed {
 		return flagValue, true
 	}
 	// ... then local config, if option is explicitly defined there

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -28,6 +28,7 @@ func TestConfig(t *testing.T) {
 	assertConfigCommand(t, configHome, "", "config", "set", "target", "http://127.0.0.1:8080")
 	assertConfigCommand(t, configHome, "", "config", "set", "target", "https://127.0.0.1")
 	assertConfigCommand(t, configHome, "target = https://127.0.0.1\n", "config", "get", "target")
+	assertConfigCommand(t, configHome, "target = local\n", "config", "get", "-t", "local", "target")
 
 	// application
 	assertConfigCommandErr(t, configHome, "Error: invalid application: \"foo\"\n", "config", "set", "application", "foo")

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -47,7 +47,7 @@ func TestQuoteFunc(t *testing.T) {
 		res := quoteArgForUrl(s)
 		if i < 32 || i > 127 {
 			assert.Equal(t, "a+z", res)
-		} else {
+		} else if testing.Verbose() { // go test -v
 			fmt.Printf("res %3d => '%s'\n", i, res)
 		}
 	}


### PR DESCRIPTION
Same as #26675, minus the last commit.

@jonmv