### PR TITLE
Add IPv6 to public zonal endpoints in GCP

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
@@ -21,7 +21,8 @@ import java.util.Set;
 public class LoadBalancerInstance {
 
     private final Optional<DomainName> hostname;
-    private final Optional<String> ipAddress;
+    private final Optional<String> ip4Address;
+    private final Optional<String> ip6Address;
     private final Optional<DnsZone> dnsZone;
     private final Set<Integer> ports;
     private final Set<String> networks;
@@ -30,11 +31,12 @@ public class LoadBalancerInstance {
     private final List<PrivateServiceId> serviceIds;
     private final CloudAccount cloudAccount;
 
-    public LoadBalancerInstance(Optional<DomainName> hostname, Optional<String> ipAddress,
+    public LoadBalancerInstance(Optional<DomainName> hostname, Optional<String> ip4Address, Optional<String> ip6Address,
                                 Optional<DnsZone> dnsZone, Set<Integer> ports, Set<String> networks, Set<Real> reals,
                                 ZoneEndpoint settings, List<PrivateServiceId> serviceIds, CloudAccount cloudAccount) {
         this.hostname = Objects.requireNonNull(hostname, "hostname must be non-null");
-        this.ipAddress = Objects.requireNonNull(ipAddress, "ip must be non-null");
+        this.ip4Address = Objects.requireNonNull(ip4Address, "ip4Address must be non-null");
+        this.ip6Address = Objects.requireNonNull(ip6Address, "ip6Address must be non-null");
         this.dnsZone = Objects.requireNonNull(dnsZone, "dnsZone must be non-null");
         this.ports = ImmutableSortedSet.copyOf(requirePorts(ports));
         this.networks = ImmutableSortedSet.copyOf(Objects.requireNonNull(networks, "networks must be non-null"));
@@ -43,9 +45,9 @@ public class LoadBalancerInstance {
         this.serviceIds = List.copyOf(Objects.requireNonNull(serviceIds, "private service id must be non-null"));
         this.cloudAccount = Objects.requireNonNull(cloudAccount, "cloudAccount must be non-null");
 
-        if (hostname.isEmpty() == ipAddress.isEmpty()) {
+        if (hostname.isEmpty() == ip4Address.isEmpty()) {
             throw new IllegalArgumentException("Exactly 1 of hostname=%s and ipAddress=%s must be set".formatted(
-                    hostname.map(DomainName::value).orElse("<empty>"), ipAddress.orElse("<empty>")));
+                    hostname.map(DomainName::value).orElse("<empty>"), ip4Address.orElse("<empty>")));
         }
     }
 
@@ -54,9 +56,14 @@ public class LoadBalancerInstance {
         return hostname;
     }
 
-    /** IP address of this (public) load balancer */
-    public Optional<String> ipAddress() {
-        return ipAddress;
+    /** IPv4 address of this (public) load balancer */
+    public Optional<String> ip4Address() {
+        return ip4Address;
+    }
+
+    /** IPv6 address of this (public) load balancer */
+    public Optional<String> ip6Address() {
+        return ip6Address;
     }
 
     /** ID of the DNS zone associated with this */
@@ -114,7 +121,7 @@ public class LoadBalancerInstance {
     public LoadBalancerInstance with(Set<Real> reals, ZoneEndpoint settings, Optional<PrivateServiceId> serviceId) {
         List<PrivateServiceId> ids = new ArrayList<>(serviceIds);
         serviceId.filter(id -> ! ids.contains(id)).ifPresent(ids::add);
-        return new LoadBalancerInstance(hostname, ipAddress, dnsZone, ports, networks,
+        return new LoadBalancerInstance(hostname, ip4Address, ip6Address, dnsZone, ports, networks,
                                         reals, settings, ids,
                                         cloudAccount);
     }
@@ -123,7 +130,7 @@ public class LoadBalancerInstance {
     public LoadBalancerInstance withServiceIds(List<PrivateServiceId> serviceIds) {
         List<PrivateServiceId> ids = new ArrayList<>(serviceIds);
         for (PrivateServiceId id : this.serviceIds) if ( ! ids.contains(id)) ids.add(id);
-        return new LoadBalancerInstance(hostname, ipAddress, dnsZone, ports, networks, reals, settings, ids, cloudAccount);
+        return new LoadBalancerInstance(hostname, ip4Address, ip6Address, dnsZone, ports, networks, reals, settings, ids, cloudAccount);
     }
 
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerInstance.java
@@ -46,7 +46,7 @@ public class LoadBalancerInstance {
         this.cloudAccount = Objects.requireNonNull(cloudAccount, "cloudAccount must be non-null");
 
         if (hostname.isEmpty() == ip4Address.isEmpty()) {
-            throw new IllegalArgumentException("Exactly 1 of hostname=%s and ipAddress=%s must be set".formatted(
+            throw new IllegalArgumentException("Exactly 1 of hostname=%s and ip4Address=%s must be set".formatted(
                     hostname.map(DomainName::value).orElse("<empty>"), ip4Address.orElse("<empty>")));
         }
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/LoadBalancerServiceMock.java
@@ -57,6 +57,7 @@ public class LoadBalancerServiceMock implements LoadBalancerService {
         var instance = new LoadBalancerInstance(
                 Optional.of(DomainName.of("lb-" + spec.application().toShortString() + "-" + spec.cluster().value())),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(new DnsZone("zone-id-1")),
                 Collections.singleton(4443),
                 ImmutableSet.of("10.2.3.0/24", "10.4.5.0/24"),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/lb/SharedLoadBalancerService.java
@@ -45,6 +45,7 @@ public class SharedLoadBalancerService implements LoadBalancerService {
         return new LoadBalancerInstance(Optional.of(DomainName.of(vipHostname)),
                                         Optional.empty(),
                                         Optional.empty(),
+                                        Optional.empty(),
                                         Set.of(4443),
                                         Set.of(),
                                         spec.reals(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializer.java
@@ -45,6 +45,7 @@ public class LoadBalancerSerializer {
     private static final String idField = "id";
     private static final String hostnameField = "hostname";
     private static final String lbIpAddressField = "ipAddress";
+    private static final String lbIp6AddressField = "ip6Address";
     private static final String stateField = "state";
     private static final String changedAtField = "changedAt";
     private static final String dnsZoneField = "dnsZone";
@@ -69,7 +70,8 @@ public class LoadBalancerSerializer {
 
         root.setString(idField, loadBalancer.id().serializedForm());
         loadBalancer.instance().flatMap(LoadBalancerInstance::hostname).ifPresent(hostname -> root.setString(hostnameField, hostname.value()));
-        loadBalancer.instance().flatMap(LoadBalancerInstance::ipAddress).ifPresent(ip -> root.setString(lbIpAddressField, ip));
+        loadBalancer.instance().flatMap(LoadBalancerInstance::ip4Address).ifPresent(ip -> root.setString(lbIpAddressField, ip));
+        loadBalancer.instance().flatMap(LoadBalancerInstance::ip6Address).ifPresent(ip -> root.setString(lbIp6AddressField, ip));
         root.setString(stateField, asString(loadBalancer.state()));
         root.setLong(changedAtField, loadBalancer.changedAt().toEpochMilli());
         loadBalancer.instance().flatMap(LoadBalancerInstance::dnsZone).ifPresent(dnsZone -> root.setString(dnsZoneField, dnsZone.id()));
@@ -123,7 +125,8 @@ public class LoadBalancerSerializer {
         object.field(networksField).traverse((ArrayTraverser) (i, network) -> networks.add(network.asString()));
 
         Optional<DomainName> hostname = optionalString(object.field(hostnameField), Function.identity()).filter(s -> !s.isEmpty()).map(DomainName::of);
-        Optional<String> ipAddress = optionalString(object.field(lbIpAddressField), Function.identity()).filter(s -> !s.isEmpty());
+        Optional<String> ip4Address = optionalString(object.field(lbIpAddressField), Function.identity()).filter(s -> !s.isEmpty());
+        Optional<String> ip6Address = optionalString(object.field(lbIp6AddressField), Function.identity()).filter(s -> !s.isEmpty());
         Optional<DnsZone> dnsZone = optionalString(object.field(dnsZoneField), DnsZone::new);
         ZoneEndpoint settings = zoneEndpoint(object.field(settingsField));
         Optional<PrivateServiceId> serviceId = optionalString(object.field(serviceIdField), PrivateServiceId::of);
@@ -131,9 +134,9 @@ public class LoadBalancerSerializer {
         object.field(serviceIdsField).traverse((ArrayTraverser) (__, serviceIdObject) -> serviceIds.add(PrivateServiceId.of(serviceIdObject.asString())));
         if (serviceIds.isEmpty()) serviceId.ifPresent(serviceIds::add); // TODO: remove after winter vacation '23
         CloudAccount cloudAccount = optionalString(object.field(cloudAccountField), CloudAccount::from).orElse(CloudAccount.empty);
-        Optional<LoadBalancerInstance> instance = hostname.isEmpty() && ipAddress.isEmpty()
+        Optional<LoadBalancerInstance> instance = hostname.isEmpty() && ip4Address.isEmpty() && ip6Address.isEmpty()
                                                   ? Optional.empty()
-                                                  : Optional.of(new LoadBalancerInstance(hostname, ipAddress, dnsZone, ports, networks, reals, settings, serviceIds, cloudAccount));
+                                                  : Optional.of(new LoadBalancerInstance(hostname, ip4Address, ip6Address, dnsZone, ports, networks, reals, settings, serviceIds, cloudAccount));
 
         return new LoadBalancer(LoadBalancerId.fromSerializedForm(object.field(idField).asString()),
                                 instance,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/LoadBalancersResponse.java
@@ -57,7 +57,8 @@ public class LoadBalancersResponse extends SlimeJsonResponse {
             lbObject.setString("instance", lb.id().application().instance().value());
             lbObject.setString("cluster", lb.id().cluster().value());
             lb.instance().flatMap(LoadBalancerInstance::hostname).ifPresent(hostname -> lbObject.setString("hostname", hostname.value()));
-            lb.instance().flatMap(LoadBalancerInstance::ipAddress).ifPresent(ipAddress -> lbObject.setString("ipAddress", ipAddress));
+            lb.instance().flatMap(LoadBalancerInstance::ip4Address).ifPresent(ip -> lbObject.setString("ipAddress", ip));
+            lb.instance().flatMap(LoadBalancerInstance::ip6Address).ifPresent(ip -> lbObject.setString("ip6Address", ip));
             lb.instance().flatMap(LoadBalancerInstance::dnsZone).ifPresent(dnsZone -> lbObject.setString("dnsZone", dnsZone.id()));
 
             Cursor networkArray = lbObject.setArray("networks");

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/persistence/LoadBalancerSerializerTest.java
@@ -40,6 +40,7 @@ public class LoadBalancerSerializerTest {
                                                 Optional.of(new LoadBalancerInstance(
                                                         Optional.of(DomainName.of("lb-host")),
                                                         Optional.empty(),
+                                                        Optional.empty(),
                                                         Optional.of(new DnsZone("zone-id-1")),
                                                         Set.of(4080, 4443),
                                                         Set.of("10.2.3.4/24"),
@@ -73,6 +74,7 @@ public class LoadBalancerSerializerTest {
                                                 Optional.of(new LoadBalancerInstance(
                                                         Optional.empty(),
                                                         Optional.of("1.2.3.4"),
+                                                        Optional.of("fd00::1"),
                                                         Optional.of(new DnsZone("zone-id-1")),
                                                         Set.of(4443),
                                                         Set.of("10.2.3.4/24", "12.3.2.1/30"),
@@ -86,6 +88,8 @@ public class LoadBalancerSerializerTest {
             var serialized = LoadBalancerSerializer.fromJson(LoadBalancerSerializer.toJson(loadBalancer));
             assertEquals(loadBalancer.id(), serialized.id());
             assertEquals(loadBalancer.instance().get().hostname(), serialized.instance().get().hostname());
+            assertEquals(loadBalancer.instance().get().ip4Address(), serialized.instance().get().ip4Address());
+            assertEquals(loadBalancer.instance().get().ip6Address(), serialized.instance().get().ip6Address());
             assertEquals(loadBalancer.instance().get().dnsZone(), serialized.instance().get().dnsZone());
             assertEquals(loadBalancer.instance().get().ports(), serialized.instance().get().ports());
             assertEquals(loadBalancer.instance().get().networks(), serialized.instance().get().networks());


### PR DESCRIPTION
Adds an IPv6 address to load balancers in front of an application cluster in a zone (zone lb), if the endpoint is public. In particular:
 - The endpoint may or may not have been specified as a private service connect endpoint.  It looks like service connect requires an private regional IPv4 address at the moment and may be disjoint from the public IPv4 endpoint.  The public IPv4 endpoint may be disabled separately in deployment.xml.  Only the public IPv4 gets a sibling IPv6 address, both pointing to a target TCP proxy, etc.
 - The private service connect endpoint is associated with a private IPv4 address.  I have not added a private IPv6 address at this point.  That may or may not be something we want.