### PR TITLE
Revert "Jonmv/always use newest cloud account in tests"

### DIFF
--- a/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
@@ -12,7 +12,6 @@ import com.yahoo.config.provision.Cloud;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.CloudName;
 import com.yahoo.config.provision.ClusterSpec;
-import com.yahoo.config.provision.ClusterSpec.Id;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.RegionName;
@@ -217,7 +216,7 @@ public class ClusterInfoTest {
                             <deployment version='1.0' empty-host-ttl='1d'>
                               <instance id='default'>
                                 <prod>
-                                  <region>us-east-1</region>
+                                  <region cloud-account='gcp:foobar'>us-east-1</region>
                                   <region empty-host-ttl='0m'>us-north-1</region>
                                   <region>us-west-1</region>
                                 </prod>
@@ -229,7 +228,10 @@ public class ClusterInfoTest {
         CloudAccount account = CloudAccount.from("gcp:foobar");
         assertEquals(Duration.ofHours(24), requestedCapacityIn(account, gcp, "default", "us-east-1", servicesXml, deploymentXml).get(new ClusterSpec.Id("testcontainer")).clusterInfo().hostTTL());
         assertEquals(Duration.ZERO, requestedCapacityIn(account, gcp, "default", "us-north-1", servicesXml, deploymentXml).get(new ClusterSpec.Id("testcontainer")).clusterInfo().hostTTL());
-        assertEquals(Duration.ZERO, requestedCapacityIn(CloudAccount.empty, gcp, "default", "us-west-1", servicesXml, deploymentXml).get(new Id("testcontainer")).clusterInfo().hostTTL());
+        assertEquals("In container cluster 'testcontainer': deployment spec specifies host TTL for prod.us-west-1 but no cloud account is specified for this zone",
+                     Exceptions.toMessageString(assertThrows(IllegalArgumentException.class,
+                                                             () -> requestedCapacityIn(account, gcp, "default", "us-west-1", servicesXml, deploymentXml))));
+
     }
 
     private Map<ClusterSpec.Id, Capacity> requestedCapacityIn(String instance, String region, String servicesXml, String deploymentXml) throws Exception {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/ApplicationController.java
@@ -682,9 +682,7 @@ public class ApplicationController {
             if (testerCertificate.isPresent()) {
                 operatorCertificates = Stream.concat(operatorCertificates.stream(), testerCertificate.stream()).toList();
             }
-            Supplier<Optional<CloudAccount>> cloudAccount = () -> decideCloudAccountOf(deployment,
-                                                                                       zone.environment().isTest() ? requireApplication(TenantAndApplicationId.from(application)).deploymentSpec()
-                                                                                                                   : applicationPackage.truncatedPackage().deploymentSpec());
+            Supplier<Optional<CloudAccount>> cloudAccount = () -> decideCloudAccountOf(deployment, applicationPackage.truncatedPackage().deploymentSpec());
             List<DataplaneTokenVersions> dataplaneTokenVersions = controller.dataplaneTokenService().listTokens(application.tenant());
             Supplier<Optional<EndpointCertificate>> endpointCertificateWrapper = () -> {
                 Optional<EndpointCertificate> data = endpointCertificate.get();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -131,15 +131,15 @@ public class InternalStepRunner implements StepRunner {
         try {
             return switch (step.get()) {
                 case deployTester -> deployTester(id, logger);
-                case installTester -> installTester(id, logger);
                 case deployInitialReal -> deployInitialReal(id, logger);
                 case installInitialReal -> installInitialReal(id, logger);
                 case deployReal -> deployReal(id, logger);
+                case installTester -> installTester(id, logger);
                 case installReal -> installReal(id, logger);
                 case startStagingSetup -> startTests(id, true, logger);
                 case endStagingSetup -> endTests(id, true, logger);
-                case startTests -> startTests(id, false, logger);
                 case endTests -> endTests(id, false, logger);
+                case startTests -> startTests(id, false, logger);
                 case copyVespaLogs -> copyVespaLogs(id, logger);
                 case deactivateReal -> deactivateReal(id, logger);
                 case deactivateTester -> deactivateTester(id, logger);


### PR DESCRIPTION
Reverts vespa-engine/vespa#28270

Controller fails to deploy routing app to test and staging in cd:

[2023-08-30 18:32:20.058486] controller-cd-3 INFO    : configserver     Container.com.yahoo.vespa.hosted.controller.maintenance.SystemUpgrader	Deploying hosted-vespa.routing on vespa version target 8.219.27 in test.cd-us-west-1
[2023-08-30 18:32:20.705250] controller-cd-3 WARNING : configserver     Container.com.yahoo.vespa.hosted.clients.configserver.ConfigServerClient	Failed to generate deployment prepare parameters
exception=
java.lang.IllegalArgumentException: hosted-vespa.routing not found
	at com.yahoo.vespa.hosted.controller.ApplicationController.lambda$requireApplication$3(ApplicationController.java:259)
	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
	at com.yahoo.vespa.hosted.controller.ApplicationController.requireApplication(ApplicationController.java:259)
	at com.yahoo.vespa.hosted.controller.ApplicationController.lambda$deploy$38(ApplicationController.java:686)
	at com.yahoo.yolean.concurrent.Memoized.get(Memoized.java:63)
	at com.yahoo.vespa.hosted.controller.api.application.v4.model.DeploymentData.cloudAccount(DeploymentData.java:121)
	at com.yahoo.vespa.hosted.clients.configserver.ConfigServerClient.lambda$deployMultipart$7(ConfigServerClient.java:246)


This PR seems related, trying to revet