### PR TITLE
- Reduce peak memory usage for unit tests from 5G to 0.5G.

### DIFF
--- a/searchlib/src/tests/tensor/dense_tensor_store/dense_tensor_store_test.cpp
+++ b/searchlib/src/tests/tensor/dense_tensor_store/dense_tensor_store_test.cpp
@@ -1,8 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <vespa/log/log.h>
-LOG_SETUP("dense_tensor_store_test");
+
 #include <vespa/vespalib/testkit/test_kit.h>
-#include <vespa/vespalib/util/memory_allocator.h>
 #include <vespa/searchlib/tensor/dense_tensor_store.h>
 #include <vespa/eval/eval/simple_value.h>
 #include <vespa/eval/eval/tensor_spec.h>
@@ -10,6 +8,9 @@ LOG_SETUP("dense_tensor_store_test");
 #include <vespa/eval/eval/value_type.h>
 #include <vespa/eval/eval/test/value_compare.h>
 #include <vespa/vespalib/util/size_literals.h>
+
+#include <vespa/log/log.h>
+LOG_SETUP("dense_tensor_store_test");
 
 using search::tensor::DenseTensorStore;
 using vespalib::eval::SimpleValue;
@@ -28,7 +29,7 @@ makeTensor(const TensorSpec &spec)
 struct Fixture
 {
     DenseTensorStore store;
-    Fixture(const vespalib::string &tensorType)
+    explicit Fixture(const vespalib::string &tensorType)
         : store(ValueType::from_spec(tensorType), {})
     {}
     void assertSetAndGetTensor(const TensorSpec &tensorSpec) {
@@ -38,14 +39,14 @@ struct Fixture
         EXPECT_EQUAL(*expTensor, *actTensor);
         assertTensorView(ref, *expTensor);
     }
-    void assertEmptyTensor(const TensorSpec &tensorSpec) {
+    void assertEmptyTensor(const TensorSpec &tensorSpec) const {
         Value::UP expTensor = makeTensor(tensorSpec);
         EntryRef ref;
         Value::UP actTensor = store.get_tensor(ref);
         EXPECT_TRUE(actTensor.get() == nullptr);
         assertTensorView(ref, *expTensor);
     }
-    void assertTensorView(EntryRef ref, const Value &expTensor) {
+    void assertTensorView(EntryRef ref, const Value &expTensor) const {
         auto cells = store.get_typed_cells(ref);
         vespalib::eval::DenseValueView actTensor(store.type(), cells);
         EXPECT_EQUAL(expTensor, actTensor);
@@ -101,6 +102,7 @@ assert_max_buffer_entries(const vespalib::string& tensor_type, uint32_t exp_entr
 TEST("require that max entries is calculated correctly")
 {
     TEST_DO(assert_max_buffer_entries("tensor(x[1])", 1_Mi));
+
     TEST_DO(assert_max_buffer_entries("tensor(x[32])", 1_Mi));
     TEST_DO(assert_max_buffer_entries("tensor(x[64])", 512_Ki));
     TEST_DO(assert_max_buffer_entries("tensor(x[1024])", 32_Ki));
@@ -109,7 +111,6 @@ TEST("require that max entries is calculated correctly")
     TEST_DO(assert_max_buffer_entries("tensor(x[33554428])", 2));
     TEST_DO(assert_max_buffer_entries("tensor(x[33554429])", 1));
     TEST_DO(assert_max_buffer_entries("tensor(x[33554432])", 1));
-    TEST_DO(assert_max_buffer_entries("tensor(x[303554432])", 1));
 }
 
 TEST_MAIN() { TEST_RUN_ALL(); }


### PR DESCRIPTION
@geirst or @toregge PR