### PR TITLE
Check cluster state version in pending state, if present

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
@@ -166,7 +166,10 @@ DistributorStripeComponent::update_bucket_database(
         }
     }
 
-    UpdateBucketDatabaseProcessor processor(getClock(), found_down_node ? up_nodes : changed_nodes, bucketSpace.get_ideal_service_layer_nodes_bundle(bucket.getBucketId()).get_available_nodes(), (update_flags & DatabaseUpdate::RESET_TRUSTED) != 0);
+    UpdateBucketDatabaseProcessor processor(getClock(),
+                                            found_down_node ? up_nodes : changed_nodes,
+                                            bucketSpace.get_ideal_service_layer_nodes_bundle(bucket.getBucketId()).get_available_nodes(),
+                                            (update_flags & DatabaseUpdate::RESET_TRUSTED) != 0);
 
     bucketSpace.getBucketDatabase().process_update(bucket.getBucketId(), processor, (update_flags & DatabaseUpdate::CREATE_IF_NONEXISTING) != 0);
 }

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
@@ -163,7 +163,10 @@ void CheckCondition::handle_internal_get_operation_reply(std::shared_ptr<api::St
                              reply->steal_trace());
             return;
         }
-        const auto state_version_now = _bucket_space.getClusterState().getVersion();
+        auto state_version_now = _bucket_space.getClusterState().getVersion();
+        if (_bucket_space.has_pending_cluster_state()) {
+            state_version_now = _bucket_space.get_pending_cluster_state().getVersion();
+        }
         if ((state_version_now != _cluster_state_version_at_creation_time)
             && (replica_set_changed_after_get_operation()
                 || distributor_no_longer_owns_bucket()))


### PR DESCRIPTION
@havardpe please review

Checking just the current state's version does not work as expected if the distributor is currently _within_ a cluster state transition. In this case, the pending state's version must be used instead. Failure to do so will make the code erroneously believe the cluster state has not changed since the start of the operation.