### PR TITLE
Stop logging a warning when empty directory in user config

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFiles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFiles.java
@@ -14,18 +14,16 @@ import com.yahoo.path.Path;
 import com.yahoo.vespa.config.ConfigDefinition;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.ConfigPayloadBuilder;
-
 import com.yahoo.yolean.Exceptions;
 
-import java.io.File;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.logging.Level;
 
 import static com.yahoo.vespa.model.container.ApplicationContainerCluster.UserConfiguredUrls;
+import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.WARNING;
 
 /**
@@ -163,7 +161,7 @@ public class UserConfiguredFiles implements Serializable {
 
         ApplicationFile file = applicationPackage.getFile(path);
         if (file.isDirectory() && (file.listFiles() == null || file.listFiles().isEmpty()))
-            logger.logApplicationPackage(WARNING, "Directory '" + path.getRelative() + "' is empty");
+            logger.logApplicationPackage(INFO, "Directory '" + path.getRelative() + "' is empty");
 
         FileReference reference = registeredFiles.get(path);
         if (reference == null) {

--- a/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFilesTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/filedistribution/UserConfiguredFilesTest.java
@@ -13,7 +13,6 @@ import com.yahoo.config.model.deploy.TestProperties;
 import com.yahoo.config.model.producer.UserConfigRepo;
 import com.yahoo.config.model.test.MockApplicationPackage;
 import com.yahoo.config.model.test.MockRoot;
-import com.yahoo.schema.processing.ReservedRankingExpressionFunctionNamesTestCase;
 import com.yahoo.vespa.config.ConfigDefinition;
 import com.yahoo.vespa.config.ConfigDefinitionKey;
 import com.yahoo.vespa.config.ConfigPayloadBuilder;
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.HashMap;


### PR DESCRIPTION
Usually not intended to use empty directories, but there are use cases for it, so log at level info.