### PR TITLE
Use generated header for sanitizer detection macros

### DIFF
--- a/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
@@ -1,7 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/vespalib/util/sanitizers.h>
+#include <vespa/config.h>
 #include <algorithm>
 #include <array>
 #include <cassert>


### PR DESCRIPTION
@toregge please review

Needed to properly detect UBSan-instrumented compilation.

