### PR TITLE
Always log last exception when BcpGroupUpdater has a failure

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/BcpGroupUpdater.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/maintenance/BcpGroupUpdater.java
@@ -84,7 +84,7 @@ public class BcpGroupUpdater extends ControllerMaintainer {
         double successFactorDeviation = asSuccessFactorDeviation(attempts, failures);
         if ( successFactorDeviation == -successFactorBaseline )
             log.log(Level.WARNING, "Could not update traffic share on any applications", lastException);
-        else if ( successFactorDeviation < -0.1 )
+        else if ( successFactorDeviation < 0 )
             log.log(Level.FINE, "Could not update traffic share on all applications", lastException);
         return successFactorDeviation;
     }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
