### PR TITLE
Query Blueprints have a longer lifetime, hence there is no need to ta…

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
@@ -4,30 +4,29 @@
 #include "iterator_pack.h"
 #include <vespa/vespalib/objects/visit.h>
 
-
 using search::fef::TermFieldMatchData;
 using search::fef::MatchData;
 using vespalib::ObjectVisitor;
 
 namespace search::queryeval {
 
-
 template <typename HEAP, typename IteratorPack>
 class DotProductSearchImpl : public DotProductSearch
 {
 private:
     using ref_t = uint32_t;
+    using Weights = vespalib::ConstArrayRef<int32_t>;
 
     struct CmpDocId {
         const uint32_t *termPos;
-        CmpDocId(const uint32_t *tp) : termPos(tp) {}
-        bool operator()(const ref_t &a, const ref_t &b) const {
+        CmpDocId(const uint32_t *tp) noexcept : termPos(tp) {}
+        bool operator()(const ref_t &a, const ref_t &b) const noexcept {
             return (termPos[a] < termPos[b]);
         }
     };
 
     TermFieldMatchData     &_tmd;
-    const std::vector<int32_t> &_weights;
+    Weights                 _weights;
     std::vector<uint32_t>   _termPos;
     CmpDocId                _cmpDocId;
     std::vector<ref_t>      _data_space;
@@ -112,7 +111,7 @@ public:
             HEAP::push(_data_begin, ++_data_stash, _cmpDocId);
         }
     }
-    Trinary is_strict() const override { return Trinary::True; }
+    Trinary is_strict() const final { return Trinary::True; }
 
     void visitMembers(vespalib::ObjectVisitor &) const override {}
 };

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
@@ -27,7 +27,7 @@ private:
     };
 
     TermFieldMatchData     &_tmd;
-    std::vector<int32_t>    _weights;
+    const std::vector<int32_t> &_weights;
     std::vector<uint32_t>   _termPos;
     CmpDocId                _cmpDocId;
     std::vector<ref_t>      _data_space;

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
@@ -36,7 +36,7 @@ private:
     };
 
     fef::TermFieldMatchData                       &_tmd;
-    std::vector<int32_t>                           _weights;
+    const std::vector<int32_t>                    &_weights;
     std::vector<uint32_t>                          _termPos;
     CmpDocId                                       _cmpDocId;
     CmpWeight                                      _cmpWeight;


### PR DESCRIPTION
…ke a copy of the readonly weights vector.

@toregge or @geirst PR