### PR TITLE
Revert "Replace metrics strings with the corresponding enum constants." MERGEOK

### DIFF
--- a/clustercontroller-core/pom.xml
+++ b/clustercontroller-core/pom.xml
@@ -20,12 +20,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.yahoo.vespa</groupId>
-            <artifactId>metrics</artifactId>
-            <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <!-- required for bundle-plugin to generate import-package statements for Java's standard library -->
             <groupId>com.yahoo.vespa</groupId>
             <artifactId>jdisc_core</artifactId>

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/NodeStateChangeChecker.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
-import ai.vespa.metrics.StorageMetrics;
 import com.yahoo.lang.MutableBoolean;
 import com.yahoo.lang.SettableOptional;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
@@ -45,7 +44,7 @@ import static java.util.logging.Level.FINE;
 public class NodeStateChangeChecker {
 
     private static final Logger log = Logger.getLogger(NodeStateChangeChecker.class.getName());
-    private static final String BUCKETS_METRIC_NAME = StorageMetrics.VDS_DATASTORED_BUCKET_SPACE_BUCKETS_TOTAL.baseName();
+    private static final String BUCKETS_METRIC_NAME = "vds.datastored.bucket_space.buckets_total";
     private static final Map<String, String> BUCKETS_METRIC_DIMENSIONS = Map.of("bucketSpace", "default");
 
     private final int requiredRedundancy;

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/NodeStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/NodeStateRequest.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core.restapiv2.requests;
 
-import ai.vespa.metrics.StorageMetrics;
 import com.yahoo.vespa.clustercontroller.core.NodeInfo;
 import com.yahoo.vespa.clustercontroller.core.RemoteClusterControllerTask;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.Metrics;
@@ -47,17 +46,17 @@ public class NodeStateRequest extends Request<Response.NodeResponse> {
     }
 
     private static void fillInMetricValue(String name, Metrics.Value value, Response.NodeResponse result) {
-        if (name.equals(StorageMetrics.VDS_DATASTORED_ALLDISKS_DOCS.baseName())) {
+        if (name.equals("vds.datastored.alldisks.docs")) {
             if (value.getLast() == null) {
                 return;
             }
             result.addMetric("unique-document-count", value.getLast());
-        } else if (name.equals(StorageMetrics.VDS_DATASTORED_ALLDISKS_BYTES.baseName())) {
+        } else if (name.equals("vds.datastored.alldisks.bytes")) {
             if (value.getLast() == null) {
                 return;
             }
             result.addMetric("unique-document-total-size", value.getLast());
-        } else if (name.equals(StorageMetrics.VDS_DATASTORED_ALLDISKS_BUCKETS.baseName())) {
+        } else if (name.equals("vds.datastored.alldisks.buckets")) {
             if (value.getLast() == null) {
                 return;
             }

--- a/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMetrics.java
+++ b/clustercontroller-reindexer/src/main/java/ai/vespa/reindexing/ReindexingMetrics.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package ai.vespa.reindexing;
 
-import ai.vespa.metrics.ClusterControllerMetrics;
 import com.yahoo.documentapi.ProgressToken;
 import com.yahoo.jdisc.Metric;
 
@@ -28,7 +27,7 @@ class ReindexingMetrics {
 
     void dump(Reindexing reindexing) {
         reindexing.status().forEach((type, status) -> {
-            metric.set(ClusterControllerMetrics.REINDEXING_PROGRESS.baseName(),
+            metric.set("reindexing.progress",
                        status.progress().map(ProgressToken::percentFinished).map(percentage -> percentage * 1e-2)
                              .orElse(status.state() == SUCCESSFUL ? 1.0 : 0.0),
                        metric.createContext(Map.of("clusterid", cluster, "documenttype", type.getName())));

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
-import ai.vespa.metrics.DistributorMetrics;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.config.content.core.StorDistributormanagerConfig;
 import com.yahoo.vespa.config.content.core.StorServerConfig;
@@ -136,13 +135,13 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
     @Override
     public void getConfig(MetricsmanagerConfig.Builder builder) {
         ContentCluster.getMetricBuilder("log", builder).
-                addedmetrics(DistributorMetrics.VDS_DISTRIBUTOR_DOCSSTORED.baseName()).
-                addedmetrics(DistributorMetrics.VDS_DISTRIBUTOR_BYTESSTORED.baseName()).
-                addedmetrics(DistributorMetrics.VDS_IDEALSTATE_DELETE_BUCKET_DONE_OK.baseName()).
-                addedmetrics(DistributorMetrics.VDS_IDEALSTATE_MERGE_BUCKET_DONE_OK.baseName()).
-                addedmetrics(DistributorMetrics.VDS_IDEALSTATE_SPLIT_BUCKET_DONE_OK.baseName()).
-                addedmetrics(DistributorMetrics.VDS_IDEALSTATE_JOIN_BUCKET_DONE_OK.baseName()).
-                addedmetrics(DistributorMetrics.VDS_IDEALSTATE_BUCKETS_RECHECKING.baseName());
+                addedmetrics("vds.distributor.docsstored").
+                addedmetrics("vds.distributor.bytesstored").
+                addedmetrics("vds.idealstate.delete_bucket.done_ok").
+                addedmetrics("vds.idealstate.merge_bucket.done_ok").
+                addedmetrics("vds.idealstate.split_bucket.done_ok").
+                addedmetrics("vds.idealstate.join_bucket.done_ok").
+                addedmetrics("vds.idealstate.buckets_rechecking");
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/storagecluster/StorageCluster.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content.storagecluster;
 
-import ai.vespa.metrics.StorageMetrics;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.config.content.core.StorIntegritycheckerConfig;
 import com.yahoo.vespa.config.content.core.StorBucketmoverConfig;
@@ -76,24 +75,24 @@ public class StorageCluster extends TreeConfigProducer<StorageNode>
     @Override
     public void getConfig(MetricsmanagerConfig.Builder builder) {
         ContentCluster.getMetricBuilder("fleetcontroller", builder).
-                addedmetrics(StorageMetrics.VDS_DATASTORED_ALLDISKS_DOCS.baseName()).
-                addedmetrics(StorageMetrics.VDS_DATASTORED_ALLDISKS_BYTES.baseName()).
-                addedmetrics(StorageMetrics.VDS_DATASTORED_ALLDISKS_BUCKETS.baseName()).
-                addedmetrics(StorageMetrics.VDS_DATASTORED_BUCKET_SPACE_BUCKETS_TOTAL.baseName());
+                addedmetrics("vds.datastored.alldisks.docs").
+                addedmetrics("vds.datastored.alldisks.bytes").
+                addedmetrics("vds.datastored.alldisks.buckets").
+                addedmetrics("vds.datastored.bucket_space.buckets_total");
 
         ContentCluster.getMetricBuilder("log", builder).
                 addedmetrics("vds.filestor.allthreads.put").
                 addedmetrics("vds.filestor.allthreads.get").
                 addedmetrics("vds.filestor.allthreads.remove").
                 addedmetrics("vds.filestor.allthreads.update").
-                addedmetrics(StorageMetrics.VDS_DATASTORED_ALLDISKS_DOCS.baseName()).
-                addedmetrics(StorageMetrics.VDS_DATASTORED_ALLDISKS_BYTES.baseName()).
-                addedmetrics(StorageMetrics.VDS_FILESTOR_QUEUESIZE.baseName()).
-                addedmetrics(StorageMetrics.VDS_FILESTOR_AVERAGEQUEUEWAIT.baseName()).
-                addedmetrics(StorageMetrics.VDS_VISITOR_CV_QUEUEWAITTIME.baseName()).
-                addedmetrics(StorageMetrics.VDS_VISITOR_ALLTHREADS_AVERAGEQUEUEWAIT.baseName()).
-                addedmetrics(StorageMetrics.VDS_VISITOR_ALLTHREADS_AVERAGEVISITORLIFETIME.baseName()).
-                addedmetrics(StorageMetrics.VDS_VISITOR_ALLTHREADS_CREATED.baseName());
+                addedmetrics("vds.datastored.alldisks.docs").
+                addedmetrics("vds.datastored.alldisks.bytes").
+                addedmetrics("vds.filestor.queuesize").
+                addedmetrics("vds.filestor.averagequeuewait").
+                addedmetrics("vds.visitor.cv_queuewaittime").
+                addedmetrics("vds.visitor.allthreads.averagequeuewait").
+                addedmetrics("vds.visitor.allthreads.averagevisitorlifetime").
+                addedmetrics("vds.visitor.allthreads.created");
     }
 
     public String getClusterName() {

--- a/container-core/src/main/java/com/yahoo/container/jdisc/state/StateHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/state/StateHandler.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.container.jdisc.state;
 
-import ai.vespa.metrics.ContainerMetrics;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -290,7 +289,7 @@ public class StateHandler extends AbstractRequestHandler implements CapabilityRe
         Tuple latencySeconds = new Tuple(NULL_DIMENSIONS, "latencySeconds", null);
         for (Map.Entry<MetricDimensions, MetricSet> entry : snapshot) {
             MetricSet metricSet = entry.getValue();
-            MetricValue val = metricSet.get(ContainerMetrics.SERVER_TOTAL_SUCCESFUL_RESPONSE_LATENCY.baseName());
+            MetricValue val = metricSet.get("serverTotalSuccessfulResponseLatency");
             if (val instanceof GaugeMetric gauge) {
                 latencySeconds.add(GaugeMetric.newInstance(gauge.getLast() / 1000,
                                                            gauge.getMax() / 1000,
@@ -298,7 +297,7 @@ public class StateHandler extends AbstractRequestHandler implements CapabilityRe
                                                            gauge.getSum() / 1000,
                                                            gauge.getCount()));
             }
-            requestsPerSecond.add(metricSet.get(ContainerMetrics.SERVER_NUM_SUCCESSFUL_RESPONSES.baseName()));
+            requestsPerSecond.add(metricSet.get("serverNumSuccessfulResponses"));
         }
         List<Tuple> lst = new ArrayList<>();
         if (requestsPerSecond.val != null) {

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricUpdater.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/metric/MetricUpdater.java
@@ -2,7 +2,6 @@
 package com.yahoo.container.jdisc.metric;
 
 import ai.vespa.metrics.ContainerMetrics;
-import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.jdisc.Metric;
@@ -142,7 +141,7 @@ public class MetricUpdater extends AbstractComponent {
                     "home", System.getProperty("java.home"),
                     "vendor", System.getProperty("java.vm.vendor"),
                     "arch", System.getProperty("os.arch")));
-            metric.set(ContainerMetrics.JDISC_JVM.baseName(), Runtime.version().feature(), ctx);
+            metric.set("jdisc.jvm", Runtime.version().feature(), ctx);
         }
 
         private void tlsMetrics() {

--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.handler;
 
-import ai.vespa.metrics.ContainerMetrics;
 import ai.vespa.cloud.ZoneInfo;
 import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.collections.Tuple2;
@@ -82,7 +81,7 @@ public class SearchHandler extends LoggingRequestHandler {
     private static final CompoundName FORCE_TIMESTAMPS = CompoundName.from("trace.timestamps");
 
     /** Event name for number of connections to the search subsystem */
-    private static final String SEARCH_CONNECTIONS = ContainerMetrics.SEARCH_CONNECTIONS.baseName();
+    private static final String SEARCH_CONNECTIONS = "search_connections";
     static final String RENDER_LATENCY_METRIC = ContainerMetrics.JDISC_RENDER_LATENCY.baseName();
     static final String MIME_DIMENSION = "mime";
     static final String RENDERER_DIMENSION = "renderer";

--- a/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/ContainerLatencySearcher.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.searchers;
 
-import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.component.chain.dependencies.After;
 import com.yahoo.metrics.simple.Gauge;
 import com.yahoo.metrics.simple.Point;
@@ -22,7 +21,7 @@ public class ContainerLatencySearcher extends Searcher {
     private final Gauge latencyGauge;
 
     public ContainerLatencySearcher(MetricReceiver metrics) {
-        latencyGauge = metrics.declareGauge(ContainerMetrics.QUERY_CONTAINER_LATENCY.baseName());
+        latencyGauge = metrics.declareGauge("query_container_latency");
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/searchers/RateLimitingSearcher.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.searchers;
 
-import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.component.annotation.Inject;
 import com.yahoo.cloud.config.ClusterInfoConfig;
 
@@ -61,7 +60,7 @@ public class RateLimitingSearcher extends Searcher {
     public static final CompoundName idDimensionKey = CompoundName.from("rate.idDimension");
     public static final CompoundName dryRunKey = CompoundName.from("rate.dryRun");
 
-    private static final String requestsOverQuotaMetricName = ContainerMetrics.REQUESTS_OVER_QUOTA.baseName();
+    private static final String requestsOverQuotaMetricName = "requestsOverQuota";
 
     /** Used to divide quota by nodes. Assumption: All nodes get the same share of traffic. */
     private final int nodeCount;

--- a/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingBenchmark.java
+++ b/container-search/src/test/java/com/yahoo/search/searchers/test/RateLimitingBenchmark.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.searchers.test;
 
-import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.cloud.config.ClusterInfoConfig;
 import com.yahoo.component.chain.Chain;
 import com.yahoo.metrics.simple.Bucket;
@@ -115,7 +114,7 @@ public class RateLimitingBenchmark {
 
     private int rejectedRequests(int id) {
         Point context = metric.pointBuilder().set("id", toClientId(id)).build();
-        UntypedMetric rejectedRequestsMetric = metricSnapshot.getMapForMetric(ContainerMetrics.REQUESTS_OVER_QUOTA.baseName()).get(context);
+        UntypedMetric rejectedRequestsMetric = metricSnapshot.getMapForMetric("requestsOverQuota").get(context);
         if (rejectedRequestsMetric == null) return 0;
         return (int)rejectedRequestsMetric.getCount();
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/nodeadmin/NodeAdminImpl.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.node.admin.nodeadmin;
 
-import ai.vespa.metrics.ContainerMetrics;
 import com.yahoo.jdisc.Timer;
 import com.yahoo.vespa.hosted.node.admin.container.ContainerStats;
 import com.yahoo.vespa.hosted.node.admin.container.metrics.Counter;
@@ -81,9 +80,9 @@ public class NodeAdminImpl implements NodeAdmin {
                 new Dimensions(Map.of("src", "node-agents")));
 
         this.procMeminfoReader = procMeminfoReader;
-        this.jvmHeapUsed = metrics.declareGauge(ContainerMetrics.MEM_HEAP_USED.baseName());
-        this.jvmHeapFree = metrics.declareGauge(ContainerMetrics.MEM_HEAP_FREE.baseName());
-        this.jvmHeapTotal = metrics.declareGauge(ContainerMetrics.MEM_HEAP_TOTAL.baseName());
+        this.jvmHeapUsed = metrics.declareGauge("mem.heap.used");
+        this.jvmHeapFree = metrics.declareGauge("mem.heap.free");
+        this.jvmHeapTotal = metrics.declareGauge("mem.heap.total");
         this.containerCount = metrics.declareGauge("container.count");
         this.metrics = metrics;
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#27511

Broke system tests:

2023-06-21 22:26:57.446
java.lang.NoClassDefFoundError: ai/vespa/metrics/StorageMetrics
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.NodeStateChangeChecker.<clinit>(NodeStateChangeChecker.java:48)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.ContentCluster.calculateEffectOfNewState(ContentCluster.java:136)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.restapiv2.requests.SetNodeStateRequest.setWantedState(SetNodeStateRequest.java:128)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.restapiv2.requests.SetNodeStateRequest.calculateResult(SetNodeStateRequest.java:61)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.restapiv2.requests.SetNodeStateRequest.calculateResult(SetNodeStateRequest.java:32)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.restapiv2.Request.doRemoteFleetControllerTask(Request.java:54)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.FleetController.processNextQueuedRemoteTask(FleetController.java:672)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.MetricUpdater.forWork(MetricUpdater.java:115)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.FleetController.tick(FleetController.java:544)
2023-06-21 22:26:57.446
	at com.yahoo.vespa.clustercontroller.core.FleetController.run(FleetController.java:1033)
2023-06-21 22:26:57.446
	at java.base/java.lang.Thread.run(Thread.java:833)