### PR TITLE
Reduce cooldown period of new OS versions

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -185,6 +185,9 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
         /** The day of week new releases are published */
         private static final DayOfWeek RELEASE_DAY = DayOfWeek.TUESDAY;
 
+        /** How far into release day we should wait before triggering. This is to give the new release some time to propagate */
+        private static final Duration COOLDOWN = Duration.ofHours(6);
+
         public CalendarVersionedRelease {
             Objects.requireNonNull(system);
         }
@@ -197,13 +200,9 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
                 predicatedInstant = predicatedInstant.plus(Duration.ofDays(1));
                 version = findVersion(predicatedInstant, currentVersion);
             }
-            Duration cooldown = remainingCooldownOf(cooldown(), version.age(instant));
+            Duration cooldown = remainingCooldownOf(COOLDOWN, version.age(instant));
             Instant schedulingInstant = schedulingInstant(instant.plus(cooldown), system);
             return Optional.of(new Change(new OsVersion(version.version(), cloud), schedulingInstant));
-        }
-
-        private Duration cooldown() {
-            return Duration.ofDays(1); // Give new releases some time to propagate
         }
 
         /** Find the most recent version available according to the scheduling step, relative to now */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
@@ -60,8 +60,8 @@ public class OsUpgradeSchedulerTest {
         // New release becomes available, but is not triggered until cool-down period has passed, and we're inside a
         // trigger period
         Version version1 = Version.fromString("7.0.0.20220301");
-        tester.clock().advance(Duration.ofDays(14));
-        assertEquals("2022-03-01T09:05:00", formatInstant(tester.clock().instant()));
+        tester.clock().advance(Duration.ofDays(13).plusHours(15));
+        assertEquals("2022-03-01T00:05:00", formatInstant(tester.clock().instant()));
 
         // Change does not become available until certification
         assertFalse(scheduler.changeIn(cloud, tester.clock().instant()).isPresent());
@@ -76,12 +76,12 @@ public class OsUpgradeSchedulerTest {
                      tester.controller().os().target(cloud).get().osVersion().version(),
                      "Target is unchanged because cooldown hasn't passed");
         tester.clock().advance(Duration.ofDays(3).plusHours(18));
-        assertEquals("2022-03-05T03:05:00", formatInstant(tester.clock().instant()));
+        assertEquals("2022-03-04T18:05:00", formatInstant(tester.clock().instant()));
         scheduler.maintain();
         assertEquals(version0,
                      tester.controller().os().target(cloud).get().osVersion().version(),
                      "Target is unchanged because we're outside trigger period");
-        tester.clock().advance(Duration.ofDays(2).plusHours(5));
+        tester.clock().advance(Duration.ofDays(2).plusHours(14));
         assertEquals("2022-03-07T08:05:00", formatInstant(tester.clock().instant()));
 
         // Time constraints have now passed, but the current target has been pinned in the meantime
@@ -111,7 +111,7 @@ public class OsUpgradeSchedulerTest {
         Optional<OsUpgradeScheduler.Change> nextChange = scheduler.changeIn(cloud, tester.clock().instant());
         assertTrue(nextChange.isPresent());
         assertEquals(expected, nextChange.get().osVersion().version());
-        assertEquals("2022-04-27T07:00:00", formatInstant(nextChange.get().scheduleAt()));
+        assertEquals("2022-04-26T07:00:00", formatInstant(nextChange.get().scheduleAt()));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class OsUpgradeSchedulerTest {
         scheduler.maintain();
         assertEquals(version0, tester.controller().os().target(cloud).get().osVersion().version());
         // Cool-down passes
-        tester.clock().advance(Duration.ofDays(1));
+        tester.clock().advance(Duration.ofHours(4));
         assertEquals(version1, scheduler.changeIn(cloud, tester.clock().instant()).get().osVersion().version());
         scheduler.maintain();
         assertEquals(version1, tester.controller().os().target(cloud).get().osVersion().version());
@@ -144,7 +144,7 @@ public class OsUpgradeSchedulerTest {
         Optional<OsUpgradeScheduler.Change> nextChange = scheduler.changeIn(cloud, tester.clock().instant());
         assertTrue(nextChange.isPresent());
         assertEquals("7.0.0.20220426", nextChange.get().osVersion().version().toFullString());
-        assertEquals("2022-04-27T02:00:00", formatInstant(nextChange.get().scheduleAt()));
+        assertEquals("2022-04-26T06:00:00", formatInstant(nextChange.get().scheduleAt()));
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-all-upgraded.json
@@ -107,7 +107,7 @@
       "scheduledAt": 1234,
       "pinned": false,
       "nextVersion": "8.2.1.20211228",
-      "nextScheduledAt": 1640743200000,
+      "nextScheduledAt": 1640671200000,
       "cloud": "cloud2",
       "nodes": [
         {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/os/responses/versions-partially-upgraded.json
@@ -166,7 +166,7 @@
       "scheduledAt": 1234,
       "pinned": false,
       "nextVersion": "8.2.1.20211228",
-      "nextScheduledAt": 1640743200000,
+      "nextScheduledAt": 1640671200000,
       "cloud": "cloud2",
       "nodes": [ ]
     }


### PR DESCRIPTION
In practice this only matters for CD systems, as non-CD will not trigger new
versions until they are certified by Factory. However, since this change will
trigger new versions earlier in CD they can also be certified earlier.

@aressem