### PR TITLE
Never clear load balancer instance

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancer.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.hosted.provision.lb;
 
 import com.yahoo.vespa.applicationmodel.InfrastructureApplication;
 import com.yahoo.vespa.hosted.provision.maintenance.LoadBalancerExpirer;
-import com.yahoo.vespa.service.duper.ConfigServerApplication;
 
 import java.time.Instant;
 import java.util.Objects;
@@ -69,8 +68,8 @@ public class LoadBalancer {
     }
 
     /** Returns a copy of this with instance set to given instance */
-    public LoadBalancer with(Optional<LoadBalancerInstance> instance) {
-        return new LoadBalancer(id, instance, state, changedAt);
+    public LoadBalancer with(LoadBalancerInstance instance) {
+        return new LoadBalancer(id, Optional.of(instance), state, changedAt);
     }
 
     public enum State {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/LoadBalancerExpirer.java
@@ -116,7 +116,7 @@ public class LoadBalancerExpirer extends NodeRepositoryMaintainer {
                                                                   new LoadBalancerSpec(lb.id().application(), lb.id().cluster(), reals,
                                                                                        lb.instance().get().settings(), lb.instance().get().cloudAccount()),
                                                                   true);
-                db.writeLoadBalancer(lb.with(Optional.of(instance)), lb.state());
+                db.writeLoadBalancer(lb.with(instance), lb.state());
             } catch (Exception e) {
                 failed.add(lb.id());
                 lastException.set(e);

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/LoadBalancerProvisionerTest.java
@@ -300,6 +300,17 @@ public class LoadBalancerProvisionerTest {
         loadBalancers = lbs.get();
         assertSame(LoadBalancer.State.active, loadBalancers.get(0).state());
         assertTrue("Load balancer has instance", loadBalancers.get(0).instance().isPresent());
+
+        // Reconfiguration of load balancer fails on next prepare, but instance is preserved
+        tester.loadBalancerService().throwOnCreate(true);
+        ZoneEndpoint settings = new ZoneEndpoint(true, true, List.of(new AllowedUrn(AccessType.awsPrivateLink, "alice"), new AllowedUrn(AccessType.gcpServiceConnect, "bob")));
+        try {
+            prepare(app1, clusterRequest(ClusterSpec.Type.container, cluster, Optional.empty(), settings));
+            fail("Expected exception");
+        } catch (LoadBalancerServiceException ignored) {
+        }
+        assertSame(LoadBalancer.State.active, loadBalancers.get(0).state());
+        assertTrue("Load balancer has instance", loadBalancers.get(0).instance().isPresent());
     }
 
     @Test


### PR DESCRIPTION
Once a load balancer instance has been provisioned, we shouldn't attempt to
clear it if future provision calls (reconfiguration) fails. The model already
disallows this and throws if state is active and instance is empty.

@jonmv