### PR TITLE
Flush memory indexes to disk then fusion disk indexes as soon as

### DIFF
--- a/searchcore/src/tests/proton/index/indexmanager_test.cpp
+++ b/searchcore/src/tests/proton/index/indexmanager_test.cpp
@@ -939,9 +939,7 @@ struct EnableInterleavedFeaturesParam
     };
     vespalib::string name = "no_restart";
     Restart restart = Restart::NONE;
-    bool restart1 = false;      // Restart after flushing 1st memory index without interleaved features
     bool doc = false;          // Feed doc after enabling interleaved fatures
-    bool restart2 = false;      // Restart after flushing 2nd memory index with interleaved fatures
     bool pruned_config = false; // Original config has been pruned
 
     EnableInterleavedFeaturesParam no_doc_restart1() && {

--- a/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
+++ b/searchcore/src/vespa/searchcore/proton/index/indexmanager.h
@@ -129,6 +129,9 @@ public:
     void setMaxFlushed(uint32_t maxFlushed) override {
         _maintainer.setMaxFlushed(maxFlushed);
     }
+    bool has_pending_urgent_flush() const override {
+        return _maintainer.has_pending_urgent_flush();
+    }
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
+++ b/searchcore/src/vespa/searchcore/proton/test/mock_index_manager.h
@@ -29,6 +29,7 @@ struct MockIndexManager : public searchcorespi::IIndexManager
     void heartBeat(SerialNum) override {}
     void compactLidSpace(uint32_t, SerialNum) override {}
     void setMaxFlushed(uint32_t) override { }
+    bool has_pending_urgent_flush() const override { return false; }
 };
 
 }

--- a/searchcore/src/vespa/searchcorespi/index/iindexmanager.h
+++ b/searchcore/src/vespa/searchcorespi/index/iindexmanager.h
@@ -200,6 +200,15 @@ public:
      * @param maxFlushed   The max number of flushed indexes before fusion is urgent.
      */
     virtual void setMaxFlushed(uint32_t maxFlushed) = 0;
+
+    /**
+     * Checks if we have a pending urgent flush due to a recent
+     * schema change (e.g. regeneration of interleaved features in
+     * disk indexes).
+     *
+     * @return whether an urgent flush is pending
+     */
+    virtual bool has_pending_urgent_flush() const = 0;
 };
 
 } // namespace searchcorespi

--- a/searchcore/src/vespa/searchcorespi/index/index_manager_explorer.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/index_manager_explorer.cpp
@@ -76,6 +76,7 @@ IndexManagerExplorer::get_state(const Inserter &inserter, bool full) const
     object.setLong("lastSerialNum", _mgr->getCurrentSerialNum());
     if (full) {
         IndexManagerStats stats(*_mgr);
+        object.setBool("pending_urgent_flush", _mgr->has_pending_urgent_flush());
         Cursor &diskIndexArrayCursor = object.setArray("diskIndexes");
         for (const auto &diskIndex : stats.getDiskIndexes()) {
             insertDiskIndex(diskIndexArrayCursor, diskIndex);

--- a/searchcore/src/vespa/searchcorespi/index/indexflushtarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexflushtarget.cpp
@@ -44,7 +44,8 @@ IndexFlushTarget::needUrgentFlush() const
     // Due to limitation of 16G address space of single datastore
     // TODO: Even better if urgency was decided by memory index itself.
     bool urgent = (_numFrozenMemoryIndexes > _maxFrozenMemoryIndexes) ||
-                  (getApproxMemoryGain().gain() > ssize_t(16_Gi));
+                  (getApproxMemoryGain().gain() > ssize_t(16_Gi)) ||
+                  _indexMaintainer.urgent_memory_index_flush();
     SerialNum flushedSerial = _indexMaintainer.getFlushedSerialNum();
     LOG(debug, "Num frozen: %u Memory gain: %" PRId64 " Urgent: %d, flushedSerial=%" PRIu64,
         _numFrozenMemoryIndexes, getApproxMemoryGain().gain(), static_cast<int>(urgent), flushedSerial);

--- a/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexfusiontarget.cpp
@@ -69,7 +69,8 @@ IndexFusionTarget::getApproxDiskGain() const
 bool
 IndexFusionTarget::needUrgentFlush() const
 {
-    bool urgent = (_fusionStats.numUnfused > _fusionStats.maxFlushed) && (_fusionStats._canRunFusion);
+    bool urgent = (_fusionStats.numUnfused > _fusionStats.maxFlushed || _indexMaintainer.urgent_disk_index_fusion()) &&
+                  (_fusionStats._canRunFusion);
     LOG(debug, "Num flushed: %d Urgent: %d", _fusionStats.numUnfused, urgent);
     return urgent;
 }

--- a/searchcore/src/vespa/searchcorespi/index/indexmaintainer.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexmaintainer.cpp
@@ -800,7 +800,7 @@ IndexMaintainer::doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex
             _frozenMemoryIndexes.emplace_back(args._oldIndex, freezeSerialNum, std::move(saveInfo), oldAbsoluteId);
         }
         _current_index = newIndex;
-        if (serial_num > flush_serial_num()) {
+        if (serial_num > flush_serial_num() && get_absolute_id() > 1) {
             consider_urgent_flush(args._oldSchema, args._newSchema, get_absolute_id());
         }
         // If schema changes triggered a need for urgent flush then we must

--- a/searchcore/src/vespa/searchcorespi/index/indexmaintainer.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/indexmaintainer.cpp
@@ -768,26 +768,8 @@ IndexMaintainer::warmupDone(std::shared_ptr<WarmupIndexCollection> current)
     }
 }
 
