### PR TITLE
- Use a single store for mapping lid to its data that are split into …

### DIFF
--- a/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
+++ b/searchlib/src/tests/docstore/store_by_bucket/store_by_bucket_test.cpp
@@ -4,7 +4,7 @@
 
 #include <vespa/document/bucket/bucketid.h>
 #include <vespa/document/base/documentid.h>
-#include <vespa/searchlib/docstore/storebybucket.h>
+#include <vespa/searchlib/docstore/compacter.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/vespalib/stllike/hash_set.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
@@ -25,8 +25,8 @@ createPayload(BucketId b) {
 }
 uint32_t userId(size_t i) { return i%100; }
 
-void
-add(StoreByBucket & sbb, size_t i) {
+BucketId
+createBucketId(size_t i) {
     constexpr size_t USED_BITS=5;
     vespalib::asciistream os;
     os << "id:a:b:n=" << userId(i) << ":" << i;
@@ -34,6 +34,11 @@ add(StoreByBucket & sbb, size_t i) {
     BucketId b = docId.getGlobalId().convertToBucketId();
     EXPECT_EQUAL(userId(i), docId.getGlobalId().getLocationSpecificBits());
     b.setUsedBits(USED_BITS);
+    return b;
+}
+void
+add(StoreByBucket & sbb, size_t i) {
+    BucketId b = createBucketId(i);
     vespalib::string s = createPayload(b);
     sbb.add(b, i%10, i, {s.c_str(), s.size()});
 }
@@ -78,7 +83,7 @@ struct StoreIndex : public StoreByBucket::StoreIndex {
 StoreIndex::~StoreIndex() = default;
 
 struct Iterator : public StoreByBucket::IndexIterator {
-    Iterator(const std::vector<StoreByBucket::Index> & where) : _where(where), _current(0) {}
+    explicit Iterator(const std::vector<StoreByBucket::Index> & where) : _where(where), _current(0) {}
 
     bool has_next() noexcept override {
         return _current < _where.size();
@@ -99,19 +104,48 @@ TEST("require that StoreByBucket gives bucket by bucket and ordered within")
     vespalib::ThreadStackExecutor executor(8);
     StoreIndex storeIndex;
     StoreByBucket sbb(storeIndex, backing, executor, CompressionConfig::LZ4);
-    for (size_t i(1); i <=500; i++) {
+    for (size_t i(1); i <= 500u; i++) {
         add(sbb, i);
     }
-    for (size_t i(1000); i > 500; i--) {
+    for (size_t i(1000); i > 500u; i--) {
         add(sbb, i);
     }
     sbb.close();
     std::sort(storeIndex._where.begin(), storeIndex._where.end());
-    //EXPECT_EQUAL(32u, sbb.getBucketCount());
     EXPECT_EQUAL(1000u, storeIndex._where.size());
     VerifyBucketOrder vbo;
     Iterator all(storeIndex._where);
     sbb.drain(vbo, all);
+}
+
+constexpr uint32_t NUM_PARTS = 3;
+
+void
+verifyIter(BucketIndexStore &store, uint32_t partId, uint32_t expected_count) {
+    auto iter = store.createIterator(partId);
+    uint32_t count(0);
+    while (iter->has_next()) {
+        StoreByBucket::Index idx = iter->next();
+        EXPECT_EQUAL(store.toPartitionId(idx._bucketId), partId);
+        count++;
+    }
+    EXPECT_EQUAL(expected_count, count);
+}
+
+TEST("test that iterators cover the whole corpus and maps to correct partid") {
+
+    BucketIndexStore bucketIndexStore(32, NUM_PARTS);
+    for (size_t i(1); i <= 500u; i++) {
+        bucketIndexStore.store(StoreByBucket::Index(createBucketId(i), 1, 2, i));
+    }
+    bucketIndexStore.prepareForIterate();
+    EXPECT_EQUAL(500u, bucketIndexStore.getLidCount());
+    EXPECT_EQUAL(32u, bucketIndexStore.getBucketCount());
+    constexpr uint32_t COUNT_0 = 175, COUNT_1 = 155, COUNT_2 = 170;
+    verifyIter(bucketIndexStore, 0, COUNT_0);
+    verifyIter(bucketIndexStore, 1, COUNT_1);
+    verifyIter(bucketIndexStore, 2, COUNT_2);
+    EXPECT_EQUAL(500u, COUNT_0 + COUNT_1 + COUNT_2);
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -4,6 +4,7 @@
 #include "logdatastore.h"
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/array.hpp>
+#include <cassert>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".searchlib.docstore.compacter");
@@ -13,7 +14,7 @@ namespace search::docstore {
 using vespalib::alloc::Alloc;
 
 namespace {
-    static constexpr size_t INITIAL_BACKING_BUFFER_SIZE = 64_Mi;
+    constexpr size_t INITIAL_BACKING_BUFFER_SIZE = 64_Mi;
 }
 
 void
@@ -23,21 +24,79 @@ Compacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, ConstBufferRef
     _ds.write(std::move(guard), fileId, lid, data);
 }
 
+BucketIndexStore::BucketIndexStore(size_t maxSignificantBucketBits, uint32_t numPartitions) noexcept
+    : _unSignificantBucketBits((maxSignificantBucketBits > 8) ? (maxSignificantBucketBits - 8) : 0),
+      _where(),
+      _numPartitions(numPartitions),
+      _readyForIterate(true)
+{}
+BucketIndexStore::~BucketIndexStore() = default;
+
+void
+BucketIndexStore::prepareForIterate() {
+    std::sort(_where.begin(), _where.end());
+    _readyForIterate = true;
+}
+
+void
+BucketIndexStore::store(const StoreByBucket::Index & index) {
+    _where.push_back(index);
+    _readyForIterate = false;
+}
+
+size_t
+BucketIndexStore::getBucketCount() const noexcept {
+    if (_where.empty()) return 0;
+
+    size_t count = 0;
+    document::BucketId prev = _where.front()._bucketId;
+    for (const auto & lid : _where) {
+        if (lid._bucketId != prev) {
+            count++;
+            prev = lid._bucketId;
+        }
+    }
+    return count + 1;
+}
+
+std::unique_ptr<StoreByBucket::IndexIterator>
+BucketIndexStore::createIterator(uint32_t partitionId) const {
+    assert(_readyForIterate);
+    return std::make_unique<LidIterator>(*this, partitionId);
+}
+
+BucketIndexStore::LidIterator::LidIterator(const BucketIndexStore & store, size_t partitionId)
+    : _store(store),
+      _partitionId(partitionId),
+      _current(_store._where.begin())
+{}
+
+bool
+BucketIndexStore::LidIterator::has_next() noexcept {
+    for (;(_current != _store._where.end()) && (_store.toPartitionId(_current->_bucketId) != _partitionId); _current++);
+    return (_current != _store._where.end()) && (_store.toPartitionId(_current->_bucketId) == _partitionId);
+}
+
+StoreByBucket::Index
+BucketIndexStore::LidIterator::next() noexcept {
+    return *_current++;
+}
+
 BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, CompressionConfig compression, LogDataStore & ds,
-                                 Executor & executor, const IBucketizer & bucketizer, FileId source, FileId destination) :
-    _unSignificantBucketBits((maxSignificantBucketBits > 8) ? (maxSignificantBucketBits - 8) : 0),
-    _sourceFileId(source),
-    _destinationFileId(destination),
-    _ds(ds),
-    _bucketizer(bucketizer),
-    _lock(),
-    _backingMemory(Alloc::alloc(INITIAL_BACKING_BUFFER_SIZE), &_lock),
-    _tmpStore(),
-    _lidGuard(ds.getLidReadGuard()),
-    _stat()
+                                 Executor & executor, const IBucketizer & bucketizer, FileId source, FileId destination)
+    : _sourceFileId(source),
+      _destinationFileId(destination),
+      _ds(ds),
+      _bucketizer(bucketizer),
+      _lock(),
+      _backingMemory(Alloc::alloc(INITIAL_BACKING_BUFFER_SIZE), &_lock),
+      _bucketIndexStore(maxSignificantBucketBits, NUM_PARTITIONS),
+      _tmpStore(),
+      _lidGuard(ds.getLidReadGuard()),
+      _stat()
 {
     for (auto & partition : _tmpStore) {
-        partition = std::make_unique<StoreByBucket>(*this, _backingMemory, executor, compression);
+        partition = std::make_unique<StoreByBucket>(_bucketIndexStore, _backingMemory, executor, compression);
     }
 }
 
@@ -53,44 +112,7 @@ BucketCompacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, ConstBuf
 {
     guard.unlock();
     BucketId bucketId = (data.size() > 0) ? _bucketizer.getBucketOf(_bucketizer.getGuard(), lid) : BucketId();
-    _tmpStore[toPartitionId(bucketId)]->add(bucketId, chunkId, lid, data);
-}
-
-void
-BucketCompacter::store(const StoreByBucket::Index & index) {
-    _where.push_back(index);
-}
-
-size_t
-BucketCompacter::getBucketCount() const noexcept {
-    if (_where.empty()) return 0;
-
-    size_t count = 0;
-    BucketId prev = _where.front()._bucketId;
-    for (const auto & lid : _where) {
-        if (lid._bucketId != prev) {
-            count++;
-            prev = lid._bucketId;
-        }
-    }
-    return count + 1;
-}
-
-BucketCompacter::LidIterator::LidIterator(const BucketCompacter & bc, size_t partitionId)
-    : _bc(bc),
-      _partitionId(partitionId),
-      _current(_bc._where.begin())
-{}
-
-bool
-BucketCompacter::LidIterator::has_next() noexcept {
-    for (;(_current != _bc._where.end()) && (_bc.toPartitionId(_current->_bucketId) != _partitionId); _current++);
-    return (_current != _bc._where.end()) && (_bc.toPartitionId(_current->_bucketId) == _partitionId);
-}
-
-StoreByBucket::Index
-BucketCompacter::LidIterator::next() noexcept {
-    return *_current++;
+    _tmpStore[_bucketIndexStore.toPartitionId(bucketId)]->add(bucketId, chunkId, lid, data);
 }
 
 void
@@ -101,13 +123,13 @@ BucketCompacter::close()
         store->close();
         chunkCount += store->getChunkCount();
     }
-    std::sort(_where.begin(), _where.end());
+    _bucketIndexStore.prepareForIterate();
     LOG(info, "Have read %ld lids and placed them in %ld buckets. Temporary compressed in %ld chunks.",
-              _where.size(), getBucketCount(), chunkCount);
+              _bucketIndexStore.getLidCount(), _bucketIndexStore.getBucketCount(), chunkCount);
 
     for (size_t partId(0); partId < _tmpStore.size(); partId++) {
-        LidIterator partIterator(*this, partId);
-        _tmpStore[partId]->drain(*this, partIterator);
+        auto partIterator = _bucketIndexStore.createIterator(partId);
+        _tmpStore[partId]->drain(*this, *partIterator);
     }
     // All partitions using _backingMemory should be destructed before clearing.
     _backingMemory.clear();

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -25,7 +25,7 @@ Compacter::write(LockGuard guard, uint32_t chunkId, uint32_t lid, ConstBufferRef
 }
 
 BucketIndexStore::BucketIndexStore(size_t maxSignificantBucketBits, uint32_t numPartitions) noexcept
-    : _unSignificantBucketBits((maxSignificantBucketBits > 8) ? (maxSignificantBucketBits - 8) : 0),
+    : _inSignificantBucketBits((maxSignificantBucketBits > 8) ? (maxSignificantBucketBits - 8) : 0),
       _where(),
       _numPartitions(numPartitions),
       _readyForIterate(true)

--- a/searchlib/src/vespa/searchlib/docstore/compacter.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.cpp
@@ -41,6 +41,8 @@ BucketCompacter::BucketCompacter(size_t maxSignificantBucketBits, CompressionCon
     }
 }
 
+BucketCompacter::~BucketCompacter() = default;
+
 FileChunk::FileId
 BucketCompacter::getDestinationId(const LockGuard & guard) const {
     return (_destinationFileId.isActive()) ? _ds.getActiveFileId(guard) : _destinationFileId;

--- a/searchlib/src/vespa/searchlib/docstore/compacter.h
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.h
@@ -23,6 +23,37 @@ private:
     LogDataStore & _ds;
 };
 
+class BucketIndexStore : public StoreByBucket::StoreIndex {
+public:
+    BucketIndexStore(size_t maxSignificantBucketBits, uint32_t numPartitions) noexcept;
+    ~BucketIndexStore() override;
+    size_t toPartitionId(document::BucketId bucketId) const noexcept {
+        uint64_t sortableBucketId = bucketId.toKey();
+        return (sortableBucketId >> _unSignificantBucketBits) % _numPartitions;
+    }
+    void store(const StoreByBucket::Index & index) override;
+    size_t getBucketCount() const noexcept;
+    size_t getLidCount() const noexcept { return _where.size(); }
+    void prepareForIterate();
+    std::unique_ptr<StoreByBucket::IndexIterator> createIterator(uint32_t partitionId) const;
+private:
+    using IndexVector = std::vector<StoreByBucket::Index, vespalib::allocator_large<StoreByBucket::Index>>;
+    class LidIterator : public StoreByBucket::IndexIterator {
+    public:
+        LidIterator(const BucketIndexStore & bc, size_t partitionId);
+        bool has_next() noexcept override;
+        StoreByBucket::Index next() noexcept override;
+    private:
+        const BucketIndexStore       & _store;
+        size_t                        _partitionId;
+        IndexVector::const_iterator   _current;
+    };
+    size_t       _unSignificantBucketBits;
+    IndexVector  _where;
+    uint32_t     _numPartitions;
+    bool         _readyForIterate;
+};
+
 /**
  * This will split the incoming data into buckets.
  * The buckets data will then be written out in bucket order.
@@ -30,8 +61,7 @@ private:
  * All data are kept compressed to minimize memory usage.
  **/
 class BucketCompacter : public IWriteData,
-                        public StoreByBucket::IWrite,
-                        public StoreByBucket::StoreIndex
+                        public StoreByBucket::IWrite
 {
     using CompressionConfig = vespalib::compression::CompressionConfig;
     using Executor = vespalib::Executor;
@@ -42,37 +72,19 @@ public:
     ~BucketCompacter() override;
     void write(LockGuard guard, uint32_t chunkId, uint32_t lid, ConstBufferRef data) override;
     void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, ConstBufferRef data) override;
-    void store(const StoreByBucket::Index & index) override;
     void close() override;
-    size_t getBucketCount() const noexcept;
 private:
-    size_t toPartitionId(BucketId bucketId) const noexcept {
-        uint64_t sortableBucketId = bucketId.toKey();
-        return (sortableBucketId >> _unSignificantBucketBits) % _tmpStore.size();
-    }
     static constexpr size_t NUM_PARTITIONS = 256;
     using GenerationHandler = vespalib::GenerationHandler;
     using Partitions = std::array<std::unique_ptr<StoreByBucket>, NUM_PARTITIONS>;
-    using IndexVector = std::vector<StoreByBucket::Index, vespalib::allocator_large<StoreByBucket::Index>>;
-    class LidIterator : public StoreByBucket::IndexIterator {
-    public:
-        LidIterator(const BucketCompacter & bc, size_t partitionId);
-        bool has_next() noexcept override;
-        StoreByBucket::Index next() noexcept override;
-    private:
-        const BucketCompacter       & _bc;
-        size_t                        _partitionId;
-        IndexVector::const_iterator   _current;
-    };
     FileId getDestinationId(const LockGuard & guard) const;
-    size_t                                 _unSignificantBucketBits;
     FileId                                 _sourceFileId;
     FileId                                 _destinationFileId;
     LogDataStore                         & _ds;
     const IBucketizer                    & _bucketizer;
     std::mutex                             _lock;
     vespalib::MemoryDataStore              _backingMemory;
-    IndexVector                            _where;
+    BucketIndexStore                       _bucketIndexStore;
     Partitions                             _tmpStore;
     GenerationHandler::Guard               _lidGuard;
     vespalib::hash_map<uint64_t, uint32_t> _stat;

--- a/searchlib/src/vespa/searchlib/docstore/compacter.h
+++ b/searchlib/src/vespa/searchlib/docstore/compacter.h
@@ -29,7 +29,7 @@ public:
     ~BucketIndexStore() override;
     size_t toPartitionId(document::BucketId bucketId) const noexcept {
         uint64_t sortableBucketId = bucketId.toKey();
-        return (sortableBucketId >> _unSignificantBucketBits) % _numPartitions;
+        return (sortableBucketId >> _inSignificantBucketBits) % _numPartitions;
     }
     void store(const StoreByBucket::Index & index) override;
     size_t getBucketCount() const noexcept;
@@ -48,7 +48,7 @@ private:
         size_t                        _partitionId;
         IndexVector::const_iterator   _current;
     };
-    size_t       _unSignificantBucketBits;
+    size_t       _inSignificantBucketBits;
     IndexVector  _where;
     uint32_t     _numPartitions;
     bool         _readyForIterate;

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.cpp
@@ -108,7 +108,7 @@ StoreByBucket::drain(IWrite & drainer, IndexIterator & indexIterator)
     _chunks.clear();
     while (indexIterator.has_next()) {
         Index idx = indexIterator.next();
-        vespalib::ConstBufferRef data(chunks[idx._id]->getLid(idx._lid));
+        vespalib::ConstBufferRef data(chunks[idx._localChunkId]->getLid(idx._lid));
         drainer.write(idx._bucketId, idx._chunkId, idx._lid, data);
     }
 }

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.h
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.h
@@ -23,38 +23,10 @@ class StoreByBucket
     using ConstBufferRef = vespalib::ConstBufferRef;
     using CompressionConfig = vespalib::compression::CompressionConfig;
 public:
