### PR TITLE
Allow start end sequence tokens as args bertbaseembedder

### DIFF
--- a/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
@@ -32,10 +32,10 @@ import java.util.Map;
  */
 public class BertBaseEmbedder extends AbstractComponent implements Embedder {
 
-    private final static int TOKEN_CLS = 101;  // [CLS]
-    private final static int TOKEN_SEP = 102;  // [SEP]
-
     private final int    maxTokens;
+    private final int    startSequenceToken;
+    private final int    endSequenceToken;
+    private final int    separatorToken;
     private final String inputIdsName;
     private final String attentionMaskName;
     private final String tokenTypeIdsName;
@@ -48,6 +48,8 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
     @Inject
     public BertBaseEmbedder(OnnxRuntime onnx, BertBaseEmbedderConfig config) {
         maxTokens = config.transformerMaxTokens();
+        startSequenceToken = config.transformerStartSequenceToken();
+        endSequenceToken = config.transformerStartSequenceToken();
         inputIdsName = config.transformerInputIds();
         attentionMaskName = config.transformerAttentionMask();
         tokenTypeIdsName = config.transformerTokenTypeIds();
@@ -107,7 +109,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
     Tensor embedTokens(List<Integer> tokens, TensorType type) {
         Tensor inputSequence = createTensorRepresentation(tokens, "d1");
         Tensor attentionMask = createAttentionMask(inputSequence);
-        Tensor tokenTypeIds = createTokenTypeIds(inputSequence);
+
 
         Map<String, Tensor> inputs;
         if (!"".equals(tokenTypeIdsName)) {
@@ -140,12 +142,12 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
 
     private List<Integer> embedWithSeperatorTokens(String text, Context context, int maxLength) {
         List<Integer> tokens = new ArrayList<>();
-        tokens.add(TOKEN_CLS);
+        tokens.add(startSequenceToken);
         tokens.addAll(embed(text, context));
-        tokens.add(TOKEN_SEP);
+        tokens.add(endSequenceToken);
         if (tokens.size() > maxLength) {
             tokens = tokens.subList(0, maxLength-1);
-            tokens.add(TOKEN_SEP);
+            tokens.add(endSequenceToken);
         }
         return tokens;
     }

--- a/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
@@ -35,7 +35,6 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
     private final int    maxTokens;
     private final int    startSequenceToken;
     private final int    endSequenceToken;
-    private final int    separatorToken;
     private final String inputIdsName;
     private final String attentionMaskName;
     private final String tokenTypeIdsName;
@@ -100,7 +99,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
         if (!type.dimensions().get(0).isIndexed()) {
             throw new IllegalArgumentException("Error in embedding to type '" + type + "': dimension should be indexed.");
         }
-        List<Integer> tokens = embedWithSeperatorTokens(text, context, maxTokens);
+        List<Integer> tokens = embedWithSeparatorTokens(text, context, maxTokens);
         return embedTokens(tokens, type);
     }
 
@@ -140,7 +139,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
         return builder.build();
     }
 
-    private List<Integer> embedWithSeperatorTokens(String text, Context context, int maxLength) {
+    private List<Integer> embedWithSeparatorTokens(String text, Context context, int maxLength) {
         List<Integer> tokens = new ArrayList<>();
         tokens.add(startSequenceToken);
         tokens.addAll(embed(text, context));

--- a/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/BertBaseEmbedder.java
@@ -108,6 +108,7 @@ public class BertBaseEmbedder extends AbstractComponent implements Embedder {
     Tensor embedTokens(List<Integer> tokens, TensorType type) {
         Tensor inputSequence = createTensorRepresentation(tokens, "d1");
         Tensor attentionMask = createAttentionMask(inputSequence);
+        Tensor tokenTypeIds = createTokenTypeIds(inputSequence);
 
 
         Map<String, Tensor> inputs;

--- a/model-integration/src/main/resources/configdefinitions/embedding.bert-base-embedder.def
+++ b/model-integration/src/main/resources/configdefinitions/embedding.bert-base-embedder.def
@@ -17,6 +17,10 @@ transformerInputIds      string default=input_ids
 transformerAttentionMask string default=attention_mask
 transformerTokenTypeIds  string default=token_type_ids
 
+# special token ids
+transformerStartSequenceToken int default=
+transformerEndSequenceToken   int default=
+
 # Output name
 transformerOutput string default=output_0
 

--- a/model-integration/src/main/resources/configdefinitions/embedding.bert-base-embedder.def
+++ b/model-integration/src/main/resources/configdefinitions/embedding.bert-base-embedder.def
@@ -18,8 +18,8 @@ transformerAttentionMask string default=attention_mask
 transformerTokenTypeIds  string default=token_type_ids
 
 # special token ids
-transformerStartSequenceToken int default=
-transformerEndSequenceToken   int default=
+transformerStartSequenceToken int default=101
+transformerEndSequenceToken   int default=102
 
 # Output name
 transformerOutput string default=output_0


### PR DESCRIPTION
This PR is to allow passing seperator and cls token ids as arguments for loading models that don't use the default bert base uncased vocab.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
