### PR TITLE
Add public api manifest header to annotations bundle.

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -64,6 +64,7 @@
             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
             <Bundle-Version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</Bundle-Version>
             <Export-Package>com.yahoo.component.annotation;version=1.0.0;-noimport:=true</Export-Package>
+            <X-JDisc-PublicApi-Package>com.yahoo.component.annotation</X-JDisc-PublicApi-Package>
             <_nouses>true</_nouses> <!-- Don't include 'uses' directives for package exports -->
           </instructions>
         </configuration>


### PR DESCRIPTION
- Must be added manually, as it's built with maven-bundle-plugin

