### PR TITLE
Consolidate rendering of raw data by using the same representation as…

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -210,8 +210,11 @@
     "methods" : [
       "public void <init>(byte[])",
       "public void <init>(byte[], boolean)",
+      "public byte[] value()",
       "public int compareTo(com.yahoo.prelude.hitfield.RawBase64)",
       "public java.lang.String toString()",
+      "public boolean equals(java.lang.Object)",
+      "public int hashCode()",
       "public bridge synthetic int compareTo(java.lang.Object)"
     ],
     "fields" : [ ]

--- a/container-search/src/main/java/com/yahoo/prelude/hitfield/RawBase64.java
+++ b/container-search/src/main/java/com/yahoo/prelude/hitfield/RawBase64.java
@@ -3,8 +3,10 @@ package com.yahoo.prelude.hitfield;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Objects;
 
 /**
+ * Wraps a byte [] and renders it as base64 encoded string
  * @author baldersheim
  */
 public class RawBase64 implements Comparable<RawBase64> {
@@ -14,9 +16,12 @@ public class RawBase64 implements Comparable<RawBase64> {
         this(content, false);
     }
     public RawBase64(byte[] content, boolean withoutPadding) {
+        Objects.requireNonNull(content);
         this.content = content;
         this.withoutPadding = withoutPadding;
     }
+
+    public byte [] value() { return content; }
 
     @Override
     public int compareTo(RawBase64 rhs) {
@@ -28,5 +33,18 @@ public class RawBase64 implements Comparable<RawBase64> {
         return withoutPadding
                 ? Base64.getEncoder().withoutPadding().encodeToString(content)
                 : Base64.getEncoder().encodeToString(content);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RawBase64 rawBase64 = (RawBase64) o;
+        return Arrays.equals(content, rawBase64.content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(content);
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/grouping/result/BucketGroupId.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/result/BucketGroupId.java
@@ -1,8 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.result;
 
-import static com.yahoo.text.Lowercase.toLowerCase;
-
 /**
  * This abstract class is used in {@link Group} instances where the identifying expression evaluated to a {@link
  * com.yahoo.search.grouping.request.BucketValue}. The range is inclusive-from and exclusive-to.

--- a/container-search/src/main/java/com/yahoo/search/grouping/result/HitRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/result/HitRenderer.java
@@ -7,7 +7,6 @@ import com.yahoo.text.Utf8String;
 import com.yahoo.text.XMLWriter;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -63,26 +62,13 @@ public abstract class HitRenderer {
 
     private static void renderGroupId(GroupId id, XMLWriter writer) {
         writer.openTag(TAG_GROUP_ID).attribute(ATR_TYPE, id.getTypeName());
-        if (id instanceof ValueGroupId) {
-            writer.content(getIdValue((ValueGroupId)id), false);
-        } else if (id instanceof BucketGroupId) {
-            BucketGroupId bucketId = (BucketGroupId)id;
-            writer.openTag(TAG_BUCKET_FROM).content(getBucketFrom(bucketId), false).closeTag();
-            writer.openTag(TAG_BUCKET_TO).content(getBucketTo(bucketId), false).closeTag();
+        if (id instanceof ValueGroupId<?> valueGroupId) {
+            writer.content(valueGroupId.getValue(), false);
+        } else if (id instanceof BucketGroupId bucketId) {
+            writer.openTag(TAG_BUCKET_FROM).content(bucketId.getFrom(), false).closeTag();
+            writer.openTag(TAG_BUCKET_TO).content(bucketId.getTo(), false).closeTag();
         }
         writer.closeTag();
-    }
-
-    private static Object getIdValue(ValueGroupId id) {
-        return id instanceof RawId ? Arrays.toString(((RawId)id).getValue()) : id.getValue();
-    }
-
-    private static Object getBucketFrom(BucketGroupId id) {
-        return id instanceof RawBucketId ? Arrays.toString(((RawBucketId)id).getFrom()) : id.getFrom();
-    }
-
-    private static Object getBucketTo(BucketGroupId id) {
-        return id instanceof RawBucketId ? Arrays.toString(((RawBucketId)id).getTo()) : id.getTo();
     }
 
     private static void renderContinuations(Map<String, Continuation> continuations, XMLWriter writer) {

--- a/container-search/src/main/java/com/yahoo/search/grouping/result/RawBucketId.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/result/RawBucketId.java
@@ -1,8 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.result;
 
-import java.util.Arrays;
-import java.util.Base64;
+import com.yahoo.prelude.hitfield.RawBase64;
 
 /**
  * This class is used in {@link Group} instances where the identifying
@@ -10,7 +9,7 @@ import java.util.Base64;
  *
  * @author Ulf Lilleengen
  */
-public class RawBucketId extends BucketGroupId<byte[]> {
+public class RawBucketId extends BucketGroupId<RawBase64> {
 
     /**
      * Constructs a new instance of this class.
@@ -20,7 +19,7 @@ public class RawBucketId extends BucketGroupId<byte[]> {
      */
     public RawBucketId(byte[] from, byte[] to) {
         super("raw_bucket",
-                from, Base64.getEncoder().withoutPadding().encodeToString(from),
-                to, Base64.getEncoder().withoutPadding().encodeToString(to));
+                new RawBase64(from, true),
+                new RawBase64(to, true));
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/grouping/result/RawId.java
+++ b/container-search/src/main/java/com/yahoo/search/grouping/result/RawId.java
@@ -1,14 +1,14 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.result;
 
-import java.util.Base64;
+import com.yahoo.prelude.hitfield.RawBase64;
 
 /**
  * This class is used in {@link Group} instances where the identifying expression evaluated to a {@link Byte} array.
  *
  * @author Simon Thoresen Hult
  */
-public class RawId extends ValueGroupId<byte[]> {
+public class RawId extends ValueGroupId<RawBase64> {
 
     /**
      * Constructs a new instance of this class.
@@ -16,6 +16,6 @@ public class RawId extends ValueGroupId<byte[]> {
      * @param value The identifying byte array.
      */
     public RawId(byte[] value) {
-        super("raw", value, Base64.getEncoder().withoutPadding().encodeToString(value));
+        super("raw", new RawBase64(value, true));
     }
 }

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -32,8 +32,6 @@ import com.yahoo.search.grouping.result.AbstractList;
 import com.yahoo.search.grouping.result.BucketGroupId;
 import com.yahoo.search.grouping.result.Group;
 import com.yahoo.search.grouping.result.GroupId;
-import com.yahoo.search.grouping.result.RawBucketId;
-import com.yahoo.search.grouping.result.RawId;
 import com.yahoo.search.grouping.result.RootGroup;
 import com.yahoo.search.grouping.result.ValueGroupId;
 import com.yahoo.search.result.Coverage;
@@ -57,7 +55,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
-import java.util.Base64;
 import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
@@ -423,32 +420,14 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
         if (!(id instanceof ValueGroupId<?> || id instanceof BucketGroupId)) return;
 
         if (id instanceof ValueGroupId<?> valueId) {
-            generator.writeStringField(GROUPING_VALUE, getIdValue(valueId));
+            generator.writeStringField(GROUPING_VALUE, valueId.getValue().toString());
         } else {
             BucketGroupId<?> bucketId = (BucketGroupId<?>) id;
             generator.writeObjectFieldStart(BUCKET_LIMITS);
-            generator.writeStringField(BUCKET_FROM, getBucketFrom(bucketId));
-            generator.writeStringField(BUCKET_TO, getBucketTo(bucketId));
+            generator.writeStringField(BUCKET_FROM, bucketId.getFrom().toString());
+            generator.writeStringField(BUCKET_TO, bucketId.getTo().toString());
             generator.writeEndObject();
         }
-    }
-
-    private static String getIdValue(ValueGroupId<?> id) {
-        return (id instanceof RawId raw)
-                ? Base64.getEncoder().withoutPadding().encodeToString(raw.getValue())
-                : id.getValue().toString();
-    }
-
-    private static String getBucketFrom(BucketGroupId<?> id) {
-        if (id instanceof RawBucketId rawBucketId)
-            return Base64.getEncoder().withoutPadding().encodeToString(rawBucketId.getFrom());
-        return id.getFrom().toString();
-    }
-
-    private static String getBucketTo(BucketGroupId<?> id) {
-        if (id instanceof RawBucketId rawBucketId)
-            return Base64.getEncoder().withoutPadding().encodeToString(rawBucketId.getTo());
-        return id.getTo().toString();
     }
 
     protected void renderTotalHitCount(Hit hit) throws IOException {

--- a/container-search/src/test/java/com/yahoo/search/grouping/result/GroupIdTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/result/GroupIdTestCase.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.grouping.result;
 
+import com.yahoo.prelude.hitfield.RawBase64;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,10 +26,10 @@ public class GroupIdTestCase {
         assertEquals(9L, rangeId.getTo());
 
         valueId = new RawId(new byte[]{6, 9});
-        assertArrayEquals(new byte[]{6, 9}, (byte[]) valueId.getValue());
+        assertEquals(new RawBase64(new byte[]{6, 9}, true), valueId.getValue());
         rangeId = new RawBucketId(new byte[]{6, 9}, new byte[]{9, 6});
-        assertArrayEquals(new byte[]{6, 9}, (byte[]) rangeId.getFrom());
-        assertArrayEquals(new byte[]{9, 6}, (byte[]) rangeId.getTo());
+        assertEquals(new RawBase64(new byte[]{6, 9}, true), rangeId.getFrom());
+        assertEquals(new RawBase64(new byte[]{9, 6}, true), rangeId.getTo());
 
         valueId = new StringId("69");
         assertEquals("69", valueId.getValue());

--- a/container-search/src/test/java/com/yahoo/search/grouping/result/HitRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/result/HitRendererTestCase.java
@@ -57,7 +57,7 @@ public class HitRendererTestCase {
                         "</group>\n");
         assertRender(newGroup(new RawId(Utf8.toBytes("foo"))),
                 "<group relevance=\"1.0\">\n" +
-                        "<id type=\"raw\">[102, 111, 111]</id>\n" +
+                        "<id type=\"raw\">Zm9v</id>\n" +
                         "</group>\n");
         assertRender(newGroup(new StringId("foo")),
                 "<group relevance=\"1.0\">\n" +
@@ -85,7 +85,7 @@ public class HitRendererTestCase {
                         "</group>\n");
         assertRender(newGroup(new RawBucketId(Utf8.toBytes("bar"), Utf8.toBytes("baz"))),
                 "<group relevance=\"1.0\">\n" +
-                        "<id type=\"raw_bucket\">\n<from>[98, 97, 114]</from>\n<to>[98, 97, 122]</to>\n</id>\n" +
+                        "<id type=\"raw_bucket\">\n<from>YmFy</from>\n<to>YmF6</to>\n</id>\n" +
                         "</group>\n");
     }
 


### PR DESCRIPTION
… in normal hits by using RawBase64.

@bratseth and @bjorncs PR
Note the subtle change of the generic return value of RawId.getValue() implemented in the base class ValueGroupId.

This is probably breaking more than it seems, but I think is better to do this now as we assume raw has not been used yet as there is attribute support came now.