### PR TITLE
Use DfaTable as default fuzzy matching algorithm for maxEditDistance …

### DIFF
--- a/searchcore/src/tests/proton/matching/matching_test.cpp
+++ b/searchcore/src/tests/proton/matching/matching_test.cpp
@@ -1167,16 +1167,16 @@ struct AttributeBlueprintParamsFixture {
    }
 };
 
-TEST_F("attribute blueprint params are extracted from rank profile", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::BruteForce))
+TEST_F("attribute blueprint params are extracted from rank profile", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::DfaTable))
 {
     auto params = f.extract();
     EXPECT_EQUAL(0.2, params.global_filter_lower_limit);
     EXPECT_EQUAL(0.8, params.global_filter_upper_limit);
     EXPECT_EQUAL(5.0, params.target_hits_max_adjustment_factor);
-    EXPECT_EQUAL(FMA::BruteForce, params.fuzzy_matching_algorithm);
+    EXPECT_EQUAL(FMA::DfaTable, params.fuzzy_matching_algorithm);
 }
 
-TEST_F("attribute blueprint params are extracted from query", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::BruteForce))
+TEST_F("attribute blueprint params are extracted from query", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::DfaTable))
 {
     f.set_query_properties("0.15", "0.75", "3.0", "dfa_explicit");
     auto params = f.extract();
@@ -1186,7 +1186,7 @@ TEST_F("attribute blueprint params are extracted from query", AttributeBlueprint
     EXPECT_EQUAL(FMA::DfaExplicit, params.fuzzy_matching_algorithm);
 }
 
-TEST_F("global filter params are scaled with active hit ratio", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::BruteForce))
+TEST_F("global filter params are scaled with active hit ratio", AttributeBlueprintParamsFixture(0.2, 0.8, 5.0, FMA::DfaTable))
 {
     auto params = f.extract(5, 10);
     EXPECT_EQUAL(0.12, params.global_filter_lower_limit);

--- a/searchlib/src/vespa/searchlib/attribute/string_search_helper.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_helper.cpp
@@ -49,14 +49,15 @@ StringSearchHelper::StringSearchHelper(QueryTermUCS4 & term, bool cased, vespali
                 ? vespalib::Regex::from_pattern(term.getTerm(), vespalib::Regex::Options::None)
                 : vespalib::Regex::from_pattern(term.getTerm(), vespalib::Regex::Options::IgnoreCase);
     } else if (isFuzzy()) {
+        auto max_edit_dist = term.getFuzzyMaxEditDistance();
         _fuzzyMatcher = std::make_unique<vespalib::FuzzyMatcher>(term.getTerm(),
-                                                                 term.getFuzzyMaxEditDistance(),
+                                                                 max_edit_dist,
                                                                  term.getFuzzyPrefixLength(),
                                                                  isCased());
         if ((fuzzy_matching_algorithm != FMA::BruteForce) &&
-            (term.getFuzzyMaxEditDistance() <= 2)) {
+            (max_edit_dist > 0 && max_edit_dist <= 2)) {
             _dfa_fuzzy_matcher = std::make_unique<DfaFuzzyMatcher>(term.getTerm(),
-                                                                   term.getFuzzyMaxEditDistance(),
+                                                                   max_edit_dist,
                                                                    term.getFuzzyPrefixLength(),
                                                                    isCased(),
                                                                    to_dfa_type(fuzzy_matching_algorithm));

--- a/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
+++ b/searchlib/src/vespa/searchlib/fef/indexproperties.cpp
@@ -439,7 +439,7 @@ TargetHitsMaxAdjustmentFactor::lookup(const Properties& props, double defaultVal
 }
 
 const vespalib::string FuzzyAlgorithm::NAME("vespa.matching.fuzzy.algorithm");
-const vespalib::FuzzyMatchingAlgorithm FuzzyAlgorithm::DEFAULT_VALUE(vespalib::FuzzyMatchingAlgorithm::BruteForce);
+const vespalib::FuzzyMatchingAlgorithm FuzzyAlgorithm::DEFAULT_VALUE(vespalib::FuzzyMatchingAlgorithm::DfaTable);
 
 vespalib::FuzzyMatchingAlgorithm
 FuzzyAlgorithm::lookup(const Properties& props)

--- a/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
+++ b/searchlib/src/vespa/searchlib/fef/ranksetup.cpp
@@ -69,7 +69,7 @@ RankSetup::RankSetup(const BlueprintFactory &factory, const IIndexEnvironment &i
       _global_filter_lower_limit(0.0),
       _global_filter_upper_limit(1.0),
       _target_hits_max_adjustment_factor(20.0),
-      _fuzzy_matching_algorithm(vespalib::FuzzyMatchingAlgorithm::BruteForce),
+      _fuzzy_matching_algorithm(vespalib::FuzzyMatchingAlgorithm::DfaTable),
       _mutateOnMatch(),
       _mutateOnFirstPhase(),
       _mutateOnSecondPhase(),


### PR DESCRIPTION
…<= 2.

@toregge please review
@vekterli FYI

This re-applies https://github.com/vespa-engine/vespa/pull/28765 with a fix that handles maxEditDistance=0.