### PR TITLE
Remove unused code branch in Bouncer component

### DIFF
--- a/storage/src/vespa/storage/storageserver/bouncer.cpp
+++ b/storage/src/vespa/storage/storageserver/bouncer.cpp
@@ -276,14 +276,6 @@ Bouncer::onDown(const std::shared_ptr<api::StorageMessage>& msg)
         isInAvailableState       = state->oneOf(_config->stopAllLoadWhenNodestateNotIn.c_str());
         feedPriorityLowerBound   = _config->feedRejectionPriorityThreshold;
     }
-    // Special case for messages storage nodes are expected to get during
-    // initializing. Request bucket info will be queued so storage can
-    // answer them at the moment they are done initializing
-    if (*state == lib::State::INITIALIZING &&
-        type.getId() == api::MessageType::REQUESTBUCKETINFO_ID)
-    {
-        return false;
-    }
     // Special case for point lookup Gets while node is in maintenance mode
     // to allow reads to complete during two-phase cluster state transitions
     if ((*state == lib::State::MAINTENANCE) && (type.getId() == api::MessageType::GET_ID) && clusterIsUp(*cluster_state)) {


### PR DESCRIPTION
@baldersheim please review

For a long time now, content nodes have transitioned directly from Down to Up on startup, and they will never pass through an Initializing state (remnant from spinning rust days).

