### PR TITLE
Properly handle open visitor timestamp ranges in request parameters

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1219,10 +1219,12 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
         parameters.setPriority(DocumentProtocol.Priority.NORMAL_4);
 
         getProperty(request, FROM_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setFromTimestamp);
-        getProperty(request, TO_TIMESTAMP, unsignedLongParser).ifPresent(parameters::setToTimestamp);
-        if (Long.compareUnsigned(parameters.getFromTimestamp(), parameters.getToTimestamp()) > 0) {
-            throw new IllegalArgumentException("toTimestamp must be greater than, or equal to, fromTimestamp");
-        }
+        getProperty(request, TO_TIMESTAMP, unsignedLongParser).ifPresent(ts -> {
+            parameters.setToTimestamp(ts);
+            if (Long.compareUnsigned(parameters.getFromTimestamp(), parameters.getToTimestamp()) > 0) {
+                throw new IllegalArgumentException("toTimestamp must be greater than, or equal to, fromTimestamp");
+            }
+        });
 
         StorageCluster storageCluster = resolveCluster(cluster, clusters);
         parameters.setRoute(storageCluster.name());


### PR DESCRIPTION
@jonmv please review
@kkraune FYI
