### PR TITLE
Levenshtein DFA successor generation optimization and UTF-32 output

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
@@ -25,7 +25,7 @@ public:
 
     template <typename DictionaryConstIteratorType>
     bool is_match(const char* word, DictionaryConstIteratorType& itr, const DfaStringComparator::DataStoreType& data_store) {
-        auto match = _dfa.match(word, &_successor);
+        auto match = _dfa.match(word, _successor);
         if (match.matches()) {
             return true;
         } else {

--- a/vespalib/src/vespa/vespalib/fuzzy/dfa_matcher.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/dfa_matcher.h
@@ -3,12 +3,14 @@
 
 #include <concepts>
 #include <cstdint>
+#include <string>
+#include <vector>
 
 namespace vespalib::fuzzy {
 
 // Concept that all DFA matcher implementations must satisfy
 template <typename T>
-concept DfaMatcher = requires(T a, std::string u8str) {
+concept DfaMatcher = requires(T a, std::string u8str, std::vector<uint32_t> u32str) {
     typename T::StateType;
     typename T::StateParamType;
     typename T::EdgeType;
@@ -85,6 +87,9 @@ concept DfaMatcher = requires(T a, std::string u8str) {
     // Precondition: implies_match_suffix(state) == true, i.e. the state is guaranteed to
     //               afford no edits anywhere.
     { a.emit_exact_match_suffix(typename T::StateType{}, u8str) } -> std::same_as<void>;
+
+    // Same as above, but for raw UTF-32 code point output
+    { a.emit_exact_match_suffix(typename T::StateType{}, u32str) } -> std::same_as<void>;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
@@ -125,11 +125,16 @@ public:
 
     [[nodiscard]] MatchResult match(std::string_view u8str, std::string* successor_out) const override;
 
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>* successor_out) const override;
+
     [[nodiscard]] size_t memory_usage() const noexcept override {
         return sizeof(DfaNodeType) * _nodes.size();
     }
 
     void dump_as_graphviz(std::ostream& os) const override;
+private:
+    template <typename SuccessorT>
+    [[nodiscard]] MatchResult match_impl(std::string_view u8str, SuccessorT* successor_out) const;
 };
 
 template <typename Traits>

--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
@@ -80,20 +80,37 @@ struct ExplicitDfaMatcher {
         return &_nodes[edge->node];
     }
     constexpr bool implies_exact_match_suffix(const StateType&) const noexcept {
-        // TODO
+        // TODO; caller will currently just fall back to explicit state stepping
         return false;
     }
     void emit_exact_match_suffix(const StateType&, std::string&) const {
         // TODO (will never be called as long as `implies_exact_match_suffix()` returns false)
         abort();
     }
+    void emit_exact_match_suffix(const StateType&, std::vector<uint32_t>&) const {
+        // TODO (will never be called as long as `implies_exact_match_suffix()` returns false)
+        abort();
+    }
 };
+
+template <uint8_t MaxEdits>
+template <typename SuccessorT>
+LevenshteinDfa::MatchResult
+ExplicitLevenshteinDfaImpl<MaxEdits>::match_impl(std::string_view u8str, SuccessorT* successor_out) const {
+    ExplicitDfaMatcher<MaxEdits> matcher(_nodes, _is_cased);
+    return MatchAlgorithm<MaxEdits>::match(matcher, u8str, successor_out);
+}
 
 template <uint8_t MaxEdits>
 LevenshteinDfa::MatchResult
 ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::string* successor_out) const {
-    ExplicitDfaMatcher<MaxEdits> matcher(_nodes, _is_cased);
-    return MatchAlgorithm<MaxEdits>::match(matcher, u8str, successor_out);
+    return match_impl(u8str, successor_out);
+}
+
+template <uint8_t MaxEdits>
+LevenshteinDfa::MatchResult
+ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::vector<uint32_t>* successor_out) const {
+    return match_impl(u8str, successor_out);
 }
 
 template <uint8_t MaxEdits>

--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
@@ -79,6 +79,14 @@ struct ExplicitDfaMatcher {
     StateType edge_to_state([[maybe_unused]] StateType node, EdgeType edge) const noexcept {
         return &_nodes[edge->node];
     }
+    constexpr bool implies_exact_match_suffix(const StateType&) const noexcept {
+        // TODO
+        return false;
+    }
+    void emit_exact_match_suffix(const StateType&, std::string&) const {
+        // TODO (will never be called as long as `implies_exact_match_suffix()` returns false)
+        abort();
+    }
 };
 
 template <uint8_t MaxEdits>
@@ -101,7 +109,7 @@ void ExplicitLevenshteinDfaImpl<MaxEdits>::dump_as_graphviz(std::ostream& os) co
         }
         for (const auto& edge : node.match_out_edges()) {
             std::string as_utf8;
-            append_utf32_char_as_utf8(as_utf8, edge.u32ch);
+            append_utf32_char(as_utf8, edge.u32ch);
             os << "    " << i << " -> " << edge.node << " [label=\"" << as_utf8 << "\"];\n";
         }
         if (node.wildcard_edge_to != DOOMED) {

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.cpp
@@ -1,7 +1,21 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "implicit_levenshtein_dfa.hpp"
+#include "unicode_utils.h"
+#include <cassert>
 
 namespace vespalib::fuzzy {
+
+template <typename Traits>
+void ImplicitLevenshteinDfa<Traits>::precompute_utf8_target_with_offsets() {
+    _target_utf8_char_offsets.reserve(_u32_str_buf.size());
+    // Important: the precomputed UTF-8 target is based on the potentially case-normalized
+    // target string, ensuring that we don't emit raw target chars for uncased successors.
+    for (uint32_t u32ch : _u32_str_buf) {
+        _target_utf8_char_offsets.emplace_back(static_cast<uint32_t>(_target_as_utf8.size()));
+        append_utf32_char(_target_as_utf8, u32ch);
+    }
+    assert(_target_as_utf8.size() < UINT32_MAX);
+}
 
 template class ImplicitLevenshteinDfa<FixedMaxEditDistanceTraits<1>>;
 template class ImplicitLevenshteinDfa<FixedMaxEditDistanceTraits<2>>;

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.cpp
@@ -5,9 +5,21 @@
 
 namespace vespalib::fuzzy {
 
+/**
+ * Builds two separate vectors that exist alongside the (possibly case-normalized) UTF-32
+ * target string:
+ *
+ *   - The UTF-8 representation of the (possibly case-normalized) target string
+ *   - An offset vector that maps each UTF-32 string index to the first byte of the
+ *     equivalent UTF-8 character.
+ *
+ * These are used for efficiently dumping an UTF-8 target string suffix from an UTF-32
+ * target string index.
+ */
 template <typename Traits>
 void ImplicitLevenshteinDfa<Traits>::precompute_utf8_target_with_offsets() {
     _target_utf8_char_offsets.reserve(_u32_str_buf.size());
+    _target_as_utf8.reserve(_u32_str_buf.size()); // Under-reserves for all non-ASCII (TODO count via simdutf?)
     // Important: the precomputed UTF-8 target is based on the potentially case-normalized
     // target string, ensuring that we don't emit raw target chars for uncased successors.
     for (uint32_t u32ch : _u32_str_buf) {

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
@@ -10,14 +10,20 @@ namespace vespalib::fuzzy {
 template <typename Traits>
 class ImplicitLevenshteinDfa final : public LevenshteinDfa::Impl {
     const std::vector<uint32_t> _u32_str_buf; // TODO std::u32string
+    std::string                 _target_as_utf8;
+    std::vector<uint32_t>       _target_utf8_char_offsets;
     const bool                  _is_cased;
 public:
     using MatchResult = LevenshteinDfa::MatchResult;
 
-    ImplicitLevenshteinDfa(std::vector<uint32_t> str, bool is_cased) noexcept
+    ImplicitLevenshteinDfa(std::vector<uint32_t> str, bool is_cased)
         : _u32_str_buf(std::move(str)),
+          _target_as_utf8(),
+          _target_utf8_char_offsets(),
           _is_cased(is_cased)
-    {}
+    {
+        precompute_utf8_target_with_offsets();
+    }
 
     ~ImplicitLevenshteinDfa() override = default;
 
@@ -28,6 +34,8 @@ public:
     }
 
     void dump_as_graphviz(std::ostream& os) const override;
+private:
+    void precompute_utf8_target_with_offsets();
 };
 
 }

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
@@ -29,12 +29,17 @@ public:
 
     [[nodiscard]] MatchResult match(std::string_view u8str, std::string* successor_out) const override;
 
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>* successor_out) const override;
+
     [[nodiscard]] size_t memory_usage() const noexcept override {
         return _u32_str_buf.size() * sizeof(uint32_t);
     }
 
     void dump_as_graphviz(std::ostream& os) const override;
 private:
+    template <typename SuccessorT>
+    [[nodiscard]] MatchResult match_impl(std::string_view u8str, SuccessorT* successor_out) const;
+
     void precompute_utf8_target_with_offsets();
 };
 

--- a/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.cpp
@@ -18,8 +18,18 @@ LevenshteinDfa& LevenshteinDfa::operator=(LevenshteinDfa&&) noexcept = default;
 LevenshteinDfa::~LevenshteinDfa() = default;
 
 LevenshteinDfa::MatchResult
-LevenshteinDfa::match(std::string_view u8str, std::string* successor_out) const {
-    return _impl->match(u8str, successor_out);
+LevenshteinDfa::match(std::string_view u8str) const {
+    return _impl->match(u8str, static_cast<std::vector<uint32_t>*>(nullptr)); // TODO rewire
+}
+
+LevenshteinDfa::MatchResult
+LevenshteinDfa::match(std::string_view u8str, std::string& successor_out) const {
+    return _impl->match(u8str, &successor_out);
+}
+
+LevenshteinDfa::MatchResult
+LevenshteinDfa::match(std::string_view u8str, std::vector<uint32_t>& successor_out) const {
+    return _impl->match(u8str, &successor_out);
 }
 
 size_t LevenshteinDfa::memory_usage() const noexcept {

--- a/vespalib/src/vespa/vespalib/fuzzy/match_algorithm.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/match_algorithm.hpp
@@ -143,21 +143,13 @@ struct MatchAlgorithm {
      * from converted UTF-32 -> UTF-8 chars as we go. This optimization cannot be used
      * when one or more of the prefix characters have been lowercase-transformed.
      *
-     * TODO we could probably also optimize the smallest suffix generation with this when
-     *   we know we can no longer insert any smaller char substitutions and the only way
-     *   to complete the string is to emit it verbatim.
-     *    - To do this we'd need both the original UTF-8 target string as well as a
-     *      secondary vector that maps u32 character index to the corresponding UTF-8 index.
-     *      Both trivial to get as part of DFA initialization.
-     *
      * TODO let matcher know if source string is pre-normalized (i.e. lowercased).
-     * TODO std::u32string output; no need to re-encode to UTF-8.
      * TODO consider opportunistically appending prefix as we go instead of only when needed.
      */
-    template <DfaMatcher Matcher>
+    template <DfaMatcher Matcher, typename SuccessorT>
     static MatchResult match(const Matcher& matcher,
                              std::string_view source,
-                             std::string* successor_out)
+                             SuccessorT* successor_out)
     {
         using StateType = typename Matcher::StateType;
         Utf8Reader u8_reader(source.data(), source.size());
@@ -217,12 +209,12 @@ struct MatchAlgorithm {
      * precondition: `last_node_with_higher_out` has either a wildcard edge or a char match
      *    edge that compares greater than `input_at_branch`.
      */
-    template <DfaMatcher Matcher>
+    template <DfaMatcher Matcher, typename SuccessorT>
     static void backtrack_and_emit_greater_suffix(
             const Matcher& matcher,
             typename Matcher::StateParamType last_state_with_higher_out,
             const uint32_t input_at_branch,
-            std::string& successor)
+            SuccessorT& successor)
     {
         auto wildcard_state = matcher.match_wildcard(last_state_with_higher_out);
         if (matcher.can_match(wildcard_state)) {
@@ -277,11 +269,11 @@ struct MatchAlgorithm {
      */
      // TODO consider variant for only emitting _prefix of suffix_ to avoid having to generate
      //  the full string? Won't generate a matching string, but will be lexicographically greater.
-    template <DfaMatcher Matcher>
+    template <DfaMatcher Matcher, typename SuccessorT>
     static void emit_smallest_matching_suffix(
             const Matcher& matcher,
             typename Matcher::StateParamType from,
-            std::string& str)
+            SuccessorT& str)
     {
         auto state = from;
         while (!matcher.is_match(state)) {
@@ -296,7 +288,7 @@ struct MatchAlgorithm {
             // Otherwise, find the smallest char that can eventually lead us to a match.
             auto wildcard_state = matcher.match_wildcard(state);
             if (matcher.can_match(wildcard_state)) {
-                str += '\x01';
+                str.push_back(0x01);
                 state = wildcard_state;
             } else {
                 const auto smallest_out_edge = matcher.smallest_explicit_out_edge(state);
@@ -305,6 +297,11 @@ struct MatchAlgorithm {
                 state = matcher.edge_to_state(state, smallest_out_edge);
             }
         }
+    }
+
+    template <typename T>
+    static constexpr bool has_8bit_value_type() noexcept {
+        return sizeof(typename T::value_type) == 1;
     }
 
     /**
@@ -325,18 +322,22 @@ struct MatchAlgorithm {
      * successor "foyd" (and _not_ "FOyd"), as the latter would imply a completely different
      * ordering when compared byte-wise against an implicitly lowercased dictionary.
      */
-    static void emit_successor_prefix(std::string& successor_out, std::string_view source,
+    template <typename SuccessorT>
+    static void emit_successor_prefix(SuccessorT& successor_out, std::string_view source,
                                       uint32_t n_prefix_u8_bytes, bool emit_raw_prefix_u8_bytes)
     {
-        if (emit_raw_prefix_u8_bytes) {
-            successor_out = source.substr(0, n_prefix_u8_bytes);
-        } else {
-            // TODO avoid duplicate work...! :I
-            successor_out.clear();
-            Utf8Reader u8_reader(source.data(), source.size());
-            while (u8_reader.getPos() < n_prefix_u8_bytes) {
-                append_utf32_char(successor_out, LowerCase::convert(u8_reader.getChar()));
+        // TODO redesign prefix output wiring
+        if constexpr (has_8bit_value_type<SuccessorT>()) {
+            if (emit_raw_prefix_u8_bytes) {
+                successor_out = source.substr(0, n_prefix_u8_bytes);
+                return;
             }
+        }
+        // TODO avoid duplicate work...! :I
+        successor_out.clear();
+        Utf8Reader u8_reader(source.data(), source.size());
+        while (u8_reader.getPos() < n_prefix_u8_bytes) {
+            append_utf32_char(successor_out, LowerCase::convert(u8_reader.getChar()));
         }
     }
 

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
@@ -54,7 +54,7 @@ namespace {
  *
  * Returns the number of bytes written.
  *
- * See comments on append_utf32_char_as_utf8() as to why this is not a generic UTF-8
+ * See comments on append_utf32_char() as to why this is not a generic UTF-8
  * encoding function that can be used in all possible scenarios.
  */
 [[nodiscard]] uint8_t encode_utf8_char(uint32_t codepoint, unsigned char* u8buf) {
@@ -118,7 +118,7 @@ namespace {
 } // anon ns
 
 // TODO optimize inlined in header for case where u32_char is < 0x80?
-void append_utf32_char_as_utf8(std::string& out_str, uint32_t u32_char) {
+void append_utf32_char(std::string& out_str, uint32_t u32_char) {
     unsigned char u8buf[4];
     uint8_t u8bytes = encode_utf8_char(u32_char, u8buf);
     out_str.append(reinterpret_cast<const char*>(u8buf), u8bytes);

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.cpp
@@ -40,6 +40,14 @@ std::vector<uint32_t> utf8_string_to_utf32(std::u8string_view u8str) {
     return utf8_string_to_utf32(std::string_view(reinterpret_cast<const char*>(u8str.data()), u8str.size()));
 }
 
+std::string utf32_string_to_utf8(std::span<const uint32_t> u32str) {
+    std::string u8out;
+    for (uint32_t u32ch : u32str) {
+        append_utf32_char(u8out, u32ch);
+    }
+    return u8out;
+}
+
 [[noreturn]] void throw_bad_code_point(uint32_t codepoint) __attribute__((noinline));
 [[noreturn]] void throw_bad_code_point(uint32_t codepoint) {
     throw std::invalid_argument(make_string("invalid UTF-32 codepoint: U+%04X (%u)", codepoint, codepoint));

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
@@ -31,6 +31,14 @@ std::vector<uint32_t> utf8_string_to_utf32(std::u8string_view u8str);
  * ... So don't copy this function for use as a general UTF-8 emitter, as it is not
  * _technically_ conformant!
  */
-void append_utf32_char_as_utf8(std::string& out_str, uint32_t u32_char);
+void append_utf32_char(std::string& out_str, uint32_t u32_char);
+
+inline void append_utf32_char(std::u32string& out_str, uint32_t u32_char) {
+    out_str.push_back(u32_char); // no conversion needed
+}
+
+inline void append_utf32_char(std::vector<uint32_t>& out_str, uint32_t u32_char) {
+    out_str.push_back(u32_char); // no conversion needed
+}
 
 }

--- a/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/unicode_utils.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <cstdint>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -14,6 +15,8 @@ std::vector<uint32_t> utf8_string_to_utf32_lowercased(std::string_view str);
 std::vector<uint32_t> utf8_string_to_utf32(std::string_view str);
 
 std::vector<uint32_t> utf8_string_to_utf32(std::u8string_view u8str);
+
+std::string utf32_string_to_utf8(std::span<const uint32_t> u32str);
 
 /**
  * Encodes a single UTF-32 codepoint `u32_char` to a 1-4 byte UTF-8 sequence and


### PR DESCRIPTION
@geirst please review
@toregge @havardpe FYI

This contains two separate optimizations.

99fd8f3e9ca9677ce25401ef606506aeecd824e6 optimizes successor suffix string generation:

Avoids explicitly stepping the DFA states and handling each transition character separately by detecting the case where the only way the generated suffix can possibly match is for it to _exactly_ match the remaining target string suffix.

This is the case when the sparse cost matrix row only has 1 column remaining, and this column is equal to the max edit distance. I.e. no more edits can possibly be done.

In local synthetic benchmarks this speeds up successor generation 4x when the target string is 64 characters.

This optimization is currently only enabled for the _implicit_ DFA type.

6ad887593b100962cf4c7186deaa598720b8f555 adds support for raw UTF-32 successor string output:

Avoids needing to encode UTF-32 characters to UTF-8 internally, as this is likely to be subsequently reversed by a caller that itself operates on UTF-32 code points.

**API change:** the `match()` function is split into one single-argument overload that does not produce a successor, and two overloads for UTF-8 and UTF-32 successor generation (now by _ref_, not pointer). This removes `nullptr` usage from the API (always a good thing).