### PR TITLE
LuceneLinguistics: optionaly consider StemMode as an analysis key

### DIFF
--- a/lucene-linguistics/src/test/java/com/yahoo/language/lucene/LuceneTokenizerTest.java
+++ b/lucene-linguistics/src/test/java/com/yahoo/language/lucene/LuceneTokenizerTest.java
@@ -197,4 +197,33 @@ public class LuceneTokenizerTest {
                 .tokenize("Dogs and Cats", Language.ENGLISH, StemMode.ALL, false);
         assertEquals(List.of("and", "Cat"), tokenStrings(tokens));
     }
+
+    @Test
+    public void compositeConfigKey() {
+        String reversingAnalyzerKey = Language.ENGLISH.languageCode()
+                + "/"
+                + StemMode.ALL;
+        LuceneAnalysisConfig enConfig = new LuceneAnalysisConfig.Builder()
+                .analysis(
+                        Map.of(reversingAnalyzerKey,
+                                new LuceneAnalysisConfig.Analysis.Builder().tokenFilters(List.of(
+                                        new LuceneAnalysisConfig
+                                                .Analysis
+                                                .TokenFilters
+                                                .Builder()
+                                                .name("reverseString"))))
+                ).build();
+        LuceneLinguistics linguistics = new LuceneLinguistics(enConfig, new ComponentRegistry<>());
+        // Matching StemMode
+        Iterable<Token> tokens = linguistics
+                .getTokenizer()
+                .tokenize("Dogs and Cats", Language.ENGLISH, StemMode.ALL, false);
+        assertEquals(List.of("sgoD", "dna", "staC"), tokenStrings(tokens));
+        // StemMode is different
+        Iterable<Token> stemModeTokens = linguistics
+                .getTokenizer()
+                .tokenize("Dogs and Cats", Language.ENGLISH, StemMode.BEST, false);
+        assertEquals(List.of("dog", "cat"), tokenStrings(stemModeTokens));
+
+    }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Considering a `StemMode` as a part of analysis key allows to have more than one analysis configuration per language. There are 5 stem modes. So, 6 analysis configurations per language are possible. E.g. for English language there are 6 valid keys: `['en', 'en/ALL', 'en/BEST', 'en/DEFAULT', 'en/NONE', 'en/SHORTEST']` (note case sensitivity). 

The `/` is used as a separator so that it doesn't clash with the `ComponentId` specification with versions.

This is not a breaking change.