### PR TITLE
Proposal for new DNS load balancing option in vespa feed client

### DIFF
--- a/vespa-feed-client-api/abi-spec.json
+++ b/vespa-feed-client-api/abi-spec.json
@@ -165,6 +165,7 @@
       "public abstract ai.vespa.feed.client.FeedClientBuilder setProxyCaCertificates(java.util.Collection)",
       "public abstract ai.vespa.feed.client.FeedClientBuilder setEndpointUris(java.util.List)",
       "public abstract ai.vespa.feed.client.FeedClientBuilder setProxy(java.net.URI)",
+      "public abstract ai.vespa.feed.client.FeedClientBuilder setDnsLoadBalancing(boolean)",
       "public abstract ai.vespa.feed.client.FeedClientBuilder setCompression(ai.vespa.feed.client.FeedClientBuilder$Compression)",
       "public abstract ai.vespa.feed.client.FeedClient build()"
     ],

--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
@@ -144,6 +144,14 @@ public interface FeedClientBuilder {
     /** Specify HTTP(S) proxy for all endpoints */
     FeedClientBuilder setProxy(URI uri);
 
+    /**
+     * Turns on DNS load balancing for the cluster.
+     *
+     * Use this option if the given endpoint resolves to a list of feed container endpoints.
+     * This list will be periodically refreshed (resolved) to get the latest container endpoints.
+     */
+    FeedClientBuilder setDnsLoadBalancing(boolean enabled);
+
     /** What compression to use for request bodies; default {@code auto}. */
     FeedClientBuilder setCompression(Compression compression);
 

--- a/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
+++ b/vespa-feed-client-api/src/main/java/ai/vespa/feed/client/FeedClientBuilder.java
@@ -145,10 +145,10 @@ public interface FeedClientBuilder {
     FeedClientBuilder setProxy(URI uri);
 
     /**
-     * Turns on DNS load balancing for the cluster.
+     * Turns on DNS load balancing to the feed cluster.
      *
      * Use this option if the given endpoint resolves to a list of feed container endpoints.
-     * This list will be periodically refreshed (resolved) to get the latest container endpoints.
+     * This list will be periodically refreshed (resolved) to get the latest endpoints.
      */
     FeedClientBuilder setDnsLoadBalancing(boolean enabled);
 

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliArguments.java
@@ -62,6 +62,7 @@ class CliArguments {
     private static final String STDIN_OPTION = "stdin";
     private static final String DOOM_OPTION = "max-failure-seconds";
     private static final String PROXY_OPTION = "proxy";
+    private static final String DNS_LOAD_BALANCING = "dns-load-balancing";
     private static final String COMPRESSION = "compression";
 
     private final CommandLine arguments;
@@ -185,6 +186,8 @@ class CliArguments {
     boolean dryrunEnabled() { return has(DRYRUN_OPTION); }
 
     boolean speedTest() { return has(SPEED_TEST_OPTION); }
+
+    boolean dnsLoadBalancing() { return has(DNS_LOAD_BALANCING); }
 
     Compression compression() throws CliArgumentsException {
         try {
@@ -368,6 +371,10 @@ class CliArguments {
                         .desc("URI to proxy endpoint")
                         .hasArg()
                         .type(URL.class)
+                        .build())
+                .addOption(Option.builder()
+                        .longOpt(DNS_LOAD_BALANCING)
+                        .desc("Turns on DNS load balancing to the feed cluster")
                         .build())
                 .addOption(Option.builder()
                         .longOpt(COMPRESSION)

--- a/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
+++ b/vespa-feed-client-cli/src/main/java/ai/vespa/feed/client/impl/CliClient.java
@@ -159,6 +159,7 @@ public class CliClient {
         cliArgs.headers().forEach(builder::addRequestHeader);
         builder.setDryrun(cliArgs.dryrunEnabled());
         builder.setSpeedTest(cliArgs.speedTest());
+        builder.setDnsLoadBalancing(cliArgs.dnsLoadBalancing());
         builder.setCompression(cliArgs.compression());
         cliArgs.doomSeconds().ifPresent(doom -> builder.setCircuitBreaker(new GracePeriodCircuitBreaker(Duration.ofSeconds(10),
                                                                                                         Duration.ofSeconds(doom))));

--- a/vespa-feed-client-cli/src/test/resources/help.txt
+++ b/vespa-feed-client-cli/src/test/resources/help.txt
@@ -15,6 +15,8 @@ Vespa feed client
                                           connections
     --disable-ssl-hostname-verification   Disable SSL hostname
                                           verification
+    --dns-load-balancing                  Turns on DNS load balancing to
+                                          the feed cluster
     --dryrun                              Let each operation succeed after
                                           1ms, instead of sending it
                                           across the network

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/EndpointResolver.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/EndpointResolver.java
@@ -1,0 +1,72 @@
+package ai.vespa.feed.client.impl;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.util.Promise.Completable;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+public class EndpointResolver {
+
+    private final Scheduler scheduler;
+
+    private final SocketAddressResolver resolver;
+
+    public EndpointResolver(Scheduler scheduler, SocketAddressResolver resolver) {
+        this.scheduler = scheduler;
+        this.resolver = resolver;
+    }
+
+    public void resolveRepeatedly(List<URI> uris, Consumer<Set<URI>> callback, long delay, TimeUnit units) {
+        scheduler.schedule(() -> {
+            resolveSync(uris, callback);
+            resolveRepeatedly(uris, callback, delay, units);
+        }, delay, units);
+    }
+
+    public void resolveSync(List<URI> uris, Consumer<Set<URI>> callback) {
+        Set<URI> addresses = uris.stream()
+                .map(this::resolveSingle)
+                .map(CompletableFuture::join) // wait and join the futures
+                .flatMap(List::stream)
+                .collect(Collectors.toSet());
+        callback.accept(addresses);
+    }
+
+    private CompletableFuture<List<URI>> resolveSingle(URI uri) {
+        Completable<List<InetSocketAddress>> result = new Completable<>();
+        resolver.resolve(uri.getHost(), uri.getPort(), result);
+        return result.thenApply(addresses -> addressesToUris(uri, addresses))
+                .exceptionally(t -> List.of()); // ignore exceptions, defer to the consumer
+    }
+
+    private List<URI> addressesToUris(URI uri, List<InetSocketAddress> addresses) {
+        return addresses.stream()
+                .map(address -> cloneUriWithAddress(uri, address))
+                .collect(Collectors.toList());
+    }
+
+    private URI cloneUriWithAddress(URI uri, InetSocketAddress address) {
+        try {
+            return new URI(
+                    uri.getScheme(),
+                    uri.getUserInfo(),
+                    address.getAddress().getHostAddress(),
+                    uri.getPort(),
+                    uri.getPath(),
+                    uri.getQuery(),
+                    uri.getFragment());
+        } catch (URISyntaxException e) {
+            // cloning an existing URI, this shouldn't happen
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/FeedClientBuilderImpl.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/FeedClientBuilderImpl.java
@@ -58,6 +58,7 @@ public class FeedClientBuilderImpl implements FeedClientBuilder {
     boolean benchmark = true;
     boolean dryrun = false;
     boolean speedTest = false;
+    boolean dnsLoadBalancing = false;
     Compression compression = auto;
     URI proxy;
 
@@ -239,6 +240,12 @@ public class FeedClientBuilderImpl implements FeedClientBuilder {
     @Override
     public FeedClientBuilderImpl setProxy(URI uri) {
         this.proxy = uri;
+        return this;
+    }
+
+    @Override
+    public FeedClientBuilderImpl setDnsLoadBalancing(boolean enabled) {
+        this.dnsLoadBalancing = enabled;
         return this;
     }
 

--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/EndpointResolverTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/EndpointResolverTest.java
@@ -1,0 +1,128 @@
+package ai.vespa.feed.client.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.SocketAddressResolver;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.junit.jupiter.api.Test;
+
+public class EndpointResolverTest {
+    private final URI HOST1 = URI.create("http://host1:8080");
+    private final URI HOST2 = URI.create("http://host2:8080");
+    private final URI UNKNOWN = URI.create("http://unknown:8080");
+
+    private class MockScheduler extends AbstractLifeCycle implements Scheduler {
+        Runnable task;
+        long delay;
+        TimeUnit units;
+        int count = 0;
+
+        @Override
+        public Task schedule(Runnable task, long delay, TimeUnit units) {
+            this.task = task;
+            this.delay = delay;
+            this.units = units;
+            count++;
+            return () -> false;
+        }
+    }
+
+    private class MockResolver implements SocketAddressResolver {
+        @Override
+        public void resolve(String host, int port, Promise<List<InetSocketAddress>> promise) {
+            if (host.equals(HOST1.getHost())) {
+                List<InetSocketAddress> addresses = List.of(getAddress(new byte[]{1, 1, 1, 1}, 8080));
+                promise.succeeded(addresses);
+            } else if (host.equals(HOST2.getHost())) {
+                List<InetSocketAddress> addresses = List.of(
+                    getAddress(new byte[]{1, 1, 1, 1}, 8080),
+                    getAddress(new byte[]{1, 1, 1, 2}, 8080));
+                promise.succeeded(addresses);
+            } else if (host.equals(UNKNOWN.getHost())) {
+                promise.failed(new UnknownHostException());
+            } else {
+                promise.succeeded(List.of());
+            }
+        }
+    }
+
+    @Test
+    void testResolve() {
+        AtomicBoolean callbackCalled = new AtomicBoolean(false);
+        EndpointResolver resolver = new EndpointResolver(new MockScheduler(), new MockResolver());
+
+        // test empty uri list
+        resolver.resolveSync(List.of(), uris -> {
+            assertTrue(uris.isEmpty());
+            callbackCalled.set(true);
+        });
+        assertTrue(callbackCalled.get());
+
+        // test UnknownHostException
+        callbackCalled.set(false);
+        resolver.resolveSync(List.of(UNKNOWN), uris -> {
+            assertTrue(uris.isEmpty());
+            callbackCalled.set(true);
+        });
+        assertTrue(callbackCalled.get());
+
+        // test single uri and single result
+        callbackCalled.set(false);
+        resolver.resolveSync(List.of(HOST1), uris -> {
+            assertEquals(Set.of(URI.create("http://1.1.1.1:8080")), uris);
+            callbackCalled.set(true);
+        });
+        assertTrue(callbackCalled.get());
+
+        // test multiple uris and multiple results
+        callbackCalled.set(false);
+        resolver.resolveSync(List.of(HOST1, HOST2, UNKNOWN), uris -> {
+            assertEquals(Set.of(URI.create("http://1.1.1.1:8080"), URI.create("http://1.1.1.2:8080")), uris);
+            callbackCalled.set(true);
+        });
+        assertTrue(callbackCalled.get());
+    }
+
+    @Test
+    void testResolveRepeatedly() {
+        AtomicBoolean callbackCalled = new AtomicBoolean(false);
+        MockScheduler scheduler = new MockScheduler();
+        EndpointResolver resolver = new EndpointResolver(scheduler, new MockResolver());
+
+        resolver.resolveRepeatedly(List.of(), uris -> {
+            assertTrue(uris.isEmpty());
+            callbackCalled.set(true);
+        }, 10, TimeUnit.SECONDS);
+
+        assertFalse(callbackCalled.get()); // not called yet
+        assertEquals(10, scheduler.delay);
+        assertEquals(TimeUnit.SECONDS, scheduler.units);
+        assertEquals(1, scheduler.count);
+
+        scheduler.task.run();
+
+        assertTrue(callbackCalled.get());
+        assertEquals(2, scheduler.count); // ensure it gets re-scheduled
+    }
+
+    private InetSocketAddress getAddress(byte[] bytes, int port) {
+        try {
+            return new InetSocketAddress(InetAddress.getByAddress(bytes), port);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Hello, this PR proposes adding an option to the feed client to use DNS load balancing. It doesn't implement any of the code (yet) but I wanted to get an opinion if this is something you would find useful.

The code changes should be relatively minimal - the endpoint passed into the `FeedClient` would be periodically resolved in the background to come up with a new set of feed container endpoints. These are the actual endpoints which would be used for feeding.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
