### PR TITLE
Default-enable fast path updates when document versions are consistent

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -865,6 +865,8 @@ TEST_F(DistributorStripeTest, fast_path_on_consistent_gets_config_is_propagated_
 {
     setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
 
+    EXPECT_TRUE(getConfig().update_fast_path_restart_enabled()); // Enabled by default
+
     configure_update_fast_path_restart_enabled(true);
     EXPECT_TRUE(getConfig().update_fast_path_restart_enabled());
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -219,7 +219,7 @@ use_btree_database bool default=true restart
 ## content nodes, the two-phase update path reverts back to the regular fast path.
 ## Since all replicas of the document were in sync, applying the update in-place
 ## shall be considered safe.
-restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=false
+restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true
 
 ## If set, no merge operations may be generated for any reason by a distributor.
 ## This is ONLY intended for system testing of certain transient edge cases and

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -219,6 +219,7 @@ use_btree_database bool default=true restart
 ## content nodes, the two-phase update path reverts back to the regular fast path.
 ## Since all replicas of the document were in sync, applying the update in-place
 ## shall be considered safe.
+## DEPRECATED -- always enabled with 3-phase updates.
 restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true
 
 ## If set, no merge operations may be generated for any reason by a distributor.


### PR DESCRIPTION
@havardpe please review
@baldersheim FYI

This feature is always _implicitly_ enabled when 3-phase updates are enabled (which is the case by default). Flip the config default to `true` as well to be more in line with what's actually the case in production.
