### PR TITLE
Require zone-scoped endpoint in config-model

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/ApplicationContainerCluster.java
@@ -17,6 +17,7 @@ import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.TreeConfigProducer;
 import com.yahoo.config.provision.AllocatedHosts;
 import com.yahoo.config.provision.HostSpec;
+import com.yahoo.config.provision.TenantName;
 import com.yahoo.container.bundle.BundleInstantiationSpecification;
 import com.yahoo.container.di.config.ApplicationBundlesConfig;
 import com.yahoo.container.handler.metrics.MetricsProxyApiConfig;
@@ -77,6 +78,8 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     public static final String PROMETHEUS_V1_HANDLER_CLASS = PrometheusV1Handler.class.getName();
     private static final BindingPattern PROMETHEUS_V1_HANDLER_BINDING_1 = SystemBindingPattern.fromHttpPath(PrometheusV1Handler.V1_PATH);
     private static final BindingPattern PROMETHEUS_V1_HANDLER_BINDING_2 = SystemBindingPattern.fromHttpPath(PrometheusV1Handler.V1_PATH + "/*");
+
+    private static final TenantName HOSTED_VESPA = TenantName.from("hosted-vespa");
 
     public static final int defaultHeapSizePercentageOfAvailableMemory = 85;
     public static final int heapSizePercentageOfTotalAvailableMemoryWhenCombinedCluster = 24;
@@ -223,8 +226,7 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
 
     /** Create list of endpoints, these will be consumed later by LbServicesProducer */
     private void createEndpoints(DeployState deployState) {
-        if (!deployState.isHosted()) return;
-        if (deployState.getProperties().applicationId().instance().isTester()) return;
+        if (!configureEndpoints(deployState)) return;
         // Add endpoints provided by the controller
         List<String> hosts = getContainers().stream().map(AbstractService::getHostName).sorted().toList();
         List<ApplicationClusterEndpoint> endpoints = new ArrayList<>();
@@ -241,6 +243,12 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
                                                                            .authMethod(ce.authMethod())
                                                                            .build())
                    ));
+        if (endpoints.stream().noneMatch(endpoint -> endpoint.scope() == ApplicationClusterEndpoint.Scope.zone)) {
+            throw new IllegalArgumentException("Expected at least one " + ApplicationClusterEndpoint.Scope.zone +
+                                               " endpoint for cluster '" + name() + "' in application '" +
+                                               deployState.getProperties().applicationId() +
+                                               "', got " + deployState.getEndpoints());
+        }
         this.endpoints = Collections.unmodifiableList(endpoints);
     }
 
@@ -373,6 +381,14 @@ public final class ApplicationContainerCluster extends ContainerCluster<Applicat
     public String name() { return getName(); }
 
     public OnnxModelCost.Calculator onnxModelCost() { return onnxModelCost; }
