### PR TITLE
When splitting a large number of nodes into their leaf groups you end…

### DIFF
--- a/vdslib/src/tests/distribution/distributiontest.cpp
+++ b/vdslib/src/tests/distribution/distributiontest.cpp
@@ -1031,4 +1031,8 @@ TEST(DistributionTest, DISABLED_benchmark_ideal_state_for_many_groups) {
     fprintf(stderr, "%.10f seconds\n", min_time);
 }
 
+TEST(DistributionTest, control_size_of_IndexList) {
+    EXPECT_EQ(24u, sizeof(Distribution::IndexList));
+}
+
 }

--- a/vdslib/src/vespa/vdslib/distribution/distribution.h
+++ b/vdslib/src/vespa/vdslib/distribution/distribution.h
@@ -12,7 +12,7 @@
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/vdslib/state/nodetype.h>
 #include <vespa/vespalib/util/exception.h>
-#include <vespa/vespalib/util/arrayref.h>
+#include <vespa/vespalib/util/small_vector.h>
 
 namespace vespa::config::content::internal {
     class InternalStorDistributionType;
@@ -148,7 +148,7 @@ public:
      * Utility function used by distributor to split copies into groups to
      * handle active per group feature.
      */
-    using IndexList = std::vector<uint16_t>;
+    using IndexList = vespalib::SmallVector<uint16_t, 4>;
     std::vector<IndexList> splitNodesIntoLeafGroups(vespalib::ConstArrayRef<uint16_t> nodes) const;
 
     static bool allDistributorsDown(const Group&, const ClusterState&);


### PR DESCRIPTION
… up with many vectors with only a single node in them.

Then it is more efficient to use a small_vector that keeps the 4 first entries within. Reduces # allocations and avoids indirection.

@geirst PR