### PR TITLE
Support replacing root disk for arm64 again

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -86,10 +86,7 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
 
     /** Returns the subset of nodes which have a replaceable root disk */
     public NodeList replaceableRootDisk() {
-        // TODO(mpolden): Support any architecture if we change how cloud images for other
-        //                architectures are managed
-        return matching(node -> node.resources().storageType() == NodeResources.StorageType.remote &&
-                                node.resources().architecture() == NodeResources.Architecture.x86_64);
+        return matching(node -> node.resources().storageType() == NodeResources.StorageType.remote);
     }
 
     /** Returns the subset of nodes which satisfy the given resources */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
@@ -55,7 +55,7 @@ public class RebuildingOsUpgrader extends OsUpgrader {
     private List<Node> rebuildableHosts(OsVersionTarget target, NodeList allNodes, Instant now) {
         NodeList hostsOfTargetType = allNodes.nodeType(target.nodeType());
         if (softRebuild) {
-            // Soft rebuild is enabled so this should act on hosts having replacable root disk
+            // Soft rebuild is enabled so this should act on hosts having replaceable root disk
             hostsOfTargetType = hostsOfTargetType.replaceableRootDisk();
         }
 


### PR DESCRIPTION
This works again with vespa-almalinux-8 AMIs created after 2023-05-13. @aressem FYI