### PR TITLE
When no endpoints are found, output the zone they were looked for in

### DIFF
--- a/client/go/internal/vespa/target_cloud.go
+++ b/client/go/internal/vespa/target_cloud.go
@@ -374,10 +374,10 @@ func (t *cloudTarget) discoverEndpoints(timeout time.Duration) (map[string]strin
 		return true, nil
 	}
 	if _, err := t.deployServiceWait(endpointFunc, func() *http.Request { return req }, timeout); err != nil {
-		return nil, fmt.Errorf("no endpoints found%s: %w", waitDescription(timeout), err)
+		return nil, fmt.Errorf("no endpoints found in zone %s%s: %w", t.deploymentOptions.Deployment.Zone, waitDescription(timeout), err)
 	}
 	if len(urlsByCluster) == 0 {
-		return nil, fmt.Errorf("no endpoints found%s", waitDescription(timeout))
+		return nil, fmt.Errorf("no endpoints found in zone %s%s", t.deploymentOptions.Deployment.Zone, waitDescription(timeout))
 	}
 	return urlsByCluster, nil
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
