### PR TITLE
Revert "Do not override TMPDIR"

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -131,7 +131,7 @@ clean:
 	rmdir -p $(BIN) $(SHARE)/man/man1 > /dev/null 2>&1 || true
 
 test: ci
-	go test ./...
+	mkdir -p $(CURDIR)/tmp && TMPDIR=$(CURDIR)/tmp go test ./...
 
 checkfmt:
 	@sh -c "test -z $$(gofmt -l .)" || { echo "one or more files need to be formatted: try make fmt to fix this automatically"; exit 1; }


### PR DESCRIPTION
Reverts vespa-engine/vespa#26990

This breaks on systems where /tmp is is mounted with noexec, e.g. when `--mount type=tmpfs,destination=/tmp` was
passed as argument to docker create.
```
vespadev-cs8-mac$ make -j 4 
Generating go/bin/vespa, go/bin/vespa-wrapper
make[3]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
?   	github.com/vespa-engine/vespa/client/go/internal/admin/clusterstate	[no test files]
ok  	github.com/vespa-engine/vespa/client/go/internal/admin/defaults	(cached)
?   	github.com/vespa-engine/vespa/client/go/internal/admin/deploy	[no test files]
?   	github.com/vespa-engine/vespa/client/go/internal/admin/envvars	[no test files]
ok  	github.com/vespa-engine/vespa/client/go/internal/admin/jvm	(cached)
fork/exec /tmp/go-build1381348638/b194/prog.test: permission denied
FAIL	github.com/vespa-engine/vespa/client/go/internal/admin/prog	0.000s
```
