### PR TITLE
Always use 16 distribution bits in perf environments

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/cluster/ContentCluster.java
@@ -519,7 +519,7 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
      * in config and not remove it again if they reduce the node count.
      */
     public int distributionBits() {
-        if (zone.environment() == Environment.prod && ! zone.equals(Zone.defaultZone())) {
+        if (zoneEnvImplies16DistributionBits() && ! zone.equals(Zone.defaultZone())) {
             return 16;
         }
         else { // hosted test zone, or self-hosted system
@@ -527,6 +527,11 @@ public class ContentCluster extends TreeConfigProducer<AnyConfigProducer> implem
             // self-hosted systems: should probably default to 16 bits, but the transition may cause problems
             return DistributionBitCalculator.getDistributionBits(getNodeCountPerGroup(), getDistributionMode());
         }
+    }
+
+    private boolean zoneEnvImplies16DistributionBits() {
+        // We want perf to behave like prod as much as possible.
+        return (zone.environment() == Environment.prod) || (zone.environment() == Environment.perf);
     }
 
     public boolean isHosted() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -629,6 +629,9 @@ public class ContentClusterTest extends ContentBaseTest {
         ContentCluster prodWith16Bits = createWithZone(xml, new Zone(Environment.prod, RegionName.from("us-east-3")));
         assertDistributionBitsInConfig(prodWith16Bits, 16);
 
+        ContentCluster perfWith16Bits = createWithZone(xml, new Zone(Environment.perf, RegionName.from("us-east-3")));
+        assertDistributionBitsInConfig(perfWith16Bits, 16);
+
         ContentCluster stagingNot16Bits = createWithZone(xml, new Zone(Environment.staging, RegionName.from("us-east-3")));
         assertDistributionBitsInConfig(stagingNot16Bits, 8);
     }


### PR DESCRIPTION
@baldersheim please review

This avoids any noise and issues caused by shuffling distribution bit limits around when sizing clusters, and makes the initial bucket parallelization levels of perf equal those of prod envs.
