### PR TITLE
Fail when unable to open file.

### DIFF
--- a/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectorfile.cpp
@@ -22,7 +22,7 @@ readHeader(vespalib::FileHeader &h,
            const vespalib::string &name)
 {
     Fast_BufferedFile file(32_Ki);
-    file.OpenReadOnly(name.c_str());
+    file.ReadOpenExisting(name.c_str());
     h.readFile(file);
 }
 
@@ -58,8 +58,7 @@ BitVectorFileWrite::open(const vespalib::string &name,
     if (tuneFileWrite.getWantDirectIO()) {
         _datFile->EnableDirectIO();
     }
-    // XXX no checking for success:
-    _datFile->OpenWriteOnly(datname.c_str());
+    _datFile->WriteOpen(datname.c_str());
 
     if (_datHeaderLen == 0) {
         assert(_numKeys == 0);

--- a/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/bitvectoridxfile.cpp
@@ -20,7 +20,7 @@ void
 readHeader(vespalib::FileHeader &h, const vespalib::string &name)
 {
     Fast_BufferedFile file(32_Ki);
-    file.OpenReadOnly(name.c_str());
+    file.ReadOpenExisting(name.c_str());
     h.readFile(file);
 }
 
@@ -66,8 +66,7 @@ BitVectorIdxFileWrite::open(const vespalib::string &name,
         _idxFile->EnableDirectIO();
     }
 
-    // XXX no checking for success:
-    _idxFile->OpenWriteOnly(idxname.c_str());
+    _idxFile->WriteOpen(idxname.c_str());
 
     if (_idxHeaderLen == 0) {
         assert(_numKeys == 0);

--- a/vespalib/src/vespa/fastlib/io/bufferedfile.cpp
+++ b/vespalib/src/vespa/fastlib/io/bufferedfile.cpp
@@ -287,7 +287,7 @@ Fast_BufferedFile::ReadOpenExisting(const char *name)
     bool ok = Close();
     ok &= _file->OpenReadOnlyExisting(true, name);
     if (!ok) {
-        fprintf(stderr, "ERROR opening %s for read: %s",
+        fprintf(stderr, "ERROR opening %s for read: %s\n",
                 _file->GetFileName(), getLastErrorString().c_str());
         assert(ok);
     }
@@ -304,7 +304,7 @@ Fast_BufferedFile::ReadOpen(const char *name)
     bool ok = Close();
     ok &= _file->OpenReadOnly(name);
     if (!ok) {
-        fprintf(stderr, "ERROR opening %s for read: %s",
+        fprintf(stderr, "ERROR opening %s for read: %s\n",
                 _file->GetFileName(), getLastErrorString().c_str());
         assert(ok);
     }
@@ -324,7 +324,7 @@ Fast_BufferedFile::WriteOpen(const char *name)
     bool ok = Close();
     ok &= _file->OpenWriteOnly(name);
     if (!ok) {
-        fprintf(stderr, "ERROR opening %s for write: %s",
+        fprintf(stderr, "ERROR opening %s for write: %s\n",
                 _file->GetFileName(), getLastErrorString().c_str());
         assert(ok);
     }


### PR DESCRIPTION
The confusing error message (`Fatal: Reading 18446744073709551615 bytes, got 0`) shown in #27768 was caused
by missing error checking when writing bitvector files.
