### PR TITLE
Set CMAKE_CXX_STANDARD to 20.

### DIFF
--- a/build_settings.cmake
+++ b/build_settings.cmake
@@ -108,7 +108,7 @@ if (VESPA_USE_SANITIZER)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-sanitize=vptr")
     endif()
 endif()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} ${CXX_SPECIFIC_WARN_OPTS} -std=c++2a -fdiagnostics-color=auto ${EXTRA_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} ${CXX_SPECIFIC_WARN_OPTS} -fdiagnostics-color=auto ${EXTRA_CXX_FLAGS}")
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 else()
@@ -147,9 +147,8 @@ SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -rdynamic" )
 
 message("-- CMAKE_SHARED_LINKER_FLAGS is ${CMAKE_SHARED_LINKER_FLAGS}")
 
-# Use C++ 17
-# TODO renable when cmake 3.8 is out.
-# set(CMAKE_CXX_STANDARD 17)
+# Use C++ 20
+set(CMAKE_CXX_STANDARD 20)
 
 # Always build shared libs if not explicitly specified
 set(BUILD_SHARED_LIBS ON)

--- a/vespamalloc/src/vespamalloc/malloc/overload.h
+++ b/vespamalloc/src/vespamalloc/malloc/overload.h
@@ -246,7 +246,7 @@ void* __libc_memalign(size_t align, size_t s)        __THROW __attribute__((leaf
 void* __libc_memalign(size_t align, size_t s)        __THROW __attribute__((leaf, malloc, alloc_size(2))) ALIAS("memalign");
 #endif
 
-int   __posix_memalign(void** r, size_t a, size_t s) __THROW __nonnull((1)) ALIAS("posix_memalign");
+int   __posix_memalign(void** r, size_t a, size_t s) __THROW __nonnull((1)) ALIAS("posix_memalign") __attribute((leaf));
 
 #if __GLIBC_PREREQ(2, 33)
 struct mallinfo2 __libc_mallinfo2()                  __THROW  ALIAS("mallinfo2");


### PR DESCRIPTION
`cmake` can add options to specify c++ standard when compiling a program linking with a library that has the `COMPILE_FEATURES` target property set. For this to work properly without accidental downgrade of features, `cmake` needs to know the baseline c++ standard. This PR is related to #2020.