### PR TITLE
Wire `CommunicationManager` config from its owner rather than self-subscribing

### DIFF
--- a/storage/src/tests/storageserver/communicationmanagertest.cpp
+++ b/storage/src/tests/storageserver/communicationmanagertest.cpp
@@ -1,31 +1,41 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storage/storageserver/communicationmanager.h>
-
-#include <vespa/messagebus/testlib/slobrok.h>
-#include <vespa/messagebus/rpcmessagebus.h>
-#include <vespa/storageapi/message/persistence.h>
-#include <vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.h>
-#include <vespa/storage/persistence/messages.h>
-#include <vespa/document/bucket/fixed_bucket_spaces.h>
-#include <tests/common/teststorageapp.h>
 #include <tests/common/dummystoragelink.h>
 #include <tests/common/testhelper.h>
-#include <vespa/document/test/make_document_bucket.h>
+#include <tests/common/teststorageapp.h>
+#include <vespa/config/helper/configgetter.hpp>
+#include <vespa/document/bucket/fixed_bucket_spaces.h>
 #include <vespa/document/fieldset/fieldsets.h>
+#include <vespa/document/test/make_document_bucket.h>
 #include <vespa/documentapi/messagebus/messages/getdocumentmessage.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/documentapi/messagebus/messages/removedocumentmessage.h>
 #include <vespa/documentapi/messagebus/messages/getdocumentreply.h>
+#include <vespa/documentapi/messagebus/messages/removedocumentmessage.h>
+#include <vespa/messagebus/rpcmessagebus.h>
+#include <vespa/messagebus/testlib/slobrok.h>
+#include <vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.h>
+#include <vespa/storage/persistence/messages.h>
+#include <vespa/storage/storageserver/communicationmanager.h>
+#include <vespa/storageapi/message/persistence.h>
+#include <vespa/vespalib/util/stringfmt.h>
 #include <thread>
