### PR TITLE
Rewire more service layer component configs

### DIFF
--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -1,29 +1,29 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <tests/common/dummystoragelink.h>
+#include <tests/common/testhelper.h>
+#include <tests/common/teststorageapp.h>
 #include <vespa/config/helper/configgetter.hpp>
-#include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/document/config/config-documenttypes.h>
+#include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/document/datatype/documenttype.h>
 #include <vespa/document/fieldvalue/document.h>
-#include <vespa/document/update/documentupdate.h>
 #include <vespa/document/repo/documenttyperepo.h>
-#include <vespa/document/test/make_document_bucket.h>
 #include <vespa/document/test/make_bucket_space.h>
+#include <vespa/document/test/make_document_bucket.h>
+#include <vespa/document/update/documentupdate.h>
+#include <vespa/metrics/updatehook.h>
 #include <vespa/storage/bucketdb/bucketmanager.h>
 #include <vespa/storage/common/global_bucket_space_distribution_converter.h>
 #include <vespa/storage/persistence/filestorage/filestormanager.h>
+#include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/state.h>
-#include <vespa/storageapi/message/bucketsplitting.h>
-#include <vespa/metrics/updatehook.h>
-#include <tests/common/teststorageapp.h>
-#include <tests/common/dummystoragelink.h>
-#include <tests/common/testhelper.h>
-#include <vespa/vdslib/state/random.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>
-#include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vdslib/state/random.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/stllike/asciistream.h>
 #include <future>
 
 #include <vespa/log/log.h>
