### PR TITLE
Close server after response metrics are visible

### DIFF
--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -172,11 +172,11 @@ public class HttpServerTest {
         driver.client()
                 .newGet("/status.html").addHeader("Host", "localhost").addHeader("Host", "vespa.ai").execute()
                 .expectStatusCode(is(BAD_REQUEST)).expectContent(containsString("reason: Duplicate Host Header"));
-        assertTrue(driver.close());
         var aggregator = ResponseMetricAggregator.getBean(driver.server());
         var metric = waitForStatistics(aggregator);
         assertEquals(400, metric.dimensions.statusCode);
         assertEquals("GET", metric.dimensions.method);
+        assertTrue(driver.close());
     }
 
     @Test


### PR DESCRIPTION
Assumption is that server did not have time to aggregate new response metric before shutdown due to slow test environment. Unable to reproduce in local environment.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
