### PR TITLE
Support exclusive allocation on non-exclusive host

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/ClusterSpec.java
@@ -77,7 +77,6 @@ public final class ClusterSpec {
         return combinedId;
     }
 
-
     /**
      * Returns whether the physical hosts running the nodes of this application can
      * also run nodes of other applications. Using exclusive nodes for containers increases security and cost.

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -336,10 +336,16 @@ public class Flags {
 
     public static final UnboundBooleanFlag EXCLUSIVE_PROVISIONING = defineFeatureFlag(
             "exclusive-provisioning", false,
-            List.of("hakonhall"), "2023-10-12", "2023-12-12",
+            List.of("hakonhall"), "2023-10-12", "2023-12-20",
             "Whether to provision a host exclusively to an application ID only based on exclusive=\"true\" from services.xml. " +
             "Enabling this will produce hosts with exclusiveTo[ApplicationId] without provisionedToApplicationId.",
             "Takes immediate effect when provisioning new hosts");
+
+    public static final UnboundBooleanFlag MAKE_EXCLUSIVE = defineFeatureFlag(
+            "make-exclusive", false,
+            List.of("hakonhall"), "2023-10-20", "2023-12-20",
+            "Allow an exclusive allocation to a non-exclusive host, but if so, make the host exclusive.",
+            "Takes immediate effect on any following preparation of clusters");
 
     public static final UnboundBooleanFlag WRITE_CONFIG_SERVER_SESSION_DATA_AS_ONE_BLOB = defineFeatureFlag(
             "write-config-server-session-data-as-blob", false,

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -212,6 +212,11 @@ public class NodeRepository extends AbstractComponent {
                ( !zone().cloud().allowHostSharing() && !sharedHosts.value().isEnabled(clusterSpec.type().name()));
     }
 
+    /** Whether the nodes of this cluster must be running on hosts that are specifically provisioned for the application. */
+    public boolean exclusiveProvisioning(ClusterSpec clusterSpec) {
+        return !zone.cloud().allowHostSharing() && clusterSpec.isExclusive();
+    }
+
     /**
      * Returns ACLs for the children of the given host.
      *

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/applications/Applications.java
@@ -63,19 +63,24 @@ public class Applications {
         db.deleteApplication(transaction);
     }
 
+    public record Lock(Mutex mutex, ApplicationId application) implements Mutex {
+        @Override
+        public void close() { mutex.close(); }
+    }
+
     /** Create a lock which provides exclusive rights to making changes to the given application */
-    public Mutex lock(ApplicationId application) {
-        return db.lock(application);
+    public Lock lock(ApplicationId application) {
+        return new Lock(db.lock(application), application);
     }
 
     /** Create a lock with a timeout which provides exclusive rights to making changes to the given application */
-    public Mutex lock(ApplicationId application, Duration timeout) {
-        return db.lock(application, timeout);
+    public Lock lock(ApplicationId application, Duration timeout) {
+        return new Lock(db.lock(application, timeout), application);
     }
 
     /** Create a lock which provides exclusive rights to perform a maintenance deployment */
-    public Mutex lockMaintenance(ApplicationId application) {
-        return db.lockMaintenance(application);
+    public Lock lockMaintenance(ApplicationId application) {
+        return new Lock(db.lockMaintenance(application), application);
     }
 
 }

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidateTest.java
@@ -23,17 +23,17 @@ public class NodeCandidateTest {
     @Test
     public void testOrdering() {
         List<NodeCandidate> expected = List.of(
-                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, true, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), false, new NodeResources(1, 1, 1, 1), Optional.empty(), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false),
-                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, true, false)
+                new NodeCandidate.ConcreteNodeCandidate(node("01", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), false, true, false, true, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("02", Node.State.active), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("04", Node.State.reserved), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("03", Node.State.inactive), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, false, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("05", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.active)), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("06", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.ready)), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("07", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.provisioned)), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("08", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.of(node("host1", Node.State.failed)), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("09", Node.State.ready), false, new NodeResources(1, 1, 1, 1), Optional.empty(), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("10", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, true, false),
+                new NodeCandidate.ConcreteNodeCandidate(node("11", Node.State.ready), false, new NodeResources(2, 2, 2, 2), Optional.empty(), true, true, false, false, true, false)
         );
         assertOrder(expected);
     }
@@ -148,7 +148,7 @@ public class NodeCandidateTest {
                           .ipConfig(IP.Config.of(List.of("::1"), List.of("::2")))
                           .build();
         return new NodeCandidate.ConcreteNodeCandidate(node, false, totalHostResources.subtract(allocatedHostResources), Optional.of(parent),
-                                                       false, exclusiveSwitch, false, true, false);
+                                                       false, exclusiveSwitch, false, false, true, false);
     }
 
     private static NodeCandidate node(String hostname, NodeResources nodeResources,


### PR DESCRIPTION
This PR is a no-op.  But when enabling the new make-exclusive flag:
- An exclusive allocation will be allowed on a non-exclusive host
- The host is then made exclusive