### PR TITLE
Avoid maintaining routing policies for non-active load balancers

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -112,7 +112,6 @@ public class RoutingController {
         Set<Endpoint> endpoints = new LinkedHashSet<>();
         // To discover the cluster name for a zone-scoped endpoint, we need to read routing policies
         for (var policy : routingPolicies.read(deployment)) {
-            if (!policy.status().isActive()) continue;
             RoutingMethod routingMethod = controller.zoneRegistry().routingMethod(policy.id().zone());
             endpoints.addAll(policy.zoneEndpointsIn(controller.system(), routingMethod));
             endpoints.add(policy.regionEndpointIn(controller.system(), routingMethod));

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializer.java
@@ -67,8 +67,7 @@ public class RoutingPolicySerializer {
             policy.instanceEndpoints().forEach(endpointId -> instanceEndpointsArray.addString(endpointId.id()));
             var applicationEndpointsArray = policyObject.setArray(applicationEndpointsField);
             policy.applicationEndpoints().forEach(endpointId -> applicationEndpointsArray.addString(endpointId.id()));
-            policyObject.setBool(loadBalancerActiveField, policy.status().isActive());
-            globalRoutingToSlime(policy.status().routingStatus(), policyObject.setObject(globalRoutingField));
+            globalRoutingToSlime(policy.routingStatus(), policyObject.setObject(globalRoutingField));
             if ( ! policy.isPublic()) policyObject.setBool(privateOnlyField, true);
         });
         return slime;
@@ -93,8 +92,7 @@ public class RoutingPolicySerializer {
                                            SlimeUtils.optionalString(inspect.field(dnsZoneField)),
                                            instanceEndpoints,
                                            applicationEndpoints,
-                                           new RoutingPolicy.Status(inspect.field(loadBalancerActiveField).asBool(),
-                                                                    globalRoutingFromSlime(inspect.field(globalRoutingField))),
+                                           routingStatusFromSlime(inspect.field(globalRoutingField)),
                                            isPublic));
         });
         return Collections.unmodifiableList(policies);
@@ -106,7 +104,7 @@ public class RoutingPolicySerializer {
         object.setLong(changedAtField, routingStatus.changedAt().toEpochMilli());
     }
 
