### PR TITLE
More throttle tweaking

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/PermanentFlags.java
@@ -368,6 +368,12 @@ public class PermanentFlags {
             "Takes effect immediately",
             APPLICATION_ID);
 
+    public static final UnboundIntFlag MAX_HOSTS_PER_HOUR = defineIntFlag(
+            "max-hosts-per-hour", 40,
+            "The number of hosts that can be provisioned per hour in a zone, before throttling is " +
+            "triggered",
+            "Takes effect immediately");
+
     private PermanentFlags() {}
 
     private static UnboundBooleanFlag defineFeatureFlag(

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningThrottlerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningThrottlerTest.java
@@ -3,10 +3,8 @@ package com.yahoo.vespa.hosted.provision.provisioning;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static com.yahoo.vespa.hosted.provision.provisioning.ProvisioningThrottler.throttle;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -17,14 +15,9 @@ class ProvisioningThrottlerTest {
     @Test
     void throttling() {
         Agent agent = Agent.system;
-        Duration window = Duration.ofHours(1);
-        assertFalse(throttle(199, 99, window, agent));
-        assertTrue(throttle(200, 99, window, agent));
-        assertFalse(throttle(40, 100, window, agent));
-        assertTrue(throttle(41, 100, window, agent));
-        assertTrue(throttle(100, 100, window, agent));
-        assertFalse(throttle(200, 2100, window, agent));
-        assertTrue(throttle(201, 2100, window, agent));
+        assertFalse(throttle(239, 10, agent));
+        assertFalse(throttle(240, 10, agent));
+        assertTrue(throttle(241, 10, agent));
     }
 
 }


### PR DESCRIPTION
Our busiest prod zone provisions 26 hosts/hour on average, on a typical release
day. In CD, the highest rate is 33 hosts/hour. Added a feature flag to simplify
further tweaking, defaulting to 40.

@bratseth or @hmusum