### PR TITLE
Revert "Set creator as contact when initiating new tenant"

### DIFF
--- a/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudTenant.java
+++ b/controller-api/src/main/java/com/yahoo/vespa/hosted/controller/tenant/CloudTenant.java
@@ -51,16 +51,11 @@ public class CloudTenant extends Tenant {
 
     /** Creates a tenant with the given name, provided it passes validation. */
     public static CloudTenant create(TenantName tenantName, Instant createdAt, Principal creator) {
-        // Initialize with creator as verified contact
-        var info = TenantInfo.empty().withContacts(new TenantContacts(List.of(
-                new TenantContacts.EmailContact(
-                        List.of(TenantContacts.Audience.TENANT, TenantContacts.Audience.NOTIFICATIONS),
-                        new Email(creator.getName(), true)))));
         return new CloudTenant(requireName(tenantName),
                                createdAt,
                                LastLoginInfo.EMPTY,
                                Optional.ofNullable(creator).map(SimplePrincipal::of),
-                               ImmutableBiMap.of(), info, List.of(), new ArchiveAccess(), Optional.empty(),
+                               ImmutableBiMap.of(), TenantInfo.empty(), List.of(), new ArchiveAccess(), Optional.empty(),
                                Instant.EPOCH, List.of(), Optional.empty(), PlanId.from("none"));
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/application/ApplicationApiCloudTest.java
@@ -49,6 +49,7 @@ import static com.yahoo.application.container.handler.Request.Method.DELETE;
 import static com.yahoo.application.container.handler.Request.Method.GET;
 import static com.yahoo.application.container.handler.Request.Method.POST;
 import static com.yahoo.application.container.handler.Request.Method.PUT;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,7 +79,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
     void tenant_info_profile() {
         var request = request("/application/v4/tenant/scoober/info/profile", GET)
                 .roles(Set.of(Role.reader(tenantName)));
-        tester.assertResponse(request, "{\"contact\":{\"name\":\"\",\"email\":\"\",\"emailVerified\":true},\"tenant\":{\"company\":\"\",\"website\":\"\"}}", 200);
+        tester.assertResponse(request, "{}", 200);
 
         var updateRequest = request("/application/v4/tenant/scoober/info/profile", PUT)
                 .data("{\"contact\":{\"name\":\"Some Name\",\"email\":\"foo@example.com\"},\"tenant\":{\"company\":\"Scoober, Inc.\",\"website\":\"https://example.com/\"}}")
@@ -100,7 +101,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
     void tenant_info_billing() {
         var request = request("/application/v4/tenant/scoober/info/billing", GET)
                 .roles(Set.of(Role.reader(tenantName)));
-        tester.assertResponse(request, "{\"contact\":{\"name\":\"\",\"email\":\"\",\"phone\":\"\"}}", 200);
+        tester.assertResponse(request, "{}", 200);
 
         var fullAddress = "{\"addressLines\":\"addressLines\",\"postalCodeOrZip\":\"postalCodeOrZip\",\"city\":\"city\",\"stateRegionProvince\":\"stateRegionProvince\",\"country\":\"country\"}";
         var fullBillingContact = "{\"contact\":{\"name\":\"name\",\"email\":\"foo@example\",\"phone\":\"phone\"},\"address\":" + fullAddress + "}";
@@ -117,7 +118,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
     void tenant_info_contacts() {
         var request = request("/application/v4/tenant/scoober/info/contacts", GET)
                 .roles(Set.of(Role.reader(tenantName)));
-        tester.assertResponse(request, "{\"contacts\":[{\"audiences\":[\"tenant\",\"notifications\"],\"email\":\"developer@scoober\",\"emailVerified\":true}]}", 200);
+        tester.assertResponse(request, "{\"contacts\":[]}", 200);
 
 
         var fullContacts = "{\"contacts\":[{\"audiences\":[\"tenant\"],\"email\":\"contact1@example.com\",\"emailVerified\":false},{\"audiences\":[\"notifications\"],\"email\":\"contact2@example.com\",\"emailVerified\":false},{\"audiences\":[\"tenant\",\"notifications\"],\"email\":\"contact3@example.com\",\"emailVerified\":false}]}";
@@ -133,7 +134,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
         var infoRequest =
                 request("/application/v4/tenant/scoober/info", GET)
                         .roles(Set.of(Role.reader(tenantName)));
-        tester.assertResponse(infoRequest, "{\"name\":\"\",\"email\":\"\",\"website\":\"\",\"contactName\":\"\",\"contactEmail\":\"\",\"contactEmailVerified\":true,\"contacts\":[{\"audiences\":[\"tenant\",\"notifications\"],\"email\":\"developer@scoober\",\"emailVerified\":true}]}", 200);
+        tester.assertResponse(infoRequest, "{}", 200);
 
         String partialInfo = "{\"contactName\":\"newName\", \"contactEmail\": \"foo@example.com\", \"billingContact\":{\"name\":\"billingName\"}}";
         var postPartial =
@@ -188,7 +189,7 @@ public class ApplicationApiCloudTest extends ControllerContainerCloudTest {
         var infoRequest =
                 request("/application/v4/tenant/scoober/info", GET)
                         .roles(Set.of(Role.reader(tenantName)));
-        tester.assertResponse(infoRequest, "{\"name\":\"\",\"email\":\"\",\"website\":\"\",\"contactName\":\"\",\"contactEmail\":\"\",\"contactEmailVerified\":true,\"contacts\":[{\"audiences\":[\"tenant\",\"notifications\"],\"email\":\"developer@scoober\",\"emailVerified\":true}]}", 200);
+        tester.assertResponse(infoRequest, "{}", 200);
 
         // name needs to be present and not blank
         var partialInfoMissingName = "{\"contactName\": \" \"}";

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/filter/SignatureFilterTest.java
@@ -71,7 +71,7 @@ public class SignatureFilterTest {
         filter = new SignatureFilter(tester.controller());
         signer = new RequestSigner(privateKey, id.serializedForm(), tester.clock());
 
-        tester.curator().writeTenant(CloudTenant.create(appId.tenant(), Instant.EPOCH, new SimplePrincipal("owner@my-tenant.my-app")));
+        tester.curator().writeTenant(CloudTenant.create(appId.tenant(), Instant.EPOCH, null));
         tester.curator().writeApplication(new Application(appId, tester.clock().instant()));
     }
 

--- a/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/user/responses/tenant-info-after-created.json
+++ b/controller-server/src/test/java/com/yahoo/vespa/hosted/controller/restapi/user/responses/tenant-info-after-created.json
@@ -5,14 +5,5 @@
   "contactName": "administrator",
   "contactEmail": "administrator@tenant",
   "contactEmailVerified": true,
-  "contacts": [
-    {
-      "audiences": [
-        "tenant",
-        "notifications"
-      ],
-      "email": "administrator@tenant",
-      "emailVerified": true
-    }
-  ]
+  "contacts": [ ]
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#28961

Fails with:

[ERROR] com.yahoo.vespa.hosted.clients.user.Auth0RoleMaintainerTest.finds_superfluous_roles -- Time elapsed: 0.004 s <<< ERROR!
java.lang.NullPointerException: Cannot invoke "java.security.Principal.getName()" because "creator" is null
        at com.yahoo.vespa.hosted.controller.tenant.CloudTenant.create(CloudTenant.java:58)
        at com.yahoo.vespa.hosted.clients.user.Auth0RoleMaintainerTest.<init>(Auth0RoleMaintainerTest.java:27)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)