### PR TITLE
Avoid using reserved identifier naming format

### DIFF
--- a/storage/src/tests/persistence/common/filestortestfixture.cpp
+++ b/storage/src/tests/persistence/common/filestortestfixture.cpp
@@ -84,11 +84,11 @@ FileStorTestFixture::TestFileStorComponents::TestFileStorComponents(
     top.open();
 }
 
-vespalib::string _Storage("storage");
+vespalib::string _storage("storage");
 
 api::StorageMessageAddress
 FileStorTestFixture::makeSelfAddress() {
-    return api::StorageMessageAddress(&_Storage, lib::NodeType::STORAGE, 0);
+    return api::StorageMessageAddress(&_storage, lib::NodeType::STORAGE, 0);
 }
 
 void

--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -66,11 +66,11 @@ namespace storage {
 
 namespace {
 
-vespalib::string _Cluster("cluster");
-vespalib::string _Storage("storage");
-api::StorageMessageAddress _Storage2(&_Storage, lib::NodeType::STORAGE, 2);
-api::StorageMessageAddress _Storage3(&_Storage, lib::NodeType::STORAGE, 3);
-api::StorageMessageAddress _Cluster1(&_Cluster, lib::NodeType::STORAGE, 1);
+vespalib::string _cluster("cluster");
+vespalib::string _storage("storage");
+api::StorageMessageAddress _storage2(&_storage, lib::NodeType::STORAGE, 2);
+api::StorageMessageAddress _storage3(&_storage, lib::NodeType::STORAGE, 3);
+api::StorageMessageAddress _cluster1(&_cluster, lib::NodeType::STORAGE, 1);
 
 struct TestFileStorComponents;
 
@@ -94,7 +94,7 @@ struct FileStorTestBase : Test {
     const document::DocumentType* _testdoctype1;
 
     FileStorTestBase() : _node(), _waitTime(LONG_WAITTIME) {}
-    ~FileStorTestBase();
+    ~FileStorTestBase() override;
 
     void SetUp() override;
     void TearDown() override;
@@ -327,7 +327,7 @@ TEST_F(FileStorManagerTest, header_only_put) {
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 105);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -342,7 +342,7 @@ TEST_F(FileStorManagerTest, header_only_put) {
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 124);
         cmd->setUpdateTimestamp(105);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -354,7 +354,7 @@ TEST_F(FileStorManagerTest, header_only_put) {
     // Getting it
     {
         auto cmd = std::make_shared<api::GetCommand>(makeDocumentBucket(bid), doc->getId(), document::AllFields::NAME);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -389,7 +389,7 @@ TEST_F(FileStorManagerTest, put) {
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 105);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -470,7 +470,7 @@ TEST_F(FileStorManagerTest, flush) {
     std::vector<std::shared_ptr<api::StorageCommand> > _commands;
     for (uint32_t i=0; i<msgCount; ++i) {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, i+1);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         _commands.push_back(cmd);
     }
     for (uint32_t i=0; i<msgCount; ++i) {
@@ -497,7 +497,7 @@ TEST_F(FileStorManagerTest, handler_priority) {
     // Populate bucket with the given data
     for (uint32_t i = 1; i < 6; i++) {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         cmd->setPriority(i * 15);
         filestorHandler.schedule(cmd);
     }
@@ -632,7 +632,7 @@ TEST_F(FileStorManagerTest, handler_pause) {
     // Populate bucket with the given data
     for (uint32_t i = 1; i < 6; i++) {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         cmd->setPriority(i * 15);
         filestorHandler.schedule(cmd);
     }
@@ -708,7 +708,7 @@ TEST_F(FileStorManagerTest, handler_timeout) {
     // Populate bucket with the given data
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         cmd->setPriority(0);
         cmd->setTimeout(50ms);
         filestorHandler.schedule(cmd);
@@ -716,7 +716,7 @@ TEST_F(FileStorManagerTest, handler_timeout) {
 
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         cmd->setPriority(200);
         cmd->setTimeout(10000ms);
         filestorHandler.schedule(cmd);
@@ -776,7 +776,7 @@ TEST_F(FileStorManagerTest, priority) {
         document::BucketId bucket(16, factory.getBucketId(documents[i]->getId()).getRawId());
 
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), documents[i], 100 + i);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         cmd->setPriority(i * 2);
         filestorHandler.schedule(cmd);
     }
@@ -835,7 +835,7 @@ TEST_F(FileStorManagerTest, split1) {
             _node->getPersistenceProvider().createBucket(makeSpiBucket(bucket));
 
             auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), documents[i], 100 + i);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             cmd->setSourceIndex(0);
 
             filestorHandler.schedule(cmd);
@@ -850,7 +850,7 @@ TEST_F(FileStorManagerTest, split1) {
             // Delete every 5th document to have delete entries in file too
             if (i % 5 == 0) {
                 auto rcmd = std::make_shared<api::RemoveCommand>(makeDocumentBucket(bucket), documents[i]->getId(), 1000000 + 100 + i);
-                rcmd->setAddress(_Storage3);
+                rcmd->setAddress(_storage3);
                 filestorHandler.schedule(rcmd);
                 filestorHandler.flush(true);
                 ASSERT_EQ(1, top.getNumReplies());
@@ -878,7 +878,7 @@ TEST_F(FileStorManagerTest, split1) {
         for (uint32_t i=0; i<documents.size(); ++i) {
             document::BucketId bucket(17, i % 3 == 0 ? 0x10001 : 0x0100001);
             auto cmd = std::make_shared<api::GetCommand>(makeDocumentBucket(bucket), documents[i]->getId(), document::AllFields::NAME);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -910,7 +910,7 @@ TEST_F(FileStorManagerTest, split1) {
                 bucket = document::BucketId(33, factory.getBucketId(documents[i]->getId()).getRawId());
             }
             auto cmd = std::make_shared<api::GetCommand>(makeDocumentBucket(bucket), documents[i]->getId(), document::AllFields::NAME);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -956,7 +956,7 @@ TEST_F(FileStorManagerTest, split_single_group) {
             _node->getPersistenceProvider().createBucket(makeSpiBucket(bucket));
 
             auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), documents[i], 100 + i);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -982,7 +982,7 @@ TEST_F(FileStorManagerTest, split_single_group) {
         for (uint32_t i=0; i<documents.size(); ++i) {
             document::BucketId bucket(17, state ? 0x10001 : 0x00001);
             auto cmd = std::make_shared<api::GetCommand>(makeDocumentBucket(bucket), documents[i]->getId(), document::AllFields::NAME);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -1010,7 +1010,7 @@ FileStorTestBase::putDoc(DummyStorageLink& top,
     _node->getPersistenceProvider().createBucket(makeSpiBucket(target));
     auto doc = std::make_shared<Document>(*_node->getTypeRepo(), *_testdoctype1, docId);
     auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(target), doc, docNum+1);
-    cmd->setAddress(_Storage3);
+    cmd->setAddress(_storage3);
     cmd->setPriority(120);
     filestorHandler.schedule(cmd);
     filestorHandler.flush(true);
@@ -1051,7 +1051,7 @@ TEST_F(FileStorManagerTest, split_empty_target_with_remapped_ops) {
             vespalib::make_string("id:ns:testdoctype1:n=%d:1234", 0x100001));
     auto doc = std::make_shared<Document>(*_node->getTypeRepo(), *_testdoctype1, docId);
     auto putCmd = std::make_shared<api::PutCommand>(makeDocumentBucket(source), doc, 1001);
-    putCmd->setAddress(_Storage3);
+    putCmd->setAddress(_storage3);
     putCmd->setPriority(120);
 
     filestorHandler.schedule(splitCmd);
@@ -1132,7 +1132,7 @@ TEST_F(FileStorManagerTest, join) {
         for (uint32_t i=0; i<documents.size(); ++i) {
             document::BucketId bucket(17, factory.getBucketId(documents[i]->getId()).getRawId());
             auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), documents[i], 100 + i);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -1144,7 +1144,7 @@ TEST_F(FileStorManagerTest, join) {
             if ((i % 5) == 0) {
                 auto rcmd = std::make_shared<api::RemoveCommand>(
                         makeDocumentBucket(bucket), documents[i]->getId(), 1000000 + 100 + i);
-                rcmd->setAddress(_Storage3);
+                rcmd->setAddress(_storage3);
                 filestorHandler.schedule(rcmd);
                 filestorHandler.flush(true);
                 ASSERT_EQ(1, top.getNumReplies());
@@ -1173,7 +1173,7 @@ TEST_F(FileStorManagerTest, join) {
             document::BucketId bucket(16, 1);
             auto cmd = std::make_shared<api::GetCommand>(
                     makeDocumentBucket(bucket), documents[i]->getId(), document::AllFields::NAME);
-            cmd->setAddress(_Storage3);
+            cmd->setAddress(_storage3);
             filestorHandler.schedule(cmd);
             filestorHandler.flush(true);
             ASSERT_EQ(1, top.getNumReplies());
@@ -1345,7 +1345,7 @@ TEST_F(FileStorManagerTest, remove_location) {
         docid << "id:ns:testdoctype1:n=" << (i << 8) << ":foo";
         Document::SP doc(createDocument("some content", docid.str()));
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 1000 + i);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1358,7 +1358,7 @@ TEST_F(FileStorManagerTest, remove_location) {
     // Issuing remove location command
     {
         auto cmd = std::make_shared<api::RemoveLocationCommand>("id.user % 512 == 0", makeDocumentBucket(bid));
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1384,7 +1384,7 @@ TEST_F(FileStorManagerTest, delete_bucket) {
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 105);
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1400,7 +1400,7 @@ TEST_F(FileStorManagerTest, delete_bucket) {
     // Delete bucket
     {
         auto cmd = std::make_shared<api::DeleteBucketCommand>(makeDocumentBucket(bid));
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         cmd->setBucketInfo(bucketInfo);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
@@ -1426,7 +1426,7 @@ TEST_F(FileStorManagerTest, delete_bucket_rejects_outdated_bucket_info) {
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 105);
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1443,7 +1443,7 @@ TEST_F(FileStorManagerTest, delete_bucket_rejects_outdated_bucket_info) {
     {
         auto cmd = std::make_shared<api::DeleteBucketCommand>(makeDocumentBucket(bid));
         cmd->setBucketInfo(api::BucketInfo(0xf000baaa, 1, 123, 1, 456));
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1471,7 +1471,7 @@ TEST_F(FileStorManagerTest, delete_bucket_with_invalid_bucket_info){
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 105);
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1485,7 +1485,7 @@ TEST_F(FileStorManagerTest, delete_bucket_with_invalid_bucket_info){
     // Attempt to delete bucket with invalid bucketinfo
     {
         auto cmd = std::make_shared<api::DeleteBucketCommand>(makeDocumentBucket(bid));
-        cmd->setAddress(_Storage2);
+        cmd->setAddress(_storage2);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1509,7 +1509,7 @@ TEST_F(FileStorManagerTest, no_timestamps) {
     // Putting it
     {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 0);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         EXPECT_EQ(api::Timestamp(0), cmd->getTimestamp());
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
@@ -1522,7 +1522,7 @@ TEST_F(FileStorManagerTest, no_timestamps) {
     // Removing it
     {
         auto cmd = std::make_shared<api::RemoveCommand>(makeDocumentBucket(bid), doc->getId(), 0);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         EXPECT_EQ(api::Timestamp(0), cmd->getTimestamp());
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
@@ -1547,7 +1547,7 @@ TEST_F(FileStorManagerTest, equal_timestamps) {
         Document::SP doc(createDocument(
                 "some content", "id:crawler:testdoctype1:n=4000:http://www.ntnu.no/"));
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1564,7 +1564,7 @@ TEST_F(FileStorManagerTest, equal_timestamps) {
         Document::SP doc(createDocument(
                 "some content", "id:crawler:testdoctype1:n=4000:http://www.ntnu.no/"));
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1579,7 +1579,7 @@ TEST_F(FileStorManagerTest, equal_timestamps) {
         Document::SP doc(createDocument(
                 "some content", "id:crawler:testdoctype1:n=4000:http://www.ntnu.nu/"));
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), doc, 100);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1611,7 +1611,7 @@ TEST_F(FileStorManagerTest, get_iter) {
     // Putting all docs to have something to visit
     for (uint32_t i=0; i<docs.size(); ++i) {
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), docs[i], 100 + i);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1674,7 +1674,7 @@ TEST_F(FileStorManagerTest, set_bucket_active_state) {
 
     {
         auto cmd = std::make_shared<api::SetBucketStateCommand>(makeDocumentBucket(bid), api::SetBucketStateCommand::ACTIVE);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1693,7 +1693,7 @@ TEST_F(FileStorManagerTest, set_bucket_active_state) {
     {
         auto cmd = std::make_shared<api::SetBucketStateCommand>(
                 makeDocumentBucket(bid), api::SetBucketStateCommand::INACTIVE);
-        cmd->setAddress(_Storage3);
+        cmd->setAddress(_storage3);
         top.sendDown(cmd);
         top.waitForMessages(1, _waitTime);
         ASSERT_EQ(1, top.getNumReplies());
@@ -1720,7 +1720,7 @@ TEST_F(FileStorManagerTest, notify_owner_distributor_on_outdated_set_bucket_stat
     createBucket(bid);
 
     auto cmd = std::make_shared<api::SetBucketStateCommand>(makeDocumentBucket(bid), api::SetBucketStateCommand::ACTIVE);
-    cmd->setAddress(_Cluster1);
+    cmd->setAddress(_cluster1);
     cmd->setSourceIndex(0);
 
     top.sendDown(cmd);
@@ -1755,7 +1755,7 @@ TEST_F(FileStorManagerTest, GetBucketDiff_implicitly_creates_bucket) {
     std::vector<api::MergeBucketCommand::Node> nodes = {1, 0};
 
     auto cmd = std::make_shared<api::GetBucketDiffCommand>(makeDocumentBucket(bid), nodes, Timestamp(1000));
-    cmd->setAddress(_Cluster1);
+    cmd->setAddress(_cluster1);
     cmd->setSourceIndex(0);
     top.sendDown(cmd);
 
@@ -1779,7 +1779,7 @@ TEST_F(FileStorManagerTest, merge_bucket_implicitly_creates_bucket) {
     std::vector<api::MergeBucketCommand::Node> nodes = {1, 2};
 
     auto cmd = std::make_shared<api::MergeBucketCommand>(makeDocumentBucket(bid), nodes, Timestamp(1000));
-    cmd->setAddress(_Cluster1);
+    cmd->setAddress(_cluster1);
     cmd->setSourceIndex(0);
     top.sendDown(cmd);
 
@@ -1800,7 +1800,7 @@ TEST_F(FileStorManagerTest, newly_created_bucket_is_ready) {
     document::BucketId bid(16, 4000);
 
     auto cmd = std::make_shared<api::CreateBucketCommand>(makeDocumentBucket(bid));
-    cmd->setAddress(_Cluster1);
+    cmd->setAddress(_cluster1);
     cmd->setSourceIndex(0);
     top.sendDown(cmd);
 
@@ -1821,7 +1821,7 @@ TEST_F(FileStorManagerTest, create_bucket_sets_active_flag_in_database_and_reply
 
     document::BucketId bid(16, 4000);
     auto cmd = std::make_shared<api::CreateBucketCommand>(makeDocumentBucket(bid));
-    cmd->setAddress(_Cluster1);
+    cmd->setAddress(_cluster1);
     cmd->setSourceIndex(0);
     cmd->setActive(true);
     c.top.sendDown(cmd);
@@ -1840,7 +1840,7 @@ TEST_F(FileStorManagerTest, create_bucket_sets_active_flag_in_database_and_reply
 template <typename Metric>
 void FileStorTestBase::assert_request_size_set(TestFileStorComponents& c, std::shared_ptr<api::StorageMessage> cmd, const Metric& metric) {
     cmd->setApproxByteSize(54321);
-    cmd->setAddress(_Storage3);
+    cmd->setAddress(_storage3);
     c.top.sendDown(cmd);
     c.top.waitForMessages(1, _waitTime);
     EXPECT_EQ(static_cast<int64_t>(cmd->getApproxByteSize()), metric.request_size.getLast());
@@ -1897,7 +1897,7 @@ TEST_F(FileStorManagerTest, test_and_set_condition_mismatch_not_counted_as_failu
     createBucket(bucket);
     auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bucket), std::move(doc), api::Timestamp(12345));
     cmd->setCondition(TestAndSetCondition("not testdoctype1"));
-    cmd->setAddress(_Storage3);
+    cmd->setAddress(_storage3);
     c.top.sendDown(cmd);
 
     api::PutReply* reply;

--- a/storage/src/tests/visiting/visitormanagertest.cpp
+++ b/storage/src/tests/visiting/visitormanagertest.cpp
@@ -37,8 +37,8 @@ namespace storage {
 namespace {
 
 using msg_ptr_vector = std::vector<api::StorageMessage::SP>;
-vespalib::string _Storage("storage");
-api::StorageMessageAddress _Address(&_Storage, lib::NodeType::STORAGE, 0);
+vespalib::string _storage("storage");
+api::StorageMessageAddress _address(&_storage, lib::NodeType::STORAGE, 0);
 }
 
 struct VisitorManagerTest : Test {
@@ -156,7 +156,7 @@ VisitorManagerTest::initializeTest(bool defer_manager_thread_start)
         document::BucketId bid(16, i);
 
         auto cmd = std::make_shared<api::CreateBucketCommand>(makeDocumentBucket(bid));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setSourceIndex(0);
         _top->sendDown(cmd);
         _top->waitForMessages(1, 60);
@@ -171,7 +171,7 @@ VisitorManagerTest::initializeTest(bool defer_manager_thread_start)
         document::BucketId bid(16, i);
 
         auto cmd = std::make_shared<api::PutCommand>(makeDocumentBucket(bid), _documents[i], i+1);
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         _top->sendDown(cmd);
         _top->waitForMessages(1, 60);
         const msg_ptr_vector replies = _top->getRepliesOnce();
@@ -191,7 +191,7 @@ VisitorManagerTest::addSomeRemoves(bool removeAll)
         document::BucketId bid(16, i % 10);
         auto cmd = std::make_shared<api::RemoveCommand>(makeDocumentBucket(bid), _documents[i]->getId(),
                                                         vespalib::count_us(clock.getSystemTime().time_since_epoch()) + docCount + i + 1);
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         _top->sendDown(cmd);
         _top->waitForMessages(1, 60);
         const msg_ptr_vector replies = _top->getRepliesOnce();
@@ -345,7 +345,7 @@ TEST_F(VisitorManagerTest, normal_usage) {
     ASSERT_NO_FATAL_FAILURE(initializeTest());
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setControlDestination("foo/bar");
     _top->sendDown(cmd);
     std::vector<document::Document::SP > docs;
@@ -365,7 +365,7 @@ TEST_F(VisitorManagerTest, resending) {
     ASSERT_NO_FATAL_FAILURE(initializeTest());
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setControlDestination("foo/bar");
     _top->sendDown(cmd);
     std::vector<document::Document::SP > docs;
@@ -412,7 +412,7 @@ TEST_F(VisitorManagerTest, visit_empty_bucket) {
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
 
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     _top->sendDown(cmd);
 
     // All data has been replied to, expecting to get a create visitor reply
@@ -425,7 +425,7 @@ TEST_F(VisitorManagerTest, multi_bucket_visit) {
     for (uint32_t i=0; i<10; ++i) {
         cmd->addBucketToBeVisited(document::BucketId(16, i));
     }
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setDataDestination("fooclient.0");
     _top->sendDown(cmd);
     std::vector<document::Document::SP> docs;
@@ -444,7 +444,7 @@ TEST_F(VisitorManagerTest, no_buckets) {
     ASSERT_NO_FATAL_FAILURE(initializeTest());
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
 
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     _top->sendDown(cmd);
 
     // Should get one reply; a CreateVisitorReply with error since no
@@ -463,7 +463,7 @@ TEST_F(VisitorManagerTest, visit_puts_and_removes) {
     ASSERT_NO_FATAL_FAILURE(initializeTest());
     addSomeRemoves();
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setVisitRemoves();
     for (uint32_t i=0; i<10; ++i) {
         cmd->addBucketToBeVisited(document::BucketId(16, i));
@@ -491,7 +491,7 @@ TEST_F(VisitorManagerTest, visit_with_timeframe_and_selection) {
     for (uint32_t i=0; i<10; ++i) {
         cmd->addBucketToBeVisited(document::BucketId(16, i));
     }
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     _top->sendDown(cmd);
     std::vector<document::Document::SP> docs;
     std::vector<document::DocumentId> docIds;
@@ -520,7 +520,7 @@ TEST_F(VisitorManagerTest, visit_with_timeframe_and_bogus_selection) {
     for (uint32_t i=0; i<10; ++i) {
         cmd->addBucketToBeVisited(document::BucketId(16, i));
     }
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
 
     _top->sendDown(cmd);
     _top->waitForMessages(1, 60);
@@ -556,7 +556,7 @@ TEST_F(VisitorManagerTest, visitor_callbacks) {
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "TestVisitor", "testvis", "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
     cmd->addBucketToBeVisited(document::BucketId(16, 5));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     _top->sendDown(cmd);
 
     // Wait until we have started the visitor
@@ -600,7 +600,7 @@ TEST_F(VisitorManagerTest, visitor_cleanup) {
         ost << "testvis" << i;
         auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "InvalidVisitor", ost.str(), "");
         cmd->addBucketToBeVisited(document::BucketId(16, 3));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setQueueTimeout(0ms);
         _top->sendDown(cmd);
         _top->waitForMessages(i+1, 60);
@@ -612,7 +612,7 @@ TEST_F(VisitorManagerTest, visitor_cleanup) {
         ost << "testvis" << (i + 10);
         auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", ost.str(), "");
         cmd->addBucketToBeVisited(document::BucketId(16, 3));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setQueueTimeout(0ms);
         _top->sendDown(cmd);
     }
@@ -681,7 +681,7 @@ TEST_F(VisitorManagerTest, visitor_cleanup) {
         ost << "testvis" << (i + 24);
         auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", ost.str(), "");
         cmd->addBucketToBeVisited(document::BucketId(16, 3));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setQueueTimeout(0ms);
         _top->sendDown(cmd);
     }
@@ -711,7 +711,7 @@ TEST_F(VisitorManagerTest, abort_on_failed_visitor_info) {
     {
         auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
         cmd->addBucketToBeVisited(document::BucketId(16, 3));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setQueueTimeout(0ms);
         _top->sendDown(cmd);
     }
@@ -745,7 +745,7 @@ TEST_F(VisitorManagerTest, abort_on_field_path_error) {
     auto cmd = std::make_shared<api::CreateVisitorCommand>(
             makeBucketSpace(), "DumpVisitor", "testvis", "testdoctype1.headerval{bogus} == 1234");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setQueueTimeout(0ms);
     _top->sendDown(cmd);
 
@@ -759,7 +759,7 @@ TEST_F(VisitorManagerTest, visitor_queue_timeout) {
     {
         auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
         cmd->addBucketToBeVisited(document::BucketId(16, 3));
-        cmd->setAddress(_Address);
+        cmd->setAddress(_address);
         cmd->setQueueTimeout(1ms);
         cmd->setTimeout(100 * 1000 * 1000ms);
         // The manager thread isn't running yet so the visitor stays on the queue
@@ -785,7 +785,7 @@ TEST_F(VisitorManagerTest, visitor_processing_timeout) {
 
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", "testvis", "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setQueueTimeout(0ms);
     cmd->setTimeout(100ms);
     _top->sendDown(cmd);
@@ -809,7 +809,7 @@ sendCreateVisitor(vespalib::duration timeout, DummyStorageLink& top, uint8_t pri
     ost << "testvis" << ++nextVisitor;
     auto cmd = std::make_shared<api::CreateVisitorCommand>(makeBucketSpace(), "DumpVisitor", ost.str(), "");
     cmd->addBucketToBeVisited(document::BucketId(16, 3));
-    cmd->setAddress(_Address);
+    cmd->setAddress(_address);
     cmd->setQueueTimeout(timeout);
     cmd->setPriority(priority);
     top.sendDown(cmd);

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -170,7 +170,7 @@ dynamic_throttle_params_from_config(const StorFilestorConfig& config, uint32_t n
 #define TLS_LINKAGE __attribute__((visibility("hidden"), tls_model("local-exec")))
 #endif
 
-thread_local PersistenceHandler * _G_threadLocalHandler TLS_LINKAGE = nullptr;
+thread_local PersistenceHandler * _g_threadLocalHandler TLS_LINKAGE = nullptr;
 
 size_t
 computeAllPossibleHandlerThreads(const vespa::config::content::StorFilestorConfig & cfg) {
@@ -198,10 +198,10 @@ FileStorManager::createRegisteredHandler(const ServiceLayerComponent & component
 
 PersistenceHandler &
 FileStorManager::getThreadLocalHandler() {
-    if (_G_threadLocalHandler == nullptr) {
-        _G_threadLocalHandler = & createRegisteredHandler(_component);
+    if (_g_threadLocalHandler == nullptr) {
+        _g_threadLocalHandler = & createRegisteredHandler(_component);
     }
-    return *_G_threadLocalHandler;
+    return *_g_threadLocalHandler;
 }
 
 void

--- a/storage/src/vespa/storageapi/messageapi/storagemessage.cpp
+++ b/storage/src/vespa/storageapi/messageapi/storagemessage.cpp
@@ -13,7 +13,7 @@ namespace storage::api {
 
 namespace {
 
-std::atomic<uint64_t> _G_lastMsgId(1000);
+std::atomic<uint64_t> _g_lastMsgId(1000);
 
 }
 
@@ -231,7 +231,7 @@ TransportContext::~TransportContext() = default;
 StorageMessage::Id
 StorageMessage::generateMsgId() noexcept
 {
-    return _G_lastMsgId.fetch_add(1, std::memory_order_relaxed);
+    return _g_lastMsgId.fetch_add(1, std::memory_order_relaxed);
 }
 
 StorageMessage::StorageMessage(const MessageType& type, Id internal_id, Id originator_id) noexcept


### PR DESCRIPTION
@baldersheim please review. No functional changes.

Identifiers of the form `_Uppercased` are considered reserved by the standard. Not likely to cause ambiguity in practice, but it's preferable to stay on the good side of the standard-gods.

