### PR TITLE
Revert "Exclude private IP addresses in other cloud accounts in ACLs"

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -58,12 +58,6 @@ public class Flags {
             // if any, or otherwise hosted-vespa:tenant-host:default.
             APPLICATION_ID, TENANT_ID, CLUSTER_ID, CLUSTER_TYPE);
 
-    public static final UnboundBooleanFlag SIMPLER_ACL = defineFeatureFlag(
-            "simpler-acl", true,
-            List.of("hakonhall"), "2023-07-04", "2023-08-04",
-            "Simplify ACL in hosted Vespa",
-            "Takes effect on the next fetch of ACL rules");
-
     public static final UnboundDoubleFlag DEFAULT_TERM_WISE_LIMIT = defineDoubleFlag(
             "default-term-wise-limit", 1.0,
             List.of("baldersheim"), "2020-12-02", "2023-12-31",

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -616,8 +616,8 @@ public final class Node implements Nodelike {
     }
 
     /** Returns the ACL for the node (trusted nodes, networks and ports) */
-    public NodeAcl acl(NodeList allNodes, LoadBalancers loadBalancers, Zone zone, boolean simplerAcl) {
-        return NodeAcl.from(this, allNodes, loadBalancers, zone, simplerAcl);
+    public NodeAcl acl(NodeList allNodes, LoadBalancers loadBalancers, Zone zone) {
+        return NodeAcl.from(this, allNodes, loadBalancers, zone);
     }
 
     @Override

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -215,11 +215,11 @@ public class NodeRepository extends AbstractComponent {
      * @param host node for which to generate ACLs
      * @return the list of node ACLs
      */
-    public List<NodeAcl> getChildAcls(Node host, boolean simplerAcl) {
+    public List<NodeAcl> getChildAcls(Node host) {
         if ( ! host.type().isHost()) throw new IllegalArgumentException("Only hosts have children");
         NodeList allNodes = nodes().list();
         return allNodes.childrenOf(host)
-                       .mapToList(childNode -> childNode.acl(allNodes, loadBalancers, zone, simplerAcl));
+                       .mapToList(childNode -> childNode.acl(allNodes, loadBalancers, zone));
     }
 
     /** Removes this application: all nodes are set dirty. */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/IP.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/IP.java
@@ -119,7 +119,7 @@ public record IP() {
                 for (var other : sortedNodes) {
                     if (node.equals(other)) continue;
                     if (canAssignIpOf(other, node)) continue;
-                    Predicate<String> sharedIpSpace = ip -> inSharedIpSpace(ip, other.cloudAccount(), node.cloudAccount());
+                    Predicate<String> sharedIpSpace = other.cloudAccount().equals(node.cloudAccount()) ? __ -> true : IP::isPublic;
 
                     var addresses = new HashSet<>(node.ipConfig().primary());
                     var otherAddresses = new HashSet<>(other.ipConfig().primary());
@@ -471,11 +471,6 @@ public record IP() {
     public static boolean isPublic(String ip) {
         InetAddress address = parse(ip);
         return ! address.isLoopbackAddress() && ! address.isLinkLocalAddress() && ! address.isSiteLocalAddress();
-    }
-
-    /** Returns true if the IP address is in the IP space of both sourceCloudAccount and targetCloudAccount. */
-    public static boolean inSharedIpSpace(String ip, CloudAccount sourceCloudAccount, CloudAccount targetCloudAccount) {
-        return sourceCloudAccount.equals(targetCloudAccount) || isPublic(ip);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/NodeAcl.java
@@ -2,7 +2,6 @@
 package com.yahoo.vespa.hosted.provision.node;
 
 import com.google.common.collect.ImmutableSet;
-import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.hosted.provision.Node;
@@ -12,16 +11,12 @@ import com.yahoo.vespa.hosted.provision.lb.LoadBalancerInstance;
 import com.yahoo.vespa.hosted.provision.lb.LoadBalancers;
 
 import java.util.Comparator;
-import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 /**
@@ -46,7 +41,7 @@ public record NodeAcl(Node node,
         this.trustedUdpPorts = ImmutableSet.copyOf(Objects.requireNonNull(trustedUdpPorts, "trustedUdpPorts must be non-null"));
     }
 
-    public static NodeAcl from(Node node, NodeList allNodes, LoadBalancers loadBalancers, Zone zone, boolean simplerAcl) {
+    public static NodeAcl from(Node node, NodeList allNodes, LoadBalancers loadBalancers, Zone zone) {
         Set<TrustedNode> trustedNodes = new TreeSet<>(Comparator.comparing(TrustedNode::hostname));
         Set<Integer> trustedPorts = new LinkedHashSet<>();
         Set<Integer> trustedUdpPorts = new LinkedHashSet<>();
@@ -58,13 +53,12 @@ public record NodeAcl(Node node,
         //   SSH opened (which is safe for 2 reasons: SSH daemon is not run inside containers, and NPT networks
         //   will (should) not forward port 22 traffic to container).
         // - parent host (for health checks and metrics)
-        // - nodes in same application (Slobrok for tenant nodes, file distribution and ZK for config servers, etc),
-        //   and parents if necessary due to NAT.
+        // - nodes in same application
         // - load balancers allocated to application
         trustedPorts.add(22);
-        allNodes.parentOf(node).map(parent -> TrustedNode.of(parent, node.cloudAccount(), simplerAcl)).ifPresent(trustedNodes::add);
+        allNodes.parentOf(node).map(TrustedNode::of).ifPresent(trustedNodes::add);
         node.allocation().ifPresent(allocation -> {
-            trustedNodes.addAll(trustedNodesForChildrenMatching(node, allNodes, n -> n.allocation().map(Allocation::owner).equals(Optional.of(allocation.owner())), Set.of(), simplerAcl));
+            trustedNodes.addAll(TrustedNode.of(allNodes.owner(allocation.owner())));
             loadBalancers.list(allocation.owner()).asList()
                          .stream()
                          .map(LoadBalancer::instance)
@@ -78,8 +72,19 @@ public record NodeAcl(Node node,
                 // Tenant nodes in other states than ready, trust:
                 // - config servers
                 // - proxy nodes
-                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.config), node.cloudAccount(), simplerAcl));
-                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.proxy), node.cloudAccount(), simplerAcl));
+                // - parents of the nodes in the same application: If some nodes are on a different IP version
+                //   or only a subset of them are dual-stacked, the communication between the nodes may be NAT-ed
+                //   via parent's IP address
+                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.config)));
+                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.proxy)));
+                node.allocation().ifPresent(allocation -> trustedNodes.addAll(TrustedNode.of(allNodes.parentsOf(allNodes.owner(allocation.owner())))));
+                if (node.state() == Node.State.ready) {
+                    // Tenant nodes in state ready, trust:
+                    // - All tenant nodes in zone. When a ready node is allocated to an application there's a brief
+                    //   window where current ACLs have not yet been applied on the node. To avoid service disruption
+                    //   during this window, ready tenant nodes trust all other tenant nodes
+                    trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.tenant)));
+                }
             }
             case config -> {
                 // Config servers trust:
@@ -87,7 +92,9 @@ public record NodeAcl(Node node,
                 // - port 19070 (RPC) from all proxy nodes (and their hosts, in case traffic is NAT-ed via parent)
                 // - port 4443 from the world
                 // - udp port 51820 from the world
-                trustedNodes.addAll(trustedNodesForChildrenMatching(node, allNodes, n -> EnumSet.of(NodeType.tenant, NodeType.proxy).contains(n.type()), RPC_PORTS, simplerAcl));
+                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.host, NodeType.tenant,
+                                                                     NodeType.proxyhost, NodeType.proxy),
+                                                   RPC_PORTS));
                 trustedPorts.add(4443);
                 if (zone.system().isPublic() && zone.cloud().allowEnclave()) {
                     trustedUdpPorts.add(WIREGUARD_PORT);
@@ -97,7 +104,7 @@ public record NodeAcl(Node node,
                 // Proxy nodes trust:
                 // - config servers
                 // - all connections from the world on 443 (production traffic) and 4443 (health checks)
-                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.config), node.cloudAccount(), simplerAcl));
+                trustedNodes.addAll(TrustedNode.of(allNodes.nodeType(NodeType.config)));
                 trustedPorts.add(443);
                 trustedPorts.add(4443);
             }
@@ -114,54 +121,26 @@ public record NodeAcl(Node node,
         return new NodeAcl(node, trustedNodes, trustedNetworks, trustedPorts, trustedUdpPorts);
     }
 
-    /** Returns the set of children matching the selector, and their parent host if traffic from child may be NATed */
-    private static Set<TrustedNode> trustedNodesForChildrenMatching(Node node, NodeList allNodes, Predicate<Node> childNodeSelector,
-                                                                    Set<Integer> ports, boolean simplerAcl) {
-        if (node.type().isHost())
-            throw new IllegalArgumentException("Host nodes cannot have NAT parents");
-
-        boolean hasIp4 = node.ipConfig().primary().stream().anyMatch(IP::isV4);
-        boolean hasIp6 = node.ipConfig().primary().stream().anyMatch(IP::isV6);
-        return allNodes.stream()
-                       .filter(n -> !n.type().isHost())
-                       .filter(childNodeSelector)
-                       .mapMulti((Node otherNode, Consumer<TrustedNode> consumer) -> {
-                           consumer.accept(TrustedNode.of(otherNode, ports, node.cloudAccount(), simplerAcl));
-
-                           // And parent host if traffic from otherNode may be NATed
-                           if (hasIp4 && otherNode.ipConfig().primary().stream().noneMatch(IP::isV4) ||
-                               hasIp6 && otherNode.ipConfig().primary().stream().noneMatch(IP::isV6)) {
-                               consumer.accept(TrustedNode.of(allNodes.parentOf(otherNode).orElseThrow(), ports, node.cloudAccount(), simplerAcl));
-                           }
-                       })
-                       .collect(Collectors.toSet());
-    }
-
     public record TrustedNode(String hostname, NodeType type, Set<String> ipAddresses, Set<Integer> ports) {
 
-        /** Trust given ports from node, and primary IP addresses shared with given cloud account */
-        public static TrustedNode of(Node node, Set<Integer> ports, CloudAccount sourceCloudAccount, boolean simplerAcl) {
-            Set<String> ipAddresses = node.ipConfig()
-                                          .primary()
-                                          .stream()
-                                          .filter(ip -> !simplerAcl || IP.inSharedIpSpace(ip, sourceCloudAccount, node.cloudAccount()))
-                                          .collect(Collectors.toSet());
-            return new TrustedNode(node.hostname(), node.type(), ipAddresses, ports);
+        /** Trust given ports from node */
+        public static TrustedNode of(Node node, Set<Integer> ports) {
+            return new TrustedNode(node.hostname(), node.type(), node.ipConfig().primary(), ports);
         }
 
-        /** The node in the given sourceCloudAccount should trust all ports from given node */
-        public static TrustedNode of(Node node, CloudAccount sourceCloudAccount, boolean simplerAcl) {
-            return of(node, Set.of(), sourceCloudAccount, simplerAcl);
+        /** Trust all ports from given node */
+        public static TrustedNode of(Node node) {
+            return of(node, Set.of());
         }
 
-        public static List<TrustedNode> of(Iterable<Node> nodes, Set<Integer> ports, CloudAccount sourceCloudAccount, boolean simplerAcl) {
+        public static List<TrustedNode> of(Iterable<Node> nodes, Set<Integer> ports) {
             return StreamSupport.stream(nodes.spliterator(), false)
-                                .map(node -> TrustedNode.of(node, ports, sourceCloudAccount, simplerAcl))
+                                .map(node -> TrustedNode.of(node, ports))
                                 .toList();
         }
 
-        public static List<TrustedNode> of(Iterable<Node> nodes, CloudAccount sourceCloudAccount, boolean simplerAcl) {
-            return of(nodes, Set.of(), sourceCloudAccount, simplerAcl);
+        public static List<TrustedNode> of(Iterable<Node> nodes) {
+            return of(nodes, Set.of());
         }
 
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodeAclResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodeAclResponse.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision.restapi;
 import com.yahoo.container.jdisc.HttpRequest;
 import com.yahoo.restapi.SlimeJsonResponse;
 import com.yahoo.slime.Cursor;
-import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.NodeAcl;
@@ -34,9 +33,8 @@ public class NodeAclResponse extends SlimeJsonResponse {
         Node node = nodeRepository.nodes().node(hostname)
                 .orElseThrow(() -> new NotFoundException("No node with hostname '" + hostname + "'"));
 
-        boolean simplerAcl = Flags.SIMPLER_ACL.bindTo(nodeRepository.flagSource()).value();
-        List<NodeAcl> acls = aclsForChildren ? nodeRepository.getChildAcls(node, simplerAcl) :
-                                               List.of(node.acl(nodeRepository.nodes().list(), nodeRepository.loadBalancers(), nodeRepository.zone(), simplerAcl));
+        List<NodeAcl> acls = aclsForChildren ? nodeRepository.getChildAcls(node) :
+                                               List.of(node.acl(nodeRepository.nodes().list(), nodeRepository.loadBalancers(), nodeRepository.zone()));
 
         Cursor trustedNodesArray = object.setArray("trustedNodes");
         acls.forEach(nodeAcl -> toSlime(nodeAcl, trustedNodesArray));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -130,7 +130,7 @@ public class MockNodeRepository extends NodeRepository {
                 .status(Status.initial()
                         .withVespaVersion(new Version("1.2.3"))
                         .withContainerImage(DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa:1.2.3")))
-                .cloudAccount(tenantAccount)
+                .cloudAccount(defaultCloudAccount)
                 .build();
         nodes.add(node5);
 
@@ -175,11 +175,9 @@ public class MockNodeRepository extends NodeRepository {
 
         // Config servers
         nodes.add(Node.create("cfg1", ipConfig(201), "cfg1.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
-                      .cloudAccount(defaultCloudAccount)
-                      .wireguardPubKey(WireguardKey.from("lololololololololololololololololololololoo=")).build());
+                          .wireguardPubKey(WireguardKey.from("lololololololololololololololololololololoo=")).build());
         nodes.add(Node.create("cfg2", ipConfig(202), "cfg2.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
-                      .cloudAccount(defaultCloudAccount)
-                      .build());
+                          .build());
 
         // Ready all nodes, except 7 and 55
         nodes = new ArrayList<>(nodes().addNodes(nodes, Agent.system));
@@ -247,8 +245,8 @@ public class MockNodeRepository extends NodeRepository {
         activate(provisioner.prepare(app3, cluster3, Capacity.from(new ClusterResources(2, 1, new NodeResources(1, 4, 100, 1)), false, true), null), app3, provisioner);
 
         List<Node> largeNodes = new ArrayList<>();
-        largeNodes.add(Node.create("node13", ipConfig(13), "host13.yahoo.com", resources(10, 48, 500, 1, fast, local), NodeType.tenant).cloudAccount(defaultCloudAccount).build());
-        largeNodes.add(Node.create("node14", ipConfig(14), "host14.yahoo.com", resources(10, 48, 500, 1, fast, local), NodeType.tenant).cloudAccount(defaultCloudAccount).build());
+        largeNodes.add(Node.create("node13", ipConfig(13), "host13.yahoo.com", resources(10, 48, 500, 1, fast, local), NodeType.tenant).build());
+        largeNodes.add(Node.create("node14", ipConfig(14), "host14.yahoo.com", resources(10, 48, 500, 1, fast, local), NodeType.tenant).build());
         nodes().addNodes(largeNodes, Agent.system);
         largeNodes.forEach(node -> nodes().setReady(new NodeMutex(node, () -> {}), Agent.system, getClass().getSimpleName()));
         ApplicationId app4 = ApplicationId.from(TenantName.from("tenant4"), ApplicationName.from("application4"), InstanceName.from("instance4"));

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/AclProvisioningTest.java
@@ -57,35 +57,32 @@ public class AclProvisioningTest {
         // Get trusted nodes for the first active node
         Node node = activeNodes.get(0);
         List<Node> hostOfNode = node.parentHostname().flatMap(tester.nodeRepository().nodes()::node).map(List::of).orElseGet(List::of);
-        Supplier<NodeAcl> nodeAcls = () -> node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
+        Supplier<NodeAcl> nodeAcls = () -> node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
 
         // Trusted nodes are active nodes in same application, proxy nodes and config servers
-        assertAcls(trustedNodesOf(List.of(activeNodes, proxyNodes, configServers.asList(), hostOfNode), node.cloudAccount()),
+        assertAcls(trustedNodesOf(List.of(activeNodes, proxyNodes, configServers.asList(), hostOfNode)),
                    Set.of("10.2.3.0/24", "10.4.5.0/24"),
                    List.of(nodeAcls.get()));
     }
 
     @Test
-    public void trusted_nodes_for_parked_node() {
+    public void trusted_nodes_for_unallocated_node() {
         NodeList configServers = tester.makeConfigServers(3, "default", Version.fromString("6.123.456"));
 
         // Populate repo
-        List<Node> tenantNodes = tester.makeReadyNodes(10, nodeResources);
+        tester.makeReadyNodes(10, nodeResources);
         List<Node> proxyNodes = tester.makeReadyNodes(3, "default", NodeType.proxy);
 
         // Allocate 2 nodes to an application
-        Set<String> deployedTenantNodes = deploy(2).stream().map(Node::hostname).collect(Collectors.toSet());
+        deploy(2);
 
-        tester.move(Node.State.parked, tenantNodes.stream()
-                .filter(node -> !deployedTenantNodes.contains(node.hostname()))
-                .toList());
+        // Get trusted nodes for a ready tenant node
+        Node node = tester.nodeRepository().nodes().list(Node.State.ready).nodeType(NodeType.tenant).first().get();
+        NodeAcl nodeAcl = node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
+        NodeList tenantNodes = tester.nodeRepository().nodes().list().nodeType(NodeType.tenant);
 
-        // Get trusted nodes for a parked tenant node
-        Node node = tester.nodeRepository().nodes().list(Node.State.parked).nodeType(NodeType.tenant).first().get();
-        NodeAcl nodeAcl = node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
-
-        // Trusted nodes are all config-nodes
-        assertAcls(trustedNodesOf(List.of(proxyNodes, configServers.asList()), node.cloudAccount()), List.of(nodeAcl));
+        // Trusted nodes are all proxy-, config-, and, tenant-nodes
+        assertAcls(trustedNodesOf(List.of(proxyNodes, configServers.asList(), tenantNodes.asList())), List.of(nodeAcl));
     }
 
     @Test
@@ -107,15 +104,14 @@ public class AclProvisioningTest {
         // Get trusted nodes for the first config server
         Node node = tester.nodeRepository().nodes().node("cfg1")
                 .orElseThrow(() -> new RuntimeException("Failed to find cfg1"));
-        NodeAcl nodeAcl = node.acl(nodes, tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
+        NodeAcl nodeAcl = node.acl(nodes, tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
 
-        // Trusted nodes is all tenant nodes, all proxy nodes, all config servers and load balancer subnets
-        // All tenant hosts because nodes are IPv6 and cfg are IPv4, so traffic is NATed.
-        // NOT proxy hosts because proxies are dual-stacked so no NAT is needed
-        assertAcls(List.of(TrustedNode.of(tenantHosts, Set.of(19070), node.cloudAccount(), true),
-                           TrustedNode.of(tenantNodes, Set.of(19070), node.cloudAccount(), true),
-                           TrustedNode.of(proxyNodes, Set.of(19070), node.cloudAccount(), true),
-                           TrustedNode.of(configNodes, node.cloudAccount(), true)),
+        // Trusted nodes is all tenant nodes+hosts, all proxy nodes+hosts, all config servers and load balancer subnets
+        assertAcls(List.of(TrustedNode.of(tenantHosts, Set.of(19070)),
+                           TrustedNode.of(tenantNodes, Set.of(19070)),
+                           TrustedNode.of(proxyHosts, Set.of(19070)),
+                           TrustedNode.of(proxyNodes, Set.of(19070)),
+                           TrustedNode.of(configNodes)),
                    Set.of("10.2.3.0/24", "10.4.5.0/24"),
                    List.of(nodeAcl));
         assertEquals(Set.of(22, 4443), nodeAcl.trustedPorts());
@@ -126,7 +122,7 @@ public class AclProvisioningTest {
         publicTester.makeConfigServers(3, "default", Version.fromString("6.123.456"));
         Node publicCfgNode = publicTester.nodeRepository().nodes().node("cfg1")
                 .orElseThrow(() -> new RuntimeException("Failed to find cfg1"));
-        NodeAcl publicNodeAcl = publicCfgNode.acl(nodes, publicTester.nodeRepository().loadBalancers(), publicTester.nodeRepository().zone(), true);
+        NodeAcl publicNodeAcl = publicCfgNode.acl(nodes, publicTester.nodeRepository().loadBalancers(), publicTester.nodeRepository().zone());
         assertEquals(Set.of(51820), publicNodeAcl.trustedUdpPorts());
     }
 
@@ -144,10 +140,10 @@ public class AclProvisioningTest {
         // Get trusted nodes for first proxy node
         NodeList proxyNodes = tester.nodeRepository().nodes().list().nodeType(NodeType.proxy);
         Node node = proxyNodes.first().get();
-        NodeAcl nodeAcl = node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
+        NodeAcl nodeAcl = node.acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
 
         // Trusted nodes is all config servers and all proxy nodes
-        assertAcls(trustedNodesOf(List.of(proxyNodes.asList(), configServers.asList()), node.cloudAccount()), List.of(nodeAcl));
+        assertAcls(trustedNodesOf(List.of(proxyNodes.asList(), configServers.asList())), List.of(nodeAcl));
         assertEquals(Set.of(22, 443, 4443), nodeAcl.trustedPorts());
         assertEquals(Set.of(), nodeAcl.trustedUdpPorts());
     }
@@ -162,7 +158,7 @@ public class AclProvisioningTest {
         List<Node> nodes = tester.makeReadyChildren(5, new NodeResources(1, 4, 10, 1),
                                                           host.hostname());
 
-        List<NodeAcl> acls = tester.nodeRepository().getChildAcls(host, true);
+        List<NodeAcl> acls = tester.nodeRepository().getChildAcls(host);
 
         // ACLs for each container on the host
         assertFalse(nodes.isEmpty());
@@ -173,7 +169,7 @@ public class AclProvisioningTest {
                     .findFirst()
                     .orElseThrow(() -> new RuntimeException("Expected to find ACL for node " + node.hostname()));
             assertEquals(host.hostname(), node.parentHostname().get());
-            assertAcls(trustedNodesOf(List.of(configServers.asList(), List.of(host)), node.cloudAccount()), nodeAcl);
+            assertAcls(trustedNodesOf(List.of(configServers.asList(), nodes, List.of(host))), nodeAcl);
         }
     }
 
@@ -186,8 +182,8 @@ public class AclProvisioningTest {
         List<Node> controllers = tester.nodeRepository().nodes().list().nodeType(NodeType.controller).asList();
 
         // Controllers and hosts all trust each other
-        NodeAcl controllerAcl = controllers.get(0).acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
-        assertAcls(trustedNodesOf(List.of(controllers), controllers.get(0).cloudAccount()), Set.of("10.2.3.0/24", "10.4.5.0/24"), List.of(controllerAcl));
+        NodeAcl controllerAcl = controllers.get(0).acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
+        assertAcls(trustedNodesOf(List.of(controllers)), Set.of("10.2.3.0/24", "10.4.5.0/24"), List.of(controllerAcl));
         assertEquals(Set.of(22, 4443, 443), controllerAcl.trustedPorts());
         assertEquals(Set.of(), controllerAcl.trustedUdpPorts());
     }
@@ -215,7 +211,7 @@ public class AclProvisioningTest {
 
         // ACL for nodes with allocation trust their respective load balancer networks, if any
         for (var host : hosts) {
-            List<NodeAcl> acls = tester.nodeRepository().getChildAcls(host, true);
+            List<NodeAcl> acls = tester.nodeRepository().getChildAcls(host);
             assertEquals(2, acls.size());
             for (var acl : acls) {
                 if (acl.node().allocation().isPresent()) {
@@ -233,19 +229,19 @@ public class AclProvisioningTest {
         tester.makeConfigServers(3, "default", Version.fromString("6.123.456"));
 
         List<Node> readyNodes = tester.makeReadyNodes(1, "default", NodeType.proxy);
-        NodeAcl nodeAcl = readyNodes.get(0).acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone(), true);
+        NodeAcl nodeAcl = readyNodes.get(0).acl(tester.nodeRepository().nodes().list(), tester.nodeRepository().loadBalancers(), tester.nodeRepository().zone());
 
         assertEquals(3, nodeAcl.trustedNodes().size());
         assertEquals(List.of(Set.of("127.0.1.1"), Set.of("127.0.1.2"), Set.of("127.0.1.3")),
                      nodeAcl.trustedNodes().stream().map(TrustedNode::ipAddresses).toList());
     }
 
-    private static List<List<TrustedNode>> trustedNodesOf(List<List<Node>> nodes, Set<Integer> ports, CloudAccount cloudAccount) {
-        return nodes.stream().map(node -> TrustedNode.of(node, ports, cloudAccount, true)).toList();
+    private static List<List<TrustedNode>> trustedNodesOf(List<List<Node>> nodes, Set<Integer> ports) {
+        return nodes.stream().map(node -> TrustedNode.of(node, ports)).toList();
     }
 
-    private static List<List<TrustedNode>> trustedNodesOf(List<List<Node>> nodes, CloudAccount cloudAccount) {
-        return trustedNodesOf(nodes, Set.of(), cloudAccount);
+    private static List<List<TrustedNode>> trustedNodesOf(List<List<Node>> nodes) {
+        return trustedNodesOf(nodes, Set.of());
     }
 
     private List<Node> deploy(int nodeCount) {

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -459,8 +459,8 @@ public class NodesV2ApiTest {
     }
 
     @Test
-    public void acls_for_exclave_tenant_host() throws Exception {
-        assertFile(new Request("http://localhost:8080/nodes/v2/acl/host5.yahoo.com"), "acl-tenant-node.json");
+    public void acl_request_by_tenant_node() throws Exception {
+        assertFile(new Request("http://localhost:8080/nodes/v2/acl/host3.yahoo.com"), "acl-tenant-node.json");
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-config-server.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-config-server.json
@@ -3,19 +3,13 @@
     {
       "hostname": "cfg1.yahoo.com",
       "type": "config",
-      "ipAddress": "::201:1",
+      "ipAddress": "127.0.201.1",
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "cfg1.yahoo.com",
       "type": "config",
-      "ipAddress": "127.0.201.1",
-      "trustedBy": "cfg1.yahoo.com"
-    },
-    {
-      "hostname": "cfg2.yahoo.com",
-      "type": "config",
-      "ipAddress": "::202:1",
+      "ipAddress": "::201:1",
       "trustedBy": "cfg1.yahoo.com"
     },
     {
@@ -25,210 +19,240 @@
       "trustedBy": "cfg1.yahoo.com"
     },
     {
-      "hostname": "dockerhost3.yahoo.com",
+      "hostname": "cfg2.yahoo.com",
+      "type": "config",
+      "ipAddress": "::202:1",
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost1.yahoo.com",
       "type": "host",
-      "ipAddress": "::102:1",
-      "ports": [
-        19070
-      ],
+      "ipAddress": "127.0.100.1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost1.yahoo.com",
+      "type": "host",
+      "ipAddress": "::100:1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost2.yahoo.com",
+      "type": "host",
+      "ipAddress": "127.0.101.1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost2.yahoo.com",
+      "type": "host",
+      "ipAddress": "::101:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "dockerhost3.yahoo.com",
       "type": "host",
       "ipAddress": "127.0.102.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
-      "hostname": "host1.yahoo.com",
-      "type": "tenant",
-      "ipAddress": "::1:1",
-      "ports": [
-        19070
-      ],
+      "hostname": "dockerhost3.yahoo.com",
+      "type": "host",
+      "ipAddress": "::102:1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost4.yahoo.com",
+      "type": "host",
+      "ipAddress": "127.0.103.1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost4.yahoo.com",
+      "type": "host",
+      "ipAddress": "::103:1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost5.yahoo.com",
+      "type": "host",
+      "ipAddress": "127.0.104.1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "dockerhost5.yahoo.com",
+      "type": "host",
+      "ipAddress": "::104:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host1.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.1.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
-      "hostname": "host10.yahoo.com",
+      "hostname": "host1.yahoo.com",
       "type": "tenant",
-      "ipAddress": "::10:1",
-      "ports": [
-        19070
-      ],
+      "ipAddress": "::1:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host10.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.10.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host10.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::10:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host13.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.13.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host13.yahoo.com",
       "type": "tenant",
       "ipAddress": "::13:1",
-      "ports": [
-        19070
-      ],
-      "trustedBy": "cfg1.yahoo.com"
-    },
-    {
-      "hostname": "host14.yahoo.com",
-      "type": "tenant",
-      "ipAddress": "::14:1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host14.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.14.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
-      "hostname": "host2.yahoo.com",
+      "hostname": "host14.yahoo.com",
       "type": "tenant",
-      "ipAddress": "::2:1",
-      "ports": [
-        19070
-      ],
+      "ipAddress": "::14:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host2.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.2.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host2.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::2:1",
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host3.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.3.1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host3.yahoo.com",
       "type": "tenant",
       "ipAddress": "::3:1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host4.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.4.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host4.yahoo.com",
       "type": "tenant",
       "ipAddress": "::4:1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host5.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.5.1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host5.yahoo.com",
       "type": "tenant",
       "ipAddress": "::5:1",
-      "ports": [
-        19070
-      ],
-      "trustedBy": "cfg1.yahoo.com"
-    },
-    {
-      "hostname": "host55.yahoo.com",
-      "type": "tenant",
-      "ipAddress": "::55:1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host55.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.55.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host55.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::55:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host6.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.6.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host6.yahoo.com",
       "type": "tenant",
       "ipAddress": "::6:1",
-      "ports": [
-        19070
-      ],
-      "trustedBy": "cfg1.yahoo.com"
-    },
-    {
-      "hostname": "host7.yahoo.com",
-      "type": "tenant",
-      "ipAddress": "::7:1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "host7.yahoo.com",
       "type": "tenant",
       "ipAddress": "127.0.7.1",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
+      "trustedBy": "cfg1.yahoo.com"
+    },
+    {
+      "hostname": "host7.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::7:1",
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     },
     {
       "hostname": "test-node-pool-102-2",
       "type": "tenant",
       "ipAddress": "::102:2",
-      "ports": [
-        19070
-      ],
+      "ports": [19070],
       "trustedBy": "cfg1.yahoo.com"
     }
   ],
@@ -244,13 +268,14 @@
   ],
   "trustedPorts": [
     {
-      "port": 22,
-      "trustedBy": "cfg1.yahoo.com"
+      "port":22,
+      "trustedBy":"cfg1.yahoo.com"
     },
     {
       "port": 4443,
       "trustedBy": "cfg1.yahoo.com"
     }
   ],
-  "trustedUdpPorts": []
+  "trustedUdpPorts": [
+  ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-tenant-node.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/acl-tenant-node.json
@@ -3,33 +3,171 @@
     {
       "hostname": "cfg1.yahoo.com",
       "type": "config",
+      "ipAddress": "127.0.201.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "cfg1.yahoo.com",
+      "type": "config",
       "ipAddress": "::201:1",
-      "trustedBy": "host5.yahoo.com"
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "cfg2.yahoo.com",
+      "type": "config",
+      "ipAddress": "127.0.202.1",
+      "trustedBy": "host3.yahoo.com"
     },
     {
       "hostname": "cfg2.yahoo.com",
       "type": "config",
       "ipAddress": "::202:1",
-      "trustedBy": "host5.yahoo.com"
+      "trustedBy": "host3.yahoo.com"
     },
     {
-      "hostname": "dockerhost2.yahoo.com",
-      "type": "host",
-      "ipAddress": "::101:1",
-      "trustedBy": "host5.yahoo.com"
+      "hostname": "host1.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.1.1",
+      "trustedBy": "host3.yahoo.com"
     },
     {
-      "hostname": "dockerhost2.yahoo.com",
-      "type": "host",
-      "ipAddress": "127.0.101.1",
-      "trustedBy": "host5.yahoo.com"
+      "hostname": "host1.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::1:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host10.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.10.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host10.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::10:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host13.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.13.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host13.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::13:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host14.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.14.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host14.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::14:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host2.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.2.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host2.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::2:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host3.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.3.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host3.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::3:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host4.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.4.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host4.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::4:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host5.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.5.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host5.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::5:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host55.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.55.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host55.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::55:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host6.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.6.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host6.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::6:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host7.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "127.0.7.1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "host7.yahoo.com",
+      "type": "tenant",
+      "ipAddress": "::7:1",
+      "trustedBy": "host3.yahoo.com"
+    },
+    {
+      "hostname": "test-node-pool-102-2",
+      "type": "tenant",
+      "ipAddress": "::102:2",
+      "trustedBy": "host3.yahoo.com"
     }
   ],
   "trustedNetworks": [],
   "trustedPorts": [
     {
       "port": 22,
-      "trustedBy": "host5.yahoo.com"
+      "trustedBy": "host3.yahoo.com"
     }
   ],
   "trustedUdpPorts": []

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -118,6 +118,5 @@
     "::201:1"
   ],
   "additionalIpAddresses": [],
-  "cloudAccount": "aws:111222333444",
   "wireguardPubkey":"lololololololololololololololololololololoo="
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg2.json
@@ -117,6 +117,5 @@
     "127.0.202.1",
     "::202:1"
   ],
-  "additionalIpAddresses": [],
-  "cloudAccount": "aws:111222333444"
+  "additionalIpAddresses": []
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/enclave-nodes-recursive.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/enclave-nodes-recursive.json
@@ -1,7 +1,6 @@
 {
   "nodes": [
     @include(docker-node2.json),
-    @include(node3.json),
-    @include(node5.json)
+    @include(node3.json)
   ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/enclave-nodes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/enclave-nodes.json
@@ -5,9 +5,6 @@
     },
     {
       "url":"http://localhost:8080/nodes/v2/node/host3.yahoo.com"
-    },
-    {
-      "url":"http://localhost:8080/nodes/v2/node/host5.yahoo.com"
     }
   ]
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node13.json
@@ -77,6 +77,5 @@
     "127.0.13.1",
     "::13:1"
   ],
-  "additionalIpAddresses": [],
-  "cloudAccount": "aws:111222333444"
+  "additionalIpAddresses": []
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node14.json
@@ -77,6 +77,5 @@
     "127.0.14.1",
     "::14:1"
   ],
-  "additionalIpAddresses": [],
-  "cloudAccount": "aws:111222333444"
+  "additionalIpAddresses": []
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5-after-changes.json
@@ -75,5 +75,5 @@
   ],
   "ipAddresses": ["127.0.5.1", "::5:1"],
   "additionalIpAddresses": [],
-  "cloudAccount": "aws:777888999000"
+  "cloudAccount": "aws:111222333444"
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node5.json
@@ -77,5 +77,5 @@
   ],
   "ipAddresses": ["127.0.5.1", "::5:1"],
   "additionalIpAddresses": [],
-  "cloudAccount": "aws:777888999000"
+  "cloudAccount": "aws:111222333444"
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#27632

Broke the MultiAccountTest::testSearchAndFeed integration test.