### PR TITLE
Skip logging when rethrowing

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -101,10 +101,10 @@ class MaintenanceDeployment implements Closeable {
                                    Exceptions.toMessageString(e));
             return Optional.empty();
         } catch (RuntimeException e) {
+            metric.add(ConfigServerMetrics.MAINTENANCE_DEPLOYMENT_FAILURE.baseName(), 1, metric.createContext(Map.of()));
             if (throwOnFailure) {
                 throw e;
             } else {
-                metric.add(ConfigServerMetrics.MAINTENANCE_DEPLOYMENT_FAILURE.baseName(), 1, metric.createContext(Map.of()));
                 log.log(Level.WARNING, "Exception on maintenance deploy of " + application, e);
             }
             return Optional.empty();

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MaintenanceDeployment.java
@@ -101,10 +101,11 @@ class MaintenanceDeployment implements Closeable {
                                    Exceptions.toMessageString(e));
             return Optional.empty();
         } catch (RuntimeException e) {
-            metric.add(ConfigServerMetrics.MAINTENANCE_DEPLOYMENT_FAILURE.baseName(), 1, metric.createContext(Map.of()));
-            log.log(Level.WARNING, "Exception on maintenance deploy of " + application, e);
             if (throwOnFailure) {
                 throw e;
+            } else {
+                metric.add(ConfigServerMetrics.MAINTENANCE_DEPLOYMENT_FAILURE.baseName(), 1, metric.createContext(Map.of()));
+                log.log(Level.WARNING, "Exception on maintenance deploy of " + application, e);
             }
             return Optional.empty();
         }


### PR DESCRIPTION
Avoids logging stack trace when HostFlavorUpgrader redeployment fails due to
lack of capacity.

@bratseth