### PR TITLE
Use graceful GOAWAY allowing all in-flight requests to complete

### DIFF
--- a/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
+++ b/container-core/src/main/java/com/yahoo/jdisc/http/server/jetty/HttpRequestDispatch.java
@@ -17,7 +17,8 @@ import jakarta.servlet.AsyncEvent;
 import jakarta.servlet.AsyncListener;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http2.ErrorCode;
+import org.eclipse.jetty.http2.HTTP2Session;
+import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnection;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EofException;
@@ -159,7 +160,7 @@ class HttpRequestDispatch {
         Connection connection = RequestUtils.getConnection(request);
         if (maxRequestsPerConnection > 0) {
             if (connection.getMessagesIn() >= maxRequestsPerConnection) {
-                gracefulShutdown(connection, "max-req-per-conn-exceeded");
+                gracefulShutdown(connection);
             }
         }
         double maxConnectionLifeInSeconds = connectorConfig.maxConnectionLife();
@@ -168,19 +169,20 @@ class HttpRequestDispatch {
             Instant expiredAt = Instant.ofEpochMilli((long) (createdAt + maxConnectionLifeInSeconds * 1000));
             boolean isExpired = Instant.now().isAfter(expiredAt);
             if (isExpired) {
-                gracefulShutdown(connection, "max-conn-life-exceeded");
+                gracefulShutdown(connection);
             }
         }
     }
 
-    private static void gracefulShutdown(Connection connection, String reason) {
-        if (connection instanceof HttpConnection) {
-            HttpConnection http1 = (HttpConnection) connection;
+    private static void gracefulShutdown(Connection connection) {
+        if (connection instanceof HttpConnection http1) {
             http1.getGenerator().setPersistent(false);
-        } else if (connection instanceof HTTP2ServerConnection) {
-            HTTP2ServerConnection http2 = (HTTP2ServerConnection) connection;
-            // Signal Jetty to do a graceful connection shutdown with GOAWAY frame
-            http2.getSession().close(ErrorCode.NO_ERROR.code, reason, Callback.NOOP);
+        } else if (connection instanceof HTTP2ServerConnection http2) {
+            // Signal Jetty to do a graceful shutdown of HTTP/2 connection.
+            // Graceful shutdown implies a GOAWAY frame with 'Error Code' = 'NO_ERROR' and 'Last-Stream-ID' = 2^31-1.
+            // In-flight requests will be allowed to complete before connection is terminated.
+            // See https://datatracker.ietf.org/doc/html/rfc9113#name-goaway for details
+            ((HTTP2Session)http2.getSession()).goAway(GoAwayFrame.GRACEFUL, Callback.NOOP);
         }
     }
 


### PR DESCRIPTION
Original code used lastRemoteStreamId in GOAWAY frame that would cause inflight requests not yet received to be rejected.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
