### PR TITLE
Handle MessageBus trace propagation for conditional removes

### DIFF
--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.h
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.h
@@ -136,7 +136,7 @@ public:
             const DistributorNodeContext& node_ctx,
             const DistributorStripeOperationContext& op_ctx,
             PersistenceOperationMetricSet& metric,
-            uint32_t trace_level = 0); // TODO remove default value
+            uint32_t trace_level);
 private:
     [[nodiscard]] bool replica_set_changed_after_get_operation() const;
 

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
@@ -42,7 +42,7 @@ private:
 
     void start_direct_remove_dispatch(DistributorStripeMessageSender& sender);
     void start_conditional_remove(DistributorStripeMessageSender& sender);
-    void on_completed_check_condition(const CheckCondition::Outcome& outcome,
+    void on_completed_check_condition(CheckCondition::Outcome& outcome,
                                       DistributorStripeMessageSender& sender);
     [[nodiscard]] bool has_condition() const noexcept;
 };


### PR DESCRIPTION
@havardpe please review

Pretty much a mirror image of the logic in `PutOperation`.