-namespace {
-
-bool
-has_matching_interleaved_features(const Schema& old_schema, const Schema& new_schema)
-{
-    for (SchemaUtil::IndexIterator itr(new_schema); itr.isValid(); ++itr) {
-        if (itr.hasMatchingOldFields(old_schema) &&
-                !itr.has_matching_use_interleaved_features(old_schema))
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
-}
-
-
 void
-IndexMaintainer::doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex>& newIndex)
+IndexMaintainer::doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex>& newIndex, SerialNum serial_num)
 {
     assert(_ctx.getThreadingService().master().isCurrentThread()); // with idle index executor
     LockGuard state_lock(_state_lock);
@@ -818,12 +800,12 @@ IndexMaintainer::doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex
             _frozenMemoryIndexes.emplace_back(args._oldIndex, freezeSerialNum, std::move(saveInfo), oldAbsoluteId);
         }
         _current_index = newIndex;
-        // Non-matching interleaved features in schemas means that we need to
-        // reconstruct or drop interleaved features in posting lists.
-        // If so, we must flush the new index to disk even if it is empty.
-        // This ensures that 2x triggerFlush will run fusion
-        // to reconstruct or drop interleaved features in the posting lists.
-        _flush_empty_current_index = !has_matching_interleaved_features(args._oldSchema, args._newSchema);
+        if (serial_num > flush_serial_num()) {
+            consider_urgent_flush(args._oldSchema, args._newSchema, get_absolute_id());
+        }
+        // If schema changes triggered a need for urgent flush then we must
+        // be able to flush the new index to disk even if it is empty.
+        _flush_empty_current_index = (_urgent_flush_id == get_absolute_id());
     }
     if (dropEmptyLast) {
         replaceSource(_current_index_id, _current_index);
@@ -887,6 +869,7 @@ IndexMaintainer::IndexMaintainer(const IndexMaintainerConfig &config,
       _last_fusion_id(),
       _next_id(),
       _current_index_id(),
+      _urgent_flush_id(),
       _current_index(),
       _flush_empty_current_index(false),
       _current_serial_num(0),
@@ -950,6 +933,7 @@ IndexMaintainer::IndexMaintainer(const IndexMaintainerConfig &config,
         pruneRemovedFields(_schema, config.getSerialNum());
     }));
     _ctx.getThreadingService().master().sync();
+    consider_initial_urgent_flush();
 }
 
 IndexMaintainer::~IndexMaintainer()
@@ -1320,7 +1304,7 @@ IndexMaintainer::setSchema(const Schema & schema, SerialNum serialNum)
     // Ensure that all index thread tasks accessing memory index have completed.
     commit_and_wait();
     // Everything should be quiet now.
-    doneSetSchema(args, new_index);
+    doneSetSchema(args, new_index, serialNum);
     // Source collection has now changed, caller must reconfigure further
     // as appropriate.
 }
