### PR TITLE
Pass transport and file distributor connection spec to SearchEnvironment

### DIFF
--- a/messagebus/src/vespa/messagebus/result.h
+++ b/messagebus/src/vespa/messagebus/result.h
@@ -3,11 +3,10 @@
 #pragma once
 
 #include "error.h"
+#include "message.h"
 #include <memory>
 
 namespace mbus {
-
-class Message;
 
 /**
  * A Result object is used as return value when trying to send a

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -7,7 +7,6 @@
 #include <vespa/storage/config/config-stor-server.h>
 #include <vespa/storage/storageserver/servicelayernode.h>
 #include <vespa/storageframework/defaultimplementation/clock/realclock.h>
-#include <vespa/searchvisitor/searchvisitor.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".storageserver.service_layer_process");
@@ -52,7 +51,7 @@ ServiceLayerProcess::shutdown()
 void
 ServiceLayerProcess::createNode()
 {
-    _externalVisitors["searchvisitor"] = std::make_shared<streaming::SearchVisitorFactory>(_configUri);
+    add_external_visitors();
     setupProvider();
     _node = std::make_unique<ServiceLayerNode>(_configUri, _context, *this, getProvider(), _externalVisitors);
     if (_storage_chain_builder) {
@@ -80,6 +79,11 @@ void
 ServiceLayerProcess::set_storage_chain_builder(std::unique_ptr<IStorageChainBuilder> builder)
 {
     _storage_chain_builder = std::move(builder);
+}
+
+void
+ServiceLayerProcess::add_external_visitors()
+{
 }
 
 } // storage

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -30,7 +30,9 @@ class ServiceLayerNode;
 class IStorageChainBuilder;
 
 class ServiceLayerProcess : public Process {
+protected:
     VisitorFactory::Map _externalVisitors;
+private:
     std::unique_ptr<ServiceLayerNode> _node;
     std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;
 
@@ -51,6 +53,7 @@ public:
     StorageNodeContext& getContext() override;
     std::string getComponentName() const override;
     void set_storage_chain_builder(std::unique_ptr<IStorageChainBuilder> builder);
+    virtual void add_external_visitors();
 };
 
 } // storage

--- a/streamingvisitors/src/tests/searchvisitor/searchvisitor_test.cpp
+++ b/streamingvisitors/src/tests/searchvisitor/searchvisitor_test.cpp
@@ -4,6 +4,7 @@
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/fieldvalue/document.h>
 #include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/fnet/transport.h>
 #include <vespa/persistence/spi/docentry.h>
 #include <vespa/searchlib/query/tree/querybuilder.h>
 #include <vespa/searchlib/query/tree/simplequery.h>
@@ -125,6 +126,7 @@ public:
     framework::defaultimplementation::FakeClock _clock;
     StorageComponentRegisterImpl      _componentRegister;
     std::unique_ptr<StorageComponent> _component;
+    FNET_Transport                    _transport;
     SearchEnvironment                 _env;
     SearchVisitorFactory              _factory;
     std::shared_ptr<DocumentTypeRepo> _repo;
@@ -159,8 +161,9 @@ public:
 
 SearchVisitorTest::SearchVisitorTest() :
     _componentRegister(),
-    _env(::config::ConfigUri("dir:cfg")),
-    _factory(::config::ConfigUri("dir:cfg")),
+    _transport(),
+    _env(::config::ConfigUri("dir:cfg"), _transport, ""),
+    _factory(::config::ConfigUri("dir:cfg"), _transport, ""),
     _repo(std::make_shared<DocumentTypeRepo>(readDocumenttypesConfig("cfg/documenttypes.cfg"))),
     _doc_type(_repo->getDocumentType("test"))
 {

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -459,11 +459,12 @@ void SearchVisitor::init(const Parameters & params)
     VISITOR_TRACE(6, "Completed lazy VSM adapter initialization");
 }
 
-SearchVisitorFactory::SearchVisitorFactory(const config::ConfigUri & configUri)
+SearchVisitorFactory::SearchVisitorFactory(const config::ConfigUri & configUri, FNET_Transport& transport, const vespalib::string& file_distributor_connection_spec)
     : VisitorFactory(),
       _configUri(configUri),
-      _env(std::make_shared<SearchEnvironment>(_configUri))
-{}
+      _env(std::make_shared<SearchEnvironment>(_configUri, transport, file_distributor_connection_spec))
+{
+}
 
 SearchVisitorFactory::~SearchVisitorFactory() = default;
 

--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.h
@@ -496,7 +496,7 @@ class SearchVisitorFactory : public storage::VisitorFactory {
     storage::Visitor* makeVisitor(storage::StorageComponent&, storage::VisitorEnvironment&env,
                          const vdslib::Parameters& params) override;
 public:
-    explicit SearchVisitorFactory(const config::ConfigUri & configUri);
+    explicit SearchVisitorFactory(const config::ConfigUri & configUri, FNET_Transport& transport, const vespalib::string& file_distributor_connection_spec);
     ~SearchVisitorFactory() override;
 };
 


### PR DESCRIPTION
in preparation for using RankingAssetsBuilder when handling config in streaming search.

@geirst : please review
