### PR TITLE
Support TLS in custom target

### DIFF
--- a/client/go/internal/cli/auth/zts/zts.go
+++ b/client/go/internal/cli/auth/zts/zts.go
@@ -1,7 +1,6 @@
 package zts
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -18,26 +17,39 @@ const DefaultURL = "https://zts.athenz.ouroath.com:4443"
 type Client struct {
 	client   util.HTTPClient
 	tokenURL *url.URL
+	domain   string
 }
 
 // NewClient creates a new client for an Athenz ZTS service located at serviceURL.
-func NewClient(client util.HTTPClient, serviceURL string) (*Client, error) {
+func NewClient(client util.HTTPClient, domain, serviceURL string) (*Client, error) {
 	tokenURL, err := url.Parse(serviceURL)
 	if err != nil {
 		return nil, err
 	}
 	tokenURL.Path = "/zts/v1/oauth2/token"
-	return &Client{tokenURL: tokenURL, client: client}, nil
+	return &Client{tokenURL: tokenURL, client: client, domain: domain}, nil
 }
 
-// AccessToken returns an access token within the given domain, using certificate to authenticate with ZTS.
-func (c *Client) AccessToken(domain string, certificate tls.Certificate) (string, error) {
-	data := fmt.Sprintf("grant_type=client_credentials&scope=%s:domain", domain)
+func (c *Client) Authenticate(request *http.Request) error {
+	accessToken, err := c.AccessToken()
+	if err != nil {
+		return err
+	}
+	if request.Header == nil {
+		request.Header = make(http.Header)
+	}
+	request.Header.Add("Authorization", "Bearer "+accessToken)
+	return nil
+}
+
+// AccessToken returns an access token within the domain configured in client c.
+func (c *Client) AccessToken() (string, error) {
+	// TODO(mpolden): This should cache and re-use tokens until expiry
+	data := fmt.Sprintf("grant_type=client_credentials&scope=%s:domain", c.domain)
 	req, err := http.NewRequest("POST", c.tokenURL.String(), strings.NewReader(data))
 	if err != nil {
 		return "", err
 	}
-	util.SetCertificates(c.client, []tls.Certificate{certificate})
 	response, err := c.client.Do(req, 10*time.Second)
 	if err != nil {
 		return "", err
@@ -45,7 +57,7 @@ func (c *Client) AccessToken(domain string, certificate tls.Certificate) (string
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("got status %d from %s", response.StatusCode, c.tokenURL.String())
+		return "", fmt.Errorf("zts: got status %d from %s", response.StatusCode, c.tokenURL.String())
 	}
 	var ztsResponse struct {
 		AccessToken string `json:"access_token"`

--- a/client/go/internal/cli/auth/zts/zts_test.go
+++ b/client/go/internal/cli/auth/zts/zts_test.go
@@ -1,7 +1,6 @@
 package zts
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/vespa-engine/vespa/client/go/internal/mock"
@@ -9,17 +8,17 @@ import (
 
 func TestAccessToken(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	client, err := NewClient(&httpClient, "http://example.com")
+	client, err := NewClient(&httpClient, "vespa.vespa", "http://example.com")
 	if err != nil {
 		t.Fatal(err)
 	}
 	httpClient.NextResponseString(400, `{"message": "bad request"}`)
-	_, err = client.AccessToken("vespa.vespa", tls.Certificate{})
+	_, err = client.AccessToken()
 	if err == nil {
 		t.Fatal("want error for non-ok response status")
 	}
 	httpClient.NextResponseString(200, `{"access_token": "foo bar"}`)
-	token, err := client.AccessToken("vespa.vespa", tls.Certificate{})
+	token, err := client.AccessToken()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -34,13 +34,18 @@ package specified as an argument to this command (default '.').
 It's possible to override the private key and certificate used through
 environment variables. This can be useful in continuous integration systems.
 
-Example of setting the certificate and key in-line:
+It's also possible override the CA certificate which can be useful when using self-signed certificates with a
+self-hosted Vespa service. See https://docs.vespa.ai/en/mtls.html for more information.
 
+Example of setting the CA certificate, certificate and key in-line:
+
+    export VESPA_CLI_DATA_PLANE_CA_CERT="my CA cert"
     export VESPA_CLI_DATA_PLANE_CERT="my cert"
     export VESPA_CLI_DATA_PLANE_KEY="my private key"
 
-Example of loading certificate and key from custom paths:
+Example of loading CA certificate, certificate and key from custom paths:
 
+    export VESPA_CLI_DATA_PLANE_CA_CERT_FILE=/path/to/cacert
     export VESPA_CLI_DATA_PLANE_CERT_FILE=/path/to/cert
     export VESPA_CLI_DATA_PLANE_KEY_FILE=/path/to/key
 

--- a/client/go/internal/cli/cmd/config_test.go
+++ b/client/go/internal/cli/cmd/config_test.go
@@ -2,15 +2,21 @@
 package cmd
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/vespa-engine/vespa/client/go/internal/cli/auth/auth0"
 	"github.com/vespa-engine/vespa/client/go/internal/mock"
-	"github.com/vespa-engine/vespa/client/go/internal/util"
 	"github.com/vespa-engine/vespa/client/go/internal/vespa"
 )
 
@@ -166,7 +172,7 @@ func TestReadAPIKey(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, []byte("foo"), key)
 
-	// Cloud CI does not read key from disk as it's not expected to have any
+	// Cloud CI never reads key from disk as it's not expected to have any
 	cli, _, _ = newTestCLI(t, "VESPA_CLI_CLOUD_CI=true")
 	key, err = cli.config.readAPIKey(cli, vespa.PublicSystem, "t1")
 	require.Nil(t, err)
@@ -186,12 +192,111 @@ func TestReadAPIKey(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, []byte("baz"), key)
 
-	// Auth0 is preferred when configured
+	// Prefer Auth0 if we have auth config
 	cli, _, _ = newTestCLI(t)
-	cli.auth0Factory = func(httpClient util.HTTPClient, options auth0.Options) (auth0Client, error) {
-		return &mockAuth0{hasCredentials: true}, nil
-	}
+	require.Nil(t, os.WriteFile(filepath.Join(cli.config.homeDir, "auth.json"), []byte("foo"), 0600))
 	key, err = cli.config.readAPIKey(cli, vespa.PublicSystem, "t1")
 	require.Nil(t, err)
 	assert.Nil(t, key)
+}
+
+func TestConfigReadTLSOptions(t *testing.T) {
+	app := vespa.ApplicationID{Tenant: "t1", Application: "a1", Instance: "i1"}
+	homeDir := t.TempDir()
+
+	// No environment variables, and no files on disk
+	assertTLSOptions(t, homeDir, app, vespa.TargetLocal, vespa.TLSOptions{})
+
+	// A single environment variable is set
+	assertTLSOptions(t, homeDir, app, vespa.TargetLocal, vespa.TLSOptions{TrustAll: true}, "VESPA_CLI_DATA_PLANE_TRUST_ALL=true")
+
+	// Key pair is provided in-line in environment variables
+	pemCert, pemKey, keyPair := createKeyPair(t)
+	assertTLSOptions(t, homeDir, app,
+		vespa.TargetLocal,
+		vespa.TLSOptions{
+			TrustAll:      true,
+			CACertificate: []byte("cacert"),
+			KeyPair:       []tls.Certificate{keyPair},
+		},
+		"VESPA_CLI_DATA_PLANE_TRUST_ALL=true",
+		"VESPA_CLI_DATA_PLANE_CA_CERT=cacert",
+		"VESPA_CLI_DATA_PLANE_CERT="+string(pemCert),
+		"VESPA_CLI_DATA_PLANE_KEY="+string(pemKey),
+	)
+
+	// Key pair is provided as file paths through environment variables
+	certFile := filepath.Join(homeDir, "cert")
+	keyFile := filepath.Join(homeDir, "key")
+	caCertFile := filepath.Join(homeDir, "cacert")
+	require.Nil(t, os.WriteFile(certFile, pemCert, 0600))
+	require.Nil(t, os.WriteFile(keyFile, pemKey, 0600))
+	require.Nil(t, os.WriteFile(caCertFile, []byte("cacert"), 0600))
+	assertTLSOptions(t, homeDir, app,
+		vespa.TargetLocal,
+		vespa.TLSOptions{
+			KeyPair:           []tls.Certificate{keyPair},
+			CACertificate:     []byte("cacert"),
+			CACertificateFile: caCertFile,
+			CertificateFile:   certFile,
+			PrivateKeyFile:    keyFile,
+		},
+		"VESPA_CLI_DATA_PLANE_CERT_FILE="+certFile,
+		"VESPA_CLI_DATA_PLANE_KEY_FILE="+keyFile,
+		"VESPA_CLI_DATA_PLANE_CA_CERT_FILE="+caCertFile,
+	)
+
+	// Key pair resides in default paths
+	defaultCertFile := filepath.Join(homeDir, app.String(), "data-plane-public-cert.pem")
+	defaultKeyFile := filepath.Join(homeDir, app.String(), "data-plane-private-key.pem")
+	require.Nil(t, os.WriteFile(defaultCertFile, pemCert, 0600))
+	require.Nil(t, os.WriteFile(defaultKeyFile, pemKey, 0600))
+	assertTLSOptions(t, homeDir, app,
+		vespa.TargetLocal,
+		vespa.TLSOptions{
+			KeyPair:         []tls.Certificate{keyPair},
+			CertificateFile: defaultCertFile,
+			PrivateKeyFile:  defaultKeyFile,
+		},
+	)
+}
+
+func assertTLSOptions(t *testing.T, homeDir string, app vespa.ApplicationID, target string, want vespa.TLSOptions, envVars ...string) {
+	t.Helper()
+	envVars = append(envVars, "VESPA_CLI_HOME="+homeDir)
+	cli, _, _ := newTestCLI(t, envVars...)
+	require.Nil(t, cli.Run("config", "set", "application", app.String()))
+	config, err := cli.config.readTLSOptions(app, vespa.TargetLocal)
+	require.Nil(t, err)
+	assert.Equal(t, want, config)
+}
+
+func createKeyPair(t *testing.T) ([]byte, []byte, tls.Certificate) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	notBefore := time.Now()
+	notAfter := notBefore.Add(24 * time.Hour)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "example.com"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	certificateDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER})
+	pemKey := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privateKeyDER})
+	kp, err := tls.X509KeyPair(pemCert, pemKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pemCert, pemKey, kp
 }

--- a/client/go/internal/cli/cmd/curl.go
+++ b/client/go/internal/cli/cmd/curl.go
@@ -4,7 +4,6 @@ package cmd
 import (
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"strings"
 
@@ -54,6 +53,7 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 					return err
 				}
 			case vespa.DocumentService, vespa.QueryService:
+				c.CaCertificate = service.TLSOptions.CACertificateFile
 				c.PrivateKey = service.TLSOptions.PrivateKeyFile
 				c.Certificate = service.TLSOptions.CertificateFile
 			default:
@@ -79,15 +79,7 @@ func addAccessToken(cmd *curl.Command, target vespa.Target) error {
 	if target.Type() != vespa.TargetCloud {
 		return nil
 	}
-	req := http.Request{}
-	if err := target.SignRequest(&req, ""); err != nil {
-		return err
-	}
-	headerValue := req.Header.Get("Authorization")
-	if headerValue == "" {
-		return fmt.Errorf("no authorization header added when signing request")
-	}
-	cmd.Header("Authorization", headerValue)
+	cmd.Header("Authorization", "secret")
 	return nil
 }
 

--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -75,7 +75,8 @@ func createServiceClients(service *vespa.Service, n int) []util.HTTPClient {
 	clients := make([]util.HTTPClient, 0, n)
 	for i := 0; i < n; i++ {
 		client := service.Client().Clone()
-		util.ForceHTTP2(client, service.TLSOptions.KeyPair) // Feeding should always use HTTP/2
+		// Feeding should always use HTTP/2
+		util.ForceHTTP2(client, service.TLSOptions.KeyPair, service.TLSOptions.CACertificate, service.TLSOptions.TrustAll)
 		clients = append(clients, client)
 	}
 	return clients

--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -14,16 +14,24 @@ import (
 	"github.com/vespa-engine/vespa/client/go/internal/vespa/document"
 )
 
-func addFeedFlags(cmd *cobra.Command, verbose *bool, connections *int) {
-	cmd.PersistentFlags().IntVarP(connections, "connections", "N", 8, "The number of connections to use")
-	cmd.PersistentFlags().BoolVarP(verbose, "verbose", "v", false, "Verbose mode. Print errors as they happen")
+func addFeedFlags(cmd *cobra.Command, options *feedOptions) {
+	cmd.PersistentFlags().IntVar(&options.connections, "connections", 8, "The number of connections to use")
+	cmd.PersistentFlags().StringVar(&options.route, "route", "", "Target Vespa route for feed operations")
+	cmd.PersistentFlags().IntVar(&options.traceLevel, "trace", 0, "The trace level of network traffic. 0 to disable")
+	cmd.PersistentFlags().IntVar(&options.timeoutSecs, "timeout", 0, "Feed operation timeout in seconds. 0 to disable")
+	cmd.PersistentFlags().BoolVar(&options.verbose, "verbose", false, "Verbose mode. Print errors as they happen")
+}
+
+type feedOptions struct {
+	connections int
+	route       string
+	verbose     bool
+	traceLevel  int
+	timeoutSecs int
 }
 
 func newFeedCmd(cli *CLI) *cobra.Command {
-	var (
-		verbose     bool
-		connections int
-	)
+	var options feedOptions
 	cmd := &cobra.Command{
 		Use:   "feed FILE",
 		Short: "Feed documents to a Vespa cluster",
@@ -56,10 +64,10 @@ $ cat documents.jsonl | vespa feed -
 				defer f.Close()
 				r = f
 			}
-			return feed(r, cli, verbose, connections)
+			return feed(r, cli, options)
 		},
 	}
-	addFeedFlags(cmd, &verbose, &connections)
+	addFeedFlags(cmd, &options)
 	return cmd
 }
 
@@ -73,20 +81,23 @@ func createServiceClients(service *vespa.Service, n int) []util.HTTPClient {
 	return clients
 }
 
-func feed(r io.Reader, cli *CLI, verbose bool, connections int) error {
+func feed(r io.Reader, cli *CLI, options feedOptions) error {
 	service, err := documentService(cli)
 	if err != nil {
 		return err
 	}
-	clients := createServiceClients(service, connections)
+	clients := createServiceClients(service, options.connections)
 	client := document.NewClient(document.ClientOptions{
-		BaseURL: service.BaseURL,
+		Timeout:    time.Duration(options.timeoutSecs) * time.Second,
+		Route:      options.route,
+		TraceLevel: options.traceLevel,
+		BaseURL:    service.BaseURL,
 	}, clients)
-	throttler := document.NewThrottler(connections)
+	throttler := document.NewThrottler(options.connections)
 	// TODO(mpolden): Make doom duration configurable
 	circuitBreaker := document.NewCircuitBreaker(10*time.Second, 0)
 	errWriter := io.Discard
-	if verbose {
+	if options.verbose {
 		errWriter = cli.Stderr
 	}
 	dispatcher := document.NewDispatcher(client, throttler, circuitBreaker, errWriter)

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -465,7 +465,6 @@ func (c *CLI) createDeploymentOptions(pkg vespa.ApplicationPackage, target vespa
 		ApplicationPackage: pkg,
 		Target:             target,
 		Timeout:            timeout,
-		HTTPClient:         c.httpClient,
 	}, nil
 }
 

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -88,18 +87,9 @@ func (c *execSubprocess) Run(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).Output()
 }
 
-type ztsClient interface {
-	AccessToken(domain string, certficiate tls.Certificate) (string, error)
-}
+type auth0Factory func(httpClient util.HTTPClient, options auth0.Options) (vespa.Authenticator, error)
 
-type auth0Client interface {
-	AccessToken() (string, error)
-	HasCredentials() bool
-}
-
-type auth0Factory func(httpClient util.HTTPClient, options auth0.Options) (auth0Client, error)
-
-type ztsFactory func(httpClient util.HTTPClient, url string) (ztsClient, error)
+type ztsFactory func(httpClient util.HTTPClient, domain, url string) (vespa.Authenticator, error)
 
 // New creates the Vespa CLI, writing output to stdout and stderr, and reading environment variables from environment.
 func New(stdout, stderr io.Writer, environment []string) (*CLI, error) {
@@ -143,11 +133,11 @@ For detailed description of flags and configuration, see 'vespa help config'.
 		httpClient: util.CreateClient(time.Second * 10),
 		exec:       &execSubprocess{},
 		now:        time.Now,
-		auth0Factory: func(httpClient util.HTTPClient, options auth0.Options) (auth0Client, error) {
+		auth0Factory: func(httpClient util.HTTPClient, options auth0.Options) (vespa.Authenticator, error) {
 			return auth0.NewClient(httpClient, options)
 		},
-		ztsFactory: func(httpClient util.HTTPClient, url string) (ztsClient, error) {
-			return zts.NewClient(httpClient, url)
+		ztsFactory: func(httpClient util.HTTPClient, domain, url string) (vespa.Authenticator, error) {
+			return zts.NewClient(httpClient, domain, url)
 		},
 	}
 	cli.isTerminal = func() bool { return isTerminal(cli.Stdout) && isTerminal(cli.Stderr) }
@@ -321,16 +311,34 @@ func (c *CLI) createTarget(opts targetOptions) (vespa.Target, error) {
 	if err != nil {
 		return nil, err
 	}
+	customURL := ""
 	if strings.HasPrefix(targetType, "http") {
-		return vespa.CustomTarget(c.httpClient, targetType), nil
+		customURL = targetType
+		targetType = vespa.TargetCustom
+	}
+	switch targetType {
+	case vespa.TargetLocal, vespa.TargetCustom:
+		return c.createCustomTarget(targetType, customURL)
+	case vespa.TargetCloud, vespa.TargetHosted:
+		return c.createCloudTarget(targetType, opts)
+	default:
+		return nil, errHint(fmt.Errorf("invalid target: %s", targetType), "Valid targets are 'local', 'cloud', 'hosted' or an URL")
+	}
+}
+
+func (c *CLI) createCustomTarget(targetType, customURL string) (vespa.Target, error) {
+	tlsOptions, err := c.config.readTLSOptions(vespa.DefaultApplication, targetType)
+	if err != nil {
+		return nil, err
 	}
 	switch targetType {
 	case vespa.TargetLocal:
-		return vespa.LocalTarget(c.httpClient), nil
-	case vespa.TargetCloud, vespa.TargetHosted:
-		return c.createCloudTarget(targetType, opts)
+		return vespa.LocalTarget(c.httpClient, tlsOptions), nil
+	case vespa.TargetCustom:
+		return vespa.CustomTarget(c.httpClient, customURL, tlsOptions), nil
+	default:
+		return nil, fmt.Errorf("invalid custom target: %s", targetType)
 	}
-	return nil, errHint(fmt.Errorf("invalid target: %s", targetType), "Valid targets are 'local', 'cloud', 'hosted' or an URL")
 }
 
 func (c *CLI) createCloudTarget(targetType string, opts targetOptions) (vespa.Target, error) {
@@ -347,48 +355,53 @@ func (c *CLI) createCloudTarget(targetType string, opts targetOptions) (vespa.Ta
 		return nil, err
 	}
 	var (
-		apiKey               []byte
-		authConfigPath       string
+		apiAuth              vespa.Authenticator
+		deploymentAuth       vespa.Authenticator
 		apiTLSOptions        vespa.TLSOptions
 		deploymentTLSOptions vespa.TLSOptions
 	)
 	switch targetType {
 	case vespa.TargetCloud:
-		apiKey, err = c.config.readAPIKey(c, system, deployment.Application.Tenant)
+		apiKey, err := c.config.readAPIKey(c, system, deployment.Application.Tenant)
 		if err != nil {
 			return nil, err
 		}
-		authConfigPath = c.config.authConfigPath()
+		if apiKey == nil {
+			authConfigPath := c.config.authConfigPath()
+			auth0, err := c.auth0Factory(c.httpClient, auth0.Options{ConfigPath: authConfigPath, SystemName: system.Name, SystemURL: system.URL})
+			if err != nil {
+				return nil, err
+			}
+			apiAuth = auth0
+		} else {
+			apiAuth = vespa.NewRequestSigner(deployment.Application.SerializedForm(), apiKey)
+		}
 		deploymentTLSOptions = vespa.TLSOptions{}
 		if !opts.noCertificate {
-			kp, err := c.config.x509KeyPair(deployment.Application, targetType)
+			kp, err := c.config.readTLSOptions(deployment.Application, targetType)
 			if err != nil {
-				return nil, errHint(err, "Deployment to cloud requires a certificate. Try 'vespa auth cert'")
+				return nil, errHint(err, "Deployment to cloud requires a certificate", "Try 'vespa auth cert' to create a self-signed certificate")
 			}
-			deploymentTLSOptions = vespa.TLSOptions{
-				KeyPair:         []tls.Certificate{kp.KeyPair},
-				CertificateFile: kp.CertificateFile,
-				PrivateKeyFile:  kp.PrivateKeyFile,
-			}
+			deploymentTLSOptions = kp
 		}
 	case vespa.TargetHosted:
-		kp, err := c.config.x509KeyPair(deployment.Application, targetType)
+		kp, err := c.config.readTLSOptions(deployment.Application, targetType)
 		if err != nil {
 			return nil, errHint(err, "Deployment to hosted requires an Athenz certificate", "Try renewing certificate with 'athenz-user-cert'")
 		}
-		apiTLSOptions = vespa.TLSOptions{
-			KeyPair:         []tls.Certificate{kp.KeyPair},
-			CertificateFile: kp.CertificateFile,
-			PrivateKeyFile:  kp.PrivateKeyFile,
+		zts, err := c.ztsFactory(c.httpClient, system.AthenzDomain, zts.DefaultURL)
+		if err != nil {
+			return nil, err
 		}
-		deploymentTLSOptions = apiTLSOptions
+		deploymentAuth = zts
+		apiTLSOptions = kp
+		deploymentTLSOptions = kp
 	default:
 		return nil, fmt.Errorf("invalid cloud target: %s", targetType)
 	}
 	apiOptions := vespa.APIOptions{
 		System:     system,
 		TLSOptions: apiTLSOptions,
-		APIKey:     apiKey,
 	}
 	deploymentOptions := vespa.CloudDeploymentOptions{
 		Deployment:  deployment,
@@ -403,15 +416,7 @@ func (c *CLI) createCloudTarget(targetType string, opts targetOptions) (vespa.Ta
 		Writer: c.Stdout,
 		Level:  vespa.LogLevel(logLevel),
 	}
-	auth0, err := c.auth0Factory(c.httpClient, auth0.Options{ConfigPath: authConfigPath, SystemName: apiOptions.System.Name, SystemURL: apiOptions.System.URL})
-	if err != nil {
-		return nil, err
-	}
-	zts, err := c.ztsFactory(c.httpClient, zts.DefaultURL)
-	if err != nil {
-		return nil, err
-	}
-	return vespa.CloudTarget(c.httpClient, zts, auth0, apiOptions, deploymentOptions, logOptions)
+	return vespa.CloudTarget(c.httpClient, apiAuth, deploymentAuth, apiOptions, deploymentOptions, logOptions)
 }
 
 // system returns the appropiate system for the target configured in this CLI.

--- a/client/go/internal/cli/cmd/test.go
+++ b/client/go/internal/cli/cmd/test.go
@@ -263,7 +263,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 
 	var response *http.Response
 	if externalEndpoint {
-		util.SetCertificates(context.cli.httpClient, []tls.Certificate{})
+		util.ConfigureTLS(context.cli.httpClient, []tls.Certificate{}, nil, false)
 		response, err = context.cli.httpClient.Do(request, 60*time.Second)
 	} else {
 		response, err = service.Do(request, 600*time.Second) // Vespa should provide a response within the given request timeout

--- a/client/go/internal/cli/cmd/testutil_test.go
+++ b/client/go/internal/cli/cmd/testutil_test.go
@@ -3,13 +3,14 @@ package cmd
 
 import (
 	"bytes"
-	"crypto/tls"
+	"net/http"
 	"path/filepath"
 	"testing"
 
 	"github.com/vespa-engine/vespa/client/go/internal/cli/auth/auth0"
 	"github.com/vespa-engine/vespa/client/go/internal/mock"
 	"github.com/vespa-engine/vespa/client/go/internal/util"
+	"github.com/vespa-engine/vespa/client/go/internal/vespa"
 )
 
 func newTestCLI(t *testing.T, envVars ...string) (*CLI, *bytes.Buffer, *bytes.Buffer) {
@@ -29,21 +30,15 @@ func newTestCLI(t *testing.T, envVars ...string) (*CLI, *bytes.Buffer, *bytes.Bu
 	httpClient := &mock.HTTPClient{}
 	cli.httpClient = httpClient
 	cli.exec = &mock.Exec{}
-	cli.auth0Factory = func(httpClient util.HTTPClient, options auth0.Options) (auth0Client, error) {
-		return &mockAuth0{}, nil
+	cli.auth0Factory = func(httpClient util.HTTPClient, options auth0.Options) (vespa.Authenticator, error) {
+		return &mockAuthenticator{}, nil
 	}
-	cli.ztsFactory = func(httpClient util.HTTPClient, url string) (ztsClient, error) {
-		return &mockZTS{}, nil
+	cli.ztsFactory = func(httpClient util.HTTPClient, domain, url string) (vespa.Authenticator, error) {
+		return &mockAuthenticator{}, nil
 	}
 	return cli, &stdout, &stderr
 }
 
-type mockZTS struct{}
+type mockAuthenticator struct{}
 
-func (z *mockZTS) AccessToken(domain string, cert tls.Certificate) (string, error) { return "", nil }
-
-type mockAuth0 struct{ hasCredentials bool }
-
-func (a *mockAuth0) AccessToken() (string, error) { return "", nil }
-
-func (a *mockAuth0) HasCredentials() bool { return a.hasCredentials }
+func (a *mockAuthenticator) Authenticate(request *http.Request) error { return nil }

--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -111,6 +111,8 @@ func NewRequestSigner(keyID string, pemPrivateKey []byte) *RequestSigner {
 	}
 }
 
+func (rs *RequestSigner) Authenticate(request *http.Request) error { return rs.SignRequest(request) }
+
 // SignRequest signs the given HTTP request using the private key in rs
 func (rs *RequestSigner) SignRequest(request *http.Request) error {
 	timestamp := rs.now().UTC().Format(time.RFC3339)

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -263,10 +263,6 @@ func Submit(opts DeploymentOptions) error {
 	}
 	request.Header.Set("Content-Type", writer.FormDataContentType())
 	serviceDescription := "Submit service"
-	sigKeyId := opts.Target.Deployment().Application.SerializedForm()
-	if err := opts.Target.SignRequest(request, sigKeyId); err != nil {
-		return fmt.Errorf("failed to sign api request: %w", err)
-	}
 	response, err := opts.HTTPClient.Do(request, time.Minute*10)
 	if err != nil {
 		return err
@@ -335,10 +331,6 @@ func uploadApplicationPackage(url *url.URL, opts DeploymentOptions) (PrepareResu
 		return PrepareResult{}, err
 	}
 
-	keyID := opts.Target.Deployment().Application.SerializedForm()
-	if err := opts.Target.SignRequest(request, keyID); err != nil {
-		return PrepareResult{}, err
-	}
 	response, err := service.Do(request, time.Minute*10)
 	if err != nil {
 		return PrepareResult{}, err

--- a/client/go/internal/vespa/deploy.go
+++ b/client/go/internal/vespa/deploy.go
@@ -45,7 +45,6 @@ type DeploymentOptions struct {
 	ApplicationPackage ApplicationPackage
 	Timeout            time.Duration
 	Version            version.Version
-	HTTPClient         util.HTTPClient
 }
 
 type LogLinePrepareResponse struct {
@@ -130,7 +129,7 @@ func Prepare(deployment DeploymentOptions) (PrepareResult, error) {
 		return PrepareResult{}, err
 	}
 	serviceDescription := "Deploy service"
-	response, err := deployment.HTTPClient.Do(req, time.Second*30)
+	response, err := deployServiceDo(req, time.Second*30, deployment)
 	if err != nil {
 		return PrepareResult{}, err
 	}
@@ -171,7 +170,7 @@ func Activate(sessionID int64, deployment DeploymentOptions) error {
 		return err
 	}
 	serviceDescription := "Deploy service"
-	response, err := deployment.HTTPClient.Do(req, time.Second*30)
+	response, err := deployServiceDo(req, time.Second*30, deployment)
 	if err != nil {
 		return err
 	}
@@ -263,12 +262,20 @@ func Submit(opts DeploymentOptions) error {
 	}
 	request.Header.Set("Content-Type", writer.FormDataContentType())
 	serviceDescription := "Submit service"
-	response, err := opts.HTTPClient.Do(request, time.Minute*10)
+	response, err := deployServiceDo(request, time.Minute*10, opts)
 	if err != nil {
 		return err
 	}
 	defer response.Body.Close()
 	return checkResponse(request, response, serviceDescription)
+}
+
+func deployServiceDo(request *http.Request, timeout time.Duration, opts DeploymentOptions) (*http.Response, error) {
+	s, err := opts.Target.Service(DeployService, 0, 0, "")
+	if err != nil {
+		return nil, err
+	}
+	return s.Do(request, timeout)
 }
 
 func checkDeploymentOpts(opts DeploymentOptions) error {
@@ -330,7 +337,6 @@ func uploadApplicationPackage(url *url.URL, opts DeploymentOptions) (PrepareResu
 	if err != nil {
 		return PrepareResult{}, err
 	}
-
 	response, err := service.Do(request, time.Minute*10)
 	if err != nil {
 		return PrepareResult{}, err

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestDeploy(t *testing.T) {
 	httpClient := mock.HTTPClient{}
-	target := LocalTarget(&httpClient)
+	target := LocalTarget(&httpClient, TLSOptions{})
 	appDir, _ := mock.ApplicationPackageDir(t, false, false)
 	opts := DeploymentOptions{
 		Target:             target,

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -24,7 +24,6 @@ func TestDeploy(t *testing.T) {
 	opts := DeploymentOptions{
 		Target:             target,
 		ApplicationPackage: ApplicationPackage{Path: appDir},
-		HTTPClient:         &httpClient,
 	}
 	_, err := Deploy(opts)
 	assert.Nil(t, err)
@@ -47,7 +46,6 @@ func TestDeployCloud(t *testing.T) {
 	opts := DeploymentOptions{
 		Target:             target,
 		ApplicationPackage: ApplicationPackage{Path: appDir},
-		HTTPClient:         &httpClient,
 	}
 	_, err := Deploy(opts)
 	require.Nil(t, err)

--- a/client/go/internal/vespa/document/dispatcher.go
+++ b/client/go/internal/vespa/document/dispatcher.go
@@ -184,10 +184,11 @@ func (d *Dispatcher) enqueue(op documentOp) error {
 	if !d.started {
 		return fmt.Errorf("dispatcher is closed")
 	}
-	group, ok := d.inflight[op.document.Id.String()]
+	key := op.document.Id.String()
+	group, ok := d.inflight[key]
 	if !ok {
 		group = &documentGroup{}
-		d.inflight[op.document.Id.String()] = group
+		d.inflight[key] = group
 	}
 	d.mu.Unlock()
 	group.add(op, op.attempts > 0)

--- a/client/go/internal/vespa/document/dispatcher_test.go
+++ b/client/go/internal/vespa/document/dispatcher_test.go
@@ -41,7 +41,7 @@ func TestDispatcher(t *testing.T) {
 	clock := &manualClock{tick: time.Second}
 	throttler := newThrottler(8, clock.now)
 	breaker := NewCircuitBreaker(time.Second, 0)
-	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard)
+	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard, false)
 	docs := []Document{
 		{Id: mustParseId("id:ns:type::doc1"), Operation: OperationPut, Body: []byte(`{"fields":{"foo": "123"}}`)},
 		{Id: mustParseId("id:ns:type::doc2"), Operation: OperationPut, Body: []byte(`{"fields":{"bar": "456"}}`)},
@@ -74,7 +74,7 @@ func TestDispatcherOrdering(t *testing.T) {
 	clock := &manualClock{tick: time.Second}
 	throttler := newThrottler(8, clock.now)
 	breaker := NewCircuitBreaker(time.Second, 0)
-	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard)
+	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard, false)
 	for _, d := range docs {
 		dispatcher.Enqueue(d)
 	}
@@ -110,7 +110,7 @@ func TestDispatcherOrderingWithFailures(t *testing.T) {
 	clock := &manualClock{tick: time.Second}
 	throttler := newThrottler(8, clock.now)
 	breaker := NewCircuitBreaker(time.Second, 0)
-	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard)
+	dispatcher := NewDispatcher(feeder, throttler, breaker, io.Discard, false)
 	for _, d := range docs {
 		dispatcher.Enqueue(d)
 	}

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -72,9 +72,13 @@ func NewClient(options ClientOptions, httpClients []util.HTTPClient) *Client {
 
 func (c *Client) queryParams() url.Values {
 	params := url.Values{}
-	if c.options.Timeout > 0 {
-		params.Set("timeout", strconv.FormatInt(c.options.Timeout.Milliseconds(), 10)+"ms")
+	timeout := c.options.Timeout
+	if timeout == 0 {
+		timeout = 200 * time.Second
+	} else {
+		timeout = timeout*11/10 + 1000
 	}
+	params.Set("timeout", strconv.FormatInt(timeout.Milliseconds(), 10)+"ms")
 	if c.options.Route != "" {
 		params.Set("route", c.options.Route)
 	}

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -166,7 +166,7 @@ func (c *Client) Send(document Document) Result {
 	}
 	defer resp.Body.Close()
 	elapsed := c.now().Sub(start)
-	return c.resultWithResponse(resp, result, document, elapsed)
+	return resultWithResponse(resp, result, document, elapsed)
 }
 
 func resultWithErr(result Result, err error) Result {
@@ -176,7 +176,7 @@ func resultWithErr(result Result, err error) Result {
 	return result
 }
 
-func (c *Client) resultWithResponse(resp *http.Response, result Result, document Document, elapsed time.Duration) Result {
+func resultWithResponse(resp *http.Response, result Result, document Document, elapsed time.Duration) Result {
 	result.HTTPStatus = resp.StatusCode
 	result.Stats.Responses++
 	result.Stats.ResponsesByCode = map[int]int64{resp.StatusCode: 1}

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -29,7 +29,7 @@ type ClientOptions struct {
 	BaseURL    string
 	Timeout    time.Duration
 	Route      string
-	TraceLevel *int
+	TraceLevel int
 }
 
 type countingHTTPClient struct {
@@ -78,8 +78,8 @@ func (c *Client) queryParams() url.Values {
 	if c.options.Route != "" {
 		params.Set("route", c.options.Route)
 	}
-	if c.options.TraceLevel != nil {
-		params.Set("tracelevel", strconv.Itoa(*c.options.TraceLevel))
+	if c.options.TraceLevel > 0 {
+		params.Set("tracelevel", strconv.Itoa(c.options.TraceLevel))
 	}
 	return params
 }

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -108,7 +108,7 @@ func TestClientSend(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("got r.Method = %q, want %q", r.Method, http.MethodPut)
 		}
-		wantURL := fmt.Sprintf("https://example.com:1337/document/v1/ns/type/docid/%s?create=true&timeout=5000ms", doc.Id.UserSpecific)
+		wantURL := fmt.Sprintf("https://example.com:1337/document/v1/ns/type/docid/%s?create=true&timeout=5500ms", doc.Id.UserSpecific)
 		if r.URL.String() != wantURL {
 			t.Errorf("got r.URL = %q, want %q", r.URL, wantURL)
 		}

--- a/client/go/internal/vespa/target_cloud.go
+++ b/client/go/internal/vespa/target_cloud.go
@@ -2,7 +2,6 @@ package vespa
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -35,8 +34,8 @@ type cloudTarget struct {
 	deploymentOptions CloudDeploymentOptions
 	logOptions        LogOptions
 	httpClient        util.HTTPClient
-	zts               zts
-	auth0             auth0
+	apiAuth           Authenticator
+	deploymentAuth    Authenticator
 }
 
 type deploymentEndpoint struct {
@@ -62,23 +61,15 @@ type logMessage struct {
 	Message string `json:"message"`
 }
 
-type zts interface {
-	AccessToken(domain string, certficiate tls.Certificate) (string, error)
-}
-
-type auth0 interface {
-	AccessToken() (string, error)
-}
-
 // CloudTarget creates a Target for the Vespa Cloud or hosted Vespa platform.
-func CloudTarget(httpClient util.HTTPClient, ztsClient zts, auth0Client auth0, apiOptions APIOptions, deploymentOptions CloudDeploymentOptions, logOptions LogOptions) (Target, error) {
+func CloudTarget(httpClient util.HTTPClient, apiAuth Authenticator, deploymentAuth Authenticator, apiOptions APIOptions, deploymentOptions CloudDeploymentOptions, logOptions LogOptions) (Target, error) {
 	return &cloudTarget{
 		httpClient:        httpClient,
 		apiOptions:        apiOptions,
 		deploymentOptions: deploymentOptions,
 		logOptions:        logOptions,
-		zts:               ztsClient,
-		auth0:             auth0Client,
+		apiAuth:           apiAuth,
+		deploymentAuth:    deploymentAuth,
 	}, nil
 }
 
@@ -118,15 +109,14 @@ func (t *cloudTarget) IsCloud() bool { return true }
 func (t *cloudTarget) Deployment() Deployment { return t.deploymentOptions.Deployment }
 
 func (t *cloudTarget) Service(name string, timeout time.Duration, runID int64, cluster string) (*Service, error) {
-	var service *Service
 	switch name {
 	case DeployService:
-		service = &Service{
+		service := &Service{
 			Name:       name,
 			BaseURL:    t.apiOptions.System.URL,
 			TLSOptions: t.apiOptions.TLSOptions,
-			zts:        t.zts,
 			httpClient: t.httpClient,
+			auth:       t.apiAuth,
 		}
 		if timeout > 0 {
 			status, err := service.Wait(timeout)
@@ -137,6 +127,7 @@ func (t *cloudTarget) Service(name string, timeout time.Duration, runID int64, c
 				return nil, fmt.Errorf("got status %d from deploy service at %s", status, service.BaseURL)
 			}
 		}
+		return service, nil
 	case QueryService, DocumentService:
 		if t.deploymentOptions.ClusterURLs == nil {
 			if err := t.waitForEndpoints(timeout, runID); err != nil {
@@ -147,38 +138,15 @@ func (t *cloudTarget) Service(name string, timeout time.Duration, runID int64, c
 		if err != nil {
 			return nil, err
 		}
-		t.deploymentOptions.TLSOptions.AthenzDomain = t.apiOptions.System.AthenzDomain
-		service = &Service{
+		return &Service{
 			Name:       name,
 			BaseURL:    url,
 			TLSOptions: t.deploymentOptions.TLSOptions,
-			zts:        t.zts,
 			httpClient: t.httpClient,
-		}
-
+			auth:       t.deploymentAuth,
+		}, nil
 	default:
 		return nil, fmt.Errorf("unknown service: %s", name)
-
-	}
-	if service.TLSOptions.KeyPair != nil {
-		util.SetCertificates(service.httpClient, service.TLSOptions.KeyPair)
-	}
-	return service, nil
-}
-
-func (t *cloudTarget) SignRequest(req *http.Request, keyID string) error {
-	if t.apiOptions.System.IsPublic() {
-		if t.apiOptions.APIKey != nil {
-			signer := NewRequestSigner(keyID, t.apiOptions.APIKey)
-			return signer.SignRequest(req)
-		} else {
-			return t.addAuth0AccessToken(req)
-		}
-	} else {
-		if t.apiOptions.TLSOptions.KeyPair == nil {
-			return fmt.Errorf("system %s requires a certificate for authentication", t.apiOptions.System.Name)
-		}
-		return nil
 	}
 }
 
@@ -190,7 +158,11 @@ func (t *cloudTarget) CheckVersion(clientVersion version.Version) error {
 	if err != nil {
 		return err
 	}
-	response, err := t.httpClient.Do(req, 10*time.Second)
+	deployService, err := t.Service(DeployService, 0, 0, "")
+	if err != nil {
+		return err
+	}
+	response, err := deployService.Do(req, 10*time.Second)
 	if err != nil {
 		return err
 	}
@@ -209,18 +181,6 @@ func (t *cloudTarget) CheckVersion(clientVersion version.Version) error {
 	if clientVersion.Less(minVersion) {
 		return fmt.Errorf("client version %s is less than the minimum supported version: %s", clientVersion, minVersion)
 	}
-	return nil
-}
-
-func (t *cloudTarget) addAuth0AccessToken(request *http.Request) error {
-	accessToken, err := t.auth0.AccessToken()
-	if err != nil {
-		return err
-	}
-	if request.Header == nil {
-		request.Header = make(http.Header)
-	}
-	request.Header.Set("Authorization", "Bearer "+accessToken)
 	return nil
 }
 
@@ -246,7 +206,6 @@ func (t *cloudTarget) PrintLog(options LogOptions) error {
 			q.Set("to", strconv.FormatInt(toMillis, 10))
 		}
 		req.URL.RawQuery = q.Encode()
-		t.SignRequest(req, t.deploymentOptions.Deployment.Application.SerializedForm())
 		return req
 	}
 	logFunc := func(status int, response []byte) (bool, error) {
@@ -275,8 +234,16 @@ func (t *cloudTarget) PrintLog(options LogOptions) error {
 	if options.Follow {
 		timeout = math.MaxInt64 // No timeout
 	}
-	_, err = wait(t.httpClient, logFunc, requestFunc, t.apiOptions.TLSOptions.KeyPair, timeout)
+	_, err = t.deployServiceWait(logFunc, requestFunc, timeout)
 	return err
+}
+
+func (t *cloudTarget) deployServiceWait(fn responseFunc, reqFn requestFunc, timeout time.Duration) (int, error) {
+	deployService, err := t.Service(DeployService, 0, 0, "")
+	if err != nil {
+		return 0, err
+	}
+	return wait(deployService, fn, reqFn, timeout)
 }
 
 func (t *cloudTarget) waitForEndpoints(timeout time.Duration, runID int64) error {
@@ -302,9 +269,6 @@ func (t *cloudTarget) waitForRun(runID int64, timeout time.Duration) error {
 		q := req.URL.Query()
 		q.Set("after", strconv.FormatInt(lastID, 10))
 		req.URL.RawQuery = q.Encode()
-		if err := t.SignRequest(req, t.deploymentOptions.Deployment.Application.SerializedForm()); err != nil {
-			util.JustExitWith(err)
-		}
 		return req
 	}
 	jobSuccessFunc := func(status int, response []byte) (bool, error) {
@@ -326,7 +290,7 @@ func (t *cloudTarget) waitForRun(runID int64, timeout time.Duration) error {
 		}
 		return true, nil
 	}
-	_, err = wait(t.httpClient, jobSuccessFunc, requestFunc, t.apiOptions.TLSOptions.KeyPair, timeout)
+	_, err = t.deployServiceWait(jobSuccessFunc, requestFunc, timeout)
 	return err
 }
 
@@ -361,9 +325,6 @@ func (t *cloudTarget) discoverEndpoints(timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
-	if err := t.SignRequest(req, t.deploymentOptions.Deployment.Application.SerializedForm()); err != nil {
-		return err
-	}
 	urlsByCluster := make(map[string]string)
 	endpointFunc := func(status int, response []byte) (bool, error) {
 		if ok, err := isCloudOK(status); !ok {
@@ -384,7 +345,7 @@ func (t *cloudTarget) discoverEndpoints(timeout time.Duration) error {
 		}
 		return true, nil
 	}
-	if _, err = wait(t.httpClient, endpointFunc, func() *http.Request { return req }, t.apiOptions.TLSOptions.KeyPair, timeout); err != nil {
+	if _, err := t.deployServiceWait(endpointFunc, func() *http.Request { return req }, timeout); err != nil {
 		return err
 	}
 	if len(urlsByCluster) == 0 {

--- a/client/go/internal/vespa/target_custom.go
+++ b/client/go/internal/vespa/target_custom.go
@@ -61,7 +61,7 @@ func (t *customTarget) Service(name string, timeout time.Duration, sessionOrRunI
 			if err != nil {
 				return nil, err
 			}
-			if !isOK(status) {
+			if ok, _ := isOK(status); !ok {
 				return nil, fmt.Errorf("got status %d from deploy service at %s", status, service.BaseURL)
 			}
 		} else {
@@ -111,8 +111,8 @@ func (t *customTarget) waitForConvergence(timeout time.Duration) error {
 	}
 	converged := false
 	convergedFunc := func(status int, response []byte) (bool, error) {
-		if !isOK(status) {
-			return false, nil
+		if ok, err := isOK(status); !ok {
+			return ok, err
 		}
 		var resp serviceConvergeResponse
 		if err := json.Unmarshal(response, &resp); err != nil {


### PR DESCRIPTION
Performance tests require mTLS, but CLI didn't support TLS for local/custom
targets. Also had to refactor a bit to better support all the various
combinations of HTTP/2 or not, HTTP or HTTPS, certificate or not, Auth0, ZTS,
API key......!

@jonmv