### PR TITLE
Add backend support for distributed condition evaluation

### DIFF
--- a/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
+++ b/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
@@ -848,7 +848,7 @@ TEST_P(StorageProtocolTest, track_memory_footprint_for_some_messages) {
     EXPECT_EQ(144u + sizeof(vespalib::string), sizeof(PutCommand));
     EXPECT_EQ(144u + sizeof(vespalib::string), sizeof(UpdateCommand));
     EXPECT_EQ(224u + sizeof(vespalib::string), sizeof(RemoveCommand));
-    EXPECT_EQ(296u, sizeof(GetCommand));
+    EXPECT_EQ(296u + sizeof(documentapi::TestAndSetCondition), sizeof(GetCommand));
 }
 
 } // storage::api

--- a/storage/src/vespa/storage/persistence/asynchandler.cpp
+++ b/storage/src/vespa/storage/persistence/asynchandler.cpp
@@ -358,7 +358,11 @@ bool
 AsyncHandler::tasConditionMatches(const api::TestAndSetCommand & cmd, MessageTracker & tracker,
                                   spi::Context & context, bool missingDocumentImpliesMatch) const {
     try {
-        TestAndSetHelper helper(_env, _spi, _bucketIdFactory, cmd, missingDocumentImpliesMatch);
+        TestAndSetHelper helper(_env, _spi, _bucketIdFactory,
+                                cmd.getCondition(),
+                                cmd.getBucket(), cmd.getDocumentId(),
+                                cmd.getDocumentType(),
+                                missingDocumentImpliesMatch);
 
         auto code = helper.retrieveAndMatch(context);
         if (code.failed()) {

--- a/storage/src/vespa/storage/persistence/persistencehandler.cpp
+++ b/storage/src/vespa/storage/persistence/persistencehandler.cpp
@@ -24,7 +24,7 @@ PersistenceHandler::PersistenceHandler(vespalib::ISequencedTaskExecutor & sequen
                     cfg.commonMergeChainOptimalizationMinimumSize),
       _asyncHandler(_env, provider, bucketOwnershipNotifier, sequencedExecutor, component.getBucketIdFactory()),
       _splitJoinHandler(_env, provider, bucketOwnershipNotifier, cfg.enableMultibitSplitOptimalization),
-      _simpleHandler(_env, provider)
+      _simpleHandler(_env, provider, component.getBucketIdFactory())
 {
 }
 

--- a/storage/src/vespa/storage/persistence/simplemessagehandler.h
+++ b/storage/src/vespa/storage/persistence/simplemessagehandler.h
@@ -7,6 +7,8 @@
 #include <vespa/storage/common/bucketmessages.h>
 #include <vespa/storageapi/message/persistence.h>
 
+namespace document { class BucketIdFactory; }
+
 namespace storage {
 
 namespace spi { struct PersistenceProvider; }
@@ -19,7 +21,9 @@ class PersistenceUtil;
  */
 class SimpleMessageHandler : public Types {
 public:
-    SimpleMessageHandler(const PersistenceUtil&, spi::PersistenceProvider&);
+    SimpleMessageHandler(const PersistenceUtil&,
+                         spi::PersistenceProvider&,
+                         const document::BucketIdFactory&);
     MessageTrackerUP handleGet(api::GetCommand& cmd, MessageTrackerUP tracker) const;
     MessageTrackerUP handleRevert(api::RevertCommand& cmd, MessageTrackerUP tracker) const;
     MessageTrackerUP handleCreateIterator(CreateIteratorCommand& cmd, MessageTrackerUP tracker) const;
@@ -27,8 +31,11 @@ public:
     MessageTrackerUP handleReadBucketList(ReadBucketList& cmd, MessageTrackerUP tracker) const;
     MessageTrackerUP handleReadBucketInfo(ReadBucketInfo& cmd, MessageTrackerUP tracker) const;
 private:
-    const PersistenceUtil    & _env;
-    spi::PersistenceProvider & _spi;
+    MessageTrackerUP handle_conditional_get(api::GetCommand& cmd, MessageTrackerUP tracker) const;
+
+    const PersistenceUtil&           _env;
+    spi::PersistenceProvider&        _spi;
+    const document::BucketIdFactory& _bucket_id_factory;
 };
 
 } // storage

--- a/storage/src/vespa/storage/persistence/testandsethelper.cpp
+++ b/storage/src/vespa/storage/persistence/testandsethelper.cpp
@@ -31,69 +31,91 @@ void TestAndSetHelper::parseDocumentSelection(const document::DocumentTypeRepo &
     document::select::Parser parser(documentTypeRepo, bucketIdFactory);
 
     try {
-        _docSelectionUp = parser.parse(_cmd.getCondition().getSelection());
+        _docSelectionUp = parser.parse(_condition.getSelection());
     } catch (const document::select::ParsingFailedException & e) {
         throw TestAndSetException(api::ReturnCode(api::ReturnCode::ILLEGAL_PARAMETERS, "Failed to parse test and set condition: "s + e.getMessage()));
     }
 }
 
 spi::GetResult TestAndSetHelper::retrieveDocument(const document::FieldSet & fieldSet, spi::Context & context) {
-    return _spi.get(_env.getBucket(_docId, _cmd.getBucket()), fieldSet, _cmd.getDocumentId(), context);
+    return _spi.get(_env.getBucket(_docId, _bucket), fieldSet, _docId, context);
 }
 
-TestAndSetHelper::TestAndSetHelper(const PersistenceUtil & env, const spi::PersistenceProvider  & spi,
-                                   const document::BucketIdFactory & bucketFactory,
-                                   const api::TestAndSetCommand & cmd, bool missingDocumentImpliesMatch)
+TestAndSetHelper::TestAndSetHelper(const PersistenceUtil& env,
+                                   const spi::PersistenceProvider& spi,
+                                   const document::BucketIdFactory& bucket_id_factory,
+                                   const documentapi::TestAndSetCondition& condition,
+                                   document::Bucket bucket,
+                                   document::DocumentId doc_id,
+                                   const document::DocumentType* doc_type_ptr,
+                                   bool missingDocumentImpliesMatch)
     : _env(env),
       _spi(spi),
-      _cmd(cmd),
-      _docId(cmd.getDocumentId()),
-      _docTypePtr(_cmd.getDocumentType()),
+      _condition(condition),
+      _bucket(bucket),
+      _docId(std::move(doc_id)),
+      _docTypePtr(doc_type_ptr),
       _missingDocumentImpliesMatch(missingDocumentImpliesMatch)
 {
     const auto & repo = _env.getDocumentTypeRepo();
     resolveDocumentType(repo);
-    parseDocumentSelection(repo, bucketFactory);
+    parseDocumentSelection(repo, bucket_id_factory);
 }
 
 TestAndSetHelper::~TestAndSetHelper() = default;
 
-api::ReturnCode
-TestAndSetHelper::retrieveAndMatch(spi::Context & context) {
-    // Walk document selection tree to build a minimal field set 
+TestAndSetHelper::Result
+TestAndSetHelper::fetch_and_match_raw(spi::Context& context) {
+    // Walk document selection tree to build a minimal field set
     FieldVisitor fieldVisitor(*_docTypePtr);
     try {
         _docSelectionUp->visit(fieldVisitor);
     } catch (const document::FieldNotFoundException& e) {
-        return api::ReturnCode(api::ReturnCode::ILLEGAL_PARAMETERS,
-                               vespalib::make_string("Condition field '%s' could not be found, or is an imported field. "
-                                                     "Imported fields are not supported in conditional mutations.",
-                                                     e.getFieldName().c_str()));
+        throw TestAndSetException(api::ReturnCode(
+                api::ReturnCode::ILLEGAL_PARAMETERS,
+                vespalib::make_string("Condition field '%s' could not be found, or is an imported field. "
+                                      "Imported fields are not supported in conditional mutations.",
+                                      e.getFieldName().c_str())));
     }
-
-    // Retrieve document
     auto result = retrieveDocument(fieldVisitor.getFieldSet(), context);
-
     // If document exists, match it with selection
     if (result.hasDocument()) {
         auto docPtr = result.getDocumentPtr();
         if (_docSelectionUp->contains(*docPtr) != document::select::Result::True) {
-            return api::ReturnCode(api::ReturnCode::TEST_AND_SET_CONDITION_FAILED,
-                                   vespalib::make_string("Condition did not match document nodeIndex=%d bucket=%" PRIx64 " %s",
-                                                         _env._nodeIndex, _cmd.getBucketId().getRawId(),
-                                                         _cmd.hasBeenRemapped() ? "remapped" : ""));
+            return {result.getTimestamp(), Result::ConditionOutcome::IsNotMatch};
         }
-
         // Document matches
-        return api::ReturnCode();
-    } else if (_missingDocumentImpliesMatch) {
-        return api::ReturnCode();
+        return {result.getTimestamp(), Result::ConditionOutcome::IsMatch};
     }
+    return {result.getTimestamp(), result.is_tombstone() ? Result::ConditionOutcome::IsTombstone
+                                                         : Result::ConditionOutcome::DocNotFound};
+}
 
-    return api::ReturnCode(api::ReturnCode::TEST_AND_SET_CONDITION_FAILED,
-                           vespalib::make_string("Document does not exist nodeIndex=%d bucket=%" PRIx64 " %s",
-                                                 _env._nodeIndex, _cmd.getBucketId().getRawId(),
-                                                 _cmd.hasBeenRemapped() ? "remapped" : ""));
+api::ReturnCode
+TestAndSetHelper::to_api_return_code(const Result& result) const {
+    switch (result.condition_outcome) {
+    case Result::ConditionOutcome::IsNotMatch:
+        return {api::ReturnCode::TEST_AND_SET_CONDITION_FAILED,
+                vespalib::make_string("Condition did not match document nodeIndex=%d bucket=%" PRIx64,
+                                      _env._nodeIndex, _bucket.getBucketId().getRawId())};
+    case Result::ConditionOutcome::IsTombstone:
+    case Result::ConditionOutcome::DocNotFound:
+        if (!_missingDocumentImpliesMatch) {
+            return {api::ReturnCode::TEST_AND_SET_CONDITION_FAILED,
+                    vespalib::make_string("Document does not exist nodeIndex=%d bucket=%" PRIx64,
+                                          _env._nodeIndex, _bucket.getBucketId().getRawId())};
+        }
+        [[fallthrough]]; // as match
+    case Result::ConditionOutcome::IsMatch:
+        return {}; // OK
+    }
+    abort();
+}
+
+api::ReturnCode
+TestAndSetHelper::retrieveAndMatch(spi::Context & context) {
+    auto result = fetch_and_match_raw(context);
+    return to_api_return_code(result);
 }
 
 } // storage

--- a/storage/src/vespa/storageapi/message/persistence.cpp
+++ b/storage/src/vespa/storageapi/message/persistence.cpp
@@ -222,7 +222,8 @@ GetReply::GetReply(const GetCommand& cmd,
                    const DocumentSP& doc,
                    Timestamp lastModified,
                    bool had_consistent_replicas,
-                   bool is_tombstone)
+                   bool is_tombstone,
+                   bool condition_matched)
     : BucketInfoReply(cmd),
       _docId(cmd.getDocumentId()),
       _fieldSet(cmd.getFieldSet()),
@@ -230,7 +231,8 @@ GetReply::GetReply(const GetCommand& cmd,
       _beforeTimestamp(cmd.getBeforeTimestamp()),
       _lastModifiedTime(lastModified),
       _had_consistent_replicas(had_consistent_replicas),
-      _is_tombstone(is_tombstone)
+      _is_tombstone(is_tombstone),
+      _condition_matched(condition_matched)
 {
 }
 


### PR DESCRIPTION
@havardpe please review
@geirst FYI

Lets the "test" part of a test-and-set condition be evaluated locally on individual content nodes. Piggybacks on top of (metadata-only) Get operations, adding a new condition selection field to the request and a boolean condition match result to the response.

Decouples the existing TaS utility code from being command-oriented, allowing it to be used in other contexts as well.

Not yet wired through any protocols.
