### PR TITLE
- Number of partitions is fixed compile time => use std::array.

### DIFF
--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -41,9 +41,8 @@ BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, CompressionCon
     _bucketizerGuard(),
     _stat()
 {
-    _tmpStore.reserve(256);
-    for (size_t i(0); i < 256; i++) {
-        _tmpStore.emplace_back(_backingMemory, executor, compression);
+    for (size_t i(0); i < _tmpStore.size(); i++) {
+        _tmpStore[i] = std::make_unique<StoreByBucket>(_backingMemory, executor, compression);
     }
 }
 
@@ -62,7 +61,7 @@ BucketCompacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, const vo
     guard.unlock();
     BucketId bucketId = (sz > 0) ? _bucketizer.getBucketOf(_bucketizerGuard, lid) : BucketId();
     uint64_t sortableBucketId = bucketId.toKey();
-    _tmpStore[(sortableBucketId >> _unSignificantBucketBits) % _tmpStore.size()].add(bucketId, chunkId, lid, buffer, sz);
+    _tmpStore[(sortableBucketId >> _unSignificantBucketBits) % _tmpStore.size()]->add(bucketId, chunkId, lid, buffer, sz);
     if ((_writeCount % 1000) == 0) {
         _bucketizerGuard = _bucketizer.getGuard();
         vespalib::steady_time now = vespalib::steady_clock::now();
@@ -79,18 +78,20 @@ BucketCompacter::close()
     size_t lidCount1(0);
     size_t bucketCount(0);
     size_t chunkCount(0);
-    for (const StoreByBucket & store : _tmpStore) {
-        lidCount1 += store.getLidCount();
-        bucketCount += store.getBucketCount();
-        chunkCount += store.getChunkCount();
+    for (const auto & store : _tmpStore) {
+        lidCount1 += store->getLidCount();
+        bucketCount += store->getBucketCount();
+        chunkCount += store->getChunkCount();
     }
     LOG(info, "Have read %ld lids and placed them in %ld buckets. Temporary compressed in %ld chunks."
               " Max bucket guard held for %" PRId64 " us, and last before close for %" PRId64 " us",
               lidCount1, bucketCount, chunkCount, vespalib::count_us(_maxBucketGuardDuration), vespalib::count_us(lastBucketGuardDuration));
 
-    for (StoreByBucket & store : _tmpStore) {
-        store.drain(*this);
+    for (auto & store_ref : _tmpStore) {
+        auto store = std::move(store_ref);
+        store->drain(*this);
     }
+    // All partitions using _backingMemory should be destructed before clearing.
     _backingMemory.clear();
 
     size_t lidCount(0);

--- a/searchlib/src/vespa/searchlib/docstore/compacter.h
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.h
@@ -41,7 +41,9 @@ public:
     void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, const void *buffer, size_t sz) override;
     void close() override;
 private:
+    static constexpr size_t NUM_PARTITIONS = 256;
     using GenerationHandler = vespalib::GenerationHandler;
+    using Partitions = std::array<std::unique_ptr<StoreByBucket>, NUM_PARTITIONS>;
     FileId getDestinationId(const LockGuard & guard) const;
     size_t                     _unSignificantBucketBits;
     FileId                     _sourceFileId;
@@ -53,7 +55,7 @@ private:
     vespalib::steady_time      _lastSample;
     std::mutex                 _lock;
     vespalib::MemoryDataStore  _backingMemory;
-    std::vector<StoreByBucket> _tmpStore;
+    Partitions                 _tmpStore;
     GenerationHandler::Guard   _lidGuard;
     GenerationHandler::Guard   _bucketizerGuard;
     vespalib::hash_map<uint64_t, uint32_t> _stat;

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.h
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.h
@@ -26,7 +26,7 @@ class StoreByBucket
 public:
     StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, CompressionConfig compression) noexcept;
     //TODO Putting the below move constructor into cpp file fails for some unknown reason. Needs to be resolved.
-    StoreByBucket(StoreByBucket &&) noexcept = default;
+    StoreByBucket(StoreByBucket &&) noexcept = delete;
     StoreByBucket(const StoreByBucket &) = delete;
     StoreByBucket & operator=(StoreByBucket &&) noexcept = delete;
     StoreByBucket & operator = (const StoreByBucket &) = delete;
@@ -72,8 +72,8 @@ private:
     std::map<uint64_t, IndexVector>              _where;
     MemoryDataStore                            & _backingMemory;
     Executor                                   & _executor;
-    std::unique_ptr<std::mutex>                  _lock;
-    std::unique_ptr<std::condition_variable>     _cond;
+    mutable std::mutex                           _lock;
+    std::condition_variable                      _cond;
     size_t                                       _numChunksPosted;
     vespalib::hash_map<uint64_t, ConstBufferRef> _chunks;
     CompressionConfig                            _compression;


### PR DESCRIPTION
- Use unique_ptr on outer object instead of unique_ptr on multiple non-movable inner objects.

@geirst PR