### PR TITLE
Let decoding and en-queuing errors bubble up

### DIFF
--- a/client/go/internal/cli/cmd/feed_test.go
+++ b/client/go/internal/cli/cmd/feed_test.go
@@ -88,3 +88,51 @@ func TestFeed(t *testing.T) {
 	require.Nil(t, cli.Run("feed", jsonFile1))
 	assert.Equal(t, "feed: got error \"something else is broken\" (no body) for put id:ns:type::doc1: retrying\n", stderr.String())
 }
+
+func TestFeedInvalid(t *testing.T) {
+	clock := &manualClock{tick: time.Second}
+	cli, stdout, stderr := newTestCLI(t)
+	httpClient := cli.httpClient.(*mock.HTTPClient)
+	httpClient.ReadBody = true
+	cli.now = clock.now
+
+	td := t.TempDir()
+	doc := []byte(`
+{
+  "put": "id:ns:type::doc1",
+  "fields": {"foo": "123"}
+},
+{
+  "put": "id:ns:type::doc2",
+  "fields": {"foo": "invalid json"
+}`)
+	jsonFile := filepath.Join(td, "docs.jsonl")
+	require.Nil(t, os.WriteFile(jsonFile, doc, 0644))
+	httpClient.NextResponseString(200, `{"message":"OK"}`)
+	require.NotNil(t, cli.Run("feed", jsonFile))
+
+	want := `{
+  "feeder.seconds": 3.000,
+  "feeder.ok.count": 1,
+  "feeder.ok.rate": 0.333,
+  "feeder.error.count": 0,
+  "feeder.inflight.count": 0,
+  "http.request.count": 1,
+  "http.request.bytes": 25,
+  "http.request.MBps": 0.000,
+  "http.exception.count": 0,
+  "http.response.count": 1,
+  "http.response.bytes": 16,
+  "http.response.MBps": 0.000,
+  "http.response.error.count": 0,
+  "http.response.latency.millis.min": 1000,
+  "http.response.latency.millis.avg": 1000,
+  "http.response.latency.millis.max": 1000,
+  "http.response.code.counts": {
+    "200": 1
+  }
+}
+`
+	assert.Equal(t, want, stdout.String())
+	assert.Contains(t, stderr.String(), "Error: failed to decode document")
+}


### PR DESCRIPTION
With this we abort immediately if we encounter a parse or en-queuing error (both
are terminal). We always print a summary because some documents may have been
fed before encountering an invalid document.

@ean