### PR TITLE
Use 64 bytes alignment for large arrays.

### DIFF
--- a/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/array_store_dynamic_type_mapper_test.cpp
+++ b/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/array_store_dynamic_type_mapper_test.cpp
@@ -134,16 +134,16 @@ TEST_F(ArrayStoreDynamicTypeMapperCharTest, type_ids_are_selected)
 
 TEST_F(ArrayStoreDynamicTypeMapperCharTest, large_arrays_grows_exponentially)
 {
-    EXPECT_EQ((std::vector<size_t>{232, 5024, 97100, 1866776}), get_large_array_sizes(4));
+    EXPECT_EQ((std::vector<size_t>{232, 13372, 276860, 5338108}), get_large_array_sizes(4));
 }
 
 TEST_F(ArrayStoreDynamicTypeMapperCharTest, avoid_entry_size_overflow)
 {
     EXPECT_EQ(32, calc_max_buffer_type_id(2.0));
-    EXPECT_EQ(410, calc_max_buffer_type_id(1.05));
-    EXPECT_EQ(507, calc_max_buffer_type_id(1.04));
-    EXPECT_EQ(661, calc_max_buffer_type_id(1.03));
-    EXPECT_EQ(968, calc_max_buffer_type_id(1.02));
+    EXPECT_EQ(395, calc_max_buffer_type_id(1.05));
+    EXPECT_EQ(485, calc_max_buffer_type_id(1.04));
+    EXPECT_EQ(626, calc_max_buffer_type_id(1.03));
+    EXPECT_EQ(900, calc_max_buffer_type_id(1.02));
 }
 
 using ArrayStoreDynamicTypeMapperInt32Test = TestBase<int32_t>;
@@ -160,10 +160,10 @@ TEST_F(ArrayStoreDynamicTypeMapperInt32Test, array_sizes_are_calculated)
 TEST_F(ArrayStoreDynamicTypeMapperInt32Test, avoid_entry_size_overflow)
 {
     EXPECT_EQ(30, calc_max_buffer_type_id(2.0));
-    EXPECT_EQ(395, calc_max_buffer_type_id(1.05));
-    EXPECT_EQ(487, calc_max_buffer_type_id(1.04));
-    EXPECT_EQ(636, calc_max_buffer_type_id(1.03));
-    EXPECT_EQ(930, calc_max_buffer_type_id(1.02));
+    EXPECT_EQ(379, calc_max_buffer_type_id(1.05));
+    EXPECT_EQ(462, calc_max_buffer_type_id(1.04));
+    EXPECT_EQ(596, calc_max_buffer_type_id(1.03));
+    EXPECT_EQ(849, calc_max_buffer_type_id(1.02));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.hpp
@@ -25,6 +25,9 @@ size_t
 DynamicArrayBufferType<ElemT>::calc_entry_size(size_t array_size) noexcept
 {
     auto entry_size = EntryMinAligner::align(sizeof(ElemType) * array_size + sizeof(uint32_t));
+    if (entry_size >= 512) {
+        entry_size = Aligner<64>::align(entry_size);
+    }
     return entry_size;
 }
 


### PR DESCRIPTION
@geirst : please review
@baldersheim : FYI
