### PR TITLE
Revert "Sample datastore stash memory usage in write thread." MERGEOK

### DIFF
--- a/vespalib/src/tests/datastore/array_store/array_store_test.cpp
+++ b/vespalib/src/tests/datastore/array_store/array_store_test.cpp
@@ -269,11 +269,11 @@ TEST(BasicStoreTest, test_with_trivial_and_non_trivial_types)
 TYPED_TEST(NumberStoreTest, control_static_sizes) {
     static constexpr size_t sizeof_deque = vespalib::datastore::DataStoreBase::sizeof_entry_ref_hold_list_deque;
     if constexpr (TestFixture::simple_type_mapper) {
-        EXPECT_EQ(432u + sizeof_deque, sizeof(this->store));
+        EXPECT_EQ(416u + sizeof_deque, sizeof(this->store));
     } else {
-        EXPECT_EQ(480u + sizeof_deque, sizeof(this->store));
+        EXPECT_EQ(464u + sizeof_deque, sizeof(this->store));
     }
-    EXPECT_EQ(256u + sizeof_deque, sizeof(typename TestFixture::ArrayStoreType::DataStoreType));
+    EXPECT_EQ(240u + sizeof_deque, sizeof(typename TestFixture::ArrayStoreType::DataStoreType));
     EXPECT_EQ(112u, sizeof(typename TestFixture::ArrayStoreType::SmallBufferType));
     MemoryUsage usage = this->store.getMemoryUsage();
     if (this->simple_buffers()) {

--- a/vespalib/src/tests/datastore/unique_store/unique_store_test.cpp
+++ b/vespalib/src/tests/datastore/unique_store/unique_store_test.cpp
@@ -464,7 +464,7 @@ TEST_F(DoubleTest, nan_is_handled)
 
 TEST_F(DoubleTest, control_memory_usage) {
     static constexpr size_t sizeof_deque = vespalib::datastore::DataStoreBase::sizeof_entry_ref_hold_list_deque;
-    EXPECT_EQ(392u + sizeof_deque, sizeof(store));
+    EXPECT_EQ(376u + sizeof_deque, sizeof(store));
     EXPECT_EQ(120u, sizeof(BufferState));
     EXPECT_EQ(28740u, store.get_values_memory_usage().allocatedBytes());
     EXPECT_EQ(24780u, store.get_values_memory_usage().usedBytes());

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.cpp
@@ -90,8 +90,6 @@ DataStoreBase::DataStoreBase(uint32_t numBuffers, uint32_t offset_bits, size_t m
       _free_lists(),
       _compaction_count(0u),
       _genHolder(),
-      _stash_allocated_bytes(),
-      _stash_used_bytes(),
       _max_entries(max_entries),
       _bufferIdLimit(0u),
       _hold_buffer_count(0u),
@@ -100,7 +98,6 @@ DataStoreBase::DataStoreBase(uint32_t numBuffers, uint32_t offset_bits, size_t m
       _disable_entry_hold_list(false),
       _initializing(false)
 {
-    save_stash_memory_usage();
 }
 
 DataStoreBase::~DataStoreBase()
@@ -298,7 +295,7 @@ DataStoreBase::getMemoryUsage() const {
     extra_used += _free_lists.size() * sizeof(FreeList);
     usage.incAllocatedBytes(extra_allocated);
     usage.incUsedBytes(extra_used);
-    merge_stash_memory_usage(usage);
+    usage.merge(_stash.get_memory_usage());
     return usage;
 }
 
@@ -406,7 +403,6 @@ DataStoreBase::on_active(uint32_t bufferId, uint32_t typeId, size_t entries_need
     BufferState *state = bufferMeta.get_state_relaxed();
     if (state == nullptr) {
         BufferState & newState = _stash.create<BufferState>();
-        save_stash_memory_usage();
         if (_disable_entry_hold_list) {
             newState.disable_entry_hold_list();
         }
@@ -528,21 +524,6 @@ DataStoreBase::inc_hold_buffer_count()
 {
     assert(_hold_buffer_count < std::numeric_limits<uint32_t>::max());
     ++_hold_buffer_count;
-}
-
-void
-DataStoreBase::save_stash_memory_usage()
-{
-    auto usage = _stash.get_memory_usage();
-    _stash_allocated_bytes.store(usage.allocatedBytes(), std::memory_order_release);
-    _stash_used_bytes.store(usage.usedBytes(), std::memory_order_release);
-}
-
-void
-DataStoreBase::merge_stash_memory_usage(vespalib::MemoryUsage& usage) const
-{
-    usage.incUsedBytes(_stash_used_bytes.load(std::memory_order_acquire));
-    usage.incAllocatedBytes(_stash_allocated_bytes.load(std::memory_order_acquire));
 }
 
 }

--- a/vespalib/src/vespa/vespalib/datastore/datastorebase.h
+++ b/vespalib/src/vespa/vespalib/datastore/datastorebase.h
@@ -261,9 +261,6 @@ private:
 
     virtual void reclaim_all_entry_refs() = 0;
 
-    void save_stash_memory_usage();
-    void merge_stash_memory_usage(vespalib::MemoryUsage& usage) const;
-
     std::vector<BufferAndMeta>    _buffers; // For fast mapping with known types
 
     // Provides a mapping from typeId -> primary buffer for that type.
@@ -275,8 +272,6 @@ private:
     std::vector<FreeList>         _free_lists;
     mutable std::atomic<uint64_t> _compaction_count;
     vespalib::GenerationHolder    _genHolder;
-    std::atomic<size_t>           _stash_allocated_bytes;
-    std::atomic<size_t>           _stash_used_bytes;
     const uint32_t                _max_entries;
     std::atomic<uint32_t>         _bufferIdLimit;
     uint32_t                      _hold_buffer_count;


### PR DESCRIPTION
Reverts vespa-engine/vespa#28104

broke build (timeout when running unit tests with valgrind).
