### PR TITLE
Add missing includes, avoid shadow warning and skip including file not

### DIFF
--- a/document/src/vespa/document/select/parse_utils.cpp
+++ b/document/src/vespa/document/select/parse_utils.cpp
@@ -24,7 +24,7 @@ parse_i64(const char* str, size_t len, int64_t& out) {
 }
 bool
 parse_double(const char* str, size_t len, double& out) {
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 170000
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION < 180000
     // Temporary workaround that also handles underflow (cf. issue 3081)
     // until libc++ supports std::from_chars for double
     char *str_end = const_cast<char*>(str) + len;

--- a/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
+++ b/eval/src/vespa/eval/eval/llvm/llvm_wrapper.cpp
@@ -14,7 +14,9 @@
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 #include <llvm/IR/DataLayout.h>
 #include <llvm/Transforms/Scalar.h>
+#if LLVM_VERSION_MAJOR < 17
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+#endif
 #include <llvm/Support/ManagedStatic.h>
 #include <vespa/eval/eval/check_type.h>
 #include <vespa/vespalib/stllike/hash_set.h>

--- a/eval/src/vespa/eval/eval/tensor_function.cpp
+++ b/eval/src/vespa/eval/eval/tensor_function.cpp
@@ -350,12 +350,12 @@ Peek::make_spec() const
     // the value peeked is child 0, so
     // children (for label computation) in spec start at 1:
     size_t child_idx = 1;
-    for (const auto & [dim_name, label_or_child] : map()) {
+    for (const auto & [outer_dim_name, label_or_child] : map()) {
         std::visit(vespalib::overload {
-                [&,&dim_name = dim_name](const TensorSpec::Label &label) {
+                [&,&dim_name = outer_dim_name](const TensorSpec::Label &label) {
                     generic_spec.emplace(dim_name, label);
                 },
-                [&,&dim_name = dim_name](const TensorFunction::Child &) {
+                [&,&dim_name = outer_dim_name](const TensorFunction::Child &) {
                     generic_spec.emplace(dim_name, child_idx++);
                 }
             }, label_or_child);

--- a/vespalib/src/vespa/vespalib/datastore/compaction_strategy.h
+++ b/vespalib/src/vespa/vespalib/datastore/compaction_strategy.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <iosfwd>
+#include <cstddef>
 #include <cstdint>
+#include <iosfwd>
 
 namespace vespalib {
 

--- a/vespalib/src/vespa/vespalib/fuzzy/table_dfa.hpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/table_dfa.hpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <algorithm>
 #include <map>
+#include <ostream>
 #include <set>
 #include <queue>
 

--- a/vespalib/src/vespa/vespalib/util/address_space.h
+++ b/vespalib/src/vespa/vespalib/util/address_space.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <iosfwd>
 
 namespace vespalib {

--- a/vespalog/src/vespa/log/log.h
+++ b/vespalog/src/vespa/log/log.h
@@ -1,6 +1,7 @@
 // Copyright Yahoo. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
+#include <cstdarg>
 #include <memory>
 #include <new>         // for placement new
 #include <sys/types.h> // for pid_t


### PR DESCRIPTION
present in llvm 17.

Issues detected when compiling with clang++ 17 / libc++ 17 / llvm 17.

@baldersheim : please review
