### PR TITLE
Avoid long (possibly infinite) pauses in maintainer when few apps

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMetricsDbMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeMetricsDbMaintainer.java
@@ -40,7 +40,7 @@ public class NodeMetricsDbMaintainer extends NodeRepositoryMaintainer {
             Set<ApplicationId> applications = activeNodesByApplication().keySet();
             if (applications.isEmpty()) return 1.0;
 
-            long pauseMs = interval().toMillis() / applications.size() - 1; // spread requests over interval
+            long pauseMs = interval().toMillis() / Math.max(3, applications.size() - 1); // spread requests over interval
             int done = 0;
             for (ApplicationId application : applications) {
                 attempts++;


### PR DESCRIPTION
Seeing "Maintainer NodeMetricsDbMaintainer failed to shutdown within PT30S" regularly in cd zones with few apps