### PR TITLE
Reduce os upgrade grace period in cd

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
@@ -50,7 +50,7 @@ public abstract class OsUpgrader {
 
     /** The duration this leaves new nodes alone before scheduling any upgrade */
     private Duration gracePeriod() {
-        return Duration.ofDays(1);
+        return nodeRepository.zone().system().isCd() ? Duration.ofHours(4) : Duration.ofDays(1);
     }
 
 }


### PR DESCRIPTION
Needed to be able to test OS upgrades for newly provisioned nodes