### PR TITLE
OS downgrades at system level

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/configserver/NodeRepository.java
@@ -55,7 +55,7 @@ public interface NodeRepository {
     void upgrade(ZoneId zone, NodeType type, Version version, boolean allowDowngrade);
 
     /** Upgrade OS for all nodes of given type to a new version */
-    void upgradeOs(ZoneId zone, NodeType type, Version version);
+    void upgradeOs(ZoneId zone, NodeType type, Version version, boolean allowDowngrade);
 
     /** Get target versions for upgrades in given zone */
     TargetVersions targetVersionsOf(ZoneId zone);

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -126,7 +126,7 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * A singleton owned by the Controller which contains the methods and state for controlling applications.
+ * A singleton owned by {@link Controller} which contains the methods and state for controlling applications.
  *
  * @author bratseth
  */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/Controller.java
@@ -30,9 +30,6 @@ import com.yahoo.vespa.hosted.controller.persistence.JobControlFlags;
 import com.yahoo.vespa.hosted.controller.restapi.dataplanetoken.DataplaneTokenService;
 import com.yahoo.vespa.hosted.controller.security.AccessControl;
 import com.yahoo.vespa.hosted.controller.support.access.SupportAccessControl;
-import com.yahoo.vespa.hosted.controller.versions.OsVersion;
-import com.yahoo.vespa.hosted.controller.versions.OsVersionStatus;
-import com.yahoo.vespa.hosted.controller.versions.OsVersionTarget;
 import com.yahoo.vespa.hosted.controller.versions.VersionStatus;
 import com.yahoo.vespa.hosted.controller.versions.VespaVersion;
 import com.yahoo.vespa.hosted.rotation.config.RotationsConfig;
@@ -40,15 +37,12 @@ import com.yahoo.yolean.concurrent.Sleeper;
 
 import java.security.SecureRandom;
 import java.time.Clock;
-import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -85,6 +79,7 @@ public class Controller extends AbstractComponent {
     private final MavenRepository mavenRepository;
     private final Metric metric;
     private final RoutingController routingController;
+    private final OsController osController;
     private final ControllerConfig controllerConfig;
     private final SecretStore secretStore;
     private final CuratorArchiveBucketDb archiveBucketDb;
@@ -132,6 +127,7 @@ public class Controller extends AbstractComponent {
         applicationController = new ApplicationController(this, curator, accessControl, clock, flagSource, serviceRegistry.billingController());
         tenantController = new TenantController(this, curator, accessControl);
         routingController = new RoutingController(this, rotationsConfig);
+        osController = new OsController(this);
         auditLogger = new AuditLogger(curator, clock);
         jobControl = new JobControl(new JobControlFlags(curator, flagSource));
         archiveBucketDb = new CuratorArchiveBucketDb(this);
@@ -159,6 +155,11 @@ public class Controller extends AbstractComponent {
     /** Returns the instance controlling routing */
     public RoutingController routing() {
         return routingController;
+    }
+
+    /** Returns the instance controlling OS upgrades */
+    public OsController os() {
+        return osController;
     }
 
     /** Returns the service registry of this */
@@ -230,96 +231,6 @@ public class Controller extends AbstractComponent {
         return versionStatus.systemVersion()
                             .map(VespaVersion::versionNumber)
                             .orElse(Vtag.currentVersion);
-    }
-
-    /** Returns the target OS version for infrastructure in this system. The controller will drive infrastructure OS
-     * upgrades to this version */
-    public Optional<OsVersionTarget> osVersionTarget(CloudName cloud) {
-        return osVersionTargets().stream().filter(target -> target.osVersion().cloud().equals(cloud)).findFirst();
-    }
-
-    /** Returns all target OS versions in this system */
-    public Set<OsVersionTarget> osVersionTargets() {
-        return curator.readOsVersionTargets();
-    }
-
-    /**
-     * Set the target OS version for given cloud in this system.
-     *
-     * @param cloud   The cloud to upgrade
-     * @param version The target OS version
-     * @param force   Allow downgrades, and override pinned target (if any)
-     * @param pin     Pin this version. This prevents automatic scheduling of upgrades until version is unpinned
-     */
-    public void upgradeOsIn(CloudName cloud, Version version, boolean force, boolean pin) {
-        if (version.isEmpty()) {
-            throw new IllegalArgumentException("Invalid version '" + version.toFullString() + "'");
-        }
-        if (!clouds().contains(cloud)) {
-            throw new IllegalArgumentException("Cloud '" + cloud + "' does not exist in this system");
-        }
-        Instant scheduledAt = clock.instant();
-        try (Mutex lock = curator.lockOsVersions()) {
-            Map<CloudName, OsVersionTarget> targets = curator.readOsVersionTargets().stream()
-                                                             .collect(Collectors.toMap(t -> t.osVersion().cloud(),
-                                                                                       Function.identity()));
-
-            OsVersionTarget currentTarget = targets.get(cloud);
-            boolean downgrade = false;
-            if (currentTarget != null) {
-                boolean versionChange = !currentTarget.osVersion().version().equals(version);
-                downgrade = version.isBefore(currentTarget.osVersion().version());
-                if (versionChange && currentTarget.pinned() && !force) {
-                    throw new IllegalArgumentException("Cannot " + (downgrade ? "downgrade" : "upgrade") + " cloud " +
-                                                       cloud.value() + "' to version " + version.toFullString() +
-                                                       ": Current target is pinned. Add 'force' parameter to override");
-                }
-                if (downgrade && !force) {
-                    throw new IllegalArgumentException("Cannot downgrade cloud '" + cloud.value() + "' to version " +
-                                                       version.toFullString() + ": Missing 'force' parameter");
-                }
-                if (!versionChange && currentTarget.pinned() == pin) return; // No change
-            }
-
-            OsVersionTarget newTarget = new OsVersionTarget(new OsVersion(version, cloud), scheduledAt, pin, downgrade);
-            targets.put(cloud, newTarget);
-            curator.writeOsVersionTargets(new TreeSet<>(targets.values()));
-            log.info("Triggered OS " + (downgrade ? "downgrade" : "upgrade") + " to " + version.toFullString() +
-                     " in cloud " + cloud.value());
-        }
-    }
-
-    /** Clear the target OS version for given cloud in this system */
-    public void cancelOsUpgradeIn(CloudName cloudName) {
-        try (Mutex lock = curator.lockOsVersions()) {
-            Map<CloudName, OsVersionTarget> targets = curator.readOsVersionTargets().stream()
-                                                             .collect(Collectors.toMap(t -> t.osVersion().cloud(),
-                                                                                       Function.identity()));
-            if (targets.remove(cloudName) == null) {
-                throw new IllegalArgumentException("Cloud '" + cloudName.value() + " has no OS upgrade target");
-            }
-            curator.writeOsVersionTargets(new TreeSet<>(targets.values()));
-        }
-    }
-
-    /** Returns the current OS version status */
-    public OsVersionStatus osVersionStatus() {
-        return curator.readOsVersionStatus();
-    }
-
-    /** Replace the current OS version status with a new one */
-    public void updateOsVersionStatus(OsVersionStatus newStatus) {
-        try (Mutex lock = curator.lockOsVersionStatus()) {
-            OsVersionStatus currentStatus = curator.readOsVersionStatus();
-            for (CloudName cloud : clouds()) {
-                Set<Version> newVersions = newStatus.versionsIn(cloud);
-                if (currentStatus.versionsIn(cloud).size() > 1 && newVersions.size() == 1) {
-                    log.info("All nodes in " + cloud + " cloud upgraded to OS version " +
-                             newVersions.iterator().next().toFullString());
-                }
-            }
-            curator.writeOsVersionStatus(newStatus);
-        }
     }
 
     /** Returns the hostname of this controller */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/OsController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/OsController.java
@@ -1,0 +1,129 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.CloudName;
+import com.yahoo.transaction.Mutex;
+import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
+import com.yahoo.vespa.hosted.controller.versions.OsVersion;
+import com.yahoo.vespa.hosted.controller.versions.OsVersionStatus;
+import com.yahoo.vespa.hosted.controller.versions.OsVersionTarget;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ *  A singleton owned by {@link Controller} which contains the methods and state for controlling OS upgrades.
+ *
+ * @author mpolden
+ */
+public record OsController(Controller controller) {
+
+    private static final Logger LOG = Logger.getLogger(OsController.class.getName());
+
+    public OsController {
+        Objects.requireNonNull(controller);
+    }
+
+    /** Returns the target OS version for infrastructure in this system. The controller will drive infrastructure OS
+     * upgrades to this version */
+    public Optional<OsVersionTarget> target(CloudName cloud) {
+        return targets().stream().filter(target -> target.osVersion().cloud().equals(cloud)).findFirst();
+    }
+
+    /** Returns all target OS versions in this system */
+    public Set<OsVersionTarget> targets() {
+        return curator().readOsVersionTargets();
+    }
+
+    /**
+     * Set the target OS version for given cloud in this system.
+     *
+     * @param version The target OS version
+     * @param cloud   The cloud to upgrade
+     * @param force   Allow downgrades, and override pinned target (if any)
+     * @param pin     Pin this version. This prevents automatic scheduling of upgrades until version is unpinned
+     */
+    public void upgradeTo(Version version, CloudName cloud, boolean force, boolean pin) {
+        if (version.isEmpty()) {
+            throw new IllegalArgumentException("Invalid version '" + version.toFullString() + "'");
+        }
+        if (!controller.clouds().contains(cloud)) {
+            throw new IllegalArgumentException("Cloud '" + cloud + "' does not exist in this system");
+        }
+        Instant scheduledAt = controller.clock().instant();
+        try (Mutex lock = curator().lockOsVersions()) {
+            Map<CloudName, OsVersionTarget> targets = curator().readOsVersionTargets().stream()
+                                                               .collect(Collectors.toMap(t -> t.osVersion().cloud(),
+                                                                                          Function.identity()));
+
+            OsVersionTarget currentTarget = targets.get(cloud);
+            boolean downgrade = false;
+            if (currentTarget != null) {
+                boolean versionChange = !currentTarget.osVersion().version().equals(version);
+                downgrade = version.isBefore(currentTarget.osVersion().version());
+                if (versionChange && currentTarget.pinned() && !force) {
+                    throw new IllegalArgumentException("Cannot " + (downgrade ? "downgrade" : "upgrade") + " cloud " +
+                                                       cloud.value() + "' to version " + version.toFullString() +
+                                                       ": Current target is pinned. Add 'force' parameter to override");
+                }
+                if (downgrade && !force) {
+                    throw new IllegalArgumentException("Cannot downgrade cloud '" + cloud.value() + "' to version " +
+                                                       version.toFullString() + ": Missing 'force' parameter");
+                }
+                if (!versionChange && currentTarget.pinned() == pin) return; // No change
+            }
+
+            OsVersionTarget newTarget = new OsVersionTarget(new OsVersion(version, cloud), scheduledAt, pin, downgrade);
+            targets.put(cloud, newTarget);
+            curator().writeOsVersionTargets(new TreeSet<>(targets.values()));
+            LOG.info("Triggered OS " + (downgrade ? "downgrade" : "upgrade") + " to " + version.toFullString() +
+                     " in cloud " + cloud.value());
+        }
+    }
+
+    /** Clear the target OS version for given cloud in this system */
+    public void cancelUpgrade(CloudName cloudName) {
+        try (Mutex lock = curator().lockOsVersions()) {
+            Map<CloudName, OsVersionTarget> targets = curator().readOsVersionTargets().stream()
+                                                               .collect(Collectors.toMap(t -> t.osVersion().cloud(),
+                                                                                          Function.identity()));
+            if (targets.remove(cloudName) == null) {
+                throw new IllegalArgumentException("Cloud '" + cloudName.value() + " has no OS upgrade target");
+            }
+            curator().writeOsVersionTargets(new TreeSet<>(targets.values()));
+        }
+    }
+
+    /** Returns the current OS version status */
+    public OsVersionStatus status() {
+        return curator().readOsVersionStatus();
+    }
+
+    /** Replace the current OS version status with a new one */
+    public void updateStatus(OsVersionStatus newStatus) {
+        try (Mutex lock = curator().lockOsVersionStatus()) {
+            OsVersionStatus currentStatus = curator().readOsVersionStatus();
+            for (CloudName cloud : controller.clouds()) {
+                Set<Version> newVersions = newStatus.versionsIn(cloud);
+                if (currentStatus.versionsIn(cloud).size() > 1 && newVersions.size() == 1) {
+                    LOG.info("All nodes in " + cloud + " cloud upgraded to OS version " +
+                             newVersions.iterator().next().toFullString());
+                }
+            }
+            curator().writeOsVersionStatus(newStatus);
+        }
+    }
+
+    private CuratorDb curator() {
+        return controller.curator();
+    }
+
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/RoutingController.java
@@ -66,8 +66,8 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toMap;
 
 /**
- * The routing controller encapsulates state and methods for inspecting and manipulating deployment endpoints in a
- * hosted Vespa system.
+ * The routing controller is owned by {@link Controller} and encapsulates state and methods for inspecting and
+ * manipulating deployment endpoints in a hosted Vespa system.
  *
  * The one-stop shop for all your routing needs!
  *

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/TenantController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/TenantController.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * A singleton owned by the Controller which contains the methods and state for controlling tenants.
+ * A singleton owned by the {@link Controller} which contains the methods and state for controlling tenants.
  *
  * @author bratseth
  * @author mpolden

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporter.java
@@ -276,7 +276,7 @@ public class MetricsReporter extends ControllerMaintainer {
     }
 
     private Map<NodeVersion, Duration> osChangeDurations() {
-        return changeDurations(controller().osVersionStatus().versions().values(), Function.identity());
+        return changeDurations(controller().os().status().versions().values(), Function.identity());
     }
 
     private <V> Map<NodeVersion, Duration> changeDurations(Collection<V> versions, Function<V, List<NodeVersion>> versionsGetter) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.controller.Controller;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.ArtifactRepository;
 import com.yahoo.vespa.hosted.controller.api.integration.deployment.OsRelease;
 import com.yahoo.vespa.hosted.controller.versions.OsVersionTarget;
+import com.yahoo.yolean.Exceptions;
 
 import java.time.DayOfWeek;
 import java.time.Duration;
@@ -19,6 +20,8 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Automatically schedule upgrades to the next OS version.
@@ -27,6 +30,8 @@ import java.util.Optional;
  */
 public class OsUpgradeScheduler extends ControllerMaintainer {
 
+    private static final Logger LOG = Logger.getLogger(OsUpgradeScheduler.class.getName());
+
     public OsUpgradeScheduler(Controller controller, Duration interval) {
         super(controller, interval);
     }
@@ -34,13 +39,22 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
     @Override
     protected double maintain() {
         Instant now = controller().clock().instant();
+        int attempts = 0;
+        int failures = 0;
         for (var cloud : controller().clouds()) {
             Optional<Change> change = changeIn(cloud, now);
             if (change.isEmpty()) continue;
             if (!change.get().scheduleAt(now)) continue;
-            controller().upgradeOsIn(cloud, change.get().version(), false);
+            try {
+                attempts++;
+                controller().upgradeOsIn(cloud, change.get().version(), false, false);
+            } catch (IllegalArgumentException e) {
+                failures++;
+                LOG.log(Level.WARNING, "Failed to schedule OS upgrade: " + Exceptions.toMessageString(e) +
+                                       ". Retrying in " + interval());
+            }
         }
-        return 0.0;
+        return asSuccessFactorDeviation(attempts, failures);
     }
 
     /** Returns the wanted change for cloud at given instant, if any */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -47,7 +47,7 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
             if (!change.get().scheduleAt(now)) continue;
             try {
                 attempts++;
-                controller().upgradeOsIn(cloud, change.get().version(), false, false);
+                controller().os().upgradeTo(change.get().version(), cloud, false, false);
             } catch (IllegalArgumentException e) {
                 failures++;
                 LOG.log(Level.WARNING, "Failed to schedule OS upgrade: " + Exceptions.toMessageString(e) +
@@ -59,7 +59,7 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
 
     /** Returns the wanted change for cloud at given instant, if any */
     public Optional<Change> changeIn(CloudName cloud, Instant instant) {
-        Optional<OsVersionTarget> currentTarget = controller().osVersionTarget(cloud);
+        Optional<OsVersionTarget> currentTarget = controller().os().target(cloud);
         if (currentTarget.isEmpty()) return Optional.empty();
         if (upgradingToNewMajor(cloud)) return Optional.empty(); // Skip further upgrades until major version upgrade is complete
 
@@ -68,7 +68,7 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
     }
 
     private boolean upgradingToNewMajor(CloudName cloud) {
-        return controller().osVersionStatus().versionsIn(cloud).stream()
+        return controller().os().status().versionsIn(cloud).stream()
                            .filter(version -> !version.isEmpty()) // Ignore empty/unknown versions
                            .map(Version::getMajor)
                            .distinct()

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgrader.java
@@ -68,8 +68,8 @@ public class OsUpgrader extends InfrastructureUpgrader<OsVersionTarget> {
     @Override
     protected Optional<OsVersionTarget> target() {
         // Return target if we have nodes in this cloud on the wrong version
-        return controller().osVersionTarget(cloud)
-                           .filter(target -> controller().osVersionStatus().nodesIn(cloud).stream()
+        return controller().os().target(cloud)
+                           .filter(target -> controller().os().status().nodesIn(cloud).stream()
                                                          .anyMatch(node -> !satisfiedBy(node.currentVersion(), target)));
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdater.java
@@ -21,7 +21,7 @@ public class OsVersionStatusUpdater extends ControllerMaintainer {
     protected double maintain() {
         try {
             OsVersionStatus newStatus = OsVersionStatus.compute(controller());
-            controller().updateOsVersionStatus(newStatus);
+            controller().os().updateStatus(newStatus);
             return 0.0;
         } catch (Exception e) {
             log.log(Level.WARNING, "Failed to compute OS version status: " + Exceptions.toMessageString(e) +

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/persistence/CuratorDb.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -335,7 +336,7 @@ public class CuratorDb {
 
     // Infrastructure upgrades
 
-    public void writeOsVersionTargets(Set<OsVersionTarget> versions) {
+    public void writeOsVersionTargets(SortedSet<OsVersionTarget> versions) {
         curator.set(osVersionTargetsPath(), asJson(osVersionTargetSerializer.toSlime(versions)));
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -59,7 +59,7 @@ public record OsVersionStatus(Map<OsVersion, List<NodeVersion>> versions) {
     /** Compute the current OS versions in this system. This is expensive and should be called infrequently */
     public static OsVersionStatus compute(Controller controller) {
         Map<OsVersion, List<NodeVersion>> osVersions = new HashMap<>();
-        controller.osVersionTargets().forEach(target -> osVersions.put(target.osVersion(), new ArrayList<>()));
+        controller.os().targets().forEach(target -> osVersions.put(target.osVersion(), new ArrayList<>()));
 
         for (var application : SystemApplication.all()) {
             for (var zone : zonesToUpgrade(controller)) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionStatus.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.controller.maintenance.OsUpgrader;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,13 +37,15 @@ public record OsVersionStatus(Map<OsVersion, List<NodeVersion>> versions) {
         this.versions = ImmutableMap.copyOf(Objects.requireNonNull(versions, "versions must be non-null"));
     }
 
-    /** Returns nodes eligible for OS upgrades that exist in given cloud */
+    /** Returns all node versions that exist in given cloud */
     public List<NodeVersion> nodesIn(CloudName cloud) {
-        return versions.entrySet().stream()
-                       .filter(entry -> entry.getKey().cloud().equals(cloud))
-                       .map(Map.Entry::getValue)
-                       .findFirst()
-                       .orElseGet(List::of);
+        List<NodeVersion> nodeVersions = new ArrayList<>();
+        versions.forEach((osVersion, nodesOnVersion) -> {
+            if (osVersion.cloud().equals(cloud)) {
+                nodeVersions.addAll(nodesOnVersion);
+            }
+        });
+        return Collections.unmodifiableList(nodeVersions);
     }
 
     /** Returns versions that exist in given cloud */

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionTarget.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/versions/OsVersionTarget.java
@@ -11,7 +11,7 @@ import java.util.Objects;
  *
  * @author mpolden
  */
-public record OsVersionTarget(OsVersion osVersion, Instant scheduledAt) implements VersionTarget, Comparable<OsVersionTarget> {
+public record OsVersionTarget(OsVersion osVersion, Instant scheduledAt, boolean pinned, boolean downgrade) implements VersionTarget, Comparable<OsVersionTarget> {
 
     public OsVersionTarget {
         Objects.requireNonNull(osVersion);
@@ -30,7 +30,7 @@ public record OsVersionTarget(OsVersion osVersion, Instant scheduledAt) implemen
 
     @Override
     public boolean downgrade() {
-        return false; // Not supported by this target type
+        return downgrade;
     }
 
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/integration/NodeRepositoryMock.java
@@ -169,7 +169,7 @@ public class NodeRepositoryMock implements NodeRepository {
     }
 
     @Override
-    public void upgradeOs(ZoneId zone, NodeType type, Version version) {
+    public void upgradeOs(ZoneId zone, NodeType type, Version version, boolean downgrade) {
         this.targetVersions.compute(zone, (ignored, targetVersions) -> {
             if (targetVersions == null) {
                 targetVersions = TargetVersions.EMPTY;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
@@ -365,7 +365,7 @@ public class MetricsReporterTest {
 
         // All nodes upgrade to initial OS version
         var version0 = Version.fromString("8.0");
-        tester.controller().upgradeOsIn(cloud, version0, false);
+        tester.controller().upgradeOsIn(cloud, version0, false, false);
         osUpgrader.maintain();
         tester.configServer().setOsVersion(version0, SystemApplication.tenantHost.id(), zone);
         tester.configServer().setOsVersion(version0, SystemApplication.configServerHost.id(), zone);
@@ -379,7 +379,7 @@ public class MetricsReporterTest {
             var currentVersion = i == 0 ? version0 : targets.get(i - 1);
             var nextVersion = targets.get(i);
             // System starts upgrading to next OS version
-            tester.controller().upgradeOsIn(cloud, nextVersion, false);
+            tester.controller().upgradeOsIn(cloud, nextVersion, false, false);
             runAll(osUpgrader, statusUpdater, reporter);
             assertOsChangeDuration(Duration.ZERO, hosts);
             assertOsNodeCount(hosts.size(), currentVersion);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/MetricsReporterTest.java
@@ -365,7 +365,7 @@ public class MetricsReporterTest {
 
         // All nodes upgrade to initial OS version
         var version0 = Version.fromString("8.0");
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
         osUpgrader.maintain();
         tester.configServer().setOsVersion(version0, SystemApplication.tenantHost.id(), zone);
         tester.configServer().setOsVersion(version0, SystemApplication.configServerHost.id(), zone);
@@ -379,7 +379,7 @@ public class MetricsReporterTest {
             var currentVersion = i == 0 ? version0 : targets.get(i - 1);
             var nextVersion = targets.get(i);
             // System starts upgrading to next OS version
-            tester.controller().upgradeOsIn(cloud, nextVersion, false, false);
+            tester.controller().os().upgradeTo(nextVersion, cloud, false, false);
             runAll(osUpgrader, statusUpdater, reporter);
             assertOsChangeDuration(Duration.ZERO, hosts);
             assertOsNodeCount(hosts.size(), currentVersion);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
@@ -43,17 +43,17 @@ public class OsUpgradeSchedulerTest {
 
         // Initial run does nothing as the cloud does not have a target
         scheduler.maintain();
-        assertTrue(tester.controller().osVersionTarget(cloud).isEmpty(), "No target set");
+        assertTrue(tester.controller().os().target(cloud).isEmpty(), "No target set");
 
         // Target is set manually
         Version version0 = Version.fromString("7.0.0.20220101");
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
 
         // Target remains unchanged as it hasn't expired yet
         for (var interval : List.of(Duration.ZERO, Duration.ofDays(30))) {
             tester.clock().advance(interval);
             scheduler.maintain();
-            assertEquals(version0, tester.controller().osVersionTarget(cloud).get().osVersion().version());
+            assertEquals(version0, tester.controller().os().target(cloud).get().osVersion().version());
         }
 
         // New release becomes available, but is not triggered until cool-down period has passed, and we're inside a
@@ -64,37 +64,37 @@ public class OsUpgradeSchedulerTest {
         assertEquals(version1, scheduler.changeIn(cloud, tester.clock().instant()).get().version());
         scheduler.maintain();
         assertEquals(version0,
-                     tester.controller().osVersionTarget(cloud).get().osVersion().version(),
+                     tester.controller().os().target(cloud).get().osVersion().version(),
                      "Target is unchanged because cooldown hasn't passed");
         tester.clock().advance(Duration.ofDays(3).plusHours(18));
         assertEquals("2022-03-07T03:05:00", formatInstant(tester.clock().instant()));
         scheduler.maintain();
         assertEquals(version0,
-                     tester.controller().osVersionTarget(cloud).get().osVersion().version(),
+                     tester.controller().os().target(cloud).get().osVersion().version(),
                      "Target is unchanged because we're outside trigger period");
         tester.clock().advance(Duration.ofHours(5));
         assertEquals("2022-03-07T08:05:00", formatInstant(tester.clock().instant()));
 
         // Time constraints have now passed, but the current target has been pinned in the meantime
-        tester.controller().upgradeOsIn(cloud, version0, false, true);
+        tester.controller().os().upgradeTo(version0, cloud, false, true);
         Optional<OsUpgradeScheduler.Change> change = scheduler.changeIn(cloud, tester.clock().instant());
         assertTrue(change.isPresent());
         assertEquals(-1, scheduler.maintain());
         assertEquals(version0,
-                     tester.controller().osVersionTarget(cloud).get().osVersion().version(),
+                     tester.controller().os().target(cloud).get().osVersion().version(),
                      "Target is unchanged because it's pinned");
 
         // Target is unpinned and new version is allowed to be scheduled
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
         scheduler.maintain();
         assertEquals(version1,
-                tester.controller().osVersionTarget(cloud).get().osVersion().version(),
+                tester.controller().os().target(cloud).get().osVersion().version(),
                 "New target set");
 
         // A few more days pass and target remains unchanged
         tester.clock().advance(Duration.ofDays(2));
         scheduler.maintain();
-        assertEquals(version1, tester.controller().osVersionTarget(cloud).get().osVersion().version());
+        assertEquals(version1, tester.controller().os().target(cloud).get().osVersion().version());
 
         // Estimate next change
         Optional<OsUpgradeScheduler.Change> nextChange = scheduler.changeIn(cloud, tester.clock().instant());
@@ -115,19 +115,19 @@ public class OsUpgradeSchedulerTest {
 
         // Set initial target
         Version version0 = Version.fromString("7.0.0.20220101");
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
 
         // Next version is triggered
         Version version1 = Version.fromString("7.0.0.20220301");
         tester.clock().advance(Duration.ofDays(44));
         assertEquals("2022-03-01T02:05:00", formatInstant(tester.clock().instant()));
         scheduler.maintain();
-        assertEquals(version0, tester.controller().osVersionTarget(cloud).get().osVersion().version());
+        assertEquals(version0, tester.controller().os().target(cloud).get().osVersion().version());
         // Cool-down passes
         tester.clock().advance(Duration.ofDays(1));
         assertEquals(version1, scheduler.changeIn(cloud, tester.clock().instant()).get().version());
         scheduler.maintain();
-        assertEquals(version1, tester.controller().osVersionTarget(cloud).get().osVersion().version());
+        assertEquals(version1, tester.controller().os().target(cloud).get().osVersion().version());
 
         // Estimate next change
         Optional<OsUpgradeScheduler.Change> nextChange = scheduler.changeIn(cloud, tester.clock().instant());
@@ -146,7 +146,7 @@ public class OsUpgradeSchedulerTest {
         // Set initial target
         CloudName cloud = tester.controller().clouds().iterator().next();
         Version version0 = Version.fromString("8.0");
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
 
         // Stable release (tagged outside trigger period) is scheduled once trigger period opens
         Version version1 = Version.fromString("8.1");
@@ -160,7 +160,7 @@ public class OsUpgradeSchedulerTest {
 
         // A newer version is triggered manually
         Version version3 = Version.fromString("8.3");
-        tester.controller().upgradeOsIn(cloud, version3, false, false);
+        tester.controller().os().upgradeTo(version3, cloud, false, false);
 
         // Nothing happens in next iteration as tagged release is older than manually triggered version
         scheduleUpgradeAfter(Duration.ofDays(7), version3, scheduler, tester);
@@ -177,7 +177,7 @@ public class OsUpgradeSchedulerTest {
         // Set initial target
         CloudName cloud = tester.controller().clouds().iterator().next();
         Version version0 = Version.fromString("8.0");
-        tester.controller().upgradeOsIn(cloud, version0, false, false);
+        tester.controller().os().upgradeTo(version0, cloud, false, false);
 
         // Latest release is not scheduled immediately
         Version version1 = Version.fromString("8.1");
@@ -214,7 +214,7 @@ public class OsUpgradeSchedulerTest {
         tester.clock().advance(duration);
         scheduler.maintain();
         CloudName cloud = tester.controller().clouds().iterator().next();
-        OsVersionTarget target = tester.controller().osVersionTarget(cloud).get();
+        OsVersionTarget target = tester.controller().os().target(cloud).get();
         assertEquals(version, target.osVersion().version());
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
@@ -40,7 +40,7 @@ public class OsVersionStatusUpdaterTest {
         // Setting a new target adds it to current status
         Version version1 = Version.fromString("7.1");
         CloudName cloud = CloudName.DEFAULT;
-        tester.controller().upgradeOsIn(cloud, version1, false);
+        tester.controller().upgradeOsIn(cloud, version1, false, false);
         statusUpdater.maintain();
 
         var osVersions = tester.controller().osVersionStatus().versions();
@@ -49,7 +49,7 @@ public class OsVersionStatusUpdaterTest {
         assertTrue(osVersions.get(new OsVersion(version1, cloud)).isEmpty(), "No nodes on current target");
 
         CloudName otherCloud = CloudName.AWS;
-        tester.controller().upgradeOsIn(otherCloud, version1, false);
+        tester.controller().upgradeOsIn(otherCloud, version1, false, false);
         statusUpdater.maintain();
 
         osVersions = tester.controller().osVersionStatus().versions();

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsVersionStatusUpdaterTest.java
@@ -35,24 +35,24 @@ public class OsVersionStatusUpdaterTest {
         tester.zoneRegistry().setOsUpgradePolicy(CloudName.DEFAULT, upgradePolicy.build());
 
         // Initially empty
-        assertSame(OsVersionStatus.empty, tester.controller().osVersionStatus());
+        assertSame(OsVersionStatus.empty, tester.controller().os().status());
 
         // Setting a new target adds it to current status
         Version version1 = Version.fromString("7.1");
         CloudName cloud = CloudName.DEFAULT;
-        tester.controller().upgradeOsIn(cloud, version1, false, false);
+        tester.controller().os().upgradeTo(version1, cloud, false, false);
         statusUpdater.maintain();
 
-        var osVersions = tester.controller().osVersionStatus().versions();
+        var osVersions = tester.controller().os().status().versions();
         assertEquals(3, osVersions.size());
         assertFalse(osVersions.get(new OsVersion(Version.emptyVersion, cloud)).isEmpty(), "All nodes on unknown version");
         assertTrue(osVersions.get(new OsVersion(version1, cloud)).isEmpty(), "No nodes on current target");
 
         CloudName otherCloud = CloudName.AWS;
-        tester.controller().upgradeOsIn(otherCloud, version1, false, false);
+        tester.controller().os().upgradeTo(version1, otherCloud, false, false);
         statusUpdater.maintain();
 
-        osVersions = tester.controller().osVersionStatus().versions();
+        osVersions = tester.controller().os().status().versions();
         assertEquals(4, osVersions.size()); // 2 in cloud, 2 in otherCloud.
         assertFalse(osVersions.get(new OsVersion(Version.emptyVersion, cloud)).isEmpty(), "All nodes on unknown version");
         assertTrue(osVersions.get(new OsVersion(version1, cloud)).isEmpty(), "No nodes on current target");

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/OsVersionTargetSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/OsVersionTargetSerializerTest.java
@@ -1,7 +1,6 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.persistence;
 
-import com.google.common.collect.ImmutableSet;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.vespa.hosted.controller.versions.OsVersion;
@@ -10,6 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -21,10 +22,10 @@ public class OsVersionTargetSerializerTest {
     @Test
     void serialization() {
         OsVersionTargetSerializer serializer = new OsVersionTargetSerializer(new OsVersionSerializer());
-        Set<OsVersionTarget> targets = ImmutableSet.of(
-                new OsVersionTarget(new OsVersion(Version.fromString("7.1"), CloudName.DEFAULT), Instant.ofEpochMilli(123)),
-                new OsVersionTarget(new OsVersion(Version.fromString("7.1"), CloudName.from("foo")), Instant.ofEpochMilli(456))
-        );
+        SortedSet<OsVersionTarget> targets = new TreeSet<>();
+        targets.add(new OsVersionTarget(new OsVersion(Version.fromString("7.1"), CloudName.DEFAULT), Instant.ofEpochMilli(123), false, false));
+        targets.add(new OsVersionTarget(new OsVersion(Version.fromString("7.1"), CloudName.from("foo")), Instant.ofEpochMilli(456), true, true));
+
         Set<OsVersionTarget> serialized = serializer.fromSlime(serializer.toSlime(targets));
         assertEquals(targets, serialized);
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -160,7 +160,7 @@ public class OsApiTest extends ControllerContainerTest {
     }
 
     private void updateVersionStatus() {
-        tester.controller().updateOsVersionStatus(OsVersionStatus.compute(tester.controller()));
+        tester.controller().os().updateStatus(OsVersionStatus.compute(tester.controller()));
     }
 
     private void completeUpgrade(ZoneId... zones) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/OsApiTest.java
@@ -96,12 +96,20 @@ public class OsApiTest extends ControllerContainerTest {
         assertFile(new Request("http://localhost:8080/os/v1/"), "versions-all-upgraded.json");
 
         // Downgrade with force is permitted
-        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.5.1\", \"cloud\": \"cloud1\", \"force\": true}", Request.Method.PATCH),
-                "{\"message\":\"Set target OS version for cloud 'cloud1' to 7.5.1\"}", 200);
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"8.2.0\", \"cloud\": \"cloud2\", \"force\": true}", Request.Method.PATCH),
+                       "{\"message\":\"Set target OS version for cloud 'cloud2' to 8.2.0\"}", 200);
 
         // Clear target for a given cloud
-        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": null, \"cloud\": \"cloud2\"}", Request.Method.PATCH),
-                "{\"message\":\"Cleared target OS version for cloud 'cloud2'\"}", 200);
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": null, \"cloud\": \"cloud1\"}", Request.Method.PATCH),
+                "{\"message\":\"Cleared target OS version for cloud 'cloud1'\"}", 200);
+
+        // Pin/unpin a version
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.5.2\", \"cloud\": \"cloud1\", \"pin\": true}", Request.Method.PATCH),
+                       "{\"message\":\"Set target OS version for cloud 'cloud1' to 7.5.2 (pinned)\"}", 200);
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.5.2\", \"cloud\": \"cloud1\", \"pin\": false}", Request.Method.PATCH),
+                       "{\"message\":\"Set target OS version for cloud 'cloud1' to 7.5.2\"}", 200);
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.5.2\", \"cloud\": \"cloud1\", \"pin\": true}", Request.Method.PATCH),
+                       "{\"message\":\"Set target OS version for cloud 'cloud1' to 7.5.2 (pinned)\"}", 200);
 
         // Error: Missing fields
         assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.6\"}", Request.Method.PATCH),
@@ -120,8 +128,12 @@ public class OsApiTest extends ControllerContainerTest {
                 "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cloud 'foo' does not exist in this system\"}", 400);
 
         // Error: Downgrade OS
-        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.4.1\", \"cloud\": \"cloud1\"}", Request.Method.PATCH),
-                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot downgrade cloud 'cloud1' to version 7.4.1\"}", 400);
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.4.1\", \"cloud\": \"cloud2\"}", Request.Method.PATCH),
+                "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot downgrade cloud 'cloud2' to version 7.4.1: Missing 'force' parameter\"}", 400);
+
+        // Error: Change a pinned version
+        assertResponse(new Request("http://localhost:8080/os/v1/", "{\"version\": \"7.5.3\", \"cloud\": \"cloud1\"}", Request.Method.PATCH),
+                       "{\"error-code\":\"BAD_REQUEST\",\"message\":\"Cannot upgrade cloud cloud1' to version 7.5.3: Current target is pinned. Add 'force' parameter to override\"}", 400);
 
         // Request firmware checks in all zones.
         assertResponse(new Request("http://localhost:8080/os/v1/firmware/", "", Request.Method.POST),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
@@ -5,6 +5,7 @@
       "targetVersion": true,
       "upgradeBudget": "PT0S",
       "scheduledAt": 1234,
+      "pinned": false,
       "cloud": "cloud1",
       "nodes": [
         {
@@ -104,6 +105,7 @@
       "targetVersion": true,
       "upgradeBudget": "PT0S",
       "scheduledAt": 1234,
+      "pinned": false,
       "nextVersion": "8.2.1.20211228",
       "nextScheduledAt": 1640743200000,
       "cloud": "cloud2",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
@@ -57,6 +57,7 @@
       "targetVersion": true,
       "upgradeBudget": "PT0S",
       "scheduledAt": 1234,
+      "pinned": false,
       "cloud": "cloud1",
       "nodes": [
         {
@@ -163,6 +164,7 @@
       "targetVersion": true,
       "upgradeBudget": "PT0S",
       "scheduledAt": 1234,
+      "pinned": false,
       "nextVersion": "8.2.1.20211228",
       "nextScheduledAt": 1640743200000,
       "cloud": "cloud2",


### PR DESCRIPTION
With this we will support changing the target version for a system to a past
version, and optionally pinning the system to that version. This is to simplify
manually stopping upgrades/rolling back.

Currently, a given zone won't downgrade existing active hosts to a lower
version, but any pending upgrades will be canceled and new hosts will use the
lower version. I couldn't think of a scenario where we'd want to downgrade
working hosts, so leaving it as-is for now.

No functional changes in the last commit.

Merge with internal PR.

@bratseth