### PR TITLE
Avoid incorrect gcc warning compiling inlined XXH3 code. Also stick t…

### DIFF
--- a/document/src/vespa/document/bucket/bucketid.cpp
+++ b/document/src/vespa/document/bucket/bucketid.cpp
@@ -8,7 +8,7 @@
 #include <vespa/vespalib/stllike/hash_set.hpp>
 #include <vespa/vespalib/util/stringfmt.h>
 #include <limits>
-#include <xxh3.h>
+#include <xxhash.h>
 
 using vespalib::nbostream;
 using vespalib::asciistream;
@@ -80,7 +80,26 @@ void BucketId::initialize() noexcept {
 uint64_t
 BucketId::hash::operator () (const BucketId& bucketId) const noexcept {
     const uint64_t raw_id = bucketId.getId();
-    return XXH3_64bits(&raw_id, sizeof(uint64_t));
+    /*
+     * This is a workaround for gcc 12 and on that produces incorrect warning
+     * /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp: In member function ‘uint64_t document::BucketId::hash::operator()(const document::BucketId&) const’:
+     * /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp:83:23: error: ‘raw_id’ may be used uninitialized [-Werror=maybe-uninitialized]
+     *   83 |     return XXH3_64bits(&raw_id, sizeof(uint64_t));
+     *      |                       ^
+     * In file included from /usr/include/xxh3.h:55,
+     *            from /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp:11:
+     * /usr/include/xxhash.h:5719:29: note: by argument 1 of type ‘const void*’ to ‘XXH64_hash_t XXH_INLINE_XXH3_64bits(const void*, size_t)’ declared here
+     * 5719 | XXH_PUBLIC_API XXH64_hash_t XXH3_64bits(XXH_NOESCAPE const void* input, size_t length)
+     *      |                             ^~~~~~~~~~~
+     * /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp:82:14: note: ‘raw_id’ declared here
+     *   82 |     uint64_t raw_id = bucketId.getId();
+     *    |              ^~~~~~
+     * cc1plus: all warnings being treated as errors
+     */
+    uint8_t raw_as_bytes[sizeof(raw_id)];
+    memcpy(raw_as_bytes, &raw_id, sizeof(raw_id));
+
+    return XXH3_64bits(raw_as_bytes, sizeof(raw_as_bytes));
 }
 
 vespalib::string

--- a/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/sparse_state.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 #include <ostream>
 #include <span>
-#include <xxh3.h> // TODO factor out?
+#include <xxhash.h> // TODO factor out?
 
 namespace vespalib::fuzzy {
 


### PR DESCRIPTION
…o including official interface.

@vekterli PR