### PR TITLE
Jonmv/reconfigure dispatch

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatchNodesConfigHolderComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/DispatchNodesConfigHolderComponent.java
@@ -1,0 +1,41 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.search;
+
+import com.yahoo.config.model.producer.TreeConfigProducer;
+import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.search.IndexedSearchCluster;
+
+/**
+ * Hold config for a dispatcher component, used to let the configurer have
+ * all configs and dispatchers injected, and match them.
+ *
+ * @author jonmv
+ */
+public class DispatchNodesConfigHolderComponent extends Component<TreeConfigProducer<?>, ComponentModel> implements
+        DispatchNodesConfig.Producer
+{
+
+    private final IndexedSearchCluster indexedSearchCluster;
+
+    public DispatchNodesConfigHolderComponent(IndexedSearchCluster indexedSearchCluster) {
+        super(toComponentModel(indexedSearchCluster.getClusterName()));
+        this.indexedSearchCluster = indexedSearchCluster;
+    }
+
+    private static ComponentModel toComponentModel(String clusterName) {
+        String dispatcherComponentId = "dispatcher-config." + clusterName; // used by DispatchConfigurer
+        return new ComponentModel(dispatcherComponentId,
+                                  com.yahoo.search.dispatch.DispatchNodesConfigHolder.class.getName(),
+                                  PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
+    }
+
+    @Override
+    public void getConfig(DispatchNodesConfig.Builder builder) {
+        indexedSearchCluster.getConfig(builder);
+    }
+
+}

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ReconfigurableDispatcherComponent.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ReconfigurableDispatcherComponent.java
@@ -1,0 +1,47 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.model.container.search;
+
+import com.yahoo.config.model.producer.TreeConfigProducer;
+import com.yahoo.osgi.provider.model.ComponentModel;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+import com.yahoo.vespa.model.container.PlatformBundles;
+import com.yahoo.vespa.model.container.component.Component;
+import com.yahoo.vespa.model.search.IndexedSearchCluster;
+
+/**
+ * Represents a dispatcher component - an instance of a dispatcher in a search container cluster
+ * knows how to communicate with one indexed search cluster and owns the connections to it.
+ *
+ * @author jonmv
+ */
+public class ReconfigurableDispatcherComponent extends Component<TreeConfigProducer<?>, ComponentModel> implements
+        DispatchConfig.Producer,
+        DispatchNodesConfig.Producer
+{
+
+    private final IndexedSearchCluster indexedSearchCluster;
+
+    public ReconfigurableDispatcherComponent(IndexedSearchCluster indexedSearchCluster) {
+        super(toComponentModel(indexedSearchCluster.getClusterName()));
+        this.indexedSearchCluster = indexedSearchCluster;
+    }
+
+    private static ComponentModel toComponentModel(String clusterName) {
+        String dispatcherComponentId = "dispatcher." + clusterName; // used by ClusterSearcher and DispatchConfigurer
+        return new ComponentModel(dispatcherComponentId,
+                                  com.yahoo.search.dispatch.ReconfigurableDispatcher.class.getName(),
+                                  PlatformBundles.SEARCH_AND_DOCPROC_BUNDLE);
+    }
+
+    @Override
+    public void getConfig(DispatchConfig.Builder builder) {
+        indexedSearchCluster.getConfig(builder);
+    }
+
+    @Override
+    public void getConfig(DispatchNodesConfig.Builder builder) {
+        indexedSearchCluster.getConfig(builder);
+    }
+
+}

--- a/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
+++ b/container-core/src/main/java/com/yahoo/container/handler/ClustersStatus.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * A component which tracks the up/down status of any clusters which should influence
  * the up down status of this container itself, as well as the separate fact (from config)
- * that such clusters are present. This is a separate fact because we might know we have clusters configured
+ * that such clusters are present. This is a separate fact because we might know we have clusters configured,
  * but we don't have positive information that they are up yet, and in this case we should be down.
  *
  * This is a separate component which has <b>no dependencies</b> such that the status tracked in this

--- a/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/BaseNodeMonitor.java
@@ -82,7 +82,7 @@ public abstract class BaseNodeMonitor<T> {
     /** Thread-safely changes the state of this node if required */
     protected abstract void setWorking(boolean working,String explanation);
 
-    /** Returns whether or not this is monitoring an internal node. Default is false. */
+    /** Returns whether this is monitoring an internal node. Default is false. */
     public boolean isInternal() { return internal; }
 
 }

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
@@ -66,7 +66,7 @@ public class ClusterMonitor<T> {
      * </ul>
      *
      * @param node the object representing the node
-     * @param internal whether or not this node is internal to this cluster
+     * @param internal whether this node is internal to this cluster
      */
     public void add(T node, boolean internal) {
         nodeMonitors.put(node, new TrafficNodeMonitor<>(node, configuration, internal));

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
@@ -96,17 +96,11 @@ public class ClusterMonitor<T> {
      * Ping all nodes which needs pinging to discover state changes
      */
     public void ping(Executor executor) {
-        for (Iterator<BaseNodeMonitor<T>> i = nodeMonitorIterator(); i.hasNext() && !closed.get(); ) {
-            BaseNodeMonitor<T> monitor= i.next();
-            nodeManager.ping(this, monitor.getNode(), executor); // Cause call to failed or responded
+        for (var monitor : nodeMonitors()) {
+            if (closed.get()) return; // Do nothing to change state if close has started.
+            nodeManager.ping(this, monitor.getNode(), executor);
         }
-        if (closed.get()) return; // Do nothing to change state if close has started.
         nodeManager.pingIterationCompleted();
-    }
-
-    /** Returns a thread-safe snapshot of the NodeMonitors of all added nodes */
-    public Iterator<BaseNodeMonitor<T>> nodeMonitorIterator() {
-        return nodeMonitors().iterator();
     }
 
     /** Returns a thread-safe snapshot of the NodeMonitors of all added nodes */

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterMonitor.java
@@ -104,6 +104,11 @@ public class ClusterMonitor<T> {
     }
 
     /** Returns a thread-safe snapshot of the NodeMonitors of all added nodes */
+    public Iterator<BaseNodeMonitor<T>> nodeMonitorIterator() {
+        return nodeMonitors().iterator();
+    }
+
+    /** Returns a thread-safe snapshot of the NodeMonitors of all added nodes */
     public List<BaseNodeMonitor<T>> nodeMonitors() {
         return List.copyOf(nodeMonitors.values());
     }
@@ -137,7 +142,7 @@ public class ClusterMonitor<T> {
             // for all pings when there are no problems (important because it ensures that
             // any thread local connections are reused) 2) a new thread will be started to execute
             // new pings when a ping is not responding
-            ExecutorService pingExecutor=Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory("search.ping"));
+            ExecutorService pingExecutor = Executors.newCachedThreadPool(ThreadFactoryFactory.getDaemonThreadFactory("search.ping"));
             while (!closed.get()) {
                 try {
                     log.finest("Activating ping");
@@ -159,7 +164,9 @@ public class ClusterMonitor<T> {
             }
             pingExecutor.shutdown();
             try {
-                pingExecutor.awaitTermination(10, TimeUnit.SECONDS);
+                if ( ! pingExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    log.warning("Timeout waiting for ping executor to terminate");
+                }
             } catch (InterruptedException e) { }
             log.info("Stopped cluster monitor thread " + getName());
         }

--- a/container-search/src/main/java/com/yahoo/search/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/ClusterSearcher.java
@@ -48,7 +48,7 @@ public abstract class ClusterSearcher<T> extends PingableSearcher implements Nod
      *
      * @param id the id of this searcher
      * @param connections the connections of the cluster
-     * @param internal whether or not this cluster is internal (part of the same installation)
+     * @param internal whether this cluster is internal (part of the same installation)
      */
     public ClusterSearcher(ComponentId id, List<T> connections, boolean internal) {
         this(id, connections, new Hasher<>(), internal);

--- a/container-search/src/main/java/com/yahoo/search/cluster/MonitorConfiguration.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/MonitorConfiguration.java
@@ -22,7 +22,7 @@ public class MonitorConfiguration  {
 
     /**
      * Returns the number of milliseconds to attempt to service a request
-     * (at different nodes) before giving up. Default is 5000 ms.
+     * (at different nodes) before giving up. See {@link #requestTimeout}.
      */
     public long getRequestTimeout() { return requestTimeout; }
 

--- a/container-search/src/main/java/com/yahoo/search/cluster/TrafficNodeMonitor.java
+++ b/container-search/src/main/java/com/yahoo/search/cluster/TrafficNodeMonitor.java
@@ -23,7 +23,7 @@ public class TrafficNodeMonitor<T> extends BaseNodeMonitor<T> {
         this.configuration = configuration;
     }
 
-    /** Whether or not this has ever responded successfully */
+    /** Whether this has ever responded successfully */
     private boolean atStartUp = true;
 
     public T getNode() { return node; }
@@ -55,7 +55,7 @@ public class TrafficNodeMonitor<T> extends BaseNodeMonitor<T> {
         respondedAt = now();
         succeededAt = respondedAt;
 
-        setWorking(true,"Responds correctly");
+        setWorking(true, "Responds correctly");
     }
 
     /**

--- a/container-search/src/main/java/com/yahoo/search/dispatch/CloseableInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CloseableInvoker.java
@@ -21,8 +21,11 @@ public abstract class CloseableInvoker implements Closeable {
     private RequestDuration duration;
 
     public void teardown(BiConsumer<Boolean, RequestDuration> teardown) {
-        this.teardown = teardown;
-        this.duration = new RequestDuration();
+        this.teardown = this.teardown == null ? teardown : (success, duration) -> {
+            this.teardown.accept(success, duration);
+            teardown.accept(success, duration);
+        };
+        this.duration = this.duration == null ? new RequestDuration() : this.duration;
     }
 
     protected void setFinalStatus(boolean success) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/CloseableInvoker.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/CloseableInvoker.java
@@ -2,7 +2,6 @@
 package com.yahoo.search.dispatch;
 
 import java.io.Closeable;
-import java.time.Duration;
 import java.util.function.BiConsumer;
 
 /**
@@ -21,10 +20,7 @@ public abstract class CloseableInvoker implements Closeable {
     private RequestDuration duration;
 
     public void teardown(BiConsumer<Boolean, RequestDuration> teardown) {
-        this.teardown = this.teardown == null ? teardown : (success, duration) -> {
-            this.teardown.accept(success, duration);
-            teardown.accept(success, duration);
-        };
+        this.teardown = this.teardown == null ? teardown : this.teardown.andThen(teardown);
         this.duration = this.duration == null ? new RequestDuration() : this.duration;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/DispatchConfigurer.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/DispatchConfigurer.java
@@ -1,0 +1,29 @@
+package com.yahoo.search.dispatch;
+
+import com.yahoo.component.AbstractComponent;
+import com.yahoo.component.ComponentId;
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.component.provider.ComponentRegistry;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+public class DispatchConfigurer extends AbstractComponent {
+
+    Map<ComponentId, DispatchNodesConfig> configById = new HashMap<>();
+
+    @Inject
+    public DispatchConfigurer(ComponentRegistry<Dispatcher> dispatchers, ComponentRegistry<DispatchNodesConfigHolder> configs) {
+        Map<ComponentId, DispatchNodesConfig> configById = configs.allComponentsById().entrySet().stream()
+                                                             .collect(toMap(entry -> new ComponentId(entry.getKey().getName().replace("-config", "")),
+                                                                            entry -> entry.getValue().config()));
+        // Throw out all unchanged config, then update dispatchers and out reference map with the updated entries.
+        configById.keySet().removeIf(id -> configById.get(id).equals(this.configById.get(id)));
+        configById.forEach((id, config) -> dispatchers.getComponent(id).updateWithNewConfig(config));
+        this.configById.putAll(configById);
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/DispatchNodesConfigHolder.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/DispatchNodesConfigHolder.java
@@ -1,0 +1,22 @@
+package com.yahoo.search.dispatch;
+
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+
+/**
+ * @author jonmv
+ */
+public class DispatchNodesConfigHolder {
+
+    private final DispatchNodesConfig config;
+
+    @Inject
+    public DispatchNodesConfigHolder(DispatchNodesConfig config) {
+        this.config = config;
+    }
+
+    public DispatchNodesConfig config() {
+        return config;
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -203,10 +203,9 @@ public class Dispatcher extends AbstractComponent {
     }
 
     private VolatileItems update(ClusterMonitor<Node> clusterMonitor) {
-        var items = new VolatileItems(new LoadBalancer(searchCluster.groupList().groups(), toLoadBalancerPolicy(dispatchConfig.distributionPolicy())),
-                                      invokerFactories.create(rpcResourcePool, searchCluster.groupList(), dispatchConfig),
-                                      clusterMonitor);
-        return items;
+        return new VolatileItems(new LoadBalancer(searchCluster.groupList().groups(), toLoadBalancerPolicy(dispatchConfig.distributionPolicy())),
+                                 invokerFactories.create(rpcResourcePool, searchCluster.groupList(), dispatchConfig),
+                                 clusterMonitor);
     }
 
     private void initialWarmup(double warmupTime) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -107,7 +107,7 @@ public class Dispatcher extends AbstractComponent {
 
     public static QueryProfileType getArgumentType() { return argumentType; }
 
-    private interface InvokerFactoryFactory {
+    interface InvokerFactoryFactory {
         InvokerFactory create(RpcConnectionPool rpcConnectionPool, SearchGroups searchGroups, DispatchConfig dispatchConfig);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/Dispatcher.java
@@ -108,7 +108,7 @@ public class Dispatcher extends AbstractComponent {
                                       (invokerFactory == null)
                                              ? new RpcInvokerFactory(rpcResourcePool, searchCluster.groupList(), dispatchConfig)
                                              : invokerFactory);
-        searchCluster.addMonitoring(clusterMonitor);
+        searchCluster.addMonitoring(clusterMonitor); // TODO: Update, rather than add ... as this creates a pinger for each node
         return items;
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/ReconfigurableDispatcher.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/ReconfigurableDispatcher.java
@@ -1,0 +1,16 @@
+package com.yahoo.search.dispatch;
+
+import com.yahoo.component.ComponentId;
+import com.yahoo.component.annotation.Inject;
+import com.yahoo.container.handler.VipStatus;
+import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+
+public class ReconfigurableDispatcher extends Dispatcher {
+
+    @Inject
+    public ReconfigurableDispatcher(ComponentId clusterId, DispatchConfig dispatchConfig, VipStatus vipStatus) {
+        super(clusterId, dispatchConfig, new DispatchNodesConfig.Builder().build(), vipStatus);
+    }
+
+}

--- a/container-search/src/main/java/com/yahoo/search/dispatch/RequestDuration.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/RequestDuration.java
@@ -5,7 +5,7 @@ import java.time.Duration;
 import java.time.Instant;
 
 /**
- * Contains start and and time. Exposes a duration, and lets you measure the time difference between 2 requests.
+ * Contains start and end time. Exposes a duration, and lets you measure the time difference between 2 requests.
  * It does use System.nanoTime to get a steady clock.
  *
  * @author baldersheim

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/Client.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/Client.java
@@ -12,7 +12,7 @@ import java.util.Optional;
  *
  * @author bratseth
  */
-interface Client {
+public interface Client {
 
     /** Creates a connection to a particular node in this */
     NodeConnection createConnection(String hostname, int port);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcConnectionPool.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcConnectionPool.java
@@ -1,11 +1,27 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.rpc;
 
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
+
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Interface for getting a connection given a node id.
  *
  * @author balderersheim
  */
-public interface RpcConnectionPool {
+public interface RpcConnectionPool extends AutoCloseable {
+
+    /** Returns a connection to the given node id. */
     Client.NodeConnection getConnection(int nodeId);
+
+
+    /** Will return a list of items that need a delayed close when updating node set. */
+    default Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) { return List.of(); }
+
+    /** Shuts down all connections in the pool, and the underlying RPC client. */
+    @Override
+    void close();
+
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcInvokerFactory.java
@@ -33,7 +33,7 @@ public class RpcInvokerFactory extends InvokerFactory {
         super(cluster, dispatchConfig);
         this.rpcResourcePool = rpcResourcePool;
         this.compressor = new CompressService();
-        decodeType = convert(dispatchConfig.summaryDecodePolicy());
+        this.decodeType = convert(dispatchConfig.summaryDecodePolicy());
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcPing.java
@@ -37,7 +37,7 @@ public class RpcPing implements Pinger, Client.ResponseReceiver {
         this.clusterMonitor = clusterMonitor;
         this.pingSequenceId = node.createPingSequenceId();
         this.pongHandler = pongHandler;
-        this. compressor = compressor;
+        this.compressor = compressor;
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
@@ -11,7 +11,6 @@ import com.yahoo.vespa.config.search.DispatchNodesConfig.Node;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -22,7 +21,7 @@ import java.util.concurrent.ThreadLocalRandom;
  *
  * @author ollivir
  */
-public class RpcResourcePool implements RpcConnectionPool, AutoCloseable {
+public class RpcResourcePool implements RpcConnectionPool {
 
     /** Connections to the search nodes this talks to, indexed by node id ("partid") */
     private volatile Map<Integer, NodeConnectionPool> nodeConnectionPools = Map.of();
@@ -45,7 +44,7 @@ public class RpcResourcePool implements RpcConnectionPool, AutoCloseable {
         });
     }
 
-    /** Will return a list of items that need a delayed close. */
+    @Override
     public Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) {
         Map<Integer, NodeConnectionPool> currentPools = new HashMap<>(nodeConnectionPools);
         Map<Integer, NodeConnectionPool> nextPools = new HashMap<>();

--- a/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/rpc/RpcResourcePool.java
@@ -3,12 +3,15 @@ package com.yahoo.search.dispatch.rpc;
 
 import com.yahoo.search.dispatch.FillInvoker;
 import com.yahoo.search.dispatch.rpc.Client.NodeConnection;
+import com.yahoo.search.dispatch.rpc.RpcClient.RpcNodeConnection;
 import com.yahoo.vespa.config.search.DispatchConfig;
 import com.yahoo.vespa.config.search.DispatchNodesConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig.Node;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -35,46 +38,35 @@ public class RpcResourcePool implements RpcConnectionPool, AutoCloseable {
     }
 
     public RpcResourcePool(DispatchConfig dispatchConfig, DispatchNodesConfig nodesConfig) {
-        super();
         rpcClient = new RpcClient("dispatch-client", dispatchConfig.numJrtTransportThreads());
         numConnections = dispatchConfig.numJrtConnectionsPerNode();
-        updateNodes(nodesConfig).forEach(item -> {
-            try {
-                item.close();
-            } catch (Exception e) {}
+        updateNodes(nodesConfig).forEach(pool -> {
+            try { pool.close(); } catch (Exception ignored) { } // Shouldn't throw.
         });
     }
 
-    /** Will return a list of items that need a delayed close */
-    public Collection<AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) {
-        List<AutoCloseable> toClose = new ArrayList<>();
-        var builder = new HashMap<Integer, NodeConnectionPool>();
+    /** Will return a list of items that need a delayed close. */
+    public Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig nodesConfig) {
+        Map<Integer, NodeConnectionPool> currentPools = new HashMap<>(nodeConnectionPools);
+        Map<Integer, NodeConnectionPool> nextPools = new HashMap<>();
         // Who can be reused
-        for (var node : nodesConfig.node()) {
-            var prev = nodeConnectionPools.get(node.key());
-            NodeConnection nc = prev != null ? prev.nextConnection() : null;
-            if (nc instanceof RpcClient.RpcNodeConnection rpcNodeConnection
-                    && rpcNodeConnection.getPort() == node.port()
-                    && rpcNodeConnection.getHostname().equals(node.host()))
+        for (Node node : nodesConfig.node()) {
+            if (   currentPools.containsKey(node.key())
+                && currentPools.get(node.key()).nextConnection() instanceof RpcNodeConnection rpcNodeConnection
+                && rpcNodeConnection.getPort() == node.port()
+                && rpcNodeConnection.getHostname().equals(node.host()))
             {
-                builder.put(node.key(), prev);
+                nextPools.put(node.key(), currentPools.remove(node.key()));
             } else {
-                var connections = new ArrayList<NodeConnection>(numConnections);
+                ArrayList<NodeConnection> connections = new ArrayList<>(numConnections);
                 for (int i = 0; i < numConnections; i++) {
                     connections.add(rpcClient.createConnection(node.host(), node.port()));
                 }
-                builder.put(node.key(), new NodeConnectionPool(connections));
+                nextPools.put(node.key(), new NodeConnectionPool(connections));
             }
         }
-        // Who are not needed any more
-        nodeConnectionPools.forEach((key, pool) -> {
-            var survivor = builder.get(key);
-            if (survivor == null || pool != survivor) {
-                toClose.add(pool);
-            }
-        });
-        this.nodeConnectionPools = Map.copyOf(builder);
-        return toClose;
+        this.nodeConnectionPools = Map.copyOf(nextPools);
+        return currentPools.values();
     }
 
     @Override

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch.searchcluster;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -51,7 +52,7 @@ public class Group {
 
     /**
      * Returns whether this group has sufficient active documents
-     * (compared to other groups) that is should receive traffic
+     * (compared to other groups) that should receive traffic
      */
     public boolean hasSufficientCoverage() {
         return hasSufficientCoverage;
@@ -66,14 +67,16 @@ public class Group {
     }
 
     public void aggregateNodeValues() {
-        long activeDocs = nodes.stream().filter(node -> node.isWorking() == Boolean.TRUE).mapToLong(Node::getActiveDocuments).sum();
+        List<Node> workingNodes = new ArrayList<>(nodes);
+        workingNodes.removeIf(node -> node.isWorking() != Boolean.TRUE);
+        long activeDocs = workingNodes.stream().mapToLong(Node::getActiveDocuments).sum();
         activeDocuments = activeDocs;
-        targetActiveDocuments = nodes.stream().filter(node -> node.isWorking() == Boolean.TRUE).mapToLong(Node::getTargetActiveDocuments).sum();
+        targetActiveDocuments = workingNodes.stream().mapToLong(Node::getTargetActiveDocuments).sum();
         isBlockingWrites = nodes.stream().anyMatch(Node::isBlockingWrites);
-        int numWorkingNodes = workingNodes();
+        int numWorkingNodes = workingNodes.size();
         if (numWorkingNodes > 0) {
             long average = activeDocs / numWorkingNodes;
-            long skew = nodes.stream().filter(node -> node.isWorking() == Boolean.TRUE).mapToLong(node -> Math.abs(node.getActiveDocuments() - average)).sum();
+            long skew = workingNodes.stream().mapToLong(node -> Math.abs(node.getActiveDocuments() - average)).sum();
             boolean balanced = skew <= activeDocs * maxContentSkew;
             if (balanced != isBalanced) {
                 if (!isSparse())

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -9,12 +9,14 @@ import com.yahoo.search.cluster.NodeManager;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.groupingBy;
 
 /**
  * A model of a search cluster we might want to dispatch queries to.
@@ -28,7 +30,7 @@ public class SearchCluster implements NodeManager<Node> {
     private final String clusterId;
     private final VipStatus vipStatus;
     private final PingFactory pingFactory;
-    private final SearchGroupsImpl groups;
+    private volatile SearchGroupsImpl groups;
     private volatile long nextLogTime = 0;
 
     /**
@@ -45,6 +47,7 @@ public class SearchCluster implements NodeManager<Node> {
                          VipStatus vipStatus, PingFactory pingFactory) {
         this(clusterId, toGroups(nodes, minActivedocsPercentage), vipStatus, pingFactory);
     }
+
     public SearchCluster(String clusterId, SearchGroupsImpl groups, VipStatus vipStatus, PingFactory pingFactory) {
         this.clusterId = clusterId;
         this.vipStatus = vipStatus;
@@ -55,13 +58,18 @@ public class SearchCluster implements NodeManager<Node> {
 
     @Override
     public String name() { return clusterId; }
-    public VipStatus getVipStatus() { return vipStatus; }
+
+    public void updateNodes(Collection<Node> newNodes, double minActivedocsPercentage) {
+        Collection<Node> retainedNodes = groups.nodes();
+        Collection<Node> currentNodes = new HashSet<>(newNodes);
+        retainedNodes.retainAll(currentNodes);
+        currentNodes.removeIf(retainedNodes::contains);
+        currentNodes.addAll(retainedNodes);
+        groups = toGroups(currentNodes, minActivedocsPercentage);
+    }
 
     public void addMonitoring(ClusterMonitor<Node> clusterMonitor) {
-        for (var group : groups()) {
-            for (var node : group.nodes())
-                clusterMonitor.add(node, true);
-        }
+        for (Node node : groups.nodes()) clusterMonitor.add(node, true);
     }
 
     private static Node findLocalCorpusDispatchTarget(String selfHostname, SearchGroups groups) {
@@ -86,14 +94,14 @@ public class SearchCluster implements NodeManager<Node> {
 
     private static SearchGroupsImpl toGroups(Collection<Node> nodes, double minActivedocsPercentage) {
         Map<Integer, Group> groups = new HashMap<>();
-        for (Map.Entry<Integer, List<Node>> group : nodes.stream().collect(Collectors.groupingBy(Node::group)).entrySet()) {
-            Group g = new Group(group.getKey(), group.getValue());
-            groups.put(group.getKey(), g);
-        }
+        nodes.stream().collect(groupingBy(Node::group)).forEach((groupId, groupNodes) -> {
+            groups.put(groupId, new Group(groupId, groupNodes));
+        });
         return new SearchGroupsImpl(Map.copyOf(groups), minActivedocsPercentage);
     }
 
     public SearchGroups groupList() { return groups; }
+
     public Group group(int id) { return groups.get(id); }
 
     private Collection<Group> groups() { return groups.groups(); }
@@ -107,14 +115,14 @@ public class SearchCluster implements NodeManager<Node> {
      * or empty if we should not dispatch directly.
      */
     public Optional<Node> localCorpusDispatchTarget() {
-        if ( localCorpusDispatchTarget == null) return Optional.empty();
+        if (localCorpusDispatchTarget == null) return Optional.empty();
 
         // Only use direct dispatch if the local group has sufficient coverage
         Group localSearchGroup = groups.get(localCorpusDispatchTarget.group());
         if ( ! localSearchGroup.hasSufficientCoverage()) return Optional.empty();
 
         // Only use direct dispatch if the local search node is not down
-        if ( localCorpusDispatchTarget.isWorking() == Boolean.FALSE) return Optional.empty();
+        if (localCorpusDispatchTarget.isWorking() == Boolean.FALSE) return Optional.empty();
 
         return Optional.of(localCorpusDispatchTarget);
     }
@@ -176,7 +184,7 @@ public class SearchCluster implements NodeManager<Node> {
         return groups().stream().allMatch(group -> group.nodes().stream().allMatch(node -> node.isWorking() != null));
     }
 
-    public long nonWorkingNodeCount() {
+    long nonWorkingNodeCount() {
         return groups().stream().flatMap(group -> group.nodes().stream()).filter(node -> node.isWorking() == Boolean.FALSE).count();
     }
 
@@ -194,7 +202,7 @@ public class SearchCluster implements NodeManager<Node> {
 
     /** Used by the cluster monitor to manage node status */
     @Override
-    public void ping(ClusterMonitor clusterMonitor, Node node, Executor executor) {
+    public void ping(ClusterMonitor<Node> clusterMonitor, Node node, Executor executor) {
         Pinger pinger = pingFactory.createPinger(node, clusterMonitor, new PongCallback(node, clusterMonitor));
         pinger.ping();
     }
@@ -233,13 +241,9 @@ public class SearchCluster implements NodeManager<Node> {
         }
     }
 
-
-
     /**
      * Calculate whether a subset of nodes in a group has enough coverage
      */
-
-
     private void trackGroupCoverageChanges(Group group, boolean fullCoverage, long medianDocuments) {
         if ( ! hasInformationAboutAllNodes()) return; // Be silent until we know what we are talking about.
         boolean changed = group.fullCoverageStatusChanged(fullCoverage);

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchCluster.java
@@ -59,12 +59,13 @@ public class SearchCluster implements NodeManager<Node> {
     @Override
     public String name() { return clusterId; }
 
+    /** Sets the new nodes to monitor to be the new nodes, but keep any existing node instances which equal the new ones. */
     public void updateNodes(Collection<Node> newNodes, double minActivedocsPercentage) {
         Collection<Node> retainedNodes = groups.nodes();
         Collection<Node> currentNodes = new HashSet<>(newNodes);
-        retainedNodes.retainAll(currentNodes);
-        currentNodes.removeIf(retainedNodes::contains);
-        currentNodes.addAll(retainedNodes);
+        retainedNodes.retainAll(currentNodes);          // Throw away all old nodes which are not in the new set.
+        currentNodes.removeIf(retainedNodes::contains); // Throw away all new nodes for which we have more information in an old object.
+        currentNodes.addAll(retainedNodes);             // Keep the old nodes that were replaced in the new set.
         groups = toGroups(currentNodes, minActivedocsPercentage);
     }
 

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
@@ -3,6 +3,8 @@ package com.yahoo.search.dispatch.searchcluster;
 import java.util.Collection;
 import java.util.Set;
 
+import static java.util.stream.Collectors.toSet;
+
 /**
  * Simple interface for groups and their nodes in the content cluster
  * @author baldersheim
@@ -14,6 +16,7 @@ public interface SearchGroups {
     default boolean isEmpty() {
         return size() == 0;
     }
+    default Set<Node> nodes() { return groups().stream().flatMap(group -> group.nodes().stream()).collect(toSet());}
     int size();
     boolean isPartialGroupCoverageSufficient(Collection<Node> nodes);
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
@@ -1,8 +1,14 @@
 package com.yahoo.search.dispatch.searchcluster;
 
+import com.yahoo.stream.CustomCollectors;
+
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static java.util.Comparator.comparingInt;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -16,7 +22,11 @@ public interface SearchGroups {
     default boolean isEmpty() {
         return size() == 0;
     }
-    default Set<Node> nodes() { return groups().stream().flatMap(group -> group.nodes().stream()).collect(toSet());}
+    default Set<Node> nodes() {
+        return groups().stream().flatMap(group -> group.nodes().stream())
+                       .sorted(comparingInt(Node::key))
+                       .collect(toCollection(LinkedHashSet::new));
+    }
     int size();
     boolean isPartialGroupCoverageSufficient(Collection<Node> nodes);
 }

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroupsImpl.java
@@ -3,10 +3,8 @@ package com.yahoo.search.dispatch.searchcluster;
 import com.google.common.math.Quantiles;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class SearchGroupsImpl implements SearchGroups {
 
@@ -42,4 +40,5 @@ public class SearchGroupsImpl implements SearchGroups {
         double[] activeDocuments = groups().stream().mapToDouble(Group::activeDocuments).toArray();
         return (long) Quantiles.median().computeInPlace(activeDocuments);
     }
+
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/DispatcherTest.java
@@ -1,27 +1,51 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.search.dispatch;
 
+import com.yahoo.compress.CompressionType;
+import com.yahoo.prelude.Pong;
 import com.yahoo.prelude.fastsearch.VespaBackEndSearcher;
 import com.yahoo.search.Query;
 import com.yahoo.search.Result;
 import com.yahoo.search.cluster.ClusterMonitor;
+import com.yahoo.search.dispatch.Dispatcher.InvokerFactoryFactory;
+import com.yahoo.search.dispatch.rpc.Client.NodeConnection;
+import com.yahoo.search.dispatch.rpc.Client.ResponseReceiver;
+import com.yahoo.search.dispatch.rpc.RpcConnectionPool;
 import com.yahoo.search.dispatch.searchcluster.MockSearchCluster;
-import com.yahoo.search.dispatch.searchcluster.SearchGroups;
 import com.yahoo.search.dispatch.searchcluster.Node;
 import com.yahoo.search.dispatch.searchcluster.PingFactory;
 import com.yahoo.search.dispatch.searchcluster.Pinger;
 import com.yahoo.search.dispatch.searchcluster.PongHandler;
 import com.yahoo.search.dispatch.searchcluster.SearchCluster;
+import com.yahoo.search.dispatch.searchcluster.SearchGroups;
+import com.yahoo.search.searchchain.Execution;
 import com.yahoo.vespa.config.search.DispatchConfig;
+import com.yahoo.vespa.config.search.DispatchNodesConfig;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.yahoo.search.dispatch.searchcluster.MockSearchCluster.createDispatchConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -146,6 +170,172 @@ public class DispatcherTest {
         assertEquals(0,
                 (dispatcher.getSearchInvoker(new Query(), null).distributionKey().get()).longValue(),
                 "Blocking group is used when there is no alternative");
+        dispatcher.deconstruct();
+    }
+
+    @Test
+    void testRpcResourceShutdownOnReconfiguration() throws InterruptedException, ExecutionException, IOException {
+        // Ping factory lets us tick each ping, so we may delay shutdown, due to monitor thread RPC usage.
+        Map<Integer, Phaser> pingPhasers = new ConcurrentHashMap<>();
+        pingPhasers.put(0, new Phaser(2));
+        pingPhasers.put(1, new Phaser(2));
+        pingPhasers.put(2, new Phaser(2));
+
+        PingFactory pingFactory = (node, monitor, pongHandler) -> () -> {
+            pingPhasers.get(node.key()).arriveAndAwaitAdvance();
+            pongHandler.handle(new Pong(2, 2));
+            pingPhasers.get(node.key()).arriveAndAwaitAdvance();
+        };
+
+        // Search cluster uses the ping factory, and zero nodes initially, later configured with two nodes.
+        SearchCluster cluster = new MockSearchCluster("cid", 0, 1, pingFactory);
+
+        // Dummy RPC layer where we manually tick responses for each node.
+        // When a response is let go, we verify the RPC resource is not yet closed.
+        // This is signalled by terminating its phaser, which is done by the dispatcher in delayed cleanup.
+        // We verify in the end that all connections have been shut down, prior to shutting down the RPC pool proper.
+        Map<Integer, Boolean > rpcResources = new HashMap<>();
+        AtomicLong cleanupThreadId = new AtomicLong();
+        AtomicInteger nodeIdOfSearcher0 = new AtomicInteger(-1);
+        RpcConnectionPool rpcPool = new RpcConnectionPool() {
+            // Returns a connection that lets us advance the searcher when we want to, as well as tracking which threads do what.
+            @Override public NodeConnection getConnection(int nodeId) {
+                nodeIdOfSearcher0.set(nodeId);
+                return new NodeConnection() {
+                    @Override public void request(String rpcMethod, CompressionType compression, int uncompressedLength, byte[] compressedPayload, ResponseReceiver responseReceiver, double timeoutSeconds) {
+                        assertTrue(rpcResources.get(nodeId));
+                    }
+                    @Override public void close() {
+                        assertFalse(rpcResources.remove(nodeId));
+                    }
+                };
+            }
+            // Verifies cleanup is done by the expected thread, by ID, and cleans up the "RPC connection" (phaser).
+            @Override public Collection<? extends AutoCloseable> updateNodes(DispatchNodesConfig config) {
+                for (DispatchNodesConfig.Node node : config.node())
+                    rpcResources.putIfAbsent(node.key(), true);
+                return rpcResources.keySet().stream()
+                                   .filter(key -> config.node().stream().noneMatch(node -> node.key() == key))
+                                   .map(key -> (AutoCloseable) () -> {
+                                       assertTrue(rpcResources.put(key, false));
+                                       cleanupThreadId.set(Thread.currentThread().getId());
+                                       getConnection(key).close();
+                                   })
+                                   .toList();
+            };
+            // In the end, we have reconfigured down to 0 nodes, and no resources should be left running after cleanup.
+            @Override public void close() {
+                assertEquals(Map.of(), rpcResources);
+            }
+        };
+
+        // This factory just forwards search to the dummy RPC layer above, nothing more.
+        InvokerFactoryFactory invokerFactories = (rpcConnectionPool, searchGroups, dispatchConfig) -> new InvokerFactory(searchGroups, dispatchConfig) {
+            @Override protected Optional<SearchInvoker> createNodeSearchInvoker(VespaBackEndSearcher searcher, Query query, int maxHits, Node node) {
+                return Optional.of(new SearchInvoker(Optional.of(node)) {
+                    @Override protected Object sendSearchRequest(Query query, Object context) {
+                        rpcPool.getConnection(node.key()).request(null, null, 0, null, null, 0);
+                        return null;
+                    };
+                    @Override protected InvokerResult getSearchResult(Execution execution) {
+                        return new InvokerResult(new Result(new Query()));
+                    }
+                    @Override protected void release() { }
+                });
+            };
+            @Override public FillInvoker createFillInvoker(VespaBackEndSearcher searcher, Result result) {
+                return new FillInvoker() {
+                    @Override protected void getFillResults(Result result, String summaryClass) { fail(); }
+                    @Override protected void sendFillRequest(Result result, String summaryClass) { fail(); }
+                    @Override protected void release() { fail(); }
+                };
+            }
+        };
+
+        Dispatcher dispatcher = new Dispatcher(dispatchConfig, rpcPool, cluster, invokerFactories);
+        ExecutorService executor = Executors.newFixedThreadPool(1);
+
+        // Set two groups with a single node each. The first cluster-monitor has nothing to do, and is shut down immediately.
+        // There are also no invokers, so the whole reconfiguration completes once the new cluster monitor has seen all nodes.
+        Future<?> reconfiguration = executor.submit(() -> {
+            dispatcher.updateWithNewConfig(new DispatchNodesConfig.Builder()
+                                                   .node(new DispatchNodesConfig.Node.Builder().key(0).group(0).port(123).host("host0"))
+                                                   .node(new DispatchNodesConfig.Node.Builder().key(1).group(1).port(123).host("host1"))
+                                                   .build());
+        });
+
+        // Let pings return, to allow the search cluster to reconfigure.
+        pingPhasers.get(0).arriveAndAwaitAdvance();
+        pingPhasers.get(0).arriveAndAwaitAdvance();
+        pingPhasers.get(1).arriveAndAwaitAdvance();
+        pingPhasers.get(1).arriveAndAwaitAdvance();
+        // We need to wait for the cluster to have at least one group, lest dispatch will fail below.
+        reconfiguration.get();
+        assertNotEquals(cleanupThreadId.get(), Thread.currentThread().getId());
+        assertEquals(1, cluster.group(0).workingNodes());
+        assertEquals(1, cluster.group(1).workingNodes());
+
+        Node node0 = cluster.group(0).nodes().get(0); // Node0 will be replaced.
+        Node node1 = cluster.group(1).nodes().get(0); // Node1 will be retained.
+
+        // Start some searches, one against each group, since we have a round-robin policy.
+        SearchInvoker search0 = dispatcher.getSearchInvoker(new Query(), null);
+        search0.search(new Query(), null);
+        // Unknown whether the first or second search hits node0, so we must track that.
+        int offset = nodeIdOfSearcher0.get();
+        SearchInvoker search1 = dispatcher.getSearchInvoker(new Query(), null);
+        search1.search(new Query(), null);
+
+        // Wait for the current cluster monitor to be mid-ping-round.
+        pingPhasers.get(0).arriveAndAwaitAdvance();
+
+        // Then reconfigure the dispatcher with new nodes, replacing node0 with node2.
+        reconfiguration = executor.submit(() -> {
+            dispatcher.updateWithNewConfig(new DispatchNodesConfig.Builder()
+                                                   .node(new DispatchNodesConfig.Node.Builder().key(2).group(0).port(123).host("host2"))
+                                                   .node(new DispatchNodesConfig.Node.Builder().key(1).group(1).port(123).host("host1"))
+                                                   .build());
+        });
+        // Reconfiguration starts, but groups are only updated once the search cluster has knowledge about all of them.
+        pingPhasers.get(1).arriveAndAwaitAdvance();
+        pingPhasers.get(1).arriveAndAwaitAdvance();
+        pingPhasers.get(2).arriveAndAwaitAdvance();
+        // Cluster has not yet updated its group reference.
+        assertEquals(1, cluster.group(0).workingNodes()); // Node0 is still working.
+        assertSame(node0, cluster.group(0).nodes().get(0));
+        pingPhasers.get(2).arriveAndAwaitAdvance();
+
+        // Old cluster monitor is waiting for that ping to complete before it can shut down, and let reconfiguration complete.
+        pingPhasers.get(0).arriveAndAwaitAdvance();
+        reconfiguration.get();
+        Node node2 = cluster.group(0).nodes().get(0);
+        assertNotSame(node0, node2);
+        assertSame(node1, cluster.group(1).nodes().get(0));
+
+        // Next search should hit group0 again, this time on node2.
+        SearchInvoker search2 = dispatcher.getSearchInvoker(new Query(), null);
+        search2.search(new Query(), null);
+
+        // Searches against nodes 1 and 2 complete.
+        (offset == 0 ? search0 : search1).close();
+        search2.close();
+
+        // We're still waiting for search against node0 to complete, before we can shut down its RPC connection.
+        assertEquals(Set.of(0, 1, 2), rpcResources.keySet());
+        (offset == 0 ? search1 : search0).close();
+        // Thread for search 0 should have closed the RPC pool now.
+        assertEquals(Set.of(1, 2), rpcResources.keySet());
+        assertEquals(cleanupThreadId.get(), Thread.currentThread().getId());
+
+        // Finally, reconfigure down to 0 nodes.
+        reconfiguration = executor.submit(() -> {
+            cleanupThreadId.set(Thread.currentThread().getId());
+            dispatcher.updateWithNewConfig(new DispatchNodesConfig.Builder().build());
+        });
+        pingPhasers.get(1).forceTermination();
+        pingPhasers.get(2).forceTermination();
+        reconfiguration.get();
+        assertNotEquals(cleanupThreadId.get(), Thread.currentThread().getId());
         dispatcher.deconstruct();
     }
 

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/MockSearchCluster.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/MockSearchCluster.java
@@ -15,7 +15,11 @@ import java.util.Map;
 public class MockSearchCluster extends SearchCluster {
 
     public MockSearchCluster(String clusterId, int groups, int nodesPerGroup) {
-        super(clusterId, buildGroupListForTest(groups, nodesPerGroup, 88.0), null, null);
+        this(clusterId, groups, nodesPerGroup, null);
+    }
+
+    public MockSearchCluster(String clusterId, int groups, int nodesPerGroup, PingFactory pingFactory) {
+        super(clusterId, buildGroupListForTest(groups, nodesPerGroup, 88.0), null, pingFactory);
     }
 
     @Override

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
@@ -13,11 +13,18 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -374,6 +381,39 @@ public class SearchClusterTest {
         group.nodes().get(1).setActiveDocuments(819);
         group.aggregateNodeValues();
         assertTrue(group.isBalanced());
+    }
+
+    @Test
+    void requireThatPreciselyTheRetainedNodesAreKeptWhenNodesAreUpdated() {
+        try (State state = new State("query", 2, IntStream.range(0, 6).mapToObj(i -> "node-" + i).toList())) {
+            List<Node> referenceNodes = List.of(new Node(0, "node-0", 0),
+                                                new Node(1, "node-1", 0),
+                                                new Node(0, "node-2", 1),
+                                                new Node(1, "node-3", 1),
+                                                new Node(0, "node-4", 2),
+                                                new Node(1, "node-5", 2));
+            SearchGroups oldGroups = state.searchCluster.groupList();
+            assertEquals(Set.copyOf(referenceNodes), oldGroups.nodes());
+
+            List<Node> updatedNodes = List.of(new Node(0, "node-1", 0),  // Swap node-0 and node-1
+                                              new Node(1, "node-0", 0),  // Swap node-1 and node-0
+                                              new Node(0, "node-4", 1),  // Swap node-2 and node-4
+                                              new Node(1, "node-3", 1),
+                                              new Node(0, "node-2", 2),  // Swap node-4 and node-2
+                                              new Node(1, "node-6", 2)); // Replace node-6
+            state.searchCluster.updateNodes(updatedNodes, 100.0);
+            SearchGroups newGroups = state.searchCluster.groupList();
+            assertEquals(Set.copyOf(updatedNodes), newGroups.nodes());
+
+            Map<Node, Node> oldNodesByIdentity = newGroups.nodes().stream().collect(toMap(identity(), identity()));
+            Map<Node, Node> newNodesByIdentity = newGroups.nodes().stream().collect(toMap(identity(), identity()));
+            assertSame(updatedNodes.get(0), newNodesByIdentity.get(updatedNodes.get(0)));
+            assertSame(updatedNodes.get(1), newNodesByIdentity.get(updatedNodes.get(1)));
+            assertSame(updatedNodes.get(2), newNodesByIdentity.get(updatedNodes.get(2)));
+            assertSame(oldNodesByIdentity.get(referenceNodes.get(3)), newNodesByIdentity.get(updatedNodes.get(3)));
+            assertSame(updatedNodes.get(4), newNodesByIdentity.get(updatedNodes.get(4)));
+            assertSame(updatedNodes.get(5), newNodesByIdentity.get(updatedNodes.get(5)));
+        }
     }
 
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
@@ -31,7 +31,7 @@ public class SearchClusterTest {
         final int nodesPerGroup;
         final VipStatus vipStatus;
         final SearchCluster searchCluster;
-        final ClusterMonitor clusterMonitor;
+        final ClusterMonitor<Node> clusterMonitor;
         final List<AtomicInteger> numDocsPerNode;
         List<AtomicInteger> pingCounts;
 
@@ -57,7 +57,7 @@ public class SearchClusterTest {
             }
             searchCluster = new SearchCluster(clusterId, 100.0, nodes,
                                               vipStatus, new Factory(nodesPerGroup, numDocsPerNode, pingCounts));
-            clusterMonitor = new ClusterMonitor(searchCluster, false);
+            clusterMonitor = new ClusterMonitor<>(searchCluster, false);
             searchCluster.addMonitoring(clusterMonitor);
         }
 


### PR DESCRIPTION
@bjorncs please review, but do not merge! I'll add some tests, and possibly change things a bit more before I'm done. 

I think it would have been easier to refactor all of this if the code style was more that of returning immutable snapshots of state, rather than passing around and using stateful objects—in particular the `SearchCluster` would benefit from updating a snapshot on every ping completion, and passing that out to users, instead of passing out something that possibly updates mid-flight. I'm not sure it's worth the effort to make these changes. The only observable changes are related to coverage, and the dispatcher looks robust w.r.t. that. 

I opted for closing down the cluster monitor for the above reason, as well as the load balancer—both hold only auxiliary state, that is quickly re-computed. The state held in the `SearchGroups`, however, is more valuable to keep. I also chose not to wait for all new nodes to have known status in the reconfiguration update. I believe the behaviour of the cluster with or without known state for these is identical, assuming the nodes are actually new, and not yet loaded with documents—furthermore, once the node set of the search cluster is updated, the observable changes (coverage) may be effected immediately anyway, again because of the above, so waiting doesn't really make sense. 