### PR TITLE
Expose enclave template version

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/ArchiveService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/ArchiveService.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.api.integration.archive;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -10,6 +11,7 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Service that manages archive storage URIs for tenant nodes.
@@ -28,4 +30,19 @@ public interface ArchiveService {
     Optional<String> findEnclaveArchiveBucket(ZoneId zoneId, CloudAccount cloudAccount);
 
     URI bucketURI(ZoneId zoneId, String bucketName);
+
+    /**
+     * @return the version of the template that was used during the last apply for the given cloud account,
+     *         or {@link Version#emptyVersion} if the version tag was not present or invalid,
+     *         or {@link Optional#empty()} if the we have no access to the cloud account (template probably not applied yet)
+     */
+    Optional<Version> getEnclaveTemplateVersion(CloudAccount cloudAccount);
+
+    static Stream<Version> parseVersion(String versionString) {
+        try {
+            return Stream.of(Version.fromString(versionString));
+        } catch (IllegalArgumentException e) {
+            return Stream.empty();
+        }
+    }
 }

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/MockArchiveService.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/api/integration/archive/MockArchiveService.java
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.controller.api.integration.archive;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.zone.ZoneId;
@@ -57,6 +58,11 @@ public class MockArchiveService implements ArchiveService {
     @Override
     public URI bucketURI(ZoneId zoneId, String bucketName) {
         return URI.create(String.format("s3://%s/", bucketName));
+    }
+
+    @Override
+    public Optional<Version> getEnclaveTemplateVersion(CloudAccount cloudAccount) {
+        return Optional.of(new Version(1, 2, 3));
     }
 
 

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/AthenzTenant.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/AthenzTenant.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.controller.api.identifiers.PropertyId;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -27,8 +28,9 @@ public class AthenzTenant extends Tenant {
      * Use {@link #create(TenantName, AthenzDomain, Property, Optional, Instant)}.
      * */
     public AthenzTenant(TenantName name, AthenzDomain domain, Property property, Optional<PropertyId> propertyId,
-                        Optional<Contact> contact, Instant createdAt, LastLoginInfo lastLoginInfo, Instant tenantRolesLastMaintained) {
-        super(name, createdAt, lastLoginInfo, contact, tenantRolesLastMaintained);
+                        Optional<Contact> contact, Instant createdAt, LastLoginInfo lastLoginInfo, Instant tenantRolesLastMaintained,
+                        List<CloudAccountInfo> cloudAccounts) {
+        super(name, createdAt, lastLoginInfo, contact, tenantRolesLastMaintained, cloudAccounts);
         this.domain = Objects.requireNonNull(domain, "domain must be non-null");
         this.property = Objects.requireNonNull(property, "property must be non-null");
         this.propertyId = Objects.requireNonNull(propertyId, "propertyId must be non-null");
@@ -62,7 +64,7 @@ public class AthenzTenant extends Tenant {
     /** Create a new Athenz tenant */
     public static AthenzTenant create(TenantName name, AthenzDomain domain, Property property,
                                       Optional<PropertyId> propertyId, Instant createdAt) {
-        return new AthenzTenant(requireName(name), domain, property, propertyId, Optional.empty(), createdAt, LastLoginInfo.EMPTY, Instant.EPOCH);
+        return new AthenzTenant(requireName(name), domain, property, propertyId, Optional.empty(), createdAt, LastLoginInfo.EMPTY, Instant.EPOCH, List.of());
     }
 
     @Override

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudAccountInfo.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudAccountInfo.java
@@ -1,0 +1,19 @@
+// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.hosted.controller.tenant;
+
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.CloudAccount;
+
+import java.util.Objects;
+
+/**
+ * @author freva
+ */
+public record CloudAccountInfo(CloudAccount cloudAccount, Version templateVersion) {
+
+    public CloudAccountInfo {
+        Objects.requireNonNull(cloudAccount, "cloudAccount must be non-null");
+        Objects.requireNonNull(templateVersion, "templateVersion must be non-null");
+    }
+
+}

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudTenant.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudTenant.java
@@ -34,8 +34,8 @@ public class CloudTenant extends Tenant {
                        BiMap<PublicKey, SimplePrincipal> developerKeys, TenantInfo info,
                        List<TenantSecretStore> tenantSecretStores, ArchiveAccess archiveAccess,
                        Optional<Instant> invalidateUserSessionsBefore, Instant tenantRoleLastMaintained,
-                       Optional<BillingReference> billingReference) {
-        super(name, createdAt, lastLoginInfo, Optional.empty(), tenantRoleLastMaintained);
+                       List<CloudAccountInfo> cloudAccounts, Optional<BillingReference> billingReference) {
+        super(name, createdAt, lastLoginInfo, Optional.empty(), tenantRoleLastMaintained, cloudAccounts);
         this.creator = creator;
         this.developerKeys = developerKeys;
         this.info = Objects.requireNonNull(info);
@@ -51,7 +51,8 @@ public class CloudTenant extends Tenant {
                                createdAt,
                                LastLoginInfo.EMPTY,
                                Optional.ofNullable(creator).map(SimplePrincipal::of),
-                               ImmutableBiMap.of(), TenantInfo.empty(), List.of(), new ArchiveAccess(), Optional.empty(), Instant.EPOCH, Optional.empty());
+                               ImmutableBiMap.of(), TenantInfo.empty(), List.of(), new ArchiveAccess(), Optional.empty(),
+                               Instant.EPOCH, List.of(), Optional.empty());
     }
 
     /** The user that created the tenant */

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/DeletedTenant.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/DeletedTenant.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.controller.tenant;
 import com.yahoo.config.provision.TenantName;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -17,7 +18,7 @@ public class DeletedTenant extends Tenant {
     private final Instant deletedAt;
 
     public DeletedTenant(TenantName name, Instant createdAt, Instant deletedAt) {
-        super(name, createdAt, LastLoginInfo.EMPTY, Optional.empty(), Instant.EPOCH);
+        super(name, createdAt, LastLoginInfo.EMPTY, Optional.empty(), Instant.EPOCH, List.of());
         this.deletedAt = Objects.requireNonNull(deletedAt, "deletedAt must be non-null");
     }
 

--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/Tenant.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/Tenant.java
@@ -5,6 +5,7 @@ import com.yahoo.config.provision.TenantName;
 import com.yahoo.vespa.hosted.controller.api.integration.organization.Contact;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -20,13 +21,15 @@ public abstract class Tenant {
     private final LastLoginInfo lastLoginInfo;
     private final Optional<Contact> contact;
     private final Instant tenantRolesLastMaintained;
+    private final List<CloudAccountInfo> cloudAccounts;
 
-    Tenant(TenantName name, Instant createdAt, LastLoginInfo lastLoginInfo, Optional<Contact> contact, Instant tenantRolesLastMaintained) {
+    Tenant(TenantName name, Instant createdAt, LastLoginInfo lastLoginInfo, Optional<Contact> contact, Instant tenantRolesLastMaintained, List<CloudAccountInfo> cloudAccounts) {
         this.name = name;
         this.createdAt = createdAt;
         this.lastLoginInfo = lastLoginInfo;
         this.contact = contact;
         this.tenantRolesLastMaintained = tenantRolesLastMaintained;
+        this.cloudAccounts = cloudAccounts;
     }
 
     /** Name of this tenant */
@@ -51,6 +54,10 @@ public abstract class Tenant {
 
     public Instant tenantRolesLastMaintained() {
         return tenantRolesLastMaintained;
+    }
+
+    public List<CloudAccountInfo> cloudAccounts() {
+        return cloudAccounts;
     }
 
     public abstract Type type();

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/TenantController.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/TenantController.java
@@ -12,6 +12,7 @@ import com.yahoo.vespa.hosted.controller.persistence.CuratorDb;
 import com.yahoo.vespa.hosted.controller.security.AccessControl;
 import com.yahoo.vespa.hosted.controller.security.Credentials;
 import com.yahoo.vespa.hosted.controller.security.TenantSpec;
+import com.yahoo.vespa.hosted.controller.tenant.CloudAccountInfo;
 import com.yahoo.vespa.hosted.controller.tenant.DeletedTenant;
 import com.yahoo.vespa.hosted.controller.tenant.LastLoginInfo;
 import com.yahoo.vespa.hosted.controller.tenant.Tenant;
@@ -162,6 +163,14 @@ public class TenantController {
         try (Mutex lock = lock(tenantName)) {
             var tenant = require(tenantName);
             curator.writeTenant(LockedTenant.of(tenant, lock).with(lastMaintained).get());
+        }
+    }
+
+    public void updateCloudAccounts(TenantName tenantName, List<CloudAccountInfo> cloudAccounts) {
+        try (Mutex lock = lock(tenantName)) {
+            var tenant = require(tenantName);
+            if (tenant.cloudAccounts().equals(cloudAccounts)) return; // no change
+            curator.writeTenant(LockedTenant.of(tenant, lock).withCloudAccounts(cloudAccounts).get());
         }
     }
 

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CloudAccountVerifier.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/CloudAccountVerifier.java
@@ -1,0 +1,55 @@
+package com.yahoo.vespa.hosted.controller.maintenance;
+
+import com.yahoo.config.provision.SystemName;
+import com.yahoo.vespa.hosted.controller.Controller;
+import com.yahoo.vespa.hosted.controller.tenant.CloudAccountInfo;
+import com.yahoo.vespa.hosted.controller.tenant.Tenant;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+
+/**
+ * Verifies the cloud accounts that may be used by a given user have applied the enclave template
+ * and extracts the version of the applied template.
+ *
+ * All maintainers that operate on external cloud accounts should use the list on the Tenant instance
+ * maintained by this class rather than the cloud-accounts feature flag.
+ *
+ * The template version can be used to determine if new features can be enabled for the cloud account.
+ *
+ * @author freva
+ */
+public class CloudAccountVerifier extends ControllerMaintainer {
+
+    private static final Logger logger = Logger.getLogger(CloudAccountVerifier.class.getName());
+
+    CloudAccountVerifier(Controller controller, Duration interval) {
+        super(controller, interval, null, Set.of(SystemName.PublicCd, SystemName.Public));
+    }
+
+    @Override
+    protected double maintain() {
+        int attempts = 0, failures = 0;
+        for (Tenant tenant : controller().tenants().asList()) {
+            try {
+                attempts++;
+                List<CloudAccountInfo> cloudAccountInfos = controller().applications().accountsOf(tenant.name()).stream()
+                        .flatMap(account -> controller().serviceRegistry()
+                                .archiveService()
+                                .getEnclaveTemplateVersion(account)
+                                .map(version -> new CloudAccountInfo(account, version))
+                                .stream())
+                        .toList();
+                controller().tenants().updateCloudAccounts(tenant.name(), cloudAccountInfos);
+            } catch (RuntimeException e) {
+                logger.log(WARNING, "Failed to verify cloud accounts for tenant " + tenant.name(), e);
+                failures++;
+            }
+        }
+        return asSuccessFactorDeviation(attempts, failures);
+    }
+}

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/ControllerMaintenance.java
@@ -85,6 +85,7 @@ public class ControllerMaintenance extends AbstractComponent {
         maintainers.add(new EnclaveAccessMaintainer(controller, intervals.defaultInterval));
         maintainers.add(new CertificatePoolMaintainer(controller, metric, intervals.certificatePoolMaintainer));
         maintainers.add(new BillingReportMaintainer(controller, intervals.billingReportMaintainer));
+        maintainers.add(new CloudAccountVerifier(controller, intervals.cloudAccountVerifier));
     }
 
     public Upgrader upgrader() { return upgrader; }
@@ -147,6 +148,7 @@ public class ControllerMaintenance extends AbstractComponent {
         private final Duration meteringMonitorMaintainer;
         private final Duration certificatePoolMaintainer;
         private final Duration billingReportMaintainer;
+        private final Duration cloudAccountVerifier;
 
         public Intervals(SystemName system) {
             this.system = Objects.requireNonNull(system);
@@ -184,6 +186,7 @@ public class ControllerMaintenance extends AbstractComponent {
             this.meteringMonitorMaintainer = duration(30, MINUTES);
             this.certificatePoolMaintainer = duration(15, MINUTES);
             this.billingReportMaintainer = duration(60, MINUTES);
+            this.cloudAccountVerifier = duration(10, MINUTES);
         }
 
         private Duration duration(long amount, TemporalUnit unit) {

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EnclaveAccessMaintainer.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/EnclaveAccessMaintainer.java
@@ -33,7 +33,7 @@ public class EnclaveAccessMaintainer extends ControllerMaintainer {
     private Set<CloudAccount> externalAccounts() {
         Set<CloudAccount> accounts = new HashSet<>();
         for (Tenant tenant : controller().tenants().asList())
-            accounts.addAll(controller().applications().accountsOf(tenant.name()));
+            tenant.cloudAccounts().forEach(accountInfo -> accounts.add(accountInfo.cloudAccount()));
 
         return accounts;
     }

--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiHandler.java
@@ -2915,6 +2915,15 @@ public class ApplicationApiHandler extends AuditLoggingRequestHandler {
             }
         }
         tenantMetaDataToSlime(tenant, applications, object.setObject("metaData"));
+
+        if (!tenant.cloudAccounts().isEmpty()) {
+            Cursor cloudAccounts = object.setArray("cloudAccounts");
+            tenant.cloudAccounts().forEach(accountInfo -> {
+                Cursor accountObject = cloudAccounts.addObject();
+                accountObject.setString("cloudAccount", accountInfo.cloudAccount().value());
+                accountObject.setString("templateVersion", accountInfo.templateVersion().toFullString());
+            });
+        }
     }
 
     private void toSlime(ArchiveAccess archiveAccess, Cursor object) {

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/EnclaveAccessMaintainerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/maintenance/EnclaveAccessMaintainerTest.java
@@ -21,17 +21,20 @@ class EnclaveAccessMaintainerTest {
     void test() {
         ControllerTester tester = new ControllerTester();
         MockEnclaveAccessService amis = tester.serviceRegistry().enclaveAccessService();
-        EnclaveAccessMaintainer sharer = new EnclaveAccessMaintainer(tester.controller(), Duration.ofMinutes(1));
+        EnclaveAccessMaintainer sharer = new EnclaveAccessMaintainer(tester.controller(), Duration.ofHours(1));
+        CloudAccountVerifier accountVerifier = new CloudAccountVerifier(tester.controller(), Duration.ofHours(1));
         assertEquals(Set.of(), amis.currentAccounts());
 
         assertEquals(1, sharer.maintain());
         assertEquals(Set.of(), amis.currentAccounts());
 
         tester.createTenant("tanten");
+        accountVerifier.maintain();
         assertEquals(1, sharer.maintain());
         assertEquals(Set.of(), amis.currentAccounts());
 
         tester.flagSource().withListFlag(PermanentFlags.CLOUD_ACCOUNTS.id(), List.of("123123123123", "321321321321"), String.class);
+        accountVerifier.maintain();
         assertEquals(1, sharer.maintain());
         assertEquals(Set.of(CloudAccount.from("aws:123123123123"), CloudAccount.from("aws:321321321321")), amis.currentAccounts());
     }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDbTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotificationsDbTest.java
@@ -10,7 +10,6 @@ import com.yahoo.config.provision.zone.ZoneId;
 import com.yahoo.path.Path;
 import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.flags.FlagSource;
-import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.hosted.controller.api.application.v4.model.ClusterMetrics;
@@ -69,6 +68,7 @@ public class NotificationsDbTest {
             new ArchiveAccess(),
             Optional.empty(),
             Instant.EPOCH,
+            List.of(),
             Optional.empty());
     private static final List<Notification> notifications = List.of(
             notification(1001, Type.deployment, Level.error, NotificationSource.from(tenant), "tenant msg"),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotifierTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/notification/NotifierTest.java
@@ -6,7 +6,6 @@ import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
-import com.yahoo.vespa.flags.Flags;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.hosted.controller.api.integration.stubs.MockMailer;
@@ -47,6 +46,7 @@ public class NotifierTest {
             new ArchiveAccess(),
             Optional.empty(),
             Instant.EPOCH,
+            List.of(),
             Optional.empty());
 
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializerTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/persistence/TenantSerializerTest.java
@@ -2,6 +2,8 @@
 package com.yahoo.vespa.hosted.controller.persistence;// Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 import com.google.common.collect.ImmutableBiMap;
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.security.KeyUtils;
 import com.yahoo.slime.Cursor;
@@ -16,6 +18,7 @@ import com.yahoo.vespa.hosted.controller.api.role.SimplePrincipal;
 import com.yahoo.vespa.hosted.controller.tenant.ArchiveAccess;
 import com.yahoo.vespa.hosted.controller.tenant.AthenzTenant;
 import com.yahoo.vespa.hosted.controller.tenant.BillingReference;
+import com.yahoo.vespa.hosted.controller.tenant.CloudAccountInfo;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
 import com.yahoo.vespa.hosted.controller.tenant.DeletedTenant;
 import com.yahoo.vespa.hosted.controller.tenant.Email;
@@ -91,7 +94,8 @@ public class TenantSerializerTest {
                 Optional.of(contact()),
                 Instant.EPOCH,
                 lastLoginInfo(321L, 654L, 987L),
-                Instant.EPOCH);
+                Instant.EPOCH,
+                List.of());
         AthenzTenant serialized = (AthenzTenant) serializer.tenantFrom(serializer.toSlime(tenant));
         assertEquals(tenant.contact(), serialized.contact());
     }
@@ -109,6 +113,7 @@ public class TenantSerializerTest {
                 new ArchiveAccess(),
                 Optional.empty(),
                 Instant.EPOCH,
+                List.of(),
                 Optional.empty());
         CloudTenant serialized = (CloudTenant) serializer.tenantFrom(serializer.toSlime(tenant));
         assertEquals(tenant.name(), serialized.name());
@@ -133,6 +138,7 @@ public class TenantSerializerTest {
                 new ArchiveAccess().withAWSRole("arn:aws:iam::123456789012:role/my-role"),
                 Optional.of(Instant.ofEpochMilli(1234567)),
                 Instant.EPOCH,
+                List.of(),
                 Optional.empty());
         CloudTenant serialized = (CloudTenant) serializer.tenantFrom(serializer.toSlime(tenant));
         assertEquals(tenant.info(), serialized.info());
@@ -185,6 +191,8 @@ public class TenantSerializerTest {
                 new ArchiveAccess().withAWSRole("arn:aws:iam::123456789012:role/my-role").withGCPMember("user:foo@example.com"),
                 Optional.empty(),
                 Instant.EPOCH,
+                List.of(new CloudAccountInfo(CloudAccount.from("aws:123456789012"), Version.fromString("1.2.3")),
+                        new CloudAccountInfo(CloudAccount.from("gcp:my-project"), Version.fromString("3.2.1"))),
                 Optional.empty());
         CloudTenant serialized = (CloudTenant) serializer.tenantFrom(serializer.toSlime(tenant));
         assertEquals(serialized.archiveAccess().awsRole().get(), "arn:aws:iam::123456789012:role/my-role");
@@ -263,7 +271,8 @@ public class TenantSerializerTest {
                 Optional.of(contact()),
                 Instant.EPOCH,
                 lastLoginInfo(321L, 654L, 987L),
-                Instant.ofEpochMilli(1_000_000));
+                Instant.ofEpochMilli(1_000_000),
+                List.of());
         assertEquals(tenant, serializer.tenantFrom(serializer.toSlime(tenant)));
     }
 
@@ -281,6 +290,7 @@ public class TenantSerializerTest {
                 new ArchiveAccess().withAWSRole("arn:aws:iam::123456789012:role/my-role").withGCPMember("user:foo@example.com"),
                 Optional.empty(),
                 Instant.EPOCH,
+                List.of(),
                 Optional.of(reference));
         var slime = serializer.toSlime(tenant);
         var deserialized = serializer.tenantFrom(slime);

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
@@ -5,6 +5,7 @@ import ai.vespa.hosted.api.MultiPartStreamer;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ApplicationName;
+import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.InstanceName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.restapi.RestApiException;
@@ -26,12 +27,14 @@ import com.yahoo.vespa.hosted.controller.restapi.ControllerContainerCloudTest;
 import com.yahoo.vespa.hosted.controller.security.Auth0Credentials;
 import com.yahoo.vespa.hosted.controller.security.CloudTenantSpec;
 import com.yahoo.vespa.hosted.controller.security.Credentials;
+import com.yahoo.vespa.hosted.controller.tenant.CloudAccountInfo;
 import com.yahoo.vespa.hosted.controller.tenant.CloudTenant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -369,10 +372,10 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
         new DeploymentTester(wrapped).newDeploymentContext(ApplicationId.from(tenantName, applicationName, InstanceName.defaultName()))
                                      .submit()
                                      .deploy();
+        tester.controller().tenants().updateCloudAccounts(tenantName, List.of(new CloudAccountInfo(CloudAccount.from("aws:123456789012"), new Version(1, 2, 4))));
 
         tester.assertResponse(request("/application/v4/tenant/scoober", GET).roles(Role.reader(tenantName)),
-                (response) -> assertFalse(response.getBodyAsString().contains("archiveAccessRole")),
-                200);
+                new File("tenant-cloud.json"));
 
         tester.assertResponse(request("/application/v4/tenant/scoober/archive-access/aws", PUT)
                         .data("{\"role\":\"arn:aws:iam::123456789012:role/my-role\"}").roles(Role.administrator(tenantName)),

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiTest.java
@@ -1372,7 +1372,7 @@ public class ApplicationApiTest extends ControllerContainerTest {
 
         // Create legacy tenant name containing underscores
         tester.controller().curator().writeTenant(new AthenzTenant(TenantName.from("my_tenant"), ATHENZ_TENANT_DOMAIN,
-                new Property("property1"), Optional.empty(), Optional.empty(), Instant.EPOCH, LastLoginInfo.EMPTY, Instant.EPOCH));
+                new Property("property1"), Optional.empty(), Optional.empty(), Instant.EPOCH, LastLoginInfo.EMPTY, Instant.EPOCH, List.of()));
 
         // POST (add) a Athenz tenant with dashes duplicates existing one with underscores
         tester.assertResponse(request("/application/v4/tenant/my-tenant", POST)

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/tenant-cloud.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/responses/tenant-cloud.json
@@ -1,0 +1,35 @@
+{
+  "tenant": "scoober",
+  "type": "CLOUD",
+  "creator": "developer@scoober",
+  "pemDeveloperKeys": [],
+  "secretStores": [],
+  "integrations": {
+    "aws": {
+      "tenantRole": "scoober-tenant-role",
+      "accounts": []
+    }
+  },
+  "quota": {
+    "budgetUsed": 1.304
+  },
+  "archiveAccess": {},
+  "applications": [
+    {
+      "tenant": "scoober",
+      "application": "albums",
+      "instance": "default",
+      "url": "http://localhost:8080/application/v4/tenant/scoober/application/albums/instance/default"
+    }
+  ],
+  "metaData": {
+    "createdAtMillis": 1600000000000,
+    "lastSubmissionToProdMillis": 1000
+  },
+  "cloudAccounts": [
+    {
+      "cloudAccount": "aws:123456789012",
+      "templateVersion": "1.2.4"
+    }
+  ]
+}

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/controller/responses/maintenance.json
@@ -34,6 +34,9 @@
       "name": "ChangeRequestMaintainer"
     },
     {
+      "name": "CloudAccountVerifier"
+    },
+    {
       "name": "CloudDatabaseMaintainer"
     },
     {
@@ -130,7 +133,5 @@
       "name": "VersionStatusUpdater"
     }
   ],
-  "inactive": [
-    "DeploymentExpirer"
-  ]
+  "inactive": ["DeploymentExpirer"]
 }

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
@@ -70,17 +70,7 @@ public class SignatureFilterTest {
         filter = new SignatureFilter(tester.controller());
         signer = new RequestSigner(privateKey, id.serializedForm(), tester.clock());
 
-        tester.curator().writeTenant(new CloudTenant(appId.tenant(),
-                                                     Instant.EPOCH,
-                                                     LastLoginInfo.EMPTY,
-                                                     Optional.empty(),
-                                                     ImmutableBiMap.of(),
-                                                     TenantInfo.empty(),
-                                                     List.of(),
-                                                     new ArchiveAccess(),
-                                                     Optional.empty(),
-                                                     Instant.EPOCH,
-                                       Optional.empty()));
+        tester.curator().writeTenant(CloudTenant.create(appId.tenant(), Instant.EPOCH, null));
         tester.curator().writeApplication(new Application(appId, tester.clock().instant()));
     }
 
@@ -129,6 +119,7 @@ public class SignatureFilterTest {
                 new ArchiveAccess(),
                 Optional.empty(),
                 Instant.EPOCH,
+                List.of(),
                 Optional.empty()));
         verifySecurityContext(requestOf(signer.signed(request.copy(), Method.POST, () -> new ByteArrayInputStream(hiBytes)), hiBytes),
                 new SecurityContext(new SimplePrincipal("user"),


### PR DESCRIPTION
Adds a maintainer that updates a list of cloud accounts that are ready for use on the tenant object. This list will be a subset of the `cloud-accounts` list. 

All maintainers/code, except the code that validates a new application package, that work on enclave accounts should use this as source rather than the feature flag. This will reduce number of errors/places where we need to handle that we cant assume `vespa-cloud-provisioner` IAM role/service account or some other resource because the tenant has not applied the terraform template yet.

The template version can be used to determine if we can start using some new feature that relies on a change in the template, f.ex. that we add some new permission.

Must be merged with internal PR.