### PR TITLE
use std::atomic<std::shared_ptr>

### DIFF
--- a/fnet/src/vespa/fnet/connection.cpp
+++ b/fnet/src/vespa/fnet/connection.cpp
@@ -526,7 +526,7 @@ FNET_Connection::FNET_Connection(FNET_TransportThread *owner,
 
 FNET_Connection::~FNET_Connection()
 {
-    assert(!_resolve_handler);
+    assert(!_resolve_handler.load());
     _num_connections.fetch_sub(1, std::memory_order_relaxed);
 }
 
@@ -541,7 +541,7 @@ FNET_Connection::Init()
     // initiate async resolve
     if (IsClient()) {
         _resolve_handler = std::make_shared<ResolveHandler>(this);
-        Owner()->owner().resolve_async(GetSpec(), _resolve_handler);
+        Owner()->owner().resolve_async(GetSpec(), _resolve_handler.load());
     }
     return true;
 }
@@ -555,11 +555,11 @@ FNET_Connection::server_adapter()
 bool
 FNET_Connection::handle_add_event()
 {
-    if (_resolve_handler) {
+    if (_resolve_handler.load()) {
         auto tweak = [this](vespalib::SocketHandle &handle) { return Owner()->tune(handle); };
-        _socket = Owner()->owner().create_client_crypto_socket(_resolve_handler->address.connect(tweak), vespalib::SocketSpec(GetSpec()));
+        _socket = Owner()->owner().create_client_crypto_socket(_resolve_handler.load()->address.connect(tweak), vespalib::SocketSpec(GetSpec()));
         _ioc_socket_fd = _socket->get_fd();
-        _resolve_handler.reset();
+        _resolve_handler.store({});
     }
     return (_socket && (_socket->get_fd() >= 0));
 }
@@ -680,7 +680,7 @@ FNET_Connection::Sync()
 void
 FNET_Connection::Close()
 {
-    _resolve_handler.reset();
+    _resolve_handler.store({});
     detach_selector();
     SetState(FNET_CLOSED);
     _ioc_socket_fd = -1;

--- a/fnet/src/vespa/fnet/connection.h
+++ b/fnet/src/vespa/fnet/connection.h
@@ -71,7 +71,7 @@ private:
         void handle_result(vespalib::SocketAddress result) override;
         ~ResolveHandler();
     };
-    using ResolveHandlerSP = std::shared_ptr<ResolveHandler>;
+    using ResolveHandlerSP = std::atomic<std::shared_ptr<ResolveHandler>>;
     FNET_IPacketStreamer    *_streamer;        // custom packet streamer
     FNET_IServerAdapter     *_serverAdapter;   // only on server side
     vespalib::CryptoSocket::UP _socket;        // socket for this conn


### PR DESCRIPTION
fixes race found by thread sanitizer.  There may well be more similar races in our code, if we generally assume that shared_ptr usage is thread safe - see snippet from C++ reference doc below.

@baldersheim please review
@toregge @vekterli @havardpe FYI

If multiple threads of execution access the same [std::shared_ptr](https://en.cppreference.com/w/cpp/memory/shared_ptr) object without synchronization and any of those accesses uses a non-const member function of shared_ptr then a data race will occur unless all such access is performed through an instance of [std::atomic](http://en.cppreference.com/w/cpp/atomic/atomic)<[std::shared_ptr](http://en.cppreference.com/w/cpp/memory/shared_ptr)>
