### PR TITLE
Ensure that application-test is included when it exists

### DIFF
--- a/client/go/internal/cli/cmd/cert_test.go
+++ b/client/go/internal/cli/cmd/cert_test.go
@@ -50,12 +50,6 @@ func testCert(t *testing.T, subcommand []string) {
 }
 
 func TestCertCompressedPackage(t *testing.T) {
-	t.Run("auth cert", func(t *testing.T) {
-		testCertCompressedPackage(t, []string{"auth", "cert"})
-	})
-}
-
-func testCertCompressedPackage(t *testing.T, subcommand []string) {
 	_, pkgDir := mock.ApplicationPackageDir(t, true, false)
 	zipFile := filepath.Join(pkgDir, "target", "application.zip")
 	err := os.MkdirAll(filepath.Dir(zipFile), 0755)
@@ -68,16 +62,14 @@ func testCertCompressedPackage(t *testing.T, subcommand []string) {
 	stdout.Reset()
 	stderr.Reset()
 
-	args := append(subcommand, pkgDir)
-	err = cli.Run(args...)
+	err = cli.Run("auth", "cert", zipFile)
 	assert.NotNil(t, err)
 	assert.Contains(t, stderr.String(), "Error: cannot add certificate to compressed application package")
 
 	err = os.Remove(zipFile)
 	assert.Nil(t, err)
 
-	args = append(subcommand, "-f", pkgDir)
-	err = cli.Run(args...)
+	err = cli.Run("auth", "cert", "-f", pkgDir)
 	assert.Nil(t, err)
 	assert.Contains(t, stdout.String(), "Success: Certificate written to")
 	assert.Contains(t, stdout.String(), "Success: Private key written to")

--- a/client/go/internal/cli/cmd/deploy_test.go
+++ b/client/go/internal/cli/cmd/deploy_test.go
@@ -133,7 +133,7 @@ func TestDeployApplicationDirectoryWithSource(t *testing.T) {
 }
 
 func TestDeployApplicationDirectoryWithPomAndTarget(t *testing.T) {
-	assertDeploy("testdata/applications/withTarget/target/application.zip",
+	assertDeploy("testdata/applications/withTarget/target/application",
 		[]string{"deploy", "--wait=0", "testdata/applications/withTarget"}, t)
 }
 
@@ -141,7 +141,7 @@ func TestDeployApplicationDirectoryWithPomAndEmptyTarget(t *testing.T) {
 	cli, _, stderr := newTestCLI(t)
 	assert.NotNil(t, cli.Run("deploy", "--wait=0", "testdata/applications/withEmptyTarget"))
 	assert.Equal(t,
-		"Error: found pom.xml, but target/application.zip does not exist: run 'mvn package' first\n",
+		"Error: found pom.xml, but testdata/applications/withEmptyTarget/target/application does not exist: run 'mvn package' first\n",
 		stderr.String())
 }
 

--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -147,7 +147,7 @@ $ vespa prod deploy`,
 			if err != nil {
 				return err
 			}
-			if !pkg.HasDeployment() {
+			if !pkg.HasDeploymentSpec() {
 				return errHint(fmt.Errorf("no deployment.xml found"), "Try creating one with vespa prod init")
 			}
 			if err := verifyTests(cli, pkg); err != nil {

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -151,17 +151,13 @@ func TestFindApplicationPackage(t *testing.T) {
 		fail:             true,
 	})
 	assertFindApplicationPackage(t, dir, pkgFixture{
-		expectedPath:     filepath.Join(dir, "target", "application.zip"),
-		existingFiles:    []string{filepath.Join(dir, "pom.xml"), filepath.Join(dir, "target", "application.zip")},
-		requirePackaging: true,
-	})
-	assertFindApplicationPackage(t, dir, pkgFixture{
-		expectedPath:  filepath.Join(dir, "target", "application.zip"),
-		existingFiles: []string{filepath.Join(dir, "target", "application.zip")},
-	})
-	assertFindApplicationPackage(t, dir, pkgFixture{
 		expectedPath:  filepath.Join(dir, "target", "application"),
 		existingFiles: []string{filepath.Join(dir, "target", "application"), filepath.Join(dir, "target", "application.zip")},
+	})
+	assertFindApplicationPackage(t, dir, pkgFixture{
+		expectedPath:     filepath.Join(dir, "target", "application"),
+		expectedTestPath: filepath.Join(dir, "target", "application-test"),
+		existingFiles:    []string{filepath.Join(dir, "target", "application"), filepath.Join(dir, "target", "application-test")},
 	})
 	zip := filepath.Join(dir, "myapp.zip")
 	assertFindApplicationPackage(t, zip, pkgFixture{


### PR DESCRIPTION
Also removes use of `target/application{,-test}.zip` as this will always contain
the same as `target/application{,-test}`.

@bratseth