### PR TITLE
Remove remaining deprecated "revert" functionality from code base

### DIFF
--- a/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
+++ b/storage/src/tests/storageapi/mbusprot/storageprotocoltest.cpp
@@ -369,20 +369,6 @@ TEST_P(StorageProtocolTest, remove) {
     EXPECT_NO_FATAL_FAILURE(assert_bucket_info_reply_fields_propagated(*reply2));
 }
 
-TEST_P(StorageProtocolTest, revert) {
-    std::vector<Timestamp> tokens;
-    tokens.push_back(59);
-    auto cmd = std::make_shared<RevertCommand>(_bucket, tokens);
-    auto cmd2 = copyCommand(cmd);
-    EXPECT_EQ(_bucket, cmd2->getBucket());
-    EXPECT_EQ(tokens, cmd2->getRevertTokens());
-
-    auto reply = std::make_shared<RevertReply>(*cmd2);
-    set_dummy_bucket_info_reply_fields(*reply);
-    auto reply2 = copyReply(reply);
-    EXPECT_NO_FATAL_FAILURE(assert_bucket_info_reply_fields_propagated(*reply2));
-}
-
 TEST_P(StorageProtocolTest, request_bucket_info) {
     {
         std::vector<document::BucketId> ids;

--- a/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
+++ b/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
@@ -491,12 +491,6 @@ TEST_F(ChangedBucketOwnershipHandlerTest, abort_outdated_remove_command) {
     expectChangeAbortsMessage<api::RemoveCommand>(false, getBucketToAllow(), docId, api::Timestamp(1234));
 }
 
-TEST_F(ChangedBucketOwnershipHandlerTest, abort_outdated_revert_command) {
-    std::vector<api::Timestamp> timestamps;
-    expectChangeAbortsMessage<api::RevertCommand>(true, getBucketToAbort(), timestamps);
-    expectChangeAbortsMessage<api::RevertCommand>(false, getBucketToAllow(), timestamps);
-}
-
 TEST_F(ChangedBucketOwnershipHandlerTest, ideal_state_abort_updates_metric) {
     expectChangeAbortsMessage<api::SplitBucketCommand>(true, getBucketToAbort());
     EXPECT_EQ(1, _handler->getMetrics().idealStateOpsAborted.getValue());

--- a/storage/src/vespa/storage/common/messagebucket.cpp
+++ b/storage/src/vespa/storage/common/messagebucket.cpp
@@ -25,8 +25,6 @@ getStorageMessageBucket(const api::StorageMessage& msg)
         return static_cast<const api::UpdateCommand&>(msg).getBucket();
     case api::MessageType::REMOVE_ID:
         return static_cast<const api::RemoveCommand&>(msg).getBucket();
-    case api::MessageType::REVERT_ID:
-        return static_cast<const api::RevertCommand&>(msg).getBucket();
     case api::MessageType::STATBUCKET_ID:
         return static_cast<const api::StatBucketCommand&>(msg).getBucket();
     case api::MessageType::REMOVELOCATION_ID:

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -286,7 +286,6 @@ FileStorHandlerImpl::messageMayBeAborted(const api::StorageMessage& msg)
     switch (msg.getType().getId()) {
     case api::MessageType::PUT_ID:
     case api::MessageType::REMOVE_ID:
-    case api::MessageType::REVERT_ID:
     case api::MessageType::MERGEBUCKET_ID:
     case api::MessageType::GETBUCKETDIFF_ID:
     case api::MessageType::APPLYBUCKETDIFF_ID:
@@ -611,7 +610,6 @@ FileStorHandlerImpl::remapMessage(api::StorageMessage& msg, const document::Buck
         break;
     }
     case api::MessageType::STAT_ID:
-    case api::MessageType::REVERT_ID:
     case api::MessageType::REMOVELOCATION_ID:
     case api::MessageType::SETBUCKETSTATE_ID:
     {

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -447,16 +447,6 @@ FileStorManager::onRemove(const shared_ptr<api::RemoveCommand>& cmd)
 }
 
 bool
-FileStorManager::onRevert(const shared_ptr<api::RevertCommand>& cmd)
-{
-    StorBucketDatabase::WrappedEntry entry(mapOperationToBucketAndDisk(*cmd, 0));
-    if (entry.exists()) {
-        handlePersistenceMessage(cmd);
-    }
-    return true;
-}
-
-bool
 FileStorManager::onRemoveLocation(const std::shared_ptr<api::RemoveLocationCommand>& cmd)
 {
     StorBucketDatabase::WrappedEntry entry(mapOperationToDisk(*cmd, cmd->getBucket()));

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -151,7 +151,6 @@ private:
     bool onUpdate(const std::shared_ptr<api::UpdateCommand>&) override;
     bool onGet(const std::shared_ptr<api::GetCommand>&) override;
     bool onRemove(const std::shared_ptr<api::RemoveCommand>&) override;
-    bool onRevert(const std::shared_ptr<api::RevertCommand>&) override;
     bool onStatBucket(const std::shared_ptr<api::StatBucketCommand>&) override;
 
     // Bucket operations

--- a/storage/src/vespa/storage/persistence/persistencehandler.cpp
+++ b/storage/src/vespa/storage/persistence/persistencehandler.cpp
@@ -65,8 +65,6 @@ PersistenceHandler::handleCommandSplitByType(api::StorageCommand& msg, MessageTr
         return _asyncHandler.handleRemove(static_cast<api::RemoveCommand&>(msg), std::move(tracker));
     case api::MessageType::UPDATE_ID:
         return _asyncHandler.handleUpdate(static_cast<api::UpdateCommand&>(msg), std::move(tracker));
-    case api::MessageType::REVERT_ID:
-        return _simpleHandler.handleRevert(static_cast<api::RevertCommand&>(msg), std::move(tracker));
     case api::MessageType::CREATEBUCKET_ID:
         return _asyncHandler.handleCreateBucket(static_cast<api::CreateBucketCommand&>(msg), std::move(tracker));
     case api::MessageType::DELETEBUCKET_ID:

--- a/storage/src/vespa/storage/persistence/persistenceutil.cpp
+++ b/storage/src/vespa/storage/persistence/persistenceutil.cpp
@@ -15,8 +15,7 @@ namespace {
     {
         return (id == api::MessageType::PUT_ID ||
                 id == api::MessageType::REMOVE_ID ||
-                id == api::MessageType::UPDATE_ID ||
-                id == api::MessageType::REVERT_ID);
+                id == api::MessageType::UPDATE_ID);
     }
 
     bool hasBucketInfo(api::MessageType::Id id)

--- a/storage/src/vespa/storage/persistence/simplemessagehandler.cpp
+++ b/storage/src/vespa/storage/persistence/simplemessagehandler.cpp
@@ -102,18 +102,6 @@ SimpleMessageHandler::handleGet(api::GetCommand& cmd, MessageTracker::UP tracker
 }
 
 MessageTracker::UP
-SimpleMessageHandler::handleRevert(api::RevertCommand& cmd, MessageTracker::UP tracker) const
-{
-    tracker->setMetric(_env._metrics.revert);
-    spi::Bucket b = spi::Bucket(cmd.getBucket());
-    const std::vector<api::Timestamp> & tokens = cmd.getRevertTokens();
-    for (const api::Timestamp & token : tokens) {
-        spi::Result result = _spi.removeEntry(b, spi::Timestamp(token));
-    }
-    return tracker;
-}
-
-MessageTracker::UP
 SimpleMessageHandler::handleGetIter(GetIterCommand& cmd, MessageTracker::UP tracker) const
 {
     tracker->setMetric(_env._metrics.visit);

--- a/storage/src/vespa/storage/persistence/simplemessagehandler.h
+++ b/storage/src/vespa/storage/persistence/simplemessagehandler.h
@@ -24,7 +24,6 @@ public:
                          spi::PersistenceProvider&,
                          const document::BucketIdFactory&);
     MessageTrackerUP handleGet(api::GetCommand& cmd, MessageTrackerUP tracker) const;
-    MessageTrackerUP handleRevert(api::RevertCommand& cmd, MessageTrackerUP tracker) const;
     MessageTrackerUP handleCreateIterator(CreateIteratorCommand& cmd, MessageTrackerUP tracker) const;
     MessageTrackerUP handleGetIter(GetIterCommand& cmd, MessageTrackerUP tracker) const;
 private:

--- a/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.cpp
+++ b/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.cpp
@@ -367,7 +367,6 @@ ChangedBucketOwnershipHandler::isMutatingExternalOperation(
     case api::MessageType::PUT_ID:
     case api::MessageType::REMOVE_ID:
     case api::MessageType::UPDATE_ID:
-    case api::MessageType::REVERT_ID:
         return true;
     default:
         return false;

--- a/storage/src/vespa/storageapi/mbusprot/protocolserialization.cpp
+++ b/storage/src/vespa/storageapi/mbusprot/protocolserialization.cpp
@@ -49,12 +49,6 @@ ProtocolSerialization::encode(const api::StorageMessage& msg) const
     case api::MessageType::REMOVE_REPLY_ID:
         onEncode(buf, static_cast<const api::RemoveReply&>(msg));
         break;
-    case api::MessageType::REVERT_ID:
-        onEncode(buf, static_cast<const api::RevertCommand&>(msg));
-        break;
-    case api::MessageType::REVERT_REPLY_ID:
-        onEncode(buf, static_cast<const api::RevertReply&>(msg));
-        break;
     case api::MessageType::DELETEBUCKET_ID:
         onEncode(buf, static_cast<const api::DeleteBucketCommand&>(msg));
         break;
@@ -140,9 +134,8 @@ ProtocolSerialization::encode(const api::StorageMessage& msg) const
         onEncode(buf, static_cast<const api::SetBucketStateReply&>(msg));
         break;
     default:
-        LOG(error, "Trying to encode unhandled type %s",
-            msg.getType().toString().c_str());
-        break;
+        LOG(error, "Trying to encode unhandled type %s", msg.getType().toString().c_str());
+        abort();
     }
 
     mbus::Blob retVal(buf.position());
@@ -174,8 +167,6 @@ ProtocolSerialization::decodeCommand(mbus::BlobRef data) const
         cmd = onDecodeGetCommand(buf); break;
     case api::MessageType::REMOVE_ID:
         cmd = onDecodeRemoveCommand(buf); break;
-    case api::MessageType::REVERT_ID:
-        cmd = onDecodeRevertCommand(buf); break;
     case api::MessageType::CREATEBUCKET_ID:
         cmd = onDecodeCreateBucketCommand(buf); break;
     case api::MessageType::DELETEBUCKET_ID:
@@ -238,8 +229,6 @@ ProtocolSerialization::decodeReply(mbus::BlobRef data, const api::StorageCommand
         reply = onDecodeGetReply(cmd, buf); break;
     case api::MessageType::REMOVE_REPLY_ID:
         reply = onDecodeRemoveReply(cmd, buf); break;
-    case api::MessageType::REVERT_REPLY_ID:
-        reply = onDecodeRevertReply(cmd, buf); break;
     case api::MessageType::CREATEBUCKET_REPLY_ID:
         reply = onDecodeCreateBucketReply(cmd, buf); break;
     case api::MessageType::DELETEBUCKET_REPLY_ID:

--- a/storage/src/vespa/storageapi/mbusprot/protocolserialization.h
+++ b/storage/src/vespa/storageapi/mbusprot/protocolserialization.h
@@ -25,8 +25,6 @@ class GetCommand;
 class GetReply;
 class RemoveCommand;
 class RemoveReply;
-class RevertCommand;
-class RevertReply;
 class DeleteBucketCommand;
 class DeleteBucketReply;
 class CreateBucketCommand;
@@ -85,8 +83,6 @@ protected:
     virtual void onEncode(GBBuf&, const api::GetReply&) const = 0;
     virtual void onEncode(GBBuf&, const api::RemoveCommand&) const = 0;
     virtual void onEncode(GBBuf&, const api::RemoveReply&) const = 0;
-    virtual void onEncode(GBBuf&, const api::RevertCommand&) const = 0;
-    virtual void onEncode(GBBuf&, const api::RevertReply&) const = 0;
     virtual void onEncode(GBBuf&, const api::DeleteBucketCommand&) const = 0;
     virtual void onEncode(GBBuf&, const api::DeleteBucketReply&) const = 0;
     virtual void onEncode(GBBuf&, const api::CreateBucketCommand&) const = 0;
@@ -124,8 +120,6 @@ protected:
     virtual SRep::UP onDecodeGetReply(const SCmd&, BBuf&) const = 0;
     virtual SCmd::UP onDecodeRemoveCommand(BBuf&) const = 0;
     virtual SRep::UP onDecodeRemoveReply(const SCmd&, BBuf&) const = 0;
-    virtual SCmd::UP onDecodeRevertCommand(BBuf&) const = 0;
-    virtual SRep::UP onDecodeRevertReply(const SCmd&, BBuf&) const = 0;
     virtual SCmd::UP onDecodeDeleteBucketCommand(BBuf&) const = 0;
     virtual SRep::UP onDecodeDeleteBucketReply(const SCmd&, BBuf&) const = 0;
     virtual SCmd::UP onDecodeCreateBucketCommand(BBuf&) const = 0;

--- a/storage/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
+++ b/storage/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
@@ -624,42 +624,6 @@ api::StorageReply::UP ProtocolSerialization7::onDecodeGetReply(const SCmd& cmd, 
 }
 
 // -----------------------------------------------------------------
-// Revert
-// -----------------------------------------------------------------
-
-void ProtocolSerialization7::onEncode(GBBuf& buf, const api::RevertCommand& msg) const {
-    encode_bucket_request<protobuf::RevertRequest>(buf, msg, [&](auto& req) {
-        auto* tokens = req.mutable_revert_tokens();
-        assert(msg.getRevertTokens().size() <= INT_MAX);
-        tokens->Reserve(static_cast<int>(msg.getRevertTokens().size()));
-        for (auto token : msg.getRevertTokens()) {
-            tokens->Add(token);
-        }
-    });
-}
-
-void ProtocolSerialization7::onEncode(GBBuf& buf, const api::RevertReply& msg) const {
-    encode_bucket_info_response<protobuf::RevertResponse>(buf, msg, no_op_encode);
-}
-
-api::StorageCommand::UP ProtocolSerialization7::onDecodeRevertCommand(BBuf& buf) const {
-    return decode_bucket_request<protobuf::RevertRequest>(buf, [&](auto& req, auto& bucket) {
-        std::vector<api::Timestamp> tokens;
-        tokens.reserve(req.revert_tokens_size());
-        for (auto token : req.revert_tokens()) {
-            tokens.emplace_back(api::Timestamp(token));
-        }
-        return std::make_unique<api::RevertCommand>(bucket, std::move(tokens));
-    });
-}
-
-api::StorageReply::UP ProtocolSerialization7::onDecodeRevertReply(const SCmd& cmd, BBuf& buf) const {
-    return decode_bucket_info_response<protobuf::RevertResponse>(buf, [&]([[maybe_unused]] auto& res) {
-        return std::make_unique<api::RevertReply>(static_cast<const api::RevertCommand&>(cmd));
-    });
-}
-
-// -----------------------------------------------------------------
 // RemoveLocation
 // -----------------------------------------------------------------
 

--- a/storage/src/vespa/storageapi/mbusprot/protocolserialization7.h
+++ b/storage/src/vespa/storageapi/mbusprot/protocolserialization7.h
@@ -41,12 +41,6 @@ public:
     SCmd::UP onDecodeGetCommand(BBuf&) const override;
     SRep::UP onDecodeGetReply(const SCmd&, BBuf&) const override;
 
-    // Revert - TODO this is deprecated, no?
-    void onEncode(GBBuf&, const api::RevertCommand&) const override;
-    void onEncode(GBBuf&, const api::RevertReply&) const override;
-    SCmd::UP onDecodeRevertCommand(BBuf&) const override;
-    SRep::UP onDecodeRevertReply(const SCmd&, BBuf&) const override;
-
     // DeleteBucket
     void onEncode(GBBuf&, const api::DeleteBucketCommand&) const override;
     void onEncode(GBBuf&, const api::DeleteBucketReply&) const override;

--- a/storage/src/vespa/storageapi/mbusprot/storagemessage.h
+++ b/storage/src/vespa/storageapi/mbusprot/storagemessage.h
@@ -9,7 +9,7 @@ class StorageMessage {
 public:
     using UP = std::unique_ptr<StorageMessage>;
 
-    virtual ~StorageMessage() {}
+    virtual ~StorageMessage() = default;
 
     virtual api::StorageMessage::SP getInternalMessage() = 0;
     virtual api::StorageMessage::CSP getInternalMessage() const = 0;

--- a/storage/src/vespa/storageapi/message/persistence.cpp
+++ b/storage/src/vespa/storageapi/message/persistence.cpp
@@ -17,8 +17,6 @@ IMPLEMENT_COMMAND(GetCommand, GetReply)
 IMPLEMENT_REPLY(GetReply)
 IMPLEMENT_COMMAND(RemoveCommand, RemoveReply)
 IMPLEMENT_REPLY(RemoveReply)
-IMPLEMENT_COMMAND(RevertCommand, RevertReply)
-IMPLEMENT_REPLY(RevertReply)
 
 TestAndSetCommand::TestAndSetCommand(const MessageType & messageType, const document::Bucket &bucket)
     : BucketInfoCommand(messageType, bucket)
@@ -303,49 +301,6 @@ RemoveReply::print(std::ostream& out, bool verbose, const std::string& indent) c
         out << ", not found";
     }
     out << ")";
-    if (verbose) {
-        out << " : ";
-        BucketInfoReply::print(out, verbose, indent);
-    }
-}
-
-RevertCommand::RevertCommand(const document::Bucket &bucket, const std::vector<Timestamp>& revertTokens)
-    : BucketInfoCommand(MessageType::REVERT, bucket),
-      _tokens(revertTokens)
-{
-}
-
-RevertCommand::~RevertCommand() = default;
-
-void
-RevertCommand::print(std::ostream& out, bool verbose, const std::string& indent) const
-{
-    out << "Revert(" << getBucketId();
-    if (verbose) {
-        out << ",";
-        for (Timestamp token : _tokens) {
-            out << "\n" << indent << "  " << token;
-        }
-    }
-    out << ")";
-    if (verbose) {
-        out << " : ";
-        BucketInfoCommand::print(out, verbose, indent);
-    }
-}
-
-RevertReply::RevertReply(const RevertCommand& cmd)
-    : BucketInfoReply(cmd),
-      _tokens(cmd.getRevertTokens())
-{
-}
-
-RevertReply::~RevertReply() = default;
-
-void
-RevertReply::print(std::ostream& out, bool verbose, const std::string& indent) const
-{
-    out << "RevertReply(" << getBucketId() << ")";
     if (verbose) {
         out << " : ";
         BucketInfoReply::print(out, verbose, indent);

--- a/storage/src/vespa/storageapi/message/persistence.h
+++ b/storage/src/vespa/storageapi/message/persistence.h
@@ -308,37 +308,4 @@ public:
     DECLARE_STORAGEREPLY(RemoveReply, onRemoveReply)
 };
 
-/**
- * @class RevertCommand
- * @ingroup message
- *
- * @brief Command for reverting a write or remove operation.
- */
-class RevertCommand : public BucketInfoCommand {
-    std::vector<Timestamp> _tokens;
-public:
-    RevertCommand(const document::Bucket &bucket,
-                  const std::vector<Timestamp>& revertTokens);
-    ~RevertCommand() override;
-    const std::vector<Timestamp>& getRevertTokens() const { return _tokens; }
-    void print(std::ostream& out, bool verbose, const std::string& indent) const override;
-    DECLARE_STORAGECOMMAND(RevertCommand, onRevert)
-};
-
-/**
- * @class RevertReply
- * @ingroup message
- *
- * @brief Reply for a revert command.
- */
-class RevertReply : public BucketInfoReply {
-    std::vector<Timestamp> _tokens;
-public:
-    explicit RevertReply(const RevertCommand& cmd);
-    ~RevertReply() override;
-    const std::vector<Timestamp>& getRevertTokens() const { return _tokens; }
-    void print(std::ostream& out, bool verbose, const std::string& indent) const override;
-    DECLARE_STORAGEREPLY(RevertReply, onRevertReply)
-};
-
 }

--- a/storage/src/vespa/storageapi/messageapi/messagehandler.h
+++ b/storage/src/vespa/storageapi/messageapi/messagehandler.h
@@ -23,7 +23,6 @@ class GetCommand; // Retrieve document
 class PutCommand; // Add document
 class UpdateCommand; // Update document
 class RemoveCommand; // Remove document
-class RevertCommand; // Revert put/remove operation
 
 class CreateVisitorCommand; // Create a new visitor
 class DestroyVisitorCommand; // Destroy a running visitor
@@ -59,7 +58,6 @@ class GetReply;
 class PutReply;
 class UpdateReply;
 class RemoveReply;
-class RevertReply;
 
 class CreateVisitorReply;
 class DestroyVisitorReply;
@@ -122,8 +120,6 @@ public:
     virtual bool onUpdateReply(const std::shared_ptr<api::UpdateReply>&) { return false; }
     virtual bool onRemove(const std::shared_ptr<api::RemoveCommand>&) { return false; }
     virtual bool onRemoveReply(const std::shared_ptr<api::RemoveReply>&) { return false; }
-    virtual bool onRevert(const std::shared_ptr<api::RevertCommand>&) { return false; }
-    virtual bool onRevertReply(const std::shared_ptr<api::RevertReply>&) { return false; }
 
     virtual bool onCreateVisitor(const std::shared_ptr<api::CreateVisitorCommand>&) { return false; }
     virtual bool onCreateVisitorReply(const std::shared_ptr<api::CreateVisitorReply>&) { return false; }

--- a/storage/src/vespa/storageapi/messageapi/storagemessage.cpp
+++ b/storage/src/vespa/storageapi/messageapi/storagemessage.cpp
@@ -44,8 +44,6 @@ const MessageType MessageType::UPDATE("Update", UPDATE_ID);
 const MessageType MessageType::UPDATE_REPLY("Update Reply", UPDATE_REPLY_ID, &MessageType::UPDATE);
 const MessageType MessageType::REMOVE("Remove", REMOVE_ID);
 const MessageType MessageType::REMOVE_REPLY("Remove Reply", REMOVE_REPLY_ID, &MessageType::REMOVE);
-const MessageType MessageType::REVERT("Revert", REVERT_ID);
-const MessageType MessageType::REVERT_REPLY("Revert Reply", REVERT_REPLY_ID, &MessageType::REVERT);
 const MessageType MessageType::VISITOR_CREATE("Visitor Create", VISITOR_CREATE_ID);
 const MessageType MessageType::VISITOR_CREATE_REPLY("Visitor Create Reply", VISITOR_CREATE_REPLY_ID, &MessageType::VISITOR_CREATE);
 const MessageType MessageType::VISITOR_DESTROY("Visitor Destroy", VISITOR_DESTROY_ID);

--- a/storage/src/vespa/storageapi/messageapi/storagemessage.h
+++ b/storage/src/vespa/storageapi/messageapi/storagemessage.h
@@ -80,8 +80,8 @@ public:
         PUT_REPLY_ID = 11,
         REMOVE_ID = 12,
         REMOVE_REPLY_ID = 13,
-        REVERT_ID = 14,
-        REVERT_REPLY_ID = 15,
+        // REVERT_ID = 14,       unused but reserved
+        // REVERT_REPLY_ID = 15, unused but reserved
         STAT_ID = 16,
         STAT_REPLY_ID = 17,
         VISITOR_CREATE_ID = 18,
@@ -164,8 +164,6 @@ public:
     static const MessageType PUT_REPLY;
     static const MessageType REMOVE;
     static const MessageType REMOVE_REPLY;
-    static const MessageType REVERT;
-    static const MessageType REVERT_REPLY;
     static const MessageType VISITOR_CREATE;
     static const MessageType VISITOR_CREATE_REPLY;
     static const MessageType VISITOR_DESTROY;


### PR DESCRIPTION
@geirst and/or @baldersheim please review

Serialization code can safely be removed, as no revert-related messages have ever flown across the wire in the new serialization format.

