### PR TITLE
Reduce default limit for HTTP/2 concurrent streams

### DIFF
--- a/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -131,7 +131,7 @@ http2Enabled                   bool  default=true
 
 http2.streamIdleTimeout double default=600
 
-http2.maxConcurrentStreams int default=4096
+http2.maxConcurrentStreams int default=512
 
 # Override the default server name when authority is missing from request.
 serverName.fallback string default=""


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
