### PR TITLE
Wire distributor operation cancelling to cluster state/config change edges

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -138,6 +138,7 @@ public:
 
     // TODO explicit notion of bucket spaces for tests
     DistributorBucketSpace& getDistributorBucketSpace();
+    const DistributorBucketSpace& getDistributorBucketSpace() const;
     BucketDatabase& getBucketDatabase(); // Implicit default space only
     BucketDatabase& getBucketDatabase(document::BucketSpace space);
     const BucketDatabase& getBucketDatabase() const; // Implicit default space only
@@ -175,6 +176,8 @@ public:
     void set_redundancy(uint32_t redundancy);
 
     void trigger_distribution_change(std::shared_ptr<lib::Distribution> distr);
+    void simulate_distribution_config_change(std::shared_ptr<lib::Distribution> new_config);
+    static std::shared_ptr<lib::Distribution> make_default_distribution_config(uint16_t redundancy, uint16_t node_count);
 
     using ConfigBuilder = vespa::config::content::core::StorDistributormanagerConfigBuilder;
 

--- a/storage/src/tests/distributor/removebucketoperationtest.cpp
+++ b/storage/src/tests/distributor/removebucketoperationtest.cpp
@@ -24,6 +24,14 @@ struct RemoveBucketOperationTest : Test, DistributorStripeTestUtil {
     void TearDown() override {
         close();
     }
+
+    void reject_with_bucket_info(RemoveBucketOperation& op, size_t msg_index) {
+        std::shared_ptr<api::StorageCommand> msg2  = _sender.command(msg_index);
+        std::shared_ptr<api::StorageReply> reply(msg2->makeReply());
+        dynamic_cast<api::DeleteBucketReply&>(*reply).setBucketInfo(api::BucketInfo(10, 200, 1));
+        reply->setResult(api::ReturnCode::REJECTED);
+        op.receive(_sender, reply);
+    }
 };
 
 TEST_F(RemoveBucketOperationTest, simple) {
@@ -36,10 +44,9 @@ TEST_F(RemoveBucketOperationTest, simple) {
 
     RemoveBucketOperation op(dummy_cluster_context,
                              BucketAndNodes(makeDocumentBucket(document::BucketId(16, 1)),
-                                            toVector<uint16_t>(1,2)));
+                                            toVector<uint16_t>(1, 2)));
     op.setIdealStateManager(&getIdealStateManager());
     op.start(_sender);
-
 
     ASSERT_EQ("Delete bucket => 1,"
               "Delete bucket => 2",
@@ -75,16 +82,11 @@ TEST_F(RemoveBucketOperationTest, bucket_info_mismatch_failure) {
     ASSERT_EQ("Delete bucket => 1", _sender.getCommands(true));
     ASSERT_EQ(1, _sender.commands().size());
 
-    std::shared_ptr<api::StorageCommand> msg2  = _sender.command(0);
-    std::shared_ptr<api::StorageReply> reply(msg2->makeReply().release());
-    dynamic_cast<api::DeleteBucketReply&>(*reply).setBucketInfo(
-            api::BucketInfo(10, 100, 1));
-    reply->setResult(api::ReturnCode::REJECTED);
-    op.receive(_sender, reply);
+    reject_with_bucket_info(op, 0);
 
     // RemoveBucketOperation should reinsert bucketinfo into database
     ASSERT_EQ("BucketId(0x4000000000000001) : "
-              "node(idx=1,crc=0xa,docs=100/100,bytes=1/1,trusted=true,active=false,ready=false)",
+              "node(idx=1,crc=0xa,docs=200/200,bytes=1/1,trusted=true,active=false,ready=false)",
               dumpBucket(document::BucketId(16, 1)));
 }
 
@@ -128,6 +130,37 @@ TEST_F(RemoveBucketOperationTest, operation_blocked_when_pending_message_to_targ
     // Not in node target set
     EXPECT_FALSE(op.shouldBlockThisOperation(api::MessageType::PUT_ID, 0, 120));
     EXPECT_FALSE(op.shouldBlockThisOperation(api::MessageType::PUT_ID, 2, 120));
+}
+
+TEST_F(RemoveBucketOperationTest, cancelled_node_does_not_update_bucket_db_upon_rejection) {
+    addNodesToBucketDB(document::BucketId(16, 1),
+                       "0=10/100/1/t,"
+                       "1=10/100/1/t,"
+                       "2=10/100/1/t");
+    set_redundancy(1);
+    enable_cluster_state("distributor:1 storage:3");
+
+    RemoveBucketOperation op(dummy_cluster_context,
+                             BucketAndNodes(makeDocumentBucket(document::BucketId(16, 1)),
+                                            toVector<uint16_t>(1,2)));
+    op.setIdealStateManager(&getIdealStateManager());
+    op.start(_sender);
+
+    ASSERT_EQ("Delete bucket => 1,"
+              "Delete bucket => 2",
+              _sender.getCommands(true));
+
+    op.cancel(_sender, CancelScope::of_node_subset({1}));
+
+    // Rejections will by default reinsert the bucket into the DB with the bucket info contained
+    // in the reply, but here the node is cancelled and should therefore not be reinserted.
+    reject_with_bucket_info(op, 0);
+    sendReply(op, 1);
+    // Node 1 not reinserted
+    ASSERT_EQ("BucketId(0x4000000000000001) : "
+              "node(idx=0,crc=0xa,docs=100/100,bytes=1/1,trusted=true,active=false,ready=false)",
+              dumpBucket(document::BucketId(16, 1)));
+    EXPECT_FALSE(op.ok());
 }
 
 } // storage::distributor

