### PR TITLE
Find project root without git

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -3,7 +3,7 @@
 # The version to release. Defaults to the current tag or revision.
 # Use env VERSION=X.Y.Z make ... to override
 VERSION ?= $(shell git describe --tags --exact-match 2> /dev/null | sed "s/^v//")
-DEVEL_VERSION := $(shell echo "0.0.0-`git rev-parse --short HEAD`")
+DEVEL_VERSION := $(shell echo "0.0.0-`git rev-parse --short HEAD 2> /dev/null || echo unknown`")
 ifeq ($(VERSION),)
 	VERSION = $(DEVEL_VERSION)
 endif

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -14,8 +14,8 @@ SHARE ?= $(PREFIX)/share
 DIST ?= $(CURDIR)/dist
 
 GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/internal/build.Version=$(VERSION)"
-GIT_ROOT := $(shell git rev-parse --show-toplevel)
-GO_TMPDIR := $(GIT_ROOT)/build/go
+PROJECT_ROOT := $(shell realpath $(CURDIR)/../..)
+GO_TMPDIR := $(PROJECT_ROOT)/build/go
 DIST_TARGETS := dist-mac dist-mac-arm64 dist-linux dist-linux-arm64 dist-win32 dist-win64
 
 all: test checkfmt install
@@ -87,7 +87,7 @@ $(DIST_TARGETS): dist-version ci manpages
 $(DIST_TARGETS):
 	mkdir -p $(DIST)/$(DIST_NAME)/bin
 	env CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(DIST)/$(DIST_NAME)/bin $(GO_FLAGS) ./...
-	cp -a $(GIT_ROOT)/LICENSE $(DIST)/$(DIST_NAME)
+	cp -a $(PROJECT_ROOT)/LICENSE $(DIST)/$(DIST_NAME)
 	if [ "$(GOOS)" = "windows" ]; then \
 		cd $(DIST) && zip -r $(DIST)/$(DIST_NAME).zip $(DIST_NAME); \
 	else \
@@ -132,6 +132,9 @@ clean:
 	rmdir -p $(BIN) $(SHARE)/man/man1 > /dev/null 2>&1 || true
 
 test: ci
+# Why custom GOTMPDIR? go builds executables for unit tests and by default these
+# end up in TMPDIR/GOTMPDIR. In some environments /tmp is mounted noexec so
+# running test executables will fail
 	mkdir -p $(GO_TMPDIR) && GOTMPDIR=$(GO_TMPDIR) go test ./...
 
 checkfmt:


### PR DESCRIPTION
This should work for both cases (noexec /tmp and/or missing git).

@aressem