### PR TITLE
Use padded base64 encoding as that seems to be the most common format.

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/hitfield/RawBase64.java
+++ b/container-search/src/main/java/com/yahoo/prelude/hitfield/RawBase64.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * @author baldersheim
  */
 public class RawBase64 implements Comparable<RawBase64> {
-    private final static Base64.Encoder encoder = Base64.getEncoder().withoutPadding();
+    private final static Base64.Encoder encoder = Base64.getEncoder();
     private final byte[] content;
     public RawBase64(byte[] content) {
         Objects.requireNonNull(content);

--- a/container-search/src/test/java/com/yahoo/search/grouping/result/GroupIdTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/result/GroupIdTestCase.java
@@ -48,8 +48,8 @@ public class GroupIdTestCase {
         assertEquals("group:long:69", new LongId(69L).toString());
         assertEquals("group:long_bucket:6:9", new LongBucketId(6L, 9L).toString());
         assertEquals("group:null", new NullId().toString());
-        assertEquals("group:raw:Bgk", new RawId(new byte[]{6, 9}).toString());
-        assertEquals("group:raw_bucket:Bgk:CQY", new RawBucketId(new byte[]{6, 9}, new byte[]{9, 6}).toString());
+        assertEquals("group:raw:Bgk=", new RawId(new byte[]{6, 9}).toString());
+        assertEquals("group:raw_bucket:Bgk=:CQY=", new RawBucketId(new byte[]{6, 9}, new byte[]{9, 6}).toString());
         assertTrue(new RootId(0).toString().startsWith("group:root:"));
         assertEquals("group:string:69", new StringId("69").toString());
         assertEquals("group:string_bucket:6:9", new StringBucketId("6", "9").toString());

--- a/container-search/src/test/java/com/yahoo/search/grouping/vespa/ResultBuilderTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/grouping/vespa/ResultBuilderTestCase.java
@@ -60,12 +60,12 @@ public class ResultBuilderTestCase {
         assertGroupId("group:6.9", new FloatResultNode(6.9));
         assertGroupId("group:69", new IntegerResultNode(69));
         assertGroupId("group:null", new NullResultNode());
-        assertGroupId("group:Bgk", new RawResultNode(new byte[]{6, 9}));
+        assertGroupId("group:Bgk=", new RawResultNode(new byte[]{6, 9}));
         assertGroupId("group:a", new StringResultNode("a"));
         assertGroupId("group:6.9:9.6", new FloatBucketResultNode(6.9, 9.6));
         assertGroupId("group:6:9", new IntegerBucketResultNode(6, 9));
         assertGroupId("group:a:b", new StringBucketResultNode("a", "b"));
-        assertGroupId("group:Bgk:CQY", new RawBucketResultNode(new RawResultNode(new byte[]{6, 9}),
+        assertGroupId("group:Bgk=:CQY=", new RawBucketResultNode(new RawResultNode(new byte[]{6, 9}),
                 new RawResultNode(new byte[]{9, 6})));
     }
 
@@ -92,7 +92,7 @@ public class ResultBuilderTestCase {
         assertResult("69", new MinAggregationResult(new IntegerResultNode(69)));
         assertResult("69.3", new MinAggregationResult(new FloatResultNode(69.3)));
         assertResult("69.6", new MinAggregationResult(new StringResultNode("69.6")));
-        assertResult("Bgk", new MinAggregationResult(new RawResultNode(new byte[]{6,9})));
+        assertResult("Bgk=", new MinAggregationResult(new RawResultNode(new byte[]{6,9})));
     }
 
     @Test


### PR DESCRIPTION
@bjorncs PR
This is required to fix issue #26947 