### PR TITLE
Hmusum/run application package maintainer more often

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -16,7 +16,7 @@ import com.yahoo.vespa.defaults.Defaults;
 import com.yahoo.vespa.filedistribution.FileDistributionConnectionPool;
 import com.yahoo.vespa.filedistribution.FileDownloader;
 import com.yahoo.vespa.filedistribution.FileReferenceDownload;
-import com.yahoo.vespa.flags.FlagSource;
+
 import java.io.File;
 import java.time.Duration;
 import java.util.List;
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.logging.Logger;
 
 import static com.yahoo.vespa.config.server.filedistribution.FileDistributionUtil.fileReferenceExistsOnDisk;
+import static com.yahoo.vespa.config.server.filedistribution.FileDistributionUtil.getOtherConfigServersInCluster;
 
 /**
  * Verifies that all active sessions has an application package on local disk.
@@ -37,20 +38,14 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
 
     private static final Logger log = Logger.getLogger(ApplicationPackageMaintainer.class.getName());
 
-    private final ApplicationRepository applicationRepository;
     private final File downloadDirectory;
     private final Supervisor supervisor = new Supervisor(new Transport("filedistribution-pool")).setDropEmptyBuffers(true);
     private final FileDownloader fileDownloader;
 
-    ApplicationPackageMaintainer(ApplicationRepository applicationRepository,
-                                 Curator curator,
-                                 Duration interval,
-                                 FlagSource flagSource,
-                                 List<String> otherConfigServersInCluster) {
-        super(applicationRepository, curator, flagSource, applicationRepository.clock(), interval, false);
-        this.applicationRepository = applicationRepository;
+    ApplicationPackageMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval) {
+        super(applicationRepository, curator, applicationRepository.flagSource(), applicationRepository.clock(), interval, false);
         this.downloadDirectory = new File(Defaults.getDefaults().underVespaHome(applicationRepository.configserverConfig().fileReferencesDir()));
-        this.fileDownloader = createFileDownloader(otherConfigServersInCluster, downloadDirectory, supervisor);
+        this.fileDownloader = createFileDownloader(applicationRepository, downloadDirectory, supervisor);
     }
 
     @Override
@@ -91,9 +86,10 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
         return  asSuccessFactorDeviation(attempts, failures);
     }
 
-    private static FileDownloader createFileDownloader(List<String> otherConfigServersInCluster,
+    private static FileDownloader createFileDownloader(ApplicationRepository applicationRepository,
                                                        File downloadDirectory,
                                                        Supervisor supervisor) {
+        List<String> otherConfigServersInCluster = getOtherConfigServersInCluster(applicationRepository.configserverConfig());
         ConfigSourceSet configSourceSet = new ConfigSourceSet(otherConfigServersInCluster);
         ConnectionPool connectionPool = new FileDistributionConnectionPool(configSourceSet, supervisor);
         return new FileDownloader(connectionPool, supervisor, downloadDirectory, Duration.ofSeconds(300));

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -40,7 +40,7 @@ public class ConfigServerMaintenance {
 
     public void startBeforeBootstrap() {
         if (moreThanOneConfigServer())
-            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(30)));
+            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(15)));
         maintainers.add(new TenantsMaintainer(applicationRepository, curator, interval, Clock.systemUTC()));
     }
 

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintenance.java
@@ -6,7 +6,7 @@ import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.application.ConfigConvergenceChecker;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.flags.FlagSource;
+
 import java.time.Clock;
 import java.time.Duration;
 import java.util.List;
@@ -26,7 +26,6 @@ public class ConfigServerMaintenance {
     private final List<Maintainer> maintainers = new CopyOnWriteArrayList<>();
     private final ApplicationRepository applicationRepository;
     private final Curator curator;
-    private final FlagSource flagSource;
     private final ConfigConvergenceChecker convergenceChecker;
     private final FileDirectory fileDirectory;
     private final Duration interval;
@@ -34,28 +33,21 @@ public class ConfigServerMaintenance {
     public ConfigServerMaintenance(ApplicationRepository applicationRepository, FileDirectory fileDirectory) {
         this.applicationRepository = applicationRepository;
         this.curator = applicationRepository.tenantRepository().getCurator();
-        this.flagSource = applicationRepository.flagSource();
         this.convergenceChecker = applicationRepository.configConvergenceChecker();
         this.fileDirectory = fileDirectory;
         this.interval = Duration.ofMinutes(applicationRepository.configserverConfig().maintainerIntervalMinutes());
     }
 
     public void startBeforeBootstrap() {
-        List<String> otherConfigServersInCluster = getOtherConfigServersInCluster(applicationRepository.configserverConfig());
-        if ( ! otherConfigServersInCluster.isEmpty())
-            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(30),
-                                                             flagSource, otherConfigServersInCluster));
-        maintainers.add(new TenantsMaintainer(applicationRepository, curator, flagSource, interval, Clock.systemUTC()));
+        if (moreThanOneConfigServer())
+            maintainers.add(new ApplicationPackageMaintainer(applicationRepository, curator, Duration.ofSeconds(30)));
+        maintainers.add(new TenantsMaintainer(applicationRepository, curator, interval, Clock.systemUTC()));
     }
 
     public void startAfterBootstrap() {
-        maintainers.add(new FileDistributionMaintainer(applicationRepository,
-                                                       curator,
-                                                       interval,
-                                                       flagSource,
-                                                       fileDirectory));
-        maintainers.add(new SessionsMaintainer(applicationRepository, curator, Duration.ofSeconds(30), flagSource));
-        maintainers.add(new ReindexingMaintainer(applicationRepository, curator, flagSource,
+        maintainers.add(new FileDistributionMaintainer(applicationRepository, curator, interval, fileDirectory));
+        maintainers.add(new SessionsMaintainer(applicationRepository, curator, Duration.ofSeconds(30)));
+        maintainers.add(new ReindexingMaintainer(applicationRepository, curator,
                                                  Duration.ofMinutes(3), convergenceChecker, Clock.systemUTC()));
     }
 
@@ -65,5 +57,9 @@ public class ConfigServerMaintenance {
     }
 
     public List<Maintainer> maintainers() { return List.copyOf(maintainers); }
+
+    private boolean moreThanOneConfigServer() {
+        return ! getOtherConfigServersInCluster(applicationRepository.configserverConfig()).isEmpty();
+    }
 
 }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/FileDistributionMaintainer.java
@@ -5,7 +5,7 @@ import com.yahoo.cloud.config.ConfigserverConfig;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.filedistribution.FileDirectory;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.flags.FlagSource;
+
 import java.time.Duration;
 
 /**
@@ -24,9 +24,8 @@ public class FileDistributionMaintainer extends ConfigServerMaintainer {
     FileDistributionMaintainer(ApplicationRepository applicationRepository,
                                Curator curator,
                                Duration interval,
-                               FlagSource flagSource,
                                FileDirectory fileDirectory) {
-        super(applicationRepository, curator, flagSource, applicationRepository.clock(), interval, false);
+        super(applicationRepository, curator, applicationRepository.flagSource(), applicationRepository.clock(), interval, false);
         ConfigserverConfig configserverConfig = applicationRepository.configserverConfig();
         this.maxUnusedFileReferenceAge = Duration.ofMinutes(configserverConfig.keepUnusedFileReferencesMinutes());
         this.fileDirectory = fileDirectory;

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ReindexingMaintainer.java
@@ -10,7 +10,6 @@ import com.yahoo.vespa.config.server.application.ApplicationReindexing.Cluster;
 import com.yahoo.vespa.config.server.application.ConfigConvergenceChecker;
 import com.yahoo.vespa.config.server.tenant.Tenant;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.flags.FlagSource;
 import com.yahoo.yolean.Exceptions;
 
 import java.time.Clock;
@@ -46,9 +45,9 @@ public class ReindexingMaintainer extends ConfigServerMaintainer {
     private final ConfigConvergenceChecker convergence;
     private final Clock clock;
 
-    public ReindexingMaintainer(ApplicationRepository applicationRepository, Curator curator, FlagSource flagSource,
+    public ReindexingMaintainer(ApplicationRepository applicationRepository, Curator curator,
                                 Duration interval, ConfigConvergenceChecker convergence, Clock clock) {
-        super(applicationRepository, curator, flagSource, clock, interval, true);
+        super(applicationRepository, curator, applicationRepository.flagSource(), clock, interval, true);
         this.convergence = convergence;
         this.clock = clock;
     }

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/SessionsMaintainer.java
@@ -3,7 +3,6 @@ package com.yahoo.vespa.config.server.maintenance;
 
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.curator.Curator;
-import com.yahoo.vespa.flags.FlagSource;
 
 import java.time.Duration;
 import java.util.logging.Level;
@@ -17,8 +16,8 @@ import java.util.logging.Level;
  */
 public class SessionsMaintainer extends ConfigServerMaintainer {
 
-    SessionsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval, FlagSource flagSource) {
-        super(applicationRepository, curator, flagSource, applicationRepository.clock(), interval, true);
+    SessionsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval) {
+        super(applicationRepository, curator, applicationRepository.flagSource(), applicationRepository.clock(), interval, true);
     }
 
     @Override

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainer.java
@@ -23,9 +23,8 @@ public class TenantsMaintainer extends ConfigServerMaintainer {
     private final Duration ttlForUnusedTenant;
     private final Clock clock;
 
-    TenantsMaintainer(ApplicationRepository applicationRepository, Curator curator, FlagSource flagSource,
-                      Duration interval, Clock clock) {
-        super(applicationRepository, curator, flagSource, applicationRepository.clock(), interval, true);
+    TenantsMaintainer(ApplicationRepository applicationRepository, Curator curator, Duration interval, Clock clock) {
+        super(applicationRepository, curator, applicationRepository.flagSource(), applicationRepository.clock(), interval, true);
         this.ttlForUnusedTenant = defaultTtlForUnusedTenant;
         this.clock = clock;
     }

--- a/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
+++ b/configserver/src/test/java/com/yahoo/vespa/config/server/maintenance/TenantsMaintainerTest.java
@@ -9,7 +9,6 @@ import com.yahoo.test.ManualClock;
 import com.yahoo.vespa.config.server.ApplicationRepository;
 import com.yahoo.vespa.config.server.session.PrepareParams;
 import com.yahoo.vespa.config.server.tenant.TenantRepository;
-import com.yahoo.vespa.flags.InMemoryFlagSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -46,7 +45,7 @@ public class TenantsMaintainerTest {
         assertNotNull(tenantRepository.getTenant(shouldNotBeDeleted));
 
         clock.advance(TenantsMaintainer.defaultTtlForUnusedTenant.plus(Duration.ofDays(1)));
-        new TenantsMaintainer(applicationRepository, tester.curator(), new InMemoryFlagSource(), Duration.ofDays(1), clock).run();
+        new TenantsMaintainer(applicationRepository, tester.curator(), Duration.ofDays(1), clock).run();
 
         // One tenant should now have been deleted
         assertNull(tenantRepository.getTenant(shouldBeDeleted));


### PR DESCRIPTION
Distribution of application packages between config servers will take shorter time (might want to reduce even further, starting with 15 seconds)