### PR TITLE
Revert "Require GCP cloud account explicitly prefixed with cloud name"

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/CloudAccount.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/CloudAccount.java
@@ -83,6 +83,8 @@ public class CloudAccount implements Comparable<CloudAccount> {
                 return empty;
             if (META_BY_CLOUD.get("aws").matches(cloudAccount))
                 return new CloudAccount(cloudAccount, CloudName.AWS);
+            if (META_BY_CLOUD.get("gcp").matches(cloudAccount)) // TODO (freva): Remove July 2023
+                return new CloudAccount(cloudAccount, CloudName.GCP);
             throw illegal(cloudAccount, "Must be on format '<cloud-name>:<account>' or 'default'");
         }
 

--- a/config-provisioning/src/test/java/com/yahoo/config/provision/CloudAccountTest.java
+++ b/config-provisioning/src/test/java/com/yahoo/config/provision/CloudAccountTest.java
@@ -32,12 +32,17 @@ class CloudAccountTest {
 
     @Test
     void gcp_accounts() {
-        CloudAccount account = CloudAccount.from("gcp:my-project");
-        assertFalse(account.isUnspecified());
-        assertEquals(account, CloudAccount.from(account.value()));
-        assertEquals("my-project", account.account());
-        assertEquals(CloudName.GCP, account.cloudName());
-        assertEquals("gcp:my-project", account.value());
+        CloudAccount oldFormat = CloudAccount.from("my-project");
+        CloudAccount newFormat = CloudAccount.from("gcp:my-project");
+        assertEquals(oldFormat, newFormat);
+
+        for (CloudAccount account : List.of(oldFormat, newFormat)) {
+            assertFalse(account.isUnspecified());
+            assertEquals(account, CloudAccount.from(account.value()));
+            assertEquals("my-project", account.account());
+            assertEquals(CloudName.GCP, account.cloudName());
+            assertEquals("gcp:my-project", account.value());
+        }
     }
 
     @Test

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ArchiveBucketsSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/ArchiveBucketsSerializerTest.java
@@ -20,8 +20,8 @@ public class ArchiveBucketsSerializerTest {
         ArchiveBuckets archiveBuckets = new ArchiveBuckets(
                 Set.of(new VespaManagedArchiveBucket("bucket1Name", "key1Arn").withTenants(Set.of(TenantName.from("t1"), TenantName.from("t2"))),
                        new VespaManagedArchiveBucket("bucket2Name", "key2Arn").withTenant(TenantName.from("t3"))),
-                Set.of(new TenantManagedArchiveBucket("bucket3Name", CloudAccount.from("gcp:acct-1"), Instant.ofEpochMilli(1234)),
-                       new TenantManagedArchiveBucket("bucket4Name", CloudAccount.from("gcp:acct-2"), Instant.ofEpochMilli(5678))));
+                Set.of(new TenantManagedArchiveBucket("bucket3Name", CloudAccount.from("acct-1"), Instant.ofEpochMilli(1234)),
+                       new TenantManagedArchiveBucket("bucket4Name", CloudAccount.from("acct-2"), Instant.ofEpochMilli(5678))));
 
         assertEquals(archiveBuckets, ArchiveBucketsSerializer.fromSlime(ArchiveBucketsSerializer.toSlime(archiveBuckets)));
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#27975

All host-admin configs are missing cloud name prefix.