### PR TITLE
Add min/sum/count suffixes to gauge metrics

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/jdisc/state/MetricsPacketsHandler.java
+++ b/container-core/src/main/java/com/yahoo/container/jdisc/state/MetricsPacketsHandler.java
@@ -231,7 +231,10 @@ public class MetricsPacketsHandler extends AbstractRequestHandler {
                 GaugeMetric gauge = (GaugeMetric) value;
                 metrics.put(name + ".average", sanitizeDouble(gauge.getAverage()))
                         .put(name + ".last", sanitizeDouble(gauge.getLast()))
-                        .put(name + ".max", sanitizeDouble(gauge.getMax()));
+                        .put(name + ".max", sanitizeDouble(gauge.getMax()))
+                        .put(name + ".min", sanitizeDouble(gauge.getMin()))
+                        .put(name + ".sum", sanitizeDouble(gauge.getSum()))
+                        .put(name + ".count", gauge.getCount());
                 if (gauge.getPercentiles().isPresent()) {
                     for (Tuple2<String, Double> prefixAndValue : gauge.getPercentiles().get()) {
                         metrics.put(name + "." + prefixAndValue.first + "percentile", prefixAndValue.second.doubleValue());
@@ -255,6 +258,9 @@ public class MetricsPacketsHandler extends AbstractRequestHandler {
                 metrics.put(name + ".average", sanitizeDouble(gauge.getAverage()));
                 metrics.put(name + ".last", sanitizeDouble(gauge.getLast()));
                 metrics.put(name + ".max", sanitizeDouble(gauge.getMax()));
+                metrics.put(name + ".min", sanitizeDouble(gauge.getMin()));
+                metrics.put(name + ".sum", sanitizeDouble(gauge.getSum()));
+                metrics.put(name + ".count", gauge.getCount());
                 if (gauge.getPercentiles().isPresent()) {
                     for (Tuple2<String, Double> prefixAndValue : gauge.getPercentiles().get()) {
                         metrics.put(name + "." + prefixAndValue.first + "percentile", prefixAndValue.second.doubleValue());

--- a/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
+++ b/container-core/src/test/java/com/yahoo/container/jdisc/state/MetricsPacketsHandlerTest.java
@@ -189,10 +189,16 @@ public class MetricsPacketsHandlerTest extends StateHandlerTestBase {
                     "gauge.metric.average" : 0.2,
                     "gauge.metric.last" : 0.2,
                     "gauge.metric.max" : 0.2,
+                    "gauge.metric.min" : 0.2,
+                    "gauge.metric.sum" : 0.2,
+                    "gauge.metric.count" : 1,
                     "configserver.requests.count" : 120,
                     "lockAttempt.lockedLoad.average" : 500.0,
                     "lockAttempt.lockedLoad.last" : 500.0,
                     "lockAttempt.lockedLoad.max" : 500.0,
+                    "lockAttempt.lockedLoad.min" : 500.0,
+                    "lockAttempt.lockedLoad.sum" : 500.0,
+                    "lockAttempt.lockedLoad.count" : 1,
                     "counter.metric.count" : 5
                   }
                 }
@@ -210,9 +216,9 @@ public class MetricsPacketsHandlerTest extends StateHandlerTestBase {
                     "host" : "some-hostname"
                   },
                   "metrics" : {
-                    "lockAttempt.lockedLoad.max" : 500.0,
                     "configserver.requests.count" : 120,
-                    "lockAttempt.lockedLoad.average" : 500.0
+                    "lockAttempt.lockedLoad.average" : 500.0,
+                    "lockAttempt.lockedLoad.max" : 500.0
                   }
                 }
                 """;


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Needed since they were introduced in [InfrastructureMetricSet](https://github.com/vespa-engine/vespa/pull/27983)