### PR TITLE
Dynamic provisioning improvements

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ProvisionedExpirer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/ProvisionedExpirer.java
@@ -38,10 +38,9 @@ public class ProvisionedExpirer extends Expirer {
         for (Node expiredNode : expired) {
             if (expiredNode.type() != NodeType.host)
                 continue;
-            nodeRepository().nodes().parkRecursively(expiredNode.hostname(), Agent.ProvisionedExpirer, "Node is stuck in provisioned");
-            if (MAXIMUM_ALLOWED_EXPIRED_HOSTS < ++previouslyExpired) {
-                nodeRepository.nodes().deprovision(expiredNode.hostname(), Agent.ProvisionedExpirer, nodeRepository.clock().instant());
-            }
+            boolean forceDeprovision = MAXIMUM_ALLOWED_EXPIRED_HOSTS < ++previouslyExpired;
+            nodeRepository().nodes().parkRecursively(expiredNode.hostname(), Agent.ProvisionedExpirer,
+                    forceDeprovision, "Node is stuck in provisioned");
         }
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/Nodes.java
@@ -403,8 +403,8 @@ public class Nodes {
      *
      * @return List of all the parked nodes in their new state
      */
-    public List<Node> parkRecursively(String hostname, Agent agent, String reason) {
-        return moveRecursively(hostname, Node.State.parked, agent, Optional.of(reason));
+    public List<Node> parkRecursively(String hostname, Agent agent, boolean forceDeprovision, String reason) {
+        return moveRecursively(hostname, Node.State.parked, agent, forceDeprovision, Optional.of(reason));
     }
 
     /**
@@ -433,12 +433,12 @@ public class Nodes {
         }
     }
 
-    private List<Node> moveRecursively(String hostname, Node.State toState, Agent agent, Optional<String> reason) {
+    private List<Node> moveRecursively(String hostname, Node.State toState, Agent agent, boolean forceDeprovision, Optional<String> reason) {
         try (RecursiveNodeMutexes locked = lockAndGetRecursively(hostname, Optional.empty())) {
             List<Node> moved = new ArrayList<>();
             NestedTransaction transaction = new NestedTransaction();
             for (NodeMutex node : locked.nodes().nodes())
-                moved.add(move(node.node().hostname(), toState, agent, false, reason, transaction));
+                moved.add(move(node.node().hostname(), toState, agent, forceDeprovision, reason, transaction));
             transaction.commit();
             return moved;
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -50,8 +50,10 @@ public interface HostProvisioner {
      *                        written to ZK immediately in case the config server goes down while waiting
      *                        for the provisioning to finish.
      * @throws NodeAllocationException if the cloud provider cannot satisfy the request
+     * @return a runnable that waits for the provisioning request to finish. It can be run without holding any locks,
+     * but may fail with an exception that should be propagated to the user initiating prepare()
      */
-    void provisionHosts(HostProvisionRequest request, Predicate<NodeResources> realHostResourcesWithinLimits, Consumer<List<ProvisionedHost>> whenProvisioned) throws NodeAllocationException;
+    Runnable provisionHosts(HostProvisionRequest request, Predicate<NodeResources> realHostResourcesWithinLimits, Consumer<List<ProvisionedHost>> whenProvisioned) throws NodeAllocationException;
 
     /**
      * Continue provisioning of given list of Nodes.

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/Preparer.java
@@ -22,6 +22,7 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.IP;
 import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner.HostSharing;
+import com.yahoo.yolean.Exceptions;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -156,7 +157,8 @@ public class Preparer {
                     // Mark the nodes that were written to ZK in the consumer for deprovisioning. While these hosts do
                     // not exist, we cannot remove them from ZK here because other nodes may already have been
                     // allocated on them, so let HostDeprovisioner deal with it
-                    hosts.forEach(host -> nodeRepository.nodes().deprovision(host.hostname(), Agent.system, nodeRepository.clock().instant()));
+                    hosts.forEach(host -> nodeRepository.nodes().parkRecursively(host.hostname(), Agent.system, true,
+                            "Failed to provision: " + Exceptions.toMessageString(e)));
                     throw e;
                 }
             } else if (allocation.hostDeficit().isPresent() && requested.canFail() &&

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesV2ApiHandler.java
@@ -153,7 +153,7 @@ public class NodesV2ApiHandler extends ThreadedHttpRequestHandler {
                                        " and marked " + hostnamesAsString(failedOrMarkedNodes.failing().asList()) + " as wantToFail");
         }
         else if (path.matches("/nodes/v2/state/parked/{hostname}")) {
-            List<Node> parkedNodes = nodeRepository.nodes().parkRecursively(path.get("hostname"), agent(request), "Parked through the nodes/v2 API");
+            List<Node> parkedNodes = nodeRepository.nodes().parkRecursively(path.get("hostname"), agent(request), false, "Parked through the nodes/v2 API");
             return new MessageResponse("Moved " + hostnamesAsString(parkedNodes) + " to " + Node.State.parked);
         }
         else if (path.matches("/nodes/v2/state/dirty/{hostname}")) {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -73,7 +73,7 @@ public class MockHostProvisioner implements HostProvisioner {
     }
 
     @Override
-    public void provisionHosts(HostProvisionRequest request, Predicate<NodeResources> realHostResourcesWithinLimits, Consumer<List<ProvisionedHost>> whenProvisioned) throws NodeAllocationException {
+    public Runnable provisionHosts(HostProvisionRequest request, Predicate<NodeResources> realHostResourcesWithinLimits, Consumer<List<ProvisionedHost>> whenProvisioned) throws NodeAllocationException {
         if (behaviour(Behaviour.failProvisionRequest)) throw new NodeAllocationException("No capacity for provision request", true);
         Flavor hostFlavor = hostFlavors.get(request.clusterType().orElse(ClusterSpec.Type.content));
         if (hostFlavor == null)
@@ -101,6 +101,7 @@ public class MockHostProvisioner implements HostProvisioner {
         }
         provisionedHosts.addAll(hosts);
         whenProvisioned.accept(hosts);
+        return () -> {};
     }
 
     @Override

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/HostResumeProvisionerTest.java
@@ -98,7 +98,11 @@ public class HostResumeProvisionerTest {
                 Stream.of(host, node).map(n -> n.ipConfig().primary()).allMatch(List::isEmpty));
 
         hostResumeProvisioner.maintain();
-        assertEquals(Set.of("host100", "host100-1"), tester.nodeRepository().nodes().list(Node.State.failed).hostnames());
+        assertEquals(Set.of(), tester.nodeRepository().nodes().list(Node.State.parked).deprovisioning().hostnames());
+        tester.clock().advance(Duration.ofSeconds(60));
+
+        hostResumeProvisioner.maintain();
+        assertEquals(Set.of("host100", "host100-1"), tester.nodeRepository().nodes().list(Node.State.parked).deprovisioning().hostnames());
     }
 
     private void deployApplication() {


### PR DESCRIPTION
Must be merged with internal PR.

Includes 3 minor fixes/improvements to provisioning in dynamically provisioned zones split into 3 commits:
1. Take unallocated lock in HCM before starting to provision. Fixes VESPA-27835: We may fail to acquire the lock after the nodes are provisioned and therefore fail to write the new nodes to ZK. These nodes are then forever lost track of.
2. In #24546 we started writing the nodes to ZK as soon as we have enough data to create the `Node` instance, but we still held the locks while waiting for the provisioning request to finish. The second commit does away with that and instead we wait for the provision request after having released the locks. This is only relevant in GCP. 
Waiting is needed to be able to propagate provisioning exception from the cloud provider (e.g. out of capacity, no matching flavor, etc.) to the user deploying new application. Note that no cleanup is done in such case in `Preparer`: We no longer hold the locks, and we may fail to acquire them at this point. Instead, the cleanup will be done by `HostResumeProvisioner` as the `HostProvisioner::provisioner` should throw a `FatalProvisioningException` for such hosts.
4. When a provisioning fail, we should get rid of the nodes faster. Today this happens by setting `wantToDeprovision` on the host & the node, but deprovisioning only happens when the host has wTD set and all the children are in `failed` or `parked` with wTD. The only way for a `reserved` node to end up in `parked` or `failed` automatically is via `ReservedExpirer`, which will kick in 40 minutes after the last time the node was attempted to be used in a `prepare()`. Now we will move both the host and the node straight to `parked` with wTD.