### PR TITLE
Fix checking of zones

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagsTarget.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/systemflags/v1/FlagsTarget.java
@@ -142,7 +142,7 @@ public interface FlagsTarget {
         var fetchVector = new FetchVector();
         if (!flagDimensions.contains(CLOUD)) fetchVector = fetchVector.with(CLOUD, cloud.value());
         if (!flagDimensions.contains(ENVIRONMENT)) fetchVector = fetchVector.with(ENVIRONMENT, virtualZoneId.environment().value());
-        if (!flagDimensions.contains(SYSTEM)) fetchVector = fetchVector.with(SYSTEM, system.value());
+        fetchVector = fetchVector.with(SYSTEM, system.value());
         if (!flagDimensions.contains(ZONE_ID)) fetchVector = fetchVector.with(ZONE_ID, virtualZoneId.value());
         return fetchVector.isEmpty() ? data : data.partialResolve(fetchVector);
     }

--- a/flags/src/main/java/com/yahoo/vespa/flags/json/RelationalCondition.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/json/RelationalCondition.java
@@ -68,6 +68,10 @@ public class RelationalCondition implements Condition {
         return fetchVector.getValue(dimension).map(predicate::test).orElse(false);
     }
 
+    public RelationalPredicate relationalPredicate() {
+        return relationalPredicate;
+    }
+
     @Override
     public WireCondition toWire() {
         var condition = new WireCondition();


### PR DESCRIPTION
When validating the zones in the controller, it needs to partially resolve the system first.  Otherwise it will find zones belonging to other systems, and fail the existence check of those.  In fact partially resolving the system probably makes sense even client-side, so that's also done (redundantly).  It is considered dangerous to mix zones from different systems in the same zone condition values array.

Also, always resolve the system: whether posting flag data to a zone (or controller) from a client, or when forwarding flag data inside the controller and to a zone (or the controller).