### PR TITLE
Avoid unaligned read while decoding serialized query stack dump.

### DIFF
--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.cpp
@@ -153,9 +153,10 @@ bool SimpleQueryStackDumpIterator::readNext() {
         break;
     case ParseItem::ITEM_PURE_WEIGHTED_LONG:
         {
-            if (p + sizeof(int64_t) > _bufEnd) return false;
-            _curr_integer_term = vespalib::nbo::n2h(*reinterpret_cast<const int64_t *>(p));
-            p += sizeof(int64_t);
+            if (p + sizeof(int64_t) > _bufEnd) {
+                return false;
+            }
+            _curr_integer_term = readUint64(p);
             _currArity = 0;
         }
         break;


### PR DESCRIPTION
@geirst : please review
