### PR TITLE
Allow version ranges in enforcer rules.

### DIFF
--- a/maven-plugins/allowed-maven-dependencies.txt
+++ b/maven-plugins/allowed-maven-dependencies.txt
@@ -11,12 +11,15 @@ com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:32.1.1-jre
 com.google.inject:guice:4.2.3:no_aop
 com.google.j2objc:j2objc-annotations:2.8
+commons-codec:commons-codec:1.15
 commons-io:commons-io:2.11.0
 javax.annotation:javax.annotation-api:1.2
 javax.inject:javax.inject:1
+org.apache-extras.beanshell:bsh:2.0b6
 org.apache.commons:commons-collections4:4.2
 org.apache.commons:commons-compress:1.23.0
 org.apache.commons:commons-lang3:3.12.0
+org.apache.maven.enforcer:enforcer-rules:3.3.0
 org.apache.maven:maven-archiver:3.6.0
 org.apache.maven:maven-artifact:3.8.7
 org.apache.maven:maven-builder-support:3.8.7
@@ -47,6 +50,7 @@ org.codehaus.plexus:plexus-interpolation:1.26
 org.codehaus.plexus:plexus-io:3.4.0
 org.codehaus.plexus:plexus-sec-dispatcher:2.0
 org.codehaus.plexus:plexus-utils:3.3.1
+org.codehaus.plexus:plexus-utils:3.5.1
 org.eclipse.aether:aether-api:1.0.0.v20140518
 org.eclipse.aether:aether-util:1.0.0.v20140518
 org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -836,6 +836,11 @@
                 <version>${maven-enforcer-plugin.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.enforcer</groupId>
+                <artifactId>enforcer-rules</artifactId>
+                <version>${maven-enforcer-plugin.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven-plugin-tools.version}</version>

--- a/vespa-enforcer-extensions/pom.xml
+++ b/vespa-enforcer-extensions/pom.xml
@@ -26,6 +26,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.enforcer</groupId>
+            <artifactId>enforcer-rules</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>

--- a/vespa-enforcer-extensions/src/main/java/com/yahoo/vespa/maven/plugin/enforcer/EnforceDependencies.java
+++ b/vespa-enforcer-extensions/src/main/java/com/yahoo/vespa/maven/plugin/enforcer/EnforceDependencies.java
@@ -3,9 +3,13 @@ package com.yahoo.vespa.maven.plugin.enforcer;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.enforcer.rule.api.EnforcerRule;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.enforcer.rules.utils.ArtifactMatcher;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
@@ -130,13 +134,23 @@ public class EnforceDependencies implements EnforcerRule {
     /** Matches simple glob like patterns using '?' and '*' */
     private static boolean segmentMatches(String value, String segmentPattern) {
         String regex = segmentPattern
-                .replace(".", "\\.").replace("*", ".*").replace(":", "\\:").replace('?', '.').replace("(", "\\(")
-                .replace(")", "\\)");
+                .replace(".", "\\.").replace("*", ".*").replace(":", "\\:")
+                .replace('?', '.').replace("(", "\\(").replace(")", "\\)")
+                .replace("[", "\\[").replace("]", "\\]");
         return Pattern.matches(regex, value);
     }
 
-    private static boolean versionMatches(String rawVersion, String segmentPattern) {
-        return segmentMatches(rawVersion, segmentPattern);
+    private static boolean versionMatches(String rawVersion, String segmentPattern) throws EnforcerRuleException {
+        if (segmentMatches(rawVersion, segmentPattern)) return true;
+
+        // Handle version ranges. Note that ArtifactMatcher treats a single version without brackets as a minimum version.
+        if (! (segmentPattern.startsWith("[") || segmentPattern.startsWith("("))) return false;
+        try {
+            var range = VersionRange.createFromVersionSpec(segmentPattern);
+            return ArtifactMatcher.containsVersion(range, new DefaultArtifactVersion(rawVersion));
+        } catch (InvalidVersionSpecificationException e) {
+            throw new EnforcerRuleException("Invalid version range: " + segmentPattern, e);
+        }
     }
 
     public void setAllowed(List<String> allowed) { this.allowedDependencies = allowed; }

--- a/vespa-enforcer-extensions/src/test/java/com/yahoo/vespa/maven/plugin/enforcer/EnforceDependenciesTest.java
+++ b/vespa-enforcer-extensions/src/test/java/com/yahoo/vespa/maven/plugin/enforcer/EnforceDependenciesTest.java
@@ -136,6 +136,34 @@ class EnforceDependenciesTest {
         assertEquals(expectedErrorMessage, exception.getMessage());
     }
 
+    @Test
+    void matches_on_version_in_allowed_range() {
+        var dependencies = Set.of(
+                artifact("com.yahoo.testing", "test", "1.2.3", "compile"));
+        var rules = Set.of("com.yahoo.testing:test:jar:[1.0,2):compile");
+        assertDoesNotThrow(() -> EnforceDependencies.validateDependencies(dependencies, rules, true));
+    }
+
+    @Test
+    void fails_on_version_outside_allowed_range() {
+        var dependencies = Set.of(
+                artifact("com.yahoo.testing", "test", "2", "compile"));
+        var rules = Set.of("com.yahoo.testing:test:jar:[1.0,2):compile");
+
+        var exception = assertThrows(
+                EnforcerRuleException.class,
+                () -> EnforceDependencies.validateDependencies(dependencies, rules, true));
+        String expectedErrorMessage =
+                """
+                Vespa dependency enforcer failed:
+                Dependencies not matching any rule:
+                 - com.yahoo.testing:test:jar:2:compile
+                Rules not matching any dependency:
+                 - com.yahoo.testing:test:jar:[1.0,2):compile
+                """;
+        assertEquals(expectedErrorMessage, exception.getMessage());
+    }
+
     private static Artifact artifact(String groupId, String artifactId, String version, String scope) {
         return artifact(groupId, artifactId, version, scope, null);
     }


### PR DESCRIPTION
I decided to just expand our `versionMatches()` by using `ArtifactMatcher.containsVersion`.

The problem with`ArtifactUtils.compareDependency` is that a rule with no classifier matches an artifact with classifier, as there is no way to specify that a rule must have an empty classifier.
