### PR TITLE
Remove trailing rules without value

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -236,6 +236,7 @@ public class SystemFlagsDataArchive {
     static String normalizeJson(String json, Set<ZoneId> zones) {
         JsonNode root = uncheck(() -> mapper.readTree(json));
         removeCommentsRecursively(root);
+        removeNullRuleValues(root);
         verifyValues(root, zones);
         return root.toString();
     }
@@ -297,6 +298,22 @@ public class SystemFlagsDataArchive {
         }
 
         node.forEach(SystemFlagsDataArchive::removeCommentsRecursively);
+    }
+
+    private static void removeNullRuleValues(JsonNode root) {
+        if (root instanceof ObjectNode objectNode) {
+            JsonNode rules = objectNode.get("rules");
+            if (rules != null) {
+                rules.forEach(ruleNode -> {
+                    if (ruleNode instanceof ObjectNode rule) {
+                        JsonNode value = rule.get("value");
+                        if (value != null && value.isNull()) {
+                            rule.remove("value");
+                        }
+                    }
+                });
+            }
+        }
     }
 
     private static String toFilePath(FlagId flagId, String filename) {

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -213,12 +213,14 @@ public class SystemFlagsDataArchive {
 
             String serializedData = flagData.serializeToJson();
             if (!JSON.equals(serializedData, normalizedRawData)) {
-                throw new IllegalArgumentException(filePath + " contains unknown non-comment fields: " +
-                        "after removing any comment fields the JSON is:\n  " +
-                        normalizedRawData +
-                        "\nbut deserializing this ended up with a JSON that are missing some of the fields:\n  " +
-                        serializedData +
-                        "\nSee https://git.ouroath.com/vespa/hosted-feature-flags for more info on the JSON syntax");
+                throw new IllegalArgumentException("""
+                                                   %s contains unknown non-comment fields or rules with null values: after removing any comment fields the JSON is:
+                                                     %s
+                                                   but deserializing this ended up with:
+                                                     %s
+                                                   These fields may be spelled wrong, or remove them?
+                                                   See https://git.ouroath.com/vespa/hosted-feature-flags for more info on the JSON syntax
+                                                   """.formatted(filePath, normalizedRawData, serializedData));
             }
         }
 

--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchiveTest.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -158,51 +159,98 @@ public class SystemFlagsDataArchiveTest {
     }
 
     @Test
-    void throws_on_null_value() {
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-            SystemFlagsDataArchive.fromDirectory(Paths.get("src/test/resources/system-flags-with-null-value/"));
-        });
-        assertEquals("""
-                     flags/my-test-flag/main.prod.us-west-1.json contains unknown non-comment fields or rules with null values: after removing any comment fields the JSON is:
-                       {"id":"my-test-flag","rules":[{"conditions":[{"type":"whitelist","dimension":"application","values":["a:b:c"]}],"value":null},{"conditions":[{"type":"whitelist","dimension":"hostname","values":["foo.com"]}],"value":true}]}
-                     but deserializing this ended up with:
-                       {"id":"my-test-flag","rules":[{"conditions":[{"type":"whitelist","dimension":"application","values":["a:b:c"]}]},{"conditions":[{"type":"whitelist","dimension":"hostname","values":["foo.com"]}],"value":true}]}
-                     These fields may be spelled wrong, or remove them?
-                     See https://git.ouroath.com/vespa/hosted-feature-flags for more info on the JSON syntax
-                     """,
-                     exception.getMessage());
+    void handles_absent_rule_value() {
+        SystemFlagsDataArchive archive = SystemFlagsDataArchive.fromDirectory(Paths.get("src/test/resources/system-flags-with-null-value/"));
+
+        // west has null value on first rule
+        List<FlagData> westFlagData = archive.flagData(prodUsWestCfgTarget);
+        assertEquals(1, westFlagData.size());
+        assertEquals(2, westFlagData.get(0).rules().size());
+        assertEquals(Optional.empty(), westFlagData.get(0).rules().get(0).getValueToApply());
+
+        // east has no value on first rule
+        List<FlagData> eastFlagData = archive.flagData(prodUsEast3CfgTarget);
+        assertEquals(1, eastFlagData.size());
+        assertEquals(2, eastFlagData.get(0).rules().size());
+        assertEquals(Optional.empty(), eastFlagData.get(0).rules().get(0).getValueToApply());
     }
 
     @Test
