### PR TITLE
Split core DFA match loop into match-only and successor-emitting specializations

### DIFF
--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.h
@@ -123,18 +123,17 @@ public:
         _nodes[from_node_idx].set_wildcard_out_edge(to_node_idx);
     }
 
-    [[nodiscard]] MatchResult match(std::string_view u8str, std::string* successor_out) const override;
+    [[nodiscard]] MatchResult match(std::string_view u8str) const override;
 
-    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>* successor_out) const override;
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::string& successor_out) const override;
+
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>& successor_out) const override;
 
     [[nodiscard]] size_t memory_usage() const noexcept override {
         return sizeof(DfaNodeType) * _nodes.size();
     }
 
     void dump_as_graphviz(std::ostream& os) const override;
-private:
-    template <typename SuccessorT>
-    [[nodiscard]] MatchResult match_impl(std::string_view u8str, SuccessorT* successor_out) const;
 };
 
 template <typename Traits>

--- a/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/explicit_levenshtein_dfa.hpp
@@ -94,23 +94,24 @@ struct ExplicitDfaMatcher {
 };
 
 template <uint8_t MaxEdits>
-template <typename SuccessorT>
 LevenshteinDfa::MatchResult
-ExplicitLevenshteinDfaImpl<MaxEdits>::match_impl(std::string_view u8str, SuccessorT* successor_out) const {
+ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str) const {
+    ExplicitDfaMatcher<MaxEdits> matcher(_nodes, _is_cased);
+    return MatchAlgorithm<MaxEdits>::match(matcher, u8str);
+}
+
+template <uint8_t MaxEdits>
+LevenshteinDfa::MatchResult
+ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::string& successor_out) const {
     ExplicitDfaMatcher<MaxEdits> matcher(_nodes, _is_cased);
     return MatchAlgorithm<MaxEdits>::match(matcher, u8str, successor_out);
 }
 
 template <uint8_t MaxEdits>
 LevenshteinDfa::MatchResult
-ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::string* successor_out) const {
-    return match_impl(u8str, successor_out);
-}
-
-template <uint8_t MaxEdits>
-LevenshteinDfa::MatchResult
-ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::vector<uint32_t>* successor_out) const {
-    return match_impl(u8str, successor_out);
+ExplicitLevenshteinDfaImpl<MaxEdits>::match(std::string_view u8str, std::vector<uint32_t>& successor_out) const {
+    ExplicitDfaMatcher<MaxEdits> matcher(_nodes, _is_cased);
+    return MatchAlgorithm<MaxEdits>::match(matcher, u8str, successor_out);
 }
 
 template <uint8_t MaxEdits>

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.h
@@ -27,9 +27,11 @@ public:
 
     ~ImplicitLevenshteinDfa() override = default;
 
-    [[nodiscard]] MatchResult match(std::string_view u8str, std::string* successor_out) const override;
+    [[nodiscard]] MatchResult match(std::string_view u8str) const override;
 
-    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>* successor_out) const override;
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::string& successor_out) const override;
+
+    [[nodiscard]] MatchResult match(std::string_view u8str, std::vector<uint32_t>& successor_out) const override;
 
     [[nodiscard]] size_t memory_usage() const noexcept override {
         return _u32_str_buf.size() * sizeof(uint32_t);
@@ -37,9 +39,6 @@ public:
 
     void dump_as_graphviz(std::ostream& os) const override;
 private:
-    template <typename SuccessorT>
-    [[nodiscard]] MatchResult match_impl(std::string_view u8str, SuccessorT* successor_out) const;
-
     void precompute_utf8_target_with_offsets();
 };
 

--- a/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/implicit_levenshtein_dfa.hpp
@@ -135,23 +135,24 @@ struct ImplicitDfaMatcher : public DfaSteppingBase<Traits> {
 };
 
 template <typename Traits>
-template <typename SuccessorT>
 LevenshteinDfa::MatchResult
-ImplicitLevenshteinDfa<Traits>::match_impl(std::string_view u8str, SuccessorT* successor_out) const {
+ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str) const {
+    ImplicitDfaMatcher<Traits> matcher(_u32_str_buf, _target_as_utf8, _target_utf8_char_offsets, _is_cased);
+    return MatchAlgorithm<Traits::max_edits()>::match(matcher, u8str);
+}
+
+template <typename Traits>
+LevenshteinDfa::MatchResult
+ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str, std::string& successor_out) const {
     ImplicitDfaMatcher<Traits> matcher(_u32_str_buf, _target_as_utf8, _target_utf8_char_offsets, _is_cased);
     return MatchAlgorithm<Traits::max_edits()>::match(matcher, u8str, successor_out);
 }
 
 template <typename Traits>
 LevenshteinDfa::MatchResult
-ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str, std::string* successor_out) const {
-    return match_impl(u8str, successor_out);
-}
-
-template <typename Traits>
-LevenshteinDfa::MatchResult
-ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str, std::vector<uint32_t>* successor_out) const {
-    return match_impl(u8str, successor_out);
+ImplicitLevenshteinDfa<Traits>::match(std::string_view u8str, std::vector<uint32_t>& successor_out) const {
+    ImplicitDfaMatcher<Traits> matcher(_u32_str_buf, _target_as_utf8, _target_utf8_char_offsets, _is_cased);
+    return MatchAlgorithm<Traits::max_edits()>::match(matcher, u8str, successor_out);
 }
 
 template <typename Traits>

--- a/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.cpp
@@ -19,17 +19,17 @@ LevenshteinDfa::~LevenshteinDfa() = default;
 
 LevenshteinDfa::MatchResult
 LevenshteinDfa::match(std::string_view u8str) const {
-    return _impl->match(u8str, static_cast<std::vector<uint32_t>*>(nullptr)); // TODO rewire
+    return _impl->match(u8str);
 }
 
 LevenshteinDfa::MatchResult
 LevenshteinDfa::match(std::string_view u8str, std::string& successor_out) const {
-    return _impl->match(u8str, &successor_out);
+    return _impl->match(u8str, successor_out);
 }
 
 LevenshteinDfa::MatchResult
 LevenshteinDfa::match(std::string_view u8str, std::vector<uint32_t>& successor_out) const {
-    return _impl->match(u8str, &successor_out);
+    return _impl->match(u8str, successor_out);
 }
 
 size_t LevenshteinDfa::memory_usage() const noexcept {

--- a/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
@@ -140,8 +140,9 @@ public:
 
     struct Impl {
         virtual ~Impl() = default;
-        [[nodiscard]] virtual MatchResult match(std::string_view u8str, std::string* successor_out) const = 0;
-        [[nodiscard]] virtual MatchResult match(std::string_view u8str, std::vector<uint32_t>* successor_out) const = 0;
+        [[nodiscard]] virtual MatchResult match(std::string_view u8str) const = 0;
+        [[nodiscard]] virtual MatchResult match(std::string_view u8str, std::string& successor_out) const = 0;
+        [[nodiscard]] virtual MatchResult match(std::string_view u8str, std::vector<uint32_t>& successor_out) const = 0;
         [[nodiscard]] virtual size_t memory_usage() const noexcept = 0;
         virtual void dump_as_graphviz(std::ostream& out) const = 0;
     };


### PR DESCRIPTION
@geirst please review
@havardpe FYI

This allows for "hybrid" schemes where raw matching (without successor generation) is done with a dedicated matcher implementation that is faster for that particular purpose.

Also gives a much tighter loop for the match-only case and removes some branches from the successor-emitting case.