### PR TITLE
Revert "Ensure internal messages are flushed before shutting down RPC subsystem, take 2"

### DIFF
--- a/storage/src/vespa/storage/common/storagelink.h
+++ b/storage/src/vespa/storage/common/storagelink.h
@@ -42,34 +42,28 @@ public:
     enum State { CREATED, OPENED, CLOSING, FLUSHINGDOWN, FLUSHINGUP, CLOSED };
 
 private:
-    const std::string            _name;
-    StorageLink*                 _up;
+    std::string _name;
+    StorageLink* _up;
     std::unique_ptr<StorageLink> _down;
-    std::atomic<State>           _state;
-    const bool                   _allow_msg_down_during_flushing;
+    std::atomic<State> _state;
 
 public:
-    StorageLink(const std::string& name, bool allow_msg_down_during_flushing);
-    explicit StorageLink(const std::string& name);
-
     StorageLink(const StorageLink &) = delete;
     StorageLink & operator = (const StorageLink &) = delete;
+    StorageLink(const std::string& name)
+        : _name(name), _up(0), _down(), _state(CREATED) {}
     ~StorageLink() override;
 
-    const std::string& getName() const noexcept { return _name; }
-    [[nodiscard]] bool isTop() const noexcept { return !_up; }
-    [[nodiscard]] bool isBottom() const noexcept { return !_down; }
-    [[nodiscard]] unsigned int size() const noexcept {
-        return (isBottom() ? 1 : _down->size() + 1);
-    }
+    const std::string& getName() const { return _name; }
+    bool isTop() const { return (_up == 0); }
+    bool isBottom() const { return (_down.get() == 0); }
+    unsigned int size() const { return (isBottom() ? 1 : _down->size() + 1); }
 
     /** Adds the link to the end of the chain. */
     void push_back(StorageLink::UP);
 
     /** Get the current state of the storage link. */
-    [[nodiscard]] State getState() const noexcept {
-        return _state.load(std::memory_order_relaxed);
-    }
+    State getState() const noexcept { return _state.load(std::memory_order_relaxed); }
 
     /**
      * Called by storage server after the storage chain have been created.

--- a/storage/src/vespa/storage/storageserver/bouncer.h
+++ b/storage/src/vespa/storage/storageserver/bouncer.h
@@ -41,7 +41,6 @@ class Bouncer : public StorageLink,
     const lib::State* _clusterState;
     std::unique_ptr<config::ConfigFetcher> _configFetcher;
     std::unique_ptr<BouncerMetrics> _metrics;
-    bool _closed;
 
 public:
     Bouncer(StorageComponentRegister& compReg, const config::ConfigUri & configUri);
@@ -61,12 +60,11 @@ private:
     void abortCommandDueToClusterDown(api::StorageMessage&, const lib::State&);
     void rejectDueToInsufficientPriority(api::StorageMessage&, api::StorageMessage::Priority);
     void reject_due_to_too_few_bucket_bits(api::StorageMessage&);
-    void reject_due_to_node_shutdown(api::StorageMessage&);
     static bool clusterIsUp(const lib::State& cluster_state);
     bool isDistributor() const;
-    static bool isExternalLoad(const api::MessageType&) noexcept;
-    static bool isExternalWriteOperation(const api::MessageType&) noexcept;
-    static bool priorityRejectionIsEnabled(int configuredPriority) noexcept {
+    bool isExternalLoad(const api::MessageType&) const noexcept;
+    bool isExternalWriteOperation(const api::MessageType&) const noexcept;
+    bool priorityRejectionIsEnabled(int configuredPriority) const noexcept {
         return (configuredPriority != -1);
     }
 
@@ -74,7 +72,7 @@ private:
      * If msg is a command containing a mutating timestamp (put, remove or
      * update commands), return that timestamp. Otherwise, return 0.
      */
-    static uint64_t extractMutationTimestampIfAny(const api::StorageMessage& msg);
+    uint64_t extractMutationTimestampIfAny(const api::StorageMessage& msg);
     bool onDown(const std::shared_ptr<api::StorageMessage>&) override;
     void handleNewState() noexcept override;
     const lib::NodeState &getDerivedNodeState(document::BucketSpace bucketSpace) const;

--- a/storage/src/vespa/storage/storageserver/communicationmanager.cpp
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.cpp
@@ -217,7 +217,7 @@ convert_to_rpc_compression_config(const vespa::config::content::core::StorCommun
 }
 
 CommunicationManager::CommunicationManager(StorageComponentRegister& compReg, const config::ConfigUri & configUri)
-    : StorageLink("Communication manager", true), // Explicitly allow msg down during flushing (will be bounced)
+    : StorageLink("Communication manager"),
       _component(compReg, "communicationmanager"),
       _metrics(),
       _shared_rpc_resources(),    // Created upon initial configuration
@@ -278,25 +278,25 @@ CommunicationManager::onClose()
     // Avoid getting config during shutdown
     _configFetcher.reset();
 
-    _closed.store(true, std::memory_order_seq_cst);
+    _closed = true;
+
+    if (_mbus) {
+        if (_messageBusSession) {
+            _messageBusSession->close();
+        }
+    }
+
+    // TODO remove? this no longer has any particularly useful semantics
     if (_cc_rpc_service) {
-        _cc_rpc_service->close(); // Auto-abort all incoming CC RPC requests from now on
+        _cc_rpc_service->close();
     }
