### PR TITLE
Reapply "Remove access logging for container clusters that are internal"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.model.admin;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.container.logging.AccessLog;
+import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.component.Handler;
@@ -21,6 +23,7 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
 
         addDefaultHandlersWithVip();
         addLogHandler();
+        addAccessLog();
         setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin)));
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -5,6 +5,7 @@ import com.yahoo.config.model.api.Reindexing;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.PlatformBundles;
@@ -30,6 +31,7 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
             TreeConfigProducer<?> parent, String subId, String name, DeployState deployState) {
         super(parent, subId, name, deployState, false);
         addDefaultHandlersWithVip();
+        addAccessLog();
         this.reindexingContext = createReindexingContext(deployState);
         setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin)));
     }

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -86,12 +86,10 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
         static final String LEGACY_APPLICATION = "app";        // app.instance
     }
 
-    private final TreeConfigProducer<?> parent;
     private final ApplicationId applicationId;
 
     public MetricsProxyContainerCluster(TreeConfigProducer<?> parent, String name, DeployState deployState) {
         super(parent, name, name, deployState, true);
-        this.parent = parent;
         applicationId = deployState.getProperties().applicationId();
 
         setRpcServerEnabled(true);
@@ -99,6 +97,7 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
 
         addPlatformBundle(METRICS_PROXY_BUNDLE_FILE);
         addClusterComponents();
+        addAccessLog();
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -24,6 +24,8 @@ import com.yahoo.container.handler.metrics.MetricsV2Handler;
 import com.yahoo.container.handler.metrics.PrometheusV1Handler;
 import com.yahoo.container.jdisc.ContainerMbusConfig;
 import com.yahoo.container.jdisc.messagebus.MbusServerProvider;
+import com.yahoo.container.logging.AccessLog;
+import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
@@ -32,6 +34,7 @@ import com.yahoo.vespa.config.search.core.RankingConstantsConfig;
 import com.yahoo.vespa.config.search.core.RankingExpressionsConfig;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainer;
+import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.BindingPattern;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
@@ -48,6 +51,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.yahoo.config.model.api.ApplicationClusterEndpoint.RoutingMethod.sharedLayer4;
+import static com.yahoo.vespa.model.container.component.AccessLogComponent.AccessLogType.jsonAccessLog;
 import static com.yahoo.vespa.model.container.docproc.DocprocChains.DOCUMENT_TYPE_MANAGER_CLASS;
 
 /**
@@ -335,6 +339,17 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     }
 
     protected boolean messageBusEnabled() { return messageBusEnabled; }
+
+    public void addAccessLog() {
+        addSimpleComponent(AccessLog.class);
+        // In hosted there is one application container per node, so we do not use the container name to distinguish log files
+        Optional<String> clusterName = isHostedVespa ? Optional.empty() : Optional.of(getName());
+        addComponent(new AccessLogComponent(this, jsonAccessLog, compressionType, clusterName, isHostedVespa));
+    }
+
+    public void addVoidAccessLog() {
+        addSimpleComponent(VoidRequestLog.class);
+    }
 
     public void addMbusServer(ComponentId chainId) {
         ComponentId serviceId = chainId.nestInNamespace(ComponentId.fromString("MbusServer"));

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ContainerCluster.java
@@ -289,7 +289,7 @@ public abstract class ContainerCluster<CONTAINER extends Container>
         return componentGroup.removeComponent(componentId);
     }
 
-    protected void addSimpleComponent(Class<?> clazz) {
+    public void addSimpleComponent(Class<?> clazz) {
         addSimpleComponent(clazz.getName());
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/DefaultThreadpoolProvider.java
@@ -31,7 +31,7 @@ class DefaultThreadpoolProvider extends SimpleComponent implements ThreadpoolCon
     public void getConfig(ThreadpoolConfig.Builder builder) {
         if (cluster instanceof ApplicationContainerCluster) {
             // Core pool size of 2xcores, and max of 100xcores and using a synchronous Q
-            // This is the deafault pool used by both federation and generally when you ask for an Executor.
+            // This is the default pool used by both federation and generally when you ask for an Executor.
             builder.corePoolSize(-2).maxthreads(-100).queueSize(0);
         } else {
             // Container clusters such as logserver, metricsproxy and clustercontroller

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -38,6 +38,7 @@ import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.logging.FileConnectionLog;
 import com.yahoo.io.IOUtils;
+import com.yahoo.jdisc.http.server.jetty.VoidRequestLog;
 import com.yahoo.osgi.provider.model.ComponentModel;
 import com.yahoo.path.Path;
 import com.yahoo.schema.OnnxModel;
@@ -428,7 +429,9 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
         }
 
         if (accessLogElements.isEmpty() && deployState.getAccessLoggingEnabledByDefault())
-            cluster.addDefaultSearchAccessLog();
+            cluster.addAccessLog();
+        else
+            cluster.addVoidAccessLog();
 
         // Add connection log if access log is configured
         if (cluster.getAllComponents().stream().anyMatch(component -> component instanceof AccessLogComponent)) {
@@ -444,7 +447,6 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
     private List<Element> getAccessLogElements(Element spec) {
         return XML.getChildren(spec, "accesslog");
     }
-
 
     protected void addHttp(DeployState deployState, Element spec, ApplicationContainerCluster cluster, ConfigModelContext context) {
         Element httpElement = XML.getChild(spec, "http");
@@ -1223,7 +1225,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
 
         private static final Pattern validPattern = Pattern.compile("-[a-zA-z0-9=:./,+*-]+");
         // debug port will not be available in hosted, don't allow
-        private static final Pattern invalidInHostedatttern = Pattern.compile("-Xrunjdwp:transport=.*");
+        private static final Pattern invalidInHostedPattern = Pattern.compile("-Xrunjdwp:transport=.*");
 
         private final Element nodesElement;
         private final DeployLogger logger;
@@ -1276,7 +1278,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             if (isHosted)
                 invalidOptions.addAll(Arrays.stream(optionList)
                         .filter(option -> !option.isEmpty())
-                        .filter(option -> Pattern.matches(invalidInHostedatttern.pattern(), option))
+                        .filter(option -> Pattern.matches(invalidInHostedPattern.pattern(), option))
                         .sorted().toList());
 
             if (invalidOptions.isEmpty()) return;

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerClusterTest.java
@@ -15,7 +15,10 @@ import com.yahoo.container.core.ApplicationMetadataConfig;
 import com.yahoo.container.di.config.PlatformBundlesConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyContainerCluster.AppDimensionNames;
+import com.yahoo.vespa.model.container.Container;
+import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,7 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.g
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.servicesWithAdminOnly;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -110,6 +114,25 @@ public class MetricsProxyContainerClusterTest {
         assertEquals(2, config.node().size());
         assertNodeConfig(config.node(0));
         assertNodeConfig(config.node(1));
+    }
+
+    @Test
+    void no_access_logging_self_hosted() {
+        VespaModel hostedModel = getModel(servicesWithTwoNodes(), self_hosted);
+        assertFalse(hasAccessLogComponent(hostedModel.getAdmin().getMetricsProxyCluster()));
+    }
+
+    @Test
+    void access_logging_hosted() {
+        VespaModel hostedModel = getModel(servicesWithTwoNodes(), hosted);
+        assertTrue(hasAccessLogComponent(hostedModel.getAdmin().getMetricsProxyCluster()));
+    }
+
+    private boolean hasAccessLogComponent(ContainerCluster<? extends Container> cluster) {
+        for (Component<?, ?> component : cluster.getAllComponents()) {
+            if (component instanceof AccessLogComponent) return true;
+        }
+        return false;
     }
 
     private void assertNodeConfig(MetricsNodesConfig.Node node) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/AccessLogTest.java
@@ -11,6 +11,7 @@ import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.container.core.AccessLogConfig;
+import com.yahoo.container.logging.AccessLog;
 import com.yahoo.container.logging.ConnectionLogConfig;
 import com.yahoo.container.logging.FileConnectionLog;
 import com.yahoo.container.logging.JSONAccessLog;
@@ -70,6 +71,11 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
         return cluster.getComponentsMap().get(ComponentId.fromString((JSONAccessLog.class.getName())));
     }
 
+    private Component<?, ?> getAccessLog(String clusterName) {
+        ApplicationContainerCluster cluster = (ApplicationContainerCluster) root.getChildren().get(clusterName);
+        return cluster.getComponentsMap().get(ComponentId.fromString((AccessLog.class.getName())));
+    }
+
     @Test
     void access_log_can_be_configured() {
         Element clusterElem = DomBuilderTest.parse(
@@ -84,6 +90,7 @@ public class AccessLogTest extends ContainerModelBuilderTestBase {
         createModel(root, clusterElem);
         assertNotNull(getJsonAccessLog("default"));
         assertNotNull(getVespaAccessLog("default"));
+        assertNotNull(getAccessLog("default"));
 
         { // vespa
             Component<?, ?> accessLogComponent = getComponent("default", VespaAccessLog.class.getName());


### PR DESCRIPTION
Reapplies https://github.com/vespa-engine/vespa/pull/26879, but makes sure that AccessLog component is always added when needed