### PR TITLE
Change JSON decoder

### DIFF
--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/briandowns/spinner v1.16.0
 	github.com/fatih/color v1.10.0
+	github.com/goccy/go-json v0.10.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.13

--- a/client/go/go.sum
+++ b/client/go/go.sum
@@ -10,6 +10,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4 h1:9349emZab16e7zQvpmsbtjc18ykshndd8y2PG3sgJbA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/client/go/internal/vespa/document/document.go
+++ b/client/go/internal/vespa/document/document.go
@@ -2,11 +2,12 @@ package document
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/goccy/go-json"
 )
 
 var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}

--- a/client/go/internal/vespa/document/document_test.go
+++ b/client/go/internal/vespa/document/document_test.go
@@ -174,7 +174,7 @@ func TestDocumentDecoder(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	}
 	_, err = r.Decode()
-	wantErr := "invalid json at byte offset 60: invalid character '\\n' in string literal"
+	wantErr := "invalid json at byte offset 122: json: string of object unexpected end of JSON input"
 	if err.Error() != wantErr {
 		t.Errorf("want error %q, got %q", wantErr, err.Error())
 	}

--- a/client/go/internal/vespa/document/document_test.go
+++ b/client/go/internal/vespa/document/document_test.go
@@ -1,6 +1,7 @@
 package document
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -178,3 +179,23 @@ func TestDocumentDecoder(t *testing.T) {
 		t.Errorf("want error %q, got %q", wantErr, err.Error())
 	}
 }
+
+func benchmarkDocumentDecoder(b *testing.B, size int) {
+	b.Helper()
+	input := fmt.Sprintf(`{"put": "id:ns:type::doc1", "fields": {"foo": "%s"}}`, strings.Repeat("s", size))
+	r := strings.NewReader(input)
+	dec := NewDecoder(r)
+	b.ResetTimer() // ignore setup time
+
+	for n := 0; n < b.N; n++ {
+		_, err := dec.Decode()
+		if err != nil {
+			b.Fatal(err)
+		}
+		r.Seek(0, 0)
+	}
+}
+
+func BenchmarkDocumentDecoderSmall(b *testing.B) { benchmarkDocumentDecoder(b, 10) }
+
+func BenchmarkDocumentDecoderLarge(b *testing.B) { benchmarkDocumentDecoder(b, 10000) }


### PR DESCRIPTION
Stdlib decoder isn't particularly fast, so switched to a different one with better performance. Some numbers:

```
$ benchstat /tmp/small_old.txt /tmp/small_new.txt
goos: darwin
goarch: arm64
pkg: github.com/vespa-engine/vespa/client/go/internal/vespa/document
                        │ /tmp/small_old.txt │         /tmp/small_new.txt          │
                        │       sec/op       │   sec/op     vs base                │
DocumentDecoderSmall-10          827.7n ± 1%   475.5n ± 0%  -42.55% (p=0.000 n=10)

$ benchstat /tmp/large_old.txt /tmp/large_new.txt
goos: darwin
goarch: arm64
pkg: github.com/vespa-engine/vespa/client/go/internal/vespa/document
                        │ /tmp/large_old.txt │          /tmp/large_new.txt          │
                        │       sec/op       │    sec/op     vs base                │
DocumentDecoderLarge-10          48.79µ ± 1%   16.76µ ± 13%  -65.65% (p=0.000 n=10)
```

@jonmv