### PR TITLE
Threat 'other symbols' as letters

### DIFF
--- a/config-model/src/test/java/com/yahoo/schema/processing/NGramTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/NGramTestCase.java
@@ -52,7 +52,7 @@ public class NGramTestCase extends AbstractSchemaTestCase {
     @Test
     void testInvalidNGramSetting1() throws IOException, ParseException {
         try {
-            Schema schema = ApplicationBuilder.buildFromFile("src/test/examples/invalidngram1.sd");
+            ApplicationBuilder.buildFromFile("src/test/examples/invalidngram1.sd");
             fail("Should cause an exception");
         }
         catch (IllegalArgumentException e) {
@@ -63,7 +63,7 @@ public class NGramTestCase extends AbstractSchemaTestCase {
     @Test
     void testInvalidNGramSetting2() throws IOException, ParseException {
         try {
-            Schema schema = ApplicationBuilder.buildFromFile("src/test/examples/invalidngram2.sd");
+            ApplicationBuilder.buildFromFile("src/test/examples/invalidngram2.sd");
             fail("Should cause an exception");
         }
         catch (IllegalArgumentException e) {
@@ -74,7 +74,7 @@ public class NGramTestCase extends AbstractSchemaTestCase {
     @Test
     void testInvalidNGramSetting3() throws IOException, ParseException {
         try {
-            Schema schema = ApplicationBuilder.buildFromFile("src/test/examples/invalidngram3.sd");
+            ApplicationBuilder.buildFromFile("src/test/examples/invalidngram3.sd");
             fail("Should cause an exception");
         }
         catch (IllegalArgumentException e) {

--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/Tokenizer.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/Tokenizer.java
@@ -107,7 +107,9 @@ public final class Tokenizer {
             if (i >= source.length()) break;
 
             int c = source.codePointAt(i);
-            if (characterClasses.isLetterOrDigit(c) || (c == '\'' && acceptApostropheAsWordCharacter(currentIndex))) {
+            if (characterClasses.isSymbol(c)) { // treat each symbol is a separate word
+                addToken(WORD, Character.toString(c), i, i + 1);
+            } else if (characterClasses.isLetterOrDigit(c) || (c == '\'' && acceptApostropheAsWordCharacter(currentIndex))) {
                 i = consumeWordOrNumber(i, currentIndex);
             } else if (Character.isWhitespace(c)) {
                 addToken(SPACE, " ", i, i + 1);

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
@@ -2580,4 +2580,16 @@ public class ParseTestCase {
     void testNoGrammar4() {
         tester.assertParsed("WEAKAND(100) foo bar baz one two 37", "foo -(bar baz \"one two\" 37)", Query.Type.TOKENIZE);
     }
+
+    @Test
+    void testEmojis() {
+        String emoji1 = "\uD83D\uDD2A"; // 🔪
+        tester.assertParsed(emoji1, emoji1, Query.Type.ANY);
+
+        String emoji2 = "\uD83D\uDE00"; // 😀
+        tester.assertParsed(emoji2, emoji2, Query.Type.ANY);
+
+        tester.assertParsed(emoji1 + emoji2, emoji1 + emoji2, Query.Type.ANY);
+    }
+
 }

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
@@ -2584,12 +2584,12 @@ public class ParseTestCase {
     @Test
     void testEmojis() {
         String emoji1 = "\uD83D\uDD2A"; // 🔪
-        tester.assertParsed(emoji1, emoji1, Query.Type.ANY);
-
         String emoji2 = "\uD83D\uDE00"; // 😀
-        tester.assertParsed(emoji2, emoji2, Query.Type.ANY);
 
+        tester.assertParsed(emoji1, emoji1, Query.Type.ANY);
+        tester.assertParsed(emoji2, emoji2, Query.Type.ANY);
         tester.assertParsed("AND " + emoji1 + " " + emoji2, emoji1 + emoji2, Query.Type.ANY);
+        tester.assertParsed("AND " + emoji1 + " foo " + emoji2, emoji1 + "foo" + emoji2, Query.Type.ANY);
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/query/parser/test/ParseTestCase.java
@@ -2589,7 +2589,7 @@ public class ParseTestCase {
         String emoji2 = "\uD83D\uDE00"; // 😀
         tester.assertParsed(emoji2, emoji2, Query.Type.ANY);
 
-        tester.assertParsed(emoji1 + emoji2, emoji1 + emoji2, Query.Type.ANY);
+        tester.assertParsed("AND " + emoji1 + " " + emoji2, emoji1 + emoji2, Query.Type.ANY);
     }
 
 }

--- a/linguistics/abi-spec.json
+++ b/linguistics/abi-spec.json
@@ -322,6 +322,7 @@
     "methods" : [
       "public void <init>()",
       "public boolean isLetter(int)",
+      "public boolean isSymbol(int)",
       "public boolean isDigit(int)",
       "public boolean isLatinDigit(int)",
       "public boolean isLatin(int)",

--- a/linguistics/src/main/java/com/yahoo/language/process/CharacterClasses.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/CharacterClasses.java
@@ -15,7 +15,6 @@ public class CharacterClasses {
     public boolean isLetter(int c) {
         if (Character.isLetter(c)) return true;
         if (Character.isDigit(c) &&  ! isLatin(c)) return true; // Not considering these digits, so treat them as letters
-        if (Character.getType(c) == Character.OTHER_SYMBOL) return true; // emojis searchable
 
         // Some CJK punctuation defined as word characters
         if (c == '\u3008' || c == '\u3009' || c == '\u300a' || c == '\u300b' ||
@@ -27,6 +26,13 @@ public class CharacterClasses {
         return type == java.lang.Character.NON_SPACING_MARK ||
                type == java.lang.Character.COMBINING_SPACING_MARK ||
                type == java.lang.Character.ENCLOSING_MARK;
+    }
+
+    /**
+     * Returns true if the character is in the class "other symbol" - emojis etc.
+     */
+    public boolean isSymbol(int c) {
+        return Character.getType(c) == Character.OTHER_SYMBOL;
     }
 
     /**

--- a/linguistics/src/main/java/com/yahoo/language/process/CharacterClasses.java
+++ b/linguistics/src/main/java/com/yahoo/language/process/CharacterClasses.java
@@ -13,9 +13,9 @@ public class CharacterClasses {
      * which are useful to view as letters even though not defined as such in unicode.
      */
     public boolean isLetter(int c) {
-        if (java.lang.Character.isLetter(c)) return true;
+        if (Character.isLetter(c)) return true;
         if (Character.isDigit(c) &&  ! isLatin(c)) return true; // Not considering these digits, so treat them as letters
-        // if (c == '_') return true;
+        if (Character.getType(c) == Character.OTHER_SYMBOL) return true; // emojis searchable
 
         // Some CJK punctuation defined as word characters
         if (c == '\u3008' || c == '\u3009' || c == '\u300a' || c == '\u300b' ||

--- a/linguistics/src/test/java/com/yahoo/language/process/GramSplitterTestCase.java
+++ b/linguistics/src/test/java/com/yahoo/language/process/GramSplitterTestCase.java
@@ -49,6 +49,17 @@ public class GramSplitterTestCase {
     }
 
     @Test
+    public void testEmojis() {
+        String emoji1 = "\uD83D\uDD2A"; // 🔪
+        String emoji2 = "\uD83D\uDE00"; // 😀
+        assertGramSplit(emoji1, 2, "[" + emoji1+ "]");
+        assertGramSplit(emoji1 + emoji2, 2, "[" + emoji1 + ", " + emoji2 + "]");
+        assertGramSplit(emoji1 + "." + emoji2, 2, "[" + emoji1 + ", " + emoji2 + "]");
+        assertGramSplit("." + emoji1 + "." + emoji2 + ".", 2, "[" + emoji1 + ", " + emoji2 + "]");
+        assertGramSplit("foo" + emoji1 + "bar" + emoji2 + "baz", 2, "[fo, oo, " + emoji1 + ", ba, ar, " + emoji2 + ", ba, az]");
+    }
+
+    @Test
     public void testSpaceCornerCases() {
         // space corner cases
         assertGramSplit("e   en   e", 1, "[e, e, n, e]");

--- a/linguistics/src/test/java/com/yahoo/language/simple/SimpleTokenizerTestCase.java
+++ b/linguistics/src/test/java/com/yahoo/language/simple/SimpleTokenizerTestCase.java
@@ -33,4 +33,12 @@ public class SimpleTokenizerTestCase extends AbstractTokenizerTestCase {
                             " ", "gods", ".", "running", ")");
     }
 
+    @Test
+    public void testTokenizeEmojis() {
+        TokenizerTester tester = new TokenizerTester().setStemMode(StemMode.ALL);
+        String emoji = "\uD83D\uDD2A"; // 🔪
+        tester.assertTokens(emoji, emoji);
+        tester.assertTokens(emoji + "foo", emoji, "foo");
+    }
+
 }

--- a/linguistics/src/test/java/com/yahoo/language/simple/SimpleTokenizerTestCase.java
+++ b/linguistics/src/test/java/com/yahoo/language/simple/SimpleTokenizerTestCase.java
@@ -1,9 +1,17 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.language.simple;
 
+import com.yahoo.language.Language;
 import com.yahoo.language.process.AbstractTokenizerTestCase;
 import com.yahoo.language.process.StemMode;
+import com.yahoo.language.process.Token;
 import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Steinar Knutsen
@@ -36,9 +44,12 @@ public class SimpleTokenizerTestCase extends AbstractTokenizerTestCase {
     @Test
     public void testTokenizeEmojis() {
         TokenizerTester tester = new TokenizerTester().setStemMode(StemMode.ALL);
-        String emoji = "\uD83D\uDD2A"; // 🔪
-        tester.assertTokens(emoji, emoji);
-        tester.assertTokens(emoji + "foo", emoji, "foo");
+
+        String emoji1 = "\uD83D\uDD2A"; // 🔪
+        String emoji2 = "\uD83D\uDE00"; // 😀
+        tester.assertTokens(emoji1, emoji1);
+        tester.assertTokens(emoji1 + "foo", emoji1, "foo");
+        tester.assertTokens(emoji1 + emoji2, emoji1, emoji2);
     }
 
 }

--- a/opennlp-linguistics/src/main/java/com/yahoo/language/opennlp/OpenNlpTokenizer.java
+++ b/opennlp-linguistics/src/main/java/com/yahoo/language/opennlp/OpenNlpTokenizer.java
@@ -25,7 +25,6 @@ import java.util.List;
  */
 public class OpenNlpTokenizer implements Tokenizer {
 
-    private final static int SPACE_CODE = 32;
     private final Normalizer normalizer;
     private final Transformer transformer;
     private final SimpleTokenizer simpleTokenizer;
@@ -74,26 +73,26 @@ public class OpenNlpTokenizer implements Tokenizer {
     }
 
     private SnowballStemmer.ALGORITHM algorithmFor(Language language) {
-        switch (language) {
-            case DANISH: return SnowballStemmer.ALGORITHM.DANISH;
-            case DUTCH: return SnowballStemmer.ALGORITHM.DUTCH;
-            case FINNISH: return SnowballStemmer.ALGORITHM.FINNISH;
-            case FRENCH: return SnowballStemmer.ALGORITHM.FRENCH;
-            case GERMAN: return SnowballStemmer.ALGORITHM.GERMAN;
-            case HUNGARIAN: return SnowballStemmer.ALGORITHM.HUNGARIAN;
-            case IRISH: return SnowballStemmer.ALGORITHM.IRISH;
-            case ITALIAN: return SnowballStemmer.ALGORITHM.ITALIAN;
-            case NORWEGIAN_BOKMAL: return SnowballStemmer.ALGORITHM.NORWEGIAN;
-            case NORWEGIAN_NYNORSK: return SnowballStemmer.ALGORITHM.NORWEGIAN;
-            case PORTUGUESE: return SnowballStemmer.ALGORITHM.PORTUGUESE;
-            case ROMANIAN: return SnowballStemmer.ALGORITHM.ROMANIAN;
-            case RUSSIAN: return SnowballStemmer.ALGORITHM.RUSSIAN;
-            case SPANISH: return SnowballStemmer.ALGORITHM.SPANISH;
-            case SWEDISH: return SnowballStemmer.ALGORITHM.SWEDISH;
-            case TURKISH: return SnowballStemmer.ALGORITHM.TURKISH;
-            case ENGLISH: return SnowballStemmer.ALGORITHM.ENGLISH;
-            default: return null;
-        }
+        return switch (language) {
+            case DANISH -> SnowballStemmer.ALGORITHM.DANISH;
+            case DUTCH -> SnowballStemmer.ALGORITHM.DUTCH;
+            case FINNISH -> SnowballStemmer.ALGORITHM.FINNISH;
+            case FRENCH -> SnowballStemmer.ALGORITHM.FRENCH;
+            case GERMAN -> SnowballStemmer.ALGORITHM.GERMAN;
+            case HUNGARIAN -> SnowballStemmer.ALGORITHM.HUNGARIAN;
+            case IRISH -> SnowballStemmer.ALGORITHM.IRISH;
+            case ITALIAN -> SnowballStemmer.ALGORITHM.ITALIAN;
+            case NORWEGIAN_BOKMAL -> SnowballStemmer.ALGORITHM.NORWEGIAN;
+            case NORWEGIAN_NYNORSK -> SnowballStemmer.ALGORITHM.NORWEGIAN;
+            case PORTUGUESE -> SnowballStemmer.ALGORITHM.PORTUGUESE;
+            case ROMANIAN -> SnowballStemmer.ALGORITHM.ROMANIAN;
+            case RUSSIAN -> SnowballStemmer.ALGORITHM.RUSSIAN;
+            case SPANISH -> SnowballStemmer.ALGORITHM.SPANISH;
+            case SWEDISH -> SnowballStemmer.ALGORITHM.SWEDISH;
+            case TURKISH -> SnowballStemmer.ALGORITHM.TURKISH;
+            case ENGLISH -> SnowballStemmer.ALGORITHM.ENGLISH;
+            default -> null;
+        };
     }
 
 }

--- a/opennlp-linguistics/src/test/java/com/yahoo/language/opennlp/OpenNlpTokenizationTestCase.java
+++ b/opennlp-linguistics/src/test/java/com/yahoo/language/opennlp/OpenNlpTokenizationTestCase.java
@@ -150,8 +150,7 @@ public class OpenNlpTokenizationTestCase {
     @Test
     public void testIndexability() {
         String input = "tafsirnya\u0648\u0643\u064F\u0646\u0652";
-        for (StemMode stemMode : new StemMode[] { StemMode.NONE,
-                StemMode.SHORTEST }) {
+        for (StemMode stemMode : new StemMode[] { StemMode.NONE, StemMode.SHORTEST }) {
             for (Language l : List.of(Language.INDONESIAN, Language.ENGLISH, Language.ARABIC)) {
                 for (boolean accentDrop : new boolean[] { true, false }) {
                     for (Token token : tokenizer.tokenize(input, l, stemMode, accentDrop)) {
@@ -162,6 +161,15 @@ public class OpenNlpTokenizationTestCase {
                 }
             }
         }
+    }
+
+    @Test
+    public void testTokenizeEmojis() {
+        String emoji = "\uD83D\uDD2A"; // 🔪
+        Iterator<Token> tokens = tokenizer.tokenize(emoji, Language.ENGLISH, StemMode.ALL, true).iterator();
+        assertTrue(tokens.hasNext());
+        assertEquals(emoji, tokens.next().getTokenString());
+        assertFalse(tokens.hasNext());
     }
 
     @Test

--- a/opennlp-linguistics/src/test/java/com/yahoo/language/opennlp/OpenNlpTokenizationTestCase.java
+++ b/opennlp-linguistics/src/test/java/com/yahoo/language/opennlp/OpenNlpTokenizationTestCase.java
@@ -165,11 +165,18 @@ public class OpenNlpTokenizationTestCase {
 
     @Test
     public void testTokenizeEmojis() {
-        String emoji = "\uD83D\uDD2A"; // 🔪
-        Iterator<Token> tokens = tokenizer.tokenize(emoji, Language.ENGLISH, StemMode.ALL, true).iterator();
-        assertTrue(tokens.hasNext());
-        assertEquals(emoji, tokens.next().getTokenString());
-        assertFalse(tokens.hasNext());
+        String emoji1 = "\uD83D\uDD2A"; // 🔪
+        Iterator<Token> tokens1 = tokenizer.tokenize(emoji1, Language.ENGLISH, StemMode.ALL, true).iterator();
+        assertTrue(tokens1.hasNext());
+        assertEquals(emoji1, tokens1.next().getTokenString());
+        assertFalse(tokens1.hasNext());
+
+        String emoji2 = "\uD83D\uDE00"; // 😀
+        Iterator<Token> tokens2 = tokenizer.tokenize(emoji1 + emoji2, Language.ENGLISH, StemMode.ALL, true).iterator();
+        assertTrue(tokens2.hasNext());
+        assertEquals(emoji1, tokens2.next().getTokenString());
+        assertEquals(emoji2, tokens2.next().getTokenString());
+        assertFalse(tokens2.hasNext());
     }
 
     @Test


### PR DESCRIPTION
The unicode class 'other symbols' contains emojis, math symbols, etc. Treat these as letter characters to support searching for them.
