### PR TITLE
Store max squared norm in file header during hnsw index save when using

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attribute_header.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_header.cpp
@@ -5,6 +5,8 @@
 #include <vespa/vespalib/data/databuffer.h>
 #include <vespa/vespalib/util/exceptions.h>
 
+using vespalib::GenericHeader;
+
 namespace search::attribute {
 
 namespace {
@@ -57,7 +59,8 @@ AttributeHeader::AttributeHeader(const vespalib::string &fileName)
       _uniqueValueCount(0),
       _totalValueCount(0),
       _createSerialNum(0u),
-      _version(0)
+      _version(0),
+      _extra_tags()
 {
 }
 
@@ -243,6 +246,10 @@ AttributeHeader::addTags(vespalib::GenericHeader &header) const
         header.putTag(Tag(predicateArityTag, params.arity()));
         header.putTag(Tag(predicateLowerBoundTag, params.lower_bound()));
         header.putTag(Tag(predicateUpperBoundTag, params.upper_bound()));
+    }
+    for (uint32_t i = 0; i < _extra_tags.getNumTags(); ++i) {
+        auto& tag = _extra_tags.getTag(i);
+        header.putTag(tag);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/attribute_header.h
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_header.h
@@ -2,15 +2,14 @@
 
 #pragma once
 
-#include <vespa/vespalib/stllike/string.h>
+#include <vespa/eval/eval/value_type.h>
 #include <vespa/searchcommon/attribute/basictype.h>
 #include <vespa/searchcommon/attribute/collectiontype.h>
 #include <vespa/searchcommon/attribute/hnsw_index_params.h>
 #include <vespa/searchcommon/attribute/predicate_params.h>
-#include <vespa/eval/eval/value_type.h>
+#include <vespa/vespalib/data/fileheader.h>
+#include <vespa/vespalib/stllike/string.h>
 #include <optional>
-
-namespace vespalib { class GenericHeader; }
 
 namespace search::attribute {
 
@@ -34,6 +33,7 @@ private:
     uint64_t    _totalValueCount;
     uint64_t    _createSerialNum;
     uint32_t    _version;
+    vespalib::GenericHeader _extra_tags;
 
     void internalExtractTags(const vespalib::GenericHeader &header);
 public:
@@ -71,6 +71,7 @@ public:
     const std::optional<HnswIndexParams>& get_hnsw_index_params() const { return _hnsw_index_params; }
     static AttributeHeader extractTags(const vespalib::GenericHeader &header, const vespalib::string &file_name);
     void addTags(vespalib::GenericHeader &header) const;
+    vespalib::GenericHeader& get_extra_tags() noexcept { return _extra_tags; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/hnsw_index.h
@@ -211,8 +211,8 @@ public:
     void get_state(const vespalib::slime::Inserter& inserter) const override;
     void shrink_lid_space(uint32_t doc_id_limit) override;
 
-    std::unique_ptr<NearestNeighborIndexSaver> make_saver() const override;
-    std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file) override;
+    std::unique_ptr<NearestNeighborIndexSaver> make_saver(vespalib::GenericHeader& header) const override;
+    std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file, const vespalib::GenericHeader& header) override;
 
     std::vector<Neighbor> find_top_k(
             uint32_t k,

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
@@ -37,6 +37,18 @@ public:
     }
 };
 
+class MipsDistanceFunctionFactoryBase : public DistanceFunctionFactory {
+protected:
+    std::shared_ptr<MaximumSquaredNormStore> _sq_norm_store;
+public:
+    MipsDistanceFunctionFactoryBase()
+        : _sq_norm_store(std::make_shared<MaximumSquaredNormStore>())
+    {
+    }
+    ~MipsDistanceFunctionFactoryBase() = default;
+    MaximumSquaredNormStore& get_max_squared_norm_store() noexcept { return *_sq_norm_store; }
+};
+
 /**
  * Factory for distance functions which can apply a transformation
  * mapping Maximum Inner Product Search to a nearest neighbor
@@ -45,10 +57,10 @@ public:
  * to the longest vector inserted so far, or at least length 1.
  */
 template<typename FloatType>
-class MipsDistanceFunctionFactory : public DistanceFunctionFactory {
-    std::shared_ptr<MaximumSquaredNormStore> _sq_norm_store;
+class MipsDistanceFunctionFactory : public MipsDistanceFunctionFactoryBase {
 public:
-    MipsDistanceFunctionFactory() : _sq_norm_store(std::make_shared<MaximumSquaredNormStore>()) {}
+    MipsDistanceFunctionFactory() : MipsDistanceFunctionFactoryBase() { }
+    ~MipsDistanceFunctionFactory() = default;
 
     BoundDistanceFunction::UP for_query_vector(const vespalib::eval::TypedCells& lhs) override;
 

--- a/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
+++ b/searchlib/src/vespa/searchlib/tensor/nearest_neighbor_index.h
@@ -14,6 +14,7 @@
 
 class FastOS_FileInterface;
 
+namespace vespalib { class GenericHeader; }
 namespace vespalib::datastore {
 class CompactionSpec;
 class CompactionStrategy;
@@ -88,14 +89,14 @@ public:
      * This function is always called by the attribute write thread,
      * and the caller ensures that an attribute read guard is held during the lifetime of the saver.
      */
-    virtual std::unique_ptr<NearestNeighborIndexSaver> make_saver() const = 0;
+    virtual std::unique_ptr<NearestNeighborIndexSaver> make_saver(vespalib::GenericHeader& header) const = 0;
 
     /**
      * Creates a loader that is used to load the index from the given file.
      *
      * This might throw std::runtime_error.
      */
-    virtual std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file) = 0;
+    virtual std::unique_ptr<NearestNeighborIndexLoader> make_loader(FastOS_FileInterface& file, const vespalib::GenericHeader& header) = 0;
 
     virtual std::vector<Neighbor> find_top_k(uint32_t k,
                                              const BoundDistanceFunction &df,

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute.cpp
@@ -357,10 +357,11 @@ TensorAttribute::onInitSave(vespalib::stringref fileName)
 {
     vespalib::GenerationHandler::Guard guard(getGenerationHandler().
                                              takeGuard());
-    auto index_saver = (_index ? _index->make_saver() : std::unique_ptr<NearestNeighborIndexSaver>());
+    auto header = this->createAttributeHeader(fileName);
+    auto index_saver = (_index ? _index->make_saver(header.get_extra_tags()) : std::unique_ptr<NearestNeighborIndexSaver>());
     return std::make_unique<TensorAttributeSaver>
         (std::move(guard),
-         this->createAttributeHeader(fileName),
+         std::move(header),
          attribute::make_entry_ref_vector_snapshot(_refVector, getCommittedDocIdLimit()),
          _tensorStore,
          std::move(index_saver));

--- a/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/tensor_attribute_loader.cpp
@@ -273,7 +273,7 @@ TensorAttributeLoader::load_index()
 {
     FileWithHeader index_file(LoadUtils::openFile(_attr, TensorAttributeSaver::index_file_suffix()));
     try {
-        auto index_loader = _index->make_loader(index_file.file());
+        auto index_loader = _index->make_loader(index_file.file(), index_file.header());
         size_t cnt = 0;
         while (index_loader->load_next()) {
             if ((++cnt % LOAD_COMMIT_INTERVAL) == 0) {


### PR DESCRIPTION
dotproduct distance metric. Adjust hnsw index load.

@geirst : please review