-#include <vespa/vespalib/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 using document::test::makeDocumentBucket;
 using namespace ::testing;
 
 namespace storage {
 
-vespalib::string _Storage("storage");
+vespalib::string _storage("storage");
+
+using CommunicationManagerConfig = vespa::config::content::core::StorCommunicationmanagerConfig;
+
+namespace {
+
+std::unique_ptr<CommunicationManagerConfig> config_from(const config::ConfigUri& cfg_uri) {
+    return config::ConfigGetter<CommunicationManagerConfig>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
+}
+
+}
 
 struct CommunicationManagerTest : Test {
 
@@ -33,13 +43,11 @@ struct CommunicationManagerTest : Test {
 
     void doTestConfigPropagation(bool isContentNode);
 
-    std::shared_ptr<api::StorageCommand> createDummyCommand(
-            api::StorageMessage::Priority priority)
-    {
+    static std::shared_ptr<api::StorageCommand> createDummyCommand(api::StorageMessage::Priority priority) {
         auto cmd = std::make_shared<api::GetCommand>(makeDocumentBucket(document::BucketId(0)),
                                                      document::DocumentId("id:ns:mytype::mydoc"),
                                                      document::AllFields::NAME);
-        cmd->setAddress(api::StorageMessageAddress::create(&_Storage, lib::NodeType::STORAGE, 1));
+        cmd->setAddress(api::StorageMessageAddress::create(&_storage, lib::NodeType::STORAGE, 1));
         cmd->setPriority(priority);
         return cmd;
     }
@@ -77,19 +85,20 @@ TEST_F(CommunicationManagerTest, simple) {
     TestServiceLayerApp storNode(storConfig.getConfigId());
     TestDistributorApp distNode(distConfig.getConfigId());
 
-    CommunicationManager distributor(distNode.getComponentRegister(),
-                                     config::ConfigUri(distConfig.getConfigId()));
-    CommunicationManager storage(storNode.getComponentRegister(),
-                                 config::ConfigUri(storConfig.getConfigId()));
-    DummyStorageLink *distributorLink = new DummyStorageLink();
-    DummyStorageLink *storageLink = new DummyStorageLink();
+    auto dist_cfg_uri = config::ConfigUri(distConfig.getConfigId());
+    auto stor_cfg_uri = config::ConfigUri(storConfig.getConfigId());
+
+    CommunicationManager distributor(distNode.getComponentRegister(), dist_cfg_uri, *config_from(dist_cfg_uri));
+    CommunicationManager storage(storNode.getComponentRegister(), stor_cfg_uri, *config_from(stor_cfg_uri));
+    auto* distributorLink = new DummyStorageLink();
+    auto* storageLink = new DummyStorageLink();
     distributor.push_back(std::unique_ptr<StorageLink>(distributorLink));
     storage.push_back(std::unique_ptr<StorageLink>(storageLink));
     distributor.open();
     storage.open();
 
-    auto stor_addr  = api::StorageMessageAddress::create(&_Storage, lib::NodeType::STORAGE, 1);
-    auto distr_addr = api::StorageMessageAddress::create(&_Storage, lib::NodeType::DISTRIBUTOR, 1);
+    auto stor_addr  = api::StorageMessageAddress::create(&_storage, lib::NodeType::STORAGE, 1);
+    auto distr_addr = api::StorageMessageAddress::create(&_storage, lib::NodeType::DISTRIBUTOR, 1);
     // It is undefined when the logical nodes will be visible in each others Slobrok
     // mirrors, so explicitly wait until mutual visibility is ensured. Failure to do this
     // might cause the below message to be immediately bounced due to failing to map the
@@ -136,9 +145,9 @@ CommunicationManagerTest::doTestConfigPropagation(bool isContentNode)
         node = std::make_unique<TestDistributorApp>(config.getConfigId());
     }
 
-    CommunicationManager commMgr(node->getComponentRegister(),
-                                 config::ConfigUri(config.getConfigId()));
-    DummyStorageLink *storageLink = new DummyStorageLink();
+    auto cfg_uri = config::ConfigUri(config.getConfigId());
+    CommunicationManager commMgr(node->getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    auto* storageLink = new DummyStorageLink();
     commMgr.push_back(std::unique_ptr<StorageLink>(storageLink));
     commMgr.open();
 
@@ -153,13 +162,12 @@ CommunicationManagerTest::doTestConfigPropagation(bool isContentNode)
     }
 
     // Test live reconfig of limits.
-    using ConfigBuilder
-        = vespa::config::content::core::StorCommunicationmanagerConfigBuilder;
+    using ConfigBuilder = vespa::config::content::core::StorCommunicationmanagerConfigBuilder;
     auto liveCfg = std::make_unique<ConfigBuilder>();
     liveCfg->mbusContentNodeMaxPendingCount = 777777;
     liveCfg->mbusDistributorNodeMaxPendingCount = 999999;
 
-    commMgr.configure(std::move(liveCfg));
+    commMgr.on_configure(*liveCfg);
     if (isContentNode) {
         EXPECT_EQ(777777, mbus.getMaxPendingCount());
     } else {
@@ -182,9 +190,9 @@ TEST_F(CommunicationManagerTest, commands_are_dequeued_in_fifo_order) {
     addSlobrokConfig(storConfig, slobrok);
     TestServiceLayerApp storNode(storConfig.getConfigId());
 
-    CommunicationManager storage(storNode.getComponentRegister(),
-                                 config::ConfigUri(storConfig.getConfigId()));
-    DummyStorageLink *storageLink = new DummyStorageLink();
+    auto cfg_uri = config::ConfigUri(storConfig.getConfigId());
+    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    auto* storageLink = new DummyStorageLink();
     storage.push_back(std::unique_ptr<StorageLink>(storageLink));
     storage.open();
 
@@ -215,9 +223,9 @@ TEST_F(CommunicationManagerTest, replies_are_dequeued_in_fifo_order) {
     addSlobrokConfig(storConfig, slobrok);
     TestServiceLayerApp storNode(storConfig.getConfigId());
 
-    CommunicationManager storage(storNode.getComponentRegister(),
-                                 config::ConfigUri(storConfig.getConfigId()));
-    DummyStorageLink *storageLink = new DummyStorageLink();
+    auto cfg_uri = config::ConfigUri(storConfig.getConfigId());
+    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    auto* storageLink = new DummyStorageLink();
     storage.push_back(std::unique_ptr<StorageLink>(storageLink));
     storage.open();
 
@@ -256,8 +264,8 @@ struct CommunicationManagerFixture {
         addSlobrokConfig(stor_config, slobrok);
 
         node = std::make_unique<TestServiceLayerApp>(stor_config.getConfigId());
-        comm_mgr = std::make_unique<CommunicationManager>(node->getComponentRegister(),
-                                                          config::ConfigUri(stor_config.getConfigId()));
+        auto cfg_uri = config::ConfigUri(stor_config.getConfigId());
+        comm_mgr = std::make_unique<CommunicationManager>(node->getComponentRegister(), cfg_uri, *config_from(cfg_uri));
         bottom_link = new DummyStorageLink();
         comm_mgr->push_back(std::unique_ptr<StorageLink>(bottom_link));
         comm_mgr->open();

--- a/storage/src/vespa/storage/storageserver/communicationmanager.h
+++ b/storage/src/vespa/storage/storageserver/communicationmanager.h
@@ -1,11 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**
- * @class CommunicationManager
- * @ingroup storageserver
- *
- * @brief Class used for sending messages over the network.
- *
- * @version $Id$
+ * Class used for sending messages over the network.
  */
 
 #pragma once
@@ -65,7 +60,6 @@ public:
 class CommunicationManager final
     : public StorageLink,
       public framework::Runnable,
-      private config::IFetcherCallback<vespa::config::content::core::StorCommunicationmanagerConfig>,
       public mbus::IMessageHandler,
       public mbus::IReplyHandler,
       private framework::MetricUpdateHook,
@@ -80,8 +74,6 @@ private:
     std::unique_ptr<rpc::ClusterControllerApiRpcService> _cc_rpc_service;
     std::unique_ptr<rpc::MessageCodecProvider> _message_codec_provider;
     Queue _eventQueue;
-    // XXX: Should perhaps use a configsubscriber and poll from StorageComponent ?
-    std::unique_ptr<config::ConfigFetcher> _configFetcher;
     using EarlierProtocol = std::pair<vespalib::steady_time , mbus::IProtocol::SP>;
     using EarlierProtocols = std::vector<EarlierProtocol>;
     std::mutex       _earlierGenerationsLock;
@@ -97,7 +89,6 @@ private:
     using BucketspacesConfig = vespa::config::content::core::BucketspacesConfig;
 
     void configureMessageBusLimits(const CommunicationManagerConfig& cfg);
-    void configure(std::unique_ptr<CommunicationManagerConfig> config) override;
     void receiveStorageReply(const std::shared_ptr<api::StorageReply>&);
     void fail_with_unresolvable_bucket_space(std::unique_ptr<documentapi::DocumentMessage> msg,
                                              const vespalib::string& error_message);
@@ -106,6 +97,7 @@ private:
 
     static const uint64_t FORWARDED_MESSAGE = 0;
 
+    std::unique_ptr<CommunicationManagerConfig> _bootstrap_config;
     std::unique_ptr<mbus::RPCMessageBus> _mbus;
     std::unique_ptr<mbus::DestinationSession> _messageBusSession;
     std::unique_ptr<mbus::SourceSession> _sourceSession;
@@ -127,8 +119,11 @@ public:
     CommunicationManager(const CommunicationManager&) = delete;
     CommunicationManager& operator=(const CommunicationManager&) = delete;
     CommunicationManager(StorageComponentRegister& compReg,
-                         const config::ConfigUri & configUri);
+                         const config::ConfigUri& configUri,
+                         const CommunicationManagerConfig& bootstrap_config);
     ~CommunicationManager() override;
+
+    void on_configure(const CommunicationManagerConfig& config);
 
     // MessageDispatcher overrides
     void dispatch_sync(std::shared_ptr<api::StorageMessage> msg) override;

--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -32,7 +32,7 @@ DistributorNode::DistributorNode(
       _timestamp_second_counter(0),
       _intra_second_pseudo_usec_counter(0),
       _num_distributor_stripes(num_distributor_stripes),
-      _retrievedCommunicationManager(std::move(communicationManager))
+      _retrievedCommunicationManager(std::move(communicationManager)) // may be nullptr
 {
     if (storage_chain_builder) {
         set_storage_chain_builder(std::move(storage_chain_builder));
@@ -88,7 +88,7 @@ DistributorNode::createChain(IStorageChainBuilder &builder)
     if (_retrievedCommunicationManager) {
         builder.add(std::move(_retrievedCommunicationManager));
     } else {
-        auto communication_manager = std::make_unique<CommunicationManager>(dcr, _configUri);
+        auto communication_manager = std::make_unique<CommunicationManager>(dcr, _configUri, *_comm_mgr_config);
         _communicationManager = communication_manager.get();
         builder.add(std::move(communication_manager));
     }

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -88,6 +88,7 @@ void
 ServiceLayerNode::subscribeToConfigs()
 {
     StorageNode::subscribeToConfigs();
+    // TODO consolidate this with existing config fetcher in StorageNode parent...
     _configFetcher.reset(new config::ConfigFetcher(_configUri.getContext()));
 }
 
@@ -162,7 +163,7 @@ ServiceLayerNode::createChain(IStorageChainBuilder &builder)
 {
     ServiceLayerComponentRegister& compReg(_context.getComponentRegister());
 
-    auto communication_manager = std::make_unique<CommunicationManager>(compReg, _configUri);
+    auto communication_manager = std::make_unique<CommunicationManager>(compReg, _configUri, *_comm_mgr_config);
     _communicationManager = communication_manager.get();
     builder.add(std::move(communication_manager));
     builder.add(std::make_unique<Bouncer>(compReg, _configUri));


### PR DESCRIPTION
@baldersheim please review. This is the start of an effort to reduce the number of freestanding config (self-)subscribers in the content layer in favor of wiring in config changes from a more centralized location.

This moves the responsibility for bootstrapping and updating config for the `CommunicationManager` component to its owner. By doing this, a dedicated `ConfigFetcher` can be removed. Since this is a component used by both the distributor and storage nodes, this reduces total thread count by 2 on a host.

We probably want to pull config subscribing even further up and out with time, but this is a start.