### PR TITLE
Make sure to shutdown maintainer properly

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MetricsFetcher.java
@@ -1,11 +1,8 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.autoscale;
 
-import com.yahoo.collections.Pair;
 import com.yahoo.config.provision.ApplicationId;
 
-import java.time.Instant;
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -21,5 +18,7 @@ public interface MetricsFetcher {
      * @param application the application to fetch metrics from
      */
     CompletableFuture<MetricsResponse> fetchMetrics(ApplicationId application);
+
+    void deconstruct();
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMetricsDbMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMetricsDbMaintainer.java
@@ -62,6 +62,12 @@ public class NodeMetricsDbMaintainer extends NodeRepositoryMaintainer {
         }
     }
 
+    @Override
+    public void shutdown() {
+        super.shutdown();
+        metricsFetcher.deconstruct();
+    }
+
     private void handleResponse(MetricsResponse response,
                                 Throwable exception,
                                 MutableInteger failures,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockMetricsFetcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockMetricsFetcher.java
@@ -10,11 +10,15 @@ import java.util.concurrent.CompletableFuture;
 /**
  * @author bratseth
  */
+@SuppressWarnings("unused") // Injected in container from test code (services.xml)
 public class MockMetricsFetcher implements MetricsFetcher {
 
     @Override
     public CompletableFuture<MetricsResponse> fetchMetrics(ApplicationId application) {
         return CompletableFuture.completedFuture(MetricsResponse.empty());
     }
+
+    @Override
+    public void deconstruct() {}
 
 }


### PR DESCRIPTION
Call deconstruct on metrics fetcher

Log message "NodeMetricsDbMaintainer failed to shutdown within PT30S" seen in the wild