### PR TITLE
Use unauthenticated path for CLI health check MERGEOK

### DIFF
--- a/client/go/internal/cli/cmd/cert.go
+++ b/client/go/internal/cli/cmd/cert.go
@@ -32,8 +32,10 @@ package specified as an argument to this command (default '.').
 It's possible to override the private key and certificate used through
 environment variables. This can be useful in continuous integration systems.
 
-It's also possible override the CA certificate which can be useful when using self-signed certificates with a
-self-hosted Vespa service. See https://docs.vespa.ai/en/operations-selfhosted/mtls.html for more information.
+It's also possible override the CA certificate which can be useful when using
+self-signed certificates with a self-hosted Vespa service.
+See https://docs.vespa.ai/en/operations-selfhosted/mtls.html for more
+information.
 
 Example of setting the CA certificate, certificate and key in-line:
 

--- a/client/go/internal/cli/cmd/curl.go
+++ b/client/go/internal/cli/cmd/curl.go
@@ -41,7 +41,7 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 			}
 			var service *vespa.Service
 			useDeploy := curlService == "deploy"
-			waiter := cli.waiter(false, time.Duration(waitSecs)*time.Second)
+			waiter := cli.waiter(time.Duration(waitSecs) * time.Second)
 			if useDeploy {
 				if cli.config.cluster() != "" {
 					return fmt.Errorf("cannot specify cluster for service %s", curlService)

--- a/client/go/internal/cli/cmd/deploy.go
+++ b/client/go/internal/cli/cmd/deploy.go
@@ -73,7 +73,7 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 					return err
 				}
 			}
-			waiter := cli.waiter(false, timeout)
+			waiter := cli.waiter(timeout)
 			if _, err := waiter.DeployService(target); err != nil {
 				return err
 			}
@@ -158,7 +158,7 @@ func newActivateCmd(cli *CLI) *cobra.Command {
 				return err
 			}
 			timeout := time.Duration(waitSecs) * time.Second
-			waiter := cli.waiter(false, timeout)
+			waiter := cli.waiter(timeout)
 			if _, err := waiter.DeployService(target); err != nil {
 				return err
 			}
