### PR TITLE
Reapply wg timestamp in node repo

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/WireguardKey.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/WireguardKey.java
@@ -1,7 +1,6 @@
 package com.yahoo.config.provision;
 
 import ai.vespa.validation.PatternedStringWrapper;
-import com.google.common.io.CharStreams;
 
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -16,6 +15,8 @@ public class WireguardKey extends PatternedStringWrapper<WireguardKey> {
 
     // See https://stackoverflow.com/questions/74438436/how-to-validate-a-wireguard-public-key
     private static final Pattern pattern = Pattern.compile("^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw480]=$");
+
+    public static final WireguardKey UNINITIALIZED = new WireguardKey("uninitialized+++++++++++++++++++++++++++++0=");
 
     public WireguardKey(String value) {
         super(value, pattern, "Wireguard key");

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -75,6 +75,8 @@ public class NodeSpec {
 
     private final Optional<WireguardKey> wireguardPubkey;
 
+    private final Optional<Instant> wireguardKeyTimestamp;
+
     private final boolean wantToRebuild;
 
     public NodeSpec(
@@ -111,6 +113,7 @@ public class NodeSpec {
             Optional<ApplicationId> exclusiveTo,
             List<TrustStoreItem> trustStore,
             Optional<WireguardKey> wireguardPubkey,
+            Optional<Instant> wireguardKeyTimestamp,
             boolean wantToRebuild) {
 
         if (state == NodeState.active) {
@@ -155,6 +158,7 @@ public class NodeSpec {
         this.exclusiveTo = Objects.requireNonNull(exclusiveTo);
         this.trustStore = Objects.requireNonNull(trustStore);
         this.wireguardPubkey = Objects.requireNonNull(wireguardPubkey);
+        this.wireguardKeyTimestamp = Objects.requireNonNull(wireguardKeyTimestamp);
         this.wantToRebuild = wantToRebuild;
     }
 
@@ -311,6 +315,8 @@ public class NodeSpec {
 
     public Optional<WireguardKey> wireguardPubkey() { return wireguardPubkey; }
 
+    public Optional<Instant> wireguardKeyTimestamp() { return wireguardKeyTimestamp; }
+
     public boolean wantToRebuild() {
         return wantToRebuild;
     }
@@ -353,6 +359,7 @@ public class NodeSpec {
                 Objects.equals(exclusiveTo, that.exclusiveTo) &&
                 Objects.equals(trustStore, that.trustStore) &&
                 Objects.equals(wireguardPubkey, that.wireguardPubkey) &&
+                Objects.equals(wireguardKeyTimestamp, that.wireguardKeyTimestamp) &&
                 Objects.equals(wantToRebuild, that.wantToRebuild);
     }
 
@@ -392,6 +399,7 @@ public class NodeSpec {
                 exclusiveTo,
                 trustStore,
                 wireguardPubkey,
+                wireguardKeyTimestamp,
                 wantToRebuild);
     }
 
@@ -431,6 +439,7 @@ public class NodeSpec {
                 + " exclusiveTo=" + exclusiveTo
                 + " trustStore=" + trustStore
                 + " wireguardPubkey=" + wireguardPubkey
+                + " wireguardKeyTimestamp=" + wireguardKeyTimestamp
                 + " wantToRebuild=" + wantToRebuild
                 + " }";
     }
@@ -469,6 +478,7 @@ public class NodeSpec {
         private Optional<ApplicationId> exclusiveTo = Optional.empty();
         private List<TrustStoreItem> trustStore = List.of();
         private Optional<WireguardKey> wireguardPubkey = Optional.empty();
+        private Optional<Instant> wireguardKeyTimestamp = Optional.empty();
         private boolean wantToRebuild = false;
 
         public Builder() {}
@@ -505,6 +515,7 @@ public class NodeSpec {
             node.exclusiveTo.ifPresent(this::exclusiveTo);
             trustStore(node.trustStore);
             node.wireguardPubkey.ifPresent(this::wireguardPubkey);
+            node.wireguardKeyTimestamp.ifPresent(this::wireguardKeyTimestamp);
             wantToRebuild(node.wantToRebuild);
         }
 
@@ -693,8 +704,13 @@ public class NodeSpec {
             return this;
         }
 
-        public Builder wireguardPubkey(WireguardKey wireguardKey) {
-            wireguardPubkey = Optional.of(wireguardKey);
+        public Builder wireguardPubkey(WireguardKey wireguardPubKey) {
+            this.wireguardPubkey = Optional.of(wireguardPubKey);
+            return this;
+        }
+
+        public Builder wireguardKeyTimestamp(Instant wireguardKeyTimestamp) {
+            this.wireguardKeyTimestamp = Optional.of(wireguardKeyTimestamp);
             return this;
         }
 
@@ -830,7 +846,7 @@ public class NodeSpec {
                                 wantedFirmwareCheck, currentFirmwareCheck, modelName,
                                 resources, realResources, ipAddresses, additionalIpAddresses,
                                 reports, events, parentHostname, archiveUri, exclusiveTo, trustStore,
-                                wireguardPubkey, wantToRebuild);
+                                wireguardPubkey, wireguardKeyTimestamp, wantToRebuild);
         }
 
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -147,10 +147,13 @@ public class RealNodeRepository implements NodeRepository {
                             .toList();
                     if (ipAddresses.isEmpty()) return;
 
+                    // Unbox to prevent NPE
+                    long keyTimestamp = node.wireguardKeyTimestamp == null ? 0L : node.wireguardKeyTimestamp;
+
                     consumer.accept(new WireguardPeer(HostName.of(node.hostname),
                                                       ipAddresses,
                                                       WireguardKey.from(node.wireguardPubkey),
-                                                      Instant.ofEpochMilli(node.wireguardKeyTimestamp)));
+                                                      Instant.ofEpochMilli(keyTimestamp)));
                 })
                 .sorted()
                 .toList();
@@ -369,9 +372,12 @@ public class RealNodeRepository implements NodeRepository {
     }
 
     private static WireguardPeer createConfigserverPeer(GetWireguardResponse.Configserver configServer) {
+        // Unbox to prevent NPE
+        long keyTimestamp = configServer.wireguardKeyTimestamp == null ? 0L : configServer.wireguardKeyTimestamp;
+
         return new WireguardPeer(HostName.of(configServer.hostname),
                                  configServer.ipAddresses.stream().map(VersionedIpAddress::from).toList(),
                                  WireguardKey.from(configServer.wireguardPubkey),
-                                 Instant.ofEpochMilli(configServer.wireguardKeyTimestamp));
+                                 Instant.ofEpochMilli(keyTimestamp));
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepository.java
@@ -147,8 +147,10 @@ public class RealNodeRepository implements NodeRepository {
                             .toList();
                     if (ipAddresses.isEmpty()) return;
 
-                    consumer.accept(new WireguardPeer(
-                            HostName.of(node.hostname), ipAddresses, WireguardKey.from(node.wireguardPubkey)));
+                    consumer.accept(new WireguardPeer(HostName.of(node.hostname),
+                                                      ipAddresses,
+                                                      WireguardKey.from(node.wireguardPubkey),
+                                                      Instant.ofEpochMilli(node.wireguardKeyTimestamp)));
                 })
                 .sorted()
                 .toList();
@@ -242,6 +244,7 @@ public class RealNodeRepository implements NodeRepository {
                 Optional.ofNullable(node.exclusiveTo).map(ApplicationId::fromSerializedForm),
                 trustStore,
                 Optional.ofNullable(node.wireguardPubkey).map(WireguardKey::from),
+                Optional.ofNullable(node.wireguardKeyTimestamp).map(Instant::ofEpochMilli),
                 node.wantToRebuild);
     }
 
@@ -368,6 +371,7 @@ public class RealNodeRepository implements NodeRepository {
     private static WireguardPeer createConfigserverPeer(GetWireguardResponse.Configserver configServer) {
         return new WireguardPeer(HostName.of(configServer.hostname),
                                  configServer.ipAddresses.stream().map(VersionedIpAddress::from).toList(),
-                                 WireguardKey.from(configServer.wireguardPubkey));
+                                 WireguardKey.from(configServer.wireguardPubkey),
+                                 Instant.ofEpochMilli(configServer.wireguardKeyTimestamp));
     }
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/GetWireguardResponse.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/GetWireguardResponse.java
@@ -35,13 +35,18 @@ public class GetWireguardResponse {
         @JsonProperty("wireguardPubkey")
         public final String wireguardPubkey;
 
+        @JsonProperty("wireguardKeyTimestamp")
+        public final Long wireguardKeyTimestamp;
+
         @JsonCreator
         public Configserver(@JsonProperty("hostname") String hostname,
                             @JsonProperty("ipAddresses") List<String> ipAddresses,
-                            @JsonProperty("wireguardPubkey") String wireguardPubkey) {
+                            @JsonProperty("wireguardPubkey") String wireguardPubkey,
+                            @JsonProperty("wireguardKeyTimestamp") Long wireguardKeyTimestamp) {
             this.hostname = hostname;
             this.ipAddresses = ipAddresses;
             this.wireguardPubkey = wireguardPubkey;
+            this.wireguardKeyTimestamp = wireguardKeyTimestamp;
         }
     }
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
@@ -95,6 +95,9 @@ public class NodeRepositoryNode {
     @JsonProperty("wireguardPubkey")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String wireguardPubkey;
+    @JsonProperty("wireguardKeyTimestamp")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Long wireguardKeyTimestamp;
 
     @JsonProperty("reports")
     public Map<String, JsonNode> reports = null;
@@ -139,6 +142,7 @@ public class NodeRepositoryNode {
                ", history=" + history +
                ", trustStore=" + trustStore +
                ", wireguardPubkey=" + wireguardPubkey +
+               ", wireguardKeyTimestamp=" + wireguardKeyTimestamp +
                ", reports=" + reports +
                '}';
     }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/TestProcessFactory.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/task/util/process/TestProcessFactory.java
@@ -63,7 +63,9 @@ public class TestProcessFactory implements ProcessFactory {
             int missingCommandIndex = spawnCommandLines.size();
             throw new IllegalStateException("Command #" + missingCommandIndex +
                     " never executed: " +
-                    expectedSpawnCalls.get(missingCommandIndex).commandDescription);
+                    expectedSpawnCalls.get(missingCommandIndex).commandDescription +
+                    "\nExpected commands:\n" + getExpectedCommandLines() +
+                    "\nActual commands:\n" + spawnCommandLines);
         }
     }
 
