### PR TITLE
Avoid PTR lookup in GCP

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
@@ -251,7 +251,7 @@ public class HostCapacityMaintainer extends NodeRepositoryMaintainer {
 
         NodePrioritizer prioritizer = new NodePrioritizer(allNodes, applicationId, clusterSpec, nodeSpec, wantedGroups,
                 true, nodeRepository().nameResolver(), nodeRepository().nodes(), nodeRepository().resourcesCalculator(),
-                nodeRepository().spareCount(), nodeSpec.cloudAccount().isEnclave(nodeRepository().zone()));
+                nodeRepository().spareCount(), nodeSpec.cloudAccount(), nodeRepository().zone());
         List<NodeCandidate> nodeCandidates = prioritizer.collect(List.of());
         MutableInteger index = new MutableInteger(0);
         return nodeCandidates

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -162,7 +162,8 @@ public class GroupPreparer {
                                                           nodeRepository.nodes(),
                                                           nodeRepository.resourcesCalculator(),
                                                           nodeRepository.spareCount(),
-                                                          requestedNodes.cloudAccount().isEnclave(nodeRepository.zone()));
+                                                          requestedNodes.cloudAccount(),
+                                                          nodeRepository.zone());
         allocation.offer(prioritizer.collect(surplusActiveNodes));
         return allocation;
     }


### PR DESCRIPTION
Allocation to shared hosts currently fails with:

```
Failed allocating address on active host h2583.prod.gcp-us-central1-f.gcp-cd.vespa.yahoo.cloud allocated to hosted-vespa.tenant-host as 'container/tenant-host/0/8': Could not resolve IP address: 2600:1900:4000:b633:0:10:1:0 (NodeCandidate)
```

Which happens because findAllocation() tries to resolve PTR records for IPv6 addresses that are assigned to newly provisioned Public CD GCP hosts (flag).