### PR TITLE
Minor cleanups in Put/Remove operation code

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -47,9 +47,10 @@ private:
     void sendPutToBucketOnNode(document::BucketSpace bucketSpace, const document::BucketId& bucketId,
                                const uint16_t node, std::vector<PersistenceMessageTracker::ToSend>& putBatch);
 
-    bool shouldImplicitlyActivateReplica(const OperationTargetList& targets) const;
+    [[nodiscard]] bool shouldImplicitlyActivateReplica(const OperationTargetList& targets) const;
 
-    bool has_unavailable_targets_in_pending_state(const OperationTargetList& targets) const;
+    [[nodiscard]] bool has_unavailable_targets_in_pending_state(const OperationTargetList& targets) const;
+    [[nodiscard]] bool at_least_one_storage_node_is_available() const;
 
     std::shared_ptr<api::PutCommand> _msg;
     DistributorStripeOperationContext& _op_ctx;

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
@@ -5,12 +5,11 @@
 #include <vespa/vdslib/state/clusterstate.h>
 
 #include <vespa/log/log.h>
-LOG_SETUP(".distributor.operation.external.remove");
+LOG_SETUP(".distributor.operations.external.remove");
 
-
-using namespace storage::distributor;
-using namespace storage;
 using document::BucketSpace;
+
+namespace storage::distributor {
 
 RemoveOperation::RemoveOperation(const DistributorNodeContext& node_ctx,
                                  DistributorStripeOperationContext& op_ctx,
@@ -99,4 +98,6 @@ void
 RemoveOperation::onClose(DistributorStripeMessageSender& sender)
 {
     _tracker.fail(sender, api::ReturnCode(api::ReturnCode::ABORTED, "Process is shutting down"));
+}
+
 }


### PR DESCRIPTION
@havardpe please review.

No changes in semantics, but removes an unneeded deep copy of the current cluster state for every processed Put (the returned reference shall always be valid in the context of a synchronous invocation on an `Operation`, though it may change between _separate_ invocations due to cluster state transitions etc.)
