### PR TITLE
Revert "Ensure internal messages are flushed before shutting down RPC subsystem"

### DIFF
--- a/storage/src/vespa/storage/common/storagelink.cpp
+++ b/storage/src/vespa/storage/common/storagelink.cpp
@@ -281,14 +281,15 @@ Queue::getNext(std::shared_ptr<api::StorageMessage>& msg, vespalib::duration tim
 
 void
 Queue::enqueue(std::shared_ptr<api::StorageMessage> msg) {
-    std::lock_guard sync(_lock);
-    _queue.emplace(std::move(msg));
+    {
+        std::lock_guard sync(_lock);
+        _queue.emplace(std::move(msg));
+    }
     _cond.notify_one();
 }
 
 void
 Queue::signal() {
-    std::lock_guard sync(_lock);
     _cond.notify_one();
 }
 

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -41,7 +41,6 @@ class Bouncer : public StorageLink,
     const lib::State* _clusterState;
     std::unique_ptr<config::ConfigFetcher> _configFetcher;
     std::unique_ptr<BouncerMetrics> _metrics;
-    bool _closed;
 
 public:
     Bouncer(StorageComponentRegister& compReg, const config::ConfigUri & configUri);
@@ -61,12 +60,11 @@ private:
     void abortCommandDueToClusterDown(api::StorageMessage&, const lib::State&);
     void rejectDueToInsufficientPriority(api::StorageMessage&, api::StorageMessage::Priority);
     void reject_due_to_too_few_bucket_bits(api::StorageMessage&);
-    void reject_due_to_node_shutdown(api::StorageMessage&);
     static bool clusterIsUp(const lib::State& cluster_state);
     bool isDistributor() const;
-    static bool isExternalLoad(const api::MessageType&) noexcept;
-    static bool isExternalWriteOperation(const api::MessageType&) noexcept;
-    static bool priorityRejectionIsEnabled(int configuredPriority) noexcept {
+    bool isExternalLoad(const api::MessageType&) const noexcept;
+    bool isExternalWriteOperation(const api::MessageType&) const noexcept;
+    bool priorityRejectionIsEnabled(int configuredPriority) const noexcept {
         return (configuredPriority != -1);
     }
 
@@ -74,7 +72,7 @@ private:
      * If msg is a command containing a mutating timestamp (put, remove or
      * update commands), return that timestamp. Otherwise, return 0.
      */
-    static uint64_t extractMutationTimestampIfAny(const api::StorageMessage& msg);
+    uint64_t extractMutationTimestampIfAny(const api::StorageMessage& msg);
     bool onDown(const std::shared_ptr<api::StorageMessage>&) override;
     void handleNewState() noexcept override;
     const lib::NodeState &getDerivedNodeState(document::BucketSpace bucketSpace) const;

--- a/storage/src/vespa/storage/storageserver/communicationmanager.h
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.h
@@ -89,7 +89,6 @@ private:
 
     void onOpen() override;
     void onClose() override;
-    void onFlush(bool downwards) override;
 
     void process(const std::shared_ptr<api::StorageMessage>& msg);
 

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
@@ -105,10 +105,6 @@ void SharedRpcResources::wait_until_slobrok_is_ready() {
     }
 }
 
-void SharedRpcResources::sync_all_threads() {
-    _transport->sync();
-}
-
 void SharedRpcResources::shutdown() {
     assert(!_shutdown);
     if (listen_port() > 0) {

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
@@ -42,8 +42,6 @@ public:
     // To be called after all RPC handlers have been registered.
     void start_server_and_register_slobrok(vespalib::stringref my_handle);
 
-    void sync_all_threads();
-
     void shutdown();
     [[nodiscard]] int listen_port() const noexcept; // Only valid if server has been started
 

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -358,7 +358,7 @@ StorageNode::shutdown()
 {
     // Try to shut down in opposite order of initialize. Bear in mind that
     // we might be shutting down after init exception causing only parts
-    // of the server to have been initialized
+    // of the server to have initialize
     LOG(debug, "Shutting down storage node of type %s", getNodeType().toString().c_str());
     if (!attemptedStopped()) {
         LOG(debug, "Storage killed before requestShutdown() was called. No "


### PR DESCRIPTION
@baldersheim or @havardpe please review

Seeing assertion failures on shutdown from the distributor in a couple of system tests after this change. Will investigate, but reverting for now.