### PR TITLE
Revert "validate for array/wset attributes"

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -1265,34 +1265,14 @@ public class RankProfile implements Cloneable {
         return Optional.empty();  // if this context does not contain this input
     }
 
-    private static class AttributeErrorType extends TensorType {
-        private final String attr;
-        private final Attribute.CollectionType collType;
-        AttributeErrorType(String attr, Attribute.CollectionType collType) {
-            super(TensorType.Value.INT8, List.of());
-            this.attr = attr;
-            this.collType = collType;
-        }
-        private void doThrow() {
-            throw new IllegalArgumentException("Cannot use attribute(" + attr +") " + collType + " as ranking expression input");
-        }
-        @Override public TensorType.Value valueType() { doThrow(); return null; }
-        @Override public int rank() { doThrow(); return 0; }
-        @Override public List<TensorType.Dimension> dimensions() { doThrow(); return null; }
-    }
-
     private void addAttributeFeatureTypes(ImmutableSDField field, Map<Reference, TensorType> featureTypes) {
         Attribute attribute = field.getAttribute();
         field.getAttributes().forEach((k, a) -> {
             String name = k;
             if (attribute == a)                              // this attribute should take the fields name
                 name = field.getName();                      // switch to that - it is separate for imported fields
-            if (a.getCollectionType().equals(Attribute.CollectionType.SINGLE)) {
-                featureTypes.put(FeatureNames.asAttributeFeature(name),
-                                 a.tensorType().orElse(TensorType.empty));
-            } else {
-                featureTypes.put(FeatureNames.asAttributeFeature(name), new AttributeErrorType(name, a.getCollectionType()));
-            }
+            featureTypes.put(FeatureNames.asAttributeFeature(name),
+                            a.tensorType().orElse(TensorType.empty));
         });
     }
 

--- a/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/TensorTransformTestCase.java
@@ -19,14 +19,12 @@ import com.yahoo.schema.AbstractSchemaTestCase;
 import com.yahoo.schema.derived.AttributeFields;
 import com.yahoo.schema.derived.RawRankProfile;
 import com.yahoo.schema.parser.ParseException;
-import com.yahoo.yolean.Exceptions;
 import ai.vespa.rankingexpression.importer.configmodelview.ImportedMlModels;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TensorTransformTestCase extends AbstractSchemaTestCase {
@@ -37,6 +35,8 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
                 "max(1.0,2.0)");
         assertTransformedExpression("min(attribute(double_field),x)",
                 "min(attribute(double_field),x)");
+        assertTransformedExpression("max(attribute(double_field),attribute(double_array_field))",
+                "max(attribute(double_field),attribute(double_array_field))");
         assertTransformedExpression("min(attribute(tensor_field_1),attribute(double_field))",
                 "min(attribute(tensor_field_1),attribute(double_field))");
         assertTransformedExpression("reduce(max(attribute(tensor_field_1),attribute(tensor_field_2)),sum)",
@@ -51,30 +51,6 @@ public class TensorTransformTestCase extends AbstractSchemaTestCase {
                 "max(query(q),1.0)");
         assertTransformedExpression("max(query(n),1.0)",
                 "max(query(n),1.0)");
-    }
-
-    @Test
-    void requireThatUsingArrayFails() throws ParseException {
-        Throwable e = assertThrows(IllegalArgumentException.class, () -> {
-                buildSearch("max(attribute(double_field),attribute(double_array_field))");
-            });
-        String msg = Exceptions.toMessageString(e);
-        assertEquals("In schema 'test', rank profile 'test':" +
-                     " The function 'testexpression' is invalid: attribute(double_array_field) is invalid:" +
-                     " Cannot use attribute(double_array_field) collectiontype: ARRAY as ranking expression input",
-                     msg);
-    }
-
-    @Test
-    void requireThatUsingWsetFails() throws ParseException {
-        Throwable e = assertThrows(IllegalArgumentException.class, () -> {
-                buildSearch("map(attribute(weightedset_field), f(x)(x+3))");
-            });
-        String msg = Exceptions.toMessageString(e);
-        assertEquals("In schema 'test', rank profile 'test':" +
-                     " The function 'testexpression' is invalid: attribute(weightedset_field) is invalid:" +
-                     " Cannot use attribute(weightedset_field) collectiontype: WEIGHTEDSET as ranking expression input",
-                     msg);
     }
 
     @Test


### PR DESCRIPTION
Reverts vespa-engine/vespa#29178

Breaks a unit test.

And: Won't this break upgrade of infrastructure for apps that use what we don't allow anymore?