@@ -1356,6 +1340,81 @@ IndexMaintainer::setMaxFlushed(uint32_t maxFlushed)
 {
     LockGuard lock(_new_search_lock);
     _maxFlushed = maxFlushed;
+}
+
+void
+IndexMaintainer::consider_urgent_flush(const Schema& old_schema, const Schema& new_schema, uint32_t flush_id)
+{
+    // Non-matching interleaved features in schemas means that we need to
+    // reconstruct or drop interleaved features in posting lists. Schedule
+    // urgent flush until all indexes are in sync.
+    for (SchemaUtil::IndexIterator itr(new_schema); itr.isValid(); ++itr) {
+        if (itr.hasMatchingOldFields(old_schema) &&
+                !itr.has_matching_use_interleaved_features(old_schema))
+        {
+            _urgent_flush_id = flush_id;
+            break;
+        }
+    }
+}
+
+void
+IndexMaintainer::consider_initial_urgent_flush()
+{
+    const Schema *prev_schema = nullptr;
+    std::optional<uint32_t> urgent_source_id;
+    auto coll = getSourceCollection();
+    uint32_t count = coll->getSourceCount();
+    for (uint32_t i = 0; i < count; ++i) {
+        IndexSearchable &is = coll->getSearchable(i);
+        const auto *const d = dynamic_cast<const DiskIndexWithDestructorCallback *>(&is);
+        if (d != nullptr) {
+            auto schema = &d->getSchema();
+            if (prev_schema != nullptr) {
+                consider_urgent_flush(*prev_schema, *schema, _last_fusion_id + coll->getSourceId(i));
+            }
+            prev_schema = schema;
+        }
+    }
+}
+
+uint32_t
+IndexMaintainer::get_urgent_flush_id() const
+{
+    LockGuard lock(_index_update_lock);
+    return _urgent_flush_id;
+}
+
+bool
+IndexMaintainer::urgent_memory_index_flush() const
+{
+    LockGuard lock(_index_update_lock);
+    for (auto& frozen : _frozenMemoryIndexes) {
+        if (frozen._absoluteId == _urgent_flush_id) {
+            return true;
+        }
+    }
+    if (get_absolute_id() == _urgent_flush_id) {
+        return true;
+    }
+    return false;
+}
+
+bool
+IndexMaintainer::urgent_disk_index_fusion() const
+{
+    uint32_t urgent_flush_id = get_urgent_flush_id();
+    LockGuard lock(_fusion_lock);
+    auto& flush_ids = _fusion_spec.flush_ids;
+    return std::find(flush_ids.begin(), flush_ids.end(), urgent_flush_id) != std::end(flush_ids);
+}
+
+bool
+IndexMaintainer::has_pending_urgent_flush() const
+{
+    uint32_t urgent_flush_id = get_urgent_flush_id();
+    LockGuard lock(_fusion_lock);
+    return urgent_flush_id > _fusion_spec.last_fusion_id;
 }
 
 }

--- a/searchcore/src/vespa/searchcorespi/index/indexmaintainer.h
+++ b/searchcore/src/vespa/searchcorespi/index/indexmaintainer.h
@@ -86,6 +86,7 @@ class IndexMaintainer : public IIndexManager,
     uint32_t               _last_fusion_id;   // Protected by SL + IUL
     uint32_t               _next_id;          // Protected by SL + IUL
     uint32_t               _current_index_id; // Protected by SL + IUL
+    uint32_t               _urgent_flush_id;  // Protected by SL + IUL
     std::shared_ptr<IMemoryIndex> _current_index;    // Protected by SL + IUL
     bool                   _flush_empty_current_index;
     std::atomic<SerialNum> _current_serial_num;// Writes protected by IUL
@@ -243,7 +244,7 @@ class IndexMaintainer : public IIndexManager,
         ~SetSchemaArgs();
     };
 
-    void doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex>& newIndex);
+    void doneSetSchema(SetSchemaArgs &args, std::shared_ptr<IMemoryIndex>& newIndex, SerialNum serial_num);
 
     Schema getSchema(void) const;
     std::shared_ptr<Schema> getActiveFusionPrunedSchema() const;
@@ -368,6 +369,12 @@ public:
     IFlushTarget::List getFlushTargets() override;
     void setSchema(const Schema & schema, SerialNum serialNum) override ;
     void setMaxFlushed(uint32_t maxFlushed) override;
+    void consider_urgent_flush(const Schema& old_schema, const Schema& new_schema, uint32_t flush_id);
+    void consider_initial_urgent_flush();
+    uint32_t get_urgent_flush_id() const;
+    bool urgent_memory_index_flush() const;
+    bool urgent_disk_index_fusion() const;
+    bool has_pending_urgent_flush() const override;
 };
 
 }


### PR DESCRIPTION
possible when enabling interleaved features.

@geirst : please review
