### PR TITLE
Rewire Bouncer component configuration flow

### DIFF
--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -19,6 +19,7 @@ namespace storage {
 
 namespace distributor { class DistributorStripePool; }
 
+class Bouncer;
 class IStorageChainBuilder;
 
 class DistributorNode
@@ -34,6 +35,7 @@ class DistributorNode
     uint32_t _intra_second_pseudo_usec_counter;
     uint32_t _num_distributor_stripes;
     std::unique_ptr<StorageLink> _retrievedCommunicationManager;
+    Bouncer* _bouncer;
 
     // If the current wall clock is more than the below number of seconds into the
     // past when compared to the highest recorded wall clock second time stamp, abort
@@ -65,6 +67,7 @@ private:
     void initializeNodeSpecific() override;
     void createChain(IStorageChainBuilder &builder) override;
     api::Timestamp generate_unique_timestamp() override;
+    void on_bouncer_config_changed() override;
 
     /**
      * Shut down necessary distributor-specific components before shutting

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -20,6 +20,7 @@ namespace storage {
 
 namespace spi { struct PersistenceProvider; }
 
+class Bouncer;
 class BucketManager;
 class FileStorManager;
 
@@ -35,8 +36,9 @@ class ServiceLayerNode
 
     // FIXME: Should probably use the fetcher in StorageNode
     std::unique_ptr<config::ConfigFetcher>   _configFetcher;
-    BucketManager                          * _bucket_manager;
-    FileStorManager                        * _fileStorManager;
+    Bouncer*                                 _bouncer;
+    BucketManager*                           _bucket_manager;
+    FileStorManager*                         _fileStorManager;
     bool                                     _init_has_been_called;
 
 public:
@@ -67,6 +69,7 @@ private:
     documentapi::Priority::Value toDocumentPriority(uint8_t storagePriority) const override;
     void createChain(IStorageChainBuilder &builder) override;
     void removeConfigSubscriptions() override;
+    void on_bouncer_config_changed() override;
 };
 
 } // storage


### PR DESCRIPTION
@baldersheim please review.

Removes own `ConfigFetcher` in favor of pushing reconfiguration responsibilities onto the components owning the Bouncer instance.

The current "superclass calls into subclass" approach isn't ideal, but the longer term plan is to hoist all config subscriptions out of `StorageNode` and into the higher-level `Process` structure. Moving this out should also help to remove the current need to know a-priori when it's safe to access the `foo_config()` accessors for any config `foo`, i.e. when you're implicitly covered by the config lock. This is currently always safe during the node/chain init steps and during any `on_foo_config_changed` callbacks.


