### PR TITLE
Add support for case-insensitive matching to Levenshtein DFAs

### DIFF
--- a/vespalib/src/vespa/vespalib/fuzzy/dfa_matcher.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/dfa_matcher.h
@@ -13,6 +13,11 @@ concept DfaMatcher = requires(T a) {
     typename T::StateParamType;
     typename T::EdgeType;
 
+    // Whether the matching is case-sensitive or not. If false, all source string code points will
+    // be implicitly lower-cased prior to state stepping. For case-insensitive (i.e. uncased)
+    // matching to have the expected semantics, the actual target string must be pre-lowercased.
+    { a.is_cased() } -> std::same_as<bool>;
+
     // Initial (starting) state of the DFA
     { a.start() } -> std::same_as<typename T::StateType>;
 

--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
@@ -96,8 +96,11 @@ public:
     using MatchResult = LevenshteinDfa::MatchResult;
 private:
     std::vector<DfaNodeType> _nodes;
+    const bool               _is_cased;
 public:
-    ExplicitLevenshteinDfaImpl() noexcept = default;
+    explicit ExplicitLevenshteinDfaImpl(bool is_cased) noexcept
+        : _is_cased(is_cased)
+    {}
     ~ExplicitLevenshteinDfaImpl() override = default;
 
     static constexpr uint8_t max_edits() noexcept { return MaxEdits; }
@@ -131,14 +134,12 @@ public:
 
 template <typename Traits>
 class ExplicitLevenshteinDfaBuilder {
-    std::vector<uint32_t> _u32_str_buf; // TODO std::u32string
+    const std::vector<uint32_t> _u32_str_buf; // TODO std::u32string
+    const bool                  _is_cased;
 public:
-    explicit ExplicitLevenshteinDfaBuilder(std::string_view str)
-        : ExplicitLevenshteinDfaBuilder(utf8_string_to_utf32(str))
-    {}
-
-    explicit ExplicitLevenshteinDfaBuilder(std::vector<uint32_t> str) noexcept
-        : _u32_str_buf(std::move(str))
+    ExplicitLevenshteinDfaBuilder(std::vector<uint32_t> str, bool is_cased) noexcept
+        : _u32_str_buf(std::move(str)),
+          _is_cased(is_cased)
     {}
 
     [[nodiscard]] LevenshteinDfa build_dfa() const;

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
@@ -9,16 +9,14 @@ namespace vespalib::fuzzy {
 
 template <typename Traits>
 class ImplicitLevenshteinDfa final : public LevenshteinDfa::Impl {
-    std::vector<uint32_t> _u32_str_buf; // TODO std::u32string
+    const std::vector<uint32_t> _u32_str_buf; // TODO std::u32string
+    const bool                  _is_cased;
 public:
     using MatchResult = LevenshteinDfa::MatchResult;
 
-    explicit ImplicitLevenshteinDfa(std::string_view str)
-        : ImplicitLevenshteinDfa(utf8_string_to_utf32(str))
-    {}
-
-    explicit ImplicitLevenshteinDfa(std::vector<uint32_t> str) noexcept
-        : _u32_str_buf(std::move(str))
+    ImplicitLevenshteinDfa(std::vector<uint32_t> str, bool is_cased) noexcept
+        : _u32_str_buf(std::move(str)),
+          _is_cased(is_cased)
     {}
 
     ~ImplicitLevenshteinDfa() override = default;

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.hpp
@@ -29,11 +29,16 @@ struct ImplicitDfaMatcher : public DfaSteppingBase<Traits> {
     using Base::is_match;
     using Base::can_match;
 
-    explicit ImplicitDfaMatcher(std::span<const uint32_t> u32_str) noexcept
-        : Base(u32_str)
+    const bool _is_cased;
+
+    ImplicitDfaMatcher(std::span<const uint32_t> u32_str, bool is_cased) noexcept
+        : Base(u32_str),
+          _is_cased(is_cased)
     {}
 
     // start, is_match, can_match, match_edit_distance are all provided by base type
+
+    bool is_cased() const noexcept { return _is_cased; }
 
     template <typename F>
     bool has_any_char_matching(const StateType& state, F&& f) const noexcept(noexcept(f(uint32_t{}))) {
@@ -109,7 +114,7 @@ struct ImplicitDfaMatcher : public DfaSteppingBase<Traits> {
 template <typename Traits>
 LevenshteinDfa::MatchResult
 ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str, std::string* successor_out) const {
-    ImplicitDfaMatcher<Traits> matcher(_u32_str_buf);
+    ImplicitDfaMatcher<Traits> matcher(_u32_str_buf, _is_cased);
     return MatchAlgorithm<Traits::max_edits()>::match(matcher, u8str, successor_out);
 }
 

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
@@ -1,20 +1,39 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "unicode_utils.h"
+#include <vespa/vespalib/text/lowercase.h>
 #include <vespa/vespalib/text/utf8.h>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <stdexcept>
 
 namespace vespalib::fuzzy {
 
-std::vector<uint32_t> utf8_string_to_utf32(std::string_view str) {
-    vespalib::stringref ch_str(str.data(), str.size());
-    vespalib::Utf8Reader utf8_reader(ch_str);
+namespace {
+
+template <bool ToLowercase>
+std::vector<uint32_t> utf8_string_to_utf32_impl(std::string_view str) {
+    stringref ch_str(str.data(), str.size());
+    Utf8Reader utf8_reader(ch_str); // TODO consider integrating simdutf library
     std::vector<uint32_t> u32ret;
     u32ret.reserve(str.size()); // Will over-allocate for all non-ASCII
     while (utf8_reader.hasMore()) {
-        u32ret.emplace_back(utf8_reader.getChar());
+        if constexpr (ToLowercase) {
+            u32ret.emplace_back(LowerCase::convert(utf8_reader.getChar()));
+        } else {
+            u32ret.emplace_back(utf8_reader.getChar());
+        }
+
     }
     return u32ret;
+}
+
+}
+
+std::vector<uint32_t> utf8_string_to_utf32_lowercased(std::string_view str) {
+    return utf8_string_to_utf32_impl<true>(str);
+}
+
+std::vector<uint32_t> utf8_string_to_utf32(std::string_view str) {
+    return utf8_string_to_utf32_impl<false>(str);
 }
 
 std::vector<uint32_t> utf8_string_to_utf32(std::u8string_view u8str) {

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
@@ -8,6 +8,9 @@
 
 namespace vespalib::fuzzy {
 
+// UTF-8 -> UTF-32 conversion with lowercasing of all characters
+std::vector<uint32_t> utf8_string_to_utf32_lowercased(std::string_view str);
+// UTF-8 -> UTF-32 conversion without case conversion
 std::vector<uint32_t> utf8_string_to_utf32(std::string_view str);
 
 std::vector<uint32_t> utf8_string_to_utf32(std::u8string_view u8str);


### PR DESCRIPTION
@geirst please review
@toregge @havardpe FYI

Adds matching modes `Cased` and `Uncased`.

`Cased` requires UTF-32 code points to match exactly, and successor strings are guaranteed to be strictly higher than the source (candidate) string in `memcmp` order. This mirrors the behavior of the current DFA implementation.

`Uncased` treats all characters as if they were lowercased, both for the target and source strings. The target (query) string is explicitly lowercased at DFA build-time to avoid duplicate work. Source strings are implicitly lowercased character by character on-demand during matching.

Important ordering note: Successor strings for `Uncased` are generated _as if_ the source string was originally all in lowercase form. This requires some extra added handling when emitting successor prefixes, as we can't just blindly copy UTF-8 bytes from the source string as we do when matching in `Cased` mode.

A new casing-dimension has been added to most parameterized unit tests.

