### PR TITLE
Avoid copying response body for successful operations

### DIFF
--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -93,7 +93,6 @@ func TestClientSend(t *testing.T) {
 			httpClient.NextResponseString(200, msg)
 			wantRes.Status = StatusSuccess
 			wantRes.HTTPStatus = 200
-			wantRes.Body = []byte(msg)
 			wantRes.BytesRecv = 23
 		} else {
 			errMsg := `something went wront`


### PR DESCRIPTION
Always copying resulted in a slight throughput drop.

@bratseth