### PR TITLE
Always copy request headers

### DIFF
--- a/client/go/internal/cli/cmd/document_test.go
+++ b/client/go/internal/cli/cmd/document_test.go
@@ -129,7 +129,7 @@ func assertDocumentSend(arguments []string, expectedOperation string, expectedMe
 		}
 	}
 	if verbose {
-		expectedCurl := "curl -X " + expectedMethod + " -H 'Content-Type: application/json; charset=utf-8' -H 'User-Agent: Vespa CLI/0.0.0-devel'"
+		expectedCurl := "curl -X " + expectedMethod + " -H 'Content-Type: application/json; charset=utf-8'"
 		if expectedPayloadFile != "" {
 			expectedCurl += " --data-binary @" + expectedPayloadFile
 		}

--- a/client/go/internal/util/http.go
+++ b/client/go/internal/util/http.go
@@ -19,20 +19,17 @@ type HTTPClient interface {
 }
 
 type defaultHTTPClient struct {
-	client       *http.Client
-	setUserAgent bool
+	client *http.Client
 }
 
 func (c *defaultHTTPClient) Do(request *http.Request, timeout time.Duration) (response *http.Response, error error) {
 	if c.client.Timeout != timeout { // Set wanted timeout
 		c.client.Timeout = timeout
 	}
-	if c.setUserAgent {
-		if request.Header == nil {
-			request.Header = make(http.Header)
-		}
-		request.Header.Set("User-Agent", fmt.Sprintf("Vespa CLI/%s", build.Version))
+	if request.Header == nil {
+		request.Header = make(http.Header)
 	}
+	request.Header.Set("User-Agent", fmt.Sprintf("Vespa CLI/%s", build.Version))
 	return c.client.Do(request)
 }
 
@@ -68,7 +65,6 @@ func ForceHTTP2(client HTTPClient, certificates []tls.Certificate, caCertificate
 	if !ok {
 		return
 	}
-	c.setUserAgent = false // Let caller control all request headers
 	var dialFunc func(ctx context.Context, network, addr string, cfg *tls.Config) (net.Conn, error)
 	if certificates == nil {
 		// No certificate, so force H2C (HTTP/2 over clear-text) by using a non-TLS Dialer
@@ -95,6 +91,5 @@ func CreateClient(timeout time.Duration) HTTPClient {
 			Timeout:   timeout,
 			Transport: http.DefaultTransport,
 		},
-		setUserAgent: true,
 	}
 }

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -17,7 +17,6 @@ import (
 	"github.com/go-json-experiment/json"
 	"github.com/klauspost/compress/gzip"
 
-	"github.com/vespa-engine/vespa/client/go/internal/build"
 	"github.com/vespa-engine/vespa/client/go/internal/util"
 )
 
@@ -27,18 +26,6 @@ const (
 	CompressionAuto Compression = iota
 	CompressionNone
 	CompressionGzip
-)
-
-var (
-	defaultHeaders http.Header = map[string][]string{
-		"User-Agent":   {fmt.Sprintf("Vespa CLI/%s", build.Version)},
-		"Content-Type": {"application/json; charset=utf-8"},
-	}
-	gzipHeaders http.Header = map[string][]string{
-		"User-Agent":       {fmt.Sprintf("Vespa CLI/%s", build.Version)},
-		"Content-Type":     {"application/json; charset=utf-8"},
-		"Content-Encoding": {"gzip"},
-	}
 )
 
 // Client represents a HTTP client for the /document/v1/ API.
@@ -233,10 +220,9 @@ func newRequest(method, url string, body io.Reader, gzipped bool) (*http.Request
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	if gzipped {
-		req.Header = gzipHeaders
-	} else {
-		req.Header = defaultHeaders
+		req.Header.Set("Content-Encoding", "gzip")
 	}
 	return req, nil
 }

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -3,6 +3,7 @@ package document
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
@@ -112,8 +113,11 @@ func TestClientSend(t *testing.T) {
 		if r.Method != tt.method {
 			t.Errorf("got r.Method = %q, want %q", r.Method, tt.method)
 		}
-		if !reflect.DeepEqual(r.Header, defaultHeaders) {
-			t.Errorf("got r.Header = %v, want %v", r.Header, defaultHeaders)
+		var headers http.Header = map[string][]string{
+			"Content-Type": {"application/json; charset=utf-8"},
+		}
+		if !reflect.DeepEqual(r.Header, headers) {
+			t.Errorf("got r.Header = %v, want %v", r.Header, headers)
 		}
 		if r.URL.String() != tt.url {
 			t.Errorf("got r.URL = %q, want %q", r.URL, tt.url)


### PR DESCRIPTION
Various authenticators (e.g. ZTS) will add request headers, so we cannot reuse
the header map when doing concurrent feeding.

@bratseth