### PR TITLE
Disable string length restriction introduced in Jackson 2.15 MERGEOK

### DIFF
--- a/container-core/src/main/java/com/yahoo/restapi/JacksonJsonMapper.java
+++ b/container-core/src/main/java/com/yahoo/restapi/JacksonJsonMapper.java
@@ -1,6 +1,9 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.restapi;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -13,10 +16,17 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
  */
 class JacksonJsonMapper {
 
-    static final ObjectMapper instance = new ObjectMapper()
+    static final ObjectMapper instance = new ObjectMapper(createFactory())
             .registerModule(new JavaTimeModule())
             .registerModule(new Jdk8Module())
             .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
     private JacksonJsonMapper() {}
+
+    private static JsonFactory createFactory() {
+        return new JsonFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+                .build();
+
+    }
 }

--- a/container-search/src/main/java/com/yahoo/search/handler/Json2SingleLevelMap.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/Json2SingleLevelMap.java
@@ -1,9 +1,12 @@
 package com.yahoo.search.handler;
 
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.processing.IllegalInputException;
 
@@ -23,10 +26,11 @@ import java.util.Map;
  */
 class Json2SingleLevelMap {
 
-    private static final ObjectMapper jsonMapper = new ObjectMapper().configure(JsonParser.Feature.ALLOW_SINGLE_QUOTES, true);
-    private final byte [] buf;
-    private final JsonParser parser;
+    private static final ObjectMapper jsonMapper = createMapper();
 
+    private final byte [] buf;
+
+    private final JsonParser parser;
     Json2SingleLevelMap(InputStream data) {
         try {
             buf = data.readAllBytes();
@@ -34,6 +38,14 @@ class Json2SingleLevelMap {
         } catch (IOException e) {
             throw new RuntimeException("Problem reading POSTed data", e);
         }
+    }
+
+    private static ObjectMapper createMapper() {
+        var jsonFactory = new JsonFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+                .configure(JsonReadFeature.ALLOW_SINGLE_QUOTES, true)
+                .build();
+        return new ObjectMapper(jsonFactory);
     }
 
     Map<String, String> parse() {

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -3,7 +3,9 @@ package com.yahoo.search.rendering;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -175,8 +177,10 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
     }
 
     private static JsonFactory createGeneratorFactory() {
-        JsonFactory factory = new JsonFactory();
-        factory.setCodec(new ObjectMapper().disable(FLUSH_AFTER_WRITE_VALUE));
+        var factory = new JsonFactoryBuilder()
+                .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+                .build();
+        factory.setCodec(new ObjectMapper(factory).disable(FLUSH_AFTER_WRITE_VALUE));
         return factory;
     }
 

--- a/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
+++ b/document/src/main/java/com/yahoo/document/json/DocumentUpdateJsonSerializer.java
@@ -2,7 +2,9 @@
 package com.yahoo.document.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.yahoo.document.DataType;
 import com.yahoo.document.Document;
 import com.yahoo.document.DocumentUpdate;
@@ -67,7 +69,9 @@ import static com.yahoo.document.json.JsonSerializationHelper.*;
  */
 public class DocumentUpdateJsonSerializer {
 
-    private final JsonFactory jsonFactory = new JsonFactory();
+    private static final JsonFactory jsonFactory = new JsonFactoryBuilder()
+            .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+            .build();
     private final JsonDocumentUpdateWriter writer = new JsonDocumentUpdateWriter();
     private JsonGenerator generator;
 

--- a/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonFeedReader.java
@@ -3,6 +3,7 @@ package com.yahoo.document.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.yahoo.document.DocumentOperation;
 import com.yahoo.document.DocumentPut;
 import com.yahoo.document.DocumentRemove;
@@ -28,7 +29,10 @@ public class JsonFeedReader implements FeedReader {
 
     private final JsonReader reader;
     private final InputStream stream;
-    private static final JsonFactory jsonFactory = new JsonFactoryBuilder().disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES).build();
+    private static final JsonFactory jsonFactory = new JsonFactoryBuilder()
+            .disable(JsonFactory.Feature.CANONICALIZE_FIELD_NAMES)
+            .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+            .build();
 
     public JsonFeedReader(InputStream stream, DocumentTypeManager docMan) {
         reader = new JsonReader(docMan, stream, jsonFactory);

--- a/document/src/main/java/com/yahoo/document/json/JsonWriter.java
+++ b/document/src/main/java/com/yahoo/document/json/JsonWriter.java
@@ -2,7 +2,9 @@
 package com.yahoo.document.json;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.yahoo.document.Document;
 import com.yahoo.document.DocumentId;
 import com.yahoo.document.DocumentType;
@@ -74,7 +76,10 @@ import static com.yahoo.document.json.document.DocumentParser.REMOVE;
  */
 public class JsonWriter implements DocumentWriter {
 
-    private static final JsonFactory jsonFactory = new JsonFactory();
+    private static final JsonFactory jsonFactory = new JsonFactoryBuilder()
+            .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+            .build();
+
     private final JsonGenerator generator;
 
     private final boolean tensorShortForm;

--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/JsonFeeder.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/JsonFeeder.java
@@ -3,9 +3,11 @@ package ai.vespa.feed.client;
 
 import ai.vespa.feed.client.FeedClient.OperationType;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -193,7 +195,9 @@ public class JsonFeeder implements Closeable {
         }
     }
 
-    private static final JsonFactory factory = new JsonFactory();
+    private static final JsonFactory factory = new JsonFactoryBuilder()
+            .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+            .build();
 
     @Override public void close() throws IOException {
         closed = true;

--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -2,7 +2,9 @@
 package com.yahoo.document.restapi.resource;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.yahoo.cloud.config.ClusterListConfig;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.concurrent.DaemonThreadFactory;
@@ -152,7 +154,9 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
         @Override public void close(CompletionHandler handler) { handler.completed(); }
     };
 
-    private static final JsonFactory jsonFactory = new JsonFactory();
+    private static final JsonFactory jsonFactory = new JsonFactoryBuilder()
+            .streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build())
+            .build();
 
     private static final String CREATE = "create";
     private static final String CONDITION = "condition";


### PR DESCRIPTION
Disable restriction only for parsers/generators which is likely to handle literals exceeding 5M

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
