### PR TITLE
Revert "Revert "Include cstdio to get declaration of FILE.""

### DIFF
--- a/vespamalloc/src/vespamalloc/malloc/mmappool.h
+++ b/vespamalloc/src/vespamalloc/malloc/mmappool.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdio>
 #include <mutex>
 #include <unordered_map>
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#28743
Unrelated to build failure, which is out of disk space.