### PR TITLE
Move access log setup for non-application containers to cluster

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -7,9 +7,6 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.vespa.model.container.Container;
-import com.yahoo.vespa.model.container.component.AccessLogComponent;
-import com.yahoo.vespa.model.container.component.AccessLogComponent.AccessLogType;
-import java.util.Optional;
 
 /**
  * Container that should be running on same host as the logserver. Sets up a handler for getting logs from logserver.
@@ -19,11 +16,8 @@ public class LogserverContainer extends Container {
 
     public LogserverContainer(TreeConfigProducer<?> parent, DeployState deployState) {
         super(parent, "" + 0, 0, deployState);
-        if (deployState.isHosted() && deployState.getProperties().applicationId().instance().isTester()) useDynamicPorts();
-        LogserverContainerCluster cluster = (LogserverContainerCluster) parent;
-        addComponent(new AccessLogComponent(cluster, AccessLogType.jsonAccessLog,
-                                            deployState.featureFlags().logFileCompressionAlgorithm("zstd"),
-                                            Optional.of(cluster.getName()), true));
+        if (deployState.isHosted() && deployState.getProperties().applicationId().instance().isTester())
+            useDynamicPorts();
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainerCluster.java
@@ -6,6 +6,7 @@ import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
+import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 
@@ -22,6 +23,12 @@ public class LogserverContainerCluster extends ContainerCluster<LogserverContain
         addDefaultHandlersWithVip();
         addLogHandler();
         setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin)));
+        if (isHostedVespa())
+            addComponent(new AccessLogComponent(this,
+                                                AccessLogComponent.AccessLogType.jsonAccessLog,
+                                                deployState.featureFlags().logFileCompressionAlgorithm("zstd"),
+                                                Optional.of(getName()),
+                                                isHostedVespa()));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainer.java
@@ -16,15 +16,13 @@ import com.yahoo.vespa.config.content.FleetcontrollerConfig;
 import com.yahoo.vespa.config.content.reindexing.ReindexingConfig;
 import com.yahoo.vespa.model.application.validation.RestartConfigs;
 import com.yahoo.vespa.model.container.Container;
-import com.yahoo.vespa.model.container.component.AccessLogComponent;
+import com.yahoo.vespa.model.container.PlatformBundles;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.SimpleComponent;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 import com.yahoo.vespa.model.container.xml.ContainerModelBuilder;
-import com.yahoo.vespa.model.container.PlatformBundles;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -64,11 +62,6 @@ public class ClusterControllerContainer extends Container implements
                    "com.yahoo.vespa.clustercontroller.apps.clustercontroller.StateRestApiV2Handler",
                    "/cluster/v2/*",
                    CLUSTERCONTROLLER_BUNDLE);
-        addComponent(new AccessLogComponent(containerCluster().orElse(null),
-                                            AccessLogComponent.AccessLogType.jsonAccessLog,
-                                            deployState.featureFlags().logFileCompressionAlgorithm("zstd"),
-                                            Optional.of("controller"),
-                                            deployState.isHosted()));
 
         // TODO: Why are bundles added here instead of in the cluster?
         addFileBundle("clustercontroller-apps");

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/clustercontroller/ClusterControllerContainerCluster.java
@@ -8,6 +8,7 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.AccessLogComponent;
 
 import java.nio.file.Path;
 import java.util.Collections;
@@ -32,6 +33,12 @@ public class ClusterControllerContainerCluster extends ContainerCluster<ClusterC
         addDefaultHandlersWithVip();
         this.reindexingContext = createReindexingContext(deployState);
         setJvmGCOptions(deployState.getProperties().jvmGCOptions(Optional.of(ClusterSpec.Type.admin)));
+        if (isHostedVespa())
+            addComponent(new AccessLogComponent(this,
+                                                AccessLogComponent.AccessLogType.jsonAccessLog,
+                                                deployState.featureFlags().logFileCompressionAlgorithm("zstd"),
+                                                Optional.of("controller"),
+                                                isHostedVespa()));
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainer.java
@@ -1,5 +1,4 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-
 package com.yahoo.vespa.model.admin.metricsproxy;
 
 import ai.vespa.metricsproxy.http.metrics.MetricsV2Handler;
@@ -22,7 +21,6 @@ import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.HostResource;
 import com.yahoo.vespa.model.PortAllocBridge;
 import com.yahoo.vespa.model.container.Container;
-import com.yahoo.vespa.model.container.component.AccessLogComponent;
 
 import java.time.Duration;
 import java.util.LinkedHashMap;
@@ -65,10 +63,6 @@ public class MetricsProxyContainer extends Container implements
         setProp("clustertype", "admin");
         setProp("index", String.valueOf(index));
         addNodeSpecificComponents();
-        addComponent(new AccessLogComponent(containerCluster().orElse(null), AccessLogComponent.AccessLogType.jsonAccessLog,
-                "zstd",
-                Optional.of("metrics-proxy"),
-                deployState.isHosted()));
     }
 
     private void addNodeSpecificComponents() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerCluster.java
@@ -32,6 +32,7 @@ import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.admin.monitoring.Monitoring;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.AccessLogComponent;
 import com.yahoo.vespa.model.container.component.Handler;
 import com.yahoo.vespa.model.container.component.SystemBindingPattern;
 
@@ -99,6 +100,12 @@ public class MetricsProxyContainerCluster extends ContainerCluster<MetricsProxyC
 
         addPlatformBundle(METRICS_PROXY_BUNDLE_FILE);
         addClusterComponents();
+        if (isHostedVespa())
+            addComponent(new AccessLogComponent(this,
+                                                AccessLogComponent.AccessLogType.jsonAccessLog,
+                                                "zstd",
+                                                Optional.of("metrics-proxy"),
+                                                isHostedVespa()));
     }
 
     @Override


### PR DESCRIPTION
Having some setup per container and some per container is confusing, want to do this before continuing work on https://github.com/vespa-engine/vespa/pull/26917