### PR TITLE
Revert "- Enable use of optimized DirectWeightedAttribute for all integer att…"

### DIFF
--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -160,14 +160,14 @@ template <>
 vespalib::string
 BitVectorTest::getSearchStr<IntegerAttribute>()
 {
-    return "-42";
+    return "[-42;-42]";
 }
 
 template <>
 vespalib::string
 BitVectorTest::getSearchStr<FloatingPointAttribute>()
 {
-    return "-42.0";
+    return "[-42.0;-42.0]";
 }
 
 template <>
@@ -365,6 +365,7 @@ BitVectorTest::checkSearch(AttributePtr v,
                            bool weights,
                            bool checkStride)
 {
+    (void) checkStride;
     sb->initRange(1, v->getCommittedDocIdLimit());
     sb->seek(1u);
     uint32_t docId = sb->getDocId();
@@ -374,7 +375,7 @@ BitVectorTest::checkSearch(AttributePtr v,
     while (docId != search::endDocId) {
         lastDocId = docId;
         ++docFreq,
-        ASSERT_TRUE(!checkStride || (docId % 5) == 2u);
+        assert(!checkStride || (docId % 5) == 2u);
         sb->unpack(docId);
         EXPECT_EQUAL(md.getDocId(), docId);
         if (v->getCollectionType() == CollectionType::SINGLE || !weights) {
@@ -430,12 +431,12 @@ BitVectorTest::test(BasicType bt, CollectionType ct, const vespalib::string &pre
     checkSearch(v, std::move(sc), 2, 1022, 205, !filter, true);
     const search::IDocumentWeightAttribute *dwa = v->asDocumentWeightAttribute();
     if (dwa != nullptr) {
-        vespalib::string key = getSearchStr<VectorType>();
-        search::IDocumentWeightAttribute::LookupResult lres = dwa->lookup(key, dwa->get_dictionary_snapshot());
+        search::IDocumentWeightAttribute::LookupResult lres = 
+            dwa->lookup(getSearchStr<VectorType>(), dwa->get_dictionary_snapshot());
         using DWSI = search::queryeval::DocumentWeightSearchIterator;
         using SI = search::queryeval::SearchIterator;
         TermFieldMatchData md;
-        SI::UP dwsi = std::make_unique<DWSI>(md, *dwa, lres);
+        SI::UP dwsi(new DWSI(md, *dwa, lres));
         if (!filter) {
             TEST_DO(checkSearch(v, std::move(dwsi), md, 2, 1022, 205, !filter, true));
         } else {

--- a/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
+++ b/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
@@ -81,7 +81,6 @@ struct StringFixture {
 };
 
 TEST("require that appropriate attributes support the document weight attribute interface") {
-    EXPECT_TRUE(make_attribute(BasicType::INT32,  CollectionType::WSET, true)->asDocumentWeightAttribute() != nullptr);
     EXPECT_TRUE(make_attribute(BasicType::INT64,  CollectionType::WSET, true)->asDocumentWeightAttribute() != nullptr);
     EXPECT_TRUE(make_attribute(BasicType::STRING, CollectionType::WSET, true)->asDocumentWeightAttribute() != nullptr);
 }
@@ -97,7 +96,7 @@ TEST("require that inappropriate attributes do not support the document weight a
     EXPECT_TRUE(make_attribute(BasicType::STRING, CollectionType::WSET,   false)->asDocumentWeightAttribute() == nullptr);
     EXPECT_TRUE(make_attribute(BasicType::STRING, CollectionType::SINGLE,  true)->asDocumentWeightAttribute() == nullptr);
     EXPECT_TRUE(make_attribute(BasicType::STRING, CollectionType::ARRAY,   true)->asDocumentWeightAttribute() == nullptr);
-    EXPECT_TRUE(make_attribute(BasicType::FLOAT,  CollectionType::WSET,    true)->asDocumentWeightAttribute() == nullptr);
+    EXPECT_TRUE(make_attribute(BasicType::INT32,  CollectionType::WSET,    true)->asDocumentWeightAttribute() == nullptr);
     EXPECT_TRUE(make_attribute(BasicType::DOUBLE, CollectionType::WSET,    true)->asDocumentWeightAttribute() == nullptr);
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -126,6 +126,7 @@ template <typename B, typename M>
 void
 MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
 {
+    assert(idx.valid());
     self.getPostingList().beginFrozen(idx, dst);
 }
 
@@ -133,6 +134,7 @@ template <typename B, typename M>
 DocumentWeightIterator
 MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx) const
 {
+    assert(idx.valid());
     return self.getPostingList().beginFrozen(idx);
 }
 
@@ -154,7 +156,7 @@ template <typename B, typename M>
 const IDocumentWeightAttribute *
 MultiValueNumericPostingAttribute<B, M>::asDocumentWeightAttribute() const
 {
-    if (this->hasWeightedSetType() && this->isIntegerType()) {
+    if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::INT64)) {
         return &_document_weight_attribute_adapter;
     }
     return nullptr;

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -146,6 +146,7 @@ template <typename B, typename T>
 void
 MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
 {
+    assert(idx.valid());
     self.getPostingList().beginFrozen(idx, dst);
 }
 
@@ -153,6 +154,7 @@ template <typename B, typename M>
 DocumentWeightIterator
 MultiValueStringPostingAttributeT<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx) const
 {
+    assert(idx.valid());
     return self.getPostingList().beginFrozen(idx);
 }
 
@@ -174,7 +176,7 @@ template <typename B, typename T>
 const IDocumentWeightAttribute *
 MultiValueStringPostingAttributeT<B, T>::asDocumentWeightAttribute() const
 {
-    if (this->hasWeightedSetType() && (this->isStringType())) {
+    if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::STRING)) {
         return &_document_weight_attribute_adapter;
     }
     return nullptr;


### PR DESCRIPTION
Reverts vespa-engine/vespa#27645

Broke range search on weightedset fields.