-    public RoutingStatus globalRoutingFromSlime(Inspector object) {
+    public RoutingStatus routingStatusFromSlime(Inspector object) {
         var status = RoutingStatus.Value.valueOf(object.field(statusField).asString());
         var agent = RoutingStatus.Agent.valueOf(object.field(agentField).asString());
         var changedAt = SlimeUtils.optionalInstant(object.field(changedAtField)).orElse(Instant.EPOCH);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ZoneRoutingPolicySerializer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/ZoneRoutingPolicySerializer.java
@@ -31,7 +31,7 @@ public class ZoneRoutingPolicySerializer {
 
     public ZoneRoutingPolicy fromSlime(ZoneId zone, Slime slime) {
         var root = slime.get();
-        return new ZoneRoutingPolicy(zone, routingPolicySerializer.globalRoutingFromSlime(root.field(GLOBAL_ROUTING_FIELD)));
+        return new ZoneRoutingPolicy(zone, routingPolicySerializer.routingStatusFromSlime(root.field(GLOBAL_ROUTING_FIELD)));
     }
 
     public Slime toSlime(ZoneRoutingPolicy policy) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/RoutingPolicy.java
@@ -28,19 +28,19 @@ public record RoutingPolicy(RoutingPolicyId id,
                             Optional<String> dnsZone,
                             Set<EndpointId> instanceEndpoints,
                             Set<EndpointId> applicationEndpoints,
-                            Status status,
+                            RoutingStatus routingStatus,
                             boolean isPublic) {
 
     /** DO NOT USE. Public for serialization purposes */
     public RoutingPolicy(RoutingPolicyId id, Optional<DomainName> canonicalName, Optional<String> ipAddress, Optional<String> dnsZone,
-                         Set<EndpointId> instanceEndpoints, Set<EndpointId> applicationEndpoints, Status status, boolean isPublic) {
+                         Set<EndpointId> instanceEndpoints, Set<EndpointId> applicationEndpoints, RoutingStatus routingStatus, boolean isPublic) {
         this.id = Objects.requireNonNull(id, "id must be non-null");
         this.canonicalName = Objects.requireNonNull(canonicalName, "canonicalName must be non-null");
         this.ipAddress = Objects.requireNonNull(ipAddress, "ipAddress must be non-null");
         this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
         this.instanceEndpoints = ImmutableSortedSet.copyOf(Objects.requireNonNull(instanceEndpoints, "instanceEndpoints must be non-null"));
         this.applicationEndpoints = ImmutableSortedSet.copyOf(Objects.requireNonNull(applicationEndpoints, "applicationEndpoints must be non-null"));
-        this.status = Objects.requireNonNull(status, "status must be non-null");
+        this.routingStatus = Objects.requireNonNull(routingStatus, "status must be non-null");
         this.isPublic = isPublic;
 
         if (canonicalName.isEmpty() == ipAddress.isEmpty())
@@ -82,9 +82,9 @@ public record RoutingPolicy(RoutingPolicyId id,
         return applicationEndpoints;
     }
 
-    /** Returns the status of this */
-    public Status status() {
-        return status;
+    /** Return status of routing */
+    public RoutingStatus routingStatus() {
+        return routingStatus;
     }
 
     /** Returns whether this has a load balancer which is available from public internet. */
@@ -98,9 +98,9 @@ public record RoutingPolicy(RoutingPolicyId id,
                id.zone().equals(deployment.zoneId());
     }
 
-    /** Returns a copy of this with status set to given status */
-    public RoutingPolicy with(Status status) {
-        return new RoutingPolicy(id, canonicalName, ipAddress, dnsZone, instanceEndpoints, applicationEndpoints, status, isPublic);
+    /** Returns a copy of this with routing status set to given status */
+    public RoutingPolicy with(RoutingStatus routingStatus) {
+        return new RoutingPolicy(id, canonicalName, ipAddress, dnsZone, instanceEndpoints, applicationEndpoints, routingStatus, isPublic);
     }
 
     /** Returns the zone endpoints of this */
@@ -140,30 +140,4 @@ public record RoutingPolicy(RoutingPolicyId id,
                        .on(Port.fromRoutingMethod(routingMethod))
                        .routingMethod(routingMethod);
     }
-
-    /** The status of a routing policy */
-    public record Status(boolean active, RoutingStatus routingStatus) {
-
-        /** DO NOT USE. Public for serialization purposes */
-        public Status {
-            Objects.requireNonNull(routingStatus, "routingStatus must be non-null");
-        }
-
-        /** Returns whether this is considered active according to the load balancer status */
-        public boolean isActive() {
-            return active;
-        }
-
-        /** Return status of routing */
-        public RoutingStatus routingStatus() {
-            return routingStatus;
-        }
-
-        /** Returns a copy of this with routing status changed */
-        public Status with(RoutingStatus routingStatus) {
-            return new Status(active, routingStatus);
-        }
-
-    }
-
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/context/DeploymentRoutingContext.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/routing/context/DeploymentRoutingContext.java
@@ -146,8 +146,7 @@ public abstract class DeploymentRoutingContext implements RoutingContext {
             // first matching policy here
             return controller.policies().read(deployment)
                              .first()
-                             .map(RoutingPolicy::status)
-                             .map(RoutingPolicy.Status::routingStatus)
+                             .map(RoutingPolicy::routingStatus)
                              .orElse(RoutingStatus.DEFAULT);
         }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentContext.java
@@ -15,7 +15,6 @@ import com.yahoo.security.KeyUtils;
 import com.yahoo.security.SignatureAlgorithm;
 import com.yahoo.security.X509CertificateBuilder;
 import com.yahoo.vespa.hosted.controller.Application;
-import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.ControllerTester;
 import com.yahoo.vespa.hosted.controller.Instance;
 import com.yahoo.vespa.hosted.controller.api.identifiers.DeploymentId;
@@ -53,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -268,22 +266,6 @@ public class DeploymentContext {
         finally {
             dispatcher.shutdown();
         }
-    }
-
-    /** Add a routing policy for this in given zone, with status set to inactive */
-    public DeploymentContext addInactiveRoutingPolicy(ZoneId zone) {
-        var clusterId = "default-inactive";
-        var id = new RoutingPolicyId(instanceId, Id.from(clusterId), zone);
-        var policies = new LinkedHashMap<>(tester.controller().routing().policies().read(instanceId).asMap());
-        policies.put(id, new RoutingPolicy(id, Optional.of(HostName.of("lb-host")),
-                                           Optional.empty(),
-                                           Optional.empty(),
-                                           Set.of(EndpointId.of("default")),
-                                           Set.of(),
-                                           new RoutingPolicy.Status(false, RoutingStatus.DEFAULT),
-                                           true));
-        tester.controller().curator().writeRoutingPolicies(instanceId, List.copyOf(policies.values()));
-        return this;
     }
 
     /** Submit given application package for deployment */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/RoutingPolicySerializerTest.java
@@ -43,7 +43,7 @@ public class RoutingPolicySerializerTest {
                                                  Optional.of("zone1"),
                                                  Set.of(),
                                                  Set.of(),
-                                                 new RoutingPolicy.Status(true, RoutingStatus.DEFAULT),
+                                                 RoutingStatus.DEFAULT,
                                                  false),
                                new RoutingPolicy(id2,
                                                  Optional.of(HostName.of("long-and-ugly-name-2")),
@@ -51,10 +51,9 @@ public class RoutingPolicySerializerTest {
                                                  Optional.empty(),
                                                  instanceEndpoints,
                                                  Set.of(),
-                                                 new RoutingPolicy.Status(false,
-                                                                          new RoutingStatus(RoutingStatus.Value.out,
-                                                                                            RoutingStatus.Agent.tenant,
-                                                                                            Instant.ofEpochSecond(123))),
+                                                 new RoutingStatus(RoutingStatus.Value.out,
+                                                                   RoutingStatus.Agent.tenant,
+                                                                   Instant.ofEpochSecond(123)),
                                                  true),
                                new RoutingPolicy(id1,
                                                  Optional.empty(),
@@ -62,7 +61,7 @@ public class RoutingPolicySerializerTest {
                                                  Optional.of("zone2"),
                                                  instanceEndpoints,
                                                  applicationEndpoints,
-                                                 new RoutingPolicy.Status(true, RoutingStatus.DEFAULT),
+                                                 RoutingStatus.DEFAULT,
                                                  true));
         var serialized = serializer.fromSlime(owner, serializer.toSlime(policies));
         assertEquals(policies.size(), serialized.size());
@@ -75,7 +74,7 @@ public class RoutingPolicySerializerTest {
             assertEquals(expected.dnsZone(), actual.dnsZone());
             assertEquals(expected.instanceEndpoints(), actual.instanceEndpoints());
             assertEquals(expected.applicationEndpoints(), actual.applicationEndpoints());
-            assertEquals(expected.status(), actual.status());
+            assertEquals(expected.routingStatus(), actual.routingStatus());
             assertEquals(expected.isPublic(), actual.isPublic());
         }
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1625,7 +1625,6 @@ public class ApplicationApiTest extends ControllerContainerTest {
                 .region(zone.region().value())
                 .build();
         app.submit(applicationPackage).deploy();
-        app.addInactiveRoutingPolicy(zone);
 
         // GET application
         tester.assertResponse(request("/application/v4/tenant/tenant1/application/application1/instance/instance1", GET)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/routing/RoutingPoliciesTest.java
@@ -309,10 +309,7 @@ public class RoutingPoliciesTest {
 
         // Remove app2 completely
         tester.controllerTester().controller().applications().requireInstance(context2.instanceId()).deployments().keySet()
-              .forEach(zone -> {
-                  tester.controllerTester().configServer().removeLoadBalancers(context2.instanceId(), zone);
-                  tester.controllerTester().controller().applications().deactivate(context2.instanceId(), zone);
-              });
+              .forEach(zone -> tester.controllerTester().controller().applications().deactivate(context2.instanceId(), zone));
         context2.flushDnsUpdates();
         expectedRecords = Set.of(
                 "c0.app1.tenant1.us-west-1.vespa.oath.cloud",
@@ -573,15 +570,15 @@ public class RoutingPoliciesTest {
 
         // Status details is stored in policy
         var policy1 = tester.routingPolicies().read(context.deploymentIdIn(zone1)).first().get();
-        assertEquals(RoutingStatus.Value.out, policy1.status().routingStatus().value());
-        assertEquals(RoutingStatus.Agent.tenant, policy1.status().routingStatus().agent());
-        assertEquals(changedAt.truncatedTo(ChronoUnit.MILLIS), policy1.status().routingStatus().changedAt());
+        assertEquals(RoutingStatus.Value.out, policy1.routingStatus().value());
+        assertEquals(RoutingStatus.Agent.tenant, policy1.routingStatus().agent());
+        assertEquals(changedAt.truncatedTo(ChronoUnit.MILLIS), policy1.routingStatus().changedAt());
 
         // Other zone remains in
         var policy2 = tester.routingPolicies().read(context.deploymentIdIn(zone2)).first().get();
-        assertEquals(RoutingStatus.Value.in, policy2.status().routingStatus().value());
-        assertEquals(RoutingStatus.Agent.system, policy2.status().routingStatus().agent());
-        assertEquals(Instant.EPOCH, policy2.status().routingStatus().changedAt());
+        assertEquals(RoutingStatus.Value.in, policy2.routingStatus().value());
+        assertEquals(RoutingStatus.Agent.system, policy2.routingStatus().agent());
+        assertEquals(Instant.EPOCH, policy2.routingStatus().changedAt());
 
         // Next deployment does not affect status
         context.submit(applicationPackage).deferLoadBalancerProvisioningIn(Environment.prod).deploy();
@@ -598,9 +595,9 @@ public class RoutingPoliciesTest {
         tester.assertTargets(context.instanceId(), EndpointId.of("r1"), 0, zone1, zone2);
 
         policy1 = tester.routingPolicies().read(context.deploymentIdIn(zone1)).first().get();
-        assertEquals(RoutingStatus.Value.in, policy1.status().routingStatus().value());
-        assertEquals(RoutingStatus.Agent.tenant, policy1.status().routingStatus().agent());
-        assertEquals(changedAt.truncatedTo(ChronoUnit.MILLIS), policy1.status().routingStatus().changedAt());
+        assertEquals(RoutingStatus.Value.in, policy1.routingStatus().value());
+        assertEquals(RoutingStatus.Agent.tenant, policy1.routingStatus().agent());
+        assertEquals(changedAt.truncatedTo(ChronoUnit.MILLIS), policy1.routingStatus().changedAt());
 
         // Deployment is set out through a new deployment.xml
         var applicationPackage2 = applicationPackageBuilder()
@@ -652,8 +649,7 @@ public class RoutingPoliciesTest {
         for (var context : contexts) {
             var policies = tester.routingPolicies().read(context.instanceId());
             assertTrue(policies.asList().stream()
-                            .map(RoutingPolicy::status)
-                            .map(RoutingPolicy.Status::routingStatus)
+                            .map(RoutingPolicy::routingStatus)
                             .map(RoutingStatus::value)
                             .allMatch(status -> status == RoutingStatus.Value.in),
                     "Global routing status for policy remains " + RoutingStatus.Value.in);
@@ -763,7 +759,7 @@ public class RoutingPoliciesTest {
                 RoutingStatus.Agent.tenant);
         context.flushDnsUpdates();
         for (var policy : tester.routingPolicies().read(context.instanceId())) {
-            assertSame(RoutingStatus.Value.in, policy.status().routingStatus().value());
+            assertSame(RoutingStatus.Value.in, policy.routingStatus().value());
         }
         tester.assertTargets(context.instanceId(), EndpointId.of("r0"), 0, zone1, zone2);
     }


### PR DESCRIPTION
When deactivating a deployment, the config server moves the load balancer to
inactive. Since the LB was still present, we kept its routing policy (and DNS
record) even though both should've been removed.