### PR TITLE
Avoid random lookup to determine if attribute has undefined value for…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.cpp
@@ -40,8 +40,7 @@ AttributeFieldValueNode(const vespalib::string& doctype,
 
 
 std::unique_ptr<document::select::Value>
-AttributeFieldValueNode::
-getValue(const Context &context) const
+AttributeFieldValueNode::getValue(const Context &context) const
 {
     const auto &sc(static_cast<const SelectContext &>(context));
     uint32_t docId(sc._docId); 

--- a/searchlib/src/vespa/searchlib/attribute/enumstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumstore.h
@@ -204,6 +204,9 @@ public:
     void free_unused_values(IndexList to_remove);
     void clear_default_value_ref() override;
     void setup_default_value_ref() override;
+    bool is_default_value_ref(Index idx) const {
+        return idx == _default_value_ref.load_relaxed();
+    }
     const AtomicIndex& get_default_value_ref() const noexcept { return _default_value_ref; }
     vespalib::MemoryUsage update_stat(const CompactionStrategy& compaction_strategy) override;
     std::unique_ptr<EnumIndexRemapper> consider_compact_values(const CompactionStrategy& compaction_strategy) override;

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
@@ -110,6 +110,9 @@ public:
     void onUpdateStat() override;
     void reclaim_memory(generation_t oldest_used_gen) override;
     void before_inc_generation(generation_t current_gen) override;
+    bool isUndefined(DocId doc) const override {
+        return acquire_enum_entry_ref(doc) == this->getEnumStore().get_default_value_ref().load_relaxed();
+    }
     EnumHandle getEnum(DocId doc) const override {
        return getE(doc);
     }

--- a/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singleenumattribute.h
@@ -111,7 +111,7 @@ public:
     void reclaim_memory(generation_t oldest_used_gen) override;
     void before_inc_generation(generation_t current_gen) override;
     bool isUndefined(DocId doc) const override {
-        return acquire_enum_entry_ref(doc) == this->getEnumStore().get_default_value_ref().load_relaxed();
+        return this->getEnumStore().is_default_value_ref(acquire_enum_entry_ref(doc));
     }
     EnumHandle getEnum(DocId doc) const override {
        return getE(doc);

--- a/searchlib/src/vespa/searchlib/attribute/singlestringattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/singlestringattribute.h
@@ -41,7 +41,6 @@ public:
     //-------------------------------------------------------------------------
     // Attribute read API
     //-------------------------------------------------------------------------
-    bool isUndefined(DocId doc) const override { return get(doc)[0] == '\0'; }
     const char * get(DocId doc) const override {
         return this->_enumStore.get_value(this->acquire_enum_entry_ref(doc));
     }


### PR DESCRIPTION
… a document.

Instead of comparing value against undefined value, compare enum reference.

@toregge PR