### PR TITLE
Remove unused config from dependency list

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/DocumentAccessProvider.java
@@ -18,11 +18,8 @@ public class DocumentAccessProvider implements Provider<VespaDocumentAccess> {
     private final VespaDocumentAccess access;
 
     @Inject
-    public DocumentAccessProvider(DocumentmanagerConfig documentmanagerConfig,
-                                  MessagebusConfig messagebusConfig, DocumentProtocolPoliciesConfig policiesConfig,
-                                  DistributionConfig distributionConfig) {
-        this.access = new VespaDocumentAccess(documentmanagerConfig, System.getProperty("config.id"),
-                                              messagebusConfig, policiesConfig, distributionConfig);
+    public DocumentAccessProvider(DocumentmanagerConfig documentmanagerConfig, MessagebusConfig messagebusConfig) {
+        this.access = new VespaDocumentAccess(documentmanagerConfig, System.getProperty("config.id"), messagebusConfig);
     }
 
     @Override

--- a/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
+++ b/container-core/src/main/java/com/yahoo/container/core/documentapi/VespaDocumentAccess.java
@@ -39,14 +39,9 @@ public class VespaDocumentAccess extends DocumentAccess {
 
     private final Memoized<DocumentAccess, RuntimeException> delegate;
 
-    VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig,
-                        String slobroksConfigId,
-                        MessagebusConfig messagebusConfig,
-                        DocumentProtocolPoliciesConfig policiesConfig,
-                        DistributionConfig distributionConfig) {
+    VespaDocumentAccess(DocumentmanagerConfig documentmanagerConfig, String slobroksConfigId, MessagebusConfig messagebusConfig) {
         super(new DocumentAccessParams().setDocumentmanagerConfig(documentmanagerConfig));
-        this.parameters = new MessageBusParams()
-                .setDocumentProtocolPoliciesConfig(policiesConfig, distributionConfig);
+        this.parameters = new MessageBusParams();
         this.parameters.setDocumentmanagerConfig(documentmanagerConfig);
         this.parameters.getRPCNetworkParams().setSlobrokConfigId(slobroksConfigId);
         this.parameters.getMessageBusParams().setMessageBusConfig(messagebusConfig);


### PR DESCRIPTION
This removes the false dependency on config that was at one time intended to be injected and used, but this was forgotten. I'm not sure we want to do that anyway, now, but before we have that discussion, let's just remove the unnecessary config, and graph reconstructions this causes. 