### PR TITLE
- Use a rwlock as reading surpasses writing by a very large factor.

### DIFF
--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -984,13 +984,8 @@ TEST_F(TwoPhasePutTest, handles_assign_update_as_two_phase_put_when_specified_fo
 ImportedAttributeVector::SP
 createImportedAttribute(const vespalib::string &name)
 {
-    auto result = ImportedAttributeVectorFactory::create(name,
-                                                         std::shared_ptr<ReferenceAttribute>(),
-                                                         std::shared_ptr<search::IDocumentMetaStoreContext>(),
-                                                         AttributeVector::SP(),
-                                                         std::shared_ptr<const search::IDocumentMetaStoreContext>(),
-                                                         true);
-    result->getSearchCache()->insert("foo", BitVectorSearchCache::Entry::SP());
+    auto result = ImportedAttributeVectorFactory::create(name, {}, {}, {}, {}, true);
+    result->getSearchCache()->insert("foo", {});
     return result;
 }
 

--- a/searchlib/src/tests/attribute/bitvector_search_cache/bitvector_search_cache_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector_search_cache/bitvector_search_cache_test.cpp
@@ -9,8 +9,9 @@ using namespace search::attribute;
 
 using BitVectorSP = BitVectorSearchCache::BitVectorSP;
 using Entry = BitVectorSearchCache::Entry;
+using EntrySP = std::shared_ptr<Entry>;
 
-Entry::SP
+EntrySP
 makeEntry()
 {
     return std::make_shared<Entry>(IDocumentMetaStoreContext::IReadGuard::SP(), BitVector::create(5), 10);
@@ -18,8 +19,8 @@ makeEntry()
 
 struct Fixture {
     BitVectorSearchCache cache;
-    Entry::SP entry1;
-    Entry::SP entry2;
+    EntrySP entry1;
+    EntrySP entry2;
     Fixture()
         : cache(),
           entry1(makeEntry()),

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -467,7 +467,7 @@ struct SearchCacheFixture : Fixture {
 
 SearchCacheFixture::~SearchCacheFixture() = default;
 
-BitVectorSearchCache::Entry::SP
+std::shared_ptr<BitVectorSearchCache::Entry>
 makeSearchCacheEntry(const std::vector<uint32_t> docIds, uint32_t docIdLimit)
 {
     std::shared_ptr<BitVector> bitVector = BitVector::create(docIdLimit);

--- a/searchlib/src/vespa/searchlib/attribute/bitvector_search_cache.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/bitvector_search_cache.cpp
@@ -3,44 +3,45 @@
 #include "bitvector_search_cache.h"
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
+#include <mutex>
 
 namespace search::attribute {
 
-using BitVectorSP = BitVectorSearchCache::BitVectorSP;
+BitVectorSearchCache::BitVectorSearchCache()
+    : _mutex(),
+      _size(0),
+      _cache()
+{}
 
-BitVectorSearchCache::BitVectorSearchCache() = default;
 BitVectorSearchCache::~BitVectorSearchCache() = default;
 
 void
-BitVectorSearchCache::insert(const vespalib::string &term, Entry::SP entry)
+BitVectorSearchCache::insert(const vespalib::string &term, std::shared_ptr<Entry> entry)
 {
-    LockGuard guard(_mutex);
+    std::unique_lock guard(_mutex);
     _cache.insert(std::make_pair(term, std::move(entry)));
+    _size.store(_cache.size());
 }
 
-BitVectorSearchCache::Entry::SP
+std::shared_ptr<BitVectorSearchCache::Entry>
 BitVectorSearchCache::find(const vespalib::string &term) const
 {
-    LockGuard guard(_mutex);
-    auto itr = _cache.find(term);
-    if (itr != _cache.end()) {
-        return itr->second;
+    if (size() > 0ul) {
+        std::shared_lock guard(_mutex);
+        auto itr = _cache.find(term);
+        if (itr != _cache.end()) {
+            return itr->second;
+        }
     }
-    return Entry::SP();
-}
-
-size_t
-BitVectorSearchCache::size() const
-{
-    LockGuard guard(_mutex);
-    return _cache.size();
+    return {};
 }
 
 void
 BitVectorSearchCache::clear()
 {
-    LockGuard guard(_mutex);
+    std::unique_lock guard(_mutex);
     _cache.clear();
+    _size.store(0ul, std::memory_order_relaxed);
 }
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -32,7 +32,7 @@ class ImportedSearchContext : public ISearchContext {
     const ImportedAttributeVector&                  _imported_attribute;
     vespalib::string                                _queryTerm;
     bool                                            _useSearchCache;
-    BitVectorSearchCache::Entry::SP                 _searchCacheLookup;
+    std::shared_ptr<BitVectorSearchCache::Entry>    _searchCacheLookup;
     IDocumentMetaStoreContext::IReadGuard::SP       _dmsReadGuardFallback;
     const ReferenceAttribute&                       _reference_attribute;
     const IAttributeVector                         &_target_attribute;


### PR DESCRIPTION
- size() does not need a lock.

@geirst or @toregge PR