@@ -101,4 +103,11 @@ public class TestProcessFactory implements ProcessFactory {
 
         return toReturn;
     }
+
+    private List<String> getExpectedCommandLines() {
+        return expectedSpawnCalls.stream()
+                .map(spawnCall -> spawnCall.commandDescription)
+                .toList();
+    }
+
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeer.java
@@ -4,6 +4,7 @@ import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.WireguardKey;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.VersionedIpAddress;
 
+import java.time.Instant;
 import java.util.List;
 
 /**
@@ -14,7 +15,8 @@ import java.util.List;
  */
 public record WireguardPeer(HostName hostname,
                             List<VersionedIpAddress> ipAddresses,
-                            WireguardKey publicKey) implements Comparable<WireguardPeer> {
+                            WireguardKey publicKey,
+                            Instant wireguardKeyTimestamp) implements Comparable<WireguardPeer> {
 
     public WireguardPeer {
         if (ipAddresses.isEmpty()) throw new IllegalArgumentException("No IP addresses for peer node " + hostname.value());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -139,6 +139,7 @@ public class RealNodeRepositoryTest {
         var hostname = "host4.yahoo.com";
         var dockerImage = "registry.example.com/repo/image-1:6.2.3";
         var wireguardKey = WireguardKey.from("111122223333444455556666777788889999000042c=");
+        var wireguardKeyTimestamp = Instant.ofEpochMilli(321L);
 
         nodeRepositoryApi.updateNodeAttributes(
                 hostname,
@@ -151,6 +152,7 @@ public class RealNodeRepositoryTest {
         assertEquals(1, hostSpec.currentRestartGeneration().orElseThrow());
         assertEquals(dockerImage, hostSpec.currentDockerImage().orElseThrow().asString());
         assertEquals(wireguardKey.value(), hostSpec.wireguardPubkey().orElseThrow().value());
+        assertEquals(wireguardKeyTimestamp, hostSpec.wireguardKeyTimestamp().orElseThrow());
     }
 
     @Test

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -139,7 +139,7 @@ public class RealNodeRepositoryTest {
         var hostname = "host4.yahoo.com";
         var dockerImage = "registry.example.com/repo/image-1:6.2.3";
         var wireguardKey = WireguardKey.from("111122223333444455556666777788889999000042c=");
-        var wireguardKeyTimestamp = Instant.ofEpochMilli(321L);
+        var wireguardKeyTimestamp = Instant.ofEpochMilli(123L); // Instant from clock in MockNodeRepository
 
         nodeRepositoryApi.updateNodeAttributes(
                 hostname,

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/RealNodeRepositoryTest.java
@@ -214,7 +214,8 @@ public class RealNodeRepositoryTest {
 
         assertWireguardPeer(cfgPeers.get(0), "cfg1.yahoo.com",
                             "::201:1",
-                            "lololololololololololololololololololololoo=");
+                            "lololololololololololololololololololololoo=",
+                            Instant.ofEpochMilli(456L));
 
         //// Exclave nodes ////
 
@@ -225,14 +226,17 @@ public class RealNodeRepositoryTest {
 
         assertWireguardPeer(exclavePeers.get(0), "dockerhost2.yahoo.com",
                             "::101:1",
-                            "000011112222333344445555666677778888999900c=");
+                            "000011112222333344445555666677778888999900c=",
+                            Instant.ofEpochMilli(123L));
     }
 
-    private void assertWireguardPeer(WireguardPeer peer, String hostname, String ipv6, String publicKey) {
+    private void assertWireguardPeer(WireguardPeer peer, String hostname, String ipv6,
+                                     String publicKey, Instant keyTimestamp) {
         assertEquals(hostname, peer.hostname().value());
         assertEquals(1, peer.ipAddresses().size());
         assertIp(peer.ipAddresses().get(0), ipv6, 6);
         assertEquals(publicKey, peer.publicKey().value());
+        assertEquals(keyTimestamp, peer.wireguardKeyTimestamp());
     }
 
     private void assertIp(VersionedIpAddress ip, String expectedIp, int expectedVersion) {

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeerTest.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.WireguardKey;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.VersionedIpAddress;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -30,6 +31,6 @@ public class WireguardPeerTest {
 
     private static WireguardPeer peer(String hostname) {
         return new WireguardPeer(HostName.of(hostname), List.of(VersionedIpAddress.from("::1:1")),
-                                 WireguardKey.generateRandomForTesting());
+                                 WireguardKey.generateRandomForTesting(), Instant.EPOCH);
     }
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -65,6 +65,7 @@ public final class Node implements Nodelike {
 
     /** Only set for configservers and exclave nodes */
     private final Optional<WireguardKey> wireguardPubKey;
+    private final Optional<Instant> wireguardKeyTimestamp;
 
     /** Record of the last event of each type happening to this node */
     private final History history;
@@ -95,7 +96,8 @@ public final class Node implements Nodelike {
                 NodeType type, Reports reports, Optional<String> modelName, Optional<TenantName> reservedTo,
                 Optional<ApplicationId> exclusiveToApplicationId, Optional<Duration> hostTTL, Optional<Instant> hostEmptyAt,
                 Optional<ClusterSpec.Type> exclusiveToClusterType, Optional<String> switchHostname,
-                List<TrustStoreItem> trustStoreItems, CloudAccount cloudAccount, Optional<WireguardKey> wireguardPubKey) {
+                List<TrustStoreItem> trustStoreItems, CloudAccount cloudAccount, Optional<WireguardKey> wireguardPubKey,
+                Optional<Instant> wireguardKeyTimestamp) {
         this.id = Objects.requireNonNull(id, "A node must have an ID");
         this.extraId = Objects.requireNonNull(extraId, "Extra ID cannot be null");
         this.hostname = requireNonEmptyString(hostname, "A node must have a hostname");
@@ -118,6 +120,7 @@ public final class Node implements Nodelike {
         this.trustStoreItems = Objects.requireNonNull(trustStoreItems).stream().distinct().toList();
         this.cloudAccount = Objects.requireNonNull(cloudAccount);
         this.wireguardPubKey = Objects.requireNonNull(wireguardPubKey);
+        this.wireguardKeyTimestamp = Objects.requireNonNull(wireguardKeyTimestamp);
 
         if (state == State.active)
             requireNonEmpty(ipConfig.primary(), "Active node " + hostname + " must have at least one valid IP address");
@@ -265,6 +268,11 @@ public final class Node implements Nodelike {
         return wireguardPubKey;
     }
 
+    /** Returns the timestamp of the wireguard key of this node. Only relevant for enclave nodes. */
+    public Optional<Instant> wireguardKeyTimestamp() {
+        return wireguardKeyTimestamp;
+    }
+
     /**
      * Returns a copy of this where wantToFail is set to true and history is updated to reflect this.
      */
@@ -359,14 +367,16 @@ public final class Node implements Nodelike {
     public Node with(Status status) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history, type,
                         reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a node with the type assigned to the given value */
     public Node with(NodeType type) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history, type,
                         reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a node with the flavor assigned to the given value */
@@ -375,35 +385,40 @@ public final class Node implements Nodelike {
         History updateHistory = history.with(new History.Event(History.Event.Type.resized, agent, instant));
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, updateHistory, type,
                         reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this with the reboot generation set to generation */
     public Node withReboot(Generation generation) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status.withReboot(generation), state, allocation,
                         history, type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this with given id set */
     public Node withId(String id) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation,
                         history, type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this with model name set to given value */
     public Node withModelName(String modelName) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, Optional.of(modelName), reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this with model name cleared */
     public Node withoutModelName() {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, Optional.empty(), reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this with a history record saying it was detected to be down at this instant */
@@ -445,21 +460,24 @@ public final class Node implements Nodelike {
     public Node with(Allocation allocation) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, Optional.of(allocation), history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this node with IP config set to the given value. */
     public Node with(IP.Config ipConfig) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this node with the parent hostname assigned to the given value. */
     public Node withParentHostname(String parentHostname) {
         return new Node(id, extraId, ipConfig, hostname, Optional.of(parentHostname), flavor, status, state, allocation,
                         history, type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withReservedTo(TenantName tenant) {
@@ -467,57 +485,73 @@ public final class Node implements Nodelike {
             throw new IllegalArgumentException("Only host nodes can be reserved, " + hostname + " has type " + type);
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, Optional.of(tenant), exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this node which is not reserved to a tenant */
     public Node withoutReservedTo() {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, Optional.empty(), exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withExclusiveToApplicationId(ApplicationId exclusiveTo) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, Optional.ofNullable(exclusiveTo), hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withExtraId(Optional<String> extraId) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withHostTTL(Duration hostTTL) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, Optional.ofNullable(hostTTL), hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withHostEmptyAt(Instant hostEmptyAt) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, Optional.ofNullable(hostEmptyAt),
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withExclusiveToClusterType(ClusterSpec.Type exclusiveTo) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        Optional.ofNullable(exclusiveTo), switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        Optional.ofNullable(exclusiveTo), switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node withWireguardPubkey(WireguardKey wireguardPubkey) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, Optional.ofNullable(wireguardPubkey));
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, Optional.ofNullable(wireguardPubkey),
+                        wireguardKeyTimestamp);
+    }
+
+    public Node withWireguardKeyTimestamp(Instant wireguardKeyTimestamp) {
+        return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
+                type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
+                exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                Optional.ofNullable(wireguardKeyTimestamp));
     }
 
     /** Returns a copy of this node with switch hostname set to given value */
     public Node withSwitchHostname(String switchHostname) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, Optional.ofNullable(switchHostname), trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, Optional.ofNullable(switchHostname), trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     /** Returns a copy of this node with switch hostname unset */
@@ -570,19 +604,22 @@ public final class Node implements Nodelike {
     public Node with(History history) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node with(Reports reports) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     public Node with(List<TrustStoreItem> trustStoreItems) {
         return new Node(id, extraId, ipConfig, hostname, parentHostname, flavor, status, state, allocation, history,
                         type, reports, modelName, reservedTo, exclusiveToApplicationId, hostTTL, hostEmptyAt,
-                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey);
+                        exclusiveToClusterType, switchHostname, trustStoreItems, cloudAccount, wireguardPubKey,
+                        wireguardKeyTimestamp);
     }
 
     private static Optional<String> requireNonEmptyString(Optional<String> value, String message) {
@@ -731,6 +768,7 @@ public final class Node implements Nodelike {
         private List<TrustStoreItem> trustStoreItems;
         private CloudAccount cloudAccount = CloudAccount.empty;
         private WireguardKey wireguardPubKey;
+        private Instant wireguardKeyTimestamp;
 
         private Builder(String id, String hostname, Flavor flavor, State state, NodeType type) {
             this.id = id;
@@ -825,6 +863,11 @@ public final class Node implements Nodelike {
             return this;
         }
 
+        public Builder wireguardKeyTimestamp(Instant wireguardKeyTimestamp) {
+            this.wireguardKeyTimestamp = wireguardKeyTimestamp;
+            return this;
+        }
+
         public Node build() {
             return new Node(id, Optional.empty(), Optional.ofNullable(ipConfig).orElse(IP.Config.EMPTY), hostname, Optional.ofNullable(parentHostname),
                             flavor, Optional.ofNullable(status).orElseGet(Status::initial), state, Optional.ofNullable(allocation),
@@ -832,7 +875,7 @@ public final class Node implements Nodelike {
                             Optional.ofNullable(modelName), Optional.ofNullable(reservedTo), Optional.ofNullable(exclusiveToApplicationId),
                             Optional.ofNullable(hostTTL), Optional.ofNullable(hostEmptyAt), Optional.ofNullable(exclusiveToClusterType),
                             Optional.ofNullable(switchHostname), Optional.ofNullable(trustStoreItems).orElseGet(List::of), cloudAccount,
-                            Optional.ofNullable(wireguardPubKey));
+                            Optional.ofNullable(wireguardPubKey), Optional.ofNullable(wireguardKeyTimestamp));
         }
 
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
@@ -4,7 +4,6 @@ package com.yahoo.vespa.hosted.provision.persistence;
 import ai.vespa.http.DomainName;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.yahoo.collections.Pair;
 import com.yahoo.component.Version;
 import com.yahoo.concurrent.UncheckedTimeoutException;
@@ -42,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
@@ -222,8 +220,9 @@ public class CuratorDb {
                                     toState.isAllocated() ? node.allocation() : Optional.empty(),
                                     node.history().recordStateTransition(node.state(), toState, agent, clock.instant()),
                                     node.type(), node.reports(), node.modelName(), node.reservedTo(),
-                                    node.exclusiveToApplicationId(), node.hostTTL(), node.hostEmptyAt(), node.exclusiveToClusterType(),
-                                    node.switchHostname(), node.trustedCertificates(), node.cloudAccount(), node.wireguardPubKey());
+                                    node.exclusiveToApplicationId(), node.hostTTL(), node.hostEmptyAt(),
+                                    node.exclusiveToClusterType(), node.switchHostname(), node.trustedCertificates(),
+                                    node.cloudAccount(), node.wireguardPubKey(), node.wireguardKeyTimestamp());
             curatorTransaction.add(createOrSet(nodePath(newNode), nodeSerializer.toJson(newNode)));
             writtenNodes.add(newNode);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -100,6 +100,7 @@ public class NodeSerializer {
     private static final String trustedCertificatesKey = "trustedCertificates";
     private static final String cloudAccountKey = "cloudAccount";
     private static final String wireguardPubKeyKey = "wireguardPubkey";
+    private static final String wireguardKeyTimestampKey = "wireguardKeyTimestamp";
 
     // Node resource fields
     private static final String flavorKey = "flavor";
@@ -190,6 +191,7 @@ public class NodeSerializer {
             object.setString(cloudAccountKey, node.cloudAccount().value());
         }
         node.wireguardPubKey().ifPresent(pubKey -> object.setString(wireguardPubKeyKey, pubKey.value()));
+        node.wireguardKeyTimestamp().ifPresent(timestamp -> object.setLong(wireguardKeyTimestampKey, timestamp.toEpochMilli()));
     }
 
     private void toSlime(Flavor flavor, Cursor object) {
@@ -284,7 +286,8 @@ public class NodeSerializer {
                         SlimeUtils.optionalString(object.field(switchHostnameKey)),
                         trustedCertificatesFromSlime(object),
                         SlimeUtils.optionalString(object.field(cloudAccountKey)).map(CloudAccount::from).orElse(CloudAccount.empty),
-                        SlimeUtils.optionalString(object.field(wireguardPubKeyKey)).map(WireguardKey::from));
+                        SlimeUtils.optionalString(object.field(wireguardPubKeyKey)).map(WireguardKey::from),
+                        SlimeUtils.optionalInstant(object.field(wireguardKeyTimestampKey)));
     }
 
     private Status statusFromSlime(Inspector object) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodePatcher.java
@@ -273,8 +273,9 @@ public class NodePatcher {
             case "trustStore":
                 return nodeWithTrustStore(node, value);
             case "wireguardPubkey":
-                return node.withWireguardPubkey(SlimeUtils.optionalString(value).map(WireguardKey::new).orElse(null));
-            default :
+                return node.withWireguardPubkey(SlimeUtils.optionalString(value).map(WireguardKey::new).orElse(null))
+                        .withWireguardKeyTimestamp(clock.instant());
+            default:
                 throw new IllegalArgumentException("Could not apply field '" + name + "' on a node: No such modifiable field");
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -193,6 +193,7 @@ class NodesResponse extends SlimeJsonResponse {
             object.setString("cloudAccount", node.cloudAccount().value());
         }
         node.wireguardPubKey().ifPresent(key -> object.setString("wireguardPubkey", key.value()));
+        node.wireguardKeyTimestamp().ifPresent(timestamp -> object.setLong("wireguardKeyTimestamp", timestamp.toEpochMilli()));
     }
 
     private Version resolveVersionFlag(StringFlag flag, Node node, Allocation allocation) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/WireguardResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/WireguardResponse.java
@@ -10,7 +10,9 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.IP;
 
 import java.net.InetAddress;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * A response containing the wireguard peer config for each configserver that has a public key.
@@ -34,13 +36,16 @@ public class WireguardResponse extends SlimeJsonResponse {
                     .toList();
             if (ipAddresses.isEmpty()) return;
 
-            addConfigserver(cfgArray.addObject(), cfg.hostname(), cfg.wireguardPubKey().get(), ipAddresses);
+            addConfigserver(cfgArray.addObject(), cfg.hostname(), cfg.wireguardPubKey().get(),
+                            cfg.wireguardKeyTimestamp(), ipAddresses);
         }
     }
 
-    private void addConfigserver(Cursor cfgEntry, String hostname, WireguardKey key, List<String> ipAddresses) {
+    private void addConfigserver(Cursor cfgEntry, String hostname, WireguardKey key, Optional<Instant> keyTimestamp,
+                                 List<String> ipAddresses) {
         cfgEntry.setString("hostname", hostname);
         cfgEntry.setString("wireguardPubkey", key.value());
+        cfgEntry.setLong("wireguardKeyTimestamp", keyTimestamp.orElse(Instant.EPOCH).toEpochMilli());
         NodesResponse.ipAddressesToSlime(ipAddresses, cfgEntry.setArray("ipAddresses"));
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/WireguardResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/WireguardResponse.java
@@ -30,11 +30,11 @@ public class WireguardResponse extends SlimeJsonResponse {
                 .nodeType(NodeType.config);
 
         for (Node cfg : configservers) {
-            if (cfg.wireguardPubKey().isEmpty()) return;
+            if (cfg.wireguardPubKey().isEmpty()) continue;
             List<String> ipAddresses = cfg.ipConfig().primary().stream()
                     .filter(WireguardResponse::isPublicIp)
                     .toList();
-            if (ipAddresses.isEmpty()) return;
+            if (ipAddresses.isEmpty()) continue;
 
             addConfigserver(cfgArray.addObject(), cfg.hostname(), cfg.wireguardPubKey().get(),
                             cfg.wireguardKeyTimestamp(), ipAddresses);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -163,6 +163,7 @@ public class MockNodeRepository extends NodeRepository {
         nodes.add(Node.create("dockerhost2", ipConfig(101, 1, 3), "dockerhost2.yahoo.com",
                               flavors.getFlavorOrThrow("large"), NodeType.host)
                           .wireguardPubKey(WireguardKey.from("000011112222333344445555666677778888999900c="))
+                          .wireguardKeyTimestamp(Instant.ofEpochMilli(123L))
                           .cloudAccount(tenantAccount).build());
         nodes.add(Node.create("dockerhost3", ipConfig(102, 1, 3), "dockerhost3.yahoo.com",
                              flavors.getFlavorOrThrow("large"), NodeType.host).cloudAccount(defaultCloudAccount).build());
@@ -176,7 +177,9 @@ public class MockNodeRepository extends NodeRepository {
         // Config servers
         nodes.add(Node.create("cfg1", ipConfig(201), "cfg1.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
                       .cloudAccount(defaultCloudAccount)
-                      .wireguardPubKey(WireguardKey.from("lololololololololololololololololololololoo=")).build());
+                      .wireguardPubKey(WireguardKey.from("lololololololololololololololololololololoo="))
+                      .wireguardKeyTimestamp(Instant.ofEpochMilli(456L))
+                      .build());
         nodes.add(Node.create("cfg2", ipConfig(202), "cfg2.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
                       .cloudAccount(defaultCloudAccount)
                       .build());

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiTest.java
@@ -405,7 +405,7 @@ public class NodesV2ApiTest {
         assertFile(new Request("http://localhost:8080/nodes/v2/node/host4.yahoo.com"), "node4-wg.json");
     }
 
-        @Test
+    @Test
     public void post_controller_node() throws Exception {
         String data = "[{\"hostname\":\"controller1.yahoo.com\", \"id\":\"fake-controller1.yahoo.com\"," +
                       createIpAddresses("127.0.0.1") +

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -119,5 +119,6 @@
   ],
   "additionalIpAddresses": [],
   "cloudAccount": "aws:111222333444",
-  "wireguardPubkey":"lololololololololololololololololololololoo="
+  "wireguardPubkey":"lololololololololololololololololololololoo=",
+  "wireguardKeyTimestamp": 456
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
@@ -117,5 +117,6 @@
   "ipAddresses": ["127.0.101.1", "::101:1"],
   "additionalIpAddresses": ["::101:2", "::101:3", "::101:4"],
   "cloudAccount": "aws:777888999000",
-  "wireguardPubkey": "000011112222333344445555666677778888999900c="
+  "wireguardPubkey": "000011112222333344445555666677778888999900c=",
+  "wireguardKeyTimestamp": 123
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
@@ -119,5 +119,5 @@
   "additionalIpAddresses": [],
   "cloudAccount": "aws:111222333444",
   "wireguardPubkey": "lololololololololololololololololololololoo=",
-  "wireguardKeyTimestamp": 789
+  "wireguardKeyTimestamp": 123
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
@@ -118,5 +118,6 @@
   "ipAddresses": ["127.0.4.1", "::4:1"],
   "additionalIpAddresses": [],
   "cloudAccount": "aws:111222333444",
-  "wireguardPubkey": "lololololololololololololololololololololoo="
+  "wireguardPubkey": "lololololololololololololololololololololoo=",
+  "wireguardKeyTimestamp": 789
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/wireguard.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/wireguard.json
@@ -3,6 +3,7 @@
     {
       "hostname": "cfg1.yahoo.com",
       "wireguardPubkey": "lololololololololololololololololololololoo=",
+      "wireguardKeyTimestamp":456,
       "ipAddresses": ["::201:1"]
     }
   ]


### PR DESCRIPTION
Only the last two commits are new. The others are a cleaned version of the previous PR.

As an alternative to null guarding in RealNR, we could perhaps set default values in the two jackson/json classes. Not sure what is best practice, and without proper testing, I'm not 100% certain it would work.