### PR TITLE
Remove xml-apis as it's part of Java standard library

### DIFF
--- a/cloud-tenant-base-dependencies-enforcer/pom.xml
+++ b/cloud-tenant-base-dependencies-enforcer/pom.xml
@@ -66,7 +66,6 @@
                                         <include>org.slf4j:log4j-over-slf4j:${slf4j.vespa.version}:provided</include>
                                         <include>org.slf4j:slf4j-api:${slf4j.vespa.version}:provided</include>
                                         <include>org.slf4j:slf4j-jdk14:${slf4j.vespa.version}:provided</include>
-                                        <include>xml-apis:xml-apis:${xml-apis.vespa.version}:provided</include>
 
                                         <!-- Vespa provided dependencies -->
                                         <include>com.yahoo.vespa:annotations:*:provided</include>

--- a/config-model-fat/pom.xml
+++ b/config-model-fat/pom.xml
@@ -98,16 +98,10 @@
               javax.security.auth.callback,
               javax.security.auth.x500,
               javax.security.auth,
-              javax.xml.datatype,
-              javax.xml.namespace,
-              javax.xml.parsers,
-              javax.xml.transform,
-              javax.xml.xpath,
+              javax.xml.*, <!-- expands to all packages in Java module java.xml -->
               org.bouncycastle.*, <!-- expands to all BC packages by Felix plugin -->
-              org.w3c.dom.bootstrap,
-              org.w3c.dom.ls,
-              org.w3c.dom,
-              org.xml.sax,
+              org.w3c.dom.*,  <!-- expands to all packages in Java module java.xml -->
+              org.xml.sax.*,  <!-- expands to all packages in Java module java.xml -->
               <!-- TODO: The fat bundle becomes more brittle for each package added below. Use interfaces in model-api instead. -->
               com.yahoo.vespa.config,
               com.yahoo.vespa.config.buildergen,
@@ -219,7 +213,6 @@
                     <i>org.slf4j:slf4j-api:*:*</i>
                     <i>org.slf4j:slf4j-jdk14:*:*</i>
                     <i>xerces:xercesImpl:*:*</i>
-                    <i>xml-apis:xml-apis:*:*</i>
                   </allowed>
                 </enforceDependencies>
               </rules>

--- a/container-dependencies-enforcer/pom.xml
+++ b/container-dependencies-enforcer/pom.xml
@@ -86,7 +86,6 @@
                                         <include>org.slf4j:log4j-over-slf4j:${slf4j.vespa.version}:provided</include>
                                         <include>org.slf4j:slf4j-api:${slf4j.vespa.version}:provided</include>
                                         <include>org.slf4j:slf4j-jdk14:${slf4j.vespa.version}:provided</include>
-                                        <include>xml-apis:xml-apis:${xml-apis.vespa.version}:provided</include>
 
                                         <!-- Vespa provided dependencies -->
                                         <include>com.yahoo.vespa:annotations:*:provided</include>

--- a/container-dependency-versions/pom.xml
+++ b/container-dependency-versions/pom.xml
@@ -159,11 +159,6 @@
                 <artifactId>slf4j-jdk14</artifactId>
                 <version>${slf4j.vespa.version}</version>
             </dependency>
-            <dependency>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-                <version>${xml-apis.vespa.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -46,7 +46,6 @@
         <jaxb-core.vespa.version>2.3.0.1</jaxb-core.vespa.version>
         <jaxb-impl.vespa.version>2.3.0</jaxb-impl.vespa.version>
         <slf4j.vespa.version>1.7.36</slf4j.vespa.version>
-        <xml-apis.vespa.version>1.4.01</xml-apis.vespa.version>
 
         <!-- END Dependencies available from the Jdisc container -->
 

--- a/jdisc_core/pom.xml
+++ b/jdisc_core/pom.xml
@@ -36,11 +36,6 @@
         <!-- jaxb end -->
 
         <dependency>
-            <!-- Newer version than the one in rt.jar, including the ElementTraversal class needed by Xerces (Aug 2015, still valid Sep 2017) -->
-            <groupId>xml-apis</groupId>
-            <artifactId>xml-apis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1120,6 +1120,12 @@
                 <groupId>xerces</groupId>
                 <artifactId>xercesImpl</artifactId>
                 <version>${xerces.vespa.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xml-apis</groupId>
+                        <artifactId>xml-apis</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency> <!-- TODO: Remove on Vespa 9 -->
                 <groupId>org.json</groupId>

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -214,7 +214,6 @@ org.tukaani:xz:1.9
 org.xerial.snappy:snappy-java:1.1.10.3
 software.amazon.ion:ion-java:1.0.2
 xerces:xercesImpl:2.12.2
-xml-apis:xml-apis:1.4.01
 
 #[test-only]
 # Contains dependencies that are used exclusively in 'test' scope


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
