### PR TITLE
Don't convert a call to a jump when this breaks reporting of

### DIFF
--- a/vespalib/src/tests/signalhandler/CMakeLists.txt
+++ b/vespalib/src/tests/signalhandler/CMakeLists.txt
@@ -5,6 +5,11 @@ vespa_add_library(vespalib_signalhandler_test_my_shared_library TEST
     DEPENDS
     vespalib
 )
+
+# Don't convert call to jump when returning a value from a function with
+# a compatible stack.
+set_source_files_properties(my_shared_library.cpp PROPERTIES COMPILE_OPTIONS "-fno-optimize-sibling-calls")
+
 vespa_add_executable(vespalib_signalhandler_test_app TEST
     SOURCES
     signalhandler_test.cpp

--- a/vespalib/src/vespa/vespalib/util/CMakeLists.txt
+++ b/vespalib/src/vespa/vespalib/util/CMakeLists.txt
@@ -100,3 +100,7 @@ vespa_add_library(vespalib_vespalib_util OBJECT
     zstdcompressor.cpp
     DEPENDS
 )
+
+# Don't convert call to jump when returning a value from a function with
+# a compatible stack.
+set_source_files_properties(signalhandler.cpp PROPERTIES COMPILE_OPTIONS "-fno-optimize-sibling-calls")


### PR DESCRIPTION
stack frames.

This replaces #26718
