### PR TITLE
- Make the MatchContext value object movable.

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -394,10 +394,9 @@ struct MyWorld {
 
     SearchReply::UP performSearch(const SearchRequest & req, size_t threads) {
         Matcher::SP matcher = createMatcher();
-        SearchSession::OwnershipBundle owned_objects;
-        owned_objects.search_handler = std::make_shared<MySearchHandler>(matcher);
-        owned_objects.context = std::make_unique<MatchContext>(std::make_unique<MockAttributeContext>(),
-                                                               std::make_unique<FakeSearchContext>());
+        SearchSession::OwnershipBundle owned_objects({std::make_unique<MockAttributeContext>(),
+                                                      std::make_unique<FakeSearchContext>()},
+                                                     std::make_shared<MySearchHandler>(matcher));
         vespalib::SimpleThreadBundle threadBundle(threads);
         SearchReply::UP reply = matcher->match(req, threadBundle, searchContext, attributeContext,
                                                *sessionManager, metaStore, metaStore.getBucketDB(),

--- a/searchcore/src/vespa/searchcore/proton/matching/CMakeLists.txt
+++ b/searchcore/src/vespa/searchcore/proton/matching/CMakeLists.txt
@@ -12,6 +12,7 @@ vespa_add_library(searchcore_matching STATIC
     i_match_loop_communicator.cpp
     indexenvironment.cpp
     match_loop_communicator.cpp
+    match_context.cpp
     match_master.cpp
     match_params.cpp
     match_phase_limit_calculator.cpp

--- a/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/blueprintbuilder.h
@@ -6,6 +6,8 @@
 #include <vespa/searchlib/query/tree/node.h>
 #include <vespa/searchlib/queryeval/blueprint.h>
 
+namespace search::queryeval { class IRequestContext; }
+
 namespace proton::matching {
 
 struct BlueprintBuilder {
@@ -14,9 +16,7 @@ struct BlueprintBuilder {
      * blueprint meta-data back into corresponding query tree nodes.
      */
     static search::queryeval::Blueprint::UP
-    build(const search::queryeval::IRequestContext & requestContext,
-          search::query::Node &node,
-          ISearchContext &context);
+    build(const search::queryeval::IRequestContext & requestContext, search::query::Node &node, ISearchContext &context);
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/isearchcontext.h
@@ -2,10 +2,9 @@
 
 #pragma once
 
-#include <vespa/searchlib/queryeval/searchable.h>
-
 #include <memory>
 
+namespace search::queryeval { class Searchable; }
 namespace searchcorespi { class IndexSearchable; }
 
 namespace proton::matching {
@@ -25,10 +24,6 @@ class ISearchContext
 protected:
     ISearchContext() = default;
 public:
-    /**
-     * Convenience typedef for an auto pointer to this interface.
-     **/
-    using UP = std::unique_ptr<ISearchContext>;
     ISearchContext(const ISearchContext &) = delete;
     ISearchContext & operator = (const ISearchContext &) = delete;
 

--- a/searchcore/src/vespa/searchcore/proton/matching/match_context.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_context.cpp
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include "match_context.h"
+#include <cassert>
+
+namespace proton::matching {
+
+MatchContext::MatchContext(std::unique_ptr<IAttributeContext> attrCtx, std::unique_ptr<ISearchContext> searchCtx) noexcept
+    : _attrCtx(std::move(attrCtx)),
+      _searchCtx(std::move(searchCtx))
+{
+    assert(_attrCtx);
+    assert(_searchCtx);
+}
+
+MatchContext::MatchContext() noexcept = default;
+MatchContext::~MatchContext() = default;
+
+}

--- a/searchcore/src/vespa/searchcore/proton/matching/match_context.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_context.h
@@ -4,25 +4,20 @@
 
 #include "isearchcontext.h"
 #include <vespa/searchcommon/attribute/iattributecontext.h>
-#include <memory>
 
 namespace proton::matching {
 
 class MatchContext {
     using IAttributeContext = search::attribute::IAttributeContext;
-    IAttributeContext::UP _attrCtx;
-    ISearchContext::UP    _searchCtx;
-
+    std::unique_ptr<IAttributeContext> _attrCtx;
+    std::unique_ptr<ISearchContext>    _searchCtx;
 public:
     using UP = std::unique_ptr<MatchContext>;
 
-    MatchContext(IAttributeContext::UP attrCtx, ISearchContext::UP searchCtx)
-        : _attrCtx(std::move(attrCtx)),
-          _searchCtx(std::move(searchCtx))
-    {
-        assert(_attrCtx);
-        assert(_searchCtx);
-    }
+    MatchContext() noexcept;
+    MatchContext(IAttributeContext::UP attrCtx, std::unique_ptr<ISearchContext> searchCtx) noexcept;
+    MatchContext(MatchContext &&) noexcept = default;
+    ~MatchContext();
 
     IAttributeContext &getAttributeContext() const { return *_attrCtx; }
     ISearchContext &getSearchContext() const { return *_searchCtx; }

--- a/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/same_element_builder.h
@@ -7,21 +7,24 @@
 #include <vespa/searchlib/queryeval/blueprint.h>
 #include <vespa/searchlib/queryeval/same_element_blueprint.h>
 
-namespace search::queryeval { class FieldSpec; }
+namespace search::queryeval {
+    class IRequestContext;
+    class FieldSpec;
+}
 
 namespace proton::matching {
 
 class SameElementBuilder
 {
-private:
-    const search::queryeval::IRequestContext                &_requestContext;
-    ISearchContext                                          &_context;
-    std::unique_ptr<search::queryeval::SameElementBlueprint> _result;
 public:
     SameElementBuilder(const search::queryeval::IRequestContext &requestContext, ISearchContext &context,
                        const search::queryeval::FieldSpec &field, bool expensive);
     void add_child(search::query::Node &node);
     search::queryeval::Blueprint::UP build();
+private:
+    const search::queryeval::IRequestContext                &_requestContext;
+    ISearchContext                                          &_context;
+    std::unique_ptr<search::queryeval::SameElementBlueprint> _result;
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.cpp
@@ -18,12 +18,20 @@ SearchSession::SearchSession(const SessionId &id, vespalib::steady_time create_t
 
 void
 SearchSession::releaseEnumGuards() {
-    _owned_objects.context->releaseEnumGuards();
+    _owned_objects.context.releaseEnumGuards();
 }
 
 SearchSession::~SearchSession() = default;
 
-SearchSession::OwnershipBundle::OwnershipBundle() = default;
+SearchSession::OwnershipBundle::OwnershipBundle(MatchContext && match_context,
+                                                std::shared_ptr<const ISearchHandler> searchHandler) noexcept
+    : context(std::move(match_context)),
+      search_handler(std::move(searchHandler)),
+      feature_overrides(),
+      readGuard()
+{}
+
+SearchSession::OwnershipBundle::OwnershipBundle() noexcept = default;
 SearchSession::OwnershipBundle::~OwnershipBundle() = default;
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/search_session.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/search_session.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "match_context.h"
 #include <vespa/searchcore/proton/documentmetastore/i_document_meta_store_context.h>
 #include <vespa/searchcore/proton/summaryengine/isearchhandler.h>
 #include <vespa/vespalib/stllike/string.h>
@@ -22,13 +23,14 @@ class MatchContext;
 class SearchSession {
 public:
     struct OwnershipBundle {
-        OwnershipBundle();
-        OwnershipBundle(OwnershipBundle &&) = default;
-        OwnershipBundle & operator = (OwnershipBundle &&) = default;
+        OwnershipBundle() noexcept;
+        OwnershipBundle(MatchContext && matchContext, std::shared_ptr<const ISearchHandler> searchHandler) noexcept;
+        OwnershipBundle(OwnershipBundle &&) noexcept = default;
+        OwnershipBundle & operator = (OwnershipBundle &&) noexcept = delete;
         ~OwnershipBundle();
+        MatchContext context;
         std::shared_ptr<const ISearchHandler> search_handler;
         std::unique_ptr<search::fef::Properties> feature_overrides;
-        std::unique_ptr<MatchContext> context;
         IDocumentMetaStoreContext::IReadGuard::SP readGuard;
     };
 private:
@@ -44,8 +46,7 @@ public:
     using SP = std::shared_ptr<SearchSession>;
 
     SearchSession(const SessionId &id, vespalib::steady_time create_time, vespalib::steady_time time_of_doom,
-                  std::unique_ptr<MatchToolsFactory> match_tools_factory,
-                  OwnershipBundle &&owned_objects);
+                  std::unique_ptr<MatchToolsFactory> match_tools_factory, OwnershipBundle &&owned_objects);
     ~SearchSession();
 
     const SessionId &getSessionId() const { return _session_id; }

--- a/searchcore/src/vespa/searchcore/proton/server/matchview.h
+++ b/searchcore/src/vespa/searchcore/proton/server/matchview.h
@@ -10,26 +10,23 @@
 
 namespace searchcorespi { class IndexSearchable; }
 
-namespace proton {
-
-namespace matching {
-
-class MatchContext;
-class Matcher;
-class SessionManager;
-
+namespace proton::matching {
+    class MatchContext;
+    class Matcher;
+    class SessionManager;
 }
 
+namespace proton {
 struct IAttributeManager;
 
 class MatchView {
     using SessionManager = matching::SessionManager;
-    std::shared_ptr<Matchers>           _matchers;
-    std::shared_ptr<searchcorespi::IndexSearchable> _indexSearchable;
-    std::shared_ptr<IAttributeManager>   _attrMgr;
-    SessionManager                     & _sessionMgr;
-    std::shared_ptr<IDocumentMetaStoreContext> _metaStore;
-    DocIdLimit                          &_docIdLimit;
+    std::shared_ptr<Matchers>                        _matchers;
+    std::shared_ptr<searchcorespi::IndexSearchable>  _indexSearchable;
+    std::shared_ptr<IAttributeManager>               _attrMgr;
+    SessionManager                                 & _sessionMgr;
+    std::shared_ptr<IDocumentMetaStoreContext>       _metaStore;
+    DocIdLimit                                      &_docIdLimit;
 
     size_t getNumDocs() const {
         return _metaStore->get().getNumActiveLids();
@@ -63,7 +60,7 @@ public:
         return _matchers->getStats(rankProfile);
     }
 
-    std::unique_ptr<matching::MatchContext> createContext() const;
+    matching::MatchContext createContext() const;
 
     std::unique_ptr<search::engine::SearchReply>
     match(std::shared_ptr<const ISearchHandler> searchHandler,

--- a/searchcore/src/vespa/searchcore/proton/server/searchview.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchview.cpp
@@ -127,7 +127,7 @@ SearchView::getDocsumsInternal(const DocsumRequest & req)
     auto store(_summarySetup->createDocsumStore());
     auto mctx = _matchView->createContext();
     auto ctx = std::make_unique<DocsumContext>(req, _summarySetup->getDocsumWriter(), *store, _matchView->getMatcher(req.ranking),
-                                               mctx->getSearchContext(), mctx->getAttributeContext(),
+                                               mctx.getSearchContext(), mctx.getAttributeContext(),
                                                *_summarySetup->getAttributeManager(), getSessionManager());
     SearchView::InternalDocsumReply reply(ctx->getDocsums(), true);
     uint64_t endGeneration = readGuard->get().getCurrentGeneration();

--- a/searchlib/src/vespa/searchlib/attribute/attributecontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributecontext.cpp
@@ -30,11 +30,11 @@ AttributeContext::getAttribute(AttributeMap & map, const string & name, bool sta
     }
 }
 
-AttributeContext::AttributeContext(const IAttributeManager & manager) :
-    _manager(manager),
-    _attributes(),
-    _enumAttributes(),
-    _cacheLock()
+AttributeContext::AttributeContext(const IAttributeManager & manager)
+    : _manager(manager),
+      _attributes(),
+      _enumAttributes(),
+      _cacheLock()
 { }
 
 AttributeContext::~AttributeContext() = default;

--- a/searchlib/src/vespa/searchlib/attribute/attributecontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributecontext.h
@@ -21,9 +21,9 @@ private:
     using IAttributeFunctor = attribute::IAttributeFunctor;
 
     const IAttributeManager & _manager;
-    mutable AttributeMap              _attributes;
-    mutable AttributeMap              _enumAttributes;
-    mutable std::mutex                _cacheLock;
+    mutable AttributeMap      _attributes;
+    mutable AttributeMap      _enumAttributes;
+    mutable std::mutex        _cacheLock;
 
     const IAttributeVector *getAttribute(AttributeMap & map, const string & name, bool stableEnum) const;
 


### PR DESCRIPTION
- Reduce code visibility.

@toregge PR