@@ -148,7 +148,9 @@ void BucketManagerTest::setupTestEnvironment(bool fakePersistenceLayer, bool noD
     _node->setTypeRepo(repo);
     _node->setupDummyPersistence();
     // Set up the 3 links
-    auto manager = std::make_unique<BucketManager>(config::ConfigUri(config.getConfigId()), _node->getComponentRegister());
+    auto config_uri = config::ConfigUri(config.getConfigId());
+    using vespa::config::content::core::StorServerConfig;
+    auto manager = std::make_unique<BucketManager>(*config_from<StorServerConfig>(config_uri), _node->getComponentRegister());
     _manager = manager.get();
     _top->push_back(std::move(manager));
     if (fakePersistenceLayer) {

--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -158,7 +158,9 @@ void BucketManagerTest::setupTestEnvironment(bool fakePersistenceLayer, bool noD
         _bottom = bottom.get();
         _top->push_back(std::move(bottom));
     } else {
-        auto bottom = std::make_unique<FileStorManager>(config::ConfigUri(config.getConfigId()),
+        using vespa::config::content::StorFilestorConfig;
+        auto filestor_cfg = config_from<StorFilestorConfig>(config_uri);
+        auto bottom = std::make_unique<FileStorManager>(*filestor_cfg,
                                                         _node->getPersistenceProvider(), _node->getComponentRegister(),
                                                         *_node, _node->get_host_info());
         _top->push_back(std::move(bottom));

--- a/storage/src/tests/bucketdb/bucketmanagertest.cpp
+++ b/storage/src/tests/bucketdb/bucketmanagertest.cpp
@@ -159,8 +159,7 @@ void BucketManagerTest::setupTestEnvironment(bool fakePersistenceLayer, bool noD
         _top->push_back(std::move(bottom));
     } else {
         using vespa::config::content::StorFilestorConfig;
-        auto filestor_cfg = config_from<StorFilestorConfig>(config_uri);
-        auto bottom = std::make_unique<FileStorManager>(*filestor_cfg,
+        auto bottom = std::make_unique<FileStorManager>(*config_from<StorFilestorConfig>(config_uri),
                                                         _node->getPersistenceProvider(), _node->getComponentRegister(),
                                                         *_node, _node->get_host_info());
         _top->push_back(std::move(bottom));

--- a/storage/src/tests/common/testhelper.h
+++ b/storage/src/tests/common/testhelper.h
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
+#include <vespa/config/helper/configgetter.h>
 #include <vespa/messagebus/testlib/slobrok.h>
 #include <vespa/vdstestlib/config/dirconfig.h>
 #include <fstream>
@@ -20,6 +21,11 @@ std::string getRootFolder(vdstestlib::DirConfig & dc);
 
 void addSlobrokConfig(vdstestlib::DirConfig& dc,
                       const mbus::Slobrok& slobrok);
+
+template <typename ConfigT>
+std::unique_ptr<ConfigT> config_from(const ::config::ConfigUri& cfg_uri) {
+    return ::config::ConfigGetter<ConfigT>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
+}
 
 // Class used to print start and end of test. Enable debug when you want to see
 // which test creates what output or where we get stuck

--- a/storage/src/tests/persistence/common/filestortestfixture.cpp
+++ b/storage/src/tests/persistence/common/filestortestfixture.cpp
@@ -1,15 +1,17 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storage/persistence/messages.h>
-#include <vespa/storage/persistence/filestorage/filestormanager.h>
-#include <vespa/storageapi/message/bucket.h>
-#include <vespa/persistence/dummyimpl/dummypersistence.h>
+#include <tests/common/testhelper.h>
 #include <tests/persistence/common/filestortestfixture.h>
-#include <vespa/document/repo/documenttyperepo.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/fieldset/fieldsets.h>
+#include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/test/make_document_bucket.h>
-#include <vespa/vdslib/state/clusterstate.h>
+#include <vespa/persistence/dummyimpl/dummypersistence.h>
 #include <vespa/persistence/spi/test.h>
+#include <vespa/storage/persistence/filestorage/filestormanager.h>
+#include <vespa/storage/persistence/messages.h>
+#include <vespa/storageapi/message/bucket.h>
+#include <vespa/vdslib/state/clusterstate.h>
 #include <sstream>
 
 using storage::spi::test::makeSpiBucket;
@@ -73,7 +75,9 @@ FileStorTestFixture::TestFileStorComponents::TestFileStorComponents(
       manager(nullptr)
 {
     injector.inject(top);
-    auto fsm = std::make_unique<FileStorManager>(config::ConfigUri(fixture._config->getConfigId()), fixture._node->getPersistenceProvider(),
+    using vespa::config::content::StorFilestorConfig;
+    auto config = config_from<StorFilestorConfig>(config::ConfigUri(fixture._config->getConfigId()));
+    auto fsm = std::make_unique<FileStorManager>(*config, fixture._node->getPersistenceProvider(),
                                                  fixture._node->getComponentRegister(), *fixture._node, fixture._node->get_host_info());
     manager = fsm.get();
     top.push_back(std::move(fsm));

--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -5,6 +5,7 @@
 #include <tests/common/teststorageapp.h>
 #include <tests/persistence/filestorage/forwardingmessagesender.h>
 #include <vespa/config/common/exceptions.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/fieldset/fieldsets.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/select/parser.h>
@@ -223,8 +224,10 @@ struct TestFileStorComponents {
     explicit TestFileStorComponents(FileStorTestBase& test, bool use_small_config = false)
         : manager(nullptr)
     {
-        auto fsm = std::make_unique<FileStorManager>(config::ConfigUri((use_small_config ? test.smallConfig : test.config)->getConfigId()),
-                                                     test._node->getPersistenceProvider(),
+        using vespa::config::content::StorFilestorConfig;
+        auto config_uri = config::ConfigUri((use_small_config ? test.smallConfig : test.config)->getConfigId());
+        auto config = config_from<StorFilestorConfig>(config_uri);
+        auto fsm = std::make_unique<FileStorManager>(*config, test._node->getPersistenceProvider(),
                                                      test._node->getComponentRegister(), *test._node, test._node->get_host_info());
         manager = fsm.get();
         top.push_back(std::move(fsm));

--- a/storage/src/tests/persistence/filestorage/filestormodifiedbucketstest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormodifiedbucketstest.cpp
@@ -1,11 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storageapi/message/bucket.h>
-#include <vespa/storage/persistence/filestorage/modifiedbucketchecker.h>
-#include <vespa/persistence/spi/test.h>
-#include <tests/persistence/common/persistenceproviderwrapper.h>
-#include <vespa/persistence/dummyimpl/dummypersistence.h>
 #include <tests/persistence/common/filestortestfixture.h>
+#include <tests/persistence/common/persistenceproviderwrapper.h>
+#include <vespa/config/helper/configgetter.hpp>
+#include <vespa/persistence/dummyimpl/dummypersistence.h>
+#include <vespa/persistence/spi/test.h>
+#include <vespa/storage/persistence/filestorage/modifiedbucketchecker.h>
+#include <vespa/storageapi/message/bucket.h>
 
 using storage::spi::test::makeSpiBucket;
 using namespace ::testing;
@@ -36,10 +37,10 @@ struct BucketCheckerInjector : FileStorTestFixture::StorageLinkInjector
           _fixture(fixture)
     {}
     void inject(DummyStorageLink& link) const override {
+        using vespa::config::content::core::StorServerConfig;
+        auto cfg = config_from<StorServerConfig>(config::ConfigUri(_fixture._config->getConfigId()));
        link.push_back(std::make_unique<ModifiedBucketChecker>(
-               _node.getComponentRegister(),
-               _node.getPersistenceProvider(),
-               config::ConfigUri(_fixture._config->getConfigId())));
+               _node.getComponentRegister(), _node.getPersistenceProvider(), *cfg));
     }
 };
 

--- a/storage/src/tests/persistence/filestorage/modifiedbucketcheckertest.cpp
+++ b/storage/src/tests/persistence/filestorage/modifiedbucketcheckertest.cpp
@@ -1,11 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <tests/common/testhelper.h>
 #include <tests/common/dummystoragelink.h>
+#include <tests/common/testhelper.h>
 #include <tests/common/teststorageapp.h>
+#include <vespa/config/common/exceptions.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/persistence/dummyimpl/dummypersistence.h>
 #include <vespa/storage/persistence/filestorage/modifiedbucketchecker.h>
-#include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace ::testing;
@@ -45,9 +46,11 @@ ModifiedBucketCheckerTest::SetUp()
     _node->setupDummyPersistence();
 
     _top.reset(new DummyStorageLink);
+    using vespa::config::content::core::StorServerConfig;
+    auto bootstrap_cfg = config_from<StorServerConfig>(config::ConfigUri(_config->getConfigId()));
     _handler = new ModifiedBucketChecker(_node->getComponentRegister(),
                                          _node->getPersistenceProvider(),
-                                         config::ConfigUri(_config->getConfigId()));
+                                         *bootstrap_cfg);
     _top->push_back(std::unique_ptr<StorageLink>(_handler));
     _bottom = new DummyStorageLink;
     _handler->push_back(std::unique_ptr<StorageLink>(_bottom));
@@ -136,7 +139,7 @@ TEST_F(ModifiedBucketCheckerTest, recheck_requests_are_chunked) {
     _top->open();
     cfgns::StorServerConfigBuilder cfgBuilder;
     cfgBuilder.bucketRecheckingChunkSize = 2;
-    _handler->configure(std::make_unique<cfgns::StorServerConfig>(cfgBuilder));
+    _handler->on_configure(*std::make_unique<cfgns::StorServerConfig>(cfgBuilder));
 
     modifyBuckets(5, 0);
     _handler->tick();
@@ -172,7 +175,7 @@ TEST_F(ModifiedBucketCheckerTest, invalid_chunk_size_config_is_rejected) {
     _top->open();
     cfgns::StorServerConfigBuilder cfgBuilder;
     cfgBuilder.bucketRecheckingChunkSize = 0;
-    EXPECT_THROW(_handler->configure(std::make_unique<cfgns::StorServerConfig>(cfgBuilder)),
+    EXPECT_THROW(_handler->on_configure(*std::make_unique<cfgns::StorServerConfig>(cfgBuilder)),
                  config::InvalidConfigException);
 }
 

--- a/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
+++ b/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
@@ -3,6 +3,7 @@
 #include <tests/common/teststorageapp.h>
 #include <tests/common/testhelper.h>
 #include <tests/common/dummystoragelink.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/base/testdocman.h>
 #include <vespa/storage/bucketdb/storbucketdb.h>
 #include <vespa/storage/persistence/messages.h>
@@ -124,11 +125,12 @@ ChangedBucketOwnershipHandlerTest::insertBuckets(uint32_t numBuckets,
 void
 ChangedBucketOwnershipHandlerTest::SetUp()
 {
+    using vespa::config::content::PersistenceConfig;
     vdstestlib::DirConfig config(getStandardConfig(true));
 
     _app.reset(new TestServiceLayerApp);
     _top.reset(new DummyStorageLink);
-    _handler = new ChangedBucketOwnershipHandler(config::ConfigUri(config.getConfigId()),
+    _handler = new ChangedBucketOwnershipHandler(*config_from<PersistenceConfig>(config::ConfigUri(config.getConfigId())),
                                                  _app->getComponentRegister());
     _top->push_back(std::unique_ptr<StorageLink>(_handler));
     _bottom = new DummyStorageLink;
@@ -139,7 +141,7 @@ ChangedBucketOwnershipHandlerTest::SetUp()
     auto pconfig = std::make_unique<vespa::config::content::PersistenceConfigBuilder>();
     pconfig->abortOutdatedMutatingIdealStateOps = true;
     pconfig->abortOutdatedMutatingExternalLoadOps = true;
-    _handler->configure(std::move(pconfig));
+    _handler->on_configure(*pconfig);
 }
 
 namespace {
@@ -466,7 +468,7 @@ TEST_F(ChangedBucketOwnershipHandlerTest, abort_outdated_remove_location) {
 TEST_F(ChangedBucketOwnershipHandlerTest, ideal_state_aborts_are_configurable) {
     auto config = std::make_unique<vespa::config::content::PersistenceConfigBuilder>();
     config->abortOutdatedMutatingIdealStateOps = false;
-    _handler->configure(std::move(config));
+    _handler->on_configure(*config);
     // Should not abort operation, even when ownership has changed.
     expectChangeAbortsMessage<api::CreateBucketCommand>(false, getBucketToAbort());
 }
@@ -508,7 +510,7 @@ TEST_F(ChangedBucketOwnershipHandlerTest, external_load_op_abort_updates_metric)
 TEST_F(ChangedBucketOwnershipHandlerTest, external_load_op_aborts_are_configurable) {
     auto config = std::make_unique<vespa::config::content::PersistenceConfigBuilder>();
     config->abortOutdatedMutatingExternalLoadOps = false;
-    _handler->configure(std::move(config));
+    _handler->on_configure(*config);
     // Should not abort operation, even when ownership has changed.
     document::DocumentId docId("id:foo:testdoctype1::bar");
     expectChangeAbortsMessage<api::RemoveCommand>(

--- a/storage/src/tests/storageserver/communicationmanagertest.cpp
+++ b/storage/src/tests/storageserver/communicationmanagertest.cpp
@@ -29,14 +29,6 @@ vespalib::string _storage("storage");
 
 using CommunicationManagerConfig = vespa::config::content::core::StorCommunicationmanagerConfig;
 
-namespace {
-
-std::unique_ptr<CommunicationManagerConfig> config_from(const config::ConfigUri& cfg_uri) {
-    return config::ConfigGetter<CommunicationManagerConfig>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
-}
-
-}
-
 struct CommunicationManagerTest : Test {
 
     static constexpr uint32_t MESSAGE_WAIT_TIME_SEC = 60;
@@ -88,8 +80,10 @@ TEST_F(CommunicationManagerTest, simple) {
     auto dist_cfg_uri = config::ConfigUri(distConfig.getConfigId());
     auto stor_cfg_uri = config::ConfigUri(storConfig.getConfigId());
 
-    CommunicationManager distributor(distNode.getComponentRegister(), dist_cfg_uri, *config_from(dist_cfg_uri));
-    CommunicationManager storage(storNode.getComponentRegister(), stor_cfg_uri, *config_from(stor_cfg_uri));
+    CommunicationManager distributor(distNode.getComponentRegister(), dist_cfg_uri,
+                                     *config_from<CommunicationManagerConfig>(dist_cfg_uri));
+    CommunicationManager storage(storNode.getComponentRegister(), stor_cfg_uri,
+                                 *config_from<CommunicationManagerConfig>(stor_cfg_uri));
     auto* distributorLink = new DummyStorageLink();
     auto* storageLink = new DummyStorageLink();
     distributor.push_back(std::unique_ptr<StorageLink>(distributorLink));
@@ -146,7 +140,8 @@ CommunicationManagerTest::doTestConfigPropagation(bool isContentNode)
     }
 
     auto cfg_uri = config::ConfigUri(config.getConfigId());
-    CommunicationManager commMgr(node->getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    CommunicationManager commMgr(node->getComponentRegister(), cfg_uri,
+                                 *config_from<CommunicationManagerConfig>(cfg_uri));
     auto* storageLink = new DummyStorageLink();
     commMgr.push_back(std::unique_ptr<StorageLink>(storageLink));
     commMgr.open();
@@ -191,7 +186,8 @@ TEST_F(CommunicationManagerTest, commands_are_dequeued_in_fifo_order) {
     TestServiceLayerApp storNode(storConfig.getConfigId());
 
     auto cfg_uri = config::ConfigUri(storConfig.getConfigId());
-    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri,
+                                 *config_from<CommunicationManagerConfig>(cfg_uri));
     auto* storageLink = new DummyStorageLink();
     storage.push_back(std::unique_ptr<StorageLink>(storageLink));
     storage.open();
@@ -224,7 +220,8 @@ TEST_F(CommunicationManagerTest, replies_are_dequeued_in_fifo_order) {
     TestServiceLayerApp storNode(storConfig.getConfigId());
 
     auto cfg_uri = config::ConfigUri(storConfig.getConfigId());
-    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+    CommunicationManager storage(storNode.getComponentRegister(), cfg_uri,
+                                 *config_from<CommunicationManagerConfig>(cfg_uri));
     auto* storageLink = new DummyStorageLink();
     storage.push_back(std::unique_ptr<StorageLink>(storageLink));
     storage.open();
@@ -265,7 +262,8 @@ struct CommunicationManagerFixture {
 
         node = std::make_unique<TestServiceLayerApp>(stor_config.getConfigId());
         auto cfg_uri = config::ConfigUri(stor_config.getConfigId());
-        comm_mgr = std::make_unique<CommunicationManager>(node->getComponentRegister(), cfg_uri, *config_from(cfg_uri));
+        comm_mgr = std::make_unique<CommunicationManager>(node->getComponentRegister(), cfg_uri,
+                                                          *config_from<CommunicationManagerConfig>(cfg_uri));
         bottom_link = new DummyStorageLink();
         comm_mgr->push_back(std::unique_ptr<StorageLink>(bottom_link));
         comm_mgr->open();

--- a/storage/src/tests/storageserver/mergethrottlertest.cpp
+++ b/storage/src/tests/storageserver/mergethrottlertest.cpp
@@ -124,10 +124,6 @@ makeSystemStateCmd(const std::string& state)
     return std::make_shared<api::SetSystemStateCommand>(lib::ClusterState(state));
 }
 
-std::unique_ptr<StorServerConfig> config_from(const ::config::ConfigUri& cfg_uri) {
-    return ::config::ConfigGetter<StorServerConfig>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
-}
-
 } // anon ns
 
 struct MergeThrottlerTest : Test {
@@ -176,7 +172,7 @@ MergeThrottlerTest::SetUp()
 {
     vdstestlib::DirConfig dir_config(getStandardConfig(true));
     auto cfg_uri = ::config::ConfigUri(dir_config.getConfigId());
-    auto config = config_from(cfg_uri);
+    auto config = config_from<StorServerConfig>(cfg_uri);
 
     for (int i = 0; i < _storageNodeCount; ++i) {
         auto server = std::make_unique<TestServiceLayerApp>(NodeIndex(i));

--- a/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
+++ b/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vdstestlib/config/dirconfig.h>
 #include <tests/common/testhelper.h>
 #include <tests/common/teststorageapp.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace ::testing;
@@ -37,9 +38,15 @@ struct Fixture {
     vdstestlib::DirConfig config{getStandardConfig(true)};
     TestServiceLayerApp app;
     ServiceLayerComponent component{app.getComponentRegister(), "dummy"};
-    MergeThrottler merge_throttler{config::ConfigUri(config.getConfigId()), app.getComponentRegister()};
+    MergeThrottler merge_throttler{*config_from(config::ConfigUri(config.getConfigId())), app.getComponentRegister()};
     TestShutdownListener shutdown_listener;
     ServiceLayerErrorListener error_listener{component, merge_throttler};
+
+    using StorServerConfig = vespa::config::content::core::StorServerConfig;
+
+    static std::unique_ptr<StorServerConfig> config_from(const ::config::ConfigUri& cfg_uri) {
+        return ::config::ConfigGetter<StorServerConfig>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
+    }
 
     Fixture();
     ~Fixture();

--- a/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
+++ b/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
@@ -1,12 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/storage/storageserver/service_layer_error_listener.h>
-#include <vespa/storage/storageserver/mergethrottler.h>
-#include <vespa/storageframework/defaultimplementation/component/componentregisterimpl.h>
-#include <vespa/vdstestlib/config/dirconfig.h>
 #include <tests/common/testhelper.h>
 #include <tests/common/teststorageapp.h>
 #include <vespa/config/helper/configgetter.hpp>
+#include <vespa/storage/storageserver/mergethrottler.h>
+#include <vespa/storage/storageserver/service_layer_error_listener.h>
+#include <vespa/storageframework/defaultimplementation/component/componentregisterimpl.h>
+#include <vespa/vdstestlib/config/dirconfig.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using namespace ::testing;
@@ -35,18 +35,14 @@ private:
 };
 
 struct Fixture {
+    using StorServerConfig = vespa::config::content::core::StorServerConfig;
+
     vdstestlib::DirConfig config{getStandardConfig(true)};
     TestServiceLayerApp app;
     ServiceLayerComponent component{app.getComponentRegister(), "dummy"};
-    MergeThrottler merge_throttler{*config_from(config::ConfigUri(config.getConfigId())), app.getComponentRegister()};
+    MergeThrottler merge_throttler{*config_from<StorServerConfig>(config::ConfigUri(config.getConfigId())), app.getComponentRegister()};
     TestShutdownListener shutdown_listener;
     ServiceLayerErrorListener error_listener{component, merge_throttler};
-
-    using StorServerConfig = vespa::config::content::core::StorServerConfig;
-
-    static std::unique_ptr<StorServerConfig> config_from(const ::config::ConfigUri& cfg_uri) {
-        return ::config::ConfigGetter<StorServerConfig>::getConfig(cfg_uri.getConfigId(), cfg_uri.getContext());
-    }
 
     Fixture();
     ~Fixture();

--- a/storage/src/tests/visiting/visitormanagertest.cpp
+++ b/storage/src/tests/visiting/visitormanagertest.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/fieldvalue/intfieldvalue.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/storageapi/message/datagram.h>
@@ -88,7 +89,9 @@ VisitorManagerTest::initializeTest(bool defer_manager_thread_start)
     _node->setupDummyPersistence();
     _node->getStateUpdater().setClusterState(std::make_shared<lib::ClusterState>("storage:1 distributor:1"));
     _top = std::make_unique<DummyStorageLink>();
-    auto vm = std::make_unique<VisitorManager>(config::ConfigUri(config.getConfigId()),
+    using vespa::config::content::core::StorVisitorConfig;
+    auto bootstrap_cfg = config_from<StorVisitorConfig>(config::ConfigUri(config.getConfigId()));
+    auto vm = std::make_unique<VisitorManager>(*bootstrap_cfg,
                                                _node->getComponentRegister(),
                                                *_messageSessionFactory,
                                                VisitorFactory::Map(),

--- a/storage/src/tests/visiting/visitormanagertest.cpp
+++ b/storage/src/tests/visiting/visitormanagertest.cpp
@@ -98,7 +98,9 @@ VisitorManagerTest::initializeTest(bool defer_manager_thread_start)
                                                defer_manager_thread_start);
     _manager = vm.get();
     _top->push_back(std::move(vm));
-    _top->push_back(std::make_unique<FileStorManager>(config::ConfigUri(config.getConfigId()), _node->getPersistenceProvider(),
+    using vespa::config::content::StorFilestorConfig;
+    auto filestor_cfg = config_from<StorFilestorConfig>(config::ConfigUri(config.getConfigId()));
+    _top->push_back(std::make_unique<FileStorManager>(*filestor_cfg, _node->getPersistenceProvider(),
                                                       _node->getComponentRegister(), *_node, _node->get_host_info()));
     _manager->setTimeBetweenTicks(10);
     _top->open();

--- a/storage/src/tests/visiting/visitortest.cpp
+++ b/storage/src/tests/visiting/visitortest.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/config/common/exceptions.h>
+#include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/fieldvalue/intfieldvalue.h>
 #include <vespa/document/fieldvalue/stringfieldvalue.h>
 #include <vespa/document/datatype/documenttype.h>
@@ -168,9 +169,10 @@ VisitorTest::initializeTest(const TestParams& params)
     }
     _node = std::make_unique<TestServiceLayerApp>(config.getConfigId());
     _top = std::make_unique<DummyStorageLink>();
+    using vespa::config::content::core::StorVisitorConfig;
+    auto bootstrap_cfg = config_from<StorVisitorConfig>(config::ConfigUri(config.getConfigId()));
     _top->push_back(std::unique_ptr<StorageLink>(_manager
-            = new VisitorManager(config::ConfigUri(config.getConfigId()),
-                                 _node->getComponentRegister(), *_messageSessionFactory)));
+            = new VisitorManager(*bootstrap_cfg, _node->getComponentRegister(), *_messageSessionFactory)));
     _bottom = new DummyStorageLink();
     _top->push_back(std::unique_ptr<StorageLink>(_bottom));
     _manager->setTimeBetweenTicks(10);

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
@@ -33,10 +33,9 @@ using namespace std::chrono_literals;
 
 namespace storage {
 
-BucketManager::BucketManager(const config::ConfigUri & configUri, ServiceLayerComponentRegister& compReg)
+BucketManager::BucketManager(const StorServerConfig& bootstrap_config, ServiceLayerComponentRegister& compReg)
     : StorageLink("Bucket manager"),
       framework::StatusReporter("bucketdb", "Bucket database"),
-      _configUri(configUri),
       _workerLock(),
       _workerCond(),
       _clusterStateLock(),
@@ -60,8 +59,7 @@ BucketManager::BucketManager(const config::ConfigUri & configUri, ServiceLayerCo
     ns.setMinUsedBits(58);
     _component.getStateUpdater().setReportedNodeState(ns);
 
-    auto server_config = config::ConfigGetter<vespa::config::content::core::StorServerConfig>::getConfig(configUri.getConfigId(), configUri.getContext());
-    _simulated_processing_delay = std::chrono::milliseconds(std::max(0, server_config->simulatedBucketRequestLatencyMsec));
+    _simulated_processing_delay = std::chrono::milliseconds(std::max(0, bootstrap_config.simulatedBucketRequestLatencyMsec));
 }
 
 BucketManager::~BucketManager()
@@ -414,9 +412,7 @@ BucketManager::dump(std::ostream& out) const
 
 void BucketManager::onOpen()
 {
-    if (!_configUri.empty()) {
-        startWorkerThread();
-    }
+    startWorkerThread();
 }
 
 void BucketManager::startWorkerThread()

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.h
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.h
@@ -10,10 +10,10 @@
 #include "bucketmanagermetrics.h"
 #include "storbucketdb.h"
 #include <vespa/config/subscription/configuri.h>
-#include <vespa/storage/bucketdb/config-stor-bucketdb.h>
 #include <vespa/storage/common/servicelayercomponent.h>
 #include <vespa/storage/common/storagelinkqueued.h>
 #include <vespa/storage/common/nodestateupdater.h>
+#include <vespa/storage/config/config-stor-server.h>
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageframework/generic/metric/metricupdatehook.h>
 #include <vespa/storageframework/generic/status/statusreporter.h>
@@ -34,6 +34,7 @@ class BucketManager : public StorageLink,
                       private framework::MetricUpdateHook
 {
 public:
+    using StorServerConfig = vespa::config::content::core::StorServerConfig;
     /** Type used for message queues */
     using BucketInfoRequestList = std::list<std::shared_ptr<api::RequestBucketInfoCommand>>;
     using BucketInfoRequestMap = std::unordered_map<document::BucketSpace, BucketInfoRequestList, document::BucketSpace::hash>;
@@ -41,7 +42,6 @@ public:
 private:
     using ReplyQueue = std::vector<api::StorageReply::SP>;
     using ConflictingBuckets = std::unordered_set<document::BucketId, document::BucketId::hash>;
-    config::ConfigUri    _configUri;
     BucketInfoRequestMap _bucketInfoRequests;
 
     /**
@@ -82,7 +82,7 @@ private:
     };
 
 public:
-    BucketManager(const config::ConfigUri&, ServiceLayerComponentRegister&);
+    BucketManager(const StorServerConfig& bootstrap_config, ServiceLayerComponentRegister&);
     BucketManager(const BucketManager&) = delete;
     BucketManager& operator=(const BucketManager&) = delete;
     ~BucketManager() override;

--- a/storage/src/vespa/storage/common/visitorfactory.h
+++ b/storage/src/vespa/storage/common/visitorfactory.h
@@ -12,6 +12,7 @@
 
 namespace storage {
 
+class StorageComponent;
 class Visitor;
 
 class VisitorEnvironment {

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.h
@@ -1,10 +1,4 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * @class storage::FileStorManager
- * @ingroup filestorage
- *
- * @version $Id$
- */
 
 #pragma once
 
@@ -42,7 +36,6 @@ namespace spi { struct PersistenceProvider; }
 
 class ContentBucketSpace;
 struct FileStorManagerTest;
-class ReadBucketList;
 class BucketOwnershipNotifier;
 class AbortBucketOperationsCommand;
 struct DoneInitializeHandler;
@@ -54,10 +47,11 @@ class ProviderErrorWrapper;
 class FileStorManager : public StorageLinkQueued,
                         public framework::HtmlStatusReporter,
                         public StateListener,
-                        private config::IFetcherCallback<vespa::config::content::StorFilestorConfig>,
                         public MessageSender,
                         public spi::BucketExecutor
 {
+    using StorFilestorConfig = vespa::config::content::StorFilestorConfig;
+
     ServiceLayerComponentRegister             & _compReg;
     ServiceLayerComponent                       _component;
     std::unique_ptr<spi::PersistenceProvider>   _provider;
@@ -69,7 +63,6 @@ class FileStorManager : public StorageLinkQueued,
     std::unique_ptr<BucketOwnershipNotifier>         _bucketOwnershipNotifier;
 
     std::unique_ptr<vespa::config::content::StorFilestorConfig> _config;
-    std::unique_ptr<config::ConfigFetcher> _configFetcher;
     bool                  _use_async_message_handling_on_schedule;
     std::shared_ptr<FileStorMetrics> _metrics;
     std::unique_ptr<FileStorHandler> _filestorHandler;
@@ -82,7 +75,7 @@ class FileStorManager : public StorageLinkQueued,
     std::unique_ptr<vespalib::IDestructorCallback> _resource_usage_listener_registration;
 
 public:
-    FileStorManager(const config::ConfigUri &, spi::PersistenceProvider&,
+    FileStorManager(const StorFilestorConfig&, spi::PersistenceProvider&,
                     ServiceLayerComponentRegister&, DoneInitializeHandler&, HostInfo&);
     FileStorManager(const FileStorManager &) = delete;
     FileStorManager& operator=(const FileStorManager &) = delete;
@@ -118,8 +111,9 @@ public:
 
     const FileStorMetrics& get_metrics() const { return *_metrics; }
 
+    void on_configure(const vespa::config::content::StorFilestorConfig& config);
+
 private:
-    void configure(std::unique_ptr<vespa::config::content::StorFilestorConfig> config) override;
     PersistenceHandler & createRegisteredHandler(const ServiceLayerComponent & component);
     VESPA_DLL_LOCAL PersistenceHandler & getThreadLocalHandler();
 

--- a/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.cpp
@@ -46,12 +46,11 @@ ModifiedBucketChecker::BucketIdListResult::reset(document::BucketSpace bucketSpa
 ModifiedBucketChecker::ModifiedBucketChecker(
         ServiceLayerComponentRegister& compReg,
         spi::PersistenceProvider& provider,
-        const config::ConfigUri& configUri)
+        const StorServerConfig& bootstrap_config)
     : StorageLink("Modified bucket checker"),
       _provider(provider),
       _component(),
       _thread(),
-      _configFetcher(std::make_unique<config::ConfigFetcher>(configUri.getContext())),
       _monitor(),
       _stateLock(),
       _bucketSpaces(),
@@ -60,8 +59,7 @@ ModifiedBucketChecker::ModifiedBucketChecker(
       _maxPendingChunkSize(100),
       _singleThreadMode(false)
 {
-    _configFetcher->subscribe<vespa::config::content::core::StorServerConfig>(configUri.getConfigId(), this);
-    _configFetcher->start();
+    on_configure(bootstrap_config);
 
     std::ostringstream threadName;
     threadName << "Modified bucket checker " << static_cast<void*>(this);
@@ -75,15 +73,14 @@ ModifiedBucketChecker::~ModifiedBucketChecker()
 }
 
 void
-ModifiedBucketChecker::configure(
-    std::unique_ptr<vespa::config::content::core::StorServerConfig> newConfig)
+ModifiedBucketChecker::on_configure(const vespa::config::content::core::StorServerConfig& newConfig)
 {
     std::lock_guard lock(_stateLock);
-    if (newConfig->bucketRecheckingChunkSize < 1) {
+    if (newConfig.bucketRecheckingChunkSize < 1) {
         throw config::InvalidConfigException(
                 "Cannot have bucket rechecking chunk size of less than 1");
     }
-    _maxPendingChunkSize = newConfig->bucketRecheckingChunkSize;
+    _maxPendingChunkSize = newConfig.bucketRecheckingChunkSize;
 }
 
 

--- a/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.h
+++ b/storage/src/vespa/storage/persistence/filestorage/modifiedbucketchecker.h
@@ -23,19 +23,18 @@ namespace spi { struct PersistenceProvider; }
 class ModifiedBucketChecker
     : public StorageLink,
       public framework::Runnable,
-      public Types,
-      private config::IFetcherCallback<
-              vespa::config::content::core::StorServerConfig>
+      public Types
 {
 public:
+    using StorServerConfig = vespa::config::content::core::StorServerConfig;
     using UP = std::unique_ptr<ModifiedBucketChecker>;
 
     ModifiedBucketChecker(ServiceLayerComponentRegister& compReg,
                           spi::PersistenceProvider& provide,
-                          const config::ConfigUri& configUri);
+                          const StorServerConfig& bootstrap_config);
     ~ModifiedBucketChecker() override;
 
-    void configure(std::unique_ptr<vespa::config::content::core::StorServerConfig>) override;
+    void on_configure(const vespa::config::content::core::StorServerConfig&);
 
     void run(framework::ThreadHandle& thread) override;
     bool tick();
@@ -88,7 +87,6 @@ private:
     spi::PersistenceProvider              & _provider;
     ServiceLayerComponent::UP               _component;
     std::unique_ptr<framework::Thread>      _thread;
-    std::unique_ptr<config::ConfigFetcher>  _configFetcher;
     std::mutex                              _monitor;
     std::condition_variable                 _cond;
     std::mutex                              _stateLock;

--- a/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.cpp
+++ b/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.cpp
@@ -22,12 +22,11 @@ LOG_SETUP(".bucketownershiphandler");
 namespace storage {
 
 ChangedBucketOwnershipHandler::ChangedBucketOwnershipHandler(
-        const config::ConfigUri& configUri,
+        const PersistenceConfig& bootstrap_config,
         ServiceLayerComponentRegister& compReg)
     : StorageLink("Changed bucket ownership handler"),
       _component(compReg, "changedbucketownershiphandler"),
       _metrics(),
-      _configFetcher(std::make_unique<config::ConfigFetcher>(configUri.getContext())),
       _state_sync_executor(1), // single thread for sequential task execution
       _stateLock(),
       _currentState(), // Not set yet, so ownership will not be valid
@@ -37,25 +36,23 @@ ChangedBucketOwnershipHandler::ChangedBucketOwnershipHandler(
       _abortMutatingIdealStateOps(false),
       _abortMutatingExternalLoadOps(false)
 {
-    _configFetcher->subscribe<vespa::config::content::PersistenceConfig>(configUri.getConfigId(), this);
-    _configFetcher->start();
+    on_configure(bootstrap_config);
     _component.registerMetric(_metrics);
 }
 
 ChangedBucketOwnershipHandler::~ChangedBucketOwnershipHandler() = default;
 
 void
-ChangedBucketOwnershipHandler::configure(
-        std::unique_ptr<vespa::config::content::PersistenceConfig> config)
+ChangedBucketOwnershipHandler::on_configure(const vespa::config::content::PersistenceConfig& config)
 {
     _abortQueuedAndPendingOnStateChange.store(
-            config->abortOperationsWithChangedBucketOwnership,
+            config.abortOperationsWithChangedBucketOwnership,
             std::memory_order_relaxed);
     _abortMutatingIdealStateOps.store(
-            config->abortOutdatedMutatingIdealStateOps,
+            config.abortOutdatedMutatingIdealStateOps,
             std::memory_order_relaxed);
     _abortMutatingExternalLoadOps.store(
-            config->abortOutdatedMutatingExternalLoadOps,
+            config.abortOutdatedMutatingExternalLoadOps,
             std::memory_order_relaxed);
 }
 

--- a/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.h
+++ b/storage/src/vespa/storage/storageserver/changedbucketownershiphandler.h
@@ -56,10 +56,7 @@ namespace lib {
  *   - RemoveCommand
  *   - RevertCommand
  */
-class ChangedBucketOwnershipHandler
-    : public StorageLink,
-      private config::IFetcherCallback<vespa::config::content::PersistenceConfig>
-{
+class ChangedBucketOwnershipHandler : public StorageLink {
 public:
     class Metrics : public metrics::MetricSet {
     public:
@@ -115,12 +112,11 @@ public:
 private:
     class ClusterStateSyncAndApplyTask;
 
-    using ConfigFetcherUP       = std::unique_ptr<config::ConfigFetcher>;
+    using PersistenceConfig = vespa::config::content::PersistenceConfig;
     using ClusterStateBundleCSP = std::shared_ptr<const lib::ClusterStateBundle>;
 
     ServiceLayerComponent         _component;
     Metrics                       _metrics;
-    ConfigFetcherUP               _configFetcher;
     vespalib::ThreadStackExecutor _state_sync_executor;
     mutable std::mutex            _stateLock;
     ClusterStateBundleCSP         _currentState;
@@ -185,7 +181,7 @@ private:
     bool enabledExternalLoadAborting() const;
 
 public:
-    ChangedBucketOwnershipHandler(const config::ConfigUri& configUri,
+    ChangedBucketOwnershipHandler(const PersistenceConfig& bootstrap_config,
                                   ServiceLayerComponentRegister& compReg);
     ~ChangedBucketOwnershipHandler() override;
 
@@ -194,7 +190,7 @@ public:
     bool onInternalReply(const std::shared_ptr<api::InternalReply>& reply) override;
     void onClose() override;
 
-    void configure(std::unique_ptr<vespa::config::content::PersistenceConfig>) override;
+    void on_configure(const PersistenceConfig&);
 
     /**
      * We want to ensure distribution config changes are thread safe wrt. our

--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -84,8 +84,6 @@ void
 DistributorNode::createChain(IStorageChainBuilder &builder)
 {
     DistributorComponentRegister& dcr(_context.getComponentRegister());
-    // TODO: All components in this chain should use a common thread instead of
-    // each having its own configfetcher.
     StorageLink::UP chain;
     if (_retrievedCommunicationManager) {
         builder.add(std::move(_retrievedCommunicationManager));

--- a/storage/src/vespa/storage/storageserver/mergethrottler.h
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.h
@@ -35,10 +35,11 @@ class AbortBucketOperationsCommand;
 
 class MergeThrottler : public framework::Runnable,
                        public StorageLink,
-                       public framework::HtmlStatusReporter,
-                       private config::IFetcherCallback<vespa::config::content::core::StorServerConfig>
+                       public framework::HtmlStatusReporter
 {
 public:
+    using StorServerConfig = vespa::config::content::core::StorServerConfig;
+
     class MergeFailureMetrics : public metrics::MetricSet {
     public:
         metrics::SumMetric<metrics::LongCountMetric> sum;
@@ -172,7 +173,6 @@ private:
     mutable std::mutex _messageLock;
     std::condition_variable _messageCond;
     mutable std::mutex _stateLock;
-    std::unique_ptr<config::ConfigFetcher> _configFetcher;
     // Messages pending to be processed by the worker thread
     std::vector<api::StorageMessage::SP> _messagesDown;
     std::vector<api::StorageMessage::SP> _messagesUp;
@@ -190,7 +190,7 @@ public:
      * windowSizeIncrement used for allowing unit tests to start out with more
      * than 1 as their window size.
      */
-    MergeThrottler(const config::ConfigUri & configUri, StorageComponentRegister&);
+    MergeThrottler(const StorServerConfig& bootstrap_config, StorageComponentRegister&);
     ~MergeThrottler() override;
 
     /** Implements document::Runnable::run */
@@ -203,6 +203,8 @@ public:
     bool onDown(const std::shared_ptr<api::StorageMessage>& msg) override;
 
     bool onSetSystemState(const std::shared_ptr<api::SetSystemStateCommand>& stateCmd) override;
+
+    void on_configure(const StorServerConfig& new_config);
 
     /*
      * When invoked, merges to the node will be BUSY-bounced by the throttler
@@ -281,11 +283,6 @@ private:
          */
         [[nodiscard]] bool isChainCompleted() const noexcept;
     };
-
-    /**
-     * Callback method for config system (IFetcherCallback)
-     */
-    void configure(std::unique_ptr<vespa::config::content::core::StorServerConfig> newConfig) override;
 
     // NOTE: unless explicitly specified, all the below functions require
     // _sync lock to be held upon call (usually implicitly via MessageGuard)

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -174,7 +174,7 @@ ServiceLayerNode::createChain(IStorageChainBuilder &builder)
     auto bucket_ownership_handler = std::make_unique<ChangedBucketOwnershipHandler>(*_persistence_bootstrap_config, compReg);
     _changed_bucket_ownership_handler = bucket_ownership_handler.get();
     builder.add(std::move(bucket_ownership_handler));
-    auto bucket_manager = std::make_unique<BucketManager>(_configUri, _context.getComponentRegister());
+    auto bucket_manager = std::make_unique<BucketManager>(server_config(), _context.getComponentRegister());
     _bucket_manager = bucket_manager.get();
     builder.add(std::move(bucket_manager));
     builder.add(std::make_unique<VisitorManager>(_configUri, _context.getComponentRegister(),

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -43,6 +43,7 @@ ServiceLayerNode::ServiceLayerNode(const config::ConfigUri & configUri,
       _externalVisitors(externalVisitors),
       _persistence_bootstrap_config(std::move(bootstrap_configs.persistence_cfg)),
       _visitor_bootstrap_config(std::move(bootstrap_configs.visitor_cfg)),
+      _filestor_bootstrap_config(std::move(bootstrap_configs.filestor_cfg)),
       _bouncer(nullptr),
       _bucket_manager(nullptr),
       _changed_bucket_ownership_handler(nullptr),
@@ -188,7 +189,8 @@ ServiceLayerNode::createChain(IStorageChainBuilder &builder)
     _modified_bucket_checker = bucket_checker.get();
     builder.add(std::move(bucket_checker));
     auto state_manager = releaseStateManager();
-    auto filstor_manager = std::make_unique<FileStorManager>(_configUri, _persistenceProvider, _context.getComponentRegister(),
+    auto filstor_manager = std::make_unique<FileStorManager>(*_filestor_bootstrap_config, _persistenceProvider,
+                                                             _context.getComponentRegister(),
                                                              getDoneInitializeHandler(), state_manager->getHostInfo());
     _fileStorManager = filstor_manager.get();
     builder.add(std::move(filstor_manager));
@@ -227,6 +229,12 @@ ServiceLayerNode::on_configure(const StorVisitorConfig& config)
     _visitor_manager->on_configure(config);
 }
 
+void
+ServiceLayerNode::on_configure(const StorFilestorConfig& config)
+{
+    assert(_fileStorManager);
+    _fileStorManager->on_configure(config);
+}
 
 ResumeGuard
 ServiceLayerNode::pause()

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -204,6 +204,8 @@ ServiceLayerNode::createChain(IStorageChainBuilder &builder)
 
     // Purge config no longer needed
     _persistence_bootstrap_config.reset();
+    _visitor_bootstrap_config.reset();
+    _filestor_bootstrap_config.reset();
 }
 
 void

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -21,6 +21,7 @@ class BucketManager;
 class ChangedBucketOwnershipHandler;
 class FileStorManager;
 class MergeThrottler;
+class ModifiedBucketChecker;
 class VisitorManager;
 
 class ServiceLayerNode
@@ -44,6 +45,7 @@ private:
     FileStorManager*                   _fileStorManager;
     MergeThrottler*                    _merge_throttler;
     VisitorManager*                    _visitor_manager;
+    ModifiedBucketChecker*             _modified_bucket_checker;
     bool                               _init_has_been_called;
 
 public:

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -7,9 +7,10 @@
 #include "storagenode.h"
 #include "vespa/vespalib/util/jsonstream.h"
 #include <vespa/config-persistence.h>
-#include <vespa/storage/visiting/visitormessagesessionfactory.h>
-#include <vespa/storage/common/visitorfactory.h>
 #include <vespa/storage/common/nodestateupdater.h>
+#include <vespa/storage/common/visitorfactory.h>
+#include <vespa/storage/visiting/config-stor-visitor.h>
+#include <vespa/storage/visiting/visitormessagesessionfactory.h>
 
 namespace storage {
 
@@ -20,6 +21,7 @@ class BucketManager;
 class ChangedBucketOwnershipHandler;
 class FileStorManager;
 class MergeThrottler;
+class VisitorManager;
 
 class ServiceLayerNode
         : public StorageNode,
@@ -29,16 +31,19 @@ class ServiceLayerNode
 {
 public:
     using PersistenceConfig = vespa::config::content::PersistenceConfig;
+    using StorVisitorConfig = vespa::config::content::core::StorVisitorConfig;
 private:
     ServiceLayerNodeContext&           _context;
     spi::PersistenceProvider&          _persistenceProvider;
     VisitorFactory::Map                _externalVisitors;
     std::unique_ptr<PersistenceConfig> _persistence_bootstrap_config;
+    std::unique_ptr<StorVisitorConfig> _visitor_bootstrap_config;
     Bouncer*                           _bouncer;
     BucketManager*                     _bucket_manager;
     ChangedBucketOwnershipHandler*     _changed_bucket_ownership_handler;
     FileStorManager*                   _fileStorManager;
     MergeThrottler*                    _merge_throttler;
+    VisitorManager*                    _visitor_manager;
     bool                               _init_has_been_called;
 
 public:
@@ -47,6 +52,7 @@ public:
     struct ServiceLayerBootstrapConfigs {
         BootstrapConfigs storage_bootstrap_configs;
         std::unique_ptr<PersistenceConfig> persistence_cfg;
+        std::unique_ptr<StorVisitorConfig> visitor_cfg;
 
         ServiceLayerBootstrapConfigs();
         ~ServiceLayerBootstrapConfigs();
@@ -68,6 +74,7 @@ public:
 
     void on_configure(const StorServerConfig& config);
     void on_configure(const PersistenceConfig& config);
+    void on_configure(const StorVisitorConfig& config);
 
     const lib::NodeType& getNodeType() const override { return lib::NodeType::STORAGE; }
 

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -7,6 +7,7 @@
 #include "storagenode.h"
 #include "vespa/vespalib/util/jsonstream.h"
 #include <vespa/config-persistence.h>
+#include <vespa/config-stor-filestor.h>
 #include <vespa/storage/common/nodestateupdater.h>
 #include <vespa/storage/common/visitorfactory.h>
 #include <vespa/storage/visiting/config-stor-visitor.h>
@@ -31,30 +32,33 @@ class ServiceLayerNode
 
 {
 public:
-    using PersistenceConfig = vespa::config::content::PersistenceConfig;
-    using StorVisitorConfig = vespa::config::content::core::StorVisitorConfig;
+    using PersistenceConfig  = vespa::config::content::PersistenceConfig;
+    using StorVisitorConfig  = vespa::config::content::core::StorVisitorConfig;
+    using StorFilestorConfig = vespa::config::content::StorFilestorConfig;
 private:
-    ServiceLayerNodeContext&           _context;
-    spi::PersistenceProvider&          _persistenceProvider;
-    VisitorFactory::Map                _externalVisitors;
-    std::unique_ptr<PersistenceConfig> _persistence_bootstrap_config;
-    std::unique_ptr<StorVisitorConfig> _visitor_bootstrap_config;
-    Bouncer*                           _bouncer;
-    BucketManager*                     _bucket_manager;
-    ChangedBucketOwnershipHandler*     _changed_bucket_ownership_handler;
-    FileStorManager*                   _fileStorManager;
-    MergeThrottler*                    _merge_throttler;
-    VisitorManager*                    _visitor_manager;
-    ModifiedBucketChecker*             _modified_bucket_checker;
-    bool                               _init_has_been_called;
+    ServiceLayerNodeContext&            _context;
+    spi::PersistenceProvider&           _persistenceProvider;
+    VisitorFactory::Map                 _externalVisitors;
+    std::unique_ptr<PersistenceConfig>  _persistence_bootstrap_config;
+    std::unique_ptr<StorVisitorConfig>  _visitor_bootstrap_config;
+    std::unique_ptr<StorFilestorConfig> _filestor_bootstrap_config;
+    Bouncer*                            _bouncer;
+    BucketManager*                      _bucket_manager;
+    ChangedBucketOwnershipHandler*      _changed_bucket_ownership_handler;
+    FileStorManager*                    _fileStorManager;
+    MergeThrottler*                     _merge_throttler;
+    VisitorManager*                     _visitor_manager;
+    ModifiedBucketChecker*              _modified_bucket_checker;
+    bool                                _init_has_been_called;
 
 public:
     using UP = std::unique_ptr<ServiceLayerNode>;
 
     struct ServiceLayerBootstrapConfigs {
         BootstrapConfigs storage_bootstrap_configs;
-        std::unique_ptr<PersistenceConfig> persistence_cfg;
-        std::unique_ptr<StorVisitorConfig> visitor_cfg;
+        std::unique_ptr<PersistenceConfig>  persistence_cfg;
+        std::unique_ptr<StorVisitorConfig>  visitor_cfg;
+        std::unique_ptr<StorFilestorConfig> filestor_cfg;
 
         ServiceLayerBootstrapConfigs();
         ~ServiceLayerBootstrapConfigs();
@@ -77,6 +81,7 @@ public:
     void on_configure(const StorServerConfig& config);
     void on_configure(const PersistenceConfig& config);
     void on_configure(const StorVisitorConfig& config);
+    void on_configure(const StorFilestorConfig& config);
 
     const lib::NodeType& getNodeType() const override { return lib::NodeType::STORAGE; }
 

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -1,10 +1,4 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * \class storage::ServiceLayerNode
- * \ingroup storageserver
- *
- * \brief Class for setting up a service layer node.
- */
 
 #pragma once
 
@@ -23,6 +17,7 @@ namespace spi { struct PersistenceProvider; }
 class Bouncer;
 class BucketManager;
 class FileStorManager;
+class MergeThrottler;
 
 class ServiceLayerNode
         : public StorageNode,
@@ -37,6 +32,7 @@ class ServiceLayerNode
     Bouncer*                  _bouncer;
     BucketManager*            _bucket_manager;
     FileStorManager*          _fileStorManager;
+    MergeThrottler*           _merge_throttler;
     bool                      _init_has_been_called;
 
 public:
@@ -53,6 +49,8 @@ public:
      * Init must be called exactly once after construction and before destruction.
      */
     void init();
+
+    void on_configure(const StorServerConfig& config);
 
     const lib::NodeType& getNodeType() const override { return lib::NodeType::STORAGE; }
 

--- a/storage/src/vespa/storage/visiting/visitormanager.cpp
+++ b/storage/src/vespa/storage/visiting/visitormanager.cpp
@@ -21,7 +21,7 @@ LOG_SETUP(".visitor.manager");
 
 namespace storage {
 
-VisitorManager::VisitorManager(const config::ConfigUri & configUri,
+VisitorManager::VisitorManager(const StorVisitorConfig& bootstrap_config,
                                StorageComponentRegister& componentRegister,
                                VisitorMessageSessionFactory& messageSF,
                                VisitorFactory::Map externalFactories,
@@ -35,7 +35,6 @@ VisitorManager::VisitorManager(const config::ConfigUri & configUri,
       _visitorLock(),
       _visitorCond(),
       _visitorCounter(0),
-      _configFetcher(std::make_unique<config::ConfigFetcher>(configUri.getContext())),
       _metrics(std::make_shared<VisitorMetrics>()),
       _maxFixedConcurrentVisitors(1),
       _maxVariableConcurrentVisitors(0),
@@ -51,8 +50,7 @@ VisitorManager::VisitorManager(const config::ConfigUri & configUri,
       _enforceQueueUse(false),
       _visitorFactories(std::move(externalFactories))
 {
-    _configFetcher->subscribe<vespa::config::content::core::StorVisitorConfig>(configUri.getConfigId(), this);
-    _configFetcher->start();
+    on_configure(bootstrap_config);
     _component.registerMetric(*_metrics);
     if (!defer_manager_thread_start) {
         create_and_start_manager_thread();
@@ -94,8 +92,6 @@ VisitorManager::updateMetrics(const MetricLockGuard &)
 void
 VisitorManager::onClose()
 {
-        // Avoid getting config during shutdown
-    _configFetcher->close();
     {
         std::lock_guard sync(_visitorLock);
         for (auto& enqueued : _visitorQueue) {
@@ -118,25 +114,25 @@ VisitorManager::print(std::ostream& out, bool verbose, const std::string& indent
 }
 
 void
-VisitorManager::configure(std::unique_ptr<vespa::config::content::core::StorVisitorConfig> config)
+VisitorManager::on_configure(const vespa::config::content::core::StorVisitorConfig& config)
 {
     std::lock_guard sync(_visitorLock);
-    if (config->defaultdocblocksize % 512 != 0) {
+    if (config.defaultdocblocksize % 512 != 0) {
         throw config::InvalidConfigException(
-                "The default docblock size needs to be a multiplum of the "
+                "The default docblock size needs to be a multiple of the "
                 "disk block size. (512b)");
     }
 
     // Do some sanity checking of input. Cannot haphazardly mix and match
     // old and new max concurrency config values
-    if (config->maxconcurrentvisitors == 0
-        && config->maxconcurrentvisitorsFixed == 0)
+    if (config.maxconcurrentvisitors == 0
+        && config.maxconcurrentvisitorsFixed == 0)
     {
         throw config::InvalidConfigException(
                 "Maximum concurrent visitor count cannot be 0.");
     }
-    else if (config->maxconcurrentvisitorsFixed == 0
-                 && config->maxconcurrentvisitorsVariable != 0)
+    else if (config.maxconcurrentvisitorsFixed == 0
+                 && config.maxconcurrentvisitorsVariable != 0)
     {
         throw config::InvalidConfigException(
                 "Cannot specify 'variable' parameter for max concurrent "
@@ -147,21 +143,21 @@ VisitorManager::configure(std::unique_ptr<vespa::config::content::core::StorVisi
     uint32_t maxConcurrentVisitorsVariable;
 
     // Concurrency parameter fixed takes precedence over legacy maxconcurrent
-    if (config->maxconcurrentvisitorsFixed > 0) {
-        maxConcurrentVisitorsFixed = config->maxconcurrentvisitorsFixed;
-        maxConcurrentVisitorsVariable = config->maxconcurrentvisitorsVariable;
+    if (config.maxconcurrentvisitorsFixed > 0) {
+        maxConcurrentVisitorsFixed = config.maxconcurrentvisitorsFixed;
+        maxConcurrentVisitorsVariable = config.maxconcurrentvisitorsVariable;
     } else {
-       maxConcurrentVisitorsFixed = config->maxconcurrentvisitors;
+       maxConcurrentVisitorsFixed = config.maxconcurrentvisitors;
        maxConcurrentVisitorsVariable = 0;
     }
 
     bool liveUpdate = !_visitorThread.empty();
     if (liveUpdate) {
-        if (_visitorThread.size() != static_cast<uint32_t>(config->visitorthreads)) {
+        if (_visitorThread.size() != static_cast<uint32_t>(config.visitorthreads)) {
             LOG(warning, "Ignoring config change requesting %u visitor "
                          "threads, still running %u. Restart storage to apply "
                          "change.",
-                         config->visitorthreads,
+                         config.visitorthreads,
                          (uint32_t) _visitorThread.size());
         }
 
@@ -174,18 +170,18 @@ VisitorManager::configure(std::unique_ptr<vespa::config::content::core::StorVisi
                 maxConcurrentVisitorsFixed, maxConcurrentVisitorsVariable);
         }
 
-        if (_maxVisitorQueueSize != static_cast<uint32_t>(config->maxvisitorqueuesize)) {
+        if (_maxVisitorQueueSize != static_cast<uint32_t>(config.maxvisitorqueuesize)) {
             LOG(info, "Altered max visitor queue size setting from %u to %u.",
-                      _maxVisitorQueueSize, config->maxvisitorqueuesize);
+                      _maxVisitorQueueSize, config.maxvisitorqueuesize);
         }
     } else {
-        if (config->visitorthreads == 0) {
+        if (config.visitorthreads == 0) {
             throw config::InvalidConfigException(
                     "No visitor threads configured. If you don't want visitors "
                     "to run, don't use visitormanager.", VESPA_STRLOC);
         }
-        _metrics->initThreads(config->visitorthreads);
-        for (int32_t i=0; i<config->visitorthreads; ++i) {
+        _metrics->initThreads(config.visitorthreads);
+        for (int32_t i=0; i<config.visitorthreads; ++i) {
             _visitorThread.emplace_back(
                     // Naked new due to a lot of private inheritance in VisitorThread and VisitorManager
                     std::shared_ptr<VisitorThread>(new VisitorThread(i, _componentRegister, _messageSessionFactory,
@@ -195,9 +191,9 @@ VisitorManager::configure(std::unique_ptr<vespa::config::content::core::StorVisi
     }
     _maxFixedConcurrentVisitors = maxConcurrentVisitorsFixed;
     _maxVariableConcurrentVisitors = maxConcurrentVisitorsVariable;
-    _maxVisitorQueueSize = config->maxvisitorqueuesize;
+    _maxVisitorQueueSize = config.maxvisitorqueuesize;
 
-    auto cmd = std::make_shared<PropagateVisitorConfig>(*config);
+    auto cmd = std::make_shared<PropagateVisitorConfig>(config);
     for (auto& thread : _visitorThread) {
         thread.first->processMessage(0, cmd);
     }

--- a/storage/src/vespa/storage/visiting/visitormanager.h
+++ b/storage/src/vespa/storage/visiting/visitormanager.h
@@ -44,10 +44,11 @@ class VisitorManager : public framework::Runnable,
                        public StorageLink,
                        public framework::HtmlStatusReporter,
                        private VisitorMessageHandler,
-                       private config::IFetcherCallback<vespa::config::content::core::StorVisitorConfig>,
                        private framework::MetricUpdateHook
 {
 private:
+    using StorVisitorConfig = vespa::config::content::core::StorVisitorConfig;
+
     StorageComponentRegister& _componentRegister;
     VisitorMessageSessionFactory& _messageSessionFactory;
     std::vector<std::pair<std::shared_ptr<VisitorThread>,
@@ -64,7 +65,6 @@ private:
     mutable std::mutex      _visitorLock;
     std::condition_variable _visitorCond;
     uint64_t _visitorCounter;
-    std::unique_ptr<config::ConfigFetcher> _configFetcher;
     std::shared_ptr<VisitorMetrics> _metrics;
     uint32_t _maxFixedConcurrentVisitors;
     uint32_t _maxVariableConcurrentVisitors;
@@ -82,7 +82,7 @@ private:
     bool _enforceQueueUse;
     VisitorFactory::Map _visitorFactories;
 public:
-    VisitorManager(const config::ConfigUri & configUri,
+    VisitorManager(const StorVisitorConfig& bootstrap_config,
                    StorageComponentRegister&,
                    VisitorMessageSessionFactory&,
                    VisitorFactory::Map external = VisitorFactory::Map(),
@@ -93,6 +93,8 @@ public:
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     uint32_t getActiveVisitorCount() const;
     void setTimeBetweenTicks(uint32_t time);
+
+    void on_configure(const vespa::config::content::core::StorVisitorConfig&);
 
     void setMaxConcurrentVisitors(uint32_t count) { // Used in unit testing
         _maxFixedConcurrentVisitors = count;
@@ -122,7 +124,6 @@ public:
 
 private:
     using MonitorGuard = std::unique_lock<std::mutex>;
-    void configure(std::unique_ptr<vespa::config::content::core::StorVisitorConfig>) override;
     void run(framework::ThreadHandle&) override;
 
     /**

--- a/storageserver/src/vespa/storageserver/app/process.h
+++ b/storageserver/src/vespa/storageserver/app/process.h
@@ -8,7 +8,7 @@
  * contains the process as a library such that it can be tested and used in
  * other pieces of code.
  *
- * Specializations of this class will exist to add the funcionality needed for
+ * Specializations of this class will exist to add the functionality needed for
  * the various process types.
  */
 

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -34,6 +34,7 @@ bucket_db_options_from_config(const config::ConfigUri& config_uri) {
 ServiceLayerProcess::ServiceLayerProcess(const config::ConfigUri& configUri)
     : Process(configUri),
       _externalVisitors(),
+      _persistence_cfg_handle(),
       _node(),
       _storage_chain_builder(),
       _context(std::make_unique<framework::defaultimplementation::RealClock>(),
@@ -53,6 +54,7 @@ ServiceLayerProcess::shutdown()
 void
 ServiceLayerProcess::setupConfig(vespalib::duration subscribe_timeout)
 {
+    _persistence_cfg_handle = _configSubscriber.subscribe<PersistenceConfig>(_configUri.getConfigId(), subscribe_timeout);
     // We reuse the StorServerConfig subscription from the parent Process
     Process::setupConfig(subscribe_timeout);
 }
@@ -63,6 +65,9 @@ ServiceLayerProcess::updateConfig()
     Process::updateConfig();
     if (_server_cfg_handle->isChanged()) {
         _node->on_configure(*_server_cfg_handle->getConfig());
+    }
+    if (_persistence_cfg_handle->isChanged()) {
+        _node->on_configure(*_persistence_cfg_handle->getConfig());
     }
 }
 
@@ -77,15 +82,19 @@ ServiceLayerProcess::createNode()
 {
     add_external_visitors();
     setupProvider();
-    // TODO dedupe, consolidate
+
     StorageNode::BootstrapConfigs bc;
     bc.bucket_spaces_cfg = _bucket_spaces_cfg_handle->getConfig();
-    bc.bouncer_cfg = _bouncer_cfg_handle->getConfig();
-    bc.comm_mgr_cfg = _comm_mgr_cfg_handle->getConfig();
-    bc.distribution_cfg = _distribution_cfg_handle->getConfig();
-    bc.server_cfg = _server_cfg_handle->getConfig();
+    bc.bouncer_cfg       = _bouncer_cfg_handle->getConfig();
+    bc.comm_mgr_cfg      = _comm_mgr_cfg_handle->getConfig();
+    bc.distribution_cfg  = _distribution_cfg_handle->getConfig();
+    bc.server_cfg        = _server_cfg_handle->getConfig();
 
-    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, std::move(bc), *this, getProvider(), _externalVisitors);
+    ServiceLayerNode::ServiceLayerBootstrapConfigs sbc;
+    sbc.storage_bootstrap_configs = std::move(bc);
+    sbc.persistence_cfg = _persistence_cfg_handle->getConfig();
+
+    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, std::move(sbc), *this, getProvider(), _externalVisitors);
     if (_storage_chain_builder) {
         _node->set_storage_chain_builder(std::move(_storage_chain_builder));
     }

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -53,6 +53,7 @@ ServiceLayerProcess::shutdown()
 void
 ServiceLayerProcess::setupConfig(vespalib::duration subscribe_timeout)
 {
+    // We reuse the StorServerConfig subscription from the parent Process
     Process::setupConfig(subscribe_timeout);
 }
 
@@ -60,6 +61,9 @@ void
 ServiceLayerProcess::updateConfig()
 {
     Process::updateConfig();
+    if (_server_cfg_handle->isChanged()) {
+        _node->on_configure(*_server_cfg_handle->getConfig());
+    }
 }
 
 bool

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -3,8 +3,9 @@
 
 #include "process.h"
 #include <vespa/config-persistence.h>
-#include <vespa/storage/storageserver/servicelayernodecontext.h>
 #include <vespa/storage/common/visitorfactory.h>
+#include <vespa/storage/storageserver/servicelayernodecontext.h>
+#include <vespa/storage/visiting/config-stor-visitor.h>
 
 namespace config { class ConfigUri; }
 
@@ -20,8 +21,10 @@ protected:
     VisitorFactory::Map _externalVisitors;
 private:
     using PersistenceConfig = vespa::config::content::PersistenceConfig;
+    using StorVisitorConfig = vespa::config::content::core::StorVisitorConfig;
 
     std::unique_ptr<config::ConfigHandle<PersistenceConfig>> _persistence_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorVisitorConfig>> _visitor_cfg_handle;
 
     std::unique_ptr<ServiceLayerNode> _node;
     std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -3,6 +3,7 @@
 
 #include "process.h"
 #include <vespa/config-persistence.h>
+#include <vespa/config-stor-filestor.h>
 #include <vespa/storage/common/visitorfactory.h>
 #include <vespa/storage/storageserver/servicelayernodecontext.h>
 #include <vespa/storage/visiting/config-stor-visitor.h>
@@ -20,11 +21,13 @@ class ServiceLayerProcess : public Process {
 protected:
     VisitorFactory::Map _externalVisitors;
 private:
-    using PersistenceConfig = vespa::config::content::PersistenceConfig;
-    using StorVisitorConfig = vespa::config::content::core::StorVisitorConfig;
+    using PersistenceConfig  = vespa::config::content::PersistenceConfig;
+    using StorVisitorConfig  = vespa::config::content::core::StorVisitorConfig;
+    using StorFilestorConfig = vespa::config::content::StorFilestorConfig;
 
-    std::unique_ptr<config::ConfigHandle<PersistenceConfig>> _persistence_cfg_handle;
-    std::unique_ptr<config::ConfigHandle<StorVisitorConfig>> _visitor_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<PersistenceConfig>>  _persistence_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorVisitorConfig>>  _visitor_cfg_handle;
+    std::unique_ptr<config::ConfigHandle<StorFilestorConfig>> _filestor_cfg_handle;
 
     std::unique_ptr<ServiceLayerNode> _node;
     std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -1,22 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * \class storage::ServiceLayerProcess
- *
- * \brief A process running a service layer.
- */
-/**
- * \class storage::MemFileServiceLayerProcess
- *
- * \brief A process running a service layer with memfile persistence provider.
- */
-/**
- * \class storage::RpcServiceLayerProcess
- *
- * \brief A process running a service layer with RPC persistence provider.
- */
 #pragma once
 
 #include "process.h"
+#include <vespa/config-persistence.h>
 #include <vespa/storage/storageserver/servicelayernodecontext.h>
 #include <vespa/storage/common/visitorfactory.h>
 
@@ -33,6 +19,10 @@ class ServiceLayerProcess : public Process {
 protected:
     VisitorFactory::Map _externalVisitors;
 private:
+    using PersistenceConfig = vespa::config::content::PersistenceConfig;
+
+    std::unique_ptr<config::ConfigHandle<PersistenceConfig>> _persistence_cfg_handle;
+
     std::unique_ptr<ServiceLayerNode> _node;
     std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;
 


### PR DESCRIPTION
@baldersheim please review. This should take care of the remaining storage chain components. 5 less config threads per host.

Each component is covered by its own commit. The `#include`-section changes are mostly just lexicographic reordering to clean things up a bit.