-    void remove_comments() {
-        assertTrue(JSON.equals("{\n" +
-                "    \"a\": {\n" +
-                "        \"b\": 1\n" +
-                "    },\n" +
-                "    \"list\": [\n" +
-                "        {\n" +
-                "            \"c\": 2\n" +
-                "        },\n" +
-                "        {\n" +
-                "        }\n" +
-                "    ]\n" +
-                "}",
-                SystemFlagsDataArchive.normalizeJson("{\n" +
-                "    \"comment\": \"comment a\",\n" +
-                "    \"a\": {\n" +
-                "        \"comment\": \"comment b\",\n" +
-                "        \"b\": 1\n" +
-                "    },\n" +
-                "    \"list\": [\n" +
-                "        {\n" +
-                "            \"comment\": \"comment c\",\n" +
-                "            \"c\": 2\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"comment\": \"comment d\"\n" +
-                "        }\n" +
-                "    ]\n" +
-                "}", Set.of())));
+    void remove_comments_and_null_value_in_rules() {
+        assertTrue(JSON.equals("""
+                               {
+                                 "rules": [
+                                   {
+                                     "conditions": [
+                                       {
+                                         "type": "whitelist",
+                                         "dimension": "hostname",
+                                         "values": [ "foo.com" ]
+                                       }
+                                     ]
+                                   },
+                                   {
+                                     "conditions": [
+                                       {
+                                         "type": "whitelist",
+                                         "dimension": "zone",
+                                         "values": [ "prod.us-west-1" ]
+                                       }
+                                     ]
+                                   },
+                                   {
+                                     "conditions": [
+                                       {
+                                         "type": "whitelist",
+                                         "dimension": "application",
+                                         "values": [ "f:o:o" ]
+                                       }
+                                     ],
+                                     "value": true
+                                   }
+                                 ]
+                               }""",
+                               SystemFlagsDataArchive.normalizeJson("""
+                               {
+                                 "comment": "bar",
+                                 "rules": [
+                                   {
+                                     "comment": "bar",
+                                     "conditions": [
+                                       {
+                                         "comment": "bar",
+                                         "type": "whitelist",
+                                         "dimension": "hostname",
+                                         "values": [ "foo.com" ]
+                                       }
+                                     ],
+                                     "value": null
+                                   },
+                                   {
+                                     "comment": "bar",
+                                     "conditions": [
+                                       {
+                                         "comment": "bar",
+                                         "type": "whitelist",
+                                         "dimension": "zone",
+                                         "values": [ "prod.us-west-1" ]
+                                       }
+                                     ]
+                                   },
+                                   {
+                                     "comment": "bar",
+                                     "conditions": [
+                                       {
+                                         "comment": "bar",
+                                         "type": "whitelist",
+                                         "dimension": "application",
+                                         "values": [ "f:o:o" ]
+                                       }
+                                     ],
+                                     "value": true
+                                   }
+                                 ]
+                               }""", Set.of(ZoneId.from("prod.us-west-1")))));
     }
 
     @Test

--- a/controller-api/src/test/resources/system-flags-with-null-value/flags/my-test-flag/main.prod.us-east-3.json
+++ b/controller-api/src/test/resources/system-flags-with-null-value/flags/my-test-flag/main.prod.us-east-3.json
@@ -1,0 +1,24 @@
+{
+    "id" : "my-test-flag",
+    "rules" : [
+        {
+            "conditions": [
+                {
+                    "type": "whitelist",
+                    "dimension": "application",
+                    "values": ["a:b:c"]
+                }
+            ]
+        },
+        {
+            "conditions": [
+                {
+                    "type": "whitelist",
+                    "dimension": "hostname",
+                    "values": ["foo.com"]
+                }
+            ],
+            "value" : true
+        }
+    ]
+}

--- a/controller-api/src/test/resources/system-flags-with-null-value/flags/my-test-flag/main.prod.us-west-1.json
+++ b/controller-api/src/test/resources/system-flags-with-null-value/flags/my-test-flag/main.prod.us-west-1.json
@@ -1,0 +1,25 @@
+{
+    "id" : "my-test-flag",
+    "rules" : [
+        {
+            "conditions": [
+                {
+                    "type": "whitelist",
+                    "dimension": "application",
+                    "values": ["a:b:c"]
+                }
+            ],
+            "value" : null
+        },
+        {
+            "conditions": [
+                {
+                    "type": "whitelist",
+                    "dimension": "hostname",
+                    "values": ["foo.com"]
+                }
+            ],
+            "value" : true
+        }
+    ]
+}

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/FlagData.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/FlagData.java
@@ -70,6 +70,16 @@ public class FlagData {
             }
         }
 