-    // Sync all RPC threads to ensure that any subsequent RPCs must observe the closed-flags we just set
+    // TODO do this after we drain queues?
     if (_shared_rpc_resources) {
-        _shared_rpc_resources->sync_all_threads();
+        _shared_rpc_resources->shutdown();
     }
 
-    if (_mbus && _messageBusSession) {
-        // Closing the mbus session unregisters the destination session and syncs the worker
-        // thread(s), so once this call returns we should not observe further incoming requests
-        // through this pipeline. Previous messages may already be in flight internally; these
-        // will be handled by flushing-phases.
-        _messageBusSession->close();
-    }
-
-    // Stopping internal message dispatch thread should stop all incoming _async_ messages
-    // from being processed. _Synchronously_ dispatched RPCs are still passing through.
+    // Stopping pumper thread should stop all incoming messages from being
+    // processed.
     if (_thread) {
         _thread->interrupt();
         _eventQueue.signal();
@@ -305,37 +305,15 @@ CommunicationManager::onClose()
     }
 
     // Emptying remaining queued messages
+    // FIXME but RPC/mbus is already shut down at this point...! Make sure we handle this
     std::shared_ptr<api::StorageMessage> msg;
     api::ReturnCode code(api::ReturnCode::ABORTED, "Node shutting down");
     while (_eventQueue.size() > 0) {
         assert(_eventQueue.getNext(msg, 0ms));
         if (!msg->getType().isReply()) {
-            std::shared_ptr<api::StorageReply> reply(dynamic_cast<api::StorageCommand&>(*msg).makeReply());
+            std::shared_ptr<api::StorageReply> reply(static_cast<api::StorageCommand&>(*msg).makeReply());
             reply->setResult(code);
             sendReply(reply);
-        }
-    }
-}
-
-void
-CommunicationManager::onFlush(bool downwards)
-{
-    if (downwards) {
-        // Sync RPC threads once more (with feeling!) to ensure that any closing done by other components
-        // during the storage chain onClose() is visible to these.
-        if (_shared_rpc_resources) {
-            _shared_rpc_resources->sync_all_threads();
-        }
-        // By this point, no inbound RPCs (requests and responses) should be allowed any further down
-        // than the Bouncer component, where they will be, well, bounced.
-    } else {
-        // All components further down the storage chain should now be completely closed
-        // and flushed, and all message-dispatching threads should have been shut down.
-        // It's possible that the RPC threads are still butting heads up against the Bouncer
-        // component, so we conclude the shutdown ceremony by taking down the RPC subsystem.
-        // This transitively waits for all RPC threads to complete.
-        if (_shared_rpc_resources) {
-            _shared_rpc_resources->shutdown();
         }
     }
 }
@@ -460,15 +438,11 @@ CommunicationManager::process(const std::shared_ptr<api::StorageMessage>& msg)
     }
 }
 
-// Called directly by RPC threads
 void CommunicationManager::dispatch_sync(std::shared_ptr<api::StorageMessage> msg) {
     LOG(spam, "Direct dispatch of storage message %s, priority %d", msg->toString().c_str(), msg->getPriority());
-    // If process is shutting down, msg will be synchronously aborted by the Bouncer component
     process(msg);
 }
 
-// Called directly by RPC threads (for incoming CC requests) and by any other request-dispatching
-// threads (i.e. calling sendUp) when address resolution fails and an internal error response is generated.
 void CommunicationManager::dispatch_async(std::shared_ptr<api::StorageMessage> msg) {
     LOG(spam, "Enqueued dispatch of storage message %s, priority %d", msg->toString().c_str(), msg->getPriority());
     _eventQueue.enqueue(std::move(msg));

--- a/storage/src/vespa/storage/storageserver/communicationmanager.h
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.h
@@ -89,7 +89,6 @@ private:
 
     void onOpen() override;
     void onClose() override;
-    void onFlush(bool downwards) override;
 
     void process(const std::shared_ptr<api::StorageMessage>& msg);
 

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.cpp
@@ -105,10 +105,6 @@ void SharedRpcResources::wait_until_slobrok_is_ready() {
     }
 }
 
-void SharedRpcResources::sync_all_threads() {
-    _transport->sync();
-}
-
 void SharedRpcResources::shutdown() {
     assert(!_shutdown);
     if (listen_port() > 0) {

--- a/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
+++ b/storage/src/vespa/storage/storageserver/rpc/shared_rpc_resources.h
@@ -42,8 +42,6 @@ public:
     // To be called after all RPC handlers have been registered.
     void start_server_and_register_slobrok(vespalib::stringref my_handle);
 
-    void sync_all_threads();
-
     void shutdown();
     [[nodiscard]] int listen_port() const noexcept; // Only valid if server has been started
 

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -358,7 +358,7 @@ StorageNode::shutdown()
 {
     // Try to shut down in opposite order of initialize. Bear in mind that
     // we might be shutting down after init exception causing only parts
-    // of the server to have been initialized
+    // of the server to have initialize
     LOG(debug, "Shutting down storage node of type %s", getNodeType().toString().c_str());
     if (!attemptedStopped()) {
         LOG(debug, "Storage killed before requestShutdown() was called. No "


### PR DESCRIPTION
Reverts vespa-engine/vespa#28871

Some assertions in system tests still seen