### PR TITLE
Use 128 bytes alignment for small allocations in MmapFileAllocator.

### DIFF
--- a/vespalib/src/tests/util/mmap_file_allocator/mmap_file_allocator_test.cpp
+++ b/vespalib/src/tests/util/mmap_file_allocator/mmap_file_allocator_test.cpp
@@ -86,17 +86,17 @@ TEST_P(MmapFileAllocatorTest, zero_sized_allocation_is_handled)
 
 TEST_P(MmapFileAllocatorTest, mmap_file_allocator_works)
 {
-    MyAlloc buf(_allocator, _allocator.alloc(400));
-    EXPECT_LE(400u, buf.size);
+    MyAlloc buf(_allocator, _allocator.alloc(300));
+    EXPECT_LE(300u, buf.size);
     EXPECT_TRUE(buf.data != nullptr);
     memcpy(buf.data, "1st", 4);
     MyAlloc buf2(_allocator, _allocator.alloc(600));
-    EXPECT_LE(5u, buf2.size);
+    EXPECT_LE(600u, buf2.size);
     EXPECT_TRUE(buf2.data != nullptr);
     EXPECT_TRUE(buf.data != buf2.data);
     memcpy(buf2.data, "fine", 5);
     EXPECT_EQ(0u, _allocator.resize_inplace(buf.asPair(), 500));
-    EXPECT_EQ(0u, _allocator.resize_inplace(buf.asPair(), 300));
+    EXPECT_EQ(0u, _allocator.resize_inplace(buf.asPair(), 200));
     EXPECT_NE(0u, _allocator.get_end_offset());
     if (GetParam().small_limit == 0) {
         int result = msync(buf.data, buf.size, MS_SYNC);
@@ -108,16 +108,16 @@ TEST_P(MmapFileAllocatorTest, mmap_file_allocator_works)
 
 TEST_P(MmapFileAllocatorTest, reuse_file_offset_works)
 {
-    constexpr size_t size_400 = 400;
+    constexpr size_t size_300 = 300;
     constexpr size_t size_600 = 600;
-    assert(hello.size() + 1 <= size_400);
+    assert(hello.size() + 1 <= size_300);
     assert(world.size() + 1 <= size_600);
     {
-        MyAlloc buf(_allocator, _allocator.alloc(size_400));
+        MyAlloc buf(_allocator, _allocator.alloc(size_300));
         memcpy(buf.data, hello.c_str(), hello.size() + 1);
     }
     {
-        MyAlloc buf(_allocator, _allocator.alloc(size_400));
+        MyAlloc buf(_allocator, _allocator.alloc(size_300));
         EXPECT_EQ(0, memcmp(buf.data, hello.c_str(), hello.size() + 1));
     }
     {

--- a/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
+++ b/vespalib/src/vespa/vespalib/util/mmap_file_allocator.cpp
@@ -77,7 +77,7 @@ MmapFileAllocator::alloc(size_t sz) const
     if (sz == 0) {
         return PtrAndSize(); // empty allocation
     }
-    static constexpr size_t alignment = 64;
+    static constexpr size_t alignment = 128;
     sz = (sz + alignment - 1) & -alignment; // round sz to a multiple of alignment
     if (sz >= _small_limit) {
         return alloc_large(sz);


### PR DESCRIPTION
@geirst : please review
