### PR TITLE
Remove scaling duration min for content clusters

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/AllocationOptimizer.java
@@ -92,6 +92,7 @@ public class AllocationOptimizer {
                      .multiply(clusterModel.loadWith(nodes, groups)) // redundancy aware adjustment with these counts
                      .divide(clusterModel.redundancyAdjustment())    // correct for double redundancy adjustment
                      .scaled(current.realResources().nodeResources());
+
         // Combine the scaled resource values computed here
         // with the currently configured non-scaled values, given in the limits, if any
         var nonScaled = limits.isEmpty() || limits.min().nodeResources().isUnspecified()

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/ClusterModel.java
@@ -168,7 +168,6 @@ public class ClusterModel {
     }
 
     public static Duration minScalingDuration(ClusterSpec clusterSpec) {
-        if (clusterSpec.isStateful()) return Duration.ofHours(6);
         return Duration.ofMinutes(5);
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingUsingBcpGroupInfoTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/AutoscalingUsingBcpGroupInfoTest.java
@@ -206,7 +206,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration2.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 50.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 3.0, 7.4, 29.0,
+                                         8, 1, 2.9, 7.4, 29.0,
                                          fixture.autoscale());
 
         // Mostly local
@@ -216,7 +216,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration3.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 90.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 2.3, 7.4, 29.0,
+                                         8, 1, 2.2, 7.4, 29.0,
                                          fixture.autoscale());
 
         // Local only
@@ -226,7 +226,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration4.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 100.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 2.2, 7.4, 29.0,
+                                         8, 1, 2.1, 7.4, 29.0,
                                          fixture.autoscale());
 
         // No group info, should be the same as the above
@@ -236,7 +236,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration5.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 100.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 2.2, 7.4, 29.0,
+                                         8, 1, 2.1, 7.4, 29.0,
                                          fixture.autoscale());
 
         // 40 query rate, no group info (for reference to the below)
@@ -266,7 +266,7 @@ public class AutoscalingUsingBcpGroupInfoTest {
         fixture.tester().clock().advance(duration8.negated());
         fixture.loader().addQueryRateMeasurements(10, __ -> 40.0);
         fixture.tester().assertResources("Scaling up cpu using bcp group cpu info",
-                                         8, 1, 1.9, 7.4, 29.0,
+                                         8, 1, 1.8, 7.4, 29.0,
                                          fixture.autoscale());
     }
 
@@ -288,16 +288,18 @@ public class AutoscalingUsingBcpGroupInfoTest {
 
         // External load is measured to zero -> 0
         fixture.tester().clock().advance(Duration.ofDays(2));
-        fixture.loader().addCpuMeasurements(0.7f, 10);
+        var duration = fixture.loader().addCpuMeasurements(0.7f, 10);
+        fixture.tester().clock().advance(duration.negated());
         fixture.loader().addQueryRateMeasurements(10, i -> 0.0);
         assertEquals(new Autoscaling.Metrics(0, 1.0, 0),
                      fixture.autoscale().metrics());
 
         // External load
         fixture.tester().clock().advance(Duration.ofDays(2));
-        fixture.loader().addCpuMeasurements(0.7f, 10);
+        duration = fixture.loader().addCpuMeasurements(0.7f, 10);
+        fixture.tester().clock().advance(duration.negated());
         fixture.loader().addQueryRateMeasurements(10, i -> 110.0);
-        assertEquals(new Autoscaling.Metrics(110, 1.1, 0.05),
+        assertEquals(new Autoscaling.Metrics(110, 1.0, 0.05),
                      round(fixture.autoscale().metrics()));
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/application2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/application2.json
@@ -94,7 +94,7 @@
           "at" : 123
         }
       ],
-      "scalingDuration": 21600000
+      "scalingDuration": 300000
     }
   }
 }


### PR DESCRIPTION
This has been a safety measure, which doesn't seem necessary any more.
