### PR TITLE
Implement edge-triggered distributor operation cancelling

### DIFF
--- a/storage/src/tests/distributor/check_condition_test.cpp
+++ b/storage/src/tests/distributor/check_condition_test.cpp
@@ -231,7 +231,7 @@ TEST_F(CheckConditionTest, failed_gets_completes_check_with_error_outcome) {
 TEST_F(CheckConditionTest, check_fails_if_condition_explicitly_cancelled) {
     test_cond_with_2_gets_sent([&](auto& cond) {
         cond.handle_reply(_sender, make_matched_reply(0));
-        cond.cancel(_sender, CancelScope::of_ownership_change());
+        cond.cancel(_sender, CancelScope::of_fully_cancelled());
         cond.handle_reply(_sender, make_matched_reply(1));
     }, [&](auto& outcome) {
         EXPECT_FALSE(outcome.matched_condition());

--- a/storage/src/tests/distributor/check_condition_test.cpp
+++ b/storage/src/tests/distributor/check_condition_test.cpp
@@ -5,6 +5,7 @@
 #include <vespa/document/fieldset/fieldsets.h>
 #include <vespa/documentapi/messagebus/messages/testandsetcondition.h>
 #include <vespa/storage/distributor/node_supported_features.h>
+#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storage/distributor/operations/external/check_condition.h>
 #include <vespa/storage/distributor/persistence_operation_metric_set.h>
 #include <vespa/storageapi/message/persistence.h>
@@ -227,6 +228,20 @@ TEST_F(CheckConditionTest, failed_gets_completes_check_with_error_outcome) {
     });
 }
 
+TEST_F(CheckConditionTest, check_fails_if_condition_explicitly_cancelled) {
+    test_cond_with_2_gets_sent([&](auto& cond) {
+        cond.handle_reply(_sender, make_matched_reply(0));
+        cond.cancel(_sender, CancelScope::of_ownership_change());
+        cond.handle_reply(_sender, make_matched_reply(1));
+    }, [&](auto& outcome) {
+        EXPECT_FALSE(outcome.matched_condition());
+        EXPECT_FALSE(outcome.not_found());
+        EXPECT_TRUE(outcome.failed());
+        EXPECT_EQ(outcome.error_code().getResult(), api::ReturnCode::ABORTED);
+    });
+}
+
+// TODO deprecate in favor of cancelling
 TEST_F(CheckConditionTest, check_fails_if_replica_set_changed_between_start_and_completion) {
     test_cond_with_2_gets_sent([&](auto& cond) {
         cond.handle_reply(_sender, make_matched_reply(0));
@@ -242,6 +257,7 @@ TEST_F(CheckConditionTest, check_fails_if_replica_set_changed_between_start_and_
     });
 }
 
+// TODO deprecate in favor of cancelling
 TEST_F(CheckConditionTest, check_fails_if_bucket_ownership_changed_between_start_and_completion_pending_transition_case) {
     test_cond_with_2_gets_sent([&](auto& cond) {
         cond.handle_reply(_sender, make_matched_reply(0));
@@ -255,6 +271,7 @@ TEST_F(CheckConditionTest, check_fails_if_bucket_ownership_changed_between_start
     });
 }
 
+// TODO deprecate in favor of cancelling
 TEST_F(CheckConditionTest, check_fails_if_bucket_ownership_changed_between_start_and_completion_completed_transition_case) {
     test_cond_with_2_gets_sent([&](auto& cond) {
         cond.handle_reply(_sender, make_matched_reply(0));

--- a/storage/src/tests/distributor/garbagecollectiontest.cpp
+++ b/storage/src/tests/distributor/garbagecollectiontest.cpp
@@ -177,7 +177,7 @@ TEST_F(GarbageCollectionOperationTest, no_replica_bucket_info_added_to_db_if_ope
     ASSERT_EQ(2, _sender.commands().size());
 
     reply_to_nth_request(*op, 0, 1234, 70);
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
     reply_to_nth_request(*op, 1, 4567, 60);
 
     // DB state is unchanged. Note that in a real scenario, the DB entry will have been removed
@@ -408,7 +408,7 @@ TEST_F(GarbageCollectionOperationPhase1FailureTest, no_second_phase_if_bucket_in
 }
 
 TEST_F(GarbageCollectionOperationPhase1FailureTest, no_second_phase_if_operation_fully_cancelled_between_phases) {
-    _op->cancel(_sender, CancelScope::of_ownership_change());
+    _op->cancel(_sender, CancelScope::of_fully_cancelled());
     receive_phase1_replies_and_assert_no_phase_2_started();
 }
 

--- a/storage/src/tests/distributor/garbagecollectiontest.cpp
+++ b/storage/src/tests/distributor/garbagecollectiontest.cpp
@@ -113,9 +113,8 @@ struct GarbageCollectionOperationTest : Test, DistributorStripeTestUtil {
         ASSERT_EQ(entry->getNodeCount(), info.size());
         EXPECT_EQ(entry->getLastGarbageCollectionTime(), last_gc_time);
         for (size_t i = 0; i < info.size(); ++i) {
-            EXPECT_EQ(info[i], entry->getNode(i)->getBucketInfo())
-                    << "Mismatching info for node " << i << ": " << info[i] << " vs "
-                    << entry->getNode(i)->getBucketInfo();
+            auto& node = entry->getNodeRef(i);
+            EXPECT_EQ(info[i], node.getBucketInfo()) << "Mismatching DB bucket info for node " << node.getNode();
         }
     }
 
@@ -170,6 +169,51 @@ TEST_F(GarbageCollectionOperationTest, replica_bucket_info_not_added_to_db_until
     ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(1234, 90, 500), api::BucketInfo(4567, 90, 500)}, 34));
 
     EXPECT_EQ(70u, gc_removed_documents_metric()); // Use max of received metrics
+}
+
+TEST_F(GarbageCollectionOperationTest, no_replica_bucket_info_added_to_db_if_operation_fully_canceled) {
+    auto op = create_op();
+    op->start(_sender);
+    ASSERT_EQ(2, _sender.commands().size());
+
+    reply_to_nth_request(*op, 0, 1234, 70);
+    op->cancel(_sender, CancelScope::of_ownership_change());
+    reply_to_nth_request(*op, 1, 4567, 60);
+
+    // DB state is unchanged. Note that in a real scenario, the DB entry will have been removed
+    // as part of the ownership change, but there are already non-cancellation behaviors that
+    // avoid creating buckets from scratch in the DB if they do not exist, so just checking to
+    // see if the bucket exists or not risks hiding missing cancellation edge handling.
+    ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(250, 50, 300), api::BucketInfo(250, 50, 300)}, 0));
+    // However, we still update our metrics if we _did_ remove documents on one or more nodes
+    EXPECT_EQ(70u, gc_removed_documents_metric());
+}
+
+TEST_F(GarbageCollectionOperationTest, no_replica_bucket_info_added_to_db_for_cancelled_node) {
+    auto op = create_op();
+    op->start(_sender);
+    ASSERT_EQ(2, _sender.commands().size());
+
+    reply_to_nth_request(*op, 0, 1234, 70);
+    op->cancel(_sender, CancelScope::of_node_subset({0}));
+    reply_to_nth_request(*op, 1, 4567, 60);
+
+    // DB state is unchanged for node 0, changed for node 1
+    ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(250, 50, 300), api::BucketInfo(4567, 90, 500)}, 34));
+}
+
+TEST_F(GarbageCollectionOperationTest, node_cancellation_is_cumulative) {
+    auto op = create_op();
+    op->start(_sender);
+    ASSERT_EQ(2, _sender.commands().size());
+
+    reply_to_nth_request(*op, 0, 1234, 70);
+    op->cancel(_sender, CancelScope::of_node_subset({0}));
+    op->cancel(_sender, CancelScope::of_node_subset({1}));
+    reply_to_nth_request(*op, 1, 4567, 60);
+
+    // DB state is unchanged for both nodes
+    ASSERT_NO_FATAL_FAILURE(assert_bucket_db_contains({api::BucketInfo(250, 50, 300), api::BucketInfo(250, 50, 300)}, 0));
 }
 
 TEST_F(GarbageCollectionOperationTest, gc_bucket_info_does_not_overwrite_later_sequenced_bucket_info_writes) {
@@ -360,6 +404,16 @@ TEST_F(GarbageCollectionOperationPhase1FailureTest, no_second_phase_if_bucket_in
     // Add a logical child of _bucket_id to the bucket tree. This implies an inconsistent split, as we never
     // want to have a tree with buckets in inner node positions, only in leaves.
     addNodesToBucketDB(BucketId(17, 1), "0=250/50/300,1=250/50/300");
+    receive_phase1_replies_and_assert_no_phase_2_started();
+}
+
+TEST_F(GarbageCollectionOperationPhase1FailureTest, no_second_phase_if_operation_fully_cancelled_between_phases) {
+    _op->cancel(_sender, CancelScope::of_ownership_change());
+    receive_phase1_replies_and_assert_no_phase_2_started();
+}
+
+TEST_F(GarbageCollectionOperationPhase1FailureTest, no_second_phase_if_operation_partially_cancelled_between_phases) {
+    _op->cancel(_sender, CancelScope::of_node_subset({0}));
     receive_phase1_replies_and_assert_no_phase_2_started();
 }
 

--- a/storage/src/tests/distributor/putoperationtest.cpp
+++ b/storage/src/tests/distributor/putoperationtest.cpp
@@ -6,6 +6,7 @@
 #include <vespa/storage/distributor/top_level_distributor.h>
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/distributor_stripe.h>
+#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storage/distributor/operations/external/putoperation.h>
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageapi/message/persistence.h>
@@ -208,6 +209,43 @@ TEST_F(PutOperationTest, failed_CreateBucket_removes_replica_from_db_and_sends_R
               _sender.getCommands(true, true, 4));
 }
 
