### PR TITLE
Add condition support to distributor `GetOperation`

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/messages/testandsetcondition.h
+++ b/documentapi/src/vespa/documentapi/messagebus/messages/testandsetcondition.h
@@ -27,6 +27,10 @@ public:
 
     const vespalib::string & getSelection() const { return _selection; }
     bool isPresent() const noexcept { return !_selection.empty(); }
+
+    bool operator==(const TestAndSetCondition& rhs) const noexcept {
+        return (_selection == rhs._selection);
+    }
 };
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/newest_replica.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/newest_replica.cpp
@@ -9,6 +9,7 @@ std::ostream& operator<<(std::ostream& os, const NewestReplica& nr) {
        << ", bucket_id " << nr.bucket_id
        << ", node " << nr.node
        << ", is_tombstone " << nr.is_tombstone
+       << ", condition_matched " << nr.condition_matched
        << ')';
     return os;
 }

--- a/storage/src/vespa/storage/distributor/operations/external/newest_replica.h
+++ b/storage/src/vespa/storage/distributor/operations/external/newest_replica.h
@@ -18,23 +18,26 @@ struct NewestReplica {
     document::BucketId bucket_id;
     uint16_t node {UINT16_MAX};
     bool is_tombstone {false};
+    bool condition_matched {false}; // Only relevant if a condition was initially sent
 
     static NewestReplica of(api::Timestamp timestamp,
                             const document::BucketId& bucket_id,
                             uint16_t node,
-                            bool is_tombstone) noexcept {
-        return {timestamp, bucket_id, node, is_tombstone};
+                            bool is_tombstone,
+                            bool condition_matched) noexcept {
+        return {timestamp, bucket_id, node, is_tombstone, condition_matched};
     }
 
     static NewestReplica make_empty() {
-        return {api::Timestamp(0), document::BucketId(), 0, false};
+        return {api::Timestamp(0), document::BucketId(), 0, false, false};
     }
 
     bool operator==(const NewestReplica& rhs) const noexcept {
         return ((timestamp == rhs.timestamp) &&
                 (bucket_id == rhs.bucket_id) &&
                 (node == rhs.node) &&
-                (is_tombstone == rhs.is_tombstone));
+                (is_tombstone == rhs.is_tombstone) &&
+                (condition_matched == rhs.condition_matched));
     }
     bool operator!=(const NewestReplica& rhs) const noexcept {
         return !(*this == rhs);

--- a/storage/src/vespa/storageapi/message/persistence.cpp
+++ b/storage/src/vespa/storageapi/message/persistence.cpp
@@ -202,7 +202,11 @@ GetCommand::getSummary() const
 {
     vespalib::asciistream stream;
     stream << "Get(BucketId(" << vespalib::hex << getBucketId().getId() << "), " << _docId.toString()
-           << ", beforetimestamp " << vespalib::dec << _beforeTimestamp << ')';
+           << ", beforetimestamp " << vespalib::dec << _beforeTimestamp;
+    if (has_condition()) {
+        stream << ", condition " << condition().getSelection();
+    }
+    stream << ')';
 
     return stream.str();
 }
@@ -211,7 +215,11 @@ GetCommand::getSummary() const
 void
 GetCommand::print(std::ostream& out, bool verbose, const std::string& indent) const
 {
-    out << "Get(" << getBucketId() << ", " << _docId << ")";
+    out << "Get(" << getBucketId() << ", " << _docId;
+    if (has_condition()) {
+        out << ", condition " << condition().getSelection();
+    }
+    out << ")";
     if (verbose) {
         out << " : ";
         BucketCommand::print(out, verbose, indent);


### PR DESCRIPTION
@havardpe please review

This involves two things:
 * Propagate input condition to sent Get requests (when present)
 * Add condition match status to newest replica metadata aggregation

