### PR TITLE
Always print documentCount field when visiting was started

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1367,8 +1367,7 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
                         try (response) {
                             callback.onEnd(response);
 
-                            if (getVisitorStatistics() != null)
-                                response.writeDocumentCount(getVisitorStatistics().getDocumentsVisited());
+                            response.writeDocumentCount(getVisitorStatistics() == null ? 0 : getVisitorStatistics().getDocumentsVisited());
 
                             if (session.get() != null)
                                 response.writeTrace(session.get().getTrace());

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -355,6 +355,7 @@ public class DocumentV1ApiTest {
                        {
                          "pathId": "/document/v1/space/music/docid",
                          "documents": [],
+                         "documentCount": 0,
                          "message": "failure?"
                        }""", response.readAll());
         assertEquals(200, response.getStatus());
@@ -383,7 +384,8 @@ public class DocumentV1ApiTest {
         response = driver.sendRequest("http://localhost/document/v1/space/music/docid?destinationCluster=content&selection=true&cluster=content&timeout=60", POST);
         assertSameJson("""
                        {
-                         "pathId": "/document/v1/space/music/docid"
+                         "pathId": "/document/v1/space/music/docid",
+                         "documentCount": 0
                        }""",
                        response.readAll());
         assertEquals(200, response.getStatus());
@@ -416,7 +418,8 @@ public class DocumentV1ApiTest {
                                       }""");
         assertSameJson("""
                        {
-                         "pathId": "/document/v1/space/music/docid"
+                         "pathId": "/document/v1/space/music/docid",
+                         "documentCount": 0
                        }""",
                        response.readAll());
         assertEquals(200, response.getStatus());
@@ -470,6 +473,7 @@ public class DocumentV1ApiTest {
         assertSameJson("""
                        {
                          "pathId": "/document/v1/space/music/docid",
+                         "documentCount": 0,
                          "message": "boom"
                        }""",
                        response.readAll());
@@ -511,6 +515,7 @@ public class DocumentV1ApiTest {
                        {
                          "pathId": "/document/v1/space/music/group/best%27",
                          "documents": [],
+                         "documentCount": 0,
                          "message": "error"
                        }""",
                        response.readAll());


### PR DESCRIPTION
@vekterli please review. Ref. https://factory.vespa.oath.cloud/testrun/62558846/test/Visiting::test_process_visit_throughput