### PR TITLE
Add bucketSpace parameter to Visit command

### DIFF
--- a/client/go/internal/cli/cmd/visit.go
+++ b/client/go/internal/cli/cmd/visit.go
@@ -23,6 +23,7 @@ import (
 type visitArgs struct {
 	contentCluster string
 	fieldSet       string
+	bucketSpace    string
 	selection      string
 	makeFeed       bool
 	jsonLines      bool
@@ -122,6 +123,7 @@ $ vespa visit --field-set "[id]" # list document IDs
 	}
 	cmd.Flags().StringVar(&vArgs.contentCluster, "content-cluster", "*", `Which content cluster to visit documents from`)
 	cmd.Flags().StringVar(&vArgs.fieldSet, "field-set", "", `Which fieldset to ask for`)
+	cmd.Flags().StringVar(&vArgs.bucketSpace, "bucket-space", "default", `Which bucket space to visit documents from. Specify "global" to visit global documents`)
 	cmd.Flags().StringVar(&vArgs.selection, "selection", "", `select subset of cluster`)
 	cmd.Flags().BoolVar(&vArgs.debugMode, "debug-mode", false, `print debugging output`)
 	cmd.Flags().BoolVar(&vArgs.jsonLines, "json-lines", true, `output documents as JSON lines`)
@@ -309,6 +311,9 @@ func runOneVisit(vArgs *visitArgs, service *vespa.Service, contToken string) (*V
 	urlPath := service.BaseURL + "/document/v1/?cluster=" + quoteArgForUrl(vArgs.contentCluster)
 	if vArgs.fieldSet != "" {
 		urlPath = urlPath + "&fieldSet=" + quoteArgForUrl(vArgs.fieldSet)
+	}
+	if vArgs.bucketSpace != "" {
+		urlPath = urlPath + "&bucketSpace=" + quoteArgForUrl(vArgs.bucketSpace)
 	}
 	if vArgs.selection != "" {
 		urlPath = urlPath + "&selection=" + quoteArgForUrl(vArgs.selection)

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -118,7 +118,7 @@ func TestVisitCommand(t *testing.T) {
 				document3 +
 				`],"documentCount":2}`,
 		},
-		"cluster=fooCC&continuation=CAFE&wantedDocumentCount=1000",
+		"cluster=fooCC&bucketSpace=default&continuation=CAFE&wantedDocumentCount=1000",
 		document1+"\n"+
 			document2+"\n"+
 			document3+"\n")


### PR DESCRIPTION
Previously, global documents could not be visited via the CLI as they exist in a non-default space ("global"). By adding the bucket-space flag argument, the visit CLI can now access global documents.

To use:

```
cd vespa/client/go
make install
./bin/vespa visit --selection="some_global_document" --bucket-space "global"
```

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.