### PR TITLE
Avoid stringop-truncation warning in ns_log::ControlFile::getLevels().

### DIFF
--- a/vespalog/src/vespa/log/control-file.h
+++ b/vespalog/src/vespa/log/control-file.h
@@ -60,7 +60,7 @@ public:
     unsigned int *getLevels(const char *name);
     void ensureComponent(const char *pattern);
 
-    static unsigned int *defaultLevels();
+    static unsigned int *defaultLevels() __attribute__((noinline));
 
     // make sure in-memory changes are synchronized to disk
     void flush();


### PR DESCRIPTION
@baldersheim : please review
