### PR TITLE
Revert unintentional removal of comparator

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/ArchiveResponse.java
@@ -27,7 +27,7 @@ public class ArchiveResponse extends SlimeJsonResponse {
             archiveObject.setString("uri", entry.getValue());
         });
         archiveUris.accountArchiveUris().entrySet().stream()
-                .sorted()
+                .sorted(Map.Entry.comparingByKey())
                 .forEach(entry -> {
             Cursor archiveObject = archivesArray.addObject();
             archiveObject.setString("account", entry.getKey().value());


### PR DESCRIPTION
This was unintentionally removed in https://github.com/vespa-engine/vespa/commit/fbdc11ed2c64aa29d7c6b567bc6aad5ff86d8135#diff-c919a62ebb6cc5297fe082cd2b50f3cec590da2c40d40cdc668ada37102495dcR30