### PR TITLE
Log unknown config definition at INFO level

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFiles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFiles.java
@@ -57,7 +57,7 @@ public class UserConfiguredFiles implements Serializable {
         ConfigDefinition configDefinition = builder.getConfigDefinition();
         if (configDefinition == null) {
             // TODO: throw new IllegalArgumentException("Unable to find config definition for " + builder);
-            logger.logApplicationPackage(Level.FINE, "Unable to find config definition " + key +
+            logger.logApplicationPackage(Level.INFO, "Unable to find config definition " + key +
                                                      ". Will not register files for file distribution for this config");
             return;
         }


### PR DESCRIPTION
I think we should try to fix this so that we can throw exception if config definition is not found, eventually. Start with logging at info level, so we can look into what is needed to make this better long-term.