+        // Remove trailing rules that have no conditions and no value to apply.
+        while (newRules.size() > 0) {
+            Rule lastRule = newRules.get(newRules.size() - 1);
+            if (lastRule.conditions().isEmpty() && lastRule.getValueToApply().isEmpty()) {
+                newRules.remove(newRules.size() - 1);
+            } else {
+                break;
+            }
+        }
+
         FetchVector newDefaultFetchVector = defaultFetchVector.without(fetchVector.dimensions());
 
         return new FlagData(id, newDefaultFetchVector, newRules);

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/Rule.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/Rule.java
@@ -83,9 +83,11 @@ public class Rule {
 
     public static Rule fromWire(WireRule wireRule) {
         List<Condition> conditions = wireRule.andConditions == null ?
-                Collections.emptyList() :
+                List.of() :
                 wireRule.andConditions.stream().map(Condition::fromWire).toList();
-        Optional<RawFlag> value = wireRule.value == null ? Optional.empty() : Optional.of(JsonNodeRawFlag.fromJsonNode(wireRule.value));
+        Optional<RawFlag> value = wireRule.value == null || wireRule.value.isNull() ?
+                                  Optional.empty() :
+                                  Optional.of(JsonNodeRawFlag.fromJsonNode(wireRule.value));
         return new Rule(value, conditions);
     }
 

--- a/flags/src/test/java/com/yahoo/vespa/flags/json/FlagDataTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/json/FlagDataTest.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.flags.json;
 
+import com.yahoo.text.JSON;
 import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.RawFlag;
 import org.junit.jupiter.api.Test;
@@ -231,7 +232,40 @@ public class FlagDataTest {
                                                      }
                                                  ]
                                              }""");
-        FlagData flagData = data.partialResolve(vector.with(FetchVector.Dimension.ZONE_ID, "zone3"));
+        assertEquals(data, new FlagData(data.id(), new FetchVector(), List.of()));
+        assertTrue(data.isEmpty());
+    }
+
+    @Test
+    void testRemovalOfSentinelRuleWithoutValue() {
+        String json = """
+                        {
+                            "id": "id1",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "type": "whitelist",
+                                            "dimension": "zone",
+                                            "values": [ "zone1", "zone2" ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "type": "whitelist",
+                                            "dimension": "cloud",
+                                            "values": [ "aws" ]
+                                        }
+                                    ],
+                                    "value": true
+                                }
+                            ]
+                        }""";
+        FlagData data = FlagData.deserialize(json);
+        assertTrue(JSON.equals(data.serializeToJson(), json));
+        FlagData flagData = data.partialResolve(vector.with(FetchVector.Dimension.CLOUD, "gcp"));
         assertEquals(flagData, new FlagData(data.id(), new FetchVector(), List.of()));
         assertTrue(flagData.isEmpty());
     }

--- a/flags/src/test/java/com/yahoo/vespa/flags/json/FlagDataTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/json/FlagDataTest.java
@@ -5,6 +5,7 @@ import com.yahoo.vespa.flags.FetchVector;
 import com.yahoo.vespa.flags.RawFlag;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -210,6 +211,29 @@ public class FlagDataTest {
                                     "id": "id1"
                                 }"""));
         assertTrue(fullyResolved.isEmpty());
