### PR TITLE
exclude dirs from link check

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -532,6 +532,6 @@ jobs:
           --typhoeus '{"connecttimeout": 10, "timeout": 30, "followlocation": false}' \
           --hydra '{"max_concurrency": 1}' \
           --ignore-urls '/slack.vespa.ai/,/localhost:8080/,/127.0.0.1:3000/,/favicon.svg/,/main.jsx/' \
-          --ignore-files '/fnet/index.html/' \
+          --ignore-files '/fnet/index.html/,/client/js/app/node_modules/,/controller-server/src/test/resources/mail/' \
           --swap-urls '(.*).md:\1.html' \
           _site


### PR DESCRIPTION
* At _site/controller-server/src/test/resources/mail/notification.html:624:

  External link https://dashboard.tld/tenant/tenant1/account/notifications failed with something very wrong.
It's possible libcurl couldn't connect to the server, or perhaps the request timed out.
Sometimes, making too many requests at once also breaks things. (status code 0)

