### PR TITLE
Remove default wait

### DIFF
--- a/client/go/internal/cli/cmd/curl.go
+++ b/client/go/internal/cli/cmd/curl.go
@@ -80,7 +80,7 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 	}
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Print the curl command that would be executed")
 	cmd.Flags().StringVarP(&curlService, "service", "s", "container", "Which service to query. Must be \"deploy\" or \"container\"")
-	cli.bindWaitFlag(cmd, 60, &waitSecs)
+	cli.bindWaitFlag(cmd, 0, &waitSecs)
 	return cmd
 }
 

--- a/client/go/internal/cli/cmd/deploy.go
+++ b/client/go/internal/cli/cmd/deploy.go
@@ -101,7 +101,7 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 	cmd.Flags().StringVarP(&logLevelArg, "log-level", "l", "error", `Log level for Vespa logs. Must be "error", "warning", "info" or "debug"`)
 	cmd.Flags().StringVarP(&versionArg, "version", "V", "", `Override the Vespa runtime version to use in Vespa Cloud`)
 	cmd.Flags().BoolVarP(&copyCert, "add-cert", "A", false, `Copy certificate of the configured application to the current application package`)
-	cli.bindWaitFlag(cmd, 60, &waitSecs)
+	cli.bindWaitFlag(cmd, 0, &waitSecs)
 	return cmd
 }
 
@@ -171,7 +171,7 @@ func newActivateCmd(cli *CLI) *cobra.Command {
 			return waitForDeploymentReady(cli, target, sessionID, timeout)
 		},
 	}
-	cli.bindWaitFlag(cmd, 60, &waitSecs)
+	cli.bindWaitFlag(cmd, 0, &waitSecs)
 	return cmd
 }
 


### PR DESCRIPTION
This was the old behavior, which was a perfectly fine default. We can't guess a
reasonable default that works for all scenarios.

This is what `vespa deploy` prints when there is no wait:

```
$ vespa deploy -t cloud -w 0
Uploading application package... done

Success: Triggered deployment of . with run ID 229

Use vespa status deployment for deployment status, or follow this deployment at
https://<console-url>/run/229
```

`--wait` can be explicitly set by the user when they really want a deadline for
the operation (this is what `--wait` means: fail if there is no success within
deadline), e.g. in CI environments or for other scripting purposes.

@bratseth

FYI @jobergum @kkraune