+TEST_F(PutOperationTest, failed_CreateBucket_does_not_send_RequestBucketInfo_if_op_fully_canceled) {
+    setup_stripe(2, 2, "distributor:1 storage:2");
+
+    auto doc = createDummyDocument("test", "test");
+    sendPut(createPut(doc));
+
+    ASSERT_EQ("Create bucket => 1,Create bucket => 0,Put => 1,Put => 0", _sender.getCommands(true));
+
+    op->cancel(_sender, CancelScope::of_ownership_change());
+    sendReply(0, api::ReturnCode::TIMEOUT, api::BucketInfo()); // CreateBucket to node 1
+
+    // DB is not touched (note: normally node 1 would be removed at the cancel-edge).
+    ASSERT_EQ("BucketId(0x4000000000008f09) : "
+              "node(idx=1,crc=0x1,docs=0/0,bytes=0/0,trusted=true,active=true,ready=false), "
+              "node(idx=0,crc=0x1,docs=0/0,bytes=0/0,trusted=true,active=false,ready=false)",
+              dumpBucket(operation_context().make_split_bit_constrained_bucket_id(doc->getId())));
+    // No new requests sent
+    ASSERT_EQ("", _sender.getCommands(true, true, 4));
+}
+
+TEST_F(PutOperationTest, failed_CreateBucket_does_not_send_RequestBucketInfo_for_cancelled_nodes) {
+    setup_stripe(2, 2, "distributor:1 storage:2");
+
+    auto doc = createDummyDocument("test", "test");
+    sendPut(createPut(doc));
+
+    ASSERT_EQ("Create bucket => 1,Create bucket => 0,Put => 1,Put => 0", _sender.getCommands(true));
+
+    op->cancel(_sender, CancelScope::of_node_subset({0}));
+    sendReply(0, api::ReturnCode::TIMEOUT, api::BucketInfo()); // CreateBucket to node 1
+    sendReply(1, api::ReturnCode::TIMEOUT, api::BucketInfo()); // CreateBucket to node 0
+
+    // Bucket info recheck only sent to node 1, as it's not cancelled
+    ASSERT_EQ("RequestBucketInfoCommand(1 buckets, super bucket BucketId(0x4000000000008f09). ) => 1",
+              _sender.getCommands(true, true, 4));
+}
+
 TEST_F(PutOperationTest, send_inline_split_before_put_if_bucket_too_large) {
     setup_stripe(1, 1, "storage:1 distributor:1");
     auto cfg = make_config();
@@ -264,6 +302,26 @@ TEST_F(PutOperationTest, return_success_if_op_acked_on_all_replicas_even_if_buck
     // has its replicas removed from the DB, this by definition has happened-after
     // the ACK was sent from the node, so returning OK here still maintains the
     // backend persistence property.
+    sendReply(0);
+    sendReply(1);
+
+    ASSERT_EQ("PutReply(id:test:testdoctype1::, BucketId(0x0000000000000000), "
+              "timestamp 100) ReturnCode(NONE)",
+              _sender.getLastReply());
+}
+
+TEST_F(PutOperationTest, return_success_if_op_acked_on_all_replicas_even_if_operation_cancelled) {
+    setup_stripe(2, 2, "storage:2 distributor:1");
+    createAndSendSampleDocument(TIMEOUT);
+
+    ASSERT_EQ("Put(BucketId(0x4000000000001dd4), "
+              "id:test:testdoctype1::, timestamp 100, size 45) => 0,"
+              "Put(BucketId(0x4000000000001dd4), "
+              "id:test:testdoctype1::, timestamp 100, size 45) => 1",
+              _sender.getCommands(true, true));
+
+    op->cancel(_sender, CancelScope::of_ownership_change());
+
     sendReply(0);
     sendReply(1);
 
@@ -491,7 +549,7 @@ TEST_F(PutOperationTest, update_correct_bucket_on_remapped_put) {
 
     {
         std::shared_ptr<api::StorageCommand> msg2  = _sender.command(0);
-        std::shared_ptr<api::StorageReply> reply(msg2->makeReply().release());
+        std::shared_ptr<api::StorageReply> reply(msg2->makeReply());
         auto* sreply = dynamic_cast<api::PutReply*>(reply.get());
         ASSERT_TRUE(sreply);
         sreply->remapBucketId(document::BucketId(17, 13));
@@ -511,6 +569,7 @@ TEST_F(PutOperationTest, update_correct_bucket_on_remapped_put) {
               dumpBucket(document::BucketId(17, 13)));
 }
 
+// TODO make this redundant through operation cancelling
 TEST_F(PutOperationTest, replica_not_resurrected_in_db_when_node_down_in_active_state) {
     setup_stripe(Redundancy(3), NodeCount(3), "distributor:1 storage:3");
 
@@ -535,6 +594,7 @@ TEST_F(PutOperationTest, replica_not_resurrected_in_db_when_node_down_in_active_
               dumpBucket(operation_context().make_split_bit_constrained_bucket_id(doc->getId())));
 }
 
+// TODO make this redundant through operation cancelling
 TEST_F(PutOperationTest, replica_not_resurrected_in_db_when_node_down_in_pending_state) {
     setup_stripe(Redundancy(3), NodeCount(4), "version:1 distributor:1 storage:3");
 
@@ -568,6 +628,8 @@ TEST_F(PutOperationTest, replica_not_resurrected_in_db_when_node_down_in_pending
 
 // TODO probably also do this for updates and removes
 // TODO consider if we should use the pending state verbatim for computing targets if it exists
+// TODO make this redundant through operation cancelling
+//   ... actually; FIXME shouldn't the ExternalOperationHandler already cover this??
 TEST_F(PutOperationTest, put_is_failed_with_busy_if_target_down_in_pending_state) {
     setup_stripe(Redundancy(3), NodeCount(4), "version:1 distributor:1 storage:3");
     auto doc = createDummyDocument("test", "test");
@@ -582,6 +644,65 @@ TEST_F(PutOperationTest, put_is_failed_with_busy_if_target_down_in_pending_state
               "timestamp 100) ReturnCode(BUSY, "
               "One or more target content nodes are unavailable in the pending cluster state)",
               _sender.getLastReply(true));
+}
+
+TEST_F(PutOperationTest, db_not_updated_if_operation_cancelled_by_ownership_change) {
+    setup_stripe(Redundancy(3), NodeCount(3), "distributor:1 storage:3");
+
+    auto doc = createDummyDocument("test", "uri");
+    auto bucket = operation_context().make_split_bit_constrained_bucket_id(doc->getId());
+    auto remap_bucket = BucketId(bucket.getUsedBits() + 1, bucket.getId());
+    addNodesToBucketDB(bucket, "0=1/2/3/t,1=1/2/3/t,2=1/2/3/t");
+
+    sendPut(createPut(doc));
+
+    ASSERT_EQ("Put => 1,Put => 2,Put => 0", _sender.getCommands(true));
+
+    operation_context().remove_nodes_from_bucket_database(makeDocumentBucket(bucket), {0, 1, 2});
+    op->cancel(_sender, CancelScope::of_ownership_change());
+
+    // Normally DB updates triggered by replies don't _create_ buckets in the DB, unless
+    // they're remapped buckets. Use a remapping to ensure we hit a create-if-missing DB path.
+    {
+        std::shared_ptr<api::StorageCommand> msg2  = _sender.command(0);
+        std::shared_ptr<api::StorageReply> reply(msg2->makeReply());
+        auto* sreply = dynamic_cast<api::PutReply*>(reply.get());
+        ASSERT_TRUE(sreply);
+        sreply->remapBucketId(remap_bucket);
+        sreply->setBucketInfo(api::BucketInfo(1,2,3,4,5));
+        op->receive(_sender, reply);
+    }
+
+    sendReply(1, api::ReturnCode::OK, api::BucketInfo(5, 6, 7));
+    sendReply(2, api::ReturnCode::OK, api::BucketInfo(7, 8, 9));
+
+    EXPECT_EQ("NONEXISTING", dumpBucket(bucket));
+    EXPECT_EQ("NONEXISTING", dumpBucket(remap_bucket));
+}
+
+TEST_F(PutOperationTest, individually_cancelled_nodes_are_not_updated_in_db) {
+    setup_stripe(Redundancy(3), NodeCount(3), "distributor:1 storage:3");
+
+    auto doc = createDummyDocument("test", "uri");
+    auto bucket = operation_context().make_split_bit_constrained_bucket_id(doc->getId());
+    addNodesToBucketDB(bucket, "0=1/2/3/t,1=1/2/3/t,2=1/2/3/t");
+
+    sendPut(createPut(doc));
+    ASSERT_EQ("Put => 1,Put => 2,Put => 0", _sender.getCommands(true));
+
+    // Simulate nodes 0 and 2 going down
+    operation_context().remove_nodes_from_bucket_database(makeDocumentBucket(bucket), {0, 2});
+    // Cancelling shall be cumulative
+    op->cancel(_sender, CancelScope::of_node_subset({0}));
+    op->cancel(_sender, CancelScope::of_node_subset({2}));
+
+    sendReply(0, api::ReturnCode::OK, api::BucketInfo(5, 6, 7));
+    sendReply(1, api::ReturnCode::OK, api::BucketInfo(6, 7, 8));
+    sendReply(2, api::ReturnCode::OK, api::BucketInfo(9, 8, 7));
+
+    EXPECT_EQ("BucketId(0x4000000000000593) : "
+              "node(idx=1,crc=0x5,docs=6/6,bytes=7/7,trusted=true,active=false,ready=false)",
+              dumpBucket(bucket));
 }
 
 TEST_F(PutOperationTest, send_to_retired_nodes_if_no_up_nodes_available) {
@@ -758,6 +879,38 @@ TEST_F(PutOperationTest, failed_condition_probe_fails_op_with_returned_error) {
               "BucketId(0x0000000000000000), timestamp 100) "
               "ReturnCode(ABORTED, Failed during write repair condition probe step. Reason: "
               "One or more replicas failed during test-and-set condition evaluation)",
+              _sender.getLastReply());
+}
+
+TEST_F(PutOperationTest, ownership_cancellation_during_condition_probe_fails_operation_on_probe_completion) {
+    ASSERT_NO_FATAL_FAILURE(set_up_tas_put_with_2_inconsistent_replica_nodes());
+
+    op->receive(_sender, make_get_reply(*sent_get_command(0), 0, false, false));
+    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->receive(_sender, make_get_reply(*sent_get_command(1), 0, false, false));
+
+    ASSERT_EQ("Get => 1,Get => 0", _sender.getCommands(true));
+    ASSERT_EQ("PutReply(id:test:testdoctype1::test, "
+              "BucketId(0x0000000000000000), timestamp 100) "
+              "ReturnCode(ABORTED, Failed during write repair condition probe step. Reason: "
+              "Operation has been cancelled (likely due to a cluster state change))",
+              _sender.getLastReply());
+}
+
+TEST_F(PutOperationTest, replica_subset_cancellation_during_condition_probe_fails_operation_on_probe_completion) {
+    ASSERT_NO_FATAL_FAILURE(set_up_tas_put_with_2_inconsistent_replica_nodes());
+
+    op->receive(_sender, make_get_reply(*sent_get_command(0), 0, false, false));
+    // 1 of 2 nodes; we still abort after the read phase since we cannot possibly fulfill
+    // the write phase for all replicas.
+    op->cancel(_sender, CancelScope::of_node_subset({0}));
+    op->receive(_sender, make_get_reply(*sent_get_command(1), 0, false, false));
+
+    ASSERT_EQ("Get => 1,Get => 0", _sender.getCommands(true));
+    ASSERT_EQ("PutReply(id:test:testdoctype1::test, "
+              "BucketId(0x0000000000000000), timestamp 100) "
+              "ReturnCode(ABORTED, Failed during write repair condition probe step. Reason: "
+              "Operation has been cancelled (likely due to a cluster state change))",
               _sender.getLastReply());
 }
 

--- a/storage/src/tests/distributor/putoperationtest.cpp
+++ b/storage/src/tests/distributor/putoperationtest.cpp
@@ -217,7 +217,7 @@ TEST_F(PutOperationTest, failed_CreateBucket_does_not_send_RequestBucketInfo_if_
 
     ASSERT_EQ("Create bucket => 1,Create bucket => 0,Put => 1,Put => 0", _sender.getCommands(true));
 
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
     sendReply(0, api::ReturnCode::TIMEOUT, api::BucketInfo()); // CreateBucket to node 1
 
     // DB is not touched (note: normally node 1 would be removed at the cancel-edge).
@@ -320,7 +320,7 @@ TEST_F(PutOperationTest, return_success_if_op_acked_on_all_replicas_even_if_oper
               "id:test:testdoctype1::, timestamp 100, size 45) => 1",
               _sender.getCommands(true, true));
 
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
 
     sendReply(0);
     sendReply(1);
@@ -659,7 +659,7 @@ TEST_F(PutOperationTest, db_not_updated_if_operation_cancelled_by_ownership_chan
     ASSERT_EQ("Put => 1,Put => 2,Put => 0", _sender.getCommands(true));
 
     operation_context().remove_nodes_from_bucket_database(makeDocumentBucket(bucket), {0, 1, 2});
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
 
     // Normally DB updates triggered by replies don't _create_ buckets in the DB, unless
     // they're remapped buckets. Use a remapping to ensure we hit a create-if-missing DB path.
@@ -886,7 +886,7 @@ TEST_F(PutOperationTest, ownership_cancellation_during_condition_probe_fails_ope
     ASSERT_NO_FATAL_FAILURE(set_up_tas_put_with_2_inconsistent_replica_nodes());
 
     op->receive(_sender, make_get_reply(*sent_get_command(0), 0, false, false));
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
     op->receive(_sender, make_get_reply(*sent_get_command(1), 0, false, false));
 
     ASSERT_EQ("Get => 1,Get => 0", _sender.getCommands(true));

--- a/storage/src/tests/distributor/removeoperationtest.cpp
+++ b/storage/src/tests/distributor/removeoperationtest.cpp
@@ -315,7 +315,7 @@ TEST_F(ExtRemoveOperationTest, cancellation_during_condition_probe_fails_operati
     ASSERT_NO_FATAL_FAILURE(set_up_tas_remove_with_2_nodes(ReplicaState::INCONSISTENT));
 
     reply_with(make_get_reply(0, 50, false, true));
-    op->cancel(_sender, CancelScope::of_ownership_change());
+    op->cancel(_sender, CancelScope::of_fully_cancelled());
     reply_with(make_get_reply(1, 50, false, true));
 
     ASSERT_EQ("Get => 1,Get => 0", _sender.getCommands(true));

--- a/storage/src/tests/distributor/removeoperationtest.cpp
+++ b/storage/src/tests/distributor/removeoperationtest.cpp
@@ -68,6 +68,7 @@ struct RemoveOperationTest : Test, DistributorStripeTestUtil {
         std::unique_ptr<api::StorageReply> reply(removec->makeReply());
         auto* removeR = dynamic_cast<api::RemoveReply*>(reply.get());
         removeR->setOldTimestamp(oldTimestamp);
+        removeR->setBucketInfo(api::BucketInfo(1,2,3,4,5));
         callback.onReceive(_sender, std::shared_ptr<api::StorageReply>(reply.release()));
     }
 
@@ -305,6 +306,45 @@ TEST_F(ExtRemoveOperationTest, failed_condition_probe_fails_op_with_returned_err
               "ReturnCode(ABORTED, Failed during write repair condition probe step. Reason: "
               "One or more replicas failed during test-and-set condition evaluation)",
               _sender.getLastReply());
+}
+
+// Note: we don't exhaustively test cancellation edges here, as we assume that Put/Update/Remove ops
+// share the same underlying PersistenceMessageTracker logic. See PutOperationTest for more tests.
+
+TEST_F(ExtRemoveOperationTest, cancellation_during_condition_probe_fails_operation_on_probe_completion) {
+    ASSERT_NO_FATAL_FAILURE(set_up_tas_remove_with_2_nodes(ReplicaState::INCONSISTENT));
+
+    reply_with(make_get_reply(0, 50, false, true));
+    op->cancel(_sender, CancelScope::of_ownership_change());
+    reply_with(make_get_reply(1, 50, false, true));
+
+    ASSERT_EQ("Get => 1,Get => 0", _sender.getCommands(true));
+    EXPECT_EQ("RemoveReply(BucketId(0x0000000000000000), "
+              "id:test:test::uri, "
+              "timestamp 100, not found) "
+              "ReturnCode(ABORTED, Failed during write repair condition probe step. Reason: "
+              "Operation has been cancelled (likely due to a cluster state change))",
+              _sender.getLastReply());
+}
+
+TEST_F(ExtRemoveOperationTest, cancelled_nodes_are_not_updated_in_db) {
+    ASSERT_NO_FATAL_FAILURE(set_up_tas_remove_with_2_nodes(ReplicaState::CONSISTENT));
+    ASSERT_EQ("Remove => 1,Remove => 0", _sender.getCommands(true));
+
+    operation_context().remove_nodes_from_bucket_database(makeDocumentBucket(bucketId), {1});
+    op->cancel(_sender, CancelScope::of_node_subset({1}));
+
+    replyToMessage(*op, 0, 50);
+    replyToMessage(*op, 1, 50);
+
+    EXPECT_EQ("BucketId(0x4000000000000593) : "
+              "node(idx=0,crc=0x1,docs=2/4,bytes=3/5,trusted=true,active=false,ready=false)",
+              dumpBucket(bucketId));
+    // Reply is still OK since the operation went through on the content nodes
+    ASSERT_EQ("RemoveReply(BucketId(0x0000000000000000), "
+              "id:test:test::uri, timestamp 100, removed doc from 50) ReturnCode(NONE)",
+              _sender.getLastReply());
+
 }
 
 TEST_F(ExtRemoveOperationTest, trace_is_propagated_from_condition_probe_gets_ok_probe_case) {

--- a/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketinfo.cpp
@@ -142,7 +142,7 @@ BucketInfo::addNode(const BucketCopy& newCopy, const std::vector<uint16_t>& reco
 bool
 BucketInfo::removeNode(unsigned short node, TrustedUpdate update)
 {
-    for (auto iter = _nodes.begin(); iter != _nodes.end(); iter++) {
+    for (auto iter = _nodes.begin(); iter != _nodes.end(); ++iter) {
         if (iter->getNode() == node) {
             _nodes.erase(iter);
             if (update == TrustedUpdate::UPDATE) {

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -10,6 +10,7 @@ vespa_add_library(storage_distributor OBJECT
     bucket_spaces_stats_provider.cpp
     bucketgctimecalculator.cpp
     bucketlistmerger.cpp
+    cancelled_replicas_pruner.cpp
     clusterinformation.cpp
     crypto_uuid_generator.cpp
     distributor_bucket_space.cpp

--- a/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.cpp
+++ b/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.cpp
@@ -4,6 +4,9 @@
 namespace storage::distributor {
 
 std::vector<BucketCopy> prune_cancelled_nodes(std::span<const BucketCopy> replicas, const CancelScope& cancel_scope) {
+    if (cancel_scope.fully_cancelled()) {
+        return {};
+    }
     std::vector<BucketCopy> pruned_replicas;
     // Expect that there will be an input entry for each cancelled node in the common case.
     pruned_replicas.reserve((replicas.size() >= cancel_scope.cancelled_nodes().size())

--- a/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.cpp
+++ b/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.cpp
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "cancelled_replicas_pruner.h"
+
+namespace storage::distributor {
+
+std::vector<BucketCopy> prune_cancelled_nodes(std::span<const BucketCopy> replicas, const CancelScope& cancel_scope) {
+    std::vector<BucketCopy> pruned_replicas;
+    // Expect that there will be an input entry for each cancelled node in the common case.
+    pruned_replicas.reserve((replicas.size() >= cancel_scope.cancelled_nodes().size())
+                            ? replicas.size() - cancel_scope.cancelled_nodes().size() : 0);
+    for (auto& candidate : replicas) {
+        if (!cancel_scope.node_is_cancelled(candidate.getNode())) {
+            pruned_replicas.emplace_back(candidate);
+        }
+    }
+    return pruned_replicas;
+}
+
+}

--- a/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.h
+++ b/storage/src/vespa/storage/distributor/cancelled_replicas_pruner.h
@@ -1,0 +1,17 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/storage/bucketdb/bucketcopy.h>
+#include <vespa/storage/distributor/operations/cancel_scope.h>
+#include <span>
+#include <vector>
+
+namespace storage::distributor {
+
+/**
+ * Returns a new vector that contains all entries of `replicas` whose nodes are _not_ tagged as
+ * cancelled in `cancel_scope`. Returned entry ordering is identical to input ordering.
+ */
+[[nodiscard]] std::vector<BucketCopy> prune_cancelled_nodes(std::span<const BucketCopy> replicas, const CancelScope& cancel_scope);
+
+}

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -281,6 +281,7 @@ DistributorStripe::enableClusterStateBundle(const lib::ClusterStateBundle& state
     enterRecoveryMode();
 
     // Clear all active messages on nodes that are down.
+    // TODO this should also be done on nodes that are no longer part of the config!
     const uint16_t old_node_count = oldState.getBaselineClusterState()->getNodeCount(lib::NodeType::STORAGE);
     const uint16_t new_node_count = baseline_state.getNodeCount(lib::NodeType::STORAGE);
     for (uint16_t i = 0; i < std::max(old_node_count, new_node_count); ++i) {

--- a/storage/src/vespa/storage/distributor/operationowner.cpp
+++ b/storage/src/vespa/storage/distributor/operationowner.cpp
@@ -73,7 +73,7 @@ OperationOwner::onClose()
 void
 OperationOwner::erase(api::StorageMessage::Id msgId)
 {
-    _sentMessageMap.pop(msgId);
+    (void)_sentMessageMap.pop(msgId);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operations/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/operations/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 vespa_add_library(storage_distributoroperation OBJECT
     SOURCES
+    cancel_scope.cpp
     operation.cpp
     DEPENDS
 )

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
@@ -1,0 +1,52 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "cancel_scope.h"
+
+namespace storage::distributor {
+
+CancelScope::CancelScope()
+    : _cancelled_nodes(),
+      _ownership_lost(false)
+{
+}
+
+CancelScope::CancelScope(ownership_change_ctor_tag) noexcept
+    : _cancelled_nodes(),
+      _ownership_lost(true)
+{
+}
+
+CancelScope::CancelScope(CancelledNodeSet nodes) noexcept
+    : _cancelled_nodes(std::move(nodes)),
+      _ownership_lost(false)
+{
+}
+
+CancelScope::~CancelScope() = default;
+
+CancelScope::CancelScope(const CancelScope&) = default;
+CancelScope& CancelScope::operator=(const CancelScope&) = default;
+
+CancelScope::CancelScope(CancelScope&&) noexcept = default;
+CancelScope& CancelScope::operator=(CancelScope&&) noexcept = default;
+
+void CancelScope::add_cancelled_node(uint16_t node) {
+    _cancelled_nodes.insert(node);
+}
+
+void CancelScope::merge(const CancelScope& other) {
+    _ownership_lost |= other._ownership_lost;
+    // Not using iterator insert(first, last) since that explicitly resizes,
+    for (uint16_t node : other._cancelled_nodes) {
+        _cancelled_nodes.insert(node);
+    }
+}
+
+CancelScope CancelScope::of_ownership_change() noexcept {
+    return CancelScope(ownership_change_ctor_tag{});
+}
+
+CancelScope CancelScope::of_node_subset(CancelledNodeSet nodes) noexcept {
+    return CancelScope(std::move(nodes));
+}
+
+}

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
@@ -5,19 +5,19 @@ namespace storage::distributor {
 
 CancelScope::CancelScope()
     : _cancelled_nodes(),
-      _ownership_lost(false)
+      _fully_cancelled(false)
 {
 }
 
-CancelScope::CancelScope(ownership_change_ctor_tag) noexcept
+CancelScope::CancelScope(fully_cancelled_ctor_tag) noexcept
     : _cancelled_nodes(),
-      _ownership_lost(true)
+      _fully_cancelled(true)
 {
 }
 
 CancelScope::CancelScope(CancelledNodeSet nodes) noexcept
     : _cancelled_nodes(std::move(nodes)),
-      _ownership_lost(false)
+      _fully_cancelled(false)
 {
 }
 
@@ -34,7 +34,7 @@ void CancelScope::add_cancelled_node(uint16_t node) {
 }
 
 void CancelScope::merge(const CancelScope& other) {
-    _ownership_lost |= other._ownership_lost;
+    _fully_cancelled |= other._fully_cancelled;
     // Not using iterator insert(first, last) since that explicitly resizes,
     for (uint16_t node : other._cancelled_nodes) {
         _cancelled_nodes.insert(node);
@@ -42,7 +42,7 @@ void CancelScope::merge(const CancelScope& other) {
 }
 
 CancelScope CancelScope::of_fully_cancelled() noexcept {
-    return CancelScope(ownership_change_ctor_tag{});
+    return CancelScope(fully_cancelled_ctor_tag{});
 }
 
 CancelScope CancelScope::of_node_subset(CancelledNodeSet nodes) noexcept {

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.cpp
@@ -41,7 +41,7 @@ void CancelScope::merge(const CancelScope& other) {
     }
 }
 
-CancelScope CancelScope::of_ownership_change() noexcept {
+CancelScope CancelScope::of_fully_cancelled() noexcept {
     return CancelScope(ownership_change_ctor_tag{});
 }
 

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.h
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.h
@@ -1,0 +1,59 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <vespa/vespalib/stllike/hash_set.h>
+
+namespace storage::distributor {
+
+/**
+ * In the face of concurrent cluster state changes, cluster topology reconfigurations etc.,
+ * it's possible for there to be pending mutating operations to nodes that the distributor
+ * no longer should keep track of. Such operations must therefore be _cancelled_, either
+ * fully or partially. A CancelScope represents the granularity at which an operation should
+ * be cancelled.
+ *
+ * In the case of one or more nodes becoming unavailable, `fully_cancelled()` will be false
+ * and `node_is_cancelled(x)` will return whether node `x` is explicitly cancelled.
+ *
+ * In the case of ownership transfers, `fully_cancelled()` will be true since the distributor
+ * should no longer have any knowledge of the bucket. `node_is_cancelled(x)` is always
+ * implicitly true for all values of `x` for full cancellations.
+ */
+class CancelScope {
+public:
+    using CancelledNodeSet = vespalib::hash_set<uint16_t>;
+private:
+    CancelledNodeSet _cancelled_nodes;
+    bool             _ownership_lost;
+
+    struct ownership_change_ctor_tag {};
+
+    explicit CancelScope(ownership_change_ctor_tag) noexcept;
+    explicit CancelScope(CancelledNodeSet nodes) noexcept;
+public:
+    CancelScope();
+    ~CancelScope();
+
+    CancelScope(const CancelScope&);
+    CancelScope& operator=(const CancelScope&);
+
+    CancelScope(CancelScope&&) noexcept;
+    CancelScope& operator=(CancelScope&&) noexcept;
+
+    void add_cancelled_node(uint16_t node);
+    void merge(const CancelScope& other);
+
+    [[nodiscard]] bool fully_cancelled() const noexcept { return _ownership_lost; }
+    [[nodiscard]] bool node_is_cancelled(uint16_t node) const noexcept {
+        return (fully_cancelled() || _cancelled_nodes.contains(node));
+    }
+
+    [[nodiscard]] const CancelledNodeSet& cancelled_nodes() const noexcept {
+        return _cancelled_nodes;
+    }
+
+    static CancelScope of_ownership_change() noexcept;
+    static CancelScope of_node_subset(CancelledNodeSet nodes) noexcept;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.h
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.h
@@ -44,6 +44,8 @@ public:
     void merge(const CancelScope& other);
 
     [[nodiscard]] bool fully_cancelled() const noexcept { return _ownership_lost; }
+    // Note: partially_cancelled() does not subsume fully_cancelled(); it must be checked independently
+    [[nodiscard]] bool partially_cancelled() const noexcept { return !_cancelled_nodes.empty(); }
     [[nodiscard]] bool node_is_cancelled(uint16_t node) const noexcept {
         return (fully_cancelled() || _cancelled_nodes.contains(node));
     }
@@ -52,7 +54,7 @@ public:
         return _cancelled_nodes;
     }
 
-    static CancelScope of_ownership_change() noexcept;
+    static CancelScope of_fully_cancelled() noexcept;
     static CancelScope of_node_subset(CancelledNodeSet nodes) noexcept;
 };
 

--- a/storage/src/vespa/storage/distributor/operations/cancel_scope.h
+++ b/storage/src/vespa/storage/distributor/operations/cancel_scope.h
@@ -24,11 +24,11 @@ public:
     using CancelledNodeSet = vespalib::hash_set<uint16_t>;
 private:
     CancelledNodeSet _cancelled_nodes;
-    bool             _ownership_lost;
+    bool             _fully_cancelled;
 
-    struct ownership_change_ctor_tag {};
+    struct fully_cancelled_ctor_tag {};
 
-    explicit CancelScope(ownership_change_ctor_tag) noexcept;
+    explicit CancelScope(fully_cancelled_ctor_tag) noexcept;
     explicit CancelScope(CancelledNodeSet nodes) noexcept;
 public:
     CancelScope();
@@ -43,9 +43,10 @@ public:
     void add_cancelled_node(uint16_t node);
     void merge(const CancelScope& other);
 
-    [[nodiscard]] bool fully_cancelled() const noexcept { return _ownership_lost; }
-    // Note: partially_cancelled() does not subsume fully_cancelled(); it must be checked independently
-    [[nodiscard]] bool partially_cancelled() const noexcept { return !_cancelled_nodes.empty(); }
+    [[nodiscard]] bool fully_cancelled() const noexcept { return _fully_cancelled; }
+    [[nodiscard]] bool is_cancelled() const noexcept {
+        return (_fully_cancelled || !_cancelled_nodes.empty());
+    }
     [[nodiscard]] bool node_is_cancelled(uint16_t node) const noexcept {
         return (fully_cancelled() || _cancelled_nodes.contains(node));
     }

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.h
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.h
@@ -17,6 +17,7 @@ namespace storage::api { class StorageReply; }
 
 namespace storage::distributor {
 
+class CancelScope;
 class DistributorBucketSpace;
 class DistributorNodeContext;
 class DistributorStripeMessageSender;
@@ -122,7 +123,8 @@ public:
     void start_and_send(DistributorStripeMessageSender& sender);
     void handle_reply(DistributorStripeMessageSender& sender,
                       const std::shared_ptr<api::StorageReply>& reply);
-    void cancel(DistributorStripeMessageSender& sender);
+    void cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope);
+    void close(DistributorStripeMessageSender& sender);
 
     [[nodiscard]] std::optional<Outcome>& maybe_outcome() noexcept {
         return _outcome;

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -60,6 +60,8 @@ private:
     void sendPutToBucketOnNode(document::BucketSpace bucketSpace, const document::BucketId& bucketId,
                                uint16_t node, std::vector<PersistenceMessageTracker::ToSend>& putBatch);
 
+    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
+
     [[nodiscard]] bool shouldImplicitlyActivateReplica(const OperationTargetList& targets) const;
 
     [[nodiscard]] bool has_unavailable_targets_in_pending_state(const OperationTargetList& targets) const;

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
@@ -156,7 +156,19 @@ void RemoveOperation::on_completed_check_condition(CheckCondition::Outcome& outc
 void
 RemoveOperation::onClose(DistributorStripeMessageSender& sender)
 {
+    if (_check_condition) {
+        _check_condition->close(sender);
+    }
     _tracker.fail(sender, api::ReturnCode(api::ReturnCode::ABORTED, "Process is shutting down"));
+}
+
+void
+RemoveOperation::on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope)
+{
+    if (_check_condition) {
+        _check_condition->cancel(sender, cancel_scope);
+    }
+    _tracker.cancel(cancel_scope);
 }
 
 bool RemoveOperation::has_condition() const noexcept {

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
@@ -29,6 +29,7 @@ public:
 
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply> &) override;
     void onClose(DistributorStripeMessageSender& sender) override;
+    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
 
 private:
     PersistenceMessageTrackerImpl       _tracker_instance;

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -71,6 +71,8 @@ public:
 
     void onClose(DistributorStripeMessageSender& sender) override;
 
+    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
+
 private:
     enum class SendState {
         NONE_SENT,
@@ -94,19 +96,20 @@ private:
     void sendReplyWithResult(DistributorStripeMessageSender&, const api::ReturnCode&);
     void ensureUpdateReplyCreated();
 
-    std::vector<BucketDatabase::Entry> get_bucket_database_entries() const;
-    bool isFastPathPossible(const std::vector<BucketDatabase::Entry>& entries) const;
+    [[nodiscard]] std::vector<BucketDatabase::Entry> get_bucket_database_entries() const;
+    [[nodiscard]] static bool isFastPathPossible(const std::vector<BucketDatabase::Entry>& entries);
     void startFastPathUpdate(DistributorStripeMessageSender& sender, std::vector<BucketDatabase::Entry> entries);
     void startSafePathUpdate(DistributorStripeMessageSender&);
-    bool lostBucketOwnershipBetweenPhases() const;
+    [[nodiscard]] bool lostBucketOwnershipBetweenPhases() const;
     void sendLostOwnershipTransientErrorReply(DistributorStripeMessageSender&);
+    void send_operation_cancelled_reply(DistributorStripeMessageSender& sender);
     void send_feed_blocked_error_reply(DistributorStripeMessageSender& sender);
     void schedulePutsWithUpdatedDocument(
             std::shared_ptr<document::Document>,
             api::Timestamp,
             DistributorStripeMessageSender&);
     void applyUpdateToDocument(document::Document&) const;
-    std::shared_ptr<document::Document> createBlankDocument() const;
+    [[nodiscard]] std::shared_ptr<document::Document> createBlankDocument() const;
     void setUpdatedForTimestamp(api::Timestamp);
     void handleFastPathReceive(DistributorStripeMessageSender&,
                                const std::shared_ptr<api::StorageReply>&);
@@ -120,20 +123,20 @@ private:
     void handle_safe_path_received_single_full_get(DistributorStripeMessageSender&, api::GetReply&);
     void handleSafePathReceivedGet(DistributorStripeMessageSender&, api::GetReply&);
     void handleSafePathReceivedPut(DistributorStripeMessageSender&, const api::PutReply&);
-    bool shouldCreateIfNonExistent() const;
+    [[nodiscard]] bool shouldCreateIfNonExistent() const;
     bool processAndMatchTasCondition(
             DistributorStripeMessageSender& sender,
             const document::Document& candidateDoc);
-    bool satisfiesUpdateTimestampConstraint(api::Timestamp) const;
+    [[nodiscard]] bool satisfiesUpdateTimestampConstraint(api::Timestamp) const;
     void addTraceFromReply(api::StorageReply& reply);
-    bool hasTasCondition() const noexcept;
+    [[nodiscard]] bool hasTasCondition() const noexcept;
     void replyWithTasFailure(DistributorStripeMessageSender& sender,
                              vespalib::stringref message);
     bool may_restart_with_fast_path(const api::GetReply& reply);
-    bool replica_set_unchanged_after_get_operation() const;
+    [[nodiscard]] bool replica_set_unchanged_after_get_operation() const;
     void restart_with_fast_path_due_to_consistent_get_timestamps(DistributorStripeMessageSender& sender);
     // Precondition: reply has not yet been sent.
-    vespalib::string update_doc_id() const;
+    [[nodiscard]] vespalib::string update_doc_id() const;
 
     using ReplicaState = std::vector<std::pair<document::BucketId, uint16_t>>;
 

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
@@ -207,6 +207,13 @@ UpdateOperation::onClose(DistributorStripeMessageSender& sender)
     _tracker.fail(sender, api::ReturnCode(api::ReturnCode::ABORTED, "Process is shutting down"));
 }
 
+void
+UpdateOperation::on_cancel(DistributorStripeMessageSender&, const CancelScope& cancel_scope)
+{
+    _tracker.cancel(cancel_scope);
+}
+
+
 // The backend behavior of "create-if-missing" updates is to return the timestamp of the
 // _new_ update operation if the document was created from scratch. The two-phase update
 // operation logic auto-detects unexpected inconsistencies and tries to reconcile

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
@@ -31,6 +31,7 @@ public:
     std::string getStatus() const override { return ""; };
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply> & msg) override;
     void onClose(DistributorStripeMessageSender& sender) override;
+    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
 
     std::pair<document::BucketId, uint16_t> getNewestTimestampLocation() const {
         return _newestTimestampLocation;

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -268,7 +268,7 @@ void GarbageCollectionOperation::merge_received_bucket_info_into_db() {
     if (_cancel_scope) {
         if (_cancel_scope->fully_cancelled()) {
             return;
-        } else {
+        } else if (_cancel_scope->partially_cancelled()) {
             _replica_info = prune_cancelled_nodes(_replica_info, *_cancel_scope);
         }
     }

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -261,9 +261,10 @@ void GarbageCollectionOperation::update_last_gc_timestamp_in_db() {
 }
 
 void GarbageCollectionOperation::merge_received_bucket_info_into_db() {
-    if (_cancel_scope.fully_cancelled()) {
-        return;
-    } else if (_cancel_scope.partially_cancelled()) {
+    if (_cancel_scope.is_cancelled()) {
+        if (_cancel_scope.fully_cancelled()) {
+            return;
+        }
         _replica_info = prune_cancelled_nodes(_replica_info, _cancel_scope);
     }
     if (!_replica_info.empty()) {

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
@@ -3,11 +3,13 @@
 
 #include "idealstateoperation.h"
 #include <vespa/document/base/documentid.h>
+#include <vespa/persistence/spi/id_and_timestamp.h>
 #include <vespa/storage/bucketdb/bucketcopy.h>
 #include <vespa/storage/distributor/messagetracker.h>
 #include <vespa/storage/distributor/operation_sequencer.h>
-#include <vespa/persistence/spi/id_and_timestamp.h>
+#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/vespalib/stllike/hash_map.h>
+#include <optional>
 #include <vector>
 
 namespace storage::distributor {
@@ -22,13 +24,14 @@ public:
 
     void onStart(DistributorStripeMessageSender& sender) override;
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply> &) override;
+    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
     const char* getName() const noexcept override { return "garbagecollection"; };
     Type getType() const noexcept override { return GARBAGE_COLLECTION; }
     bool shouldBlockThisOperation(uint32_t, uint16_t, uint8_t) const override;
-    bool is_two_phase() const noexcept {
+    [[nodiscard]] bool is_two_phase() const noexcept {
         return ((_phase == Phase::ReadMetadataPhase) || (_phase == Phase::WriteRemovesPhase));
     }
-    bool is_done() const noexcept { return _is_done; }
+    [[nodiscard]] bool is_done() const noexcept { return _is_done; }
 
 protected:
     MessageTracker _tracker;
@@ -54,13 +57,14 @@ private:
     RemoveCandidates              _remove_candidates;
     std::vector<SequencingHandle> _gc_write_locks;
     std::vector<BucketCopy>       _replica_info;
+    std::optional<CancelScope>    _cancel_scope;
     uint32_t                      _max_documents_removed;
     bool                          _is_done;
 
     static RemoveCandidates steal_selection_matches_as_candidates(api::RemoveLocationReply& reply);
 
     void send_current_phase_remove_locations(DistributorStripeMessageSender& sender);
-    std::vector<spi::IdAndTimestamp> compile_phase_two_send_set() const;
+    [[nodiscard]] std::vector<spi::IdAndTimestamp> compile_phase_two_send_set() const;
 
     void handle_ok_legacy_reply(uint16_t from_node, const api::RemoveLocationReply& reply);
     void handle_ok_phase1_reply(api::RemoveLocationReply& reply);

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
@@ -9,7 +9,6 @@
 #include <vespa/storage/distributor/operation_sequencer.h>
 #include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/vespalib/stllike/hash_map.h>
-#include <optional>
 #include <vector>
 
 namespace storage::distributor {
@@ -57,7 +56,7 @@ private:
     RemoveCandidates              _remove_candidates;
     std::vector<SequencingHandle> _gc_write_locks;
     std::vector<BucketCopy>       _replica_info;
-    std::optional<CancelScope>    _cancel_scope;
+    CancelScope                   _cancel_scope;
     uint32_t                      _max_documents_removed;
     bool                          _is_done;
 

--- a/storage/src/vespa/storage/distributor/operations/operation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/operation.cpp
@@ -12,7 +12,8 @@ LOG_SETUP(".distributor.callback");
 namespace storage::distributor {
 
 Operation::Operation()
-    : _startTime()
+    : _startTime(),
+      _cancelled(false)
 {
 }
 
@@ -43,6 +44,11 @@ Operation::copyMessageSettings(const api::StorageCommand& source, api::StorageCo
     target.getTrace().setLevel(source.getTrace().getLevel());
     target.setTimeout(source.getTimeout());
     target.setPriority(source.getPriority());
+}
+
+void Operation::cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) {
+    _cancelled = true;
+    on_cancel(sender, cancel_scope);
 }
 
 void

--- a/storage/src/vespa/storage/distributor/operations/operation.h
+++ b/storage/src/vespa/storage/distributor/operations/operation.h
@@ -16,6 +16,7 @@ class StorageComponent;
 
 namespace distributor {
 
+class CancelScope;
 class DistributorStripeOperationContext;
 class PendingMessageTracker;
 class OperationSequencer;
@@ -40,7 +41,7 @@ public:
        on the owner of the message that was replied to.
     */
     virtual void receive(DistributorStripeMessageSender& sender,
-                 const std::shared_ptr<api::StorageReply> & msg)
+                         const std::shared_ptr<api::StorageReply> & msg)
     {
         onReceive(sender, msg);
     }
@@ -58,6 +59,21 @@ public:
     */
     virtual void start(DistributorStripeMessageSender& sender, vespalib::system_time startTime);
     void start(DistributorStripeMessageSender& sender);
+
+    /**
+     * Explicitly cancel the operation. Cancelled operations may or may not (depending on
+     * the operation implementation) be immediately aborted, but they should either way
+     * never insert any bucket information into the bucket DB after cancel() has been called.
+     */
+    void cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope);
+
+    /**
+     * Whether cancel() has been invoked at least once on this instance. This does not
+     * distinguish between cancellations caused by ownership transfers and those caused
+     * by nodes becoming unavailable; Operation implementations that care about this need
+     * to implement cancel() themselves and inspect the provided CancelScope.
+     */
+    [[nodiscard]] bool is_cancelled() const noexcept { return _cancelled; }
 
     /**
      * Returns true if we are blocked to start this operation given
@@ -93,8 +109,15 @@ private:
                            const std::shared_ptr<api::StorageReply> & msg) = 0;
 
 protected:
+    virtual void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) {
+        (void)sender;
+        (void)cancel_scope;
+    }
+
     static constexpr vespalib::duration MAX_TIMEOUT = 3600s;
+
     vespalib::system_time _startTime;
+    bool                  _cancelled;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/operations/operation.h
+++ b/storage/src/vespa/storage/distributor/operations/operation.h
@@ -63,7 +63,8 @@ public:
     /**
      * Explicitly cancel the operation. Cancelled operations may or may not (depending on
      * the operation implementation) be immediately aborted, but they should either way
-     * never insert any bucket information into the bucket DB after cancel() has been called.
+     * never insert any bucket information _for cancelled nodes_ into the bucket DB after
+     * cancel() has been called.
      */
     void cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope);
 

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
@@ -1,10 +1,12 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "persistencemessagetracker.h"
+#include "cancelled_replicas_pruner.h"
 #include "distributor_bucket_space_repo.h"
 #include "distributor_bucket_space.h"
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/storageapi/message/persistence.h>
+#include <algorithm>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".persistencemessagetracker");
@@ -18,12 +20,15 @@ PersistenceMessageTrackerImpl::PersistenceMessageTrackerImpl(
         DistributorStripeOperationContext& op_ctx,
         api::Timestamp revertTimestamp)
     : MessageTracker(node_ctx),
+      _remapBucketInfo(),
+      _bucketInfo(),
       _metric(metric),
       _reply(std::move(reply)),
       _op_ctx(op_ctx),
       _revertTimestamp(revertTimestamp),
       _trace(_reply->getTrace().getLevel()),
       _requestTimer(node_ctx.clock()),
+      _cancel_scope(),
       _n_persistence_replies_total(0),
       _n_successful_persistence_replies(0),
       _priority(_reply->getPriority()),
@@ -34,8 +39,37 @@ PersistenceMessageTrackerImpl::PersistenceMessageTrackerImpl(
 PersistenceMessageTrackerImpl::~PersistenceMessageTrackerImpl() = default;
 
 void
+PersistenceMessageTrackerImpl::cancel(const CancelScope& cancel_scope)
+{
+    if (!_cancel_scope) {
+        _cancel_scope = cancel_scope;
+    } else {
+        _cancel_scope->merge(cancel_scope);
+    }
+}
+
+void
+PersistenceMessageTrackerImpl::prune_cancelled_nodes_if_present(
+        BucketInfoMap& bucket_and_replicas,
+        const CancelScope& cancel_scope)
+{
+    for (auto& info : bucket_and_replicas) {
+        info.second = prune_cancelled_nodes(info.second, cancel_scope);
+    }
+}
+
+void
 PersistenceMessageTrackerImpl::updateDB()
 {
+    if (_cancel_scope) {
+        if (_cancel_scope->fully_cancelled()) {
+            return; // Fully cancelled ops cannot mutate the DB at all
+        } else {
+            prune_cancelled_nodes_if_present(_bucketInfo, *_cancel_scope);
+            prune_cancelled_nodes_if_present(_remapBucketInfo, *_cancel_scope);
+        }
+    }
+
     for (const auto & entry : _bucketInfo) {
         _op_ctx.update_bucket_database(entry.first, entry.second);
     }
@@ -229,12 +263,22 @@ PersistenceMessageTrackerImpl::updateFailureResult(const api::BucketInfoReply& r
     _success = false;
 }
 
+bool
+PersistenceMessageTrackerImpl::node_is_effectively_cancelled(uint16_t node) const noexcept
+{
+    if (!_cancel_scope) {
+        return false;
+    }
+    return _cancel_scope->node_is_cancelled(node); // Implicitly covers the fully cancelled case
+}
+
 void
 PersistenceMessageTrackerImpl::handleCreateBucketReply(api::BucketInfoReply& reply, uint16_t node)
 {
     LOG(spam, "Received CreateBucket reply for %s from node %u", reply.getBucketId().toString().c_str(), node);
     if (!reply.getResult().success()
-        && reply.getResult().getResult() != api::ReturnCode::EXISTS)
+        && (reply.getResult().getResult() != api::ReturnCode::EXISTS)
+        && !node_is_effectively_cancelled(node))
     {
         LOG(spam, "Create bucket reply failed, so deleting it from bucket db");
         // We don't know if the bucket exists at this point, so we remove it from the DB.

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
@@ -57,9 +57,10 @@ PersistenceMessageTrackerImpl::prune_cancelled_nodes_if_present(
 void
 PersistenceMessageTrackerImpl::updateDB()
 {
-    if (_cancel_scope.fully_cancelled()) {
-        return; // Fully cancelled ops cannot mutate the DB at all
-    } else if (_cancel_scope.partially_cancelled()) {
+    if (_cancel_scope.is_cancelled()) {
+        if (_cancel_scope.fully_cancelled()) {
+            return; // Fully cancelled ops cannot mutate the DB at all
+        }
         prune_cancelled_nodes_if_present(_bucketInfo, _cancel_scope);
         prune_cancelled_nodes_if_present(_remapBucketInfo, _cancel_scope);
     }

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.cpp
@@ -64,7 +64,7 @@ PersistenceMessageTrackerImpl::updateDB()
     if (_cancel_scope) {
         if (_cancel_scope->fully_cancelled()) {
             return; // Fully cancelled ops cannot mutate the DB at all
-        } else {
+        } else if (_cancel_scope->partially_cancelled()) {
             prune_cancelled_nodes_if_present(_bucketInfo, *_cancel_scope);
             prune_cancelled_nodes_if_present(_remapBucketInfo, *_cancel_scope);
         }

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -4,9 +4,11 @@
 #include "distributor_stripe_component.h"
 #include "distributormetricsset.h"
 #include "messagetracker.h"
+#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storageframework/generic/clock/timer.h>
 #include <vespa/storageapi/messageapi/bucketinfocommand.h>
 #include <vespa/storageapi/messageapi/bucketinforeply.h>
+#include <optional>
 
 namespace storage::distributor {
 
@@ -14,6 +16,7 @@ struct PersistenceMessageTracker {
     virtual ~PersistenceMessageTracker() = default;
     using ToSend = MessageTracker::ToSend;
 
+    virtual void cancel(const CancelScope& cancel_scope) = 0;
     virtual void fail(MessageSender&, const api::ReturnCode&) = 0;
     virtual void queueMessageBatch(std::vector<ToSend> messages) = 0;
     virtual uint16_t receiveReply(MessageSender&, api::BucketInfoReply&) = 0;
@@ -26,14 +29,9 @@ struct PersistenceMessageTracker {
 };
 
 class PersistenceMessageTrackerImpl final
-        : public PersistenceMessageTracker,
-          public MessageTracker
+    : public PersistenceMessageTracker,
+      public MessageTracker
 {
-private:
-    using BucketInfoMap = std::map<document::Bucket, std::vector<BucketCopy>>;
-    BucketInfoMap _remapBucketInfo;
-    BucketInfoMap _bucketInfo;
-
 public:
     PersistenceMessageTrackerImpl(PersistenceOperationMetricSet& metric,
                                   std::shared_ptr<api::BucketInfoReply> reply,
@@ -41,6 +39,8 @@ public:
                                   DistributorStripeOperationContext& op_ctx,
                                   api::Timestamp revertTimestamp = 0);
     ~PersistenceMessageTrackerImpl() override;
+
+    void cancel(const CancelScope& cancel_scope) override;
 
     void updateDB();
     void updateMetrics();
@@ -67,8 +67,11 @@ public:
     void queueMessageBatch(std::vector<MessageTracker::ToSend> messages) override;
 
 private:
-    using MessageBatch = std::vector<uint64_t>;
+    using MessageBatch  = std::vector<uint64_t>;
+    using BucketInfoMap = std::map<document::Bucket, std::vector<BucketCopy>>;
 
+    BucketInfoMap                         _remapBucketInfo;
+    BucketInfoMap                         _bucketInfo;
     std::vector<MessageBatch>             _messageBatches;
     PersistenceOperationMetricSet&        _metric;
     std::shared_ptr<api::BucketInfoReply> _reply;
@@ -77,20 +80,24 @@ private:
     std::vector<BucketNodePair>           _revertNodes;
     mbus::Trace                           _trace;
     framework::MilliSecTimer              _requestTimer;
+    std::optional<CancelScope>            _cancel_scope;
     uint32_t                              _n_persistence_replies_total;
     uint32_t                              _n_successful_persistence_replies;
     uint8_t                               _priority;
     bool                                  _success;
 
-    bool canSendReplyEarly() const;
+    static void prune_cancelled_nodes_if_present(BucketInfoMap& bucket_and_replicas,
+                                                 const CancelScope& cancel_scope);
+    [[nodiscard]] bool canSendReplyEarly() const;
     void addBucketInfoFromReply(uint16_t node, const api::BucketInfoReply& reply);
     void logSuccessfulReply(uint16_t node, const api::BucketInfoReply& reply) const;
-    bool hasSentReply() const noexcept { return !_reply; }
-    bool shouldRevert() const;
-    bool has_majority_successful_replies() const noexcept;
-    bool has_minority_test_and_set_failure() const noexcept;
+    [[nodiscard]] bool hasSentReply() const noexcept { return !_reply; }
+    [[nodiscard]] bool shouldRevert() const;
+    [[nodiscard]] bool has_majority_successful_replies() const noexcept;
+    [[nodiscard]] bool has_minority_test_and_set_failure() const noexcept;
     void sendReply(MessageSender& sender);
     void updateFailureResult(const api::BucketInfoReply& reply);
+    [[nodiscard]] bool node_is_effectively_cancelled(uint16_t node) const noexcept;
     void handleCreateBucketReply(api::BucketInfoReply& reply, uint16_t node);
     void handlePersistenceReply(api::BucketInfoReply& reply, uint16_t node);
     void transfer_trace_state_to_reply();

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -8,7 +8,6 @@
 #include <vespa/storageframework/generic/clock/timer.h>
 #include <vespa/storageapi/messageapi/bucketinfocommand.h>
 #include <vespa/storageapi/messageapi/bucketinforeply.h>
-#include <optional>
 
 namespace storage::distributor {
 
@@ -80,7 +79,7 @@ private:
     std::vector<BucketNodePair>           _revertNodes;
     mbus::Trace                           _trace;
     framework::MilliSecTimer              _requestTimer;
-    std::optional<CancelScope>            _cancel_scope;
+    CancelScope                           _cancel_scope;
     uint32_t                              _n_persistence_replies_total;
     uint32_t                              _n_successful_persistence_replies;
     uint8_t                               _priority;

--- a/storage/src/vespa/storage/distributor/sentmessagemap.h
+++ b/storage/src/vespa/storage/distributor/sentmessagemap.h
@@ -10,19 +10,23 @@ class Operation;
 
 class SentMessageMap {
 public:
+    using Map = std::map<api::StorageMessage::Id, std::shared_ptr<Operation>>;
+
     SentMessageMap();
     ~SentMessageMap();
 
-    std::shared_ptr<Operation> pop(api::StorageMessage::Id id);
-    std::shared_ptr<Operation> pop();
+    [[nodiscard]] std::shared_ptr<Operation> pop(api::StorageMessage::Id id);
+    [[nodiscard]] std::shared_ptr<Operation> pop();
 
     void insert(api::StorageMessage::Id id, const std::shared_ptr<Operation> & msg);
     void clear();
-    uint32_t size() const { return _map.size(); }
+    [[nodiscard]] uint32_t size() const { return _map.size(); }
     [[nodiscard]] bool empty() const noexcept { return _map.empty(); }
     std::string toString() const;
+
+    Map::const_iterator begin() const noexcept { return _map.cbegin(); }
+    Map::const_iterator end() const noexcept { return _map.cend(); }
 private:
-    using Map = std::map<api::StorageMessage::Id, std::shared_ptr<Operation>>;
     Map _map;
 };
 


### PR DESCRIPTION
@havardpe please review. Most of the added lines are from new test cases. Quite a bit of interaction with the existing `CheckCondition` read phase.

Will be used for ensuring active operations do not mutate the bucket database upon completion with stale entries for buckets that may no longer be valid for that distributor to handle. Removes the need for today's "always-on" implicit checks for node state and bucket ownership upon every single DB update (which is potentially ABA-susceptible). Moving to edge-triggering is intentionally done to avoid ABA problems.

Cancellation cases are:
 * Distributor ownership of bucket has changed
 * Subset of target nodes has become unavailable

Note: cancellation is not yet wired in; this code is cold 🥶
