### PR TITLE
Use version ranges and properties in enforcers

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -58,7 +58,7 @@
                                         <include>com.sun.activation:javax.activation:1.2.0:provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:${jaxb.vespa.version}:provided</include>
                                         <include>com.sun.xml.bind:jaxb-impl:${jaxb.vespa.version}:provided</include>
-                                        <include>commons-logging:commons-logging:1.2:provided</include>
+                                        <include>commons-logging:commons-logging:${commons-logging.vespa.version}:provided</include>
                                         <include>javax.inject:javax.inject:${javax.inject.vespa.version}:provided</include>
                                         <include>javax.servlet:javax.servlet-api:${javax.servlet-api.vespa.version}:provided</include>
                                         <include>javax.ws.rs:javax.ws.rs-api:${javax.ws.rs-api.vespa.version}:provided</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -198,7 +198,7 @@
                                         <include>org.opentest4j:opentest4j:1.2.0:test</include>
                                         <include>org.osgi:org.osgi.compendium:[4.1.0, 5):test</include>
                                         <include>org.osgi:org.osgi.core:[4.1.0, 5):test</include>
-                                        <include>xerces:xercesImpl:2.12.2:test</include>
+                                        <include>xerces:xercesImpl:${xerces.vespa.version}:test</include>
                                     </allowed>
                                 </enforceDependencies>
                             </rules>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -186,7 +186,7 @@
                                         <include>org.eclipse.jetty:jetty-servlet:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-util:${jetty.vespa.version}:test</include>
 
