### PR TITLE
- Use a single templated fixture to avoid copy-paste errors when exte…

### DIFF
--- a/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
+++ b/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
@@ -62,39 +62,28 @@ void populate_string(AttributeVector::SP attr_ptr) {
     set_doc(attr, 7, "foo", 10);
 }
 
-template<CollectionType::Type CT>
-struct LongFixture {
+template<BasicType::Type BT, CollectionType::Type CT>
+struct Fixture {
     AttributeVector::SP attr;
     const IDocumentWeightAttribute *api;
-    LongFixture()
-        : attr(make_attribute(BasicType::INT64, CollectionType::WSET, true)),
+    Fixture()
+        : attr(make_attribute(BT, CT, true)),
           api(attr->asDocumentWeightAttribute())
     {
         ASSERT_TRUE(api != nullptr);
         add_docs(attr);
-        populate_long(attr);
+        if (BT == BasicType::STRING) {
+            populate_string(attr);
+        } else {
+            populate_long(attr);
+        }
     }
 };
 
-using LongWsetFixture = LongFixture<CollectionType::WSET>;
-using LongArrayFixture = LongFixture<CollectionType::ARRAY>;
-
-template<CollectionType::Type CT>
-struct StringFixture {
-    AttributeVector::SP attr;
-    const IDocumentWeightAttribute *api;
-    StringFixture()
-        : attr(make_attribute(BasicType::STRING, CT, true)),
-          api(attr->asDocumentWeightAttribute())
-    {
-        ASSERT_TRUE(api != nullptr);
-        add_docs(attr);
-        populate_string(attr);
-    }
-};
-
-using StringWsetFixture = StringFixture<CollectionType::WSET>;
-using StringArrayFixture = StringFixture<CollectionType::ARRAY>;
+using LongWsetFixture = Fixture<BasicType::INT64, CollectionType::WSET>;
+using LongArrayFixture = Fixture<BasicType::INT64, CollectionType::ARRAY>;
+using StringWsetFixture = Fixture<BasicType::STRING, CollectionType::WSET>;
+using StringArrayFixture = Fixture<BasicType::STRING, CollectionType::ARRAY>;
 
 TEST("require that appropriate attributes support the document weight attribute interface") {
     EXPECT_TRUE(make_attribute(BasicType::INT32,  CollectionType::WSET, true)->asDocumentWeightAttribute() != nullptr);


### PR DESCRIPTION
…nding tests.

@geirst PR