### PR TITLE
Match GCP flavours with smallest exclusive resources

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -98,10 +98,10 @@ public class CapacityPolicies {
             Architecture architecture = adminClusterArchitecture(applicationId);
 
             if (nodeRepository.exclusiveAllocation(clusterSpec)) {
-                var resources = smallestExclusiveResources(4); //TODO: use 8Gb as default when no apps are using 4Gb
+                var resources = legacySmallestExclusiveResources(); //TODO: use 8Gb as default when no apps are using 4Gb
                 return versioned(clusterSpec, Map.of(new Version(0), resources,
                                                      new Version(8, 182, 12), resources.with(architecture),
-                                                     new Version(8, 187), smallestExclusiveResources(8).with(architecture)));
+                                                     new Version(8, 187), smallestExclusiveResources().with(architecture)));
             }
 
             if (clusterSpec.id().value().equals("cluster-controllers")) {
@@ -163,10 +163,17 @@ public class CapacityPolicies {
     }
 
     // The lowest amount of resources that can be exclusive allocated (i.e. a matching host flavor for this exists)
-    private NodeResources smallestExclusiveResources(int memoryGb) {
+    private NodeResources legacySmallestExclusiveResources() {
         return (zone.cloud().name().equals(CloudName.GCP))
-                ? new NodeResources(1, memoryGb, 50, 0.3)
-                : new NodeResources(0.5, memoryGb, 50, 0.3);
+               ? new NodeResources(1, 4, 50, 0.3)
+               : new NodeResources(0.5, 4, 50, 0.3);
+    }
+
+    // The lowest amount of resources that can be exclusive allocated (i.e. a matching host flavor for this exists)
+    private NodeResources smallestExclusiveResources() {
+        return (zone.cloud().name().equals(CloudName.GCP))
+                ? new NodeResources(2, 8, 50, 0.3)
+                : new NodeResources(0.5, 8, 50, 0.3);
     }
 
     // The lowest amount of resources that can be shared (i.e. a matching host flavor for this exists)


### PR DESCRIPTION
@bratseth @bjormel please review. 

This would normally be illegal, i.e., modifying an existing entry. However, in this case, no hosts would exist with the modified flavour anyway, since that _flavour_ does not exist in GCP. 