### PR TITLE
Add dedicated condition probe metrics for `PutOperation`/`RemoveOperation`

### DIFF
--- a/storage/src/tests/distributor/putoperationtest.cpp
+++ b/storage/src/tests/distributor/putoperationtest.cpp
@@ -73,7 +73,8 @@ public:
                                             operation_context(),
                                             getDistributorBucketSpace(),
                                             msg,
-                                            metrics().puts);
+                                            metrics().puts,
+                                            metrics().put_condition_probes);
         op->start(_sender);
     }
 

--- a/storage/src/tests/distributor/removeoperationtest.cpp
+++ b/storage/src/tests/distributor/removeoperationtest.cpp
@@ -41,7 +41,8 @@ struct RemoveOperationTest : Test, DistributorStripeTestUtil {
                 operation_context(),
                 getDistributorBucketSpace(),
                 msg,
-                metrics().removes);
+                metrics().removes,
+                metrics().remove_condition_probes);
 
         op->start(_sender);
     }

--- a/storage/src/vespa/storage/distributor/distributormetricsset.cpp
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.cpp
@@ -16,11 +16,13 @@ BucketDbMetrics::~BucketDbMetrics() = default;
 DistributorMetricSet::DistributorMetricSet()
     : MetricSet("distributor", {{"distributor"}}, ""),
       puts("puts", this),
+      put_condition_probes("put_condition_probes", this),
       updates(this),
       update_puts("update_puts", this),
       update_gets("update_gets", this),
       update_metadata_gets("update_metadata_gets", this),
       removes("removes", this),
+      remove_condition_probes("remove_condition_probes", this),
       removelocations("removelocations", this),
       gets("gets", this),
       stats("stats", this),

