### PR TITLE
Make the all tenants console view quicker

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/MockBillingController.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/billing/MockBillingController.java
@@ -28,7 +28,7 @@ public class MockBillingController implements BillingController {
     Map<TenantName, PlanId> plans = new HashMap<>();
     Map<TenantName, PaymentInstrument> activeInstruments = new HashMap<>();
     Map<TenantName, List<Bill>> committedBills = new HashMap<>();
-    Map<TenantName, Bill> uncommittedBills = new HashMap<>();
+    public Map<TenantName, Bill> uncommittedBills = new HashMap<>();
     Map<TenantName, List<Bill.LineItem>> unusedLineItems = new HashMap<>();
     Map<TenantName, CollectionMethod> collectionMethod = new HashMap<>();
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2.java
@@ -31,7 +31,9 @@ import com.yahoo.vespa.hosted.controller.tenant.Tenant;
 
 import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
@@ -82,6 +84,8 @@ public class BillingApiHandlerV2 extends RestApiRequestHandler<BillingApiHandler
                  */
                 .addRoute(RestApi.route("/billing/v2/accountant")
                         .get(self::accountant))
+                .addRoute(RestApi.route("/billing/v2/accountant/preview")
+                        .get(self::accountantPreview))
                 .addRoute(RestApi.route("/billing/v2/accountant/preview/tenant/{tenant}")
                         .get(self::previewBill)
                         .post(Slime.class, self::createBill))
@@ -200,21 +204,39 @@ public class BillingApiHandlerV2 extends RestApiRequestHandler<BillingApiHandler
     // --------- ACCOUNTANT API ----------
 
     private Slime accountant(RestApi.RequestContext requestContext) {
+        var response = new Slime();
+        var tenantsResponse = response.setObject().setArray("tenants");
+
+        tenants.asList().stream().sorted(Comparator.comparing(Tenant::name)).forEach(tenant -> {
+            var tenantResponse = tenantsResponse.addObject();
+            tenantResponse.setString("tenant", tenant.name().value());
+            toSlime(tenantResponse.setObject("plan"), planFor(tenant.name()));
+            toSlime(tenantResponse.setObject("quota"), billing.getQuota(tenant.name()));
+            tenantResponse.setString("collection", billing.getCollectionMethod(tenant.name()).name());
+            tenantResponse.setString("lastBill", LocalDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC).format(DateTimeFormatter.ISO_DATE));
+            tenantResponse.setString("unbilled", "0.00");
+        });
+
+        return response;
+    }
+
+    private Slime accountantPreview(RestApi.RequestContext requestContext) {
         var untilAt = untilParameter(requestContext);
         var usagePerTenant = billing.createUncommittedBills(untilAt);
 
         var response = new Slime();
         var tenantsResponse = response.setObject().setArray("tenants");
 
-        tenants.asList().stream().sorted(Comparator.comparing(Tenant::name)).forEach(tenant -> {
-            var usage = Optional.ofNullable(usagePerTenant.get(tenant.name()));
+        usagePerTenant.entrySet().stream().sorted(Comparator.comparing(x -> x.getValue().sum())).forEachOrdered(x -> {
+            var tenant = x.getKey();
+            var usage = x.getValue();
             var tenantResponse = tenantsResponse.addObject();
-            tenantResponse.setString("tenant", tenant.name().value());
-            toSlime(tenantResponse.setObject("plan"), planFor(tenant.name()));
-            toSlime(tenantResponse.setObject("quota"), billing.getQuota(tenant.name()));
-            tenantResponse.setString("collection", billing.getCollectionMethod(tenant.name()).name());
-            tenantResponse.setString("lastBill", usage.map(Bill::getStartDate).map(DateTimeFormatter.ISO_DATE::format).orElse(null));
-            tenantResponse.setString("unbilled", usage.map(Bill::sum).map(BigDecimal::toPlainString).orElse("0.00"));
+            tenantResponse.setString("tenant", tenant.value());
+            toSlime(tenantResponse.setObject("plan"), planFor(tenant));
+            toSlime(tenantResponse.setObject("quota"), billing.getQuota(tenant));
+            tenantResponse.setString("collection", billing.getCollectionMethod(tenant).name());
+            tenantResponse.setString("lastBill", usage.getStartDate().format(DateTimeFormatter.ISO_DATE));
+            tenantResponse.setString("unbilled", usage.sum().toPlainString());
         });
 
         return response;

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2Test.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/billing/BillingApiHandlerV2Test.java
@@ -116,7 +116,16 @@ public class BillingApiHandlerV2Test extends ControllerContainerCloudTest {
 
         var accountantRequest = request("/billing/v2/accountant").roles(Role.hostedAccountant());
         tester.assertResponse(accountantRequest, """
-                {"tenants":[{"tenant":"tenant1","plan":{"id":"trial","name":"Free Trial - for testing purposes"},"quota":{"budget":-1.0},"collection":"AUTO","lastBill":null,"unbilled":"0.00"}]}""");
+                {"tenants":[{"tenant":"tenant1","plan":{"id":"trial","name":"Free Trial - for testing purposes"},"quota":{"budget":-1.0},"collection":"AUTO","lastBill":"1970-01-01","unbilled":"0.00"}]}""");
+    }
+
+    @Test
+    void require_accountant_preview() {
+        var accountantRequest = request("/billing/v2/accountant/preview").roles(Role.hostedAccountant());
+        billingController.uncommittedBills.put(tenant, BillingApiHandlerTest.createBill());
+
+        tester.assertResponse(accountantRequest, """
+                        {"tenants":[{"tenant":"tenant1","plan":{"id":"trial","name":"Free Trial - for testing purposes"},"quota":{"budget":-1.0},"collection":"AUTO","lastBill":"2020-05-23","unbilled":"123.00"}]}""");
     }
 
     @Test


### PR DESCRIPTION
- mock output for some columns we are going to remove from the view
- create a new API call to show only tenants that have utilisation