### PR TITLE
Limit 64-byte dynamic array buffer type alignment based on element type.

### DIFF
--- a/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/array_store_dynamic_type_mapper_test.cpp
+++ b/vespalib/src/tests/datastore/array_store_dynamic_type_mapper/array_store_dynamic_type_mapper_test.cpp
@@ -134,16 +134,16 @@ TEST_F(ArrayStoreDynamicTypeMapperCharTest, type_ids_are_selected)
 
 TEST_F(ArrayStoreDynamicTypeMapperCharTest, large_arrays_grows_exponentially)
 {
-    EXPECT_EQ((std::vector<size_t>{232, 13372, 276860, 5338108}), get_large_array_sizes(4));
+    EXPECT_EQ((std::vector<size_t>{232, 5024, 97100, 1866776}), get_large_array_sizes(4));
 }
 
 TEST_F(ArrayStoreDynamicTypeMapperCharTest, avoid_entry_size_overflow)
 {
     EXPECT_EQ(32, calc_max_buffer_type_id(2.0));
-    EXPECT_EQ(395, calc_max_buffer_type_id(1.05));
-    EXPECT_EQ(485, calc_max_buffer_type_id(1.04));
-    EXPECT_EQ(626, calc_max_buffer_type_id(1.03));
-    EXPECT_EQ(900, calc_max_buffer_type_id(1.02));
+    EXPECT_EQ(410, calc_max_buffer_type_id(1.05));
+    EXPECT_EQ(507, calc_max_buffer_type_id(1.04));
+    EXPECT_EQ(661, calc_max_buffer_type_id(1.03));
+    EXPECT_EQ(968, calc_max_buffer_type_id(1.02));
 }
 
 using ArrayStoreDynamicTypeMapperInt32Test = TestBase<int32_t>;

--- a/vespalib/src/tests/datastore/dynamic_array_buffer_type/dynamic_array_buffer_type_test.cpp
+++ b/vespalib/src/tests/datastore/dynamic_array_buffer_type/dynamic_array_buffer_type_test.cpp
@@ -5,6 +5,7 @@
 #include <ostream>
 
 using vespalib::datastore::ArrayStoreConfig;
+using vespalib::datastore::AtomicEntryRef;
 using vespalib::datastore::BufferTypeBase;
 using vespalib::datastore::DynamicArrayBufferType;
 using vespalib::datastore::EntryCount;
@@ -203,6 +204,13 @@ TEST_F(DynamicArrayBufferTypeTest, entry_size_is_calculated)
     EXPECT_EQ(16, get_entry_size<int64_t>(1));
     EXPECT_EQ(24, get_entry_size<int64_t>(2));
     EXPECT_EQ(20, get_entry_size<WrapInt32>(4));
+
+    EXPECT_EQ(1028, get_entry_size<WrapInt32>(256));
+    EXPECT_EQ(1028, get_entry_size<AtomicEntryRef>(256));
+    EXPECT_EQ(1088, get_entry_size<int32_t>(256));
+    EXPECT_EQ(1088, get_entry_size<int64_t>(128));
+    EXPECT_EQ(1088, get_entry_size<float>(256));
+    EXPECT_EQ(1088, get_entry_size<double>(128));
 }
 
 TEST_F(DynamicArrayBufferTypeTest, initialize_reserved_entries)

--- a/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.h
+++ b/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.h
@@ -7,6 +7,7 @@
 #include "array_store_config.h"
 #include <algorithm>
 #include <memory>
+#include <type_traits>
 
 namespace vespalib::datastore {
 
@@ -33,6 +34,7 @@ public:
     static constexpr size_t entry_min_align = std::max(alignof(uint32_t), alignof(ElemT));
     using EntryMinAligner = Aligner<entry_min_align>;
     static constexpr uint32_t dynamic_array_buffer_underflow_size = 64u;
+    static constexpr bool align_for_simd = std::disjunction_v<std::is_same<ElemT, double>,std::is_same<ElemT, float>, std::is_same<ElemT, int64_t>, std::is_same<ElemT, int32_t>>;
 protected:
     static const ElemType& empty_entry() noexcept;
     ElemType* get_entry(void *buffer, size_t offset) noexcept { return get_entry(buffer, offset, entry_size()); }

--- a/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.hpp
+++ b/vespalib/src/vespa/vespalib/datastore/dynamic_array_buffer_type.hpp
@@ -25,7 +25,7 @@ size_t
 DynamicArrayBufferType<ElemT>::calc_entry_size(size_t array_size) noexcept
 {
     auto entry_size = EntryMinAligner::align(sizeof(ElemType) * array_size + sizeof(uint32_t));
-    if (entry_size >= 512) {
+    if (align_for_simd && entry_size >= 512) {
         entry_size = Aligner<64>::align(entry_size);
     }
     return entry_size;


### PR DESCRIPTION
@geirst : please review
@baldersheim : FYI
