### PR TITLE
Balder/refactor flushengine runloop

### DIFF
--- a/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
+++ b/searchcore/src/tests/proton/flushengine/flushengine_test.cpp
@@ -450,6 +450,17 @@ struct Fixture
     }
 };
 
+TEST("require that leaf defaults are sane") {
+    test::DummyFlushTarget leaf("dummy");
+    EXPECT_FALSE(leaf.needUrgentFlush());
+    EXPECT_EQUAL(0.0, leaf.get_replay_operation_cost());
+    EXPECT_TRUE(IFlushTarget::Priority::NORMAL == leaf.getPriority());
+    EXPECT_TRUE(50 == static_cast<int>(IFlushTarget::Priority::NORMAL));
+    EXPECT_TRUE(100 == static_cast<int>(IFlushTarget::Priority::HIGH));
+    EXPECT_TRUE(IFlushTarget::Priority::NORMAL < IFlushTarget::Priority::HIGH);
+    EXPECT_TRUE(IFlushTarget::Priority::HIGH > IFlushTarget::Priority::NORMAL);
+}
+
 TEST_F("require that strategy controls flush target", Fixture(1, IINTERVAL))
 {
     vespalib::Gate fooG, barG;

--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -344,6 +344,10 @@ TEST_F(IndexManagerTest, require_that_large_memory_footprint_triggers_urgent_flu
     EXPECT_TRUE(IndexFlushTarget(_index_manager->getMaintainer(), FlushStats(17_Gi)).needUrgentFlush());
 }
 
+TEST_F(IndexManagerTest, require_that_flush_priority_is_high) {
+    EXPECT_EQ(IFlushTarget::Priority::HIGH, IndexFlushTarget(_index_manager->getMaintainer()).getPriority());
+}
+
 TEST_F(IndexManagerTest, require_that_multiple_flushes_gives_multiple_indexes)
 {
     size_t flush_count = 10;

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -155,7 +155,7 @@ FlushableAttribute::FlushableAttribute(AttributeVectorSP attr,
                                        vespalib::ISequencedTaskExecutor &
                                        attributeFieldWriter,
                                        const HwInfo &hwInfo)
-    : IFlushTarget(make_string("attribute.flush.%s", attr->getName().c_str()), Type::SYNC, Component::ATTRIBUTE),
+    : LeafFlushTarget(make_string("attribute.flush.%s", attr->getName().c_str()), Type::SYNC, Component::ATTRIBUTE),
       _attr(attr),
       _cleanUpAfterFlush(true),
       _lastStats(),

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
@@ -19,7 +19,7 @@ class TransientResourceUsage;
 /**
  * Implementation of IFlushTarget interface for attribute vectors.
  */
-class FlushableAttribute : public searchcorespi::IFlushTarget
+class FlushableAttribute : public searchcorespi::LeafFlushTarget
 {
 private:
     /**
@@ -29,15 +29,15 @@ private:
     using AttributeVectorSP = std::shared_ptr<search::AttributeVector>;
     using FlushStats = searchcorespi::FlushStats;
 
-    AttributeVectorSP           _attr;
-    bool                        _cleanUpAfterFlush;
-    FlushStats                  _lastStats;
-    const search::TuneFileAttributes _tuneFileAttributes;
+    AttributeVectorSP                        _attr;
+    bool                                     _cleanUpAfterFlush;
+    FlushStats                               _lastStats;
+    const search::TuneFileAttributes         _tuneFileAttributes;
     const search::common::FileHeaderContext &_fileHeaderContext;
-    vespalib::ISequencedTaskExecutor &_attributeFieldWriter;
-    HwInfo                       _hwInfo;
-    std::shared_ptr<AttributeDirectory> _attrDir;
-    double                       _replay_operation_cost;
+    vespalib::ISequencedTaskExecutor        &_attributeFieldWriter;
+    HwInfo                                   _hwInfo;
+    std::shared_ptr<AttributeDirectory>      _attrDir;
+    double                                   _replay_operation_cost;
 
     Task::UP internalInitFlush(SerialNum currentSerial);
 

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summarycompacttarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summarycompacttarget.cpp
@@ -66,7 +66,7 @@ private:
 }
 
 SummaryGCTarget::SummaryGCTarget(const vespalib::string & name, vespalib::Executor & summaryService, IDocumentStore & docStore)
-    : IFlushTarget(name, Type::GC, Component::DOCUMENT_STORE),
+    : LeafFlushTarget(name, Type::GC, Component::DOCUMENT_STORE),
       _summaryService(summaryService),
       _docStore(docStore),
       _lastStats()

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summarycompacttarget.h
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summarycompacttarget.h
@@ -12,7 +12,7 @@ namespace proton {
 /**
  * This class implements the IFlushTarget interface to proxy a summary manager.
  */
-class SummaryGCTarget : public searchcorespi::IFlushTarget {
+class SummaryGCTarget : public searchcorespi::LeafFlushTarget {
 public:
     using FlushStats = searchcorespi::FlushStats;
     using IDocumentStore = search::IDocumentStore;

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summaryflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summaryflushtarget.cpp
@@ -43,7 +43,7 @@ public:
 
 SummaryFlushTarget::SummaryFlushTarget(IDocumentStore & docStore,
                                        vespalib::Executor & summaryService)
-    : IFlushTarget("summary.flush", Type::SYNC, Component::DOCUMENT_STORE),
+    : LeafFlushTarget("summary.flush", Type::SYNC, Component::DOCUMENT_STORE),
       _docStore(docStore),
       _summaryService(summaryService),
       _lastStats()

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summaryflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summaryflushtarget.h
@@ -9,7 +9,7 @@ namespace proton {
 /**
  * This class implements the IFlushTarget interface to proxy a summary manager.
  */
-class SummaryFlushTarget : public searchcorespi::IFlushTarget {
+class SummaryFlushTarget : public searchcorespi::LeafFlushTarget {
 private:
     using FlushStats = searchcorespi::FlushStats;
     search::IDocumentStore & _docStore;

--- a/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/docsummary/summarymanager.cpp
@@ -42,7 +42,7 @@ namespace proton {
 
 namespace {
 
-class ShrinkSummaryLidSpaceFlushTarget : public  ShrinkLidSpaceFlushTarget
+class ShrinkSummaryLidSpaceFlushTarget : public ShrinkLidSpaceFlushTarget
 {
     using ICompactableLidSpace = search::common::ICompactableLidSpace;
     vespalib::Executor & _summaryService;

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -150,7 +150,7 @@ DocumentMetaStoreFlushTarget::
 DocumentMetaStoreFlushTarget(const DocumentMetaStore::SP dms, ITlsSyncer &tlsSyncer,
                              const vespalib::string & baseDir, const TuneFileAttributes &tuneFileAttributes,
                              const FileHeaderContext &fileHeaderContext, const HwInfo &hwInfo)
-    : IFlushTarget("documentmetastore.flush", Type::SYNC, Component::ATTRIBUTE),
+    : LeafFlushTarget("documentmetastore.flush", Type::SYNC, Component::ATTRIBUTE),
       _dms(dms),
       _tlsSyncer(tlsSyncer),
       _baseDir(baseDir),

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
@@ -19,7 +19,7 @@ class TransientResourceUsage;
 /**
  * Implementation of IFlushTarget interface for document meta store.
  **/
-class DocumentMetaStoreFlushTarget : public searchcorespi::IFlushTarget
+class DocumentMetaStoreFlushTarget : public searchcorespi::LeafFlushTarget
 {
 private:
     /**
@@ -29,16 +29,16 @@ private:
     using DocumentMetaStoreSP = std::shared_ptr<DocumentMetaStore>;
     using FlushStats = searchcorespi::FlushStats;
 
-    DocumentMetaStoreSP         _dms;
-    ITlsSyncer                 &_tlsSyncer;
-    vespalib::string            _baseDir;
-    bool                        _cleanUpAfterFlush;
-    FlushStats                  _lastStats;
-    const search::TuneFileAttributes _tuneFileAttributes;
+    DocumentMetaStoreSP                      _dms;
+    ITlsSyncer                              &_tlsSyncer;
+    vespalib::string                         _baseDir;
+    bool                                     _cleanUpAfterFlush;
+    FlushStats                               _lastStats;
+    const search::TuneFileAttributes         _tuneFileAttributes;
     const search::common::FileHeaderContext &_fileHeaderContext;
-    HwInfo                      _hwInfo;
-    std::shared_ptr<AttributeDiskLayout> _diskLayout;
-    std::shared_ptr<AttributeDirectory> _dmsDir;
+    HwInfo                                   _hwInfo;
+    std::shared_ptr<AttributeDiskLayout>     _diskLayout;
+    std::shared_ptr<AttributeDirectory>      _dmsDir;
 
 public:
     using SP = std::shared_ptr<DocumentMetaStoreFlushTarget>;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
@@ -12,15 +12,9 @@ CachedFlushTarget::CachedFlushTarget(const IFlushTarget::SP &target)
       _memoryGain(target->getApproxMemoryGain()),
       _diskGain(target->getApproxDiskGain()),
       _approxBytesToWriteToDisk(target->getApproxBytesToWriteToDisk()),
+      _replay_operation_cost(target->get_replay_operation_cost()),
       _needUrgentFlush(target->needUrgentFlush()),
       _priority(target->getPriority())
 { }
-
-
-uint64_t
-CachedFlushTarget::getApproxBytesToWriteToDisk() const
-{
-    return _approxBytesToWriteToDisk;
-}
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.cpp
@@ -11,11 +11,10 @@ CachedFlushTarget::CachedFlushTarget(const IFlushTarget::SP &target)
       _lastFlushTime(target->getLastFlushTime()),
       _memoryGain(target->getApproxMemoryGain()),
       _diskGain(target->getApproxDiskGain()),
+      _approxBytesToWriteToDisk(target->getApproxBytesToWriteToDisk()),
       _needUrgentFlush(target->needUrgentFlush()),
-      _approxBytesToWriteToDisk(target->getApproxBytesToWriteToDisk())
-{
-    // empty
-}
+      _priority(target->getPriority())
+{ }
 
 
 uint64_t
@@ -23,6 +22,5 @@ CachedFlushTarget::getApproxBytesToWriteToDisk() const
 {
     return _approxBytesToWriteToDisk;
 }
-
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
@@ -19,8 +19,9 @@ private:
     Time              _lastFlushTime;
     MemoryGain        _memoryGain;
     DiskGain          _diskGain;
-    bool              _needUrgentFlush;
     uint64_t          _approxBytesToWriteToDisk;
+    bool              _needUrgentFlush;
+    Priority          _priority;
 
 public:
     /**
@@ -47,6 +48,7 @@ public:
     SerialNum getFlushedSerialNum() const override { return _flushedSerialNum; }
     Time    getLastFlushTime() const override { return _lastFlushTime; }
     bool     needUrgentFlush() const override { return _needUrgentFlush; }
+    Priority getPriority() const override { return _priority; }
 
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override {
         return _target->initFlush(currentSerial, std::move(flush_token));

--- a/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/cachedflushtarget.h
@@ -20,6 +20,7 @@ private:
     MemoryGain        _memoryGain;
     DiskGain          _diskGain;
     uint64_t          _approxBytesToWriteToDisk;
+    double            _replay_operation_cost;
     bool              _needUrgentFlush;
     Priority          _priority;
 
@@ -49,13 +50,14 @@ public:
     Time    getLastFlushTime() const override { return _lastFlushTime; }
     bool     needUrgentFlush() const override { return _needUrgentFlush; }
     Priority getPriority() const override { return _priority; }
+    double get_replay_operation_cost() const override { return _replay_operation_cost; }
 
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override {
         return _target->initFlush(currentSerial, std::move(flush_token));
     }
     FlushStats getLastFlushStats() const override { return _target->getLastFlushStats(); }
 
-    uint64_t getApproxBytesToWriteToDisk() const override;
+    uint64_t getApproxBytesToWriteToDisk() const override { return _approxBytesToWriteToDisk; }
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.cpp
@@ -204,7 +204,7 @@ FlushEngine::run()
         LOG(debug, "Making another check for something to flush, last was '%s'", prevFlushName.c_str());
         if (prune()) {
             // Prune attempted on one or more handlers
-            wait(idleInterval);
+            wait_for_slot(IFlushTarget::Priority::NORMAL);
         } else {
             auto [needWait, name] = checkAndFlush(prevFlushName);
             prevFlushName = name;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushengine.h
@@ -50,7 +50,7 @@ private:
     };
     using FlushMap = std::map<uint32_t, FlushInfo>;
     using FlushHandlerMap = HandlerMap<IFlushHandler>;
-    bool                           _closed;
+    std::atomic<bool>              _closed;
     const uint32_t                 _maxConcurrent;
     const vespalib::duration       _idleInterval;
     uint32_t                       _taskId;    
@@ -75,15 +75,20 @@ private:
     std::pair<FlushContext::List,bool> getSortedTargetList();
     std::shared_ptr<search::IFlushToken> get_flush_token(const FlushContext& ctx);
     FlushContext::SP initNextFlush(const FlushContext::List &lst);
-    vespalib::string flushNextTarget(const vespalib::string & name);
+    vespalib::string flushNextTarget(const vespalib::string & name, const FlushContext::List & contexts);
     void flushAll(const FlushContext::List &lst);
     bool prune();
     uint32_t initFlush(const FlushContext &ctx);
     uint32_t initFlush(const IFlushHandler::SP &handler, const IFlushTarget::SP &target);
     void flushDone(const FlushContext &ctx, uint32_t taskId);
     bool canFlushMore(const std::unique_lock<std::mutex> &guard) const;
+    void wait_for_slot(IFlushTarget::Priority priority);
     bool wait(vespalib::duration minimumWaitTimeIfReady, bool ignorePendingPrune);
+    void wait(vespalib::duration minimumWaitTimeIfReady) {
+        wait(minimumWaitTimeIfReady, false);
+    }
     bool isFlushing(const std::lock_guard<std::mutex> &guard, const vespalib::string & name) const;
+    std::pair<bool, vespalib::string> checkAndFlush(vespalib::string prev);
 
     friend class FlushTask;
     friend class FlushEngineExplorer;

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.cpp
@@ -22,61 +22,10 @@ FlushTargetProxy::FlushTargetProxy(const IFlushTarget::SP &target,
 {
 }
 
-
-IFlushTarget::MemoryGain
-FlushTargetProxy::getApproxMemoryGain() const
-{
-    return _target->getApproxMemoryGain();
-}
-
-
-IFlushTarget::DiskGain
-FlushTargetProxy::getApproxDiskGain() const
-{
-    return _target->getApproxDiskGain();
-}
-
-
-IFlushTarget::SerialNum
-FlushTargetProxy::getFlushedSerialNum() const
-{
-    return _target->getFlushedSerialNum();
-}
-
-
-IFlushTarget::Time
-FlushTargetProxy::getLastFlushTime() const
-{
-    return _target->getLastFlushTime();
-}
-
-
-bool
-FlushTargetProxy::needUrgentFlush() const
-{
-    return _target->needUrgentFlush();
-}
-
-
 IFlushTarget::Task::UP
 FlushTargetProxy::initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token)
 {
     return _target->initFlush(currentSerial, std::move(flush_token));
 }
-
-
-FlushStats
-FlushTargetProxy::getLastFlushStats() const
-{
-    return _target->getLastFlushStats();
-}
-
-
-uint64_t
-FlushTargetProxy::getApproxBytesToWriteToDisk() const
-{
-    return _target->getApproxBytesToWriteToDisk();
-}
-
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
@@ -41,14 +41,15 @@ public:
      */
     const IFlushTarget::SP & getFlushTarget() const { return _target; }
     // Implements IFlushTarget.
-    MemoryGain getApproxMemoryGain() const override;
-    DiskGain getApproxDiskGain() const override;
-    SerialNum getFlushedSerialNum() const override;
-    Time getLastFlushTime() const override;
-    bool needUrgentFlush() const override;
+    MemoryGain getApproxMemoryGain() const override { return _target->getApproxMemoryGain(); }
+    DiskGain getApproxDiskGain() const override { return _target->getApproxDiskGain(); }
+    SerialNum getFlushedSerialNum() const override { return _target->getFlushedSerialNum(); }
+    Time getLastFlushTime() const override { return _target->getLastFlushTime(); }
+    bool needUrgentFlush() const override { return _target->needUrgentFlush(); }
+    Priority getPriority() const override { return _target->getPriority(); }
+    uint64_t getApproxBytesToWriteToDisk() const override { return _target->getApproxBytesToWriteToDisk(); }
+    searchcorespi::FlushStats getLastFlushStats() const override { return _target->getLastFlushStats(); }
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
-    searchcorespi::FlushStats getLastFlushStats() const override;
-    uint64_t getApproxBytesToWriteToDisk() const override;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/flushtargetproxy.h
@@ -49,6 +49,7 @@ public:
     Priority getPriority() const override { return _target->getPriority(); }
     uint64_t getApproxBytesToWriteToDisk() const override { return _target->getApproxBytesToWriteToDisk(); }
     searchcorespi::FlushStats getLastFlushStats() const override { return _target->getLastFlushStats(); }
+    double get_replay_operation_cost() const override { return _target->get_replay_operation_cost(); }
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.cpp
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.cpp
@@ -6,6 +6,7 @@
 namespace proton {
 
 using searchcorespi::IFlushTarget;
+using searchcorespi::LeafFlushTarget;
 using searchcorespi::FlushStats;
 using searchcorespi::FlushTask;
 
@@ -46,7 +47,7 @@ ShrinkLidSpaceFlushTarget::ShrinkLidSpaceFlushTarget(const vespalib::string &nam
                                                      SerialNum flushedSerialNum,
                                                      Time lastFlushTime,
                                                      std::shared_ptr<ICompactableLidSpace> target)
-    : IFlushTarget(name, type, component),
+    : LeafFlushTarget(name, type, component),
 
       _target(std::move(target)),
       _flushedSerialNum(flushedSerialNum),
@@ -78,12 +79,6 @@ IFlushTarget::Time
 ShrinkLidSpaceFlushTarget::getLastFlushTime() const
 {
     return _lastFlushTime;
-}
-
-bool
-ShrinkLidSpaceFlushTarget::needUrgentFlush() const
-{
-    return false;
 }
 
 IFlushTarget::Task::UP

--- a/searchcore/src/vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.h
+++ b/searchcore/src/vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.h
@@ -11,7 +11,7 @@ namespace proton {
 /**
  * Implements a flush target that shrinks lid space in target.
  */
-class ShrinkLidSpaceFlushTarget : public searchcorespi::IFlushTarget
+class ShrinkLidSpaceFlushTarget : public searchcorespi::LeafFlushTarget
 {
     /**
      * Task representing that shrinking has been performed.
@@ -46,7 +46,6 @@ public:
     DiskGain getApproxDiskGain() const override;
     SerialNum getFlushedSerialNum() const override;
     Time getLastFlushTime() const override;
-    bool needUrgentFlush() const override;
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
     searchcorespi::FlushStats getLastFlushStats() const override;
     uint64_t getApproxBytesToWriteToDisk() const override;

--- a/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.cpp
+++ b/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.cpp
@@ -30,10 +30,4 @@ JobTrackedFlushTarget::initFlush(SerialNum currentSerial, std::shared_ptr<search
     return FlushTask::UP();
 }
 
-uint64_t
-JobTrackedFlushTarget::getApproxBytesToWriteToDisk() const
-{
-    return _target->getApproxBytesToWriteToDisk();
-}
-
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
@@ -40,6 +40,7 @@ public:
     bool needUrgentFlush() const override {
         return _target->needUrgentFlush();
     }
+    Priority getPriority() const override { return _target->getPriority(); }
     searchcorespi::FlushTask::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
     searchcorespi::FlushStats getLastFlushStats() const override {
         return _target->getLastFlushStats();

--- a/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
+++ b/searchcore/src/vespa/searchcore/proton/metrics/job_tracked_flush_target.h
@@ -19,7 +19,7 @@ private:
 public:
     JobTrackedFlushTarget(std::shared_ptr<IJobTracker> tracker,
                           std::shared_ptr<searchcorespi::IFlushTarget> target);
-    ~JobTrackedFlushTarget();
+    ~JobTrackedFlushTarget() override;
 
     const IJobTracker &getTracker() const { return *_tracker; }
     const searchcorespi::IFlushTarget &getTarget() const { return *_target; }
@@ -40,14 +40,18 @@ public:
     bool needUrgentFlush() const override {
         return _target->needUrgentFlush();
     }
+    double get_replay_operation_cost() const override {
+        return _target->get_replay_operation_cost();
+    }
     Priority getPriority() const override { return _target->getPriority(); }
     searchcorespi::FlushTask::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
     searchcorespi::FlushStats getLastFlushStats() const override {
         return _target->getLastFlushStats();
     }
 
-    uint64_t getApproxBytesToWriteToDisk() const override;
+    uint64_t getApproxBytesToWriteToDisk() const override {
+        return _target->getApproxBytesToWriteToDisk();
+    }
 };
 
 } // namespace proton
-

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_flush_target.cpp
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_flush_target.cpp
@@ -5,10 +5,10 @@
 namespace proton::test {
 
 DummyFlushTarget::DummyFlushTarget(const vespalib::string &name) noexcept
-    : searchcorespi::IFlushTarget(name)
+    : searchcorespi::LeafFlushTarget(name, Type::OTHER, Component::OTHER)
 {}
 DummyFlushTarget::DummyFlushTarget(const vespalib::string &name, const Type &type, const Component &component) noexcept
-    : searchcorespi::IFlushTarget(name, type, component)
+    : searchcorespi::LeafFlushTarget(name, type, component)
 {}
 DummyFlushTarget::~DummyFlushTarget() = default;
 

--- a/searchcore/src/vespa/searchcore/proton/test/dummy_flush_target.h
+++ b/searchcore/src/vespa/searchcore/proton/test/dummy_flush_target.h
@@ -5,7 +5,7 @@
 
 namespace proton::test {
 
-struct DummyFlushTarget : public searchcorespi::IFlushTarget
+struct DummyFlushTarget : public searchcorespi::LeafFlushTarget
 {
     DummyFlushTarget(const vespalib::string &name) noexcept;
     DummyFlushTarget(const vespalib::string &name, const Type &type, const Component &component) noexcept;
@@ -14,7 +14,6 @@ struct DummyFlushTarget : public searchcorespi::IFlushTarget
     DiskGain getApproxDiskGain() const override { return DiskGain(0, 0); }
     SerialNum getFlushedSerialNum() const override { return 0; }
     Time getLastFlushTime() const override { return Time(); }
-    bool needUrgentFlush() const override { return false; }
     searchcorespi::FlushTask::UP initFlush(SerialNum, std::shared_ptr<search::IFlushToken>) override {
         return searchcorespi::FlushTask::UP();
     }

--- a/searchcore/src/vespa/searchcorespi/flush/iflushtarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/flush/iflushtarget.cpp
@@ -16,4 +16,8 @@ IFlushTarget::IFlushTarget(const vespalib::string &name, const Type &type, const
 
 IFlushTarget::~IFlushTarget() = default;
 
+LeafFlushTarget::LeafFlushTarget(const vespalib::string &name, const Type &type, const Component &component) noexcept
+    : IFlushTarget(name, type, component)
+{}
+
 }

--- a/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
+++ b/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
@@ -39,8 +39,8 @@ public:
     };
 
     enum class Priority {
-        NORMAL,
-        HIGH
+        NORMAL = 50,
+        HIGH = 100
     };
 
 private:
@@ -138,7 +138,7 @@ public:
     /**
      * Return cost of replaying a feed operation relative to cost of reading a feed operation from tls.
      */
-    virtual double get_replay_operation_cost() const { return 0.0; }
+    virtual double get_replay_operation_cost() const = 0;
 
     /**
      * Returns the last serial number for the transaction applied to
@@ -161,9 +161,10 @@ public:
      *
      * @return true if an urgent flush is needed
      */
-    virtual bool needUrgentFlush() const { return false; }
+    virtual bool needUrgentFlush() const = 0;
 
-    virtual Priority getPriority() const { return Priority::NORMAL; }
+    /// Returns a priority for this target
+    virtual Priority getPriority() const = 0;
 
     /**
      * Initiates the flushing of temporary memory. This method must perform
@@ -182,7 +183,14 @@ public:
      * @return The stats for the last flush.
      */
     virtual FlushStats getLastFlushStats() const = 0;
+};
 
+class LeafFlushTarget : public IFlushTarget {
+public:
+    LeafFlushTarget(const vespalib::string &name, const Type &type, const Component &component) noexcept;
+    bool needUrgentFlush() const override { return false; }
+    Priority getPriority() const override { return Priority::NORMAL; }
+    double get_replay_operation_cost() const override { return 0.0; }
 };
 
 } // namespace searchcorespi

--- a/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
+++ b/searchcore/src/vespa/searchcorespi/flush/iflushtarget.h
@@ -38,6 +38,11 @@ public:
         OTHER
     };
 
+    enum class Priority {
+        NORMAL,
+        HIGH
+    };
+
 private:
     vespalib::string _name;
     Type      _type;
@@ -157,6 +162,8 @@ public:
      * @return true if an urgent flush is needed
      */
     virtual bool needUrgentFlush() const { return false; }
+
+    virtual Priority getPriority() const { return Priority::NORMAL; }
 
     /**
      * Initiates the flushing of temporary memory. This method must perform

--- a/searchcore/src/vespa/searchcorespi/index/indexflushtarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexflushtarget.cpp
@@ -10,7 +10,7 @@ LOG_SETUP(".searchcorespi.index.indexflushtarget");
 namespace searchcorespi::index {
 
 IndexFlushTarget::IndexFlushTarget(IndexMaintainer &indexMaintainer, IndexMaintainer::FlushStats flushStats)
-    : IFlushTarget("memoryindex.flush", Type::FLUSH, Component::INDEX),
+    : LeafFlushTarget("memoryindex.flush", Type::FLUSH, Component::INDEX),
       _indexMaintainer(indexMaintainer),
       _flushStats(flushStats),
       _numFrozenMemoryIndexes(indexMaintainer.getNumFrozenMemoryIndexes()),

--- a/searchcore/src/vespa/searchcorespi/index/indexflushtarget.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexflushtarget.h
@@ -9,7 +9,7 @@ namespace searchcorespi::index {
 /**
  * Flush target for flushing a memory index in an IndexMaintainer.
  **/
-class IndexFlushTarget : public IFlushTarget {
+class IndexFlushTarget : public LeafFlushTarget {
 private:
     IndexMaintainer                   &_indexMaintainer;
     const IndexMaintainer::FlushStats  _flushStats;

--- a/searchcore/src/vespa/searchcorespi/index/indexflushtarget.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexflushtarget.h
@@ -29,6 +29,7 @@ public:
     Time    getLastFlushTime() const override;
 
     bool needUrgentFlush() const override;
+    Priority getPriority() const override { return Priority::HIGH; }
 
     Task::UP initFlush(SerialNum currentSerial, std::shared_ptr<search::IFlushToken> flush_token) override;
     FlushStats getLastFlushStats() const override { return _lastStats; }

--- a/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.cpp
@@ -38,7 +38,7 @@ public:
 
 }
 IndexFusionTarget::IndexFusionTarget(IndexMaintainer &indexMaintainer)
-    : IFlushTarget("memoryindex.fusion", Type::GC, Component::INDEX),
+    : LeafFlushTarget("memoryindex.fusion", Type::GC, Component::INDEX),
       _indexMaintainer(indexMaintainer),
       _fusionStats(indexMaintainer.getFusionStats()),
       _lastStats()

--- a/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.h
@@ -9,7 +9,7 @@ namespace searchcorespi::index {
 /**
  * Flush target for doing fusion on disk indexes in an IndexMaintainer.
  **/
-class IndexFusionTarget : public IFlushTarget {
+class IndexFusionTarget : public LeafFlushTarget {
 private:
     IndexMaintainer &_indexMaintainer;
     IndexMaintainer::FusionStats _fusionStats;


### PR DESCRIPTION
@geirst and @toregge PR
This should have no semantic changes. It is refactoring, and a fix for the flush proxy targets not forwarding all methods.