+    }
+
+    @Test
+    void testRemovalOfSentinelRuleWithNullValue() {
+        FlagData data = FlagData.deserialize("""
+                                             {
+                                                 "id": "id1",
+                                                 "rules": [
+                                                     {
+                                                         "conditions": [
+                                                             {
+                                                                 "type": "whitelist",
+                                                                 "dimension": "zone",
+                                                                 "values": [ "zone1", "zone2" ]
+                                                             }
+                                                         ],
+                                                         "value": null
+                                                     }
+                                                 ]
+                                             }""");
+        FlagData flagData = data.partialResolve(vector.with(FetchVector.Dimension.ZONE_ID, "zone3"));
+        assertEquals(flagData, new FlagData(data.id(), new FetchVector(), List.of()));
+        assertTrue(flagData.isEmpty());
     }
 
     private void verify(Optional<String> expectedValue, FetchVector vector) {

--- a/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
+++ b/flags/src/test/java/com/yahoo/vespa/flags/json/SerializationTest.java
@@ -108,24 +108,25 @@ public class SerializationTest {
 
     @Test
     void jsonWithStrayFields() {
-        String json = "{\n" +
-                "    \"id\": \"id3\",\n" +
-                "    \"foo\": true,\n" +
-                "    \"rules\": [\n" +
-                "        {\n" +
-                "            \"conditions\": [\n" +
-                "                {\n" +
-                "                    \"type\": \"whitelist\",\n" +
-                "                    \"dimension\": \"zone\",\n" +
-                "                    \"bar\": \"zoo\"\n" +
-                "                }\n" +
-                "            ],\n" +
-                "            \"other\": true\n" +
-                "        }\n" +
-                "    ],\n" +
-                "    \"attributes\": {\n" +
-                "    }\n" +
-                "}";
+        String json = """
+                      {
+                          "id": "id3",
+                          "foo": true,
+                          "rules": [
+                              {
+                                  "conditions": [
+                                      {
+                                          "type": "whitelist",
+                                          "dimension": "zone",
+                                          "bar": "zoo"
+                                      }
+                                  ],
+                                  "other": true
+                              }
+                          ],
+                          "attributes": {
+                          }
+                      }""";
 
         WireFlagData wireData = WireFlagData.deserialize(json);
 
@@ -140,6 +141,6 @@ public class SerializationTest {
 
         assertThat(wireData.serializeToJson(), equalTo("{\"id\":\"id3\",\"rules\":[{\"conditions\":[{\"type\":\"whitelist\",\"dimension\":\"zone\"}]}],\"attributes\":{}}"));
 
-        assertThat(FlagData.deserialize(json).serializeToJson(), equalTo("{\"id\":\"id3\",\"rules\":[{\"conditions\":[{\"type\":\"whitelist\",\"dimension\":\"zone\"}]}]}"));
+        assertThat(FlagData.deserialize(json).serializeToJson(), equalTo("{\"id\":\"id3\"}"));
     }
 }


### PR DESCRIPTION
Matching a rule without a value - either absent (correct) or null (will fail normalization check) - will result in evaluating the flag to the code default.  Therefore, any trailing rules without a value can be removed.

Trimming trailing rules also has the benefit of possibly ending up without any rules, which is equivalent to not specifying the flag data at all.  When publishing flag data to a zone, an empty flag data is handled the same as deleting that flag data, saving space.