### PR TITLE
lucene-linguistics: add default Chinese, Japanese, and Korean support

### DIFF
--- a/lucene-linguistics/src/main/java/com/yahoo/language/lucene/DefaultAnalyzers.java
+++ b/lucene-linguistics/src/main/java/com/yahoo/language/lucene/DefaultAnalyzers.java
@@ -6,6 +6,7 @@ import org.apache.lucene.analysis.ar.ArabicAnalyzer;
 import org.apache.lucene.analysis.bg.BulgarianAnalyzer;
 import org.apache.lucene.analysis.bn.BengaliAnalyzer;
 import org.apache.lucene.analysis.ca.CatalanAnalyzer;
+import org.apache.lucene.analysis.cjk.CJKAnalyzer;
 import org.apache.lucene.analysis.ckb.SoraniAnalyzer;
 import org.apache.lucene.analysis.cz.CzechAnalyzer;
 import org.apache.lucene.analysis.da.DanishAnalyzer;
@@ -58,7 +59,10 @@ class DefaultAnalyzers {
                 entry(Language.BENGALI, new BengaliAnalyzer()),
                 // analyzerClasses.put(Language.BRASILIAN, new BrazilianAnalyzer())
                 entry(Language.CATALAN, new CatalanAnalyzer()),
-                // cjk analyzer?
+                entry(Language.CHINESE_SIMPLIFIED, new CJKAnalyzer()),
+                entry(Language.CHINESE_TRADITIONAL, new CJKAnalyzer()),
+                entry(Language.JAPANESE, new CJKAnalyzer()),
+                entry(Language.KOREAN, new CJKAnalyzer()),
                 entry(Language.KURDISH, new SoraniAnalyzer()),
                 entry(Language.CZECH, new CzechAnalyzer()),
                 entry(Language.DANISH, new DanishAnalyzer()),


### PR DESCRIPTION
This PR configures defaults for Chinese, Japanese, and Korean languages.

No additional dependencies are added.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
