### PR TITLE
Add content cluster name to generated feed block message

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -845,7 +845,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                     .stateDeriver(createBucketSpaceStateDeriver())
                     .deferredActivation(options.enableTwoPhaseClusterStateActivation())
                     .feedBlock(createResourceExhaustionCalculator()
-                            .inferContentClusterFeedBlockOrNull(cluster.getNodeInfos()))
+                            .inferContentClusterFeedBlockOrNull(cluster))
                     .deriveAndBuild();
             stateVersionTracker.updateLatestCandidateStateBundle(candidateBundle);
             invokeCandidateStateListeners(candidateBundle);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ResourceExhaustionCalculator.java
@@ -78,15 +78,16 @@ public class ResourceExhaustionCalculator {
         }
     }
 
-    public static String decoratedMessage(String msg) {
-        // Add a user-friendly documentation link to the error message
-        return "%s. See https://docs.vespa.ai/en/operations/feed-block.html".formatted(msg);
+    public static String decoratedMessage(ContentCluster cluster, String msg) {
+        // Disambiguate content cluster and add a user-friendly documentation link to the error message
+        return "in content cluster '%s': %s. See https://docs.vespa.ai/en/operations/feed-block.html".formatted(cluster.getName(), msg);
     }
 
-    public ClusterStateBundle.FeedBlock inferContentClusterFeedBlockOrNull(Collection<NodeInfo> nodeInfos) {
+    public ClusterStateBundle.FeedBlock inferContentClusterFeedBlockOrNull(ContentCluster cluster) {
         if (!feedBlockEnabled) {
             return null;
         }
+        var nodeInfos = cluster.getNodeInfos();
         var exhaustions = enumerateNodeResourceExhaustionsAcrossAllNodes(nodeInfos);
         if (exhaustions.isEmpty()) {
             return null;
@@ -99,7 +100,7 @@ public class ResourceExhaustionCalculator {
         if (exhaustions.size() > maxDescriptions) {
             description += String.format(" (... and %d more)", exhaustions.size() - maxDescriptions);
         }
-        description = decoratedMessage(description);
+        description = decoratedMessage(cluster, description);
         // FIXME we currently will trigger a cluster state recomputation even if the number of
         // exhaustions is greater than what is returned as part of the description. Though at
         // that point, cluster state recomputations will be the least of your worries...!

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
@@ -117,8 +117,8 @@ public class ClusterFeedBlockTest extends FleetControllerTest {
         assertFalse(ctrl.getClusterStateBundle().clusterFeedIsBlocked());
     }
 
-    private static String decorate(String msg) {
-        return ResourceExhaustionCalculator.decoratedMessage(msg);
+    private String decorate(String msg) {
+        return ResourceExhaustionCalculator.decoratedMessage(ctrl.getCluster(), msg);
     }
 
     @Test


### PR DESCRIPTION
@hakonhall please review. Follow-up of #27898
@kkraune FYI

Messages now prefixed with content cluster name to help disambiguate which cluster is exceeding its limits in multi-cluster deployments.

Example message:
```
in content cluster 'my-cool-cluster': disk on node 1 [my-node-1.example.com] is 81.0% full
(the configured limit is 80.0%). See https://docs.vespa.ai/en/operations/feed-block.html
```

