### PR TITLE
Hosted feature flags validation

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -75,4 +75,6 @@ public enum SystemName {
         return Stream.of(values()).filter(predicate).collect(Collectors.toUnmodifiableSet());
     }
 
+    public static Set<SystemName> hostedVespa() { return EnumSet.of(main, cd, Public, PublicCd); }
+
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagValidationException.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagValidationException.java
@@ -1,0 +1,11 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.systemflags.v1;
+
+/**
+ * @author hakonhall
+ */
+public class FlagValidationException extends RuntimeException {
+    public FlagValidationException(String message) {
+        super(message);
+    }
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -171,13 +171,11 @@ public class SystemFlagsDataArchive {
     private static void addFile(Builder builder, String rawData, Path filePath, ZoneRegistry zoneRegistry, boolean force) {
         String filename = filePath.getFileName().toString();
 
-        if (!force) {
-            if (filename.startsWith("."))
-                return; // Ignore files starting with '.'
+        if (filename.startsWith("."))
+            return; // Ignore files starting with '.'
 
-            if (!FlagsTarget.filenameForSystem(filename, zoneRegistry.system()))
-                return; // Ignore files for other systems
-        }
+        if (!force && !FlagsTarget.filenameForSystem(filename, zoneRegistry.system()))
+            return; // Ignore files for other systems
 
         FlagId directoryDeducedFlagId = new FlagId(filePath.getName(filePath.getNameCount()-2).toString());
         FlagData flagData;

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/SystemFlagsDataArchive.java
@@ -184,7 +184,8 @@ public class SystemFlagsDataArchive {
         if (rawData.isBlank()) {
             flagData = new FlagData(directoryDeducedFlagId);
         } else {
-            Set<ZoneId> zones = zoneRegistry.zones().all().zones().stream().map(ZoneApi::getVirtualId).collect(Collectors.toSet());
+            Set<ZoneId> zones = force ? zoneRegistry.zones().all().zones().stream().map(ZoneApi::getVirtualId).collect(Collectors.toSet())
+                                      : Set.of();
             String normalizedRawData = normalizeJson(rawData, zones);
             flagData = FlagData.deserialize(normalizedRawData);
             if (!directoryDeducedFlagId.equals(flagData.id())) {
@@ -250,7 +251,8 @@ public class SystemFlagsDataArchive {
                         throw new FlagValidationException("Major Vespa version must be at least 8: " + versionString);
                 });
                 case ZONE_ID -> validateStringValues(condition, zoneIdString -> {
-                    if (!zones.contains(ZoneId.from(zoneIdString)))
+                    ZoneId zoneId = ZoneId.from(zoneIdString);
+                    if (!zones.isEmpty() && !zones.contains(zoneId))
                         throw new FlagValidationException("Unknown zone: " + zoneIdString);
                 });
             }

--- a/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagsTargetTest.java
+++ b/controller-api/src/test/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagsTargetTest.java
@@ -1,0 +1,41 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.api.systemflags.v1;
+
+import com.yahoo.config.provision.SystemName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author hakonhall
+ */
+class FlagsTargetTest {
+    @Test
+    void sanityCheckFilename() {
+        assertTrue(FlagsTarget.filenameForSystem("default.json", SystemName.main));
+        assertTrue(FlagsTarget.filenameForSystem("main.json", SystemName.main));
+        assertTrue(FlagsTarget.filenameForSystem("main.controller.json", SystemName.main));
+        assertTrue(FlagsTarget.filenameForSystem("main.prod.json", SystemName.main));
+        assertTrue(FlagsTarget.filenameForSystem("main.prod.us-west-1.json", SystemName.main));
+        assertTrue(FlagsTarget.filenameForSystem("main.prod.abc-foo-3.json", SystemName.main));
+
+        assertFalse(FlagsTarget.filenameForSystem("public.json", SystemName.main));
+        assertFalse(FlagsTarget.filenameForSystem("public.controller.json", SystemName.main));
+        assertFalse(FlagsTarget.filenameForSystem("public.prod.json", SystemName.main));
+        assertFalse(FlagsTarget.filenameForSystem("public.prod.us-west-1.json", SystemName.main));
+        assertFalse(FlagsTarget.filenameForSystem("public.prod.abc-foo-3.json", SystemName.main));
+
+        assertFlagValidationException("First part of flag filename is neither 'default' nor a valid system: defaults.json", "defaults.json");
+        assertFlagValidationException("Invalid flag filename: default", "default");
+        assertFlagValidationException("Invalid flag filename: README", "README");
+        assertFlagValidationException("First part of flag filename is neither 'default' nor a valid system: nosystem.json", "nosystem.json");
+        assertFlagValidationException("Invalid environment in flag filename: main.noenv.json", "main.noenv.json");
+        assertFlagValidationException("Invalid region in flag filename: main.prod.%badregion.json", "main.prod.%badregion.json");
+    }
+
+    private void assertFlagValidationException(String expectedMessage, String filename) {
+        FlagValidationException e = assertThrows(FlagValidationException.class, () -> FlagsTarget.filenameForSystem(filename, SystemName.main));
+        assertEquals(expectedMessage, e.getMessage());
+    }
+
+}


### PR DESCRIPTION
Specifying the zone as a dimension for a condition always fails due to a bug, and is fixed in this PR.  The bug is that the controller validates any and all the zones are members of ... an empty set, which obviously always fails.

This PR changes validation:
 - On the client-side (the `hv` command), avoid testing for the existence of a zone, whether it is a zone inferred from the filename or in a zone condition.  Validate the existence of these in the controller.  This ensures any Vespa version mismatch between the hv tool and the controller, only the controller decides existence of a zone.
 - Only files in the flags directory are zipped.  Files beginning with '.' are ignored.  All other files must have the correct filename format, and either they must be destined for the current system (including default.json), or another system, otherwise an exception is thrown.  However as mentioned above, the existence of a zone is not checked, but e.g. the region name must be valid.   In the controller, all files in the zip archive must be destined for the implied system.  If the controller detects an unknown file in the zip archive, an error is returned WITHOUT trying to deploy against all targets.