### PR TITLE
Schedule latest OS version

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeScheduler.java
@@ -160,15 +160,10 @@ public class OsUpgradeScheduler extends ControllerMaintainer {
 
         @Override
         public Change change(Version currentVersion, Instant instant) {
-            OsRelease release = artifactRepository.osRelease(currentVersion.getMajor(), tag());
+            OsRelease release = artifactRepository.osRelease(currentVersion.getMajor(), OsRelease.Tag.latest);
             Duration cooldown = remainingCooldownOf(cooldown(), release.age(instant));
             Instant scheduleAt = schedulingInstant(instant.plus(cooldown), system);
             return new Change(new OsVersion(release.version(), cloud), scheduleAt);
-        }
-
-        /** Returns the release tag tracked by this system */
-        private OsRelease.Tag tag() {
-            return system.isCd() ? OsRelease.Tag.latest : OsRelease.Tag.stable;
         }
 
         /** The cool-down period that must pass before a release can be used */

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/OsUpgradeSchedulerTest.java
@@ -148,7 +148,7 @@ public class OsUpgradeSchedulerTest {
     }
 
     @Test
-    void schedule_stable_release() {
+    void schedule_latest_release() {
         ControllerTester tester = new ControllerTester();
         OsUpgradeScheduler scheduler = new OsUpgradeScheduler(tester.controller(), Duration.ofDays(1));
         Instant t0 = Instant.parse("2021-06-22T00:42:12.00Z"); // Outside trigger period
@@ -161,7 +161,7 @@ public class OsUpgradeSchedulerTest {
 
         // Stable release (tagged outside trigger period) is scheduled once trigger period opens
         Version version1 = Version.fromString("8.1");
-        tester.serviceRegistry().artifactRepository().addRelease(new OsRelease(version1, OsRelease.Tag.stable,
+        tester.serviceRegistry().artifactRepository().addRelease(new OsRelease(version1, OsRelease.Tag.latest,
                                                                                Instant.parse("2021-06-21T23:59:00.00Z")));
         scheduleUpgradeAfter(Duration.ZERO, version0, scheduler, tester);
 


### PR DESCRIPTION
Since we now certify versions in CD, there's no reason to wait for a version to
be promoted to stable.

@aressem