### PR TITLE
Abort waiting on authentication failure

### DIFF
--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -120,6 +120,8 @@ func TestCustomTargetAwaitDeployment(t *testing.T) {
 func TestCloudTargetWait(t *testing.T) {
 	var logWriter bytes.Buffer
 	target, client := createCloudTarget(t, &logWriter)
+	client.NextResponseError(errAuth)
+	assertService(t, true, target, "deploy", time.Second) // No retrying on auth error
 	client.NextStatus(401)
 	assertService(t, true, target, "deploy", time.Second) // No retrying on 4xx
 	client.NextStatus(500)


### PR DESCRIPTION
Avoids waiting when e.g. Vespa Cloud credentials have expired.

@bratseth