### PR TITLE
Propagate existing `StorageNode` config from main `Process` reconfig loop

### DIFF
--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -18,12 +18,13 @@ namespace storage {
 DistributorNode::DistributorNode(
         const config::ConfigUri& configUri,
         DistributorNodeContext& context,
+        BootstrapConfigs bootstrap_configs,
         ApplicationGenerationFetcher& generationFetcher,
         uint32_t num_distributor_stripes,
         StorageLink::UP communicationManager,
         std::unique_ptr<IStorageChainBuilder> storage_chain_builder)
-    : StorageNode(configUri, context, generationFetcher,
-                  std::make_unique<HostInfo>(),
+    : StorageNode(configUri, context, std::move(bootstrap_configs),
+                  generationFetcher, std::make_unique<HostInfo>(),
                   !communicationManager ? NORMAL : SINGLE_THREADED_TEST_MODE),
       _threadPool(framework::TickingThreadPool::createDefault("distributor", 100ms, 1, 5s)),
       _stripe_pool(std::make_unique<distributor::DistributorStripePool>()),

--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -1,11 +1,4 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * \class storage::DistributorNode
- * \ingroup storageserver
- *
- * \brief Class for setting up a distributor node.
- */
-
 #pragma once
 
 #include "distributornodecontext.h"
@@ -49,6 +42,7 @@ public:
 
     DistributorNode(const config::ConfigUri & configUri,
                     DistributorNodeContext&,
+                    BootstrapConfigs bootstrap_configs,
                     ApplicationGenerationFetcher& generationFetcher,
                     uint32_t num_distributor_stripes,
                     std::unique_ptr<StorageLink> communicationManager,

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -30,22 +30,21 @@ class ServiceLayerNode
           private NodeStateReporter
 
 {
-    ServiceLayerNodeContext  & _context;
-    spi::PersistenceProvider & _persistenceProvider;
-    VisitorFactory::Map        _externalVisitors;
+    ServiceLayerNodeContext&  _context;
+    spi::PersistenceProvider& _persistenceProvider;
+    VisitorFactory::Map       _externalVisitors;
 
-    // FIXME: Should probably use the fetcher in StorageNode
-    std::unique_ptr<config::ConfigFetcher>   _configFetcher;
-    Bouncer*                                 _bouncer;
-    BucketManager*                           _bucket_manager;
-    FileStorManager*                         _fileStorManager;
-    bool                                     _init_has_been_called;
+    Bouncer*                  _bouncer;
+    BucketManager*            _bucket_manager;
+    FileStorManager*          _fileStorManager;
+    bool                      _init_has_been_called;
 
 public:
     using UP = std::unique_ptr<ServiceLayerNode>;
 
     ServiceLayerNode(const config::ConfigUri & configUri,
                      ServiceLayerNodeContext& context,
+                     BootstrapConfigs bootstrap_configs,
                      ApplicationGenerationFetcher& generationFetcher,
                      spi::PersistenceProvider& persistenceProvider,
                      const VisitorFactory::Map& externalVisitors);
@@ -61,14 +60,12 @@ public:
 
 private:
     void report(vespalib::JsonStream &writer) const override;
-    void subscribeToConfigs() override;
     void initializeNodeSpecific() override;
     void perform_post_chain_creation_init_steps() override;
     void handleLiveConfigUpdate(const InitialGuard & initGuard) override;
     VisitorMessageSession::UP createSession(Visitor&, VisitorThread&) override;
     documentapi::Priority::Value toDocumentPriority(uint8_t storagePriority) const override;
     void createChain(IStorageChainBuilder &builder) override;
-    void removeConfigSubscriptions() override;
     void on_bouncer_config_changed() override;
 };
 

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -66,6 +66,11 @@ removePidFile(const vespalib::string& pidfile)
 
 } // End of anonymous namespace
 
+StorageNode::BootstrapConfigs::BootstrapConfigs() = default;
+StorageNode::BootstrapConfigs::~BootstrapConfigs() = default;
+StorageNode::BootstrapConfigs::BootstrapConfigs(BootstrapConfigs&&) noexcept = default;
+StorageNode::BootstrapConfigs& StorageNode::BootstrapConfigs::operator=(BootstrapConfigs&&) noexcept = default;
+
 StorageNode::StorageNode(
         const config::ConfigUri & configUri,
         StorageNodeContext& context,

--- a/storage/src/vespa/storage/storageserver/storagenode.cpp
+++ b/storage/src/vespa/storage/storageserver/storagenode.cpp
@@ -69,11 +69,11 @@ removePidFile(const vespalib::string& pidfile)
 StorageNode::StorageNode(
         const config::ConfigUri & configUri,
         StorageNodeContext& context,
+        BootstrapConfigs bootstrap_configs,
         ApplicationGenerationFetcher& generationFetcher,
         std::unique_ptr<HostInfo> hostInfo,
         RunMode mode)
     : _singleThreadedDebugMode(mode == SINGLE_THREADED_TEST_MODE),
-      _configFetcher(),
       _hostInfo(std::move(hostInfo)),
       _context(context),
       _generationFetcher(generationFetcher),
@@ -90,10 +90,11 @@ StorageNode::StorageNode(
       _chain(),
       _configLock(),
       _initial_config_mutex(),
-      _bucket_spaces_config(),
-      _comm_mgr_config(),
-      _distribution_config(),
-      _server_config(),
+      _bouncer_config(std::move(bootstrap_configs.bouncer_cfg)),
+      _bucket_spaces_config(std::move(bootstrap_configs.bucket_spaces_cfg)),
+      _comm_mgr_config(std::move(bootstrap_configs.comm_mgr_cfg)),
+      _distribution_config(std::move(bootstrap_configs.distribution_cfg)),
+      _server_config(std::move(bootstrap_configs.server_cfg)),
       _component(),
       _node_identity(),
       _configUri(configUri),
@@ -103,38 +104,14 @@ StorageNode::StorageNode(
 }
 
 void
-StorageNode::subscribeToConfigs()
-{
-    _configFetcher = std::make_unique<config::ConfigFetcher>(_configUri.getContext());
-    _configFetcher->subscribe<StorBouncerConfig>(_configUri.getConfigId(), this);
-    _configFetcher->subscribe<BucketspacesConfig>(_configUri.getConfigId(), this);
-    _configFetcher->subscribe<CommunicationManagerConfig>(_configUri.getConfigId(), this);
-    _configFetcher->subscribe<StorDistributionConfig>(_configUri.getConfigId(), this);
-    _configFetcher->subscribe<StorServerConfig>(_configUri.getConfigId(), this);
-
-    _configFetcher->start();
-
-    // All the below config instances were synchronously populated as part of start()ing the config fetcher
-    std::lock_guard configLockGuard(_configLock);
-    _bouncer_config.promote_staging_to_active();
-    _bucket_spaces_config.promote_staging_to_active();
-    _comm_mgr_config.promote_staging_to_active();
-    _distribution_config.promote_staging_to_active();
-    _server_config.promote_staging_to_active();
-}
-
-void
 StorageNode::initialize(const NodeStateReporter & nodeStateReporter)
 {
     // Avoid racing with concurrent reconfigurations before we've set up the entire
     // node component stack.
+    // TODO no longer needed... probably
     std::lock_guard<std::mutex> concurrent_config_guard(_initial_config_mutex);
 
     _context.getComponentRegister().registerShutdownListener(*this);
-
-    // Fetch configs needed first. These functions will just grab the config
-    // and store them away, while having the config lock.
-    subscribeToConfigs();
 
     // First update some basics that doesn't depend on anything else to be
     // available
@@ -260,7 +237,7 @@ StorageNode::handleLiveConfigUpdate(const InitialGuard & initGuard)
         DIFFERWARN(clusterName, "Cannot alter cluster name of node live");
         DIFFERWARN(nodeIndex, "Cannot alter node index of node live");
         DIFFERWARN(isDistributor, "Cannot alter role of node live");
-        _server_config.active = std::make_unique<StorServerConfig>(oldC); // TODO isn't this a no-op...?
+        _server_config.active = std::make_unique<StorServerConfig>(oldC); // TODO this overwrites from ServiceLayerNode
         _server_config.staging.reset();
         _deadLockDetector->enableWarning(server_config().enableDeadLockDetectorWarnings);
         _deadLockDetector->enableShutdown(server_config().enableDeadLockDetector);
@@ -347,13 +324,6 @@ StorageNode::notifyDoneInitializing()
 StorageNode::~StorageNode() = default;
 
 void
-StorageNode::removeConfigSubscriptions()
-{
-    LOG(debug, "Removing config subscribers");
-    _configFetcher.reset();
-}
-
-void
 StorageNode::shutdown()
 {
     // Try to shut down in opposite order of initialize. Bear in mind that
@@ -364,8 +334,6 @@ StorageNode::shutdown()
         LOG(debug, "Storage killed before requestShutdown() was called. No "
                    "reason has been given for why we're stopping.");
     }
-    // Remove the subscription to avoid more callbacks from config
-    removeConfigSubscriptions();
 
     if (_chain) {
         LOG(debug, "Closing storage chain");
@@ -535,13 +503,20 @@ StorageNode::set_storage_chain_builder(std::unique_ptr<IStorageChainBuilder> bui
 }
 
 template <typename ConfigT>
-StorageNode::ConfigWrapper<ConfigT>::ConfigWrapper() = default;
+StorageNode::ConfigWrapper<ConfigT>::ConfigWrapper() noexcept = default;
+
+template <typename ConfigT>
+StorageNode::ConfigWrapper<ConfigT>::ConfigWrapper(std::unique_ptr<ConfigT> initial_active) noexcept
+    : staging(),
+      active(std::move(initial_active))
+{
+}
 
 template <typename ConfigT>
 StorageNode::ConfigWrapper<ConfigT>::~ConfigWrapper() = default;
 
 template <typename ConfigT>
-void StorageNode::ConfigWrapper<ConfigT>::promote_staging_to_active() {
+void StorageNode::ConfigWrapper<ConfigT>::promote_staging_to_active() noexcept {
     assert(staging);
     active = std::move(staging);
 }

--- a/storage/src/vespa/storage/storageserver/storagenode.h
+++ b/storage/src/vespa/storage/storageserver/storagenode.h
@@ -71,6 +71,11 @@ public:
         std::unique_ptr<CommunicationManagerConfig> comm_mgr_cfg;
         std::unique_ptr<StorDistributionConfig>     distribution_cfg;
         std::unique_ptr<StorServerConfig>           server_cfg;
+
+        BootstrapConfigs();
+        ~BootstrapConfigs();
+        BootstrapConfigs(BootstrapConfigs&&) noexcept;
+        BootstrapConfigs& operator=(BootstrapConfigs&&) noexcept;
     };
 
     StorageNode(const config::ConfigUri& configUri,

--- a/storage/src/vespa/storage/storageserver/storagenode.h
+++ b/storage/src/vespa/storage/storageserver/storagenode.h
@@ -49,30 +49,40 @@ struct StorageNodeContext;
 namespace lib { class NodeType; }
 
 
-class StorageNode : private config::IFetcherCallback<vespa::config::content::core::StorServerConfig>,
-                    private config::IFetcherCallback<vespa::config::content::StorDistributionConfig>,
-                    private config::IFetcherCallback<vespa::config::content::core::BucketspacesConfig>,
-                    private config::IFetcherCallback<vespa::config::content::core::StorCommunicationmanagerConfig>,
-                    private config::IFetcherCallback<vespa::config::content::core::StorBouncerConfig>,
-                    private framework::MetricUpdateHook,
+class StorageNode : private framework::MetricUpdateHook,
                     private DoneInitializeHandler,
                     private framework::defaultimplementation::ShutdownListener
 {
 public:
+    using BucketspacesConfig         = vespa::config::content::core::BucketspacesConfig;
+    using CommunicationManagerConfig = vespa::config::content::core::StorCommunicationmanagerConfig;
+    using StorBouncerConfig          = vespa::config::content::core::StorBouncerConfig;
+    using StorDistributionConfig     = vespa::config::content::StorDistributionConfig;
+    using StorServerConfig           = vespa::config::content::core::StorServerConfig;
+
     enum RunMode { NORMAL, SINGLE_THREADED_TEST_MODE };
 
     StorageNode(const StorageNode &) = delete;
     StorageNode & operator = (const StorageNode &) = delete;
 
+    struct BootstrapConfigs {
+        std::unique_ptr<StorBouncerConfig>          bouncer_cfg;
+        std::unique_ptr<BucketspacesConfig>         bucket_spaces_cfg;
+        std::unique_ptr<CommunicationManagerConfig> comm_mgr_cfg;
+        std::unique_ptr<StorDistributionConfig>     distribution_cfg;
+        std::unique_ptr<StorServerConfig>           server_cfg;
+    };
+
     StorageNode(const config::ConfigUri& configUri,
                 StorageNodeContext& context,
+                BootstrapConfigs bootstrap_configs,
                 ApplicationGenerationFetcher& generationFetcher,
                 std::unique_ptr<HostInfo> hostInfo,
                 RunMode = NORMAL);
     ~StorageNode() override;
 
     virtual const lib::NodeType& getNodeType() const = 0;
-    bool attemptedStopped() const;
+    [[nodiscard]] bool attemptedStopped() const;
     void notifyDoneInitializing() override;
     void waitUntilInitialized(vespalib::duration timeout = 15s);
     void updateMetrics(const MetricLockGuard & guard) override;
@@ -88,19 +98,17 @@ public:
     void requestShutdown(vespalib::stringref reason) override;
     DoneInitializeHandler& getDoneInitializeHandler() { return *this; }
 
+    void configure(std::unique_ptr<StorServerConfig> config);
+    void configure(std::unique_ptr<StorDistributionConfig> config);
+    void configure(std::unique_ptr<BucketspacesConfig>);
+    void configure(std::unique_ptr<CommunicationManagerConfig> config);
+    void configure(std::unique_ptr<StorBouncerConfig> config);
+
     // For testing
     StorageLink* getChain() { return _chain.get(); }
     virtual void initializeStatusWebServer();
-protected:
-    using BucketspacesConfig         = vespa::config::content::core::BucketspacesConfig;
-    using CommunicationManagerConfig = vespa::config::content::core::StorCommunicationmanagerConfig;
-    using StorBouncerConfig          = vespa::config::content::core::StorBouncerConfig;
-    using StorDistributionConfig     = vespa::config::content::StorDistributionConfig;
-    using StorServerConfig           = vespa::config::content::core::StorServerConfig;
 private:
     bool _singleThreadedDebugMode;
-    // Subscriptions to config
-    std::unique_ptr<config::ConfigFetcher> _configFetcher;
 
     std::unique_ptr<HostInfo> _hostInfo;
 
@@ -131,26 +139,20 @@ private:
         std::unique_ptr<ConfigT> staging;
         std::unique_ptr<ConfigT> active;
 
-        ConfigWrapper();
+        ConfigWrapper() noexcept;
+        explicit ConfigWrapper(std::unique_ptr<ConfigT> initial_active) noexcept;
         ~ConfigWrapper();
 
-        void promote_staging_to_active();
+        void promote_staging_to_active() noexcept;
     };
 
     template <typename ConfigT>
     void stage_config_change(ConfigWrapper<ConfigT>& my_cfg, std::unique_ptr<ConfigT> new_cfg);
 
-    /** Implementation of config callbacks. */
-    void configure(std::unique_ptr<StorServerConfig> config) override;
-    void configure(std::unique_ptr<StorDistributionConfig> config) override;
-    void configure(std::unique_ptr<BucketspacesConfig>) override;
-    void configure(std::unique_ptr<CommunicationManagerConfig> config) override;
-    void configure(std::unique_ptr<StorBouncerConfig> config) override;
-
 protected:
     // Lock taken while doing configuration of the server.
     std::mutex _configLock;
-    std::mutex _initial_config_mutex;
+    std::mutex _initial_config_mutex; // TODO can probably be removed
     using InitialGuard = std::lock_guard<std::mutex>;
 
     ConfigWrapper<StorBouncerConfig>          _bouncer_config;
@@ -193,13 +195,11 @@ protected:
     std::unique_ptr<StateManager> releaseStateManager();
 
     void initialize(const NodeStateReporter & reporter);
-    virtual void subscribeToConfigs();
     virtual void initializeNodeSpecific() = 0;
     virtual void perform_post_chain_creation_init_steps() = 0;
     virtual void createChain(IStorageChainBuilder &builder) = 0;
     virtual void handleLiveConfigUpdate(const InitialGuard & initGuard);
     void shutdown();
-    virtual void removeConfigSubscriptions();
 
     virtual void on_bouncer_config_changed() { /* no-op by default */ }
 public:

--- a/storageserver/src/tests/storageservertest.cpp
+++ b/storageserver/src/tests/storageservertest.cpp
@@ -43,7 +43,7 @@ struct Node {
 struct Distributor : public Node {
     DistributorProcess _process;
 
-    Distributor(vdstestlib::DirConfig& config);
+    explicit Distributor(vdstestlib::DirConfig& config);
     ~Distributor() override;
 
     StorageNode& getNode() override { return _process.getNode(); }
@@ -54,7 +54,7 @@ struct Storage : public Node {
     DummyServiceLayerProcess _process;
     StorageComponent::UP _component;
 
-    Storage(vdstestlib::DirConfig& config);
+    explicit Storage(vdstestlib::DirConfig& config);
     ~Storage() override;
 
     StorageNode& getNode() override { return _process.getNode(); }
@@ -75,8 +75,7 @@ Storage::Storage(vdstestlib::DirConfig& config)
 {
     _process.setupConfig(60000ms);
     _process.createNode();
-    _component = std::make_unique<StorageComponent>(
-    getContext().getComponentRegister(), "test");
+    _component = std::make_unique<StorageComponent>(getContext().getComponentRegister(), "test");
 }
 
 Storage::~Storage() = default;
@@ -93,7 +92,6 @@ StorageServerTest::SetUp()
     storConfig = std::make_unique<vdstestlib::DirConfig>(getStandardConfig(true));
     addSlobrokConfig(*distConfig, *slobrok);
     addSlobrokConfig(*storConfig, *slobrok);
-    storConfig->getConfig("stor-filestor").set("fail_disk_after_error_count", "1");
     systemResult = system("mkdir -p vdsroot/disks/d0");
     systemResult = system("mkdir -p vdsroot.distributor");
 }
@@ -101,6 +99,7 @@ StorageServerTest::SetUp()
 void
 StorageServerTest::TearDown()
 {
+    // TODO wipe temp dirs
     storConfig.reset(nullptr);
     distConfig.reset(nullptr);
     slobrok.reset(nullptr);

--- a/storageserver/src/vespa/storageserver/app/distributorprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/distributorprocess.cpp
@@ -61,9 +61,6 @@ DistributorProcess::setupConfig(vespalib::duration subscribeTimeout)
     using vespa::config::content::core::StorDistributormanagerConfig;
     using vespa::config::content::core::StorVisitordispatcherConfig;
 
-    auto distr_cfg = config::ConfigGetter<StorDistributormanagerConfig>::getConfig(
-            _configUri.getConfigId(), _configUri.getContext(), subscribeTimeout);
-    _num_distributor_stripes = adjusted_num_distributor_stripes(distr_cfg->numDistributorStripes);
     _distributorConfigHandler = _configSubscriber.subscribe<StorDistributormanagerConfig>(_configUri.getConfigId(), subscribeTimeout);
     _visitDispatcherConfigHandler = _configSubscriber.subscribe<StorVisitordispatcherConfig>(_configUri.getConfigId(), subscribeTimeout);
     Process::setupConfig(subscribeTimeout);
@@ -99,8 +96,19 @@ DistributorProcess::configUpdated()
 void
 DistributorProcess::createNode()
 {
-    _node = std::make_unique<DistributorNode>(_configUri, _context, *this, _num_distributor_stripes, StorageLink::UP(), std::move(_storage_chain_builder));
-    _node->handleConfigChange(*_distributorConfigHandler->getConfig());
+    auto distributor_config = _distributorConfigHandler->getConfig();
+    _num_distributor_stripes = adjusted_num_distributor_stripes(distributor_config->numDistributorStripes);
+    // TODO dedupe, consolidate
+    StorageNode::BootstrapConfigs bc;
+    bc.bucket_spaces_cfg = _bucket_spaces_cfg_handle->getConfig();
+    bc.bouncer_cfg = _bouncer_cfg_handle->getConfig();
+    bc.comm_mgr_cfg = _comm_mgr_cfg_handle->getConfig();
+    bc.distribution_cfg = _distribution_cfg_handle->getConfig();
+    bc.server_cfg = _server_cfg_handle->getConfig();
+
+    _node = std::make_unique<DistributorNode>(_configUri, _context, std::move(bc), *this, _num_distributor_stripes,
+                                              StorageLink::UP(), std::move(_storage_chain_builder));
+    _node->handleConfigChange(*distributor_config);
     _node->handleConfigChange(*_visitDispatcherConfigHandler->getConfig());
 }
 

--- a/storageserver/src/vespa/storageserver/app/process.cpp
+++ b/storageserver/src/vespa/storageserver/app/process.cpp
@@ -1,11 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "process.h"
+
+#include <vespa/config/subscription/configsubscriber.hpp>
 #include <vespa/document/repo/document_type_repo_factory.h>
 #include <vespa/storage/storageserver/storagenode.h>
 #include <vespa/storage/storageserver/storagenodecontext.h>
 #include <vespa/vespalib/util/exceptions.h>
-#include <vespa/config/subscription/configsubscriber.hpp>
 
 #include <vespa/log/log.h>
 LOG_SETUP(".process");
@@ -24,11 +25,17 @@ Process::~Process() = default;
 void
 Process::setupConfig(vespalib::duration subscribeTimeout)
 {
-    _documentHandler = _configSubscriber.subscribe<document::config::DocumenttypesConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _document_cfg_handle      = _configSubscriber.subscribe<DocumentTypesConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _bucket_spaces_cfg_handle = _configSubscriber.subscribe<BucketspacesConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _comm_mgr_cfg_handle      = _configSubscriber.subscribe<CommunicationManagerConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _bouncer_cfg_handle       = _configSubscriber.subscribe<StorBouncerConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _distribution_cfg_handle  = _configSubscriber.subscribe<StorDistributionConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _server_cfg_handle        = _configSubscriber.subscribe<StorServerConfig>(_configUri.getConfigId(), subscribeTimeout);
+
     if (!_configSubscriber.nextConfig()) {
-        throw vespalib::TimeoutException("Could not subscribe to document config within timeout");
+        throw vespalib::TimeoutException("Could not subscribe to configs within timeout");
     }
-    _repos.push_back(DocumentTypeRepoFactory::make(*_documentHandler->getConfig()));
+    _repos.push_back(DocumentTypeRepoFactory::make(*_document_cfg_handle->getConfig()));
     getContext().getComponentRegister().setDocumentTypeRepo(_repos.back());
 }
 
@@ -36,26 +43,46 @@ bool
 Process::configUpdated()
 {
     _configSubscriber.nextGenerationNow();
-    if (_documentHandler->isChanged()) {
+    if (_document_cfg_handle->isChanged()) {
         LOG(info, "Document config detected changed");
         return true;
     }
-    return false;
+    bool changed = (_bucket_spaces_cfg_handle->isChanged()
+                 || _comm_mgr_cfg_handle->isChanged()
+                 || _bouncer_cfg_handle->isChanged()
+                 || _distribution_cfg_handle->isChanged()
+                 || _server_cfg_handle->isChanged());
+    return changed;
 }
 
 void
 Process::updateConfig()
 {
-    if (_documentHandler->isChanged()) {
-        _repos.push_back(DocumentTypeRepoFactory::make(*_documentHandler->getConfig()));
+    if (_document_cfg_handle->isChanged()) {
+        _repos.push_back(DocumentTypeRepoFactory::make(*_document_cfg_handle->getConfig()));
         getNode().setNewDocumentRepo(_repos.back());
+    }
+    if (_bucket_spaces_cfg_handle->isChanged()) {
+        getNode().configure(_bucket_spaces_cfg_handle->getConfig());
+    }
+    if (_comm_mgr_cfg_handle->isChanged()) {
+        getNode().configure(_comm_mgr_cfg_handle->getConfig());
+    }
+    if (_bouncer_cfg_handle->isChanged()) {
+        getNode().configure(_bouncer_cfg_handle->getConfig());
+    }
+    if (_distribution_cfg_handle->isChanged()) {
+        getNode().configure(_distribution_cfg_handle->getConfig());
+    }
+    if (_server_cfg_handle->isChanged()) {
+        getNode().configure(_server_cfg_handle->getConfig());
     }
 }
 
 void
 Process::shutdown()
 {
-    removeConfigSubscriptions();
+    removeConfigSubscriptions(); // TODO remove? unused
 }
 
 int64_t

--- a/storageserver/src/vespa/storageserver/app/process.h
+++ b/storageserver/src/vespa/storageserver/app/process.h
@@ -14,10 +14,15 @@
 
 #pragma once
 
-#include <vespa/document/config/config-documenttypes.h>
-#include <vespa/storage/storageserver/applicationgenerationfetcher.h>
-#include <vespa/config/subscription/configuri.h>
+#include <vespa/config-bucketspaces.h>
+#include <vespa/config-stor-distribution.h>
 #include <vespa/config/subscription/configsubscriber.h>
+#include <vespa/config/subscription/configuri.h>
+#include <vespa/document/config/config-documenttypes.h>
+#include <vespa/storage/config/config-stor-bouncer.h>
+#include <vespa/storage/config/config-stor-communicationmanager.h>
+#include <vespa/storage/config/config-stor-server.h>
+#include <vespa/storage/storageserver/applicationgenerationfetcher.h>
 
 namespace document { class DocumentTypeRepo; }
 
@@ -28,19 +33,32 @@ struct StorageNodeContext;
 
 class Process : public ApplicationGenerationFetcher {
 protected:
+    using DocumentTypesConfig        = document::config::DocumenttypesConfig;
+    using BucketspacesConfig         = vespa::config::content::core::BucketspacesConfig;
+    using CommunicationManagerConfig = vespa::config::content::core::StorCommunicationmanagerConfig;
+    using StorBouncerConfig          = vespa::config::content::core::StorBouncerConfig;
+    using StorDistributionConfig     = vespa::config::content::StorDistributionConfig;
+    using StorServerConfig           = vespa::config::content::core::StorServerConfig;
+
     using DocumentTypeRepoSP = std::shared_ptr<const document::DocumentTypeRepo>;
     config::ConfigUri _configUri;
     DocumentTypeRepoSP getTypeRepo() { return _repos.back(); }
     config::ConfigSubscriber _configSubscriber;
 
+    std::unique_ptr<config::ConfigHandle<DocumentTypesConfig>>        _document_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<BucketspacesConfig>>         _bucket_spaces_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<CommunicationManagerConfig>> _comm_mgr_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorBouncerConfig>>          _bouncer_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorDistributionConfig>>     _distribution_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorServerConfig>>           _server_cfg_handle;
+
 private:
-    config::ConfigHandle<document::config::DocumenttypesConfig>::UP _documentHandler;
     std::vector<DocumentTypeRepoSP> _repos;
 
 public:
     using UP = std::unique_ptr<Process>;
 
-    Process(const config::ConfigUri & configUri);
+    explicit Process(const config::ConfigUri & configUri);
     ~Process() override;
 
     virtual void setupConfig(vespalib::duration subscribeTimeout);

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -51,11 +51,37 @@ ServiceLayerProcess::shutdown()
 }
 
 void
+ServiceLayerProcess::setupConfig(vespalib::duration subscribe_timeout)
+{
+    Process::setupConfig(subscribe_timeout);
+}
+
+void
+ServiceLayerProcess::updateConfig()
+{
+    Process::updateConfig();
+}
+
+bool
+ServiceLayerProcess::configUpdated()
+{
+    return Process::configUpdated();
+}
+
+void
 ServiceLayerProcess::createNode()
 {
     add_external_visitors();
     setupProvider();
-    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, *this, getProvider(), _externalVisitors);
+    // TODO dedupe, consolidate
+    StorageNode::BootstrapConfigs bc;
+    bc.bucket_spaces_cfg = _bucket_spaces_cfg_handle->getConfig();
+    bc.bouncer_cfg = _bouncer_cfg_handle->getConfig();
+    bc.comm_mgr_cfg = _comm_mgr_cfg_handle->getConfig();
+    bc.distribution_cfg = _distribution_cfg_handle->getConfig();
+    bc.server_cfg = _server_cfg_handle->getConfig();
+
+    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, std::move(bc), *this, getProvider(), _externalVisitors);
     if (_storage_chain_builder) {
         _node->set_storage_chain_builder(std::move(_storage_chain_builder));
     }

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -45,6 +45,10 @@ public:
 
     void shutdown() override;
 
+    void setupConfig(vespalib::duration subscribe_timeout) override;
+    bool configUpdated() override;
+    void updateConfig() override;
+
     virtual void setupProvider() = 0;
     virtual spi::PersistenceProvider& getProvider() = 0;
 


### PR DESCRIPTION
@baldersheim please review. There are more changes brewing in the pipeline (tearing out config fetchers from individual storage chain components in `ServiceLayerNode`), but I would like the main wiring changes to go out first.
