### PR TITLE
Add feature flag for new content layer metadata features

### DIFF
--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -116,6 +116,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"mortent", "olaa"}) default boolean enableDataplaneProxy() { return false; }
         @ModelFeatureFlag(owners = {"baldersheim"}) default boolean enableNestedMultivalueGrouping() { return false; }
         @ModelFeatureFlag(owners = {"jonmv"}) default boolean useReconfigurableDispatcher() { return false; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default int contentLayerMetadataFeatureLevel() { return 0; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -86,6 +86,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private boolean allowUserFilters = true;
     private List<DataplaneToken> dataplaneTokens;
     private boolean enableDataplaneProxy;
+    private int contentLayerMetadataFeatureLevel = 0;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -144,6 +145,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public boolean enableGlobalPhase() { return true; } // Enable global-phase by default for unit tests only
     @Override public List<DataplaneToken> dataplaneTokens() { return dataplaneTokens; }
     @Override public boolean enableDataplaneProxy() { return enableDataplaneProxy; }
+    @Override public int contentLayerMetadataFeatureLevel() { return contentLayerMetadataFeatureLevel; }
 
     public TestProperties sharedStringRepoNoReclaim(boolean sharedStringRepoNoReclaim) {
         this.sharedStringRepoNoReclaim = sharedStringRepoNoReclaim;
@@ -376,6 +378,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setEnableDataplaneProxy(boolean enable) {
         this.enableDataplaneProxy = enable;
+        return this;
+    }
+
+    public TestProperties setContentLayerMetadataFeatureLevel(int level) {
+        this.contentLayerMetadataFeatureLevel = level;
         return this;
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1479,6 +1479,23 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(expectedGroupsAllowedDown, config.max_number_of_groups_allowed_to_be_down());
     }
 
+    private boolean resolveDistributorOperationCancellationConfig(Integer featureLevel) throws Exception {
+        var properties = new TestProperties();
+        if (featureLevel != null) {
+            properties.setContentLayerMetadataFeatureLevel(featureLevel);
+        }
+        var cfg = resolveStorDistributormanagerConfig(properties);
+        return cfg.enable_operation_cancellation();
+    }
+
+    @Test
+    void distributor_operation_cancelling_config_controlled_by_properties() throws Exception {
+        assertFalse(resolveDistributorOperationCancellationConfig(null)); // defaults to false
+        assertFalse(resolveDistributorOperationCancellationConfig(0));
+        assertTrue(resolveDistributorOperationCancellationConfig(1));
+        assertTrue(resolveDistributorOperationCancellationConfig(2));
+    }
+
     private String servicesWithGroups(int groupCount, double minGroupUpRatio) {
         String services = String.format("<?xml version='1.0' encoding='UTF-8' ?>" +
                 "<services version='1.0'>" +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -201,6 +201,7 @@ public class ModelContextImpl implements ModelContext {
         private final boolean enableDataplaneProxy;
         private final boolean enableNestedMultivalueGrouping;
         private final boolean useReconfigurableDispatcher;
+        private final int contentLayerMetadataFeatureLevel;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.defaultTermwiseLimit = flagValue(source, appId, version, Flags.DEFAULT_TERM_WISE_LIMIT);
@@ -243,6 +244,7 @@ public class ModelContextImpl implements ModelContext {
             this.enableDataplaneProxy = flagValue(source, appId, version, Flags.ENABLE_DATAPLANE_PROXY);
             this.enableNestedMultivalueGrouping = flagValue(source, appId, version, Flags.ENABLE_NESTED_MULTIVALUE_GROUPING);
             this.useReconfigurableDispatcher = flagValue(source, appId, version, Flags.USE_RECONFIGURABLE_DISPATCHER);
+            this.contentLayerMetadataFeatureLevel = flagValue(source, appId, version, Flags.CONTENT_LAYER_METADATA_FEATURE_LEVEL);
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }
@@ -293,6 +295,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public boolean enableDataplaneProxy() { return enableDataplaneProxy; }
         @Override public boolean enableNestedMultivalueGrouping() { return enableNestedMultivalueGrouping; }
         @Override public boolean useReconfigurableDispatcher() { return useReconfigurableDispatcher; }
+        @Override public int contentLayerMetadataFeatureLevel() { return contentLayerMetadataFeatureLevel; }
 
         private static <V> V flagValue(FlagSource source, ApplicationId appId, Version vespaVersion, UnboundFlag<? extends V, ?, ?> flag) {
             return flag.bindTo(source)

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -398,6 +398,14 @@ public class Flags {
             "Takes effect immediately",
             APPLICATION_ID);
 
+    public static final UnboundIntFlag CONTENT_LAYER_METADATA_FEATURE_LEVEL = defineIntFlag(
+            "content-layer-metadata-feature-level", 0,
+            List.of("vekterli"), "2022-09-12", "2024-02-01",
+            "Value semantics: 0) legacy behavior, 1) operation cancellation, 2) operation " +
+            "cancellation and ephemeral content node sequence numbers for bucket replicas",
+            "Takes effect at redeployment",
+            APPLICATION_ID);
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,


### PR DESCRIPTION
@baldersheim please review

Exposed as an integer rather than a bool to account for future additions without needing to add more feature flags. In particular this is because those features are expected to build on top of the preexisting features, so it's not a mix and match situation.

Only values 0 (legacy) and 1 (operation cancellation) map to any underlying configs at this time, though any higher number will transparently enable cancellation. Value 2 is documented based on its intended future™️ semantics.

Side note: technically this config _currently_ takes effect immediately, but this will be changed to be sticky upon startup since it's not safe to change these things live for a distributor process.