--- a/storage/src/vespa/storage/distributor/distributormetricsset.h
+++ b/storage/src/vespa/storage/distributor/distributormetricsset.h
@@ -20,24 +20,26 @@ struct BucketDbMetrics : metrics::MetricSet {
 class DistributorMetricSet : public metrics::MetricSet {
 public:
     PersistenceOperationMetricSet puts;
-    UpdateMetricSet updates;
+    PersistenceOperationMetricSet put_condition_probes;
+    UpdateMetricSet               updates;
     PersistenceOperationMetricSet update_puts;
     PersistenceOperationMetricSet update_gets;
     PersistenceOperationMetricSet update_metadata_gets;
     PersistenceOperationMetricSet removes;
+    PersistenceOperationMetricSet remove_condition_probes;
     PersistenceOperationMetricSet removelocations;
     PersistenceOperationMetricSet gets;
     PersistenceOperationMetricSet stats;
     PersistenceOperationMetricSet getbucketlists;
-    VisitorMetricSet visits;
-    metrics::DoubleAverageMetric stateTransitionTime;
-    metrics::DoubleAverageMetric set_cluster_state_processing_time;
-    metrics::DoubleAverageMetric activate_cluster_state_processing_time;
-    metrics::DoubleAverageMetric recoveryModeTime;
-    metrics::LongValueMetric docsStored;
-    metrics::LongValueMetric bytesStored;
-    BucketDbMetrics mutable_dbs;
-    BucketDbMetrics read_only_dbs;
+    VisitorMetricSet              visits;
+    metrics::DoubleAverageMetric  stateTransitionTime;
+    metrics::DoubleAverageMetric  set_cluster_state_processing_time;
+    metrics::DoubleAverageMetric  activate_cluster_state_processing_time;
+    metrics::DoubleAverageMetric  recoveryModeTime;
+    metrics::LongValueMetric      docsStored;
+    metrics::LongValueMetric      bytesStored;
+    BucketDbMetrics               mutable_dbs;
+    BucketDbMetrics               read_only_dbs;
 
     explicit DistributorMetricSet();
     ~DistributorMetricSet() override;

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -332,7 +332,9 @@ bool ExternalOperationHandler::onPut(const std::shared_ptr<api::PutCommand>& cmd
     if (allow) {
         _op = std::make_shared<PutOperation>(_node_ctx, _op_ctx,
                                              _op_ctx.bucket_space_repo().get(bucket_space),
-                                             std::move(cmd), getMetrics().puts, std::move(handle));
+                                             std::move(cmd),
+                                             getMetrics().puts, getMetrics().put_condition_probes,
+                                             std::move(handle));
     } else {
         _msg_sender.sendUp(makeConcurrentMutationRejectionReply(*cmd, cmd->getDocumentId(), metrics));
     }
@@ -386,7 +388,8 @@ bool ExternalOperationHandler::onRemove(const std::shared_ptr<api::RemoveCommand
         auto &distributorBucketSpace(_op_ctx.bucket_space_repo().get(bucket_space));
 
         _op = std::make_shared<RemoveOperation>(_node_ctx, _op_ctx, distributorBucketSpace, std::move(cmd),
-                                                getMetrics().removes, std::move(handle));
+                                                getMetrics().removes, getMetrics().remove_condition_probes,
+                                                std::move(handle));
     } else {
         _msg_sender.sendUp(makeConcurrentMutationRejectionReply(*cmd, cmd->getDocumentId(), metrics));
     }

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
@@ -58,7 +58,7 @@ CheckCondition::CheckCondition(const document::Bucket& bucket,
                                const documentapi::TestAndSetCondition& tas_condition,
                                const DistributorBucketSpace& bucket_space,
                                const DistributorNodeContext& node_ctx,
-                               PersistenceOperationMetricSet& metric,
+                               PersistenceOperationMetricSet& condition_probe_metrics,
                                uint32_t trace_level,
                                private_ctor_tag)
     : _doc_id_bucket(bucket),
@@ -66,7 +66,8 @@ CheckCondition::CheckCondition(const document::Bucket& bucket,
       _node_ctx(node_ctx),
       _cluster_state_version_at_creation_time(_bucket_space.getClusterState().getVersion()),
       _cond_get_op(),
-      _sent_message_map()
+      _sent_message_map(),
+      _outcome()
 {
     // Condition checks only return metadata back to the distributor and thus have an empty fieldset.
     // Side note: the BucketId provided to the GetCommand is ignored; GetOperation computes explicitly from the doc ID.
@@ -75,8 +76,8 @@ CheckCondition::CheckCondition(const document::Bucket& bucket,
     get_cmd->getTrace().setLevel(trace_level);
     _cond_get_op = std::make_shared<GetOperation>(_node_ctx, _bucket_space,
                                                   _bucket_space.getBucketDatabase().acquire_read_guard(),
-                                                  std::move(get_cmd),
-                                                  metric, api::InternalReadConsistency::Strong);
+                                                  std::move(get_cmd), condition_probe_metrics,
+                                                  api::InternalReadConsistency::Strong);
 }
 
 CheckCondition::~CheckCondition() = default;
@@ -220,7 +221,7 @@ CheckCondition::create_if_inconsistent_replicas(const document::Bucket& bucket,
                                                 const documentapi::TestAndSetCondition& tas_condition,
                                                 const DistributorNodeContext& node_ctx,
                                                 const DistributorStripeOperationContext& op_ctx,
-                                                PersistenceOperationMetricSet& metric,
+                                                PersistenceOperationMetricSet& condition_probe_metrics,
                                                 uint32_t trace_level)
 {
     // TODO move this check to the caller?
@@ -237,8 +238,8 @@ CheckCondition::create_if_inconsistent_replicas(const document::Bucket& bucket,
     if (!all_nodes_support_document_condition_probe(entries, op_ctx)) {
         return {}; // Want write-repair, but one or more nodes are too old to use the feature
     }
-    return std::make_shared<CheckCondition>(bucket, doc_id, tas_condition, bucket_space,
-                                            node_ctx, metric, trace_level, private_ctor_tag{});
+    return std::make_shared<CheckCondition>(bucket, doc_id, tas_condition, bucket_space, node_ctx,
+                                            condition_probe_metrics, trace_level, private_ctor_tag{});
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.h
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.h
@@ -114,7 +114,7 @@ public:
                    const documentapi::TestAndSetCondition& tas_condition,
                    const DistributorBucketSpace& bucket_space,
                    const DistributorNodeContext& node_ctx,
-                   PersistenceOperationMetricSet& metric,
+                   PersistenceOperationMetricSet& condition_probe_metrics,
                    uint32_t trace_level,
                    private_ctor_tag);
     ~CheckCondition();
@@ -135,7 +135,7 @@ public:
             const documentapi::TestAndSetCondition& tas_condition,
             const DistributorNodeContext& node_ctx,
             const DistributorStripeOperationContext& op_ctx,
-            PersistenceOperationMetricSet& metric,
+            PersistenceOperationMetricSet& condition_probe_metrics,
             uint32_t trace_level);
 private:
     [[nodiscard]] bool replica_set_changed_after_get_operation() const;

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -28,6 +28,7 @@ public:
                  DistributorBucketSpace& bucketSpace,
                  std::shared_ptr<api::PutCommand> msg,
                  PersistenceOperationMetricSet& metric,
+                 PersistenceOperationMetricSet& condition_probe_metrics,
                  SequencingHandle sequencingHandle = SequencingHandle());
     ~PutOperation() override;
 
@@ -44,7 +45,7 @@ private:
     document::BucketId                 _doc_id_bucket_id;
     const DistributorNodeContext&      _node_ctx;
     DistributorStripeOperationContext& _op_ctx;
-    PersistenceOperationMetricSet&     _temp_metric;
+    PersistenceOperationMetricSet&     _condition_probe_metrics;
     DistributorBucketSpace&            _bucket_space;
     std::shared_ptr<CheckCondition>    _check_condition;
 

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
@@ -19,6 +19,7 @@ public:
                     DistributorBucketSpace& bucketSpace,
                     std::shared_ptr<api::RemoveCommand> msg,
                     PersistenceOperationMetricSet& metric,
+                    PersistenceOperationMetricSet& condition_probe_metrics,
                     SequencingHandle sequencingHandle = SequencingHandle());
     ~RemoveOperation() override;
 