@@ -179,7 +179,7 @@ func waitForDeploymentReady(cli *CLI, target vespa.Target, sessionOrRunID int64,
 	if timeout == 0 {
 		return nil
 	}
-	waiter := cli.waiter(false, timeout)
+	waiter := cli.waiter(timeout)
 	if _, err := waiter.Deployment(target, sessionOrRunID); err != nil {
 		return err
 	}

--- a/client/go/internal/cli/cmd/document.go
+++ b/client/go/internal/cli/cmd/document.go
@@ -298,7 +298,7 @@ func documentService(cli *CLI, waitSecs int) (*vespa.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	waiter := cli.waiter(false, time.Duration(waitSecs)*time.Second)
+	waiter := cli.waiter(time.Duration(waitSecs) * time.Second)
 	return waiter.Service(target, cli.config.cluster())
 }
 

--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -108,7 +108,7 @@ func createServices(n int, timeout time.Duration, waitSecs int, cli *CLI) ([]uti
 	}
 	services := make([]util.HTTPClient, 0, n)
 	baseURL := ""
-	waiter := cli.waiter(false, time.Duration(waitSecs)*time.Second)
+	waiter := cli.waiter(time.Duration(waitSecs) * time.Second)
 	for i := 0; i < n; i++ {
 		service, err := waiter.Service(target, cli.config.cluster())
 		if err != nil {

--- a/client/go/internal/cli/cmd/query.go
+++ b/client/go/internal/cli/cmd/query.go
@@ -64,7 +64,7 @@ func query(cli *CLI, arguments []string, timeoutSecs, waitSecs int, curl bool) e
 	if err != nil {
 		return err
 	}
-	waiter := cli.waiter(false, time.Duration(waitSecs)*time.Second)
+	waiter := cli.waiter(time.Duration(waitSecs) * time.Second)
 	service, err := waiter.Service(target, cli.config.cluster())
 	if err != nil {
 		return err

--- a/client/go/internal/cli/cmd/root.go
+++ b/client/go/internal/cli/cmd/root.go
@@ -345,9 +345,7 @@ func (c *CLI) confirm(question string, confirmByDefault bool) (bool, error) {
 	}
 }
 
-func (c *CLI) waiter(once bool, timeout time.Duration) *Waiter {
-	return &Waiter{Once: once, Timeout: timeout, cli: c}
-}
+func (c *CLI) waiter(timeout time.Duration) *Waiter { return &Waiter{Timeout: timeout, cli: c} }
 
 // target creates a target according the configuration of this CLI and given opts.
 func (c *CLI) target(opts targetOptions) (vespa.Target, error) {

--- a/client/go/internal/cli/cmd/status_test.go
+++ b/client/go/internal/cli/cmd/status_test.go
@@ -60,7 +60,7 @@ func TestStatusCommandMultiClusterWait(t *testing.T) {
 	client.NextStatus(400)
 	assert.NotNil(t, cli.Run("status", "--cluster", "foo", "--wait", "10"))
 	assert.Equal(t, "Waiting up to 10s for cluster discovery...\nWaiting up to 10s for container foo...\n"+
-		"Error: unhealthy container foo after waiting up to 10s: status 400 at http://127.0.0.1:8080/ApplicationStatus: aborting wait: got status 400\n", stderr.String())
+		"Error: unhealthy container foo after waiting up to 10s: status 400 at http://127.0.0.1:8080/status.html: aborting wait: got status 400\n", stderr.String())
 }
 
 func TestStatusCommandWithUrlTarget(t *testing.T) {
@@ -79,14 +79,14 @@ func TestStatusError(t *testing.T) {
 	cli.httpClient = client
 	assert.NotNil(t, cli.Run("status", "container"))
 	assert.Equal(t,
-		"Error: unhealthy container default: status 500 at http://127.0.0.1:8080/ApplicationStatus: wait timed out\n",
+		"Error: unhealthy container default: status 500 at http://127.0.0.1:8080/status.html: wait timed out\n",
 		stderr.String())
 
 	stderr.Reset()
 	client.NextResponseError(io.EOF)
 	assert.NotNil(t, cli.Run("status", "container", "-t", "http://example.com"))
 	assert.Equal(t,
-		"Error: unhealthy container at http://example.com/ApplicationStatus: EOF\n",
+		"Error: unhealthy container at http://example.com/status.html: EOF\n",
 		stderr.String())
 }
 
@@ -189,7 +189,7 @@ func assertStatus(expectedTarget string, args []string, t *testing.T) {
 			clusterName = "foo"
 			mockServiceStatus(client, clusterName)
 		}
-		client.NextResponse(mock.HTTPResponse{URI: "/ApplicationStatus", Status: 200})
+		client.NextResponse(mock.HTTPResponse{URI: "/status.html", Status: 200})
 	}
 	cli, stdout, _ := newTestCLI(t)
 	cli.httpClient = client
@@ -200,14 +200,14 @@ func assertStatus(expectedTarget string, args []string, t *testing.T) {
 		prefix += " " + clusterName
 	}
 	assert.Equal(t, prefix+" at "+expectedTarget+" is ready\n", stdout.String())
-	assert.Equal(t, expectedTarget+"/ApplicationStatus", client.LastRequest.URL.String())
+	assert.Equal(t, expectedTarget+"/status.html", client.LastRequest.URL.String())
 
 	// Test legacy command
 	statusArgs = []string{"status query"}
 	stdout.Reset()
 	assert.Nil(t, cli.Run(append(statusArgs, args...)...))
 	assert.Equal(t, prefix+" at "+expectedTarget+" is ready\n", stdout.String())
-	assert.Equal(t, expectedTarget+"/ApplicationStatus", client.LastRequest.URL.String())
+	assert.Equal(t, expectedTarget+"/status.html", client.LastRequest.URL.String())
 }
 
 func assertDocumentStatus(target string, args []string, t *testing.T) {
@@ -223,5 +223,5 @@ func assertDocumentStatus(target string, args []string, t *testing.T) {
 		"Container (document API) at "+target+" is ready\n",
 		stdout.String(),
 		"vespa status container")
-	assert.Equal(t, target+"/ApplicationStatus", client.LastRequest.URL.String())
+	assert.Equal(t, target+"/status.html", client.LastRequest.URL.String())
 }

--- a/client/go/internal/cli/cmd/test.go
+++ b/client/go/internal/cli/cmd/test.go
@@ -220,7 +220,7 @@ func verify(step step, defaultCluster string, defaultParameters map[string]strin
 		service, ok = context.clusters[cluster]
 		if !ok {
 			// Cache service so we don't have to discover it for every step
-			waiter := context.cli.waiter(false, time.Duration(waitSecs)*time.Second)
+			waiter := context.cli.waiter(time.Duration(waitSecs) * time.Second)
 			service, err = waiter.Service(target, cluster)
 			if err != nil {
 				return "", "", err

--- a/client/go/internal/cli/cmd/waiter.go
+++ b/client/go/internal/cli/cmd/waiter.go
@@ -11,16 +11,11 @@ import (
 
 // Waiter waits for Vespa services to become ready, within a timeout.
 type Waiter struct {
-	// Once species whether we should wait at least one time, irregardless of timeout.
-	Once bool
-
 	// Timeout specifies how long we should wait for an operation to complete.
 	Timeout time.Duration // TODO(mpolden): Consider making this a budget
 
 	cli *CLI
 }
-
-func (w *Waiter) wait() bool { return w.Once || w.Timeout > 0 }
 
 // DeployService returns the service providing the deploy API on given target,
 func (w *Waiter) DeployService(target vespa.Target) (*vespa.Service, error) {
@@ -74,8 +69,6 @@ func (w *Waiter) Services(target vespa.Target) ([]*vespa.Service, error) {
 func (w *Waiter) maybeWaitFor(service *vespa.Service) error {
 	if w.Timeout > 0 {
 		w.cli.printInfo("Waiting up to ", color.CyanString(w.Timeout.String()), " for ", service.Description(), "...")
-	}
-	if w.wait() {
 		return service.Wait(w.Timeout)
 	}
 	return nil

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -125,12 +125,8 @@ func (s *Service) SetClient(client util.HTTPClient) { s.httpClient = client }
 
 // Wait polls the health check of this service until it succeeds or timeout passes.
 func (s *Service) Wait(timeout time.Duration) error {
-	url := s.BaseURL
-	if s.deployAPI {
-		url += "/status.html" // because /ApplicationStatus is not publicly reachable in Vespa Cloud
-	} else {
-		url += "/ApplicationStatus"
-	}
+	// A path that does not need authentication, on any target
+	url := strings.TrimRight(s.BaseURL, "/") + "/status.html"
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return err

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -88,7 +88,7 @@ func TestCustomTargetWait(t *testing.T) {
 		client.NextResponseError(io.EOF)
 	}
 	// Then succeeds
-	client.NextResponse(mock.HTTPResponse{URI: "/ApplicationStatus", Status: 200})
+	client.NextResponse(mock.HTTPResponse{URI: "/status.html", Status: 200})
 	assertService(t, false, target, "", time.Second)
 }
 
@@ -153,10 +153,10 @@ func TestCloudTargetWait(t *testing.T) {
 	assert.Equal(t, 2, len(services))
 
 	client.NextResponse(response)
-	client.NextResponse(mock.HTTPResponse{URI: "/ApplicationStatus", Status: 500})
+	client.NextResponse(mock.HTTPResponse{URI: "/status.html", Status: 500})
 	assertService(t, true, target, "default", 0)
 	client.NextResponse(response)
-	client.NextResponse(mock.HTTPResponse{URI: "/ApplicationStatus", Status: 200})
+	client.NextResponse(mock.HTTPResponse{URI: "/status.html", Status: 200})
 	assertService(t, false, target, "feed", 0)
 }
 


### PR DESCRIPTION
Different CLI commands support waiting for services, but we don't want waiting
to depend on the user having configured the right certificate. We therefore
check `/status.html` instead.

@tokle