### PR TITLE
Do not override TMPDIR

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -131,7 +131,7 @@ clean:
 	rmdir -p $(BIN) $(SHARE)/man/man1 > /dev/null 2>&1 || true
 
 test: ci
-	mkdir -p $(CURDIR)/tmp && TMPDIR=$(CURDIR)/tmp go test ./...
+	go test ./...
 
 checkfmt:
 	@sh -c "test -z $$(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }


### PR DESCRIPTION
This breaks test result caching for tests that write temporary files.

@jonmv