### PR TITLE
Wire MessageBus reply traces through conditional Put pipeline

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -220,6 +220,15 @@ public:
         return cmd;
     }
 
+    template <typename ReplyType>
+    requires std::is_base_of_v<api::StorageReply, ReplyType>
+    [[nodiscard]] std::shared_ptr<ReplyType> sent_reply(size_t idx) {
+        assert(idx < _sender.replies().size());
+        auto reply = std::dynamic_pointer_cast<ReplyType>(_sender.reply(idx));
+        assert(reply != nullptr);
+        return reply;
+    }
+
     void config_enable_condition_probing(bool enable);
     void tag_content_node_supports_condition_probing(uint16_t index, bool supported);
 

--- a/storage/src/vespa/storage/distributor/operations/external/getoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/getoperation.h
@@ -88,28 +88,25 @@ private:
     };
 
     using GroupVector = std::vector<BucketChecksumGroup>;
+    using DbReplicaState = std::vector<std::pair<document::BucketId, uint16_t>>;
 
     // Organize the different copies by bucket/checksum pairs. We should
     // try to request GETs from each bucket and each different checksum
     // within that bucket.
-    std::map<GroupId, GroupVector> _responses;
-
-    const DistributorNodeContext& _node_ctx;
-    const DistributorBucketSpace &_bucketSpace;
-
-    std::shared_ptr<api::GetCommand> _msg;
-
-    api::ReturnCode _returnCode;
+    std::map<GroupId, GroupVector>      _responses;
+    const DistributorNodeContext&       _node_ctx;
+    const DistributorBucketSpace&       _bucketSpace;
+    std::shared_ptr<api::GetCommand>    _msg;
+    api::ReturnCode                     _returnCode;
     std::shared_ptr<document::Document> _doc;
-
-    std::optional<NewestReplica> _newest_replica;
-
-    PersistenceOperationMetricSet& _metric;
-    framework::MilliSecTimer _operationTimer;
-    std::vector<std::pair<document::BucketId, uint16_t>> _replicas_in_db;
-    api::InternalReadConsistency _desired_read_consistency;
-    bool _has_replica_inconsistency;
-    bool _any_replicas_failed;
+    std::optional<NewestReplica>        _newest_replica;
+    PersistenceOperationMetricSet&      _metric;
+    framework::MilliSecTimer            _operationTimer;
+    DbReplicaState                      _replicas_in_db;
+    vespalib::Trace                     _trace;
+    api::InternalReadConsistency        _desired_read_consistency;
+    bool                                _has_replica_inconsistency;
+    bool                                _any_replicas_failed;
 
     void sendReply(DistributorStripeMessageSender& sender);
     bool sendForChecksum(DistributorStripeMessageSender& sender, const document::BucketId& id, GroupVector& res);

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -50,7 +50,7 @@ private:
 
     void start_direct_put_dispatch(DistributorStripeMessageSender& sender);
     void start_conditional_put(DistributorStripeMessageSender& sender);
-    void on_completed_check_condition(const CheckCondition::Outcome& outcome,
+    void on_completed_check_condition(CheckCondition::Outcome& outcome,
                                       DistributorStripeMessageSender& sender);
     void insertDatabaseEntryAndScheduleCreateBucket(const OperationTargetList& copies, bool setOneActive,
                                                     const api::StorageCommand& originalCommand,

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -23,10 +23,12 @@ struct PersistenceMessageTracker {
     virtual void queueCommand(api::BucketCommand::SP, uint16_t target) = 0;
     virtual void flushQueue(MessageSender&) = 0;
     virtual uint16_t handleReply(api::BucketReply& reply) = 0;
+    virtual void add_trace_tree_to_reply(vespalib::Trace trace) = 0;
 };
 
-class PersistenceMessageTrackerImpl : public PersistenceMessageTracker,
-                                      public MessageTracker
+class PersistenceMessageTrackerImpl final
+        : public PersistenceMessageTracker,
+          public MessageTracker
 {
 private:
     using BucketInfoMap = std::map<document::Bucket, std::vector<BucketCopy>>;
@@ -92,12 +94,14 @@ private:
     void updateFailureResult(const api::BucketInfoReply& reply);
     void handleCreateBucketReply(api::BucketInfoReply& reply, uint16_t node);
     void handlePersistenceReply(api::BucketInfoReply& reply, uint16_t node);
+    void transfer_trace_state_to_reply();
 
     void queueCommand(std::shared_ptr<api::BucketCommand> msg, uint16_t target) override {
         MessageTracker::queueCommand(std::move(msg), target);
     }
     void flushQueue(MessageSender& s) override { MessageTracker::flushQueue(s); }
     uint16_t handleReply(api::BucketReply& r) override { return MessageTracker::handleReply(r); }
+    void add_trace_tree_to_reply(vespalib::Trace trace) override;
 };
 
 }


### PR DESCRIPTION
@havardpe please review. Note the added default arg to `CheckCondition::create_if_inconsistent_replicas` which should keep the signatures compatible.

`CheckCondition::Outcome` now exposes the resulting trace (if any) of the operations that were sent as part of the condition probe. The outcome-accessor is changed to return a non-const reference to allow for moving away the trace payload and into a higher-level reply.

Turns out `GetOperation` did not aggregate reply traces as expected, and `PersistenceMessageTrackerImpl` did not transfer trace state upon failures (only success case). This makes this commit bigger than initially expected, but trace coverage should now be improved on a general basis, not just for conditional Put operations.