-                                        <include>org.hamcrest:hamcrest-core:1.3:test</include>
+                                        <include>org.hamcrest:hamcrest-core:${hamcrest.vespa.version}:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.json:json:${org.json.vespa.version}:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-api:${junit.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -144,7 +144,7 @@
                                         <include>com.microsoft.onnxruntime:onnxruntime:jar:${onnxruntime.vespa.version}:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>
-                                        <include>io.airlift:airline:0.9:test</include>
+                                        <include>io.airlift:airline:${airline.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient:0.6.0:test</include>
                                         <include>io.prometheus:simpleclient_common:0.6.0:test</include>
                                         <include>junit:junit:4.13.2:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -145,8 +145,8 @@
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>
                                         <include>io.airlift:airline:${airline.vespa.version}:test</include>
-                                        <include>io.prometheus:simpleclient:0.6.0:test</include>
-                                        <include>io.prometheus:simpleclient_common:0.6.0:test</include>
+                                        <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
+                                        <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
                                         <include>junit:junit:4.13.2:test</include>
                                         <include>net.java.dev.jna:jna:5.11.0:test</include>
                                         <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -195,7 +195,7 @@
                                         <include>org.junit.platform:junit-platform-engine:${junit.platform.vespa.version}:test</include>
                                         <include>org.junit.vintage:junit-vintage-engine:${junit.vespa.version}:test</include>
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>
-                                        <include>org.opentest4j:opentest4j:1.2.0:test</include>
+                                        <include>org.opentest4j:opentest4j:${opentest4j.vespa.version}:test</include>
                                         <include>org.osgi:org.osgi.compendium:[4.1.0, 5):test</include>
                                         <include>org.osgi:org.osgi.core:[4.1.0, 5):test</include>
                                         <include>xerces:xercesImpl:${xerces.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -140,7 +140,7 @@
                                         <!-- 3rd party test dependencies -->
                                         <include>com.google.code.findbugs:jsr305:${findbugs.vespa.version}:test</include>
                                         <include>com.google.protobuf:protobuf-java:3.21.7:test</include>
-                                        <include>com.ibm.icu:icu4j:70.1:test</include>
+                                        <include>com.ibm.icu:icu4j:${icu4j.vespa.version}:test</include>
                                         <include>com.microsoft.onnxruntime:onnxruntime:jar:${onnxruntime.vespa.version}:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -152,7 +152,7 @@
                                         <include>net.openhft:zero-allocation-hashing:jar:${zero-allocation-hashing.vespa.version}:test</include>
                                         <include>org.antlr:antlr-runtime:${antlr.vespa.version}:test</include>
                                         <include>org.antlr:antlr4-runtime:${antlr4.vespa.version}:test</include>
-                                        <include>org.apache.commons:commons-exec:1.3:test</include>
+                                        <include>org.apache.commons:commons-exec:${commons-exec.vespa.version}:test</include>
                                         <include>org.apache.commons:commons-math3:${commons.math3.vespa.version}:test</include>
                                         <include>org.apache.felix:org.apache.felix.framework:${felix.vespa.version}:test</include>
                                         <include>org.apache.felix:org.apache.felix.log:${felix.log.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -139,7 +139,7 @@
 
                                         <!-- 3rd party test dependencies -->
                                         <include>com.google.code.findbugs:jsr305:${findbugs.vespa.version}:test</include>
-                                        <include>com.google.protobuf:protobuf-java:3.21.7:test</include>
+                                        <include>com.google.protobuf:protobuf-java:${protobuf.vespa.version}:test</include>
                                         <include>com.ibm.icu:icu4j:${icu4j.vespa.version}:test</include>
                                         <include>com.microsoft.onnxruntime:onnxruntime:jar:${onnxruntime.vespa.version}:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -50,12 +50,12 @@
 
                                         <!-- Guava with its internal dependencies -->
                                         <include>com.google.guava:guava:${guava.vespa.version}:provided</include>
-                                        <include>com.google.errorprone:error_prone_annotations:2.18.0:provided</include>
-                                        <include>com.google.guava:failureaccess:1.0.1:provided</include>
-                                        <include>com.google.j2objc:j2objc-annotations:2.8:provided</include>
+                                        <include>com.google.errorprone:error_prone_annotations:[2.18.0, 3):provided</include>
+                                        <include>com.google.guava:failureaccess:[1.0.1, 2):provided</include>
+                                        <include>com.google.j2objc:j2objc-annotations:[2.8, 3):provided</include>
 
                                         <include>com.google.inject:guice:jar:no_aop:${guice.vespa.version}:provided</include>
-                                        <include>com.sun.activation:javax.activation:1.2.0:provided</include>
+                                        <include>com.sun.activation:javax.activation:[1.2.0, 2):provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:${jaxb.vespa.version}:provided</include>
                                         <include>com.sun.xml.bind:jaxb-impl:${jaxb.vespa.version}:provided</include>
                                         <include>commons-logging:commons-logging:${commons-logging.vespa.version}:provided</include>
@@ -196,8 +196,8 @@
                                         <include>org.junit.vintage:junit-vintage-engine:${junit.vespa.version}:test</include>
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>
                                         <include>org.opentest4j:opentest4j:1.2.0:test</include>
-                                        <include>org.osgi:org.osgi.compendium:4.1.0:test</include>
-                                        <include>org.osgi:org.osgi.core:4.1.0:test</include>
+                                        <include>org.osgi:org.osgi.compendium:[4.1.0, 5):test</include>
+                                        <include>org.osgi:org.osgi.core:[4.1.0, 5):test</include>
                                         <include>xerces:xercesImpl:2.12.2:test</include>
                                     </allowed>
                                 </enforceDependencies>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -162,7 +162,7 @@
                                         <include>org.apache.httpcomponents:httpclient:${apache.httpclient.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents:httpcore:${apache.httpcore.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents:httpmime:${apache.httpclient.vespa.version}:test</include>
-                                        <include>org.apache.opennlp:opennlp-tools:1.9.3:test</include>
+                                        <include>org.apache.opennlp:opennlp-tools:${opennlp.vespa.version}:test</include>
                                         <include>org.apiguardian:apiguardian-api:1.1.2:test</include>
                                         <include>org.bouncycastle:bcpkix-jdk18on:${bouncycastle.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcprov-jdk18on:${bouncycastle.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -138,7 +138,7 @@
                                         <include>com.yahoo.vespa:vsm:*:test</include>
 
                                         <!-- 3rd party test dependencies -->
-                                        <include>com.google.code.findbugs:jsr305:3.0.2:test</include>
+                                        <include>com.google.code.findbugs:jsr305:${findbugs.vespa.version}:test</include>
                                         <include>com.google.protobuf:protobuf-java:3.21.7:test</include>
                                         <include>com.ibm.icu:icu4j:70.1:test</include>
                                         <include>com.microsoft.onnxruntime:onnxruntime:jar:${onnxruntime.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -163,7 +163,7 @@
                                         <include>org.apache.httpcomponents:httpcore:${apache.httpcore.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents:httpmime:${apache.httpclient.vespa.version}:test</include>
                                         <include>org.apache.opennlp:opennlp-tools:${opennlp.vespa.version}:test</include>
-                                        <include>org.apiguardian:apiguardian-api:1.1.2:test</include>
+                                        <include>org.apiguardian:apiguardian-api:${apiguardian.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcpkix-jdk18on:${bouncycastle.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcprov-jdk18on:${bouncycastle.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcutil-jdk18on:${bouncycastle.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -21,7 +21,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.3.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.yahoo.vespa</groupId>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -148,14 +148,14 @@
                                         <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
                                         <include>junit:junit:${junit4.vespa.version}:test</include>
-                                        <include>net.java.dev.jna:jna:5.11.0:test</include>
-                                        <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>
-                                        <include>org.antlr:antlr-runtime:3.5.3:test</include>
-                                        <include>org.antlr:antlr4-runtime:4.11.1:test</include>
+                                        <include>net.java.dev.jna:jna:${jna.vespa.version}:test</include>
+                                        <include>net.openhft:zero-allocation-hashing:jar:${zero-allocation-hashing.vespa.version}:test</include>
+                                        <include>org.antlr:antlr-runtime:${antlr.vespa.version}:test</include>
+                                        <include>org.antlr:antlr4-runtime:${antlr4.vespa.version}:test</include>
                                         <include>org.apache.commons:commons-exec:1.3:test</include>
-                                        <include>org.apache.commons:commons-math3:3.6.1:test</include>
+                                        <include>org.apache.commons:commons-math3:${commons.math3.vespa.version}:test</include>
                                         <include>org.apache.felix:org.apache.felix.framework:${felix.vespa.version}:test</include>
-                                        <include>org.apache.felix:org.apache.felix.log:1.0.1:test</include>
+                                        <include>org.apache.felix:org.apache.felix.log:${felix.log.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.client5:httpclient5:${apache.httpclient5.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.core5:httpcore5:${apache.httpcore5.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.core5:httpcore5-h2:${apache.httpcore5.vespa.version}:test</include>
@@ -172,7 +172,7 @@
                                         <include>org.eclipse.jetty.http2:http2-hpack:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty.http2:http2-http-client-transport:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty.http2:http2-server:${jetty.vespa.version}:test</include>
-                                        <include>org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2:test</include>
+                                        <include>org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:${jetty-servlet-api.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-client:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-java-client:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-java-server:${jetty.vespa.version}:test</include>
@@ -187,7 +187,7 @@
                                         <include>org.eclipse.jetty:jetty-util:${jetty.vespa.version}:test</include>
 
                                         <include>org.hamcrest:hamcrest-core:1.3:test</include>
-                                        <include>org.hdrhistogram:HdrHistogram:2.1.12:test</include>
+                                        <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.json:json:${org.json.vespa.version}:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-api:${junit.vespa.version}:test</include>
                                         <include>org.junit.jupiter:junit-jupiter-engine:${junit.vespa.version}:test</include>

--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -147,7 +147,7 @@
                                         <include>io.airlift:airline:${airline.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
-                                        <include>junit:junit:4.13.2:test</include>
+                                        <include>junit:junit:${junit4.vespa.version}:test</include>
                                         <include>net.java.dev.jna:jna:5.11.0:test</include>
                                         <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>
                                         <include>org.antlr:antlr-runtime:3.5.3:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -151,7 +151,7 @@
                                         <include>com.yahoo.vespa:vsm:*:test</include>
 
                                         <!-- 3rd party test dependencies -->
-                                        <include>com.google.code.findbugs:jsr305:3.0.2:test</include>
+                                        <include>com.google.code.findbugs:jsr305:${findbugs.vespa.version}:test</include>
                                         <include>com.google.protobuf:protobuf-java:${protobuf.vespa.version}:test</include>
                                         <include>com.ibm.icu:icu4j:70.1:test</include>
                                         <include>com.microsoft.onnxruntime:onnxruntime:${onnxruntime.vespa.version}:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -157,7 +157,7 @@
                                         <include>com.microsoft.onnxruntime:onnxruntime:${onnxruntime.vespa.version}:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>
-                                        <include>io.airlift:airline:0.9:test</include>
+                                        <include>io.airlift:airline:${airline.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient:0.6.0:test</include>
                                         <include>io.prometheus:simpleclient_common:0.6.0:test</include>
                                         <include>junit:junit:4.13.2:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -160,7 +160,7 @@
                                         <include>io.airlift:airline:${airline.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
-                                        <include>junit:junit:4.13.2:test</include>
+                                        <include>junit:junit:${junit4.vespa.version}:test</include>
                                         <include>net.java.dev.jna:jna:5.11.0:test</include>
                                         <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>
                                         <include>org.antlr:antlr-runtime:3.5.3:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -201,7 +201,7 @@
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>
                                         <include>org.osgi:org.osgi.compendium:[4.1.0, 5):test</include>
                                         <include>org.osgi:org.osgi.core:[4.1.0, 5):test</include>
-                                        <include>xerces:xercesImpl:2.12.2:test</include>
+                                        <include>xerces:xercesImpl:${xerces.vespa.version}:test</include>
                                     </allowed>
                                 </enforceDependencies>
                             </rules>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -158,8 +158,8 @@
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>
                                         <include>io.airlift:airline:${airline.vespa.version}:test</include>
-                                        <include>io.prometheus:simpleclient:0.6.0:test</include>
-                                        <include>io.prometheus:simpleclient_common:0.6.0:test</include>
+                                        <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
+                                        <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
                                         <include>junit:junit:4.13.2:test</include>
                                         <include>net.java.dev.jna:jna:5.11.0:test</include>
                                         <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -195,7 +195,7 @@
                                         <include>org.eclipse.jetty:jetty-server:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-servlet:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-util:${jetty.vespa.version}:test</include>
-                                        <include>org.hamcrest:hamcrest-core:1.3:test</include>
+                                        <include>org.hamcrest:hamcrest-core:${hamcrest.vespa.version}:test</include>
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.json:json:${org.json.vespa.version}:test</include> <!-- TODO: Remove on Vespa 9 -->
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -161,15 +161,15 @@
                                         <include>io.prometheus:simpleclient:${prometheus.client.vespa.version}:test</include>
                                         <include>io.prometheus:simpleclient_common:${prometheus.client.vespa.version}:test</include>
                                         <include>junit:junit:${junit4.vespa.version}:test</include>
-                                        <include>net.java.dev.jna:jna:5.11.0:test</include>
-                                        <include>net.openhft:zero-allocation-hashing:jar:0.16:test</include>
-                                        <include>org.antlr:antlr-runtime:3.5.3:test</include>
-                                        <include>org.antlr:antlr4-runtime:4.11.1:test</include>
+                                        <include>net.java.dev.jna:jna:${jna.vespa.version}:test</include>
+                                        <include>net.openhft:zero-allocation-hashing:jar:${zero-allocation-hashing.vespa.version}:test</include>
+                                        <include>org.antlr:antlr-runtime:${antlr.vespa.version}:test</include>
+                                        <include>org.antlr:antlr4-runtime:${antlr4.vespa.version}:test</include>
                                         <include>org.apache.commons:commons-exec:1.3:test</include>
-                                        <include>org.apache.commons:commons-math3:3.6.1:test</include>
+                                        <include>org.apache.commons:commons-math3:${commons.math3.vespa.version}:test</include>
                                         <include>org.apache.felix:org.apache.felix.framework:${felix.vespa.version}:test</include>
                                         <include>org.apache.felix:org.apache.felix.framework:${felix.vespa.version}:test</include>
-                                        <include>org.apache.felix:org.apache.felix.log:1.0.1:test</include>
+                                        <include>org.apache.felix:org.apache.felix.log:${felix.log.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.client5:httpclient5:${apache.httpclient5.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.core5:httpcore5:${apache.httpcore5.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents.core5:httpcore5-h2:${apache.httpcore5.vespa.version}:test</include>
@@ -183,7 +183,7 @@
                                         <include>org.eclipse.jetty.http2:http2-common:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty.http2:http2-hpack:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty.http2:http2-server:${jetty.vespa.version}:test</include>
-                                        <include>org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:5.0.2:test</include>
+                                        <include>org.eclipse.jetty.toolchain:jetty-jakarta-servlet-api:${jetty-servlet-api.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-client:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-java-server:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-alpn-server:${jetty.vespa.version}:test</include>
@@ -196,7 +196,7 @@
                                         <include>org.eclipse.jetty:jetty-servlet:${jetty.vespa.version}:test</include>
                                         <include>org.eclipse.jetty:jetty-util:${jetty.vespa.version}:test</include>
                                         <include>org.hamcrest:hamcrest-core:1.3:test</include>
-                                        <include>org.hdrhistogram:HdrHistogram:2.1.12:test</include>
+                                        <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.json:json:${org.json.vespa.version}:test</include> <!-- TODO: Remove on Vespa 9 -->
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>
                                         <include>org.osgi:org.osgi.compendium:4.1.0:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -176,7 +176,7 @@
                                         <include>org.apache.httpcomponents:httpclient:${apache.httpclient.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents:httpcore:${apache.httpcore.vespa.version}:test</include>
                                         <include>org.apache.httpcomponents:httpmime:${apache.httpclient.vespa.version}:test</include>
-                                        <include>org.apache.opennlp:opennlp-tools:1.9.3:test</include>
+                                        <include>org.apache.opennlp:opennlp-tools:${opennlp.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcpkix-jdk18on:${bouncycastle.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcprov-jdk18on:${bouncycastle.vespa.version}:test</include>
                                         <include>org.bouncycastle:bcutil-jdk18on:${bouncycastle.vespa.version}:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -153,7 +153,7 @@
                                         <!-- 3rd party test dependencies -->
                                         <include>com.google.code.findbugs:jsr305:${findbugs.vespa.version}:test</include>
                                         <include>com.google.protobuf:protobuf-java:${protobuf.vespa.version}:test</include>
-                                        <include>com.ibm.icu:icu4j:70.1:test</include>
+                                        <include>com.ibm.icu:icu4j:${icu4j.vespa.version}:test</include>
                                         <include>com.microsoft.onnxruntime:onnxruntime:${onnxruntime.vespa.version}:test</include>
                                         <include>com.thaiopensource:jing:20091111:test</include>
                                         <include>commons-codec:commons-codec:${commons-codec.vespa.version}:test</include>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -69,12 +69,12 @@
 
                                         <!-- Guava with its internal dependencies -->
                                         <include>com.google.guava:guava:${guava.vespa.version}:provided</include>
-                                        <include>com.google.errorprone:error_prone_annotations:2.18.0:provided</include>
-                                        <include>com.google.guava:failureaccess:1.0.1:provided</include>
-                                        <include>com.google.j2objc:j2objc-annotations:2.8:provided</include>
+                                        <include>com.google.errorprone:error_prone_annotations:[2.18.0, 3):provided</include>
+                                        <include>com.google.guava:failureaccess:[1.0.1, 2):provided</include>
+                                        <include>com.google.j2objc:j2objc-annotations:[2.8, 3):provided</include>
 
                                         <include>com.google.inject:guice:jar:no_aop:${guice.vespa.version}:provided</include>
-                                        <include>com.sun.activation:javax.activation:1.2.0:provided</include>
+                                        <include>com.sun.activation:javax.activation:[1.2.0, 2):provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:${jaxb.vespa.version}:provided</include>
                                         <include>com.sun.xml.bind:jaxb-impl:${jaxb.vespa.version}:provided</include>
                                         <include>commons-logging:commons-logging:${commons-logging.vespa.version}:provided</include>
@@ -199,8 +199,8 @@
                                         <include>org.hdrhistogram:HdrHistogram:${hdrhistogram.vespa.version}:test</include>
                                         <include>org.json:json:${org.json.vespa.version}:test</include> <!-- TODO: Remove on Vespa 9 -->
                                         <include>org.lz4:lz4-java:${org.lz4.vespa.version}:test</include>
-                                        <include>org.osgi:org.osgi.compendium:4.1.0:test</include>
-                                        <include>org.osgi:org.osgi.core:4.1.0:test</include>
+                                        <include>org.osgi:org.osgi.compendium:[4.1.0, 5):test</include>
+                                        <include>org.osgi:org.osgi.core:[4.1.0, 5):test</include>
                                         <include>xerces:xercesImpl:2.12.2:test</include>
                                     </allowed>
                                 </enforceDependencies>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -77,7 +77,7 @@
                                         <include>com.sun.activation:javax.activation:1.2.0:provided</include>
                                         <include>com.sun.xml.bind:jaxb-core:${jaxb.vespa.version}:provided</include>
                                         <include>com.sun.xml.bind:jaxb-impl:${jaxb.vespa.version}:provided</include>
-                                        <include>commons-logging:commons-logging:1.2:provided</include>
+                                        <include>commons-logging:commons-logging:${commons-logging.vespa.version}:provided</include>
                                         <include>javax.inject:javax.inject:${javax.inject.vespa.version}:provided</include>
                                         <include>javax.servlet:javax.servlet-api:${javax.servlet-api.vespa.version}:provided</include>
                                         <include>javax.ws.rs:javax.ws.rs-api:${javax.ws.rs-api.vespa.version}:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -91,8 +91,7 @@
             <dependency>
               <groupId>commons-logging</groupId>
               <artifactId>commons-logging</artifactId>
-                <!-- This version is exported by jdisc via jcl-over-slf4j. -->
-              <version>1.2</version>
+              <version>${commons-logging.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -74,6 +74,7 @@
         <commons-exec.vespa.version>1.3</commons-exec.vespa.version>
         <commons-io.vespa.version>2.11.0</commons-io.vespa.version>
         <commons.math3.vespa.version>3.6.1</commons.math3.vespa.version>
+        <commons-compress.vespa.version>1.23.0</commons-compress.vespa.version>
         <eclipse-collections.vespa.version>11.0.0</eclipse-collections.vespa.version>
         <felix.vespa.version>7.0.5</felix.vespa.version>
         <felix.log.vespa.version>1.0.1</felix.log.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -81,10 +81,10 @@
         <hamcrest.vespa.version>1.3</hamcrest.vespa.version>
         <hdrhistogram.vespa.version>2.1.12</hdrhistogram.vespa.version>
         <icu4j.vespa.version>70.1</icu4j.vespa.version>
+        <java-jjwt.vespa.version>0.11.5</java-jjwt.vespa.version>
         <jersey.vespa.version>2.25</jersey.vespa.version>
         <jetty.vespa.version>11.0.15</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
-        <jjwt.vespa.version>0.11.5</jjwt.vespa.version>
         <jna.vespa.version>5.11.0</jna.vespa.version>
         <joda-time.vespa.version>2.12.2</joda-time.vespa.version>
         <junit.vespa.version>5.8.1</junit.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -83,6 +83,7 @@
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>
         <jjwt.vespa.version>0.11.5</jjwt.vespa.version>
         <jna.vespa.version>5.11.0</jna.vespa.version>
+        <joda-time.vespa.version>2.12.2</joda-time.vespa.version>
         <junit.vespa.version>5.8.1</junit.vespa.version>
         <junit.platform.vespa.version>1.8.1</junit.platform.vespa.version>
         <maven-archiver.vespa.version>3.6.0</maven-archiver.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -82,6 +82,7 @@
         <hdrhistogram.vespa.version>2.1.12</hdrhistogram.vespa.version>
         <icu4j.vespa.version>70.1</icu4j.vespa.version>
         <java-jjwt.vespa.version>0.11.5</java-jjwt.vespa.version>
+        <java-jwt.vespa.version>3.10.0</java-jwt.vespa.version>
         <jersey.vespa.version>2.25</jersey.vespa.version>
         <jetty.vespa.version>11.0.15</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -94,6 +94,7 @@
         <junit4.vespa.version>4.13.2</junit4.vespa.version>
         <maven-archiver.vespa.version>3.6.0</maven-archiver.vespa.version>
         <maven-wagon.vespa.version>2.10</maven-wagon.vespa.version>
+        <mimepull.vespa.version>1.9.6</mimepull.vespa.version>
         <mockito.vespa.version>4.0.0</mockito.vespa.version>
         <netty.vespa.version>4.1.94.Final</netty.vespa.version>
         <netty-tcnative.vespa.version>2.0.61.Final</netty-tcnative.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -54,6 +54,7 @@
         <apache.httpcore.vespa.version>4.4.16</apache.httpcore.vespa.version>
         <apache.httpclient5.vespa.version>5.2.1</apache.httpclient5.vespa.version>
         <apache.httpcore5.vespa.version>5.2.2</apache.httpcore5.vespa.version>
+        <apiguardian.vespa.version>1.1.2</apiguardian.vespa.version>
         <asm.vespa.version>9.3</asm.vespa.version>
 
         <!-- Athenz dependencies. Make sure these dependencies match those in Vespa's internal repositories -->

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -97,6 +97,7 @@
         <netty-tcnative.vespa.version>2.0.61.Final</netty-tcnative.vespa.version>
         <onnxruntime.vespa.version>1.13.1</onnxruntime.vespa.version>
         <opennlp.vespa.version>1.9.3</opennlp.vespa.version>
+        <opentest4j.vespa.version>1.2.0</opentest4j.vespa.version>
         <org.json.vespa.version>20230227</org.json.vespa.version>
         <org.lz4.vespa.version>1.8.0</org.lz4.vespa.version>
         <prometheus.client.vespa.version>0.6.0</prometheus.client.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -70,6 +70,7 @@
         <bouncycastle.vespa.version>1.74</bouncycastle.vespa.version>
         <curator.vespa.version>5.4.0</curator.vespa.version>
         <commons-codec.vespa.version>1.15</commons-codec.vespa.version>
+        <commons-exec.vespa.version>1.3</commons-exec.vespa.version>
         <commons-io.vespa.version>2.11.0</commons-io.vespa.version>
         <commons.math3.vespa.version>3.6.1</commons.math3.vespa.version>
         <eclipse-collections.vespa.version>11.0.0</eclipse-collections.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -93,6 +93,7 @@
         <netty.vespa.version>4.1.94.Final</netty.vespa.version>
         <netty-tcnative.vespa.version>2.0.61.Final</netty-tcnative.vespa.version>
         <onnxruntime.vespa.version>1.13.1</onnxruntime.vespa.version>
+        <opennlp.vespa.version>1.9.3</opennlp.vespa.version>
         <org.json.vespa.version>20230227</org.json.vespa.version>
         <org.lz4.vespa.version>1.8.0</org.lz4.vespa.version>
         <prometheus.client.vespa.version>0.6.0</prometheus.client.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -30,6 +30,8 @@
     <properties>
         
         <!-- BEGIN Dependencies available from the Jdisc container, see container-dependency-versions/pom.xml -->
+
+        <!-- DO NOT UPGRADE THESE TO A NEW MAJOR VERSION WITHOUT CHECKING FOR BINARY COMPATIBILITY -->
         <aopalliance.vespa.version>1.0</aopalliance.vespa.version>
         <commons-logging.vespa.version>1.2</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
         <error-prone-annotations.vespa.version>2.18.0</error-prone-annotations.vespa.version>
@@ -43,9 +45,11 @@
         <jaxb.vespa.version>2.3.0</jaxb.vespa.version>
         <slf4j.vespa.version>1.7.32</slf4j.vespa.version>
         <xml-apis.vespa.version>1.4.01</xml-apis.vespa.version>
+
         <!-- END Dependencies available from the Jdisc container -->
 
-        <!-- Dependencies used internally in Vespa, not visible for users -->
+
+        <!-- Dependencies used internally in Vespa, not visible for users, or only visible in test classpath -->
 
         <airline.vespa.version>0.9</airline.vespa.version>
         <antlr.vespa.version>3.5.3</antlr.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -102,6 +102,7 @@
         <spifly.vespa.version>1.3.6</spifly.vespa.version>
         <surefire.vespa.version>3.0.0-M9</surefire.vespa.version>
         <wiremock.vespa.version>2.35.0</wiremock.vespa.version>
+        <xerces.vespa.version>2.12.2</xerces.vespa.version>
         <zero-allocation-hashing.vespa.version>0.16</zero-allocation-hashing.vespa.version>
         <zookeeper.client.vespa.version>3.8.0</zookeeper.client.vespa.version>
 

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -77,6 +77,7 @@
         <felix.log.vespa.version>1.0.1</felix.log.vespa.version>
         <findbugs.vespa.version>3.0.2</findbugs.vespa.version> <!-- Should be kept in sync with guava -->
         <hdrhistogram.vespa.version>2.1.12</hdrhistogram.vespa.version>
+        <icu4j.vespa.version>70.1</icu4j.vespa.version>
         <jersey.vespa.version>2.25</jersey.vespa.version>
         <jetty.vespa.version>11.0.15</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -86,6 +86,7 @@
         <joda-time.vespa.version>2.12.2</joda-time.vespa.version>
         <junit.vespa.version>5.8.1</junit.vespa.version>
         <junit.platform.vespa.version>1.8.1</junit.platform.vespa.version>
+        <junit4.vespa.version>4.13.2</junit4.vespa.version>
         <maven-archiver.vespa.version>3.6.0</maven-archiver.vespa.version>
         <maven-wagon.vespa.version>2.10</maven-wagon.vespa.version>
         <mockito.vespa.version>4.0.0</mockito.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -31,6 +31,7 @@
         
         <!-- BEGIN Dependencies available from the Jdisc container, see container-dependency-versions/pom.xml -->
         <aopalliance.vespa.version>1.0</aopalliance.vespa.version>
+        <commons-logging.vespa.version>1.2</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
         <error-prone-annotations.vespa.version>2.18.0</error-prone-annotations.vespa.version>
         <guava.vespa.version>32.1.1-jre</guava.vespa.version>
         <guice.vespa.version>4.2.3</guice.vespa.version>
@@ -45,6 +46,7 @@
         <!-- END Dependencies available from the Jdisc container -->
 
         <!-- Dependencies used internally in Vespa, not visible for users -->
+
         <airline.vespa.version>0.9</airline.vespa.version>
         <antlr.vespa.version>3.5.3</antlr.vespa.version>
         <antlr4.vespa.version>4.11.1</antlr4.vespa.version>

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -76,6 +76,7 @@
         <felix.vespa.version>7.0.5</felix.vespa.version>
         <felix.log.vespa.version>1.0.1</felix.log.vespa.version>
         <findbugs.vespa.version>3.0.2</findbugs.vespa.version> <!-- Should be kept in sync with guava -->
+        <hamcrest.vespa.version>1.3</hamcrest.vespa.version>
         <hdrhistogram.vespa.version>2.1.12</hdrhistogram.vespa.version>
         <icu4j.vespa.version>70.1</icu4j.vespa.version>
         <jersey.vespa.version>2.25</jersey.vespa.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -727,7 +727,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-exec</artifactId>
-                <version>1.3</version>
+                <version>${commons-exec.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1081,6 +1081,11 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.opentest4j</groupId>
+                <artifactId>opentest4j</artifactId>
+                <version>${opentest4j.vespa.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
                 <version>${asm.vespa.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -841,6 +841,11 @@
                 <version>${maven-enforcer-plugin.vespa.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.maven.enforcer</groupId>
+                <artifactId>enforcer-rules</artifactId>
+                <version>${maven-enforcer-plugin.vespa.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.maven.plugin-tools</groupId>
                 <artifactId>maven-plugin-annotations</artifactId>
                 <version>${maven-plugin-tools.vespa.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -884,7 +884,7 @@
             <dependency>
                 <groupId>org.apache.opennlp</groupId>
                 <artifactId>opennlp-tools</artifactId>
-                <version>1.9.3</version>
+                <version>${opennlp.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.velocity</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1005,19 +1005,19 @@
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
+                <version>${hamcrest.vespa.version}</version>
                 <scope>test</scope> <!-- TODO: remove scope from parent pom -->
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-core</artifactId>
-                <version>1.3</version>
+                <version>${hamcrest.vespa.version}</version>
                 <scope>test</scope> <!-- TODO: remove scope from parent pom -->
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
+                <version>${hamcrest.vespa.version}</version>
                 <scope>test</scope> <!-- TODO: remove scope from parent pom -->
             </dependency>
             <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -622,17 +622,17 @@
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-api</artifactId>
-                <version>${jjwt.vespa.version}</version>
+                <version>${java-jjwt.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-impl</artifactId>
-                <version>${jjwt.vespa.version}</version>
+                <version>${java-jjwt.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-jackson</artifactId>
-                <version>${jjwt.vespa.version}</version>
+                <version>${java-jjwt.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>joda-time</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -637,7 +637,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.12.2</version>
+                <version>${joda-time.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.openhft</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -892,6 +892,11 @@
                 <version>2.3</version>
             </dependency>
             <dependency>
+                <groupId>org.apiguardian</groupId>
+                <artifactId>apiguardian-api</artifactId>
+                <version>${apiguardian.vespa.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
                 <version>3.11.1</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -722,7 +722,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.23.0</version>
+                <version>${commons-compress.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -559,7 +559,7 @@
             <dependency>
                 <groupId>com.ibm.icu</groupId>
                 <artifactId>icu4j</artifactId>
-                <version>70.1</version>
+                <version>${icu4j.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.infradna.tool</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -692,7 +692,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.2</version>
+                <version>${junit4.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1124,7 +1124,7 @@
             <dependency>
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
-                <version>2.12.2</version>
+                <version>${xerces.vespa.version}</version>
             </dependency>
             <dependency> <!-- TODO: Remove on Vespa 9 -->
                 <groupId>org.json</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1058,7 +1058,7 @@
             <dependency>
                 <groupId>org.jvnet.mimepull</groupId>
                 <artifactId>mimepull</artifactId>
-                <version>1.9.6</version>
+                <version>${mimepull.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.lz4</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -463,7 +463,7 @@
             <dependency>
                 <groupId>com.auth0</groupId>
                 <artifactId>java-jwt</artifactId>
-                <version>3.10.0</version>
+                <version>${java-jwt.vespa.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/tenant-cd-api/pom.xml
+++ b/tenant-cd-api/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>org.apiguardian</groupId>
             <artifactId>apiguardian-api</artifactId>
-            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
Since all relevant versions are now properties in `dependency-versions/pom.xml`, we can use properties instead of ranges in most cases. We can consider using ranges for the 13 dep versions that we expose from Jdisc, to prevent unintended major version upgrades, but there is a clear warning in the pom.