### PR TITLE
Change compression library

### DIFF
--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/briandowns/spinner v1.16.0
 	github.com/fatih/color v1.10.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+	github.com/klauspost/compress v1.16.5
 	github.com/mattn/go-colorable v0.1.8
 	github.com/mattn/go-isatty v0.0.13
 	github.com/pkg/browser v0.0.0-20210706143420-7d21f8c997e2

--- a/client/go/go.sum
+++ b/client/go/go.sum
@@ -17,6 +17,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
+github.com/klauspost/compress v1.16.5 h1:IFV2oUNUzZaz+XyusxpLzpzS8Pt5rh0Z16For/djlyI=
+github.com/klauspost/compress v1.16.5/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -2,7 +2,6 @@ package document
 
 import (
 	"bytes"
-	"compress/gzip"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +13,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/klauspost/compress/gzip"
 
 	"github.com/vespa-engine/vespa/client/go/internal/util"
 )

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -275,6 +275,7 @@ func TestClientMethodAndURL(t *testing.T) {
 }
 
 func benchmarkClientSend(b *testing.B, compression Compression, document Document) {
+	b.Helper()
 	httpClient := mock.HTTPClient{}
 	client, _ := NewClient(ClientOptions{
 		Compression: compression,
@@ -293,6 +294,7 @@ func BenchmarkClientSend(b *testing.B) {
 }
 
 func BenchmarkClientSendCompressed(b *testing.B) {
-	doc := Document{Create: true, Id: mustParseId("id:ns:type::doc1"), Operation: OperationUpdate, Body: []byte(`{"fields":{"foo": "my document"}}`)}
+	body := fmt.Sprintf(`{"fields":{"foo": "%s"}}`, strings.Repeat("my document", 100))
+	doc := Document{Create: true, Id: mustParseId("id:ns:type::doc1"), Operation: OperationUpdate, Body: []byte(body)}
 	benchmarkClientSend(b, CompressionGzip, doc)
 }


### PR DESCRIPTION
Gives a decent boost over stdlib:

```
$ benchstat /tmp/old.txt /tmp/new.txt
goos: darwin
goarch: arm64
pkg: github.com/vespa-engine/vespa/client/go/internal/vespa/document
                        │ /tmp/old.txt │            /tmp/new.txt             │
                        │    sec/op    │   sec/op     vs base                │
ClientSendCompressed-10   13.243µ ± 1%   4.701µ ± 1%  -64.50% (p=0.000 n=10)
```

This library also provides a pure-Go implementation of zstd for when we want to
add that.

Review, but hold merge.

@jonmv