### PR TITLE
Remove extra 1-minute naps when waiting for provisioning

### DIFF
--- a/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
+++ b/controller-server/src/main/java/com/yahoo/vespa/hosted/controller/deployment/InternalStepRunner.java
@@ -289,8 +289,8 @@ public class InternalStepRunner implements StepRunner {
                 case LOAD_BALANCER_NOT_READY, PARENT_HOST_NOT_READY -> {
                     logger.log(e.message()); // Consider splitting these messages in summary and details, on config server.
                     Instant someTimeAfterStart = startTime.plusSeconds(200);
-                    Instant inALittleWhile = controller.clock().instant().plusSeconds(60);
-                    controller.jobController().locked(id, run -> run.sleepingUntil(someTimeAfterStart.isAfter(inALittleWhile) ? someTimeAfterStart : inALittleWhile));
+                    if (someTimeAfterStart.isAfter(controller.clock().instant()))
+                        controller.jobController().locked(id, run -> run.sleepingUntil(someTimeAfterStart));
                     return result;
                 }
                 case NODE_ALLOCATION_FAILURE -> {


### PR DESCRIPTION
@freva I think this should be OK now. If not, we can revert, or I can try a different approach. 