### PR TITLE
- Since we have a legacy build that builds vespa image for older cpus…

### DIFF
--- a/default_build_settings.cmake
+++ b/default_build_settings.cmake
@@ -130,17 +130,12 @@ function(vespa_use_default_build_settings)
     message("-- CMAKE_SYSTEM_PROCESSOR = ${CMAKE_SYSTEM_PROCESSOR}")
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
       if(APPLE AND (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")))
-      elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        # Require haswell cpu or newer when compiling with clang on linux.
-        set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-march=haswell -mtune=skylake")
+      elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 13.0)
+        # Temporary workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108599
+        set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-march=ivybridge")
       else()
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
-          # Temporary workaround for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108599
-	  # Also xxhash-0.8.2 heavy inlining being too hard on GCC 12 and up
-          set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-march=ivybridge")
-        else()
-          set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-msse3 -mcx16 -mtune=intel")
-        endif()
+        # Default to haswell cpu or newer
+        set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-march=haswell -mtune=skylake")
       endif()
     elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
       set(DEFAULT_VESPA_CPU_ARCH_FLAGS "-march=armv8.2-a+fp16+rcpc+dotprod+crypto -mtune=neoverse-n1")

--- a/document/src/vespa/document/bucket/bucketid.cpp
+++ b/document/src/vespa/document/bucket/bucketid.cpp
@@ -81,7 +81,7 @@ uint64_t
 BucketId::hash::operator () (const BucketId& bucketId) const noexcept {
     const uint64_t raw_id = bucketId.getId();
     /*
-     * This is a workaround for gcc 12 and on that produces incorrect warning
+     * This is a workaround for gcc 12 and on that produces incorrect warning when compiled with -march=haswell or newer
      * /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp: In member function ‘uint64_t document::BucketId::hash::operator()(const document::BucketId&) const’:
      * /home/balder/git/vespa/document/src/vespa/document/bucket/bucketid.cpp:83:23: error: ‘raw_id’ may be used uninitialized [-Werror=maybe-uninitialized]
      *   83 |     return XXH3_64bits(&raw_id, sizeof(uint64_t));
@@ -95,6 +95,8 @@ BucketId::hash::operator () (const BucketId& bucketId) const noexcept {
      *   82 |     uint64_t raw_id = bucketId.getId();
      *    |              ^~~~~~
      * cc1plus: all warnings being treated as errors
+     *
+     * Same issue in storage/src/vespa/storage/persistence/filestorhandlerimpl.cpp:FileStorHandlerImpl::dispersed_bucket_bits
      */
     uint8_t raw_as_bytes[sizeof(raw_id)];
     memcpy(raw_as_bytes, &raw_id, sizeof(raw_id));

--- a/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestorhandlerimpl.cpp
@@ -897,7 +897,13 @@ FileStorHandlerImpl::flush()
 uint64_t
 FileStorHandlerImpl::dispersed_bucket_bits(const document::Bucket& bucket) noexcept {
     const uint64_t raw_id = bucket.getBucketId().getId();
-    return XXH3_64bits(&raw_id, sizeof(uint64_t));
+    /*
+     * This is a workaround for gcc 12 and on that produces incorrect warning when compiled with -march=haswell or newer
+     * See document/src/vespa/document/bucket/bucketid.cpp: In member function ‘uint64_t document::BucketId::hash::operator()(const document::BucketId&) const
+     */
+    uint8_t raw_as_bytes[sizeof(raw_id)];
+    memcpy(raw_as_bytes, &raw_id, sizeof(raw_id));
+    return XXH3_64bits(&raw_as_bytes, sizeof(raw_id));
 }
 
 FileStorHandlerImpl::Stripe::Stripe(const FileStorHandlerImpl & owner, MessageSender & messageSender)


### PR DESCRIPTION
… we can now require haswell.

- We still need to keep ivybridge for gcc 13 due to known bug.

@vekterli @aressem @toregge PR