-    StoreByBucket(MemoryDataStore & backingMemory, Executor & executor, CompressionConfig compression) noexcept;
-    //TODO Putting the below move constructor into cpp file fails for some unknown reason. Needs to be resolved.
-    StoreByBucket(StoreByBucket &&) noexcept = delete;
-    StoreByBucket(const StoreByBucket &) = delete;
-    StoreByBucket & operator=(StoreByBucket &&) noexcept = delete;
-    StoreByBucket & operator = (const StoreByBucket &) = delete;
-    ~StoreByBucket();
-    class IWrite {
-    public:
-        using BucketId=document::BucketId;
-        virtual ~IWrite() = default;
-        virtual void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, ConstBufferRef data) = 0;
-    };
-    void add(document::BucketId bucketId, uint32_t chunkId, uint32_t lid, ConstBufferRef data);
-    void close();
-    /// close() must have been called prior to calling getBucketCount() or drain()
-    void drain(IWrite & drain);
-    size_t getBucketCount() const;
-
-    size_t getChunkCount() const;
-    size_t getLidCount() const {
-        return _where.size();
-    }
-private:
-    void incChunksPosted();
-    void waitAllProcessed();
-    Chunk::UP createChunk();
-    void closeChunk(Chunk::UP chunk);
     struct Index {
         using BucketId=document::BucketId;
         Index(BucketId bucketId, uint32_t id, uint32_t chunkId, uint32_t entry) noexcept :
-            _bucketId(bucketId), _id(id), _chunkId(chunkId), _lid(entry)
+                _bucketId(bucketId), _id(id), _chunkId(chunkId), _lid(entry)
         { }
         bool operator < (const Index & b) const noexcept {
             return BucketId::bucketIdToKey(_bucketId.getRawId()) < BucketId::bucketIdToKey(b._bucketId.getRawId());
@@ -65,9 +37,41 @@ private:
         uint32_t _lid;
     };
     using IndexVector = std::vector<Index, vespalib::allocator_large<Index>>;
+    struct IWrite {
+        using BucketId=document::BucketId;
+        virtual ~IWrite() = default;
+        virtual void write(BucketId bucketId, uint32_t chunkId, uint32_t lid, ConstBufferRef data) = 0;
+    };
+    struct IndexIterator {
+        virtual ~IndexIterator() = default;
+        virtual bool has_next() noexcept = 0;
+        virtual Index next() noexcept = 0;
+    };
+    struct StoreIndex {
+        virtual ~StoreIndex() = default;
+        virtual void store(const Index & index) = 0;
+    };
+    StoreByBucket(StoreIndex & storeIndex, MemoryDataStore & backingMemory,
+                  Executor & executor, CompressionConfig compression) noexcept;
+    //TODO Putting the below move constructor into cpp file fails for some unknown reason. Needs to be resolved.
+    StoreByBucket(StoreByBucket &&) noexcept = delete;
+    StoreByBucket(const StoreByBucket &) = delete;
+    StoreByBucket & operator=(StoreByBucket &&) noexcept = delete;
+    StoreByBucket & operator = (const StoreByBucket &) = delete;
+    ~StoreByBucket();
+    void add(document::BucketId bucketId, uint32_t chunkId, uint32_t lid, ConstBufferRef data);
+    void close();
+    /// close() must have been called prior to calling getBucketCount() or drain()
+    void drain(IWrite & drain, IndexIterator & iterator);
+    size_t getChunkCount() const noexcept;
+private:
+    void incChunksPosted();
+    void waitAllProcessed();
+    Chunk::UP createChunk();
+    void closeChunk(Chunk::UP chunk);
     uint64_t                                     _chunkSerial;
     Chunk::UP                                    _current;
-    IndexVector                                  _where;
+    StoreIndex                                 & _storeIndex;
     MemoryDataStore                            & _backingMemory;
     Executor                                   & _executor;
     mutable std::mutex                           _lock;

--- a/searchlib/src/vespa/searchlib/docstore/storebybucket.h
+++ b/searchlib/src/vespa/searchlib/docstore/storebybucket.h
@@ -25,14 +25,14 @@ class StoreByBucket
 public:
     struct Index {
         using BucketId=document::BucketId;
-        Index(BucketId bucketId, uint32_t id, uint32_t chunkId, uint32_t entry) noexcept :
-                _bucketId(bucketId), _id(id), _chunkId(chunkId), _lid(entry)
+        Index(BucketId bucketId, uint32_t localChunkId, uint32_t chunkId, uint32_t entry) noexcept :
+                _bucketId(bucketId), _localChunkId(localChunkId), _chunkId(chunkId), _lid(entry)
         { }
         bool operator < (const Index & b) const noexcept {
             return BucketId::bucketIdToKey(_bucketId.getRawId()) < BucketId::bucketIdToKey(b._bucketId.getRawId());
         }
         BucketId _bucketId;
-        uint32_t _id;
+        uint32_t _localChunkId;
         uint32_t _chunkId;
         uint32_t _lid;
     };


### PR DESCRIPTION
…partitions and chunks.

- This enable memory to be released after compaction is done.

@geirst PR