### PR TITLE
Simplify waiting for url when getting config

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
+++ b/config/src/main/java/com/yahoo/vespa/config/ConfigPayloadApplier.java
@@ -16,6 +16,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
@@ -244,7 +245,7 @@ public class ConfigPayloadApplier<T extends ConfigInstance.Builder> {
 
     private UrlReference resolveUrl(String url) {
         if ( ! isClientside()) return new UrlReference(url);
-        File file = urlDownloader.waitFor(new UrlReference(url), 60 * 60);
+        File file = urlDownloader.waitFor(new UrlReference(url), Duration.ofMinutes(60));
         return new UrlReference(file.getAbsolutePath());
     }
 

--- a/config/src/test/java/com/yahoo/vespa/config/ConfigPayloadApplierTest.java
+++ b/config/src/test/java/com/yahoo/vespa/config/ConfigPayloadApplierTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
@@ -90,7 +91,7 @@ public class ConfigPayloadApplierTest {
     private static class MockDownloader extends UrlDownloader {
 
         @Override
-        public File waitFor(UrlReference urlReference, long timeout) {
+        public File waitFor(UrlReference urlReference, Duration timeout) {
             return new File("resolvedUrl", urlReference.value());
         }
 


### PR DESCRIPTION
No need to loop, as there are no temporary errors handled, so this can be simplified. Also, config library will retry if downloading fails