### PR TITLE
Reduce sleep time until next deployment when parent host not ready

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -250,7 +250,7 @@ public class InternalStepRunner implements StepRunner {
                 case LOAD_BALANCER_NOT_READY, PARENT_HOST_NOT_READY -> {
                     logger.log(e.message()); // Consider splitting these messages in summary and details, on config server.
                     Instant someTimeAfterStart = startTime.plusSeconds(200);
-                    Instant inALittleWhile = controller.clock().instant().plusSeconds(90);
+                    Instant inALittleWhile = controller.clock().instant().plusSeconds(60);
                     controller.jobController().locked(id, run -> run.sleepingUntil(someTimeAfterStart.isAfter(inALittleWhile) ? someTimeAfterStart : inALittleWhile));
                     return result;
                 }


### PR DESCRIPTION
Provisioning is faster now, should be able to try more often