### PR TITLE
Disable CPU arena allocator for ONNX

### DIFF
--- a/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
+++ b/model-integration/src/main/java/ai/vespa/modelintegration/evaluator/OnnxEvaluatorOptions.java
@@ -41,6 +41,7 @@ public class OnnxEvaluatorOptions {
         options.setExecutionMode(executionMode);
         options.setInterOpNumThreads(executionMode == PARALLEL ? interOpThreads : 1);
         options.setIntraOpNumThreads(intraOpThreads);
+        options.setCPUArenaAllocator(false);
         if (loadCuda) {
             options.addCUDA(gpuDeviceNumber);
         }


### PR DESCRIPTION
The arena memory allocator pre-allocates excessive of memory up front. Disabling matches the existing configuration in ONNX integration for backend.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
