### PR TITLE
Preserve prefix of input DFA successor string

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.cpp
@@ -47,7 +47,6 @@ DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uin
     : _dfa(vespalib::fuzzy::LevenshteinDfa::build(extract_suffix(target, prefix_size), max_edits, (cased ? LevenshteinDfa::Casing::Cased : LevenshteinDfa::Casing::Uncased), dfa_type)),
       _successor(),
       _prefix(extract_prefix(target, prefix_size, cased)),
-      _successor_suffix(),
       _prefix_size(prefix_size),
       _cased(cased)
 {

--- a/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
@@ -20,7 +20,6 @@ private:
     vespalib::fuzzy::LevenshteinDfa _dfa;
     std::vector<uint32_t>           _successor;
     std::vector<uint32_t>           _prefix;
-    std::vector<uint32_t>           _successor_suffix;
     uint32_t                        _prefix_size;
     bool                            _cased;
 
@@ -50,14 +49,14 @@ public:
                 _successor.resize(_prefix.size());
                 _successor.emplace_back(1);
             } else {
-                auto match = _dfa.match(word, _successor_suffix);
+                _successor.resize(_prefix.size());
+                auto match = _dfa.match(word, _successor);
                 if (match.matches()) {
                     return true;
                 }
-                _successor.resize(_prefix.size());
-                _successor.insert(_successor.end(), _successor_suffix.begin(), _successor_suffix.end());
             }
         } else {
+            _successor.clear();
             auto match = _dfa.match(word, _successor);
             if (match.matches()) {
                 return true;

--- a/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/levenshtein_dfa.h
@@ -179,16 +179,23 @@ public:
      * Attempts to match the source string `source` with the target string this DFA was
      * built with, emitting a successor string into `successor_out` on mismatch.
      *
-     * See `match(source)` for semantics of returned MatchResult.
+     * In the case of a _match_, the following holds:
      *
-     * In the case of a _match_, the contents of `successor_out` is unspecified. It may be
-     * preemptively modified as part of the matching loop itself.
+     *   - The returned MatchResult has the same semantics as `match(source)`.
+     *   - `successor_out` has a _prefix_ equal to its value that was originally passed
+     *     in at the time of match() being called. The _suffix_ of the string is unspecified,
+     *     i.e. it may or may not have been modified.
      *
      * In the case of a _mismatch_, the following holds:
      *
-     *   - `successor_out` contains the next (in byte-wise ordering) possible _matching_
-     *     string S so that there exists no other matching string S' that is greater than
-     *     `source` but smaller than S.
+     *   - `successor_out` has a _prefix_ equal to its value that was originally passed
+     *      in at the time of match() being called.
+     *   - `successor_out` has a _suffix_ that contains the next (in byte-wise ordering)
+     *     possible _matching_ string S so that there exists no other matching string S'
+     *     that is greater than `source` but smaller than S.
+     *     The caller must explicitly be aware of any prefixes it sends in, as it is
+     *     entirely ignored for the purposes of ordering the successor string vis-a-vis
+     *     the input source string.
      *   - `successor_out` contains UTF-8 bytes that are within what UTF-8 can legally
      *     encode in bitwise form, but the _code points_ they encode may not be valid.
      *     In particular, surrogate pair ranges and U+10FFFF+1 may be encoded, neither of

--- a/vespalib/src/vespa/vespalib/fuzzy/match_algorithm.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/match_algorithm.hpp
@@ -150,11 +150,9 @@ struct MatchAlgorithm {
                              std::string_view source,
                              SuccessorT& successor_out)
     {
-        successor_out.clear(); // TODO allow for preserving existing prefix
-
         using StateType = typename Matcher::StateType;
         Utf8Reader u8_reader(source.data(), source.size());
-        uint32_t n_prefix_chars    = 0;
+        uint32_t n_prefix_chars    = static_cast<uint32_t>(successor_out.size()); // Don't touch any existing prefix
         uint32_t char_after_prefix = 0;
         StateType last_state_with_higher_out = StateType{};
 


### PR DESCRIPTION
@toregge @geirst please review

If a non-empty string is passed as a successor to the DFA, the contents of the string will be preserved, i.e. the successor will always be _appended_ to any existing data. This allows for less manual fiddling when implementing prefix locking by the caller (no need to concatenate a prefix with the generated successor string).

Note: this has some added cognitive cost where the caller now has the entire responsibility of resetting the successor between calls.

The existing fuzzy matcher has been updated to no longer require a separation between successor prefix and suffix—it can now safely reuse the successor prefix between calls.

