### PR TITLE
Ignore json library

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "com.yahoo.vespa:cloud-tenant-base",
     "com.yahoo.vespa:parent",
     "com.yahoo.vespa:zookeeper-server-parent",
+    "github.com/go-json-experiment/json",
     "javax.servlet:javax.servlet-api"
   ]
 }


### PR DESCRIPTION
Not compatible with Go version (1.19) currently used by build systems.

Closes #27683

@bjorncs