### PR TITLE
Implement command to generate markdown files from --help pages

### DIFF
--- a/client/go/internal/cli/cmd/gendoc.go
+++ b/client/go/internal/cli/cmd/gendoc.go
@@ -1,0 +1,29 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func newGendocCmd(cli *CLI) *cobra.Command {
+	return &cobra.Command{
+		Use:               "gendoc directory",
+		Short:             "Generate documentation from '--help' pages and write as markdown files to a given directory",
+		Args:              cobra.ExactArgs(1),
+		Hidden:            true, // Not intended to be called by users
+		DisableAutoGenTag: true,
+		SilenceUsage:      true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := args[0]
+			err := doc.GenMarkdownTree(cli.cmd, dir)
+			if err != nil {
+				return fmt.Errorf("failed to write documentation pages: %w", err)
+			}
+			cli.printSuccess("Documentation pages written to ", dir)
+			return nil
+		},
+	}
+}

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -264,6 +264,7 @@ func (c *CLI) configureCommands() {
 	rootCmd.AddCommand(documentCmd)                 // document
 	rootCmd.AddCommand(newLogCmd(c))                // log
 	rootCmd.AddCommand(newManCmd(c))                // man
+	rootCmd.AddCommand(newGendocCmd(c))             // gendoc
 	prodCmd.AddCommand(newProdInitCmd(c))           // prod init
 	prodCmd.AddCommand(newProdDeployCmd(c))         // prod deploy
 	rootCmd.AddCommand(prodCmd)                     // prod


### PR DESCRIPTION
This PR implements a new CLI command which generates markdown files from the --help pages in the Vespa CLI.
The plan is to use this to automatically generate documentation for the CLI (see https://jira.ouryahoo.com/browse/VESPA-26867).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.