### PR TITLE
Improve timeout handling in /doc/v1

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1430,9 +1430,9 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
     // ------------------------------------------------ Helpers ------------------------------------------------
 
     private static long doomMillis(HttpRequest request) {
-        long connectedAtMillis = request.getConnectedAt(MILLISECONDS);
+        long createdAtMillis = request.creationTime(MILLISECONDS);
         long requestTimeoutMillis = getProperty(request, TIMEOUT, timeoutMillisParser).orElse(defaultTimeout.toMillis());
-        return connectedAtMillis + requestTimeoutMillis;
+        return createdAtMillis + requestTimeoutMillis;
     }
 
     private static String requireProperty(HttpRequest request, String name) {


### PR DESCRIPTION
Set timeout based on qhen HTTP request was connected to the container, instead of when it is dispatched to the document API; this should reduce the chance of the client going away before we close the request from the handler

@bjorncs please review. 

@vekterli the `handlerTimeout` is used to let visits complete (after visitor (session) timeout occurs). Perhaps we need to pad those with a negative number instead? 

Also, reducing the `handlerTimeout` to `500ms` is probably OK because the feed client adds a second, and 10% of the user-specified timeout, before aborting a request. I don't feel good about this, though. It would feel better to adhere strictly to the timeout specified in the HTTP request. However, visiting would then in most cases return strictly ahead of the specified timeout, which could be a bit weird ... ? But perhaps we should just accept that, anyway? That is, remove the `handlerTimeout` altogether, and always try to respond within timeout relative to connection time, and instead subtract a specific visitor buffer of the current `5s` ... ?