### PR TITLE
Use updated groups when computing VIP status on monitor callbacks

### DIFF
--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
@@ -25,7 +25,10 @@ import java.util.stream.IntStream;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author baldersheim
@@ -152,6 +155,18 @@ public class SearchClusterTest {
             }
         }
 
+    }
+
+    @Test
+    void requireThatVipStatusWorksWhenReconfiguredFromZeroNodes() {
+        try (State test = new State("test", 2, "a", "b")) {
+            test.clusterMonitor.start();
+            test.searchCluster.updateNodes(List.of(), test.clusterMonitor, 100.0);
+            assertEquals(Set.of(), test.searchCluster.groupList().nodes());
+
+            test.searchCluster.updateNodes(List.of(new Node("test", 0, "a", 0), new Node("test", 1, "b", 0)), test.clusterMonitor, 100.0);
+            assertTrue(test.vipStatus.isInRotation());
+        }
     }
 
     @Test


### PR DESCRIPTION
@bjorncs please review.

Without this change, the callbacks from monitoring use the old state, which has 0 nodes, when computing VIP status changes ... meaning the cluster is _not ready_, since it has 0 working nodes. Still, the cluster monitor thinks it's already notified the search cluster that the nodes came up, and then nothing more happens. 

I'd like to refactor a lot of this code, tbh, but it probably works now ...