### PR TITLE
Simplify token API by using fixed context for fingerprints

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/dataplanetoken/DataplaneTokenService.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/dataplanetoken/DataplaneTokenService.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 public class DataplaneTokenService {
 
     private static final String TOKEN_PREFIX = "vespa_cloud_";
-    private static final byte[] FINGERPRINT_CONTEXT = new byte[0];
     private static final int TOKEN_BYTES = 32;
     private static final int CHECK_HASH_BYTES = 32;
 
@@ -57,7 +56,7 @@ public class DataplaneTokenService {
      * @return a DataplaneToken containing the secret generated token
      */
     public DataplaneToken generateToken(TenantName tenantName, TokenId tokenId, Principal principal) {
-        TokenDomain tokenDomain = new TokenDomain(FINGERPRINT_CONTEXT, tenantName.value().getBytes(StandardCharsets.UTF_8));
+        TokenDomain tokenDomain = TokenDomain.of(tenantName.value());
         Token token = TokenGenerator.generateToken(tokenDomain, TOKEN_PREFIX, TOKEN_BYTES);
         TokenCheckHash checkHash = TokenCheckHash.of(token, CHECK_HASH_BYTES);
         DataplaneTokenVersions.Version newTokenVersion = new DataplaneTokenVersions.Version(

--- a/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cloud/CloudDataPlaneFilter.java
+++ b/jdisc-security-filters/src/main/java/com/yahoo/jdisc/http/filter/security/cloud/CloudDataPlaneFilter.java
@@ -63,7 +63,7 @@ public class CloudDataPlaneFilter extends JsonSecurityRequestFilterBase {
 
     CloudDataPlaneFilter(CloudDataPlaneFilterConfig cfg, X509Certificate reverseProxyCert) {
         this.legacyMode = cfg.legacyMode();
-        this.tokenDomain = new TokenDomain(new byte[0], cfg.tokenContext().getBytes(StandardCharsets.UTF_8));
+        this.tokenDomain = TokenDomain.of(cfg.tokenContext());
         if (legacyMode) {
             allowedClients = List.of();
             log.fine(() -> "Legacy mode enabled");

--- a/jdisc-security-filters/src/test/java/com/yahoo/jdisc/http/filter/security/cloud/CloudDataPlaneFilterTest.java
+++ b/jdisc-security-filters/src/test/java/com/yahoo/jdisc/http/filter/security/cloud/CloudDataPlaneFilterTest.java
@@ -53,9 +53,9 @@ class CloudDataPlaneFilterTest {
     private static final String TOKEN_CONTEXT = "my-token-context";
     private static final String TOKEN_ID = "my-token-id";
     private static final Token VALID_TOKEN =
-            TokenGenerator.generateToken(TokenDomain.of("fp-ctx", TOKEN_CONTEXT), "vespa_token_", CHECK_HASH_BYTES);
+            TokenGenerator.generateToken(TokenDomain.of(TOKEN_CONTEXT), "vespa_token_", CHECK_HASH_BYTES);
     private static final Token UNKNOWN_TOKEN =
-            TokenGenerator.generateToken(TokenDomain.of("fp-ctx", TOKEN_CONTEXT), "vespa_token_", CHECK_HASH_BYTES);
+            TokenGenerator.generateToken(TokenDomain.of(TOKEN_CONTEXT), "vespa_token_", CHECK_HASH_BYTES);
 
     @Test
     void accepts_any_trusted_client_certificate_in_legacy_mode() {

--- a/security-utils/src/main/java/com/yahoo/security/token/TokenDomain.java
+++ b/security-utils/src/main/java/com/yahoo/security/token/TokenDomain.java
@@ -26,32 +26,34 @@ import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
  * never be made to match, be it accidentally or deliberately.
  * </p>
  */
-public record TokenDomain(byte[] fingerprintContext, byte[] checkHashContext) {
+public record TokenDomain(byte[] checkHashContext) {
+
+    public TokenDomain {
+        if (Arrays.equals(checkHashContext, TokenFingerprint.FINGERPRINT_CONTEXT)) {
+            throw new IllegalArgumentException("Fingerprint and check hash contexts can not be equal");
+        }
+    }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TokenDomain that = (TokenDomain) o;
-        return Arrays.equals(fingerprintContext, that.fingerprintContext) &&
-                Arrays.equals(checkHashContext, that.checkHashContext);
+        return Arrays.equals(checkHashContext, that.checkHashContext);
     }
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(fingerprintContext);
-        result = 31 * result + Arrays.hashCode(checkHashContext);
-        return result;
+        return Arrays.hashCode(checkHashContext);
     }
 
     @Override
     public String toString() {
-        return "'%s'/'%s'".formatted(fromUtf8Bytes(fingerprintContext), fromUtf8Bytes(checkHashContext));
+        return "'%s'".formatted(fromUtf8Bytes(checkHashContext));
     }
 
-    public static TokenDomain of(String fingerprintContext, String checkHashContext) {
-        return new TokenDomain(toUtf8Bytes(fingerprintContext),
-                               toUtf8Bytes(checkHashContext));
+    public static TokenDomain of(String checkHashContext) {
+        return new TokenDomain(toUtf8Bytes(checkHashContext));
     }
 
 }

--- a/security-utils/src/main/java/com/yahoo/security/token/TokenFingerprint.java
+++ b/security-utils/src/main/java/com/yahoo/security/token/TokenFingerprint.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.HexFormat;
 
 import static com.yahoo.security.ArrayUtils.hex;
+import static com.yahoo.security.ArrayUtils.toUtf8Bytes;
 
 /**
  * <p>A token fingerprint represents an opaque sequence of bytes that is expected
@@ -21,6 +22,7 @@ public record TokenFingerprint(byte[] hashBytes) {
 
     public static final int FINGERPRINT_BITS  = 128;
     public static final int FINGERPRINT_BYTES = FINGERPRINT_BITS / 8;
+    public static final byte[] FINGERPRINT_CONTEXT = toUtf8Bytes("Vespa token fingerprint");
 
     @Override
     public boolean equals(Object o) {
@@ -50,7 +52,7 @@ public record TokenFingerprint(byte[] hashBytes) {
     }
 
     public static TokenFingerprint of(Token token) {
-        return new TokenFingerprint(token.toDerivedBytes(FINGERPRINT_BYTES, token.domain().fingerprintContext()));
+        return new TokenFingerprint(token.toDerivedBytes(FINGERPRINT_BYTES, FINGERPRINT_CONTEXT));
     }
 
     public static TokenFingerprint ofRawBytes(byte[] hashBytes) {


### PR DESCRIPTION
@bjorncs @tokle please review.

Fingerprints are now always derived using the a fixed context of `"Vespa token fingerprint"`. Enforcement has been added that a `TokenDomain` cannot be initialized with a context equal to the fingerprint context.

This changes the fingerprint outputs from their previous values, but that's fine since they are not yet in use anywhere.
