### PR TITLE
Jdk21 prep 2

### DIFF
--- a/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/session/PrepareParamsTest.java
@@ -9,9 +9,7 @@ import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.jdisc.HttpRequest;
-
 import com.yahoo.security.X509CertificateUtils;
-
 import com.yahoo.slime.Cursor;
 import com.yahoo.slime.Injector;
 import com.yahoo.slime.ObjectInserter;
@@ -29,7 +27,6 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.OptionalInt;
-;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/TestReport.java
+++ b/vespa-osgi-testrunner/src/main/java/com/yahoo/vespa/testrunner/TestReport.java
@@ -336,15 +336,15 @@ public class TestReport {
 
         StackTraceElement[] stack = thrown.getStackTrace();
         int i = 0;
-        int previousNativeFrame = -1;
+        int firstReflectFrame = -1;
         int cutoff = 0;
         boolean rootedInTestFramework = false;
         while (++i < stack.length) {
             rootedInTestFramework |= testFrameworkRootClass.equals(stack[i].getClassName());
-            if (stack[i].isNativeMethod())
-                previousNativeFrame = i; // Native method invokes the first user test frame.
-            if (rootedInTestFramework && previousNativeFrame > 0) {
-                cutoff = previousNativeFrame;
+            if (firstReflectFrame == -1 && stack[i].getClassName().startsWith("jdk.internal.reflect."))
+                firstReflectFrame = i; // jdk.internal.reflect class invokes the first user test frame, on both jdk 17 and 21.
+            if (rootedInTestFramework && firstReflectFrame > 0) {
+                cutoff = firstReflectFrame;
                 break;
             }
             boolean isDynamicTestInvocation = "org.junit.jupiter.engine.descriptor.DynamicTestTestDescriptor".equals(stack[i].getClassName());


### PR DESCRIPTION
FYI: @bjorncs 

Sample stack trace on JDK 17:
```
  0 = {java.lang.StackTraceElement@2243} "org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:35)"
  1 = {java.lang.StackTraceElement@2244} "org.junit.jupiter.api.Assertions.fail(Assertions.java:115)"
  2 = {java.lang.StackTraceElement@2245} "com.yahoo.vespa.test.samples.FailingTestAndBothAftersTest.test(FailingTestAndBothAftersTest.java:19)"
  3 = {java.lang.StackTraceElement@2246} "java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)"
  4 = {java.lang.StackTraceElement@2247} "java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)"
  5 = {java.lang.StackTraceElement@2248} "java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)"
  6 = {java.lang.StackTraceElement@2249} "java.base/java.lang.reflect.Method.invoke(Method.java:568)"
```

JDK 21:
```
 0 = {java.lang.StackTraceElement@2331} "org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:35)"
  1 = {java.lang.StackTraceElement@2332} "org.junit.jupiter.api.Assertions.fail(Assertions.java:115)"
  2 = {java.lang.StackTraceElement@2333} "com.yahoo.vespa.test.samples.FailingTestAndBothAftersTest.test(FailingTestAndBothAftersTest.java:19)"
  3 = {java.lang.StackTraceElement@2334} "java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)"
  4 = {java.lang.StackTraceElement@2335} "java.base/java.lang.reflect.Method.invoke(Method.java:580)"
```

