### PR TITLE
Jonmv/more depl orch data in app v4

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/LogRetriever.java
@@ -2,10 +2,13 @@
 package com.yahoo.vespa.config.server.http;
 
 import ai.vespa.util.http.hc5.VespaHttpClientBuilder;
+import com.yahoo.container.jdisc.EmptyResponse;
 import com.yahoo.container.jdisc.HttpResponse;
 import com.yahoo.yolean.Exceptions;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.util.Timeout;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -18,7 +21,10 @@ import java.util.Optional;
  */
 public class LogRetriever {
 
-    private final CloseableHttpClient httpClient = VespaHttpClientBuilder.custom().buildClient();
+    private final CloseableHttpClient httpClient = VespaHttpClientBuilder.custom()
+                                                                         .connectTimeout(Timeout.ofSeconds(5))
+                                                                         .socketTimeout(Timeout.ofSeconds(45))
+                                                                         .buildClient();
 
     @SuppressWarnings("deprecation")
     public HttpResponse getLogs(String logServerUri, Optional<Instant> deployTime) {
@@ -29,12 +35,8 @@ public class LogRetriever {
             // It takes some time before nodes are up after first-time deployment, return empty log for up to 2 minutes
             // if getting logs fail
             if (deployTime.isPresent() && Instant.now().isBefore(deployTime.get().plus(Duration.ofMinutes(2))))
-                return new HttpResponse(200) {
-                    @Override
-                    public void render(OutputStream outputStream) throws IOException {
-                        outputStream.write("".getBytes(StandardCharsets.UTF_8));
-                    }
-                };
+                return new EmptyResponse();
+
             return HttpErrorResponse.internalServerError("Failed to get logs: " + Exceptions.toMessageString(e));
         }
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/DeploymentTrigger.java
@@ -405,7 +405,7 @@ public class DeploymentTrigger {
 
     private void abortIfOutdated(JobStatus job, List<DeploymentStatus.Job> jobs) {
         job.lastTriggered()
-           .filter(last -> ! last.hasEnded() && last.reason().isEmpty())
+           .filter(last -> ! last.hasEnded() && last.reason().reason().isEmpty())
            .ifPresent(last -> {
                if (jobs.stream().noneMatch(versions ->    versions.versions().targetsMatch(last.versions())
                                                        && versions.versions().sourcesMatchIfPresent(last.versions()))) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/JobController.java
@@ -36,6 +36,7 @@ import com.yahoo.vespa.hosted.controller.application.TenantAndApplicationId;
 import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackage;
 import com.yahoo.vespa.hosted.controller.application.pkg.ApplicationPackageDiff;
 import com.yahoo.vespa.hosted.controller.application.pkg.TestPackage;
+import com.yahoo.vespa.hosted.controller.deployment.Run.Reason;
 import com.yahoo.vespa.hosted.controller.notification.Notification;
 import com.yahoo.vespa.hosted.controller.notification.Notification.Type;
 import com.yahoo.vespa.hosted.controller.notification.NotificationSource;
@@ -717,7 +718,8 @@ public class JobController {
                 throw new IllegalArgumentException("Cannot start " + type + " for " + id + "; it is already running!");
 
             RunId newId = new RunId(id, type, last.map(run -> run.id().number()).orElse(0L) + 1);
-            curator.writeLastRun(Run.initial(newId, versions, isRedeployment, controller.clock().instant(), profile, reason));
+            curator.writeLastRun(Run.initial(newId, versions, isRedeployment, controller.clock().instant(), profile,
+                                             new Reason(reason, Optional.empty(), Optional.empty())));
             metric.jobStarted(newId.job());
         });
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Run.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/Run.java
@@ -344,6 +344,10 @@ public class Run {
             throw new IllegalStateException("This run ended at " + end.get() + " -- it can't be further modified!");
     }
 
-    public record Reason(Optional<String> reason, Optional<JobId> dependent, Optional<Change> change) { }
+    public record Reason(Optional<String> reason, Optional<JobId> dependent, Optional<Change> change) {
+        private static final Reason empty = new Reason(Optional.empty(), Optional.empty(), Optional.empty());
+        public static Reason empty() { return empty; }
+        public static Reason because(String reason) { return new Reason(Optional.of(reason), Optional.empty(), Optional.empty()); }
+    }
 
 }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentUpgrader.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentUpgrader.java
@@ -71,7 +71,7 @@ public class DeploymentUpgrader extends ControllerMaintainer {
 
                         log.log(Level.FINE, "Upgrading deployment of " + instance.id() + " in " + deployment.zone());
                         attempts.incrementAndGet();
-                        controller().jobController().start(instance.id(), JobType.deploymentTo(deployment.zone()), target, true, Optional.of("automated upgrade"));
+                        controller().jobController().start(instance.id(), JobType.deploymentTo(deployment.zone()), target, true, Run.Reason.because("automated upgrade"));
                     } catch (Exception e) {
                         failures.incrementAndGet();
                         log.log(Level.WARNING, "Failed upgrading " + deployment + " of " + instance +

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -126,6 +126,13 @@ class JobControllerApiHandlerHelper {
         detailsObject.setBool("active", ! run.hasEnded());
         detailsObject.setString("status", nameOf(run.status()));
         run.reason().reason().ifPresent(reason -> detailsObject.setString("reason", reason));
+        run.reason().dependent().ifPresent(dependent -> {
+            Cursor dependentObject = detailsObject.setObject("dependent");
+            dependentObject.setString("instance", dependent.application().instance().value());
+            dependentObject.setString("region", dependent.type().zone().region().value());
+            run.reason().change().flatMap(Change::platform).ifPresent(platform -> dependentObject.setString("platform", platform.toFullString()));
+            run.reason().change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("revision", revision.number()));
+        });
         try {
             jobController.updateTestLog(runId);
             jobController.updateVespaLog(runId);
@@ -499,6 +506,13 @@ class JobControllerApiHandlerHelper {
             run.end().ifPresent(end -> runObject.setLong("end", end.toEpochMilli()));
             runObject.setString("status", nameOf(run.status()));
             run.reason().reason().ifPresent(reason -> runObject.setString("reason", reason));
+            run.reason().dependent().ifPresent(dependent -> {
+                Cursor dependentObject = runObject.setObject("dependent");
+                dependentObject.setString("instance", dependent.application().instance().value());
+                dependentObject.setString("region", dependent.type().zone().region().value());
+                run.reason().change().flatMap(Change::platform).ifPresent(platform -> dependentObject.setString("platform", platform.toFullString()));
+                run.reason().change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("revision", revision.number()));
+            });
             toSlime(runObject.setObject("versions"), run.versions(), application);
             Cursor runStepsArray = runObject.setArray("steps");
             run.steps().forEach((step, info) -> {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -125,7 +125,7 @@ class JobControllerApiHandlerHelper {
         Run run = jobController.run(runId);
         detailsObject.setBool("active", ! run.hasEnded());
         detailsObject.setString("status", nameOf(run.status()));
-        run.reason().ifPresent(reason -> detailsObject.setString("reason", reason));
+        run.reason().reason().ifPresent(reason -> detailsObject.setString("reason", reason));
         try {
             jobController.updateTestLog(runId);
             jobController.updateVespaLog(runId);
@@ -498,7 +498,7 @@ class JobControllerApiHandlerHelper {
             runObject.setLong("start", run.start().toEpochMilli());
             run.end().ifPresent(end -> runObject.setLong("end", end.toEpochMilli()));
             runObject.setString("status", nameOf(run.status()));
-            run.reason().ifPresent(reason -> runObject.setString("reason", reason));
+            run.reason().reason().ifPresent(reason -> runObject.setString("reason", reason));
             toSlime(runObject.setObject("versions"), run.versions(), application);
             Cursor runStepsArray = runObject.setArray("steps");
             run.steps().forEach((step, info) -> {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/JobControllerApiHandlerHelper.java
@@ -131,7 +131,7 @@ class JobControllerApiHandlerHelper {
             dependentObject.setString("instance", dependent.application().instance().value());
             dependentObject.setString("region", dependent.type().zone().region().value());
             run.reason().change().flatMap(Change::platform).ifPresent(platform -> dependentObject.setString("platform", platform.toFullString()));
-            run.reason().change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("revision", revision.number()));
+            run.reason().change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("build", revision.number()));
         });
         try {
             jobController.updateTestLog(runId);
@@ -505,7 +505,7 @@ class JobControllerApiHandlerHelper {
             dependentObject.setString("instance", dependent.application().instance().value());
             dependentObject.setString("region", dependent.type().zone().region().value());
             reason.change().flatMap(Change::platform).ifPresent(platform -> dependentObject.setString("platform", platform.toFullString()));
-            reason.change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("revision", revision.number()));
+            reason.change().flatMap(Change::revision).ifPresent(revision -> dependentObject.setLong("build", revision.number()));
         });
         toSlime(runObject.setObject("versions"), versions, application);
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/DeploymentExpirerTest.java
@@ -73,7 +73,7 @@ public class DeploymentExpirerTest {
         // Dev application expires when enough time has passed since most recent attempt
         // Redeployments done by DeploymentUpgrader do not affect this
         tester.clock().advance(Duration.ofDays(12).plus(Duration.ofSeconds(1)));
-        tester.jobs().start(devApp.instanceId(), DeploymentContext.devUsEast1, lastRun.versions(), true, Optional.of("upgrade"));
+        tester.jobs().start(devApp.instanceId(), DeploymentContext.devUsEast1, lastRun.versions(), true, Run.Reason.because("upgrade"));
         expirer.maintain();
         assertEquals(0, permanentDeployments(devApp.instance()));
         assertEquals(1, permanentDeployments(prodApp.instance()));

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunnerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/JobRunnerTest.java
@@ -14,6 +14,7 @@ import com.yahoo.vespa.hosted.controller.deployment.JobController;
 import com.yahoo.vespa.hosted.controller.deployment.JobMetrics;
 import com.yahoo.vespa.hosted.controller.deployment.JobProfile;
 import com.yahoo.vespa.hosted.controller.deployment.Run;
+import com.yahoo.vespa.hosted.controller.deployment.Run.Reason;
 import com.yahoo.vespa.hosted.controller.deployment.RunStatus;
 import com.yahoo.vespa.hosted.controller.deployment.Step;
 import com.yahoo.vespa.hosted.controller.deployment.Step.Status;
@@ -423,7 +424,7 @@ public class JobRunnerTest {
     }
 
     private void start(JobController jobs, ApplicationId id, JobType type) {
-        jobs.start(id, type, versions, false, Optional.empty());
+        jobs.start(id, type, versions, false, Reason.empty());
     }
 
     public static ExecutorService inThreadExecutor() {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/run-status.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/testdata/run-status.json
@@ -54,6 +54,14 @@
         "deployedDirectly": false
       }
     },
-    "reason": "because"
+    "reason": "because",
+    "dependent": {
+      "id": "tenant:application:default",
+        "type": "prod.us-east-3"
+    },
+    "change": {
+      "platform": "1.2.3",
+      "build": 122
+    }
   }
 ]

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
@@ -170,7 +170,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 3
+            "build": 3
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -233,7 +233,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 2
+            "build": 2
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -296,7 +296,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -369,7 +369,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-east-3",
-            "revision": 3
+            "build": 3
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -399,7 +399,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-east-3",
-            "revision": 3
+            "build": 3
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -485,7 +485,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-east-3",
-            "revision": 3
+            "build": 3
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -571,7 +571,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 3
+            "build": 3
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -657,7 +657,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 2
+            "build": 2
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -743,7 +743,7 @@
           "dependent": {
             "instance": "default",
             "region": "us-central-1",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
@@ -366,6 +366,11 @@
       "environment": "staging",
       "toRun": [
         {
+          "dependent": {
+            "instance": "default",
+            "region": "us-east-3",
+            "revision": 3
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview-2.json
@@ -167,6 +167,11 @@
           "start": 14403000,
           "end": 14403000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 3
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -225,6 +230,11 @@
           "start": 1000,
           "end": 1000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 2
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -283,6 +293,11 @@
           "start": 0,
           "end": 0,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -376,6 +391,11 @@
           "start": 14503000,
           "end": 14503000,
           "status": "installationFailed",
+          "dependent": {
+            "instance": "default",
+            "region": "us-east-3",
+            "revision": 3
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -457,6 +477,11 @@
           "start": 14403000,
           "end": 14403000,
           "status": "installationFailed",
+          "dependent": {
+            "instance": "default",
+            "region": "us-east-3",
+            "revision": 3
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -538,6 +563,11 @@
           "start": 14403000,
           "end": 14403000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 3
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -619,6 +649,11 @@
           "start": 1000,
           "end": 1000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 2
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -700,6 +735,11 @@
           "start": 0,
           "end": 0,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "us-central-1",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
@@ -79,6 +79,11 @@
           "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/system-test/run/2",
           "start": 1600000000000,
           "status": "running",
+          "dependent": {
+            "instance": "instance1",
+            "region": "us-central-1",
+            "revision": 4
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -137,6 +142,11 @@
           "start": 1600000000000,
           "end": 1600000000000,
           "status": "success",
+          "dependent": {
+            "instance": "instance1",
+            "region": "us-central-1",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -209,6 +219,11 @@
           "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/staging-test/run/2",
           "start": 1600000000000,
           "status": "running",
+          "dependent": {
+            "instance": "instance1",
+            "region": "us-central-1",
+            "revision": 4
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -283,6 +298,11 @@
           "start": 1600000000000,
           "end": 1600000000000,
           "status": "success",
+          "dependent": {
+            "instance": "instance1",
+            "region": "us-central-1",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/deployment-overview.json
@@ -82,7 +82,7 @@
           "dependent": {
             "instance": "instance1",
             "region": "us-central-1",
-            "revision": 4
+            "build": 4
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -145,7 +145,7 @@
           "dependent": {
             "instance": "instance1",
             "region": "us-central-1",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -222,7 +222,7 @@
           "dependent": {
             "instance": "instance1",
             "region": "us-central-1",
-            "revision": 4
+            "build": 4
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -301,7 +301,7 @@
           "dependent": {
             "instance": "instance1",
             "region": "us-central-1",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-enclave.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-enclave.json
@@ -5,11 +5,11 @@
   "steps": [
     {
       "type": "instance",
-      "dependencies": [],
+      "dependencies": [ ],
       "declared": true,
       "instance": "default",
       "readyAt": 0,
-      "deploying": {},
+      "deploying": { },
       "latestVersions": {
         "platform": {
           "platform": "6.1.0",
@@ -21,7 +21,7 @@
               "upgrade": false
             }
           ],
-          "blockers": []
+          "blockers": [ ]
         },
         "application": {
           "application": {
@@ -42,21 +42,21 @@
               }
             }
           ],
-          "blockers": []
+          "blockers": [ ]
         }
       },
       "delayCause": null
     },
     {
       "type": "test",
-      "dependencies": [],
+      "dependencies": [ ],
       "declared": true,
       "instance": "default",
       "readyAt": 0,
       "jobName": "staging-test",
       "url": "https://some.url:43/instance/default/job/staging-test",
       "environment": "staging",
-      "toRun": [],
+      "toRun": [ ],
       "enclave": {
         "cloudAccount": "aws:123456789012"
       },
@@ -67,6 +67,11 @@
           "start": 1600000000000,
           "end": 1600000000000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "aws-us-east-1c",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -140,14 +145,14 @@
     },
     {
       "type": "test",
-      "dependencies": [],
+      "dependencies": [ ],
       "declared": true,
       "instance": "default",
       "readyAt": 0,
       "jobName": "system-test",
       "url": "https://some.url:43/instance/default/job/system-test",
       "environment": "test",
-      "toRun": [],
+      "toRun": [ ],
       "enclave": {
         "cloudAccount": "aws:123456789012"
       },
@@ -158,6 +163,11 @@
           "start": 1600000000000,
           "end": 1600000000000,
           "status": "success",
+          "dependent": {
+            "instance": "default",
+            "region": "aws-us-east-1c",
+            "revision": 1
+          },
           "versions": {
             "targetPlatform": "6.1.0",
             "targetApplication": {
@@ -215,7 +225,11 @@
     },
     {
       "type": "deployment",
-      "dependencies": [0, 1, 2],
+      "dependencies": [
+        0,
+        1,
+        2
+      ],
       "declared": true,
       "instance": "default",
       "readyAt": 1600000000000,
@@ -230,7 +244,7 @@
         "sourceUrl": "repository1/tree/commit1",
         "commit": "commit1"
       },
-      "toRun": [],
+      "toRun": [ ],
       "enclave": {
         "cloudAccount": "aws:123456789012"
       },

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-enclave.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/overview-enclave.json
@@ -70,7 +70,7 @@
           "dependent": {
             "instance": "default",
             "region": "aws-us-east-1c",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",
@@ -166,7 +166,7 @@
           "dependent": {
             "instance": "default",
             "region": "aws-us-east-1c",
-            "revision": 1
+            "build": 1
           },
           "versions": {
             "targetPlatform": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
@@ -9,7 +9,7 @@
       "dependent": {
         "instance": "default",
         "region": "us-east-3",
-        "revision": 3
+        "build": 3
       },
       "versions": {
         "targetPlatform": "6.1.0",
@@ -95,7 +95,7 @@
       "dependent": {
         "instance": "default",
         "region": "us-east-3",
-        "revision": 3
+        "build": 3
       },
       "versions": {
         "targetPlatform": "6.1.0",
@@ -181,7 +181,7 @@
       "dependent": {
         "instance": "default",
         "region": "us-central-1",
-        "revision": 3
+        "build": 3
       },
       "versions": {
         "targetPlatform": "6.1.0",
@@ -267,7 +267,7 @@
       "dependent": {
         "instance": "default",
         "region": "us-central-1",
-        "revision": 2
+        "build": 2
       },
       "versions": {
         "targetPlatform": "6.1.0",
@@ -353,7 +353,7 @@
       "dependent": {
         "instance": "default",
         "region": "us-central-1",
-        "revision": 1
+        "build": 1
       },
       "versions": {
         "targetPlatform": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-runs.json
@@ -6,6 +6,11 @@
       "start": 14503000,
       "end": 14503000,
       "status": "installationFailed",
+      "dependent": {
+        "instance": "default",
+        "region": "us-east-3",
+        "revision": 3
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {
@@ -87,6 +92,11 @@
       "start": 14403000,
       "end": 14403000,
       "status": "installationFailed",
+      "dependent": {
+        "instance": "default",
+        "region": "us-east-3",
+        "revision": 3
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {
@@ -168,6 +178,11 @@
       "start": 14403000,
       "end": 14403000,
       "status": "success",
+      "dependent": {
+        "instance": "default",
+        "region": "us-central-1",
+        "revision": 3
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {
@@ -249,6 +264,11 @@
       "start": 1000,
       "end": 1000,
       "status": "success",
+      "dependent": {
+        "instance": "default",
+        "region": "us-central-1",
+        "revision": 2
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {
@@ -330,6 +350,11 @@
       "start": 0,
       "end": 0,
       "status": "success",
+      "dependent": {
+        "instance": "default",
+        "region": "us-central-1",
+        "revision": 1
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
@@ -4,7 +4,7 @@
   "dependent": {
     "instance": "default",
     "region": "us-east-3",
-    "revision": 3
+    "build": 3
   },
   "log": {
     "deployTester": [

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/staging-test-log.json
@@ -1,6 +1,11 @@
 {
   "active": false,
   "status": "installationFailed",
+  "dependent": {
+    "instance": "default",
+    "region": "us-east-3",
+    "revision": 3
+  },
   "log": {
     "deployTester": [
       {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
@@ -4,7 +4,7 @@
   "dependent": {
     "instance": "instance1",
     "region": "us-central-1",
-    "revision": 1
+    "build": 1
   },
   "log": {
     "deployTester": [

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-details.json
@@ -1,6 +1,11 @@
 {
   "active": false,
   "status": "success",
+  "dependent": {
+    "instance": "instance1",
+    "region": "us-central-1",
+    "revision": 1
+  },
   "log": {
     "deployTester": [
       {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-job.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-job.json
@@ -5,6 +5,11 @@
       "url": "http://localhost:8080/application/v4/tenant/tenant1/application/application1/instance/instance1/job/system-test/run/2",
       "start": 1600000000000,
       "status": "running",
+      "dependent": {
+        "instance": "instance1",
+        "region": "us-central-1",
+        "revision": 4
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {
@@ -63,6 +68,11 @@
       "start": 1600000000000,
       "end": 1600000000000,
       "status": "success",
+      "dependent": {
+        "instance": "instance1",
+        "region": "us-central-1",
+        "revision": 1
+      },
       "versions": {
         "targetPlatform": "6.1.0",
         "targetApplication": {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-job.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-job.json
@@ -8,7 +8,7 @@
       "dependent": {
         "instance": "instance1",
         "region": "us-central-1",
-        "revision": 4
+        "build": 4
       },
       "versions": {
         "targetPlatform": "6.1.0",
@@ -71,7 +71,7 @@
       "dependent": {
         "instance": "instance1",
         "region": "us-central-1",
-        "revision": 1
+        "build": 1
       },
       "versions": {
         "targetPlatform": "6.1.0",

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-log.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-log.json
@@ -4,7 +4,7 @@
   "dependent": {
     "instance": "default",
     "region": "us-central-1",
-    "revision": 1
+    "build": 1
   },
   "log": {
     "deployTester": [

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-log.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/system-test-log.json
@@ -1,6 +1,11 @@
 {
   "active": false,
   "status": "success",
+  "dependent": {
+    "instance": "default",
+    "region": "us-central-1",
+    "revision": 1
+  },
   "log": {
     "deployTester": [
       {


### PR DESCRIPTION
@freva please review.
@ldalves FYI.

This adds a 
```json
"dependent": {
  "instance": "my-instance",
  "region": "my-region",
  "platform": "1.2.3",
  "build": 321
}
```
to test runs, to inform the viewer of what production deployment caused the test to trigger, and because of what change to the production deployment. 

I noticed there is already a `"toRun"` array for each job step, which contains the planned runs; I made sure the new triggering information was added there as well. 