### PR TITLE
Improve error message for invalid clients.pem

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -574,7 +574,12 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
             Reader reader = file.createReader();
             String certPem = IOUtils.readAll(reader);
             reader.close();
-            List<X509Certificate> x509Certificates = X509CertificateUtils.certificateListFromPem(certPem);
+            List<X509Certificate> x509Certificates;
+            try {
+                x509Certificates = X509CertificateUtils.certificateListFromPem(certPem);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("File %s contains an invalid certificate".formatted(file.getPath().getRelative()), e);
+            }
             if (x509Certificates.isEmpty()) {
                 throw new IllegalArgumentException("File %s does not contain any certificates.".formatted(file.getPath().getRelative()));
             }

--- a/security-utils/src/main/java/com/yahoo/security/X509CertificateUtils.java
+++ b/security-utils/src/main/java/com/yahoo/security/X509CertificateUtils.java
@@ -4,6 +4,7 @@ package com.yahoo.security;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -73,15 +74,18 @@ public class X509CertificateUtils {
     }
 
     private static X509Certificate toX509Certificate(Object pemObject) throws CertificateException {
-        if (pemObject instanceof X509Certificate) {
-            return (X509Certificate) pemObject;
+        if (pemObject instanceof X509Certificate certificate) {
+            return certificate;
         }
-        if (pemObject instanceof X509CertificateHolder) {
+        if (pemObject instanceof X509CertificateHolder certificateHolder) {
             return new JcaX509CertificateConverter()
                     .setProvider(BouncyCastleProviderHolder.getInstance())
-                    .getCertificate((X509CertificateHolder) pemObject);
+                    .getCertificate(certificateHolder);
         }
-        throw new IllegalArgumentException("Invalid type of PEM object: " + pemObject);
+        if (pemObject instanceof PrivateKeyInfo) {
+            throw new IllegalArgumentException("Expected X509 certificate, but got private key");
+        }
+        throw new IllegalArgumentException("Invalid type of PEM object, got " + pemObject.getClass().getName());
     }
 
     public static String toPem(X509Certificate certificate) {


### PR DESCRIPTION
I noticed a deployment which had put their private key in `clients.pem`, which
resulted in a confusing error message.

@bjorncs