### PR TITLE
Throw if no nodes are matched by restart filter

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -618,17 +618,9 @@ public class Nodes {
      * @return the nodes in their new state
      */
     public List<Node> restartActive(Predicate<Node> filter) {
-        return restart(NodeFilter.in(Set.of(Node.State.active)).and(filter));
-    }
-
-    /**
-     * Increases the restart generation of the any nodes matching given filter.
-     *
-     * @return the nodes in their new state
-     */
-    public List<Node> restart(Predicate<Node> filter) {
-        return performOn(filter, (node, lock) -> write(node.withRestart(node.allocation().get().restartGeneration().withIncreasedWanted()),
-                                                       lock));
+        return performOn(NodeFilter.in(Set.of(State.active)).and(filter),
+                         (node, lock) -> write(node.withRestart(node.allocation().get().restartGeneration().withIncreasedWanted()),
+                                               lock));
     }
 
     /**

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeRepositoryProvisioner.java
@@ -15,7 +15,6 @@ import com.yahoo.config.provision.NodeType;
 import com.yahoo.config.provision.ProvisionLock;
 import com.yahoo.config.provision.ProvisionLogger;
 import com.yahoo.config.provision.Provisioner;
-import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.jdisc.Metric;
 import com.yahoo.transaction.Mutex;
@@ -145,7 +144,10 @@ public class NodeRepositoryProvisioner implements Provisioner {
 
     @Override
     public void restart(ApplicationId application, HostFilter filter) {
-        nodeRepository.nodes().restartActive(ApplicationFilter.from(application).and(NodeHostFilter.from(filter)));
+        List<Node> updated = nodeRepository.nodes().restartActive(ApplicationFilter.from(application).and(NodeHostFilter.from(filter)));
+        if (updated.isEmpty()) {
+            throw new IllegalArgumentException("No matching nodes found");
+        }
     }
 
     @Override


### PR DESCRIPTION
This is exposed through the controller application API and we want the request
to fail if the user misspells something, e.g. cluster name.

@jonmv