@@ -36,7 +37,7 @@ private:
     document::BucketId                  _doc_id_bucket_id;
     const DistributorNodeContext&       _node_ctx;
     DistributorStripeOperationContext&  _op_ctx;
-    PersistenceOperationMetricSet&      _temp_metric;
+    PersistenceOperationMetricSet&      _condition_probe_metrics;
     DistributorBucketSpace&             _bucket_space;
     std::shared_ptr<CheckCondition>     _check_condition;
 

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -139,6 +139,7 @@ private:
 
     UpdateMetricSet&                    _updateMetric;
     PersistenceOperationMetricSet&      _putMetric;
+    PersistenceOperationMetricSet&      _put_condition_probe_metrics;
     PersistenceOperationMetricSet&      _getMetric;
     PersistenceOperationMetricSet&      _metadata_get_metrics;
     std::shared_ptr<api::UpdateCommand> _updateCmd;

--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.cpp
@@ -58,8 +58,8 @@ PersistenceFailuresMetricSet::clone(std::vector<Metric::UP>& ownerList, CopyType
     if (copyType == INACTIVE) {
         return MetricSet::clone(ownerList, INACTIVE, owner, includeUnused);
     }
-    return (PersistenceFailuresMetricSet*)
-            (new PersistenceFailuresMetricSet(owner))->assignValues(*this);
+    return dynamic_cast<PersistenceFailuresMetricSet*>(
+            (new PersistenceFailuresMetricSet(owner))->assignValues(*this));
 }
 
 PersistenceOperationMetricSet::PersistenceOperationMetricSet(const std::string& name, MetricSet* owner)
@@ -68,6 +68,11 @@ PersistenceOperationMetricSet::PersistenceOperationMetricSet(const std::string& 
       ok("ok", {{"logdefault"},{"yamasdefault"}}, vespalib::make_string("The number of successful %s operations performed", name.c_str()), this),
       failures(this)
 { }
+
+PersistenceOperationMetricSet::PersistenceOperationMetricSet(const std::string& name)
+    : PersistenceOperationMetricSet(name, nullptr)
+{
+}
 
 PersistenceOperationMetricSet::~PersistenceOperationMetricSet() = default;
 
@@ -78,9 +83,8 @@ PersistenceOperationMetricSet::clone(std::vector<Metric::UP>& ownerList, CopyTyp
     if (copyType == INACTIVE) {
         return MetricSet::clone(ownerList, INACTIVE, owner, includeUnused);
     }
-    return (PersistenceOperationMetricSet*)
-            (new PersistenceOperationMetricSet(getName(), owner))
-                ->assignValues(*this);
+    return dynamic_cast<PersistenceOperationMetricSet*>(
+            (new PersistenceOperationMetricSet(getName(), owner))->assignValues(*this));
 }
 
 void

--- a/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
+++ b/storage/src/vespa/storage/distributor/persistence_operation_metric_set.h
@@ -40,10 +40,11 @@ class PersistenceOperationMetricSet : public metrics::MetricSet
     mutable std::mutex _mutex;
 public:
     metrics::DoubleAverageMetric latency;
-    metrics::LongCountMetric ok;
+    metrics::LongCountMetric     ok;
     PersistenceFailuresMetricSet failures;
 
-    PersistenceOperationMetricSet(const std::string& name, metrics::MetricSet* owner = nullptr);
+    PersistenceOperationMetricSet(const std::string& name, metrics::MetricSet* owner);
+    explicit PersistenceOperationMetricSet(const std::string& name);
     ~PersistenceOperationMetricSet() override;
 
     MetricSet * clone(std::vector<Metric::UP>& ownerList, CopyType copyType,
@@ -57,7 +58,6 @@ public:
      */
     void updateFromResult(const api::ReturnCode& result);
 
-    friend class LockWrapper;
     class LockWrapper {
         std::unique_lock<std::mutex> _lock;
         PersistenceOperationMetricSet& _self;


### PR DESCRIPTION
@havardpe please review.

Follows the same pattern as that used for sub-operation metrics for write-repair during Update processing.

