### PR TITLE
Add TestNG as banned dependency

### DIFF
--- a/hosted-tenant-base/pom.xml
+++ b/hosted-tenant-base/pom.xml
@@ -284,6 +284,9 @@
                                                 <exclude>org.junit.platform:junit-platform-engine:(${junit.platform.vespa.tenant.version},):jar:*</exclude>
                                                 <exclude>org.junit.platform:junit-platform-commons:(,${junit.platform.vespa.tenant.version}):jar:*</exclude>
                                                 <exclude>org.junit.platform:junit-platform-commons:(${junit.platform.vespa.tenant.version},):jar:*</exclude>
+
+                                                <!-- Ban testng as its presence breaks the Java based test framework for Cloud -->
+                                                <exclude>org.testng:testng:*:jar:test</exclude>
                                             </excludes>
                                         </bannedDependencies>
                                     </rules>


### PR DESCRIPTION
TestNG breaks our junit5 based test framework for Vespa Cloud

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
