### PR TITLE
- Use asBitVectorIterator instead of isBitVector + casting to present…

### DIFF
--- a/searchlib/src/vespa/searchlib/common/bitvectoriterator.h
+++ b/searchlib/src/vespa/searchlib/common/bitvectoriterator.h
@@ -23,7 +23,7 @@ private:
     void doUnpack(uint32_t docId) override final {
         _tfmd.resetOnlyDocId(docId);
     }
-    bool isBitVector() const override { return true; }
+    BitVectorIterator * asBitVector() noexcept override { return this; }
     fef::TermFieldMatchData  &_tfmd;
 public:
     virtual bool isInverted() const = 0;

--- a/searchlib/src/vespa/searchlib/common/bitvectoriterator.h
+++ b/searchlib/src/vespa/searchlib/common/bitvectoriterator.h
@@ -20,17 +20,16 @@ protected:
     const BitVector & _bv;
 private:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
-    void doUnpack(uint32_t docId) override final {
+    void doUnpack(uint32_t docId) final {
         _tfmd.resetOnlyDocId(docId);
     }
-    BitVectorIterator * asBitVector() noexcept override { return this; }
+    BitVectorMeta asBitVector() const noexcept override { return {&_bv, _docIdLimit, isInverted()}; }
     fef::TermFieldMatchData  &_tfmd;
 public:
     virtual bool isInverted() const = 0;
-    const void *getBitValues() const { return _bv.getStart(); }
 
     Trinary is_strict() const override { return Trinary::False; }
-    uint32_t getDocIdLimit() const { return _docIdLimit; }
+    uint32_t getDocIdLimit() const noexcept { return _docIdLimit; }
     static UP create(const BitVector *const other, fef::TermFieldMatchData &matchData, bool strict, bool inverted = false);
     static UP create(const BitVector *const other, uint32_t docIdLimit,
                      fef::TermFieldMatchData &matchData, bool strict, bool inverted = false);

--- a/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
@@ -55,6 +55,9 @@ public:
     BitVector::UP get_hits(uint32_t begin_id) override {
         return _wrapped_search->get_hits(begin_id);
     }
+    BitVectorIterator * asBitVector() noexcept override {
+        return _wrapped_search->asBitVector();
+    }
     Trinary is_strict() const override {
         return _wrapped_search->is_strict();
     }

--- a/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
+++ b/searchlib/src/vespa/searchlib/queryeval/filter_wrapper.h
@@ -17,10 +17,10 @@ namespace search::queryeval {
 class FilterWrapper : public SearchIterator {
 private:
     std::vector<fef::TermFieldMatchData> _unused_md;
-    fef::TermFieldMatchDataArray _tfmda;
-    std::unique_ptr<SearchIterator> _wrapped_search;
+    fef::TermFieldMatchDataArray         _tfmda;
+    std::unique_ptr<SearchIterator>      _wrapped_search;
 public:
-    FilterWrapper(size_t num_fields)
+    explicit FilterWrapper(size_t num_fields)
       : _unused_md(num_fields),
         _tfmda(),
         _wrapped_search()
@@ -55,7 +55,7 @@ public:
     BitVector::UP get_hits(uint32_t begin_id) override {
         return _wrapped_search->get_hits(begin_id);
     }
-    BitVectorIterator * asBitVector() noexcept override {
+    BitVectorMeta asBitVector() const noexcept override {
         return _wrapped_search->asBitVector();
     }
     Trinary is_strict() const override {

--- a/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/multibitvectoriterator.cpp
@@ -119,8 +119,10 @@ public:
           _mbv(getChildren().size() + 1)
     {
         for (const auto & child : getChildren()) {
-            const auto * bv = child->asBitVector();
-            _mbv.addBitVector(Meta(bv->getBitValues(), bv->isInverted()), bv->getDocIdLimit());
+            BitVectorMeta bv = child->asBitVector();
+            if (bv.valid()) {
+                _mbv.addBitVector(Meta(bv.vector()->getStart(), bv.inverted()), bv.getDocidLimit());
+            }
         }
     }
     void initRange(uint32_t beginId, uint32_t endId) override {
@@ -168,9 +170,9 @@ SearchIterator::UP
 MultiBitVectorIterator<Update>::andWith(UP filter, uint32_t estimate)
 {
     (void) estimate;
-    const BitVectorIterator * bv = filter->asBitVector();
-    if (bv && acceptExtraFilter()) {
-        _mbv.addBitVector(Meta(bv->getBitValues(), bv->isInverted()), bv->getDocIdLimit());
+    BitVectorMeta bv = filter->asBitVector();
+    if (bv.valid() && acceptExtraFilter()) {
+        _mbv.addBitVector(Meta(bv.vector()->getStart(), bv.inverted()), bv.getDocidLimit());
         insert(getChildren().size(), std::move(filter));
         _mbv.reset();
     }

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
@@ -15,7 +15,10 @@ namespace vespalib::slime {
     struct Inserter;
 }
 
-namespace search { class BitVector; }
+namespace search {
+    class BitVector;
+    class BitVectorIterator;
+}
 namespace search::attribute { class ISearchContext; }
 
 namespace search::queryeval {
@@ -331,7 +334,8 @@ public:
     /**
      * @return true if it is a bitvector
      */
-    virtual bool isBitVector() const { return false; }
+    bool isBitVector() noexcept { return asBitVector() != nullptr; }
+    virtual BitVectorIterator * asBitVector() noexcept { return nullptr; }
     /**
      * @return true if it is a source blender
      */

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
@@ -15,10 +15,7 @@ namespace vespalib::slime {
     struct Inserter;
 }
 
-namespace search {
-    class BitVector;
-    class BitVectorIterator;
-}
+namespace search { class BitVector; }
 namespace search::attribute { class ISearchContext; }
 
 namespace search::queryeval {
@@ -334,8 +331,23 @@ public:
     /**
      * @return true if it is a bitvector
      */
-    bool isBitVector() noexcept { return asBitVector() != nullptr; }
-    virtual BitVectorIterator * asBitVector() noexcept { return nullptr; }
+    class BitVectorMeta {
+    public:
+        BitVectorMeta() noexcept : BitVectorMeta(nullptr, 0, false) {}
+        BitVectorMeta(const BitVector * bv, uint32_t docidLimit, bool inverted_in) noexcept
+            : _bv(bv), _docidLimit(docidLimit), _inverted(inverted_in)
+        {}
+        const BitVector * vector() const noexcept { return _bv; }
+        bool inverted () const noexcept { return _inverted; }
+        uint32_t getDocidLimit() const noexcept { return _docidLimit; }
+        bool valid() const noexcept { return _bv != nullptr; }
+    private:
+        const BitVector * _bv;
+        uint32_t          _docidLimit;
+        bool              _inverted;
+    };
+    bool isBitVector() const noexcept { return asBitVector().valid(); }
+    virtual BitVectorMeta asBitVector() const noexcept { return {}; }
     /**
      * @return true if it is a source blender
      */


### PR DESCRIPTION
… a BitVectorIterator interface.

- Allow Filter wrapper to expose underlying BitVector.
   - This ensures that the bitvectors are handled first during termwise evaluation, as they have a constant cost and will reduce the cost for the ones coming later on.

@havardpe PR