### PR TITLE
The reserved document for a multivalue attribute vector should have an

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_initializer/attribute_initializer_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_initializer/attribute_initializer_test.cpp
@@ -277,11 +277,7 @@ TEST("require that reserved document is reinitialized during load")
     auto read_view = mvav->make_read_view(IMultiValueAttribute::WeightedSetTag<const char*>(), stash);
     ASSERT_TRUE(read_view != nullptr);
     auto reserved_values = read_view->get_values(0u);
-    EXPECT_EQUAL(1u, reserved_values.size());
-    if (reserved_values.size() >= 1) {
-        EXPECT_EQUAL(1, reserved_values[0].weight());
-        EXPECT_EQUAL(vespalib::string(""), vespalib::string(reserved_values[0].value()));
-    }
+    EXPECT_EQUAL(0u, reserved_values.size());
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -453,19 +453,6 @@ AttributeVector::set_reserved_doc_values()
         return;
     }
     clearDoc(docId);
-    if (hasMultiValue()) {
-        if (isFloatingPointType()) {
-            auto * vec = dynamic_cast<FloatingPointAttribute *>(this);
-            bool appendedUndefined = vec->append(0, attribute::getUndefined<double>(), 1);
-            assert(appendedUndefined);
-            (void) appendedUndefined;
-        } else if (isStringType()) {
-            auto * vec = dynamic_cast<StringAttribute *>(this);
-            bool appendedUndefined = vec->append(0, StringAttribute::defaultValue(), 1);
-            assert(appendedUndefined);
-            (void) appendedUndefined;
-        }
-    }
     commit();
 }
 


### PR DESCRIPTION
empty vector.

@geirst : please review
@baldersheim : FYI
