### PR TITLE
Encapsulate wireguard key + timestamp in new class

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/WireguardKeyWithTimestamp.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/WireguardKeyWithTimestamp.java
@@ -1,0 +1,39 @@
+package com.yahoo.config.provision;
+
+import com.yahoo.jdisc.Timer;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Random;
+
+/**
+ * @author gjoranv
+ */
+public record WireguardKeyWithTimestamp(WireguardKey key, Instant timestamp) {
+
+    public static final int KEY_ROTATION_BASE = 60;
+    public static final int KEY_ROTATION_VARIANCE = 10;
+    public static final int KEY_EXPIRY = KEY_ROTATION_BASE + KEY_ROTATION_VARIANCE + 5;
+
+    public WireguardKeyWithTimestamp {
+        if (key == null) throw new IllegalArgumentException("Wireguard key cannot be null");
+        if (timestamp == null) timestamp = Instant.EPOCH;
+    }
+
+    public static WireguardKeyWithTimestamp from(String key, long msTimestamp) {
+        return new WireguardKeyWithTimestamp(WireguardKey.from(key), Instant.ofEpochMilli(msTimestamp));
+    }
+
+    public boolean isDueForRotation(Timer timer, ChronoUnit unit, Random random) {
+        return timer.currentTime().isAfter(keyRotationDueAt(unit, random));
+    }
+
+    public boolean hasExpired(Timer timer, ChronoUnit unit) {
+        return timer.currentTime().isAfter(timestamp.plus(KEY_EXPIRY, unit));
+    }
+
+    private Instant keyRotationDueAt(ChronoUnit unit, Random random) {
+        return timestamp.plus(KEY_ROTATION_BASE + random.nextInt(KEY_ROTATION_VARIANCE), unit);
+    }
+
+}

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/NodeSpec.java
@@ -9,6 +9,7 @@ import com.yahoo.config.provision.DockerImage;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.WireguardKey;
+import com.yahoo.config.provision.WireguardKeyWithTimestamp;
 import com.yahoo.vespa.hosted.node.admin.task.util.file.DiskSize;
 
 import java.net.URI;
