### PR TITLE
Avoid race between config thread and updating file config source

### DIFF
--- a/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/di/ContainerTest.java
@@ -286,7 +286,7 @@ public class ContainerTest extends ContainerTestBase {
         Future<ComponentGraph> newGraph = exec.submit(() -> getNewComponentGraph(container, currentGraph));
         dirConfigSource.awaitConfigChecked(10_000);
         try {
-            newGraph.get(1, TimeUnit.SECONDS);
+            newGraph.get(1500, TimeUnit.MILLISECONDS);
             fail("Expected waiting for new config.");
         } catch (TimeoutException ignored) {
             // expect to time out
@@ -297,7 +297,7 @@ public class ContainerTest extends ContainerTestBase {
         container.reloadConfig(3);
 
         dirConfigSource.awaitConfigChecked(10_000);
-        assertNotNull(newGraph.get(30, TimeUnit.SECONDS));
+        assertNotNull(newGraph.get(1000, TimeUnit.MILLISECONDS));
 
         container.shutdownConfigRetriever();
         container.shutdown(newGraph.get());


### PR DESCRIPTION
@bjorncs or @baldersheim this is dirty, but should at least improve the current situation while I work on a proper test config source 🙈 