### PR TITLE
Reuse buffer holding body after document is processed

### DIFF
--- a/client/go/internal/vespa/document/dispatcher.go
+++ b/client/go/internal/vespa/document/dispatcher.go
@@ -137,6 +137,7 @@ func (d *Dispatcher) processResults() {
 		if d.shouldRetry(op, op.result) {
 			d.enqueue(op.resetResult(), true)
 		} else {
+			op.document.Reset()
 			d.inflightWg.Done()
 		}
 		d.dispatchNext(op.document.Id)


### PR DESCRIPTION
That way total memory allocated won't equal size of the JSON input.

@bratseth