--- a/storage/src/tests/distributor/removelocationtest.cpp
+++ b/storage/src/tests/distributor/removelocationtest.cpp
@@ -67,4 +67,6 @@ TEST_F(RemoveLocationOperationTest, simple) {
               _sender.getLastReply());
 }
 
+// TODO test cancellation (implicitly covered via operation PersistenceMessageTracker)
+
 } // storage::distributor

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -54,6 +54,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _inhibit_default_merges_when_global_merges_pending(false),
       _enable_two_phase_garbage_collection(false),
       _enable_condition_probing(false),
+      _enable_operation_cancellation(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
 }
@@ -179,6 +180,7 @@ DistributorConfiguration::configure(const vespa::config::content::core::StorDist
     _inhibit_default_merges_when_global_merges_pending = config.inhibitDefaultMergesWhenGlobalMergesPending;
     _enable_two_phase_garbage_collection = config.enableTwoPhaseGarbageCollection;
     _enable_condition_probing = config.enableConditionProbing;
+    _enable_operation_cancellation = config.enableOperationCancellation;
 
     _minimumReplicaCountingMode = config.minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -293,6 +293,12 @@ public:
     [[nodiscard]] bool enable_condition_probing() const noexcept {
         return _enable_condition_probing;
     }
+    void set_enable_operation_cancellation(bool enable) noexcept {
+        _enable_operation_cancellation = enable;
+    }
+    [[nodiscard]] bool enable_operation_cancellation() const noexcept {
+        return _enable_operation_cancellation;
+    }
 
     uint32_t num_distributor_stripes() const noexcept { return _num_distributor_stripes; }
 
@@ -354,6 +360,7 @@ private:
     bool _inhibit_default_merges_when_global_merges_pending;
     bool _enable_two_phase_garbage_collection;
     bool _enable_condition_probing;
+    bool _enable_operation_cancellation;
 
     DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
 

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -313,3 +313,8 @@ enable_two_phase_garbage_collection bool default=true
 ## replicas will trigger an implicit distributed condition probe to resolve the outcome of
 ## the condition across all divergent replicas.
 enable_condition_probing bool default=true
+
+## If true, changes in the cluster where a subset of the nodes become unavailable or buckets
+## change ownership between distributors will trigger an explicit cancellation of all pending
+## requests partially or fully "invalidated" by such a change.
+enable_operation_cancellation bool default=false

--- a/storage/src/vespa/storage/distributor/CMakeLists.txt
+++ b/storage/src/vespa/storage/distributor/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(storage_distributor OBJECT
     activecopy.cpp
     blockingoperationstarter.cpp
     bucket_db_prune_elision.cpp
+    bucket_ownership_calculator.cpp
     bucket_space_distribution_configs.cpp
     bucket_space_distribution_context.cpp
     bucket_space_state_map.cpp

--- a/storage/src/vespa/storage/distributor/bucket_ownership_calculator.cpp
+++ b/storage/src/vespa/storage/distributor/bucket_ownership_calculator.cpp
@@ -1,0 +1,41 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "bucket_ownership_calculator.h"
+#include <vespa/document/bucket/bucket.h>
+#include <vespa/vdslib/distribution/distribution.h>
+#include <vespa/vdslib/state/clusterstate.h>
+
+namespace storage::distributor {
+
+namespace {
+
+uint64_t superbucket_from_id(const document::BucketId& id, uint16_t distribution_bits) noexcept {
+    // The n LSBs of the bucket ID contain the superbucket number. Mask off the rest.
+    return id.getRawId() & ~(UINT64_MAX << distribution_bits);
+}
+
+}
+
+bool
+BucketOwnershipCalculator::this_distributor_owns_bucket(const document::BucketId& bucket_id) const
+{
+    // TODO "no distributors available" case is the same for _all_ buckets; cache once in constructor.
+    // TODO "too few bits used" case can be cheaply checked without needing exception
+    try {
+        const auto bits = _state.getDistributionBitCount();
+        const auto this_superbucket = superbucket_from_id(bucket_id, bits);
+        if (_cached_decision_superbucket == this_superbucket) {
+            return _cached_owned;
+        }
+        uint16_t distributor = _distribution.getIdealDistributorNode(_state, bucket_id, "uim");
+        _cached_decision_superbucket = this_superbucket;
+        _cached_owned = (distributor == _this_node_index);
+        return _cached_owned;
+    } catch (lib::TooFewBucketBitsInUseException&) {
+        // Ignore; implicitly not owned
+    } catch (lib::NoDistributorsAvailableException&) {
+        // Ignore; implicitly not owned
+    }
+    return false;
+}
+
+}

--- a/storage/src/vespa/storage/distributor/bucket_ownership_calculator.h
+++ b/storage/src/vespa/storage/distributor/bucket_ownership_calculator.h
@@ -1,0 +1,44 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include <cstdint>
+
+namespace document { class BucketId; }
+
+namespace storage::lib {
+class ClusterState;
+class Distribution;
+}
+
+namespace storage::distributor {
+
+/**
+ * Calculator for determining if a bucket is owned by the current distributor.
+ * Ideal state calculations are cached and reused for all consecutive sub-buckets
+ * under the same super bucket. The cache is invalidated when a new super bucket
+ * is encountered, so it only provides a benefit when invoked in bucket ID order.
+ *
+ * Not thread safe due to internal caching.
+ */
+class BucketOwnershipCalculator {
+    const lib::ClusterState& _state;
+    const lib::Distribution& _distribution;
+    mutable uint64_t         _cached_decision_superbucket;
+    const uint16_t           _this_node_index;
+    mutable bool             _cached_owned;
+public:
+    BucketOwnershipCalculator(const lib::ClusterState& state,
+                              const lib::Distribution& distribution,
+                              uint16_t this_node_index) noexcept
+        : _state(state),
+          _distribution(distribution),
+          _cached_decision_superbucket(UINT64_MAX),
+          _this_node_index(this_node_index),
+          _cached_owned(false)
+    {
+    }
+
+    [[nodiscard]] bool this_distributor_owns_bucket(const document::BucketId& bucket_id) const;
+};
+
+}

--- a/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_interface.h
@@ -18,6 +18,7 @@ namespace storage::distributor {
 class DistributorMetricSet;
 class NodeSupportedFeaturesRepo;
 class PendingMessageTracker;
+class Operation;
 
 /**
  * TODO STRIPE add class comment.
@@ -27,7 +28,7 @@ class DistributorStripeInterface : public DistributorStripeMessageSender
 public:
     virtual DistributorMetricSet& getMetrics() = 0;
     virtual void enableClusterStateBundle(const lib::ClusterStateBundle& state) = 0;
-    virtual const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const = 0;
+    [[nodiscard]] virtual const lib::ClusterState* pendingClusterStateOrNull(const document::BucketSpace&) const = 0;
     virtual void notifyDistributionChangeEnabled() = 0;
 
     /**
@@ -57,7 +58,9 @@ public:
     /**
      * Returns true if the node is currently initializing.
      */
-    virtual bool initializing() const = 0;
+    [[nodiscard]] virtual bool initializing() const = 0;
+
+    [[nodiscard]] virtual std::shared_ptr<Operation> maintenance_op_from_message_id(uint64_t msg_id) const noexcept = 0;
     virtual void handleCompletedMerge(const std::shared_ptr<api::MergeBucketReply>&) = 0;
     virtual const DistributorConfiguration& getConfig() const = 0;
     virtual ChainedMessageSender& getMessageSender() = 0;

--- a/storage/src/vespa/storage/distributor/messagetracker.h
+++ b/storage/src/vespa/storage/distributor/messagetracker.h
@@ -25,7 +25,7 @@ public:
         uint16_t _target;
     };
 
-    MessageTracker(const ClusterContext& cluster_context);
+    explicit MessageTracker(const ClusterContext& cluster_context);
     MessageTracker(MessageTracker&&) noexcept = default;
     MessageTracker& operator=(MessageTracker&&) noexcept = delete;
     MessageTracker(const MessageTracker &) = delete;

--- a/storage/src/vespa/storage/distributor/operationowner.cpp
+++ b/storage/src/vespa/storage/distributor/operationowner.cpp
@@ -70,10 +70,27 @@ OperationOwner::onClose()
     }
 }
 
-void
+std::shared_ptr<Operation>
+OperationOwner::find_by_id(api::StorageMessage::Id msg_id) const noexcept
+{
+    return _sentMessageMap.find_by_id_or_empty(msg_id);
+}
+
+bool
+OperationOwner::try_cancel_by_id(api::StorageMessage::Id id, const CancelScope& cancel_scope)
+{
+    auto* op = _sentMessageMap.find_by_id_or_nullptr(id);
+    if (!op) {
+        return false;
+    }
+    op->cancel(_sender, cancel_scope);
+    return true;
+}
+
+std::shared_ptr<Operation>
 OperationOwner::erase(api::StorageMessage::Id msgId)
 {
-    (void)_sentMessageMap.pop(msgId);
+    return _sentMessageMap.pop(msgId);
 }
 
 }

--- a/storage/src/vespa/storage/distributor/operationowner.h
+++ b/storage/src/vespa/storage/distributor/operationowner.h
@@ -9,6 +9,7 @@ namespace storage::framework { struct Clock; }
 
 namespace storage::distributor {
 
+class CancelScope;
 class Operation;
 
 /**
@@ -87,10 +88,19 @@ public:
     bool start(const std::shared_ptr<Operation>& operation, Priority priority) override;
 
     /**
-       If the given message exists, create a reply and pass it to the
-       appropriate callback.
+     * If the given message exists, remove it from the internal operation mapping.
+     *
+     * Returns the operation the message belonged to, if any.
      */
-    void erase(api::StorageMessage::Id msgId);
+    [[nodiscard]] std::shared_ptr<Operation> erase(api::StorageMessage::Id msgId);
+
+    /**
+     * Returns a strong ref to the pending operation with the given msg_id if it exists.
+     * Otherwise returns an empty shared_ptr.
+     */
+    [[nodiscard]] std::shared_ptr<Operation> find_by_id(api::StorageMessage::Id msg_id) const noexcept;
+
+    [[nodiscard]] bool try_cancel_by_id(api::StorageMessage::Id msg_id, const CancelScope& cancel_scope);
 
     [[nodiscard]] DistributorStripeMessageSender& sender() noexcept { return _sender; }
 

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
@@ -178,6 +178,8 @@ void CheckCondition::handle_internal_get_operation_reply(std::shared_ptr<api::St
         if (_bucket_space.has_pending_cluster_state()) {
             state_version_now = _bucket_space.get_pending_cluster_state().getVersion();
         }
+        // TODO disable these explicit (and possibly costly) checks when cancellation is enabled,
+        //  as cancellation shall cover a superset of the cases that can be detected here.
         if ((state_version_now != _cluster_state_version_at_creation_time)
             && (replica_set_changed_after_get_operation()
                 || distributor_no_longer_owns_bucket()))

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
@@ -28,8 +28,8 @@ PutOperation::PutOperation(const DistributorNodeContext& node_ctx,
                            PersistenceOperationMetricSet& condition_probe_metrics,
                            SequencingHandle sequencing_handle)
     : SequencedOperation(std::move(sequencing_handle)),
-      _tracker_instance(metric, std::make_shared<api::PutReply>(*msg), node_ctx, op_ctx, msg->getTimestamp()),
-      _tracker(_tracker_instance),
+      _tracker(metric, std::make_shared<api::PutReply>(*msg), node_ctx,
+               op_ctx, _cancel_scope, msg->getTimestamp()),
       _msg(std::move(msg)),
       _doc_id_bucket_id(document::BucketIdFactory{}.getBucketId(_msg->getDocumentId())),
       _node_ctx(node_ctx),
@@ -253,7 +253,6 @@ PutOperation::on_cancel(DistributorStripeMessageSender& sender, const CancelScop
     if (_check_condition) {
         _check_condition->cancel(sender, cancel_scope);
     }
-    _tracker.cancel(cancel_scope);
 }
 
 bool

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.h
@@ -39,8 +39,7 @@ public:
     void onClose(DistributorStripeMessageSender& sender) override;
 
 private:
-    PersistenceMessageTrackerImpl      _tracker_instance;
-    PersistenceMessageTracker&         _tracker;
+    PersistenceMessageTracker          _tracker;
     std::shared_ptr<api::PutCommand>   _msg;
     document::BucketId                 _doc_id_bucket_id;
     const DistributorNodeContext&      _node_ctx;

--- a/storage/src/vespa/storage/distributor/operations/external/removelocationoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/removelocationoperation.cpp
@@ -23,12 +23,7 @@ RemoveLocationOperation::RemoveLocationOperation(
         std::shared_ptr<api::RemoveLocationCommand> msg,
         PersistenceOperationMetricSet& metric)
     : Operation(),
-      _trackerInstance(metric,
-               std::make_shared<api::RemoveLocationReply>(*msg),
-               node_ctx,
-               op_ctx,
-               0),
-      _tracker(_trackerInstance),
+      _tracker(metric, std::make_shared<api::RemoveLocationReply>(*msg), node_ctx, op_ctx, _cancel_scope, 0),
       _msg(std::move(msg)),
       _node_ctx(node_ctx),
       _parser(parser),

--- a/storage/src/vespa/storage/distributor/operations/external/removelocationoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/removelocationoperation.h
@@ -10,8 +10,7 @@ namespace storage::distributor {
 
 class DistributorBucketSpace;
 
-class RemoveLocationOperation  : public Operation
-{
+class RemoveLocationOperation : public Operation {
 public:
     RemoveLocationOperation(const DistributorNodeContext& node_ctx,
                             DistributorStripeOperationContext& op_ctx,
@@ -32,14 +31,11 @@ public:
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply>&) override;
     void onClose(DistributorStripeMessageSender& sender) override;
 private:
-    PersistenceMessageTrackerImpl _trackerInstance;
-    PersistenceMessageTracker& _tracker;
-
+    PersistenceMessageTracker                   _tracker;
     std::shared_ptr<api::RemoveLocationCommand> _msg;
-
-    const DistributorNodeContext& _node_ctx;
-    const DocumentSelectionParser& _parser;
-    DistributorBucketSpace &_bucketSpace;
+    const DistributorNodeContext&               _node_ctx;
+    const DocumentSelectionParser&              _parser;
+    DistributorBucketSpace&                     _bucketSpace;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.cpp
@@ -19,10 +19,8 @@ RemoveOperation::RemoveOperation(const DistributorNodeContext& node_ctx,
                                  PersistenceOperationMetricSet& condition_probe_metrics,
                                  SequencingHandle sequencingHandle)
     : SequencedOperation(std::move(sequencingHandle)),
-      _tracker_instance(metric,
-               std::make_shared<api::RemoveReply>(*msg),
-               node_ctx, op_ctx, msg->getTimestamp()),
-      _tracker(_tracker_instance),
+      _tracker(metric, std::make_shared<api::RemoveReply>(*msg), node_ctx,
+               op_ctx, _cancel_scope, msg->getTimestamp()),
       _msg(std::move(msg)),
       _doc_id_bucket_id(document::BucketIdFactory{}.getBucketId(_msg->getDocumentId())),
       _node_ctx(node_ctx),
@@ -168,7 +166,6 @@ RemoveOperation::on_cancel(DistributorStripeMessageSender& sender, const CancelS
     if (_check_condition) {
         _check_condition->cancel(sender, cancel_scope);
     }
-    _tracker.cancel(cancel_scope);
 }
 
 bool RemoveOperation::has_condition() const noexcept {

--- a/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/removeoperation.h
@@ -32,8 +32,7 @@ public:
     void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
 
 private:
-    PersistenceMessageTrackerImpl       _tracker_instance;
-    PersistenceMessageTracker&          _tracker;
+    PersistenceMessageTracker           _tracker;
     std::shared_ptr<api::RemoveCommand> _msg;
     document::BucketId                  _doc_id_bucket_id;
     const DistributorNodeContext&       _node_ctx;

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.cpp
@@ -25,9 +25,8 @@ UpdateOperation::UpdateOperation(const DistributorNodeContext& node_ctx,
                                  std::vector<BucketDatabase::Entry> entries,
                                  UpdateMetricSet& metric)
     : Operation(),
-      _trackerInstance(metric, std::make_shared<api::UpdateReply>(*msg),
-                       node_ctx, op_ctx, msg->getTimestamp()),
-      _tracker(_trackerInstance),
+      _tracker(metric, std::make_shared<api::UpdateReply>(*msg), node_ctx,
+               op_ctx, _cancel_scope, msg->getTimestamp()),
       _msg(msg),
       _entries(std::move(entries)),
       _new_timestamp(_msg->getTimestamp()),
@@ -206,13 +205,6 @@ UpdateOperation::onClose(DistributorStripeMessageSender& sender)
 {
     _tracker.fail(sender, api::ReturnCode(api::ReturnCode::ABORTED, "Process is shutting down"));
 }
-
-void
-UpdateOperation::on_cancel(DistributorStripeMessageSender&, const CancelScope& cancel_scope)
-{
-    _tracker.cancel(cancel_scope);
-}
-
 
 // The backend behavior of "create-if-missing" updates is to return the timestamp of the
 // _new_ update operation if the document was created from scratch. The two-phase update

--- a/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/updateoperation.h
@@ -31,25 +31,22 @@ public:
     std::string getStatus() const override { return ""; };
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply> & msg) override;
     void onClose(DistributorStripeMessageSender& sender) override;
-    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
 
     std::pair<document::BucketId, uint16_t> getNewestTimestampLocation() const {
         return _newestTimestampLocation;
     }
 
 private:
-    PersistenceMessageTrackerImpl _trackerInstance;
-    PersistenceMessageTracker& _tracker;
-    std::shared_ptr<api::UpdateCommand> _msg;
-    std::vector<BucketDatabase::Entry> _entries;
-    const api::Timestamp _new_timestamp;
-    const bool _is_auto_create_update;
-
-    const DistributorNodeContext& _node_ctx;
-    DistributorStripeOperationContext& _op_ctx;
-    DistributorBucketSpace &_bucketSpace;
+    PersistenceMessageTracker               _tracker;
+    std::shared_ptr<api::UpdateCommand>     _msg;
+    std::vector<BucketDatabase::Entry>      _entries;
+    const api::Timestamp                    _new_timestamp;
+    const bool                              _is_auto_create_update;
+    const DistributorNodeContext&           _node_ctx;
+    DistributorStripeOperationContext&      _op_ctx;
+    DistributorBucketSpace&                 _bucketSpace;
     std::pair<document::BucketId, uint16_t> _newestTimestampLocation;
-    api::BucketInfo _infoAtSendTime; // Should be same across all replicas
+    api::BucketInfo                         _infoAtSendTime; // Should be same across all replicas
 
     bool anyStorageNodesAvailable() const;
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -23,7 +23,6 @@ GarbageCollectionOperation::GarbageCollectionOperation(const ClusterContext& clu
       _cluster_state_version_at_phase1_start_time(0),
       _remove_candidates(),
       _replica_info(),
-      _cancel_scope(),
       _max_documents_removed(0),
       _is_done(false)
 {}
@@ -148,10 +147,6 @@ GarbageCollectionOperation::onReceive(DistributorStripeMessageSender& sender,
             mark_operation_complete();
         }
     }
-}
-
-void GarbageCollectionOperation::on_cancel(DistributorStripeMessageSender&, const CancelScope& cancel_scope) {
-    _cancel_scope.merge(cancel_scope);
 }
 
 void GarbageCollectionOperation::update_replica_response_info_from_reply(uint16_t from_node, const api::RemoveLocationReply& reply) {

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h
@@ -7,7 +7,6 @@
 #include <vespa/storage/bucketdb/bucketcopy.h>
 #include <vespa/storage/distributor/messagetracker.h>
 #include <vespa/storage/distributor/operation_sequencer.h>
-#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 #include <vector>
 
@@ -23,7 +22,6 @@ public:
 
     void onStart(DistributorStripeMessageSender& sender) override;
     void onReceive(DistributorStripeMessageSender& sender, const std::shared_ptr<api::StorageReply> &) override;
-    void on_cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) override;
     const char* getName() const noexcept override { return "garbagecollection"; };
     Type getType() const noexcept override { return GARBAGE_COLLECTION; }
     bool shouldBlockThisOperation(uint32_t, uint16_t, uint8_t) const override;
@@ -56,7 +54,6 @@ private:
     RemoveCandidates              _remove_candidates;
     std::vector<SequencingHandle> _gc_write_locks;
     std::vector<BucketCopy>       _replica_info;
-    CancelScope                   _cancel_scope;
     uint32_t                      _max_documents_removed;
     bool                          _is_done;
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.cpp
@@ -28,6 +28,7 @@ IdealStateOperation::IdealStateOperation(const BucketAndNodes& bucketAndNodes)
     : _manager(nullptr),
       _bucketSpace(nullptr),
       _bucketAndNodes(bucketAndNodes),
+      _detailedReason(),
       _priority(255),
       _ok(true)
 {

--- a/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/idealstateoperation.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/storage/distributor/maintenance/maintenanceoperation.h>
+#include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storageapi/messageapi/storagemessage.h>
 #include <vespa/storageapi/messageapi/storagereply.h>
 #include <vespa/storageapi/messageapi/maintenancecommand.h>
@@ -110,7 +111,7 @@ public:
     using Vector = std::vector<SP>;
     using Map = std::map<document::BucketId, SP>;
 
-    IdealStateOperation(const BucketAndNodes& bucketAndNodes);
+    explicit IdealStateOperation(const BucketAndNodes& bucketAndNodes);
 
     ~IdealStateOperation() override;
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/splitoperation.cpp
@@ -50,7 +50,7 @@ SplitOperation::onStart(DistributorStripeMessageSender& sender)
 void
 SplitOperation::onReceive(DistributorStripeMessageSender&, const api::StorageReply::SP& msg)
 {
-    auto & rep = static_cast<api::SplitBucketReply&>(*msg);
+    auto& rep = dynamic_cast<api::SplitBucketReply&>(*msg);
 
     uint16_t node = _tracker.handleReply(rep);
 
@@ -61,7 +61,9 @@ SplitOperation::onReceive(DistributorStripeMessageSender&, const api::StorageRep
 
     std::ostringstream ost;
 
-    if (rep.getResult().success()) {
+    if (_cancel_scope.node_is_cancelled(node)) {
+        _ok = false;
+    } else if (rep.getResult().success()) {
         BucketDatabase::Entry entry = _bucketSpace->getBucketDatabase().get(rep.getBucketId());
 
         if (entry.valid()) {

--- a/storage/src/vespa/storage/distributor/operations/operation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/operation.cpp
@@ -13,7 +13,7 @@ namespace storage::distributor {
 
 Operation::Operation()
     : _startTime(),
-      _cancelled(false)
+      _cancel_scope()
 {
 }
 
@@ -47,7 +47,7 @@ Operation::copyMessageSettings(const api::StorageCommand& source, api::StorageCo
 }
 
 void Operation::cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope) {
-    _cancelled = true;
+    _cancel_scope.merge(cancel_scope);
     on_cancel(sender, cancel_scope);
 }
 

--- a/storage/src/vespa/storage/distributor/operations/operation.h
+++ b/storage/src/vespa/storage/distributor/operations/operation.h
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include "cancel_scope.h"
 #include <vespa/vdslib/state/nodetype.h>
 #include <vespa/storage/distributor/distributormessagesender.h>
 #include <vespa/vespalib/util/time.h>
@@ -68,13 +69,15 @@ public:
      */
     void cancel(DistributorStripeMessageSender& sender, const CancelScope& cancel_scope);
 
+    [[nodiscard]] const CancelScope& cancel_scope() const noexcept { return _cancel_scope; }
+
     /**
      * Whether cancel() has been invoked at least once on this instance. This does not
      * distinguish between cancellations caused by ownership transfers and those caused
      * by nodes becoming unavailable; Operation implementations that care about this need
-     * to implement cancel() themselves and inspect the provided CancelScope.
+     * to inspect cancel_scope() themselves.
      */
-    [[nodiscard]] bool is_cancelled() const noexcept { return _cancelled; }
+    [[nodiscard]] bool is_cancelled() const noexcept { return _cancel_scope.is_cancelled(); }
 
     /**
      * Returns true if we are blocked to start this operation given
@@ -118,7 +121,7 @@ protected:
     static constexpr vespalib::duration MAX_TIMEOUT = 3600s;
 
     vespalib::system_time _startTime;
-    bool                  _cancelled;
+    CancelScope           _cancel_scope;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -69,9 +69,19 @@ private:
     uint8_t                               _priority;
     bool                                  _success;
 
-    // Returns true iff `bucket_and_replicas` have at least 1 usable entry after pruning
-    [[nodiscard]]static bool prune_cancelled_nodes_if_present(BucketInfoMap& bucket_and_replicas,
-                                                              const CancelScope& cancel_scope);
+    enum class PostPruningStatus {
+        ReplicasStillPresent,
+        NoReplicasPresent
+    };
+
+    constexpr static bool still_has_replicas(PostPruningStatus status) {
+        return status == PostPruningStatus::ReplicasStillPresent;
+    }
+
+    // Returns ReplicasStillPresent iff `bucket_and_replicas` has at least 1 usable entry after pruning,
+    // otherwise returns NoReplicasPresent
+    [[nodiscard]] static PostPruningStatus prune_cancelled_nodes_if_present(BucketInfoMap& bucket_and_replicas,
+                                                                            const CancelScope& cancel_scope);
     [[nodiscard]] bool canSendReplyEarly() const;
     void addBucketInfoFromReply(uint16_t node, const api::BucketInfoReply& reply);
     void logSuccessfulReply(uint16_t node, const api::BucketInfoReply& reply) const;

--- a/storage/src/vespa/storage/distributor/persistencemessagetracker.h
+++ b/storage/src/vespa/storage/distributor/persistencemessagetracker.h
@@ -11,47 +11,29 @@
 
 namespace storage::distributor {
 
-struct PersistenceMessageTracker {
-    virtual ~PersistenceMessageTracker() = default;
+class PersistenceMessageTracker final : public MessageTracker {
+public:
     using ToSend = MessageTracker::ToSend;
 
-    virtual void cancel(const CancelScope& cancel_scope) = 0;
-    virtual void fail(MessageSender&, const api::ReturnCode&) = 0;
-    virtual void queueMessageBatch(std::vector<ToSend> messages) = 0;
-    virtual uint16_t receiveReply(MessageSender&, api::BucketInfoReply&) = 0;
-    virtual std::shared_ptr<api::BucketInfoReply>& getReply() = 0;
-    virtual void updateFromReply(MessageSender&, api::BucketInfoReply&, uint16_t node) = 0;
-    virtual void queueCommand(api::BucketCommand::SP, uint16_t target) = 0;
-    virtual void flushQueue(MessageSender&) = 0;
-    virtual uint16_t handleReply(api::BucketReply& reply) = 0;
-    virtual void add_trace_tree_to_reply(vespalib::Trace trace) = 0;
-};
-
-class PersistenceMessageTrackerImpl final
-    : public PersistenceMessageTracker,
-      public MessageTracker
-{
-public:
-    PersistenceMessageTrackerImpl(PersistenceOperationMetricSet& metric,
-                                  std::shared_ptr<api::BucketInfoReply> reply,
-                                  const DistributorNodeContext& node_ctx,
-                                  DistributorStripeOperationContext& op_ctx,
-                                  api::Timestamp revertTimestamp = 0);
-    ~PersistenceMessageTrackerImpl() override;
-
-    void cancel(const CancelScope& cancel_scope) override;
+    PersistenceMessageTracker(PersistenceOperationMetricSet& metric,
+                              std::shared_ptr<api::BucketInfoReply> reply,
+                              const DistributorNodeContext& node_ctx,
+                              DistributorStripeOperationContext& op_ctx,
+                              CancelScope& cancel_scope,
+                              api::Timestamp revertTimestamp = 0);
+    ~PersistenceMessageTracker();
 
     void updateDB();
     void updateMetrics();
     [[nodiscard]] bool success() const noexcept { return _success; }
-    void fail(MessageSender& sender, const api::ReturnCode& result) override;
+    void fail(MessageSender& sender, const api::ReturnCode& result);
 
     /**
        Returns the node the reply was from.
     */
-    uint16_t receiveReply(MessageSender& sender, api::BucketInfoReply& reply) override;
-    void updateFromReply(MessageSender& sender, api::BucketInfoReply& reply, uint16_t node) override;
-    std::shared_ptr<api::BucketInfoReply>& getReply() override { return _reply; }
+    uint16_t receiveReply(MessageSender& sender, api::BucketInfoReply& reply);
+    void updateFromReply(MessageSender& sender, api::BucketInfoReply& reply, uint16_t node);
+    std::shared_ptr<api::BucketInfoReply>& getReply() { return _reply; }
 
     using BucketNodePair = std::pair<document::Bucket, uint16_t>;
 
@@ -63,7 +45,9 @@ public:
        have at most (messages.size() - initial redundancy) messages left in the
        queue and have it's first message be done.
     */
-    void queueMessageBatch(std::vector<MessageTracker::ToSend> messages) override;
+    void queueMessageBatch(std::vector<MessageTracker::ToSend> messages);
+
+    void add_trace_tree_to_reply(vespalib::Trace trace);
 
 private:
     using MessageBatch  = std::vector<uint64_t>;
@@ -79,14 +63,15 @@ private:
     std::vector<BucketNodePair>           _revertNodes;
     mbus::Trace                           _trace;
     framework::MilliSecTimer              _requestTimer;
-    CancelScope                           _cancel_scope;
+    CancelScope&                          _cancel_scope;
     uint32_t                              _n_persistence_replies_total;
     uint32_t                              _n_successful_persistence_replies;
     uint8_t                               _priority;
     bool                                  _success;
 
-    static void prune_cancelled_nodes_if_present(BucketInfoMap& bucket_and_replicas,
-                                                 const CancelScope& cancel_scope);
+    // Returns true iff `bucket_and_replicas` have at least 1 usable entry after pruning
+    [[nodiscard]]static bool prune_cancelled_nodes_if_present(BucketInfoMap& bucket_and_replicas,
+                                                              const CancelScope& cancel_scope);
     [[nodiscard]] bool canSendReplyEarly() const;
     void addBucketInfoFromReply(uint16_t node, const api::BucketInfoReply& reply);
     void logSuccessfulReply(uint16_t node, const api::BucketInfoReply& reply) const;
@@ -100,13 +85,6 @@ private:
     void handleCreateBucketReply(api::BucketInfoReply& reply, uint16_t node);
     void handlePersistenceReply(api::BucketInfoReply& reply, uint16_t node);
     void transfer_trace_state_to_reply();
-
-    void queueCommand(std::shared_ptr<api::BucketCommand> msg, uint16_t target) override {
-        MessageTracker::queueCommand(std::move(msg), target);
-    }
-    void flushQueue(MessageSender& s) override { MessageTracker::flushQueue(s); }
-    uint16_t handleReply(api::BucketReply& r) override { return MessageTracker::handleReply(r); }
-    void add_trace_tree_to_reply(vespalib::Trace trace) override;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/sentmessagemap.h
+++ b/storage/src/vespa/storage/distributor/sentmessagemap.h
@@ -15,6 +15,11 @@ public:
     SentMessageMap();
     ~SentMessageMap();
 
+    // Find by message ID, or nullptr if not found
+    [[nodiscard]] Operation* find_by_id_or_nullptr(api::StorageMessage::Id id) const noexcept;
+    // Find by message ID, or empty shared_ptr if not found
+    [[nodiscard]] std::shared_ptr<Operation> find_by_id_or_empty(api::StorageMessage::Id id) const noexcept;
+
     [[nodiscard]] std::shared_ptr<Operation> pop(api::StorageMessage::Id id);
     [[nodiscard]] std::shared_ptr<Operation> pop();
 


### PR DESCRIPTION
@havardpe please review

This wires cancellation of pending operations/messages to content nodes in the following scenarios:

 * One or more content nodes become unavailable in a newly received cluster state version (triggered when first received, i.e. at the pending state start edge).
 * One or more nodes are removed from the distribution config.
 * The set of available distributors changes, which in turn changes the ownership of a fraction of the set of super buckets. Pending operations to buckets that were owned by the current distributor in the previous state, but not in the new state, are all cancelled.

Introduce cancellation support for internal maintenance operations. As part of this, move `CancelScope` tracking out into the parent `Operation` class to unify cancellation tracking across both client and maintenance operations.

Remove interface vs. impl indirection for `PersistenceMessageTracker` since it's only ever had a single implementation and it likely never will have another.

Add config for enabling cancellation (defaults to false).

