### PR TITLE
Remove unused document config update logic

### DIFF
--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -93,12 +93,10 @@ StorageNode::StorageNode(
       _serverConfig(),
       _clusterConfig(),
       _distributionConfig(),
-      _doctypesConfig(),
       _bucketSpacesConfig(),
       _newServerConfig(),
       _newClusterConfig(),
       _newDistributionConfig(),
-      _newDoctypesConfig(),
       _newBucketSpacesConfig(),
       _component(),
       _node_identity(),
@@ -476,23 +474,6 @@ StorageNode::configure(std::unique_ptr<StorDistributionConfig> config) {
         _newDistributionConfig = std::move(config);
     }
     if (_distributionConfig) {
-        InitialGuard concurrent_config_guard(_initial_config_mutex);
-        handleLiveConfigUpdate(concurrent_config_guard);
-    }
-}
-void
-StorageNode::configure(std::unique_ptr<document::config::DocumenttypesConfig> config,
-                       bool hasChanged, int64_t generation)
-{
-    log_config_received(*config);
-    (void) generation;
-    if (!hasChanged)
-        return;
-    {
-        std::lock_guard configLockGuard(_configLock);
-        _newDoctypesConfig = std::move(config);
-    }
-    if (_doctypesConfig) {
         InitialGuard concurrent_config_guard(_initial_config_mutex);
         handleLiveConfigUpdate(concurrent_config_guard);
     }

--- a/storage/src/vespa/storage/storageserver/storagenode.h
+++ b/storage/src/vespa/storage/storageserver/storagenode.h
@@ -130,8 +130,6 @@ private:
     void configure(std::unique_ptr<StorServerConfig> config) override;
     void configure(std::unique_ptr<UpgradingConfig> config) override;
     void configure(std::unique_ptr<StorDistributionConfig> config) override;
-    virtual void configure(std::unique_ptr<document::config::DocumenttypesConfig> config,
-                           bool hasChanged, int64_t generation);
     void configure(std::unique_ptr<BucketspacesConfig>) override;
     void configure(std::unique_ptr<CommunicationManagerConfig> config) override;
 
@@ -146,7 +144,6 @@ protected:
     std::unique_ptr<StorServerConfig> _serverConfig;
     std::unique_ptr<UpgradingConfig> _clusterConfig;
     std::unique_ptr<StorDistributionConfig> _distributionConfig;
-    std::unique_ptr<document::config::DocumenttypesConfig> _doctypesConfig;
     std::unique_ptr<BucketspacesConfig> _bucketSpacesConfig;
     std::unique_ptr<CommunicationManagerConfig> _comm_mgr_config;
 
@@ -154,7 +151,6 @@ protected:
     std::unique_ptr<StorServerConfig> _newServerConfig;
     std::unique_ptr<UpgradingConfig> _newClusterConfig;
     std::unique_ptr<StorDistributionConfig> _newDistributionConfig;
-    std::unique_ptr<document::config::DocumenttypesConfig> _newDoctypesConfig;
     std::unique_ptr<BucketspacesConfig> _newBucketSpacesConfig;
     std::unique_ptr<CommunicationManagerConfig> _new_comm_mgr_config;
     std::unique_ptr<StorageComponent> _component;


### PR DESCRIPTION
@baldersheim please review

Actual document config changes are propagated in from the top-level `Process` via an entirely different call chain. Having the unused one around is just confusing, so remove it.
