### PR TITLE
Suppress GCC false positive compiler warning when compiling with sanitizers

### DIFF
--- a/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <vespa/vespalib/util/sanitizers.h>
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -81,6 +82,9 @@ public:
             static_assert(std::is_same_v<uint8_t,  std::decay_t<decltype(s.costs[0])>>);
             // FIXME GCC 12.2 worse-than-useless(tm) warning false positives :I
 #pragma GCC diagnostic push
+#ifdef VESPA_USE_SANITIZER
+#  pragma GCC diagnostic ignored "-Wstringop-overread" // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98465 etc.
+#endif
 #pragma GCC diagnostic ignored "-Warray-bounds"
             return (XXH3_64bits(s.indices.data(), s.sz * sizeof(uint32_t)) ^
                     XXH3_64bits(s.costs.data(), s.sz));


### PR DESCRIPTION
@baldersheim please review

Looks like GCC gets confused during compilation of inlined xxhash functions when the input buffer is backed by a `std::array`, even when the length argument is a runtime value. An xxhash branch that can only kick in when the input length is >= 9 bytes triggers a compilation warning (and thus error) that 8 bytes at the start of the buffer is being read, with GCC staunchly insisting that the available buffer size is only 4 bytes.

We only see this warning when compiling with UBSan instrumentation, so presumably it injects enough changes into the GCC intermediate representation to thoroughly confuse it.

For now, suppress the warning when compiling with sanitizers. Revisit on GCC 13 to see if the warning is gone.