+
+    /** Returns whether the deployment in given deploy state should have endpoints */
+    private static boolean configureEndpoints(DeployState deployState) {
+        if (!deployState.isHosted()) return false;
+        if (deployState.getProperties().applicationId().instance().isTester()) return false;
+        if (deployState.getProperties().applicationId().tenant().equals(HOSTED_VESPA)) return false;
+        return true;
+    }
 
     public static class MbusParams {
         // the amount of the maxpendingbytes to process concurrently, typically 0.2 (20%)

--- a/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
+++ b/config-model/src/test/java/com/yahoo/config/model/provision/ModelProvisioningTest.java
@@ -5,6 +5,8 @@ import com.yahoo.cloud.config.ZookeeperServerConfig;
 import com.yahoo.cloud.config.log.LogdConfig;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.container.ContainerServiceType;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -43,6 +45,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,8 +59,8 @@ import static com.yahoo.config.provision.NodeResources.Architecture;
 import static com.yahoo.config.provision.NodeResources.DiskSpeed;
 import static com.yahoo.config.provision.NodeResources.StorageType;
 import static com.yahoo.vespa.defaults.Defaults.getDefaults;
-import static com.yahoo.vespa.model.search.NodeResourcesTuning.GB;
 import static com.yahoo.vespa.model.Host.memoryOverheadGb;
+import static com.yahoo.vespa.model.search.NodeResourcesTuning.GB;
 import static com.yahoo.vespa.model.test.utils.ApplicationPackageUtils.generateSchemas;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -183,7 +186,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 5;
         tester.addHosts(numberOfHosts);
         int numberOfContentNodes = 2;
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("bar.indexing"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
         Map<String, ContentCluster> contentClusters = model.getContentClusters();
         ContentCluster cluster = contentClusters.get("bar");
@@ -226,7 +229,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(8);
         tester.addHosts(new NodeResources(20, 200, 2000, 1.0), 1);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1", "container2"));
 
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(1, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
@@ -249,7 +252,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(1);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1"));
 
         assertEquals(1, model.hostSystem().getHosts().size());
         HostResource host = model.hostSystem().getHosts().iterator().next();
@@ -281,7 +284,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(5);
         TestLogger logger = new TestLogger();
-        VespaModel model = tester.createModel(xmlWithNodes, true, new DeployState.Builder().deployLogger(logger));
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1").deployLogger(logger));
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(2, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
         assertEquals(18, physicalMemoryPercentage(model.getContainerClusters().get("container1")), "Heap size is lowered with combined clusters");
@@ -318,7 +321,7 @@ public class ModelProvisioningTest {
                         "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(5);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1"));
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(2, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
         assertEquals(30, physicalMemoryPercentage(model.getContainerClusters().get("container1")), "Heap size is lowered with combined clusters");
@@ -350,7 +353,7 @@ public class ModelProvisioningTest {
                         "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(7);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1"));
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(2, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
         assertEquals(65, physicalMemoryPercentage(model.getContainerClusters().get("container1")), "Heap size is normal");
@@ -378,7 +381,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(5);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1"));
 
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(2, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
@@ -414,7 +417,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(8);
-        VespaModel model = tester.createModel(xmlWithNodes, true);
+        VespaModel model = tester.createModel(xmlWithNodes, true, deployStateWithClusterEndpoints("container1", "container2"));
 
         assertEquals(2, model.getContentClusters().get("content1").getRootGroup().getNodes().size(), "Nodes in content1");
         assertEquals(2, model.getContainerClusters().get("container1").getContainers().size(), "Nodes in container1");
@@ -523,7 +526,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 67;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check container cluster
@@ -630,7 +633,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 73;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -675,7 +678,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 73;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -736,7 +739,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 10;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check container cluster
@@ -784,7 +787,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 67;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check container cluster
@@ -884,7 +887,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 21;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ClusterControllerContainerCluster clusterControllers = model.getAdmin().getClusterControllers();
@@ -934,7 +937,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 11;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true, "node-1-3-50-09");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-09");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
@@ -959,7 +962,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 12;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true, "node-1-3-50-03", "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"), "node-1-3-50-03", "node-1-3-50-04");
         assertEquals(10+2, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
@@ -988,7 +991,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 16;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true, "node-1-3-50-15", "node-1-3-50-05", "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo", "bar"), "node-1-3-50-15", "node-1-3-50-05", "node-1-3-50-04");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         // Check slobroks clusters
@@ -1027,7 +1030,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 7;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo.indexing", "bar.indexing"));
         assertEquals(7, model.getRoot().hostSystem().getHosts().size());
 
         // Check cluster controllers
@@ -1080,7 +1083,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts+1);
 
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         Admin admin = model.getAdmin();
@@ -1126,7 +1129,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts+1);
 
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         Admin admin = model.getAdmin();
@@ -1179,7 +1182,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 6; // We only have 6 content nodes -> 3 groups with redundancy 2 in each
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false);
+        VespaModel model = tester.createModel(services, false, deployStateWithClusterEndpoints("bar.indexing"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1254,7 +1257,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 5;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false, "node-1-3-50-05", "node-1-3-50-04", "node-1-3-50-03");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, false, deployStateWithClusterEndpoints("bar.indexing"), "node-1-3-50-05", "node-1-3-50-04", "node-1-3-50-03");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1283,7 +1286,9 @@ public class ModelProvisioningTest {
         int numberOfHosts = 3;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false, false, true, "node-1-3-50-03");
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, false, false, true,
+                                              NodeResources.unspecified(), 0, Optional.empty(),
+                                              deployStateWithClusterEndpoints("bar.indexing"), "node-1-3-50-03");
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1321,7 +1326,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 6;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false);
+        VespaModel model = tester.createModel(services, false, deployStateWithClusterEndpoints("container"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1364,7 +1369,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 1; // We only have 1 content node -> 1 groups with redundancy 1
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false);
+        VespaModel model = tester.createModel(services, false, deployStateWithClusterEndpoints("bar.indexing"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1443,7 +1448,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 5;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false);
+        VespaModel model = tester.createModel(services, false, deployStateWithClusterEndpoints("container"));
         model.hostSystem().getHosts().forEach(host -> assertTrue(host.spec().membership().get().cluster().isExclusive()));
     }
 
@@ -1469,7 +1474,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 1;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, false);
+        VespaModel model = tester.createModel(services, false, deployStateWithClusterEndpoints("bar.indexing"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         ContentCluster cluster = model.getContentClusters().get("bar");
@@ -1548,7 +1553,9 @@ public class ModelProvisioningTest {
         tester.addHosts(new NodeResources(8, 200, 1000000, 0.3), 5); // Content-foo
         tester.addHosts(new NodeResources(10, 64, 200, 0.3), 6); // Content-bar
         tester.addHosts(new NodeResources(0.5, 2, 10, 0.3), 6); // Cluster-controller
-        VespaModel model = tester.createModel(services, true, NodeResources.unspecified(), 0);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, false, false,
+                                              NodeResources.unspecified(), 0, Optional.empty(),
+                                              deployStateWithClusterEndpoints("container", "container2"));
         assertEquals(totalHosts, model.getRoot().hostSystem().getHosts().size());
     }
 
@@ -1557,7 +1564,7 @@ public class ModelProvisioningTest {
         String services =
                 "<?xml version='1.0' encoding='utf-8' ?>" +
                 "<services>" +
-                "   <container version='1.0' id='container'>" +
+                "   <container version='1.0' id='default'>" +
                 "      <nodes count='[4, 6]'>" +
                 "         <resources vcpu='[11.5, 13.5]' memory='[10Gb, 100Gb]' disk='[30Gb, 1Tb]'/>" +
                 "      </nodes>" +
@@ -1587,7 +1594,7 @@ public class ModelProvisioningTest {
         String services =
                 "<?xml version='1.0' encoding='utf-8' ?>" +
                 "<services>" +
-                "   <container version='1.0' id='container'>" +
+                "   <container version='1.0' id='default'>" +
                 "      <nodes count='[4, 6]'>" +
                 "         <resources vcpu='[11.5, 13.5]' memory='[10Gb, 100Gb]' disk='[30Gb, 1Tb]'/>" +
                 "      </nodes>" +
@@ -1619,7 +1626,7 @@ public class ModelProvisioningTest {
                         "<services>" +
                         "   <admin version='4.0'>" +
                         "   </admin>" +
-                        "   <container version='1.0' id='container'>" +
+                        "   <container version='1.0' id='default'>" +
                         "      <nodes count='2'>" +
                         "         <resources vcpu='2' memory='8Gb' disk='30Gb'/>" +
                         "      </nodes>" +
@@ -1678,7 +1685,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 3;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
         assertEquals(3, model.getContainerClusters().get("container").getContainers().size());
         assertNotNull(model.getAdmin().getLogserver());
@@ -1698,7 +1705,7 @@ public class ModelProvisioningTest {
         int numberOfHosts = 3;
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
         assertEquals("-DfooOption=xyz", model.getContainerClusters().get("container").getContainers().get(0).getAssignedJvmOptions());
     }
@@ -1739,7 +1746,7 @@ public class ModelProvisioningTest {
                 "</container>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(2);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(2, model.getHosts().size());
         assertEquals(1, model.getContainerClusters().size());
         assertEquals(2, model.getContainerClusters().get("foo").getContainers().size());
@@ -1797,7 +1804,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.setHosted(true);
         tester.addHosts(4);
-        VespaModel model = tester.createModel(new Zone(Environment.dev, RegionName.from("us-central-1")), services, true);
+        VespaModel model = tester.createModel(new Zone(Environment.dev, RegionName.from("us-central-1")), services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(3, model.getHosts().size(), "We get 1 node per cluster and no admin node apart from the dedicated cluster controller");
         assertEquals(1, model.getContainerClusters().size());
         assertEquals(1, model.getContainerClusters().get("foo").getContainers().size());
@@ -1895,7 +1902,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.setHosted(true);
         tester.addHosts(6);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container1"));
 
         var contentCluster = model.getContentClusters().get("content");
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
@@ -1924,7 +1931,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.setHosted(true);
         tester.addHosts(6);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container1"));
 
         var contentCluster = model.getContentClusters().get("content");
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
@@ -1953,7 +1960,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.setHosted(true);
         tester.addHosts(6);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("container1"));
 
         var contentCluster = model.getContentClusters().get("content");
         ProtonConfig.Builder protonBuilder = new ProtonConfig.Builder();
@@ -2039,7 +2046,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(6);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(6, model.getRoot().hostSystem().getHosts().size());
         assertEquals(3, model.getAdmin().getSlobroks().size());
         assertEquals(2, model.getContainerClusters().get("foo").getContainers().size());
@@ -2058,7 +2065,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(2);
-        VespaModel model = tester.createModel(services, true);
+        VespaModel model = tester.createModel(services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(2, model.getRoot().hostSystem().getHosts().size());
         assertEquals(2, model.getAdmin().getSlobroks().size());
         assertEquals(2, model.getContainerClusters().get("foo").getContainers().size());
@@ -2342,7 +2349,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(9);
-        VespaModel model = tester.createModel(servicesXml, true);
+        VespaModel model = tester.createModel(servicesXml, true, deployStateWithClusterEndpoints("qrs", "zk"));
 
         Map<String, Boolean> tests = Map.of("qrs", false,
                                             "zk", true,
@@ -2381,7 +2388,7 @@ public class ModelProvisioningTest {
                         "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(9);
-        VespaModel model = tester.createModel(servicesXml, true, new DeployState.Builder().properties(new TestProperties()));
+        VespaModel model = tester.createModel(servicesXml, true, deployStateWithClusterEndpoints("qrs").properties(new TestProperties()));
 
         var fleetControllerConfigBuilder = new FleetcontrollerConfig.Builder();
         model.getConfig(fleetControllerConfigBuilder, "admin/standalone/cluster-controllers/0/components/clustercontroller-content-configurer");
@@ -2400,7 +2407,7 @@ public class ModelProvisioningTest {
                 "</services>";
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(4);
-        VespaModel model = tester.createModel(servicesXml, true, "node-1-3-50-04");
+        VespaModel model = tester.createModel(Zone.defaultZone(), servicesXml, true, deployStateWithClusterEndpoints("zk"), "node-1-3-50-04");
         ApplicationContainerCluster cluster = model.getContainerClusters().get("zk");
         assertEquals(1, cluster.getContainers().stream().filter(Container::isRetired).count());
         assertEquals(3, cluster.getContainers().stream().filter(c -> !c.isRetired()).count());
@@ -2419,7 +2426,7 @@ public class ModelProvisioningTest {
         };
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(5);
-        VespaModel model = tester.createModel(servicesXml.apply(3), true);
+        VespaModel model = tester.createModel(servicesXml.apply(3), true, deployStateWithClusterEndpoints("zk"));
 
         {
             ApplicationContainerCluster cluster = model.getContainerClusters().get("zk");
@@ -2429,7 +2436,7 @@ public class ModelProvisioningTest {
             assertTrue(config.build().server().stream().noneMatch(ZookeeperServerConfig.Server::joining), "Initial servers are not joining");
         }
         {
-            VespaModel nextModel = tester.createModel(Zone.defaultZone(), servicesXml.apply(3), true, false, false, NodeResources.unspecified(), 0, Optional.of(model), new DeployState.Builder(), "node-1-3-50-04", "node-1-3-50-03");
+            VespaModel nextModel = tester.createModel(Zone.defaultZone(), servicesXml.apply(3), true, false, false, NodeResources.unspecified(), 0, Optional.of(model), deployStateWithClusterEndpoints("zk"), "node-1-3-50-04", "node-1-3-50-03");
             ApplicationContainerCluster cluster = nextModel.getContainerClusters().get("zk");
             ZookeeperServerConfig.Builder config = new ZookeeperServerConfig.Builder();
             cluster.getContainers().forEach(c -> c.getConfig(config));
@@ -2495,7 +2502,8 @@ public class ModelProvisioningTest {
 
          VespaModelTester tester = new VespaModelTester();
          tester.addHosts(new NodeResources(1, 3, 10, 5, NodeResources.DiskSpeed.slow), 5);
-         VespaModel model = tester.createModel(services, true, NodeResources.unspecified(), 0);
+         VespaModel model = tester.createModel(Zone.defaultZone(), services, true, false, false, NodeResources.unspecified(), 0, Optional.empty(), deployStateWithClusterEndpoints("test.indexing"));
+
          ContentSearchCluster cluster = model.getContentClusters().get("test").getSearch();
          assertEquals(2, cluster.getSearchNodes().size());
          assertEquals(40, getProtonConfig(cluster, 0).hwinfo().disk().writespeed(), 0.001);
@@ -2519,7 +2527,7 @@ public class ModelProvisioningTest {
 
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(new NodeResources(1, 3, 10, 5), 5);
-        VespaModel model = tester.createModel(services, true, new NodeResources(1.0, 3.0, 9.0, 1.0), 0);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, false, false, new NodeResources(1.0, 3.0, 9.0, 1.0), 0, Optional.empty(), deployStateWithClusterEndpoints("test.indexing"));
         ContentSearchCluster cluster = model.getContentClusters().get("test").getSearch();
         assertEquals(2, cluster.getSearchNodes().size());
     }
@@ -2568,7 +2576,7 @@ public class ModelProvisioningTest {
         VespaModelTester tester = new VespaModelTester();
         tester.addHosts(new NodeResources(1, 3, 10, 1), 4);
         tester.addHosts(new NodeResources(1, 128, 100, 0.3), 1);
-        VespaModel model = tester.createModel(services, true, NodeResources.unspecified(), 0);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, false, false, NodeResources.unspecified(), 0, Optional.empty(), deployStateWithClusterEndpoints("test.indexing"));
         ContentSearchCluster cluster = model.getContentClusters().get("test").getSearch();
         ProtonConfig cfg = getProtonConfig(model, cluster.getSearchNodes().get(0).getConfigId());
         assertEquals(2000, cfg.flush().memory().maxtlssize()); // from config override
@@ -2590,7 +2598,7 @@ public class ModelProvisioningTest {
         tester.useDedicatedNodeForLogserver(useDedicatedNodeForLogserver);
         tester.addHosts(numberOfHosts);
 
-        VespaModel model = tester.createModel(Zone.defaultZone(), services, true);
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, deployStateWithClusterEndpoints("foo"));
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         Admin admin = model.getAdmin();
@@ -2630,6 +2638,15 @@ public class ModelProvisioningTest {
 
     private static boolean hostNameExists(HostSystem hostSystem, String hostname) {
         return hostSystem.getHosts().stream().map(HostResource::getHost).anyMatch(host -> host.getHostname().equals(hostname));
+    }
+
+    private static DeployState.Builder deployStateWithClusterEndpoints(String... cluster) {
+        Set<ContainerEndpoint> endpoints = Arrays.stream(cluster)
+                                                 .map(c -> new ContainerEndpoint(c,
+                                                                                 ApplicationClusterEndpoint.Scope.zone,
+                                                                                 List.of(c + ".example.com")))
+                                                 .collect(Collectors.toSet());
+        return new DeployState.Builder().endpoints(endpoints);
     }
 
     record TestLogger(List<LogMessage> msgs) implements DeployLogger {

--- a/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ClusterInfoTest.java
@@ -2,6 +2,8 @@
 package com.yahoo.vespa.model;
 
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.provision.InMemoryProvisioner;
@@ -20,14 +22,14 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
 import com.yahoo.config.provision.Zone;
-import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author bratseth
@@ -251,6 +253,7 @@ public class ClusterInfoTest {
                                                                   .setCloudAccount(account)
                                                                   .setApplicationId(ApplicationId.from(TenantName.defaultName(), ApplicationName.defaultName(), InstanceName.from(instance)))
                                                                   .setZone(new Zone(Environment.prod, RegionName.from(region))))
+                                  .endpoints(Set.of(new ContainerEndpoint("testcontainer", ApplicationClusterEndpoint.Scope.zone, List.of("tc.example.com"))))
                                   .modelHostProvisioner(provisioner)
                                   .provisioned(provisioner.provisioned())
                                   .build();

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyContainerTest.java
@@ -6,8 +6,8 @@ import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.PublicDimensions;
 import ai.vespa.metricsproxy.rpc.RpcConnectorConfig;
 import ai.vespa.metricsproxy.service.VespaServicesConfig;
+import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.vespa.model.VespaModel;
-import com.yahoo.vespa.model.test.VespaModelTester;
 import org.junit.jupiter.api.Test;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
@@ -16,11 +16,12 @@ import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.T
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.containerConfigId;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getModel;
-
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getNodeDimensionsConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getRpcConnectorConfig;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.getVespaServicesConfig;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author gjoranv
@@ -29,11 +30,8 @@ public class MetricsProxyContainerTest {
 
     @Test
     void one_metrics_proxy_container_is_added_to_every_node() {
-        var numberOfHosts = 7;
-        var tester = new VespaModelTester();
-        tester.addHosts(numberOfHosts);
-
-        VespaModel model = tester.createModel(hostedServicesWithManyNodes(), true);
+        int numberOfHosts = 7;
+        VespaModel model = getModel(hostedServicesWithManyNodes(), hosted, new DeployState.Builder(), numberOfHosts);
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         for (var host : model.hostSystem().getHosts()) {
@@ -48,11 +46,8 @@ public class MetricsProxyContainerTest {
 
     @Test
     void one_metrics_proxy_container_is_added_to_every_node_also_when_dedicated_CCC() {
-        var numberOfHosts = 7;
-        var tester = new VespaModelTester();
-        tester.addHosts(numberOfHosts);
-
-        VespaModel model = tester.createModel(hostedServicesWithManyNodes(), true);
+        int numberOfHosts = 7;
+        VespaModel model = getModel(hostedServicesWithManyNodes(), hosted, new DeployState.Builder(), numberOfHosts);
         assertEquals(numberOfHosts, model.getRoot().hostSystem().getHosts().size());
 
         for (var host : model.hostSystem().getHosts()) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/admin/metricsproxy/MetricsProxyModelTester.java
@@ -9,11 +9,16 @@ import ai.vespa.metricsproxy.metric.dimensions.ApplicationDimensionsConfig;
 import ai.vespa.metricsproxy.metric.dimensions.NodeDimensionsConfig;
 import ai.vespa.metricsproxy.rpc.RpcConnectorConfig;
 import ai.vespa.metricsproxy.service.VespaServicesConfig;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.search.config.QrStartConfig;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.admin.monitoring.MetricsConsumer;
 import com.yahoo.vespa.model.test.VespaModelTester;
+
+import java.util.List;
+import java.util.Set;
 
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.hosted;
 import static com.yahoo.vespa.model.admin.metricsproxy.MetricsProxyModelTester.TestMode.self_hosted;
@@ -42,11 +47,18 @@ class MetricsProxyModelTester {
     }
 
     static VespaModel getModel(String servicesXml, TestMode testMode, DeployState.Builder builder) {
-        var numberOfHosts = testMode == hosted ? 4 : 1;
+        return getModel(servicesXml, testMode, new DeployState.Builder(), 4);
+    }
+
+    static VespaModel getModel(String servicesXml, TestMode testMode, DeployState.Builder builder, int hostCount) {
+        var numberOfHosts = testMode == hosted ? hostCount : 1;
         var tester = new VespaModelTester();
         tester.addHosts(numberOfHosts);
         tester.setHosted(testMode == hosted);
-        if (testMode == hosted) tester.setApplicationId(MY_TENANT, MY_APPLICATION, MY_INSTANCE);
+        if (testMode == hosted) {
+            tester.setApplicationId(MY_TENANT, MY_APPLICATION, MY_INSTANCE);
+            builder.endpoints(Set.of(new ContainerEndpoint("foo", ApplicationClusterEndpoint.Scope.zone, List.of("foo.example.com"))));
+        }
         return tester.createModel(servicesXml, true, builder);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/AccessControlFilterExcludeValidatorTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.MapConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -20,9 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -98,6 +102,7 @@ public class AccessControlFilterExcludeValidatorTest {
                                 .setHostedVespa(true)
                                 .setAthenzDomain(AthenzDomain.from("foo.bar"))
                                 .allowDisableMtls(allowExcludes))
+                .endpoints(Set.of(new ContainerEndpoint("container-cluster-with-access-control", ApplicationClusterEndpoint.Scope.zone, List.of("example.com"))))
                 .deployLogger(logger)
                 .zone(zone)
                 .build();

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudDataPlaneFilterValidatorTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -35,6 +37,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -149,6 +152,7 @@ public class CloudDataPlaneFilterValidatorTest {
                         new TestProperties()
                                 .setEndpointCertificateSecrets(Optional.of(new EndpointCertificateSecrets("CERT", "KEY")))
                                 .setHostedVespa(true))
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("c.example.com"))))
                 .zone(new Zone(SystemName.PublicCd, Environment.dev, RegionName.defaultName()))
                 .build();
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudHttpConnectorValidatorTest.java
@@ -3,11 +3,16 @@
 package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -96,6 +101,7 @@ class CloudHttpConnectorValidatorTest {
                                 .withServices(servicesXml)
                                 .build())
                 .properties(new TestProperties().setHostedVespa(hosted))
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("c.example.com"))))
                 .build();
         var model = new VespaModel(new NullConfigModelRegistry(), state);
         new CloudHttpConnectorValidator().validate(model, state);

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/CloudUserFilterValidatorTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -12,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -59,6 +63,7 @@ class CloudUserFilterValidatorTest {
                 .build();
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(app)
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("container.example.com"))))
                 .properties(new TestProperties().setHostedVespa(isHosted).setAllowUserFilters(false))
                 .build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ContainerInCloudValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ContainerInCloudValidatorTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -11,8 +13,9 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -50,10 +53,13 @@ public class ContainerInCloudValidatorTest {
         ApplicationPackage app = new MockApplicationPackage.Builder()
                 .withServices(servicesXml)
                 .build();
-        DeployState deployState = new DeployState.Builder()
+        DeployState.Builder builder = new DeployState.Builder()
                 .applicationPackage(app)
-                .properties(new TestProperties().setHostedVespa(isHosted).setAllowUserFilters(false))
-                .build();
+                .properties(new TestProperties().setHostedVespa(isHosted).setAllowUserFilters(false));
+        if (isHosted) {
+            builder.endpoints(Set.of(new ContainerEndpoint("routing", ApplicationClusterEndpoint.Scope.zone, List.of("routing.example.com"))));
+        }
+        DeployState deployState = builder.build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         new ContainerInCloudValidator().validate(model, deployState);
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EndpointCertificateSecretsValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/EndpointCertificateSecretsValidatorTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.EndpointCertificateSecrets;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -14,7 +16,9 @@ import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,6 +77,7 @@ public class EndpointCertificateSecretsValidatorTest {
         DeployState.Builder builder = new DeployState.Builder()
                 .applicationPackage(app)
                 .zone(new Zone(Environment.prod, RegionName.from("foo")))
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(
                         new TestProperties()
                                 .setHostedVespa(true)

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/JvmHeapSizeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/JvmHeapSizeValidatorTest.java
@@ -7,6 +7,8 @@ import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.OnnxModelCost;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -19,6 +21,8 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -85,6 +89,7 @@ class JvmHeapSizeValidatorTest {
                                 .withServices(servicesXml)
                                 .build())
                 .modelHostProvisioner(new InMemoryProvisioner(5, new NodeResources(4, nodeGb, 125, 0.3), true))
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("c.example.com"))))
                 .properties(new TestProperties().setHostedVespa(true).setDynamicHeapSize(true))
                 .onnxModelCost(new ModelCostDummy(modelCostBytes))
                 .build();

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/QuotaValidatorTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class QuotaValidatorTest {
 
+    private static final String CONTAINER_CLUSTER = "testCluster.indexing";
     private final Zone publicZone = new Zone(SystemName.Public, Environment.prod, RegionName.from("foo"));
     private final Zone publicCdZone = new Zone(SystemName.PublicCd, Environment.prod, RegionName.from("foo"));
     private final Zone devZone = new Zone(SystemName.Public, Environment.dev, RegionName.from("foo"));
@@ -27,14 +28,14 @@ public class QuotaValidatorTest {
     @Test
     void test_deploy_under_quota() {
         var tester = new ValidationTester(8, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
-        tester.deploy(null, getServices(4), Environment.prod, null);
+        tester.deploy(null, getServices(4), Environment.prod, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void test_deploy_above_quota_clustersize() {
         var tester = new ValidationTester(14, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
         try {
-            tester.deploy(null, getServices(11), Environment.prod, null);
+            tester.deploy(null, getServices(11), Environment.prod, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("Clusters testCluster exceeded max cluster size of 10", e.getMessage());
@@ -45,7 +46,7 @@ public class QuotaValidatorTest {
     void test_deploy_above_quota_budget() {
         var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null);
+            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $1.63 but your quota is $1.25: Contact support to upgrade your plan.", e.getMessage());
@@ -56,7 +57,7 @@ public class QuotaValidatorTest {
     void test_deploy_above_quota_budget_in_publiccd() {
         var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota.withBudget(BigDecimal.ONE)).setZone(publicCdZone));
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null);
+            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("publiccd: The resources used cost $1.63 but your quota is $1.00: Contact support to upgrade your plan.", e.getMessage());
@@ -67,7 +68,7 @@ public class QuotaValidatorTest {
     void test_deploy_max_resources_above_quota() {
         var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicCdZone));
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null);
+            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("publiccd: The resources used cost $1.63 but your quota is $1.25: Contact support to upgrade your plan.", e.getMessage());
@@ -82,7 +83,7 @@ public class QuotaValidatorTest {
 
         // There is downscaling to 1 node per cluster in dev
         try {
-            tester.deploy(null, getServices(2, false), Environment.dev, null);
+            tester.deploy(null, getServices(2, false), Environment.dev, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $0.16 but your quota is $0.01: Contact support to upgrade your plan.", e.getMessage());
@@ -90,7 +91,7 @@ public class QuotaValidatorTest {
 
         // Override so that we will get 2 nodes in content cluster
         try {
-            tester.deploy(null, getServices(2, true), Environment.dev, null);
+            tester.deploy(null, getServices(2, true), Environment.dev, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $0.33 but your quota is $0.01: Contact support to upgrade your plan.", e.getMessage());
@@ -102,7 +103,7 @@ public class QuotaValidatorTest {
         var quota = Quota.unlimited().withBudget(BigDecimal.valueOf(-1));
         var tester = new ValidationTester(13, false, new TestProperties().setHostedVespa(true).setQuota(quota).setZone(publicZone));
         try {
-            tester.deploy(null, getServices(10), Environment.prod, null);
+            tester.deploy(null, getServices(10), Environment.prod, null, CONTAINER_CLUSTER);
             fail();
         } catch (RuntimeException e) {
             assertEquals("The resources used cost $-.-- but your quota is $--.--: Please free up some capacity.",

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/SecretStoreValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/SecretStoreValidatorTest.java
@@ -3,6 +3,8 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -11,6 +13,9 @@ import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.model.VespaModel;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -80,6 +85,7 @@ public class SecretStoreValidatorTest {
         DeployState.Builder builder = new DeployState.Builder()
                 .applicationPackage(app)
                 .zone(new Zone(Environment.prod, RegionName.from("foo")))
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setHostedVespa(true));
         final DeployState deployState = builder.build();
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UriBindingsValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UriBindingsValidatorTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.model.application.validation;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.application.api.DeployLogger;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.test.MockApplicationPackage;
@@ -16,8 +18,11 @@ import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author bjorncs
@@ -99,6 +104,7 @@ public class UriBindingsValidatorTest {
                 .deployLogger(deployLogger)
                 .zone(testProperties.zone())
                 .properties(testProperties)
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .build();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), deployState);
         new UriBindingsValidator().validate(model, deployState);
@@ -120,7 +126,7 @@ public class UriBindingsValidatorTest {
         return String.join(
                 "\n",
                 "<services version='1.0'>",
-                "  <container version='1.0'>",
+                "  <container version='1.0' id='default'>",
                 "    <http>",
                 "      <server port='8080' id='main' />",
                 "      <filtering>",

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UrlConfigValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/UrlConfigValidatorTest.java
@@ -3,7 +3,9 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ConfigDefinitionRepo;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.application.provider.MockFileRegistry;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -20,7 +22,9 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.yahoo.config.provision.Environment.prod;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -85,6 +89,7 @@ public class UrlConfigValidatorTest {
         var builder = new DeployState.Builder()
                 .applicationPackage(app)
                 .zone(new Zone(systemName, prod, RegionName.from("us-east-3")))
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setHostedVespa(isHosted))
                 .fileRegistry(new MockFileRegistry());
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/ValidationTester.java
@@ -3,7 +3,9 @@ package com.yahoo.vespa.model.application.validation;
 
 import com.yahoo.collections.Pair;
 import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ConfigChangeAction;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.Provisioned;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -20,7 +22,11 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.yahoo.config.model.test.MockApplicationPackage.BOOK_SCHEMA;
 import static com.yahoo.config.model.test.MockApplicationPackage.MUSIC_SCHEMA;
@@ -67,12 +73,14 @@ public class ValidationTester {
      * @param services the services file content
      * @param environment the environment this deploys to
      * @param validationOverrides the validation overrides file content, or null if none
+     * @param containerCluster container cluster(s) which are declared in services
      * @return the new model and any change actions
      */
     public Pair<VespaModel, List<ConfigChangeAction>> deploy(VespaModel previousModel,
                                                              String services,
                                                              Environment environment,
-                                                             String validationOverrides) {
+                                                             String validationOverrides,
+                                                             String... containerCluster) {
         Instant now = LocalDate.parse("2000-01-01", DateTimeFormatter.ISO_DATE).atStartOfDay().atZone(ZoneOffset.UTC).toInstant();
         Provisioned provisioned = hostProvisioner.startProvisionedRecording();
         ApplicationPackage newApp = new MockApplicationPackage.Builder()
@@ -81,10 +89,16 @@ public class ValidationTester {
                 .withValidationOverrides(validationOverrides)
                 .build();
         VespaModelCreatorWithMockPkg newModelCreator = new VespaModelCreatorWithMockPkg(newApp);
+        Stream<String> clusters = containerCluster.length == 0 ? Stream.of("default") : Arrays.stream(containerCluster);
+        Set<ContainerEndpoint> containerEndpoints = clusters.map(name -> new ContainerEndpoint(name,
+                                                                                               ApplicationClusterEndpoint.Scope.zone,
+                                                                                               List.of(name + ".example.com")))
+                                                            .collect(Collectors.toSet());
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
                                                              .zone(new Zone(SystemName.defaultSystem(),
                                                                             environment,
                                                                             RegionName.defaultName()))
+                                                             .endpoints(containerEndpoints)
                                                              .applicationPackage(newApp)
                                                              .properties(properties)
                                                              .modelHostProvisioner(hostProvisioner)

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentClusterRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentClusterRemovalValidatorTest.java
@@ -1,17 +1,13 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
-import com.yahoo.collections.Pair;
 import com.yahoo.config.application.api.ValidationId;
 import com.yahoo.config.application.api.ValidationOverrides;
-import com.yahoo.config.model.api.ConfigChangeAction;
 import com.yahoo.config.provision.Environment;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.application.validation.ValidationTester;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -25,9 +21,9 @@ public class ContentClusterRemovalValidatorTest {
 
     @Test
     void testContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, null);
+            tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, null, "newContentClusterId.indexing");
             fail("Expected exception due to content cluster id change");
         }
         catch (IllegalArgumentException expected) {
@@ -39,8 +35,8 @@ public class ContentClusterRemovalValidatorTest {
 
     @Test
     void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null).getFirst();
-        var result = tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, removalOverride); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices("contentClusterId"), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        var result = tester.deploy(previous, getServices("newContentClusterId"), Environment.prod, removalOverride, "newContentClusterId.indexing"); // Allowed due to override
         assertEquals(result.getFirst().getContainerClusters().values().stream()
                            .flatMap(cluster -> cluster.getContainers().stream())
                            .map(container -> container.getServiceInfo())

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ContentTypeRemovalValidatorTest.java
@@ -24,9 +24,9 @@ public class ContentTypeRemovalValidatorTest {
     void testContentTypeRemovalValidation() {
         ValidationTester tester = new ValidationTester();
 
-        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null, "test.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices("book"), Environment.prod, null);
+            tester.deploy(previous, getServices("book"), Environment.prod, null, "test.indexing");
             fail("Expected exception due to removal of schema 'music");
         }
         catch (IllegalArgumentException expected) {
@@ -41,8 +41,8 @@ public class ContentTypeRemovalValidatorTest {
     void testOverridingContentTypeRemovalValidation() {
         ValidationTester tester = new ValidationTester();
 
-        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null).getFirst();
-        tester.deploy(previous, getServices("book"), Environment.prod, removalOverride); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices("music"), Environment.prod, null, "test.indexing").getFirst();
+        tester.deploy(previous, getServices("book"), Environment.prod, removalOverride, "test.indexing"); // Allowed due to override
     }
 
     private static String getServices(String documentType) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/GlobalDocumentChangeValidatorTest.java
@@ -25,9 +25,9 @@ public class GlobalDocumentChangeValidatorTest {
 
     private void testChangeGlobalAttribute(boolean allowed, boolean oldGlobal, boolean newGlobal, String validationOverrides) {
         ValidationTester tester = new ValidationTester();
-        VespaModel oldModel = tester.deploy(null, getServices(oldGlobal), Environment.prod, validationOverrides).getFirst();
+        VespaModel oldModel = tester.deploy(null, getServices(oldGlobal), Environment.prod, validationOverrides, "default.indexing").getFirst();
         try {
-            tester.deploy(oldModel, getServices(newGlobal), Environment.prod, validationOverrides).getSecond();
+            tester.deploy(oldModel, getServices(newGlobal), Environment.prod, validationOverrides, "default.indexing").getSecond();
             assertTrue(allowed);
         } catch (IllegalStateException e) {
             assertFalse(allowed);
@@ -37,7 +37,8 @@ public class GlobalDocumentChangeValidatorTest {
                     e.getMessage());
         }
     }
-    private static final String getServices(boolean isGlobal) {
+
+    private static String getServices(boolean isGlobal) {
         return "<services version='1.0'>" +
                 "  <content id='default' version='1.0'>" +
                 "    <redundancy>1</redundancy>" +

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexingModeChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/IndexingModeChangeValidatorTest.java
@@ -10,9 +10,10 @@ import com.yahoo.vespa.model.application.validation.ValidationTester;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author bratseth
@@ -33,7 +34,7 @@ public class IndexingModeChangeValidatorTest {
         }
         catch (ValidationException e) {
             assertEquals("indexing-mode-change:\n" +
-                    "\tDocument type 'music' in cluster 'default' changed indexing mode from 'indexed' to 'streaming'\n" +
+                    "\tDocument type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'streaming'\n" +
                     "To allow this add <allow until='yyyy-mm-dd'>indexing-mode-change</allow> to validation-overrides.xml, see https://docs.vespa.ai/en/reference/validation-overrides.html",
                     e.getMessage());
         }
@@ -49,7 +50,7 @@ public class IndexingModeChangeValidatorTest {
                 tester.deploy(oldModel, getServices("streaming"), Environment.prod, validationOverrides).getSecond();
 
         assertReindexingChange( // allowed=true due to validation override
-                "Document type 'music' in cluster 'default' changed indexing mode from 'indexed' to 'streaming'",
+                "Document type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'streaming'",
                 changeActions);
     }
 
@@ -63,7 +64,7 @@ public class IndexingModeChangeValidatorTest {
                 tester.deploy(oldModel, getServices("store-only"), Environment.prod, validationOverrides).getSecond();
 
         assertReindexingChange( // allowed=true due to validation override
-                "Document type 'music' in cluster 'default' changed indexing mode from 'indexed' to 'store-only'",
+                "Document type 'music' in cluster 'default-content' changed indexing mode from 'indexed' to 'store-only'",
                 changeActions);
     }
 
@@ -79,10 +80,10 @@ public class IndexingModeChangeValidatorTest {
 
     private static String getServices(String indexingMode) {
         return "<services version='1.0'>" +
-               "  <container id='default-container' version='1.0'>" +
+               "  <container id='default' version='1.0'>" +
                "    <nodes count='1'/>" +
                "  </container>" +
-               "  <content id='default' version='1.0'>" +
+               "  <content id='default-content' version='1.0'>" +
                "    <redundancy>1</redundancy>" +
                "    <documents>" +
                "      <document type='music' mode='" + indexingMode + "'/>" +

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/NodeResourceChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/NodeResourceChangeValidatorTest.java
@@ -1,7 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.application.validation.change;
 
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
 import com.yahoo.config.model.api.ConfigChangeAction;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -17,8 +19,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * @author bratseth
@@ -50,7 +54,7 @@ public class NodeResourceChangeValidatorTest {
         ConfigChangeAction contentAction = validate(model(1, 1, 1, 1), model(1, 1, 2, 1)).get(0);
         assertEquals(ConfigChangeAction.Type.RESTART, contentAction.getType());
         assertEquals("service 'searchnode' of type searchnode on host3", contentAction.getServices().get(0).toString());
-        assertEquals(false, contentAction.ignoreForInternalRedeploy());
+        assertFalse(contentAction.ignoreForInternalRedeploy());
     }
 
     private List<ConfigChangeAction> validate(VespaModel current, VespaModel next) {
@@ -61,6 +65,10 @@ public class NodeResourceChangeValidatorTest {
         var properties = new TestProperties();
         properties.setHostedVespa(true);
         var deployState = new DeployState.Builder().properties(properties)
+                                                   .endpoints(Set.of(
+                                                           new ContainerEndpoint("container1", ApplicationClusterEndpoint.Scope.zone, List.of("c1.example.com")),
+                                                           new ContainerEndpoint("container2", ApplicationClusterEndpoint.Scope.zone, List.of("c2.example.com"))
+                                                   ))
                                                    .modelHostProvisioner(new Provisioner());
         return new VespaModelCreatorWithMockPkg(
                 null,

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyChangeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyChangeValidatorTest.java
@@ -24,8 +24,8 @@ public class RedundancyChangeValidatorTest {
     public void testChangingRedundancyToOne() {
         try {
             var tester = new ValidationTester(6);
-            VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null).getFirst();
-            tester.deploy(previous, getServices("test", 1), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null, "test.indexing").getFirst();
+            tester.deploy(previous, getServices("test", 1), Environment.prod, null, "test.indexing");
             fail("Expected exception");
         }
         catch (IllegalArgumentException e) {
@@ -41,11 +41,11 @@ public class RedundancyChangeValidatorTest {
     @Test
     public void testChangingRedundancyToOneWithValidationOverride() {
         var tester = new ValidationTester(6);
-        VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null).getFirst();
-        previous = tester.deploy(previous, getServices("test", 1), Environment.prod, redundancyOverride).getFirst();
+        VespaModel previous = tester.deploy(null, getServices("test", 2), Environment.prod, null, "test.indexing").getFirst();
+        previous = tester.deploy(previous, getServices("test", 1), Environment.prod, redundancyOverride, "test.indexing").getFirst();
 
         // Staying at one does not require an override
-        tester.deploy(previous, getServices("test", 1), Environment.prod, null);
+        tester.deploy(previous, getServices("test", 1), Environment.prod, null, "test.indexing");
     }
 
     private static String getServices(String contentClusterId, int redundancy) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
@@ -21,9 +21,9 @@ public class RedundancyIncreaseValidatorTest {
 
     @Test
     void testRedundancyIncreaseValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices(3), Environment.prod, null);
+            tester.deploy(previous, getServices(3), Environment.prod, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy increase");
         }
         catch (IllegalArgumentException expected) {
@@ -37,8 +37,8 @@ public class RedundancyIncreaseValidatorTest {
 
     @Test
     void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null).getFirst();
-        tester.deploy(previous, getServices(3), Environment.prod, redundancyIncreaseOverride); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(3), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
     }
 
     private static String getServices(int redundancy) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/ResourcesReductionValidatorTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class ResourcesReductionValidatorTest {
 
+    private static final String CONTAINER_CLUSTER = "default.indexing";
+
     private final NodeResources hostResources = new NodeResources(64, 128, 1000, 10);
     private final InMemoryProvisioner provisioner           = new InMemoryProvisioner(30, hostResources, true, InMemoryProvisioner.defaultHostResources);
     private final InMemoryProvisioner provisionerSelfHosted = new InMemoryProvisioner(30, hostResources, true, NodeResources.unspecified());
@@ -30,9 +32,9 @@ public class ResourcesReductionValidatorTest {
     void fail_when_reduction_by_over_50_percent() {
         var fromResources = new NodeResources(8, 64, 800, 1);
         var toResources = new NodeResources(8, 16, 800, 1);
-        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null);
+            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         } catch (IllegalArgumentException expected) {
             assertResourceReductionException(expected,
@@ -45,9 +47,9 @@ public class ResourcesReductionValidatorTest {
     void fail_when_reducing_multiple_resources_by_over_50_percent() {
         var fromResources = new NodeResources(8, 64, 800, 1);
         var toResources = new NodeResources(3, 16, 200, 1);
-        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null);
+            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         } catch (IllegalArgumentException expected) {
             assertResourceReductionException(expected,
@@ -58,20 +60,20 @@ public class ResourcesReductionValidatorTest {
 
     @Test
     void small_resource_decrease_is_allowed() {
-        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(1.5, 64, 800, 1)), Environment.prod, null).getFirst();
-        tester.deploy(previous, contentServices(6, new NodeResources(.5, 48, 600, 1)), Environment.prod, null);
+        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(1.5, 64, 800, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(6, new NodeResources(.5, 48, 600, 1)), Environment.prod, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void reorganizing_resources_is_allowed() {
-        VespaModel previous = tester.deploy(null, contentServices(12, new NodeResources(2, 10, 100, 1)), Environment.prod, null).getFirst();
-        tester.deploy(previous, contentServices(4, new NodeResources(6, 30, 300, 1)), Environment.prod, null);
+        VespaModel previous = tester.deploy(null, contentServices(12, new NodeResources(2, 10, 100, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(4, new NodeResources(6, 30, 300, 1)), Environment.prod, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void overriding_resource_decrease() {
-        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(8, 64, 800, 1)), Environment.prod, null).getFirst();
-        tester.deploy(previous, contentServices(6, new NodeResources(8, 16, 800, 1)), Environment.prod, resourcesReductionOverride); // Allowed due to override
+        VespaModel previous = tester.deploy(null, contentServices(6, new NodeResources(8, 64, 800, 1)), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(6, new NodeResources(8, 16, 800, 1)), Environment.prod, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
     }
 
     @Test
@@ -108,23 +110,22 @@ public class ResourcesReductionValidatorTest {
     void reduction_is_detected_when_going_from_unspecified_resources_content() {
         NodeResources toResources = defaultResources.withDiskGb(defaultResources.diskGb() / 5);
         try {
-            VespaModel previous = tester.deploy(null, contentServices(6, null), Environment.prod, null).getFirst();
-            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, contentServices(6, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(6, toResources), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
+        } catch (IllegalArgumentException expected) {
+            assertResourceReductionException(expected,
+                                             defaultResources.multipliedBy(6),
+                                             toResources.multipliedBy(6));
         }
-        catch (IllegalArgumentException expected) {
-                assertResourceReductionException(expected,
-                                                 defaultResources.multipliedBy(6),
-                                                 toResources.multipliedBy(6));
-            }
     }
 
     @Test
     void reduction_is_detected_when_going_to_unspecified_resources_content() {
         NodeResources fromResources = defaultResources.withVcpu(defaultResources.vcpu() * 3);
         try {
-            VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null).getFirst();
-            tester.deploy(previous, contentServices(6, null), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, contentServices(6, fromResources), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(6, null), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -140,8 +141,8 @@ public class ResourcesReductionValidatorTest {
         int toNodes = 14;
         try {
             ValidationTester tester = new ValidationTester(33);
-            VespaModel previous = tester.deploy(null, contentServices(fromNodes, null), Environment.prod, null).getFirst();
-            tester.deploy(previous, contentServices(toNodes, null), Environment.prod, null);
+            VespaModel previous = tester.deploy(null, contentServices(fromNodes, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+            tester.deploy(previous, contentServices(toNodes, null), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -156,9 +157,9 @@ public class ResourcesReductionValidatorTest {
     void testSizeReductionValidationSelfhosted() {
         var tester = new ValidationTester(provisionerSelfHosted);
 
-        VespaModel previous = tester.deploy(null, contentServices(10, null), Environment.prod, null).getFirst();
+        VespaModel previous = tester.deploy(null, contentServices(10, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
         try {
-            tester.deploy(previous, contentServices(4, null), Environment.prod, null);
+            tester.deploy(previous, contentServices(4, null), Environment.prod, null, CONTAINER_CLUSTER);
             fail("Expected exception due to resources reduction");
         }
         catch (IllegalArgumentException expected) {
@@ -174,16 +175,16 @@ public class ResourcesReductionValidatorTest {
     void testSizeReductionValidationMinimalDecreaseIsAllowed() {
         ValidationTester tester = new ValidationTester(30);
 
-        VespaModel previous = tester.deploy(null, contentServices(3, null), Environment.prod, null).getFirst();
-        tester.deploy(previous, contentServices(2, null), Environment.prod, null);
+        VespaModel previous = tester.deploy(null, contentServices(3, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(2, null), Environment.prod, null, CONTAINER_CLUSTER);
     }
 
     @Test
     void testOverridingSizeReductionValidation() {
         ValidationTester tester = new ValidationTester(33);
 
-        VespaModel previous = tester.deploy(null, contentServices(30, null), Environment.prod, null).getFirst();
-        tester.deploy(previous, contentServices(14, null), Environment.prod, resourcesReductionOverride); // Allowed due to override
+        VespaModel previous = tester.deploy(null, contentServices(30, null), Environment.prod, null, CONTAINER_CLUSTER).getFirst();
+        tester.deploy(previous, contentServices(14, null), Environment.prod, resourcesReductionOverride, CONTAINER_CLUSTER); // Allowed due to override
     }
 
     private void assertResourceReductionException(Exception e, NodeResources currentResources, NodeResources newResources) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/RedundancyOnFirstDeploymentValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/first/RedundancyOnFirstDeploymentValidatorTest.java
@@ -24,7 +24,7 @@ public class RedundancyOnFirstDeploymentValidatorTest {
     @Test
     void testRedundancyOnFirstDeploymentValidation() {
         try {
-            tester.deploy(null, getServices(1), Environment.prod, null);
+            tester.deploy(null, getServices(1), Environment.prod, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy 1");
         }
         catch (IllegalArgumentException expected) {
@@ -38,7 +38,7 @@ public class RedundancyOnFirstDeploymentValidatorTest {
 
     @Test
     void testOverridingRedundancyOnFirstDeploymentValidation() {
-        tester.deploy(null, getServices(1), Environment.prod, redundancyOneOverride); // Allowed due to override
+        tester.deploy(null, getServices(1), Environment.prod, redundancyOneOverride, "contentClusterId.indexing"); // Allowed due to override
     }
 
     private static String getServices(int redundancy) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/ContentBuilderTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.model.builder.xml.dom;
 import com.yahoo.collections.CollectionUtil;
 import com.yahoo.config.ConfigInstance;
 import com.yahoo.config.application.api.ApplicationPackage;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.builder.xml.test.DomBuilderTest;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -17,8 +19,8 @@ import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.content.ContentSearchCluster;
 import com.yahoo.vespa.model.content.cluster.ContentCluster;
 import com.yahoo.vespa.model.content.engines.ProtonEngine;
-import com.yahoo.vespa.model.search.SearchCluster;
 import com.yahoo.vespa.model.search.IndexedSearchCluster;
+import com.yahoo.vespa.model.search.SearchCluster;
 import com.yahoo.vespa.model.search.SearchNode;
 import com.yahoo.vespa.model.search.StreamingSearchCluster;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
@@ -27,10 +29,17 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static com.yahoo.config.model.api.container.ContainerServiceType.CLUSTERCONTROLLER_CONTAINER;
 import static com.yahoo.config.model.api.container.ContainerServiceType.METRICS_PROXY_CONTAINER;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author baldersheim
@@ -750,7 +759,8 @@ public class ContentBuilderTest extends DomBuilderTest {
         {
             String hostedXml = singleNodeContentXml();
 
-            DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(new TestProperties().setHostedVespa(true));
+            DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(new TestProperties().setHostedVespa(true))
+                                                                              .endpoints(Set.of(new ContainerEndpoint("search.indexing", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))));
             VespaModel model = new VespaModelCreatorWithMockPkg(new MockApplicationPackage.Builder()
                     .withServices(hostedXml)
                     .withSearchDefinition(MockApplicationPackage.MUSIC_SCHEMA)

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/search/ImplicitIndexingClusterTest.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.container.search;
 
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -8,9 +10,13 @@ import com.yahoo.config.model.provision.InMemoryProvisioner;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.VespaModel;
+import com.yahoo.vespa.model.container.ApplicationContainer;
 import com.yahoo.vespa.model.container.ContainerCluster;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithMockPkg;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -41,7 +47,7 @@ public class ImplicitIndexingClusterTest {
 
 
         VespaModel vespaModel = buildMultiTenantVespaModel(servicesXml);
-        ContainerCluster jdisc = vespaModel.getContainerClusters().get("jdisc");
+        ContainerCluster<ApplicationContainer> jdisc = vespaModel.getContainerClusters().get("jdisc");
         assertNotNull(jdisc.getDocproc(), "Docproc not added to jdisc");
         assertNotNull(jdisc.getDocprocChains().allChains().getComponent("indexing"), "Indexing chain not added to jdisc");
     }
@@ -50,6 +56,7 @@ public class ImplicitIndexingClusterTest {
         ModelContext.Properties properties = new TestProperties().setMultitenant(true).setHostedVespa(true);
         DeployState.Builder deployStateBuilder = new DeployState.Builder()
                 .properties(properties)
+                .endpoints(Set.of(new ContainerEndpoint("jdisc", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .modelHostProvisioner(new InMemoryProvisioner(6, false));
 
         return new VespaModelCreatorWithMockPkg(new MockApplicationPackage.Builder()

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilderTest.java
@@ -338,6 +338,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                 .modelHostProvisioner(provisioner)
                 .provisioned(provisioner.startProvisionedRecording())
                 .applicationPackage(applicationPackage)
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setMultitenant(true)
                                                 .setHostedVespa(true)
                                                 .setZone(new Zone(environment, RegionName.from(region))))
@@ -548,7 +549,8 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         final var deployState = new DeployState.Builder()
                 .applicationPackage(applicationPackage)
                 .zone(new Zone(Environment.prod, RegionName.from("us-east-1")))
-                .endpoints(Set.of(new ContainerEndpoint("comics-search", ApplicationClusterEndpoint.Scope.global, List.of("nalle", "balle"))))
+                .endpoints(Set.of(new ContainerEndpoint("comics-search", ApplicationClusterEndpoint.Scope.global, List.of("nalle", "balle")),
+                                  new ContainerEndpoint("comics-search", ApplicationClusterEndpoint.Scope.zone, List.of("nalle", "balle"))))
                 .properties(new TestProperties().setHostedVespa(true))
                 .build();
 
@@ -573,6 +575,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
                 .modelHostProvisioner(new InMemoryProvisioner(true, false, "host1.yahoo.com", "host2.yahoo.com"))
                 .applicationPackage(applicationPackage)
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties()
                         .setMultitenant(true)
                         .setHostedVespa(true))
@@ -590,6 +593,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
                 .modelHostProvisioner(provisioner)
                 .provisioned(provisioner.startProvisionedRecording())
                 .applicationPackage(applicationPackage)
+                .endpoints(Set.of(new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                 .properties(new TestProperties().setMultitenant(true)
                                                 .setHostedVespa(true)
                                                 .setCloudAccount(cloudAccount))
@@ -632,6 +636,7 @@ public class ContainerModelBuilderTest extends ContainerModelBuilderTestBase {
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
                 .applicationPackage(applicationPackage)
                 .properties(new TestProperties().setHostedVespa(true))
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("c.example.com"))))
                 .build());
 
         AbstractConfigProducerRoot modelRoot = model.getRoot();

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/EmbedderTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/EmbedderTestCase.java
@@ -5,6 +5,8 @@ import com.yahoo.component.ComponentId;
 import com.yahoo.config.InnerNode;
 import com.yahoo.config.ModelNode;
 import com.yahoo.config.ModelReference;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -19,10 +21,10 @@ import com.yahoo.vespa.config.ConfigPayloadBuilder;
 import com.yahoo.vespa.model.VespaModel;
 import com.yahoo.vespa.model.container.ApplicationContainerCluster;
 import com.yahoo.vespa.model.container.component.BertEmbedder;
+import com.yahoo.vespa.model.container.component.ColBertEmbedder;
 import com.yahoo.vespa.model.container.component.Component;
 import com.yahoo.vespa.model.container.component.HuggingFaceEmbedder;
 import com.yahoo.vespa.model.container.component.HuggingFaceTokenizer;
-import com.yahoo.vespa.model.container.component.ColBertEmbedder;
 import com.yahoo.vespa.model.test.utils.VespaModelCreatorWithFilePkg;
 import com.yahoo.yolean.Exceptions;
 import org.junit.jupiter.api.Test;
@@ -35,6 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -190,7 +193,11 @@ public class EmbedderTestCase {
     private VespaModel loadModel(Path path, boolean hosted) throws Exception {
         FilesApplicationPackage applicationPackage = FilesApplicationPackage.fromFile(path.toFile());
         TestProperties properties = new TestProperties().setHostedVespa(hosted);
-        DeployState state = new DeployState.Builder().properties(properties).applicationPackage(applicationPackage).build();
+        DeployState state = new DeployState.Builder()
+                .properties(properties)
+                .endpoints(hosted ? Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))) : Set.of())
+                .applicationPackage(applicationPackage)
+                .build();
         return new VespaModel(state);
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JvmOptionsTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/xml/JvmOptionsTest.java
@@ -5,6 +5,8 @@ package com.yahoo.vespa.model.container.xml;
 import com.yahoo.collections.Pair;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.builder.xml.test.DomBuilderTest;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -15,10 +17,12 @@ import com.yahoo.vespa.model.container.ContainerCluster;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -82,9 +86,11 @@ public class JvmOptionsTest extends ContainerModelBuilderTestBase {
         ApplicationPackage applicationPackage = new MockApplicationPackage.Builder().withServices(servicesXml).build();
         // Need to create VespaModel to make deploy properties have effect
         final TestLogger logger = new TestLogger();
+        Set<ContainerEndpoint> endpoints = isHosted ? Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))) : Set.of();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
                 .applicationPackage(applicationPackage)
                 .deployLogger(logger)
+                .endpoints(endpoints)
                 .properties(new TestProperties().setHostedVespa(isHosted))
                 .build());
         QrStartConfig.Builder qrStartBuilder = new QrStartConfig.Builder();
@@ -109,9 +115,11 @@ public class JvmOptionsTest extends ContainerModelBuilderTestBase {
         ApplicationPackage applicationPackage = new MockApplicationPackage.Builder().withServices(servicesXml).build();
         // Need to create VespaModel to make deploy properties have effect
         final TestLogger logger = new TestLogger();
+        Set<ContainerEndpoint> endpoints = isHosted ? Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))) : Set.of();
         VespaModel model = new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
                 .applicationPackage(applicationPackage)
                 .deployLogger(logger)
+                .endpoints(endpoints)
                 .properties(new TestProperties().setJvmGCOptions(featureFlagDefault).setHostedVespa(isHosted))
                 .build());
         QrStartConfig.Builder qrStartBuilder = new QrStartConfig.Builder();
@@ -249,6 +257,7 @@ public class JvmOptionsTest extends ContainerModelBuilderTestBase {
         new VespaModel(new NullConfigModelRegistry(), new DeployState.Builder()
                 .applicationPackage(app)
                 .deployLogger(logger)
+                .endpoints(properties.hostedVespa() ? Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))) : Set.of())
                 .properties(properties)
                 .build());
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.content;
 
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.ModelContext;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.deploy.TestProperties;
@@ -48,8 +50,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ContentClusterTest extends ContentBaseTest {
 
@@ -382,8 +391,8 @@ public class ContentClusterTest extends ContentBaseTest {
         return createEnd2EndOneNode(properties, services);
     }
 
-    VespaModel createEnd2EndOneNode(ModelContext.Properties properties, String services) {
-        DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(properties);
+    VespaModel createEnd2EndOneNode(ModelContext.Properties properties, String services, ContainerEndpoint ...containerEndpoint) {
+        DeployState.Builder deployStateBuilder = new DeployState.Builder().properties(properties).endpoints(Set.of(containerEndpoint));
         List<String> sds = ApplicationPackageUtils.generateSchemas("type1");
         return (new VespaModelCreatorWithMockPkg(null, services, sds)).create(deployStateBuilder);
     }
@@ -1333,7 +1342,7 @@ public class ContentClusterTest extends ContentBaseTest {
                 "<?xml version='1.0' encoding='UTF-8' ?>" +
                         "<services version='1.0'>" +
                         "  <container id='default' version='1.0' />" +
-                        " </services>");
+                        " </services>", new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com")));
         assertEquals(Map.of(), noContentModel.getContentClusters());
         assertNull(noContentModel.getAdmin().getClusterControllers(), "No cluster controller without content");
 
@@ -1348,7 +1357,7 @@ public class ContentClusterTest extends ContentBaseTest {
                         "      <document mode='index' type='type1' />" +
                         "    </documents>" +
                         "  </content>" +
-                        " </services>");
+                        " </services>", new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com")));
         assertNotNull(oneContentModel.getAdmin().getClusterControllers(), "Shared cluster controller with content");
 
         String twoContentServices = "<?xml version='1.0' encoding='UTF-8' ?>" +
@@ -1379,7 +1388,7 @@ public class ContentClusterTest extends ContentBaseTest {
                 " </services>";
         VespaModel twoContentModel = createEnd2EndOneNode(new TestProperties().setHostedVespa(true)
                         .setMultitenant(true),
-                twoContentServices);
+                twoContentServices, new ContainerEndpoint("default", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com")));
         assertNotNull(twoContentModel.getAdmin().getClusterControllers(), "Shared cluster controller with content");
 
         ClusterControllerContainerCluster clusterControllers = twoContentModel.getAdmin().getClusterControllers();

--- a/config-model/src/test/java/com/yahoo/vespa/model/ml/ImportedModelTester.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/ml/ImportedModelTester.java
@@ -1,18 +1,20 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.model.ml;
 
-import com.yahoo.config.FileReference;
-import com.yahoo.config.model.ApplicationPackageTester;
 import ai.vespa.rankingexpression.importer.configmodelview.MlModelImporter;
-import com.yahoo.config.model.deploy.DeployState;
-import com.yahoo.io.GrowableByteBuffer;
-import com.yahoo.io.IOUtils;
-import com.yahoo.path.Path;
 import ai.vespa.rankingexpression.importer.lightgbm.LightGBMImporter;
 import ai.vespa.rankingexpression.importer.onnx.OnnxImporter;
 import ai.vespa.rankingexpression.importer.tensorflow.TensorFlowImporter;
 import ai.vespa.rankingexpression.importer.vespa.VespaImporter;
 import ai.vespa.rankingexpression.importer.xgboost.XGBoostImporter;
+import com.yahoo.config.FileReference;
+import com.yahoo.config.model.ApplicationPackageTester;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
+import com.yahoo.config.model.deploy.DeployState;
+import com.yahoo.io.GrowableByteBuffer;
+import com.yahoo.io.IOUtils;
+import com.yahoo.path.Path;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.serialization.TypedBinaryFormat;
 import com.yahoo.vespa.model.VespaModel;
@@ -22,8 +24,11 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Helper for testing of imported models.
@@ -51,6 +56,7 @@ public class ImportedModelTester {
         this.modelName = modelName;
         this.applicationDir = applicationDir;
         deployState = deployStateBuilder.applicationPackage(ApplicationPackageTester.create(applicationDir.toString()).app())
+                                        .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("default.example.com"))))
                                         .modelImporters(importers)
                                         .build();
     }

--- a/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/test/ModelAmendingTestCase.java
@@ -7,10 +7,13 @@ import com.yahoo.config.model.ConfigModelContext;
 import com.yahoo.config.model.ConfigModelRegistry;
 import com.yahoo.config.model.MapConfigModelRegistry;
 import com.yahoo.config.model.admin.AdminModel;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.builder.xml.ConfigModelBuilder;
 import com.yahoo.config.model.builder.xml.ConfigModelId;
 import com.yahoo.config.model.deploy.DeployState;
 import com.yahoo.config.model.producer.TreeConfigProducer;
+import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.model.AbstractService;
 import com.yahoo.vespa.model.HostResource;
@@ -26,8 +29,11 @@ import org.w3c.dom.Element;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Demonstrates how a model can be added at build time to amend another model.
@@ -73,7 +79,9 @@ public class ModelAmendingTestCase {
                         "</services>";
         VespaModelTester tester = new VespaModelTester(amendingModelRepo);
         tester.addHosts(12);
-        VespaModel model = tester.createModel(services);
+        DeployState.Builder builder = new DeployState.Builder().endpoints(Set.of(new ContainerEndpoint("test1", ApplicationClusterEndpoint.Scope.zone, List.of("t1.example.com")),
+                                                                                 new ContainerEndpoint("test2", ApplicationClusterEndpoint.Scope.zone, List.of("t2.example.com"))));
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, builder);
 
         // Check that all hosts are amended
         for (HostResource host : model.getAdmin().hostSystem().getHosts()) {
@@ -120,7 +128,9 @@ public class ModelAmendingTestCase {
                         "</services>";
         VespaModelTester tester = new VespaModelTester(amendingModelRepo);
         tester.addHosts(12);
-        VespaModel model = tester.createModel(services);
+        DeployState.Builder builder = new DeployState.Builder().endpoints(Set.of(new ContainerEndpoint("test1", ApplicationClusterEndpoint.Scope.zone, List.of("t1.example.com")),
+                                                                                 new ContainerEndpoint("test2", ApplicationClusterEndpoint.Scope.zone, List.of("t2.example.com"))));
+        VespaModel model = tester.createModel(Zone.defaultZone(), services, true, builder);
 
         // Check that all hosts are amended
         for (HostResource host : model.getAdmin().hostSystem().getHosts()) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/DeployTester.java
@@ -140,7 +140,19 @@ public class DeployTester {
      * Do the initial "deploy" with the existing API-less code as the deploy API doesn't support first deploys yet.
      */
     public PrepareResult deployApp(String applicationPath, String vespaVersion)  {
-        return deployApp(applicationPath, new PrepareParams.Builder().vespaVersion(vespaVersion));
+        String endpoints = """
+                [
+                  {
+                    "clusterId": "container",
+                    "names": [
+                      "c.example.com"
+                    ],
+                    "scope": "zone",
+                    "routingMethod": "exclusive"
+                  }
+                ]
+                """;
+        return deployApp(applicationPath, new PrepareParams.Builder().containerEndpoints(endpoints).vespaVersion(vespaVersion));
     }
 
     /**

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployNodeAllocationTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/deploy/HostedDeployNodeAllocationTest.java
@@ -63,10 +63,22 @@ public class HostedDeployNodeAllocationTest {
                 .provisioner(new MockProvisioner().hostProvisioner(provisioner))
                 .hostedConfigserverConfig(Zone.defaultZone())
                 .build();
-
+        String endpoints = """
+                [
+                  {
+                    "clusterId": "container",
+                    "names": [
+                      "c.example.com"
+                    ],
+                    "scope": "zone",
+                    "routingMethod": "exclusive"
+                  }
+                ]
+                """;
         try {
             tester.deployApp("src/test/apps/hosted/", new PrepareParams.Builder()
                     .vespaVersion("7.3")
+                    .containerEndpoints(endpoints)
                     .quota(new Quota(Optional.of(4), Optional.of(0))));
             fail("Expected to get a QuotaExceededException");
         } catch (QuotaExceededException e) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
@@ -63,7 +63,19 @@ public class TenantsMaintainerTest {
     }
 
     private PrepareParams.Builder prepareParams(TenantName tenantName) {
-        return new PrepareParams.Builder().applicationId(applicationId(tenantName));
+        String endpoints = """
+                [
+                  {
+                    "clusterId": "container",
+                    "names": [
+                      "c.example.com"
+                    ],
+                    "scope": "zone",
+                    "routingMethod": "exclusive"
+                  }
+                ]
+                """;
+        return new PrepareParams.Builder().containerEndpoints(endpoints).applicationId(applicationId(tenantName));
     }
 
     private ApplicationId applicationId(TenantName tenantName) {

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/model/LbServicesProducerTest.java
@@ -81,7 +81,7 @@ public class LbServicesProducerTest {
 
     private LbServicesConfig createModelAndGetLbServicesConfig(RegionName regionName) {
         Zone zone = new Zone(Environment.prod, regionName);
-        Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder().zone(zone));
+        Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder().endpoints(Set.of(new ContainerEndpoint("mydisc", ApplicationClusterEndpoint.Scope.zone, List.of("md.example.com")))).zone(zone));
         return getLbServicesConfig(new Zone(Environment.prod, regionName), testModel);
     }
 
@@ -126,7 +126,7 @@ public class LbServicesProducerTest {
 
     @Test
     public void testRoutingConfigForTesterApplication() {
-        Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder());
+        Map<TenantName, Set<ApplicationInfo>> testModel = createTestModel(new DeployState.Builder().endpoints(Set.of(new ContainerEndpoint("mydisc", ApplicationClusterEndpoint.Scope.zone, List.of("md.example.com")))));
 
         // No config for tester application
         assertNull(getLbServicesConfig(Zone.defaultZone(), testModel)

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/provision/StaticProvisionerTest.java
@@ -4,6 +4,8 @@ package com.yahoo.vespa.config.server.provision;
 import com.yahoo.cloud.config.ModelConfig;
 import com.yahoo.config.application.api.ApplicationPackage;
 import com.yahoo.config.model.NullConfigModelRegistry;
+import com.yahoo.config.model.api.ApplicationClusterEndpoint;
+import com.yahoo.config.model.api.ContainerEndpoint;
 import com.yahoo.config.model.api.HostProvisioner;
 import com.yahoo.config.model.application.provider.FilesApplicationPackage;
 import com.yahoo.config.model.deploy.DeployState;
@@ -16,6 +18,8 @@ import org.xml.sax.SAXException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
@@ -50,6 +54,7 @@ public class StaticProvisionerTest {
         DeployState deployState = new DeployState.Builder()
                 .applicationPackage(app)
                 .modelHostProvisioner(provisioner)
+                .endpoints(Set.of(new ContainerEndpoint("container", ApplicationClusterEndpoint.Scope.zone, List.of("c.example.com"))))
                 .properties(new TestProperties()
                         .setMultitenant(true)
                         .setHostedVespa(true))


### PR DESCRIPTION
A container cluster in a hosted system should always have a zone endpoint. This
change adds a safe-guard (in `ApplicationContainerCluster`) to prevent
generating a routing config not containing required endpoints.

Large diff is due to the high number of tests that violated this new constraint.

@hmusum

FYI @tokle