### PR TITLE
Revert: Less memory for default node resources in dev cd zone

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/CapacityPolicies.java
@@ -9,11 +9,11 @@ import com.yahoo.config.provision.ClusterResources;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.NodeResources;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.flags.StringFlag;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -113,10 +113,6 @@ public class CapacityPolicies {
             }
 
             return versioned(clusterSpec, Map.of(new Version(0), smallestSharedResources())).with(architecture);
-        }
-
-        if (zone.environment() == Environment.dev && zone.system() == SystemName.cd) {
-            return versioned(clusterSpec, Map.of(new Version(0), new NodeResources(1.5, 4, 50, 0.3)));
         }
 
         if (clusterSpec.type() == ClusterSpec.Type.content) {


### PR DESCRIPTION
Reverts change in https://github.com/vespa-engine/vespa/pull/27235

Trying this, might have to revert if we don't have enough resources