@@ -73,9 +74,7 @@ public class NodeSpec {
 
     private final List<TrustStoreItem> trustStore;
 
-    private final Optional<WireguardKey> wireguardPubkey;
-
-    private final Optional<Instant> wireguardKeyTimestamp;
+    private final Optional<WireguardKeyWithTimestamp> wireguardKeyWithTimestamp;
 
     private final boolean wantToRebuild;
 
@@ -112,8 +111,7 @@ public class NodeSpec {
             Optional<URI> archiveUri,
             Optional<ApplicationId> exclusiveTo,
             List<TrustStoreItem> trustStore,
-            Optional<WireguardKey> wireguardPubkey,
-            Optional<Instant> wireguardKeyTimestamp,
+            Optional<WireguardKeyWithTimestamp> wireguardPubkey,
             boolean wantToRebuild) {
 
         if (state == NodeState.active) {
@@ -157,8 +155,7 @@ public class NodeSpec {
         this.archiveUri = Objects.requireNonNull(archiveUri);
         this.exclusiveTo = Objects.requireNonNull(exclusiveTo);
         this.trustStore = Objects.requireNonNull(trustStore);
-        this.wireguardPubkey = Objects.requireNonNull(wireguardPubkey);
-        this.wireguardKeyTimestamp = Objects.requireNonNull(wireguardKeyTimestamp);
+        this.wireguardKeyWithTimestamp = Objects.requireNonNull(wireguardPubkey);
         this.wantToRebuild = wantToRebuild;
     }
 
@@ -313,9 +310,7 @@ public class NodeSpec {
         return trustStore;
     }
 
-    public Optional<WireguardKey> wireguardPubkey() { return wireguardPubkey; }
-
-    public Optional<Instant> wireguardKeyTimestamp() { return wireguardKeyTimestamp; }
+    public Optional<WireguardKeyWithTimestamp> wireguardKeyWithTimestamp() { return wireguardKeyWithTimestamp; }
 
     public boolean wantToRebuild() {
         return wantToRebuild;
@@ -358,8 +353,7 @@ public class NodeSpec {
                 Objects.equals(archiveUri, that.archiveUri) &&
                 Objects.equals(exclusiveTo, that.exclusiveTo) &&
                 Objects.equals(trustStore, that.trustStore) &&
-                Objects.equals(wireguardPubkey, that.wireguardPubkey) &&
-                Objects.equals(wireguardKeyTimestamp, that.wireguardKeyTimestamp) &&
+                Objects.equals(wireguardKeyWithTimestamp, that.wireguardKeyWithTimestamp) &&
                 Objects.equals(wantToRebuild, that.wantToRebuild);
     }
 
@@ -398,8 +392,7 @@ public class NodeSpec {
                 archiveUri,
                 exclusiveTo,
                 trustStore,
-                wireguardPubkey,
-                wireguardKeyTimestamp,
+                wireguardKeyWithTimestamp,
                 wantToRebuild);
     }
 
@@ -438,8 +431,7 @@ public class NodeSpec {
                 + " archiveUri=" + archiveUri
                 + " exclusiveTo=" + exclusiveTo
                 + " trustStore=" + trustStore
-                + " wireguardPubkey=" + wireguardPubkey
-                + " wireguardKeyTimestamp=" + wireguardKeyTimestamp
+                + " wireguardPubkey=" + wireguardKeyWithTimestamp
                 + " wantToRebuild=" + wantToRebuild
                 + " }";
     }
@@ -477,8 +469,7 @@ public class NodeSpec {
         private Optional<URI> archiveUri = Optional.empty();
         private Optional<ApplicationId> exclusiveTo = Optional.empty();
         private List<TrustStoreItem> trustStore = List.of();
-        private Optional<WireguardKey> wireguardPubkey = Optional.empty();
-        private Optional<Instant> wireguardKeyTimestamp = Optional.empty();
+        private Optional<WireguardKeyWithTimestamp> wireguardPubkey = Optional.empty();
         private boolean wantToRebuild = false;
 
         public Builder() {}
@@ -514,8 +505,7 @@ public class NodeSpec {
             node.archiveUri.ifPresent(this::archiveUri);
             node.exclusiveTo.ifPresent(this::exclusiveTo);
             trustStore(node.trustStore);
-            node.wireguardPubkey.ifPresent(this::wireguardPubkey);
-            node.wireguardKeyTimestamp.ifPresent(this::wireguardKeyTimestamp);
+            node.wireguardKeyWithTimestamp.ifPresent(this::wireguardKeyWithTimestamp);
             wantToRebuild(node.wantToRebuild);
         }
 
@@ -704,13 +694,13 @@ public class NodeSpec {
             return this;
         }
 
-        public Builder wireguardPubkey(WireguardKey wireguardPubKey) {
-            this.wireguardPubkey = Optional.of(wireguardPubKey);
+        public Builder wireguardPubkey(WireguardKey wireguardPubkey) {
+            this.wireguardPubkey = Optional.of(new WireguardKeyWithTimestamp(wireguardPubkey, Instant.EPOCH));
             return this;
         }
 
-        public Builder wireguardKeyTimestamp(Instant wireguardKeyTimestamp) {
-            this.wireguardKeyTimestamp = Optional.of(wireguardKeyTimestamp);
+        public Builder wireguardKeyWithTimestamp(WireguardKeyWithTimestamp wireguardPubKey) {
+            this.wireguardPubkey = Optional.of(wireguardPubKey);
             return this;
         }
 
@@ -846,7 +836,7 @@ public class NodeSpec {
                                 wantedFirmwareCheck, currentFirmwareCheck, modelName,
                                 resources, realResources, ipAddresses, additionalIpAddresses,
                                 reports, events, parentHostname, archiveUri, exclusiveTo, trustStore,
-                                wireguardPubkey, wireguardKeyTimestamp, wantToRebuild);
+                                wireguardPubkey, wantToRebuild);
         }
 
 

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/GetWireguardResponse.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/GetWireguardResponse.java
@@ -27,27 +27,23 @@ public class GetWireguardResponse {
     public static class Configserver {
 
         @JsonProperty("hostname")
-        public final String hostname;
+        public String hostname;
 
         @JsonProperty("ipAddresses")
-        public final List<String> ipAddresses;
+        public List<String> ipAddresses;
 
+        @JsonProperty("wireguard")
+        public NodeRepositoryNode.WireguardKeyWithTimestamp wireguardKeyWithTimestamp;
+
+
+        // TODO wg: remove when all nodes use new key+timestamp format
         @JsonProperty("wireguardPubkey")
-        public final String wireguardPubkey;
-
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public String wireguardPubkey;
         @JsonProperty("wireguardKeyTimestamp")
-        public final Long wireguardKeyTimestamp;
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public Long wireguardKeyTimestamp;
 
-        @JsonCreator
-        public Configserver(@JsonProperty("hostname") String hostname,
-                            @JsonProperty("ipAddresses") List<String> ipAddresses,
-                            @JsonProperty("wireguardPubkey") String wireguardPubkey,
-                            @JsonProperty("wireguardKeyTimestamp") Long wireguardKeyTimestamp) {
-            this.hostname = hostname;
-            this.ipAddresses = ipAddresses;
-            this.wireguardPubkey = wireguardPubkey;
-            this.wireguardKeyTimestamp = wireguardKeyTimestamp;
-        }
     }
 
 }

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/configserver/noderepository/bindings/NodeRepositoryNode.java
@@ -92,6 +92,10 @@ public class NodeRepositoryNode {
     @JsonProperty("trustStore")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public List<TrustStoreItem> trustStore;
+    @JsonProperty("wireguard")
+    public WireguardKeyWithTimestamp wireguardKeyWithTimestamp;
+
+    // TODO wg: remove separate key and timestamp when all nodes use new keyWithTimestamp
     @JsonProperty("wireguardPubkey")
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String wireguardPubkey;
@@ -141,10 +145,22 @@ public class NodeRepositoryNode {
                ", exclusiveTo='" + exclusiveTo + '\'' +
                ", history=" + history +
                ", trustStore=" + trustStore +
-               ", wireguardPubkey=" + wireguardPubkey +
-               ", wireguardKeyTimestamp=" + wireguardKeyTimestamp +
+               ", wireguard=" + wireguardKeyTimestamp +
                ", reports=" + reports +
                '}';
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class WireguardKeyWithTimestamp {
+        @JsonProperty("key")
+        public String key;
+        @JsonProperty("timestamp")
+        public long timestamp;
+
+        public WireguardKeyWithTimestamp(@JsonProperty("key") String key, @JsonProperty("timestamp") long timestamp) {
+            this.key = key;
+            this.timestamp = timestamp;
+        }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeer.java
+++ b/node-admin/src/main/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeer.java
@@ -1,10 +1,9 @@
 package com.yahoo.vespa.hosted.node.admin.wireguard;
 
 import com.yahoo.config.provision.HostName;
-import com.yahoo.config.provision.WireguardKey;
+import com.yahoo.config.provision.WireguardKeyWithTimestamp;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.VersionedIpAddress;
 
-import java.time.Instant;
 import java.util.List;
 
 /**
@@ -15,8 +14,7 @@ import java.util.List;
  */
 public record WireguardPeer(HostName hostname,
                             List<VersionedIpAddress> ipAddresses,
-                            WireguardKey publicKey,
-                            Instant wireguardKeyTimestamp) implements Comparable<WireguardPeer> {
+                            WireguardKeyWithTimestamp keyWithTimestamp) implements Comparable<WireguardPeer> {
 
     public WireguardPeer {
         if (ipAddresses.isEmpty()) throw new IllegalArgumentException("No IP addresses for peer node " + hostname.value());

--- a/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeerTest.java
+++ b/node-admin/src/test/java/com/yahoo/vespa/hosted/node/admin/wireguard/WireguardPeerTest.java
@@ -2,6 +2,7 @@ package com.yahoo.vespa.hosted.node.admin.wireguard;
 
 import com.yahoo.config.provision.HostName;
 import com.yahoo.config.provision.WireguardKey;
+import com.yahoo.config.provision.WireguardKeyWithTimestamp;
 import com.yahoo.vespa.hosted.node.admin.task.util.network.VersionedIpAddress;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,7 @@ public class WireguardPeerTest {
 
     private static WireguardPeer peer(String hostname) {
         return new WireguardPeer(HostName.of(hostname), List.of(VersionedIpAddress.from("::1:1")),
-                                 WireguardKey.generateRandomForTesting(), Instant.EPOCH);
+                                 new WireguardKeyWithTimestamp(WireguardKey.generateRandomForTesting(), Instant.EPOCH));
     }
+
 }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/CuratorDb.java
@@ -222,7 +222,7 @@ public class CuratorDb {
                                     node.type(), node.reports(), node.modelName(), node.reservedTo(),
                                     node.exclusiveToApplicationId(), node.hostTTL(), node.hostEmptyAt(),
                                     node.exclusiveToClusterType(), node.switchHostname(), node.trustedCertificates(),
-                                    node.cloudAccount(), node.wireguardPubKey(), node.wireguardKeyTimestamp());
+                                    node.cloudAccount(), node.wireguardPubKey());
             curatorTransaction.add(createOrSet(nodePath(newNode), nodeSerializer.toJson(newNode)));
             writtenNodes.add(newNode);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -21,6 +21,7 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.WireguardKey;
+import com.yahoo.config.provision.WireguardKeyWithTimestamp;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.config.provision.ZoneEndpoint;
 import com.yahoo.config.provision.ZoneEndpoint.AccessType;
@@ -161,8 +162,8 @@ public class MockNodeRepository extends NodeRepository {
         // Emulate host in tenant account
         nodes.add(Node.create("dockerhost2", ipConfig(101, 1, 3), "dockerhost2.yahoo.com",
                               flavors.getFlavorOrThrow("large"), NodeType.host)
-                          .wireguardPubKey(WireguardKey.from("000011112222333344445555666677778888999900c="))
-                          .wireguardKeyTimestamp(Instant.ofEpochMilli(123L))
+                          .wireguardKey(new WireguardKeyWithTimestamp(WireguardKey.from("000011112222333344445555666677778888999900c="),
+                                                                      Instant.ofEpochMilli(123L)))
                           .cloudAccount(tenantAccount).build());
         nodes.add(Node.create("dockerhost3", ipConfig(102, 1, 3), "dockerhost3.yahoo.com",
                              flavors.getFlavorOrThrow("large"), NodeType.host).cloudAccount(defaultCloudAccount).build());
@@ -176,8 +177,8 @@ public class MockNodeRepository extends NodeRepository {
         // Config servers
         nodes.add(Node.create("cfg1", ipConfig(201), "cfg1.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
                       .cloudAccount(defaultCloudAccount)
-                      .wireguardPubKey(WireguardKey.from("lololololololololololololololololololololoo="))
-                      .wireguardKeyTimestamp(Instant.ofEpochMilli(456L))
+                      .wireguardKey(new WireguardKeyWithTimestamp(WireguardKey.from("lololololololololololololololololololololoo="),
+                                                                  Instant.ofEpochMilli(456L)))
                       .build());
         nodes.add(Node.create("cfg2", ipConfig(202), "cfg2.yahoo.com", flavors.getFlavorOrThrow("default"), NodeType.config)
                       .cloudAccount(defaultCloudAccount)

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/cfg1.json
@@ -119,6 +119,10 @@
   ],
   "additionalIpAddresses": [],
   "cloudAccount": "aws:111222333444",
-  "wireguardPubkey":"lololololololololololololololololololololoo=",
+  "wireguard": {
+    "key": "lololololololololololololololololololololoo=",
+    "timestamp": 456
+  },
+  "wireguardPubkey": "lololololololololololololololololololololoo=",
   "wireguardKeyTimestamp": 456
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/docker-node2.json
@@ -117,6 +117,10 @@
   "ipAddresses": ["127.0.101.1", "::101:1"],
   "additionalIpAddresses": ["::101:2", "::101:3", "::101:4"],
   "cloudAccount": "aws:777888999000",
+  "wireguard": {
+    "key": "000011112222333344445555666677778888999900c=",
+    "timestamp": 123
+  },
   "wireguardPubkey": "000011112222333344445555666677778888999900c=",
   "wireguardKeyTimestamp": 123
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/node4-wg.json
@@ -118,6 +118,10 @@
   "ipAddresses": ["127.0.4.1", "::4:1"],
   "additionalIpAddresses": [],
   "cloudAccount": "aws:111222333444",
+  "wireguard": {
+    "key": "lololololololololololololololololololololoo=",
+    "timestamp": 123
+  },
   "wireguardPubkey": "lololololololololololololololololololololoo=",
   "wireguardKeyTimestamp": 123
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/wireguard.json
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/restapi/responses/wireguard.json
@@ -4,7 +4,11 @@
       "hostname": "cfg1.yahoo.com",
       "wireguardPubkey": "lololololololololololololololololololololoo=",
       "wireguardKeyTimestamp":456,
-      "ipAddresses": ["::201:1"]
+      "ipAddresses": ["::201:1"],
+      "wireguard": {
+        "key": "lololololololololololololololololololololoo=",
+        "timestamp": 456
+      }
     }
   ]
 }


### PR DESCRIPTION
- Use 'wireguard' object with key and timestamp for Rest api.
- Keep zk node format unchanged.

