### PR TITLE
- Instead of keeping a map of bucketId => lids, just append everythin…

### DIFF
--- a/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
+++ b/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
@@ -7,7 +7,6 @@
 #include <vespa/searchlib/docstore/storebybucket.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/hash_set.h>
-#include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 #include <vespa/log/log.h>
@@ -79,6 +78,7 @@ TEST("require that StoreByBucket gives bucket by bucket and ordered within")
     for (size_t i(1000); i > 500; i--) {
         add(sbb, i);
     }
+    sbb.close();
     EXPECT_EQUAL(32u, sbb.getBucketCount());
     EXPECT_EQUAL(1000u, sbb.getLidCount());
     VerifyBucketOrder vbo;

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -79,7 +79,8 @@ BucketCompacter::close()
     size_t lidCount1(0);
     size_t bucketCount(0);
     size_t chunkCount(0);
-    for (const StoreByBucket & store : _tmpStore) {
+    for (StoreByBucket & store : _tmpStore) {
+        store.close();
         lidCount1 += store.getLidCount();
         bucketCount += store.getBucketCount();
         chunkCount += store.getChunkCount();

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.h
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.h
@@ -7,7 +7,6 @@
 #include <vespa/vespalib/data/memorydatastore.h>
 #include <vespa/vespalib/util/executor.h>
 #include <vespa/vespalib/stllike/hash_map.h>
-#include <map>
 #include <condition_variable>
 
 namespace search::docstore {
@@ -34,19 +33,18 @@ public:
     class IWrite {
     public:
         using BucketId=document::BucketId;
-        virtual ~IWrite() { }
+        virtual ~IWrite() = default;
         virtual void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz) = 0;
     };
     void add(document::BucketId bucketId, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz);
+    void close();
+    /// close() must have been called prior to calling getBucketCount() or drain()
     void drain(IWrite & drain);
+    size_t getBucketCount() const;
+
     size_t getChunkCount() const;
-    size_t getBucketCount() const { return _where.size(); }
     size_t getLidCount() const {
-        size_t lidCount(0);
-        for (const auto & it : _where) {
-            lidCount += it.second.size();
-        }
-        return lidCount;
+        return _where.size();
     }
 private:
     void incChunksPosted();
@@ -69,7 +67,7 @@ private:
     using IndexVector = std::vector<Index, vespalib::allocator_large<Index>>;
     uint64_t                                     _chunkSerial;
     Chunk::UP                                    _current;
-    std::map<uint64_t, IndexVector>              _where;
+    IndexVector                                  _where;
     MemoryDataStore                            & _backingMemory;
     Executor                                   & _executor;
     std::unique_ptr<std::mutex>                  _lock;


### PR DESCRIPTION
…g to a vector and sort when complete.

- This significantly improves memory usage during compaction. Instead of many heap allocations
- You now get fewer mmapped allocations that are dropped when done.

@geirst or @toregge PR