### PR TITLE
Generate Levenshtein successor prefix "as we go" during match loop

### DIFF
--- a/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
@@ -58,8 +58,8 @@ namespace vespalib::fuzzy {
  * ====== Unicode support ======
  *
  * Matching and successor generation is fully Unicode-aware. All input strings are expected
- * to be in UTF-8, and the generated successor is also encoded as UTF-8 (with some caveats;
- * see the documentation for match()).
+ * to be in UTF-8, and the generated successor is encoded as UTF-8 (with some caveats; see
+ * the documentation for match()) or UTF-32, depending on the chosen `match()` overload.
  *
  * Internally, matching is done on UTF-32 code points and the DFA itself is built around
  * UTF-32. This is unlike Lucene, which converts a UTF-32 DFA to an equivalent UTF-8 DFA.
@@ -159,7 +159,7 @@ public:
 
     /**
      * Attempts to match the source string `source` with the target string this DFA was
-     * built with, emitting a successor string on mismatch if `successor_out` != nullptr.
+     * built with.
      *
      * `source` must not contain any null UTF-8 chars.
      *
@@ -181,11 +181,14 @@ public:
      *
      * See `match(source)` for semantics of returned MatchResult.
      *
+     * In the case of a _match_, the contents of `successor_out` is unspecified. It may be
+     * preemptively modified as part of the matching loop itself.
+     *
      * In the case of a _mismatch_, the following holds:
      *
-     *   - `successor_out` is modified to contain the next (in byte-wise ordering) possible
-     *     _matching_ string S so that there exists no other matching string S' that is
-     *     greater than `source` but smaller than S.
+     *   - `successor_out` contains the next (in byte-wise ordering) possible _matching_
+     *     string S so that there exists no other matching string S' that is greater than
+     *     `source` but smaller than S.
      *   - `successor_out` contains UTF-8 bytes that are within what UTF-8 can legally
      *     encode in bitwise form, but the _code points_ they encode may not be valid.
      *     In particular, surrogate pair ranges and U+10FFFF+1 may be encoded, neither of
@@ -203,12 +206,8 @@ public:
      * is what is passed to the DFA match() function.
      *
      * Memory allocation:
-     * This function does not directly or indirectly allocate any heap memory if either:
-     *
-     *   - the input string is within the max edit distance, or
-     *   - `successor_out` is nullptr, or
-     *   - `successor_out` has sufficient capacity to hold the generated successor
-     *
+     * This function does not directly or indirectly allocate any heap memory if the
+     * `successor_out` string provided is large enough to fit any generated successor.
      * By reusing the successor string across many calls, this therefore amortizes memory
      * allocations down to near zero per invocation.
      */
@@ -220,7 +219,8 @@ public:
      * internally, and is therefore expected to be more efficient.
      *
      * The code point ordering of the UTF-32 successor string is identical to that its UTF-8
-     * equivalent.
+     * equivalent. This includes the special cases where the successor may contain code points
+     * outside the legal Unicode range.
      */
     [[nodiscard]] MatchResult match(std::string_view source, std::vector<uint32_t>& successor_out) const;
 

--- a/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
@@ -112,11 +112,11 @@ std::ostream& operator<<(std::ostream& os, const FixedSparseState<MaxEdits>& s) 
         if (i != 0) {
             os << ", ";
         }
-        for (size_t j = last_idx; j < s.indices[i]; ++j) {
+        for (size_t j = last_idx; j < s.index(i); ++j) {
             os << "-, ";
         }
-        last_idx = s.indices[i] + 1;
-        os << static_cast<uint32_t>(s.costs[i]);
+        last_idx = s.index(i) + 1;
+        os << static_cast<uint32_t>(s.cost(i));
     }
     os << "]";
     return os;


### PR DESCRIPTION
@geirst please review
@toregge @havardpe FYI

Moving away from on-demand/deferred generation means that we only decode (and possibly case-normalize) UTF-8 characters _once_ instead of twice in the case of UTF-32 output or non-normalized input.

These changes make it much more easy to add future support for preserving a caller-supplied successor prefix, which would be used for prefix-locked dictionary matching. It also makes the successor logic itself significantly less hairy.

Note: this subtly changes the API to potentially _always_ mutate the input successor string. The API documentation has been updated to reflect this. No current users of the API should be affected.