### PR TITLE
Allocate all groups in one go

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -22,16 +22,28 @@ public class ClusterMembership {
     private ClusterMembership(String stringValue, Version vespaVersion, Optional<DockerImage> dockerImageRepo,
                               ZoneEndpoint zoneEndpoint) {
         String[] components = stringValue.split("/");
-        if (components.length < 4)
+        if (components.length < 3)
             throw new RuntimeException("Could not parse '" + stringValue + "' to a cluster membership. " +
                                        "Expected 'clusterType/clusterId/groupId/index[/retired][/exclusive][/stateful][/combinedId]'");
+
+        Integer groupIndex = components[2].isEmpty() ? null : Integer.parseInt(components[2]);
+        Integer nodeIndex;
+        int missingElements = 0;
+        try {
+            nodeIndex = Integer.parseInt(components[3]);
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
+            // Legacy form missing the group component
+            nodeIndex = groupIndex;
+            groupIndex = null;
+            missingElements = 1;
+        }
 
         boolean exclusive = false;
         boolean stateful = false;
         var combinedId = Optional.<String>empty();
         boolean retired = false;
-        if (components.length > 4) {
-            for (int i = 4; i < components.length; i++) {
+        if (components.length > (4 - missingElements)) {
+            for (int i = (4 - missingElements); i < components.length; i++) {
                 String component = components[i];
                 switch (component) {
                     case "exclusive" -> exclusive = true;
@@ -44,7 +56,7 @@ public class ClusterMembership {
 
         this.cluster = ClusterSpec.specification(ClusterSpec.Type.valueOf(components[0]),
                                                  ClusterSpec.Id.from(components[1]))
-                                  .group(components[2].isEmpty() ? null : ClusterSpec.Group.from(Integer.parseInt(components[2])))
+                                  .group(groupIndex == null ? null : ClusterSpec.Group.from(groupIndex))
                                   .vespaVersion(vespaVersion)
                                   .exclusive(exclusive)
                                   .combinedId(combinedId.map(ClusterSpec.Id::from))
@@ -52,7 +64,7 @@ public class ClusterMembership {
                                   .loadBalancerSettings(zoneEndpoint)
                                   .stateful(stateful)
                                   .build();
-        this.index = Integer.parseInt(components[3]);
+        this.index = nodeIndex;
         this.retired = retired;
         this.stringValue = toStringValue();
     }

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterMembership.java
@@ -44,7 +44,7 @@ public class ClusterMembership {
 
         this.cluster = ClusterSpec.specification(ClusterSpec.Type.valueOf(components[0]),
                                                  ClusterSpec.Id.from(components[1]))
-                                  .group(ClusterSpec.Group.from(Integer.parseInt(components[2])))
+                                  .group(components[2].isEmpty() ? null : ClusterSpec.Group.from(Integer.parseInt(components[2])))
                                   .vespaVersion(vespaVersion)
                                   .exclusive(exclusive)
                                   .combinedId(combinedId.map(ClusterSpec.Id::from))
@@ -67,7 +67,7 @@ public class ClusterMembership {
     protected String toStringValue() {
         return cluster.type().name() +
                "/" + cluster.id().value() +
-               (cluster.group().isPresent() ? "/" + cluster.group().get().index() : "") +
+               (cluster.group().isPresent() ? "/" + cluster.group().get().index() : "/") +
                "/" + index +
                ( cluster.isExclusive() ? "/exclusive" : "") +
                ( retired ? "/retired" : "") +

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -102,19 +102,18 @@ public final class ClusterSpec {
 
     /** Creates a ClusterSpec when requesting a cluster */
     public static Builder request(Type type, Id id) {
-        return new Builder(type, id, false);
+        return new Builder(type, id);
     }
 
     /** Creates a ClusterSpec for an existing cluster, group id and Vespa version needs to be set */
     public static Builder specification(Type type, Id id) {
-        return new Builder(type, id, true);
+        return new Builder(type, id);
     }
 
     public static class Builder {
 
         private final Type type;
         private final Id id;
-        private final boolean specification;
 
         private Optional<Group> groupId = Optional.empty();
         private Optional<DockerImage> dockerImageRepo = Optional.empty();
@@ -124,19 +123,13 @@ public final class ClusterSpec {
         private ZoneEndpoint zoneEndpoint = ZoneEndpoint.defaultEndpoint;
         private boolean stateful;
 
-        private Builder(Type type, Id id, boolean specification) {
+        private Builder(Type type, Id id) {
             this.type = type;
             this.id = id;
-            this.specification = specification;
             this.stateful = type.isContent(); // Default to true for content clusters
         }
 
         public ClusterSpec build() {
-            if (specification) {
-                if (groupId.isEmpty()) throw new IllegalArgumentException("groupId is required to be set when creating a ClusterSpec with specification()");
-                if (vespaVersion == null) throw new IllegalArgumentException("vespaVersion is required to be set when creating a ClusterSpec with specification()");
-            } else
-                if (groupId.isPresent()) throw new IllegalArgumentException("groupId is not allowed to be set when creating a ClusterSpec with request()");
             return new ClusterSpec(type, id, groupId, vespaVersion, exclusive, combinedId, dockerImageRepo, zoneEndpoint, stateful);
         }
 

--- a/config-provisioning/src/main/java/com/yahoo/config/provision/NodeAllocationException.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/NodeAllocationException.java
@@ -16,6 +16,11 @@ public class NodeAllocationException extends RuntimeException {
         this.retryable = retryable;
     }
 
+    public NodeAllocationException(String message, Throwable cause, boolean retryable) {
+        super(message, cause);
+        this.retryable = retryable;
+    }
+
     public boolean retryable() {
         return retryable;
     }

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/ClusterMembershipTest.java
@@ -100,7 +100,9 @@ public class ClusterMembershipTest {
         assertEquals("id1", instance.cluster().id().value());
         assertFalse(instance.cluster().group().isPresent());
         assertEquals(3, instance.index());
-        assertEquals("container/id1/3", instance.stringValue());
+        assertEquals("container/id1//3", instance.stringValue());
+        // Legacy form:
+        assertEquals(instance, ClusterMembership.from("container/id1/3", instance.cluster().vespaVersion(), Optional.empty()));
     }
 
     private void assertContentService(ClusterMembership instance) {
@@ -109,7 +111,7 @@ public class ClusterMembershipTest {
         assertFalse(instance.cluster().group().isPresent());
         assertEquals(37, instance.index());
         assertFalse(instance.retired());
-        assertEquals("content/id1/37/stateful", instance.stringValue());
+        assertEquals("content/id1//37/stateful", instance.stringValue());
     }
 
     private void assertContentServiceWithGroup(ClusterMembership instance) {
@@ -127,7 +129,9 @@ public class ClusterMembershipTest {
         assertEquals("id1", instance.cluster().id().value());
         assertEquals(37, instance.index());
         assertTrue(instance.retired());
-        assertEquals("content/id1/37/retired/stateful", instance.stringValue());
+        assertEquals("content/id1//37/retired/stateful", instance.stringValue());
+        // Legacy form:
+        assertEquals(instance, ClusterMembership.from("content/id1/37/retired/stateful", instance.cluster().vespaVersion(), Optional.empty()));
     }
 
     private void assertContentServiceWithGroupAndRetire(ClusterMembership instance) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/LockedNodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/LockedNodeList.java
@@ -24,7 +24,7 @@ public final class LockedNodeList extends NodeList {
         this.lock = Objects.requireNonNull(lock, "lock must be non-null");
     }
 
-    /** Returns a new LockedNodeList with the for the same lock. */
+    /** Returns a new LockedNodeList with the same lock. */
     public LockedNodeList childList(List<Node> nodes) {
         return new LockedNodeList(nodes, lock);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
@@ -268,11 +268,9 @@ public class HostCapacityMaintainer extends NodeRepositoryMaintainer {
                 // build() requires a version, even though it is not (should not be) used
                 .vespaVersion(Vtag.currentVersion)
                 .build();
-        NodeSpec nodeSpec = NodeSpec.from(clusterCapacity.count(), nodeResources, false, true,
+        NodeSpec nodeSpec = NodeSpec.from(clusterCapacity.count(), 1, nodeResources, false, true,
                                           nodeRepository().zone().cloud().account(), Duration.ZERO);
-        int wantedGroups = 1;
-
-        NodePrioritizer prioritizer = new NodePrioritizer(allNodes, applicationId, clusterSpec, nodeSpec, wantedGroups,
+        NodePrioritizer prioritizer = new NodePrioritizer(allNodes, applicationId, clusterSpec, nodeSpec,
                 true, nodeRepository().nameResolver(), nodeRepository().nodes(), nodeRepository().resourcesCalculator(),
                 nodeRepository().spareCount(), nodeSpec.cloudAccount().isExclave(nodeRepository().zone()));
         List<NodeCandidate> nodeCandidates = prioritizer.collect(List.of());

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Activator.java
@@ -72,7 +72,6 @@ class Activator {
 
         NodeList reserved = applicationNodes.state(Node.State.reserved).matching(node -> hostnames.contains(node.hostname()));
         reserved = updatePortsFrom(hosts, reserved);
-        reserved = updateGroupFrom(hosts, reserved);
         nodeRepository.nodes().reserve(reserved.asList()); // Re-reserve nodes to avoid reservation expiry
 
         NodeList oldActive = applicationNodes.state(Node.State.active); // All nodes active now
@@ -236,18 +235,6 @@ class Activator {
                 node = node.with(allocation);
             }
             updated.add(node);
-        }
-        return NodeList.copyOf(updated);
-    }
-
-    /**
-     * Reserved nodes are stored before they are assigned a group.
-     */
-    private NodeList updateGroupFrom(Collection<HostSpec> hosts, NodeList nodes) {
-        List<Node> updated = new ArrayList<>();
-        for (Node node : nodes) {
-            var membership = getHost(node.hostname(), hosts).membership().get();
-            updated.add(node.with(node.allocation().get().with(membership)));
         }
         return NodeList.copyOf(updated);
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupIndices.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupIndices.java
@@ -1,0 +1,163 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.provision.provisioning;
+
+import com.yahoo.config.provision.ClusterSpec;
+import com.yahoo.config.provision.Flavor;
+import com.yahoo.config.provision.NodeResources;
+import com.yahoo.vespa.hosted.provision.Node;
+import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.vespa.hosted.provision.node.Agent;
+
+import java.time.Clock;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Knows how to assign a group index to a number of nodes (some of which have an index already),
+ * such that the nodes are placed in the desired groups with minimal group movement.
+ *
+ * @author bratseth
+ */
+class GroupIndices {
+
+    private final NodeSpec requested;
+    private final NodeList allNodes;
+    private final Clock clock;
+
+    GroupIndices(NodeSpec requested, NodeList allNodes, Clock clock) {
+        if (requested.groups() > 1 && requested.count().isEmpty())
+            throw new IllegalArgumentException("Unlimited nodes cannot be grouped");
+        this.requested = requested;
+        this.allNodes = allNodes;
+        this.clock = clock;
+    }
+
+    Collection<NodeCandidate> assignTo(Collection<NodeCandidate> nodes) {
+        int[] countInGroup = countInEachGroup(nodes);
+        nodes = byUnretiringPriority(nodes).stream().map(node -> unretireNodeInExpandedGroup(node, countInGroup)).toList();
+        nodes = nodes.stream().map(node -> assignGroupToNewNode(node, countInGroup)).toList();
+        nodes = byUnretiringPriority(nodes).stream().map(node -> moveNodeInSurplusGroup(node, countInGroup)).toList();
+        nodes = byRetiringPriority(nodes).stream().map(node -> retireSurplusNodeInGroup(node, countInGroup)).toList();
+        nodes = nodes.stream().filter(node -> ! shouldRemove(node)).toList();
+        return nodes;
+    }
+
+    /** Prefer to retire nodes we want the least */
+    private List<NodeCandidate> byRetiringPriority(Collection<NodeCandidate> candidates) {
+        return candidates.stream().sorted(Comparator.reverseOrder()).toList();
+    }
+
+    /** Prefer to unretire nodes we don't want to retire, and otherwise those with lower index */
+    private List<NodeCandidate> byUnretiringPriority(Collection<NodeCandidate> candidates) {
+        return candidates.stream()
+                         .sorted(Comparator.comparing(NodeCandidate::wantToRetire)
+                                           .thenComparing(n -> n.allocation().get().membership().index()))
+                         .toList();
+    }
+
+    private int[] countInEachGroup(Collection<NodeCandidate> nodes) {
+        int[] countInGroup = new int[requested.groups()];
+        for (var node : nodes) {
+            if (node.allocation().get().membership().retired()) continue;
+            var currentGroup = node.allocation().get().membership().cluster().group();
+            if (currentGroup.isEmpty()) continue;
+            if (currentGroup.get().index() >= requested.groups()) continue;
+            countInGroup[currentGroup.get().index()]++;
+        }
+        return countInGroup;
+    }
+
+    /** Assign a group to new or to be reactivated nodes. */
+    private NodeCandidate assignGroupToNewNode(NodeCandidate node, int[] countInGroup) {
+        if (node.state() == Node.State.active && node.allocation().get().membership().retired()) return node;
+        if (node.state() == Node.State.active && node.allocation().get().membership().cluster().group().isPresent()) return node;
+        return inFirstGroupWithDeficiency(node, countInGroup);
+    }
+
+    private NodeCandidate moveNodeInSurplusGroup(NodeCandidate node, int[] countInGroup) {
+        var currentGroup = node.allocation().get().membership().cluster().group();
+        if (currentGroup.isEmpty()) return node; // Shouldn't happen
+        if (currentGroup.get().index() < requested.groups()) return node;
+        return inFirstGroupWithDeficiency(node, countInGroup);
+    }
+
+    private NodeCandidate retireSurplusNodeInGroup(NodeCandidate node, int[] countInGroup) {
+        if (node.allocation().get().membership().retired()) return node;
+        var currentGroup = node.allocation().get().membership().cluster().group();
+        if (currentGroup.isEmpty()) return node;
+        if (currentGroup.get().index() >= requested.groups()) return node;
+        if (requested.count().isEmpty()) return node; // Can't retire
+        if (countInGroup[currentGroup.get().index()] <= requested.count().get() / requested.groups()) return node;
+        countInGroup[currentGroup.get().index()]--;
+        return node.withNode(node.toNode().retire(Agent.application, clock.instant()));
+    }
+
+    /** Unretire nodes that are already in the correct group when the group is deficient. */
+    private NodeCandidate unretireNodeInExpandedGroup(NodeCandidate node, int[] countInGroup) {
+        if ( ! node.allocation().get().membership().retired()) return node;
+        var currentGroup = node.allocation().get().membership().cluster().group();
+        if (currentGroup.isEmpty()) return node;
+        if (currentGroup.get().index() >= requested.groups()) return node;
+        if (node.preferToRetire() || node.wantToRetire()) return node;
+        if (requested.count().isPresent() && countInGroup[currentGroup.get().index()] >= requested.count().get() / requested.groups()) return node;
+        node = unretire(node);
+        if (node.allocation().get().membership().retired()) return node;
+        countInGroup[currentGroup.get().index()]++;
+        return node;
+    }
+
+    private NodeCandidate inFirstGroupWithDeficiency(NodeCandidate node, int[] countInGroup) {
+        for (int group = 0; group < requested.groups(); group++) {
+            if (requested.count().isEmpty() || countInGroup[group] < requested.count().get() / requested.groups()) {
+                return inGroup(group, node, countInGroup);
+            }
+        }
+        return node;
+    }
+
+    private boolean shouldRemove(NodeCandidate node) {
+        var currentGroup = node.allocation().get().membership().cluster().group();
+        if (currentGroup.isEmpty()) return true; // new and not assigned an index: Not needed
+        return currentGroup.get().index() >= requested.groups();
+    }
+
+    private NodeCandidate inGroup(int group, NodeCandidate node, int[] countInGroup) {
+        node = unretire(node);
+        if (node.allocation().get().membership().retired()) return node;
+        var membership = node.allocation().get().membership();
+        var currentGroup = membership.cluster().group();
+        countInGroup[group]++;
+        if ( ! currentGroup.isEmpty() && currentGroup.get().index() < requested.groups())
+            countInGroup[membership.cluster().group().get().index()]--;
+        return node.withNode(node.toNode().with(node.allocation().get().with(membership.with(membership.cluster().with(Optional.of(ClusterSpec.Group.from(group)))))));
+    }
+
+    /** Attempt to unretire the given node if it is retired. */
+    private NodeCandidate unretire(NodeCandidate node) {
+        if (node.retiredNow()) return node;
+        if ( ! node.allocation().get().membership().retired()) return node;
+        if ( ! hasCompatibleResources(node) ) return node;
+        var parent = node.parentHostname().flatMap(hostname -> allNodes.node(hostname));
+        if (parent.isPresent() && (parent.get().status().wantToRetire() || parent.get().status().preferToRetire())) return node;
+        node = node.withNode();
+        if ( ! requested.isCompatible(node.resources()))
+            node = node.withNode(resize(node.toNode()));
+        return node.withNode(node.toNode().unretire());
+    }
+
+    private Node resize(Node node) {
+        NodeResources hostResources = allNodes.parentOf(node).get().flavor().resources();
+        return node.with(new Flavor(requested.resources().get()
+                                             .with(hostResources.diskSpeed())
+                                             .with(hostResources.storageType())
+                                             .with(hostResources.architecture())),
+                         Agent.application, clock.instant());
+    }
+
+    private boolean hasCompatibleResources(NodeCandidate candidate) {
+        return requested.isCompatible(candidate.resources()) || candidate.isResizable;
+    }
+
+}

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -143,9 +143,9 @@ public class GroupPreparer {
                 throw new NodeAllocationException(allocation.allocationFailureDetails(), true);
 
             // Carry out and return allocation
+            List<Node> acceptedNodes = allocation.finalNodes();
             nodeRepository.nodes().reserve(allocation.reservableNodes());
             nodeRepository.nodes().addReservedNodes(new LockedNodeList(allocation.newNodes(), allocationLock));
-            List<Node> acceptedNodes = allocation.finalNodes();
             surplusActiveNodes.removeAll(acceptedNodes);
             return acceptedNodes;
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/GroupPreparer.java
@@ -61,14 +61,14 @@ public class GroupPreparer {
     // but it may not change the set of active nodes, as the active nodes must stay in sync with the
     // active config model which is changed on activate
     public PrepareResult prepare(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes,
-                                 List<Node> surplusActiveNodes, NodeIndices indices, int wantedGroups,
+                                 List<Node> surplusActiveNodes, NodeIndices indices,
                                  LockedNodeList allNodes) {
         log.log(Level.FINE, () -> "Preparing " + cluster.type().name() + " " + cluster.id() + " with requested resources " +
                                   requestedNodes.resources().orElse(NodeResources.unspecified()));
         // Try preparing in memory without global unallocated lock. Most of the time there should be no changes,
         // and we can return nodes previously allocated.
         NodeAllocation probeAllocation = prepareAllocation(application, cluster, requestedNodes, surplusActiveNodes,
-                                                           indices::probeNext, wantedGroups, allNodes);
+                                                           indices::probeNext, allNodes);
         if (probeAllocation.fulfilledAndNoChanges()) {
             List<Node> acceptedNodes = probeAllocation.finalNodes();
             surplusActiveNodes.removeAll(acceptedNodes);
@@ -77,7 +77,7 @@ public class GroupPreparer {
         } else {
             // There were some changes, so re-do the allocation with locks
             indices.resetProbe();
-            List<Node> prepared = prepareWithLocks(application, cluster, requestedNodes, surplusActiveNodes, indices, wantedGroups);
+            List<Node> prepared = prepareWithLocks(application, cluster, requestedNodes, surplusActiveNodes, indices);
             return new PrepareResult(prepared, createUnlockedNodeList());
         }
     }
@@ -87,12 +87,12 @@ public class GroupPreparer {
 
     /// Note that this will write to the node repo.
     private List<Node> prepareWithLocks(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes,
-                                        List<Node> surplusActiveNodes, NodeIndices indices, int wantedGroups) {
+                                        List<Node> surplusActiveNodes, NodeIndices indices) {
         try (Mutex lock = nodeRepository.applications().lock(application);
              Mutex allocationLock = nodeRepository.nodes().lockUnallocated()) {
             LockedNodeList allNodes = nodeRepository.nodes().list(allocationLock);
             NodeAllocation allocation = prepareAllocation(application, cluster, requestedNodes, surplusActiveNodes,
-                                                          indices::next, wantedGroups, allNodes);
+                                                          indices::next, allNodes);
             NodeType hostType = allocation.nodeType().hostType();
             if (canProvisionDynamically(hostType) && allocation.hostDeficit().isPresent()) {
                 HostSharing sharing = hostSharing(cluster, hostType);
@@ -134,15 +134,13 @@ public class GroupPreparer {
                 // Non-dynamically provisioned zone with a deficit because we just now retired some nodes.
                 // Try again, but without retiring
                 indices.resetProbe();
-                List<Node> accepted = prepareWithLocks(application, cluster, cns.withoutRetiring(), surplusActiveNodes, indices, wantedGroups);
+                List<Node> accepted = prepareWithLocks(application, cluster, cns.withoutRetiring(), surplusActiveNodes, indices);
                 log.warning("Prepared " + application + " " + cluster.id() + " without retirement due to lack of capacity");
                 return accepted;
             }
 
             if (! allocation.fulfilled() && requestedNodes.canFail())
-                throw new NodeAllocationException((cluster.group().isPresent() ? "Node allocation failure on " + cluster.group().get()
-                                                                               : "") + allocation.allocationFailureDetails(),
-                                                  true);
+                throw new NodeAllocationException(allocation.allocationFailureDetails(), true);
 
             // Carry out and return allocation
             nodeRepository.nodes().reserve(allocation.reservableNodes());
@@ -154,7 +152,7 @@ public class GroupPreparer {
     }
 
     private NodeAllocation prepareAllocation(ApplicationId application, ClusterSpec cluster, NodeSpec requestedNodes,
-                                             List<Node> surplusActiveNodes, Supplier<Integer> nextIndex, int wantedGroups,
+                                             List<Node> surplusActiveNodes, Supplier<Integer> nextIndex,
                                              LockedNodeList allNodes) {
 
         NodeAllocation allocation = new NodeAllocation(allNodes, application, cluster, requestedNodes, nextIndex, nodeRepository);
@@ -162,7 +160,6 @@ public class GroupPreparer {
                                                           application,
                                                           cluster,
                                                           requestedNodes,
-                                                          wantedGroups,
                                                           nodeRepository.zone().cloud().dynamicProvisioning(),
                                                           nodeRepository.nameResolver(),
                                                           nodeRepository.nodes(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -413,6 +413,8 @@ class NodeAllocation {
 
         GroupIndices groupIndices = new GroupIndices(requestedNodes, allNodes, nodeRepository.clock());
         Collection<NodeCandidate> finalNodes = groupIndices.assignTo(nodes.values());
+        nodes.clear();
+        finalNodes.forEach(candidate -> nodes.put(candidate.toNode().hostname(), candidate));
         return finalNodes.stream().map(NodeCandidate::toNode).toList();
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -59,7 +59,7 @@ class NodeAllocation {
     /** The number of already allocated nodes of compatible size */
     private int acceptedAndCompatible = 0;
 
-    /** The number of already allocated nodes which can be made compatible*/
+    /** The number of already allocated nodes which can be made compatible */
     private int acceptedAndCompatibleOrResizable = 0;
 
     /** The number of nodes rejected because of clashing parentHostname */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodePrioritizer.java
@@ -46,7 +46,7 @@ public class NodePrioritizer {
     private final boolean enclave;
 
     public NodePrioritizer(LockedNodeList allNodes, ApplicationId application, ClusterSpec clusterSpec, NodeSpec nodeSpec,
-                           int wantedGroups, boolean dynamicProvisioning, NameResolver nameResolver, Nodes nodes,
+                           boolean dynamicProvisioning, NameResolver nameResolver, Nodes nodes,
                            HostResourcesCalculator hostResourcesCalculator, int spareCount, boolean enclave) {
         this.allNodes = allNodes;
         this.calculator = hostResourcesCalculator;
@@ -70,12 +70,9 @@ public class NodePrioritizer {
                         .stream())
                 .distinct()
                 .count();
-        this.topologyChange = currentGroups != wantedGroups;
+        this.topologyChange = currentGroups != requestedNodes.groups();
 
-        this.currentClusterSize = (int) nonRetiredNodesInCluster.state(Node.State.active).stream()
-                .map(node -> node.allocation().flatMap(alloc -> alloc.membership().cluster().group()))
-                .filter(clusterSpec.group()::equals)
-                .count();
+        this.currentClusterSize = (int) nonRetiredNodesInCluster.state(Node.State.active).stream().count();
 
         // In dynamically provisioned zones, we can always take spare hosts since we can provision new on-demand,
         // NodeCandidate::compareTo will ensure that they will not be used until there is no room elsewhere.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -96,19 +96,17 @@ public class NodeRepositoryProvisioner implements Provisioner {
             validate(actual, target, cluster, application);
             logIfDownscaled(requested.minResources().nodes(), actual.minResources().nodes(), cluster, logger);
 
-            groups = target.groups();
             resources = getNodeResources(cluster, target.nodeResources(), application);
-            nodeSpec = NodeSpec.from(target.nodes(), resources, cluster.isExclusive(), actual.canFail(),
+            nodeSpec = NodeSpec.from(target.nodes(), target.groups(), resources, cluster.isExclusive(), actual.canFail(),
                                      requested.cloudAccount().orElse(nodeRepository.zone().cloud().account()),
                                      requested.clusterInfo().hostTTL());
         }
         else {
-            groups = 1; // type request with multiple groups is not supported
             cluster = cluster.withExclusivity(true);
             resources = getNodeResources(cluster, requested.minResources().nodeResources(), application);
             nodeSpec = NodeSpec.from(requested.type(), nodeRepository.zone().cloud().account());
         }
-        return asSortedHosts(preparer.prepare(application, cluster, nodeSpec, groups),
+        return asSortedHosts(preparer.prepare(application, cluster, nodeSpec),
                              requireCompatibleResources(resources, cluster));
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeListMicroBenchmarkTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeListMicroBenchmarkTest.java
@@ -58,7 +58,6 @@ public class NodeListMicroBenchmarkTest {
             nodeList.childrenOf(nodes.get(indexes.get(i)));
         }
         Duration duration = Duration.between(start, Instant.now());
-        System.out.println("Calling NodeList.childrenOf took " + duration + " (" + duration.toNanos() / iterations / 1000 + " microseconds per invocation)");
     }
 
     private List<Node> createHosts() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeListMicroBenchmarkTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeListMicroBenchmarkTest.java
@@ -58,6 +58,7 @@ public class NodeListMicroBenchmarkTest {
             nodeList.childrenOf(nodes.get(indexes.get(i)));
         }
         Duration duration = Duration.between(start, Instant.now());
+        System.out.println("Calling NodeList.childrenOf took " + duration + " (" + duration.toNanos() / iterations / 1000 + " microseconds per invocation)");
     }
 
     private List<Node> createHosts() {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
@@ -94,7 +94,6 @@ public class DynamicAllocationTest {
             hostsWithChildren.add(node.parentHostname().get());
         }
         assertEquals(4 - spareCount, hostsWithChildren.size());
-
     }
 
     /**

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicAllocationTest.java
@@ -341,8 +341,8 @@ public class DynamicAllocationTest {
         tester.activate(application, hosts);
 
         NodeList activeNodes = tester.nodeRepository().nodes().list().owner(application);
-        assertEquals(Set.of("127.0.127.2", "::2"), activeNodes.asList().get(0).ipConfig().primary());
-        assertEquals(Set.of("127.0.127.13", "::d"), activeNodes.asList().get(1).ipConfig().primary());
+        assertEquals(Set.of("127.0.127.2", "::2"), activeNodes.asList().get(1).ipConfig().primary());
+        assertEquals(Set.of("127.0.127.13", "::d"), activeNodes.asList().get(0).ipConfig().primary());
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
@@ -334,7 +334,7 @@ public class DynamicProvisioningTest {
                 .flagSource(flagSource)
                 .build();
 
-        ApplicationId app = ProvisioningTester.applicationId();
+        ApplicationId app = ProvisioningTester.applicationId("a1");
         ClusterSpec cluster = ClusterSpec.request(ClusterSpec.Type.content, new ClusterSpec.Id("cluster1")).vespaVersion("8").build();
         Capacity capacity = Capacity.from(new ClusterResources(4, 2, new NodeResources(2, 4, 50, 0.1, DiskSpeed.any, StorageType.any, Architecture.any)));
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
@@ -24,17 +24,17 @@ public class NodeCandidateTest {
     @Test
     public void testOrdering() {
         List<NodeCandidate> expected = List.of(
-                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, true, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), new NodeResources(1, 1, 1, 1), Optional.empty(), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false)
+                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, true, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), false, new NodeResources(1, 1, 1, 1), Optional.empty(), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false)
         );
         assertOrder(expected);
     }
@@ -148,7 +148,7 @@ public class NodeCandidateTest {
         Node parent = Node.create(hostname + "parent", hostname, new Flavor(totalHostResources), Node.State.ready, NodeType.host)
                           .ipConfig(IP.Config.of(Set.of("::1"), Set.of("::2")))
                           .build();
-        return new NodeCandidate.ConcreteNodeCandidate(node, totalHostResources.subtract(allocatedHostResources), Optional.of(parent),
+        return new NodeCandidate.ConcreteNodeCandidate(node, false, totalHostResources.subtract(allocatedHostResources), Optional.of(parent),
                                                        false, exclusiveSwitch, false, true, false);
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/VirtualNodeProvisioningTest.java
@@ -23,6 +23,7 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.transaction.NestedTransaction;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
+import com.yahoo.yolean.Exceptions;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -442,9 +443,8 @@ public class VirtualNodeProvisioningTest {
                          "Could not satisfy request for 3 nodes with " +
                          "[vcpu: 2.0, memory: 4.0 Gb, disk: 100.0 Gb, bandwidth: 1.0 Gbps, architecture: any] " +
                          "in tenant2.app2 container cluster 'my-container' 6.39: " +
-                         "Node allocation failure on group 0: " +
                          "Not enough suitable nodes available due to host exclusivity constraints",
-                         e.getMessage());
+                         Exceptions.toMessageString(e));
         }
 
         // Adding 3 nodes of another application for the same tenant works
@@ -469,8 +469,8 @@ public class VirtualNodeProvisioningTest {
             assertEquals("Could not satisfy request for 2 nodes with " +
                          "[vcpu: 1.0, memory: 4.0 Gb, disk: 100.0 Gb, bandwidth: 1.0 Gbps, storage type: remote, architecture: any] " +
                          "in tenant.app1 content cluster 'my-content'" +
-                         " 6.42: Node allocation failure on group 0",
-                         e.getMessage());
+                         " 6.42",
+                         Exceptions.toMessageString(e));
         }
     }
 

--- a/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
@@ -27,6 +27,8 @@ public class Exceptions {
         for (; t != null; t = t.getCause()) {
             message = getMessage(t);
             if (message == null) continue;
+            message = message.trim();
+            if (message.isEmpty()) continue;
             if (message.equals(lastMessage)) continue;
             if (b.length() > 0) {
                 b.append(": ");

--- a/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
+++ b/vespajlib/src/main/java/com/yahoo/yolean/Exceptions.java
@@ -27,7 +27,6 @@ public class Exceptions {
         for (; t != null; t = t.getCause()) {
             message = getMessage(t);
             if (message == null) continue;
-            message = message.trim();
             if (message.isEmpty()) continue;
             if (message.equals(lastMessage)) continue;
             if (b.length() > 0) {


### PR DESCRIPTION
With many groups and dynamic allocation allocating group by group is too slow.

This leaves a number of simplification opportunities untaken, but I wanted to keep this diff as small as possible.