### PR TITLE
- Add explicit test that onInsert/onRemove is called correctly when c…

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
+++ b/vespalib/src/vespa/vespalib/stllike/lrucache_map.hpp
@@ -204,9 +204,7 @@ lrucache_map<P>::removeOld() {
              (_tail != _head) && removeOldest(*last);
              last = & HashTable::getByInternalIndex(_tail))
         {
-            _tail = last->second._prev;
-            HashTable::getByInternalIndex(_tail).second._next = LinkedValueBase::npos;
-            HashTable::erase(*this, HashTable::hash(last->first), HashTable::find(last->first));
+            erase(last->first);
         }
     }
 }


### PR DESCRIPTION
…ache is full,

  do not rely on monitoring cache size.
- Call correct method for properly erasing an element, even if it is old :)

@geirst PR