### PR TITLE
Move `HwInfo` from searchcore to vespalib

### DIFF
--- a/searchcore/src/apps/tests/persistenceconformance_test.cpp
+++ b/searchcore/src/apps/tests/persistenceconformance_test.cpp
@@ -4,7 +4,6 @@
 #include <vespa/persistence/conformancetest/conformancetest.h>
 #include <vespa/searchcore/proton/test/dummydbowner.h>
 #include <vespa/searchcore/proton/common/alloc_config.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/matching/querylimiter.h>
 #include <vespa/searchcore/proton/metrics/metricswireservice.h>
 #include <vespa/searchcore/proton/persistenceengine/ipersistenceengineowner.h>
@@ -34,6 +33,7 @@
 #include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/document/test/make_bucket_space.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <filesystem>
 
 #include <vespa/log/log.h>
@@ -60,6 +60,7 @@ using search::index::Schema;
 using search::transactionlog::TransLogServer;
 using storage::spi::ConformanceTest;
 using storage::spi::PersistenceProvider;
+using vespalib::HwInfo;
 
 using PersistenceFactory = ConformanceTest::PersistenceFactory;
 using DocumenttypesConfigSP = DocumentDBConfig::DocumenttypesConfigSP;

--- a/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_manager/attribute_manager_test.cpp
@@ -8,7 +8,6 @@
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 #include <vespa/searchcore/proton/attribute/sequential_attributes_initializer.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/documentmetastore/documentmetastorecontext.h>
 #include <vespa/searchcore/proton/documentmetastore/documentmetastore.h>
 #include <vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.h>
@@ -36,6 +35,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <vespa/config-attributes.h>
@@ -71,6 +71,7 @@ using search::test::DirectoryHandler;
 using vespa::config::search::AttributesConfig;
 using vespa::config::search::AttributesConfigBuilder;
 using vespalib::eval::ValueType;
+using vespalib::HwInfo;
 
 using AVConfig = search::attribute::Config;
 using AttrSpecList = proton::AttributeCollectionSpec::AttributeList;

--- a/searchcore/src/tests/proton/attribute/attribute_populator/attribute_populator_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_populator/attribute_populator_test.cpp
@@ -3,7 +3,6 @@
 #include <vespa/searchcore/proton/attribute/attribute_populator.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/searchcore/proton/attribute/attributemanager.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/test/test.h>
 #include <vespa/searchlib/attribute/interlock.h>
 #include <vespa/searchlib/index/dummyfileheadercontext.h>
@@ -17,6 +16,7 @@
 #include <vespa/vespalib/testkit/testapp.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 #include <vespa/log/log.h>
@@ -72,7 +72,7 @@ struct Fixture
     DummyFileHeaderContext _fileHeader;
     ForegroundTaskExecutor _attributeFieldWriter;
     ForegroundThreadExecutor _shared;
-    HwInfo                 _hwInfo;
+    vespalib::HwInfo         _hwInfo;
     AttributeManager::SP _mgr;
     std::unique_ptr<AttributePopulator> _pop;
     DocContext _ctx;

--- a/searchcore/src/tests/proton/attribute/attribute_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attribute_test.cpp
@@ -6,7 +6,6 @@
 #include <vespa/searchcore/proton/attribute/filter_attribute_manager.h>
 #include <vespa/searchcore/proton/attribute/ifieldupdatecallback.h>
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/test/attribute_utils.h>
 #include <vespa/searchcore/proton/test/mock_attribute_manager.h>
 #include <vespa/searchcorespi/flush/iflushtarget.h>
@@ -55,6 +54,7 @@
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
 #include <vespa/vespalib/util/gate.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
 #include <vespa/vespalib/util/sequencedtaskexecutorobserver.h>
 
@@ -100,6 +100,7 @@ using vespalib::eval::Value;
 using vespalib::eval::ValueType;
 using vespalib::GateCallback;
 using vespalib::IDestructorCallback;
+using vespalib::HwInfo;
 
 using AVBasicType = search::attribute::BasicType;
 using AVCollectionType = search::attribute::CollectionType;

--- a/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributeflush_test.cpp
@@ -39,6 +39,7 @@ using AVCollectionType = search::attribute::CollectionType;
 using searchcorespi::IFlushTarget;
 using searchcorespi::FlushStats;
 using std::chrono::duration_cast;
+using vespalib::HwInfo;
 using namespace std::literals;
 
 using GateSP = std::shared_ptr<Gate>;

--- a/searchcore/src/tests/proton/attribute/attributes_state_explorer/attributes_state_explorer_test.cpp
+++ b/searchcore/src/tests/proton/attribute/attributes_state_explorer/attributes_state_explorer_test.cpp
@@ -2,7 +2,6 @@
 
 #include <vespa/searchcore/proton/attribute/attribute_manager_explorer.h>
 #include <vespa/searchcore/proton/attribute/attributemanager.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/test/attribute_utils.h>
 #include <vespa/searchcore/proton/test/attribute_vectors.h>
 #include <vespa/searchlib/attribute/interlock.h>
@@ -12,6 +11,7 @@
 #include <vespa/vespalib/data/slime/slime.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/sequencedtaskexecutor.h>
 
 #include <vespa/log/log.h>
@@ -28,6 +28,7 @@ using vespalib::Slime;
 using search::TuneFileAttributes;
 using search::index::DummyFileHeaderContext;
 using search::test::DirectoryHandler;
+using vespalib::HwInfo;
 
 const vespalib::string TEST_DIR = "test_output";
 

--- a/searchcore/src/tests/proton/docsummary/docsummary_test.cpp
+++ b/searchcore/src/tests/proton/docsummary/docsummary_test.cpp
@@ -98,6 +98,7 @@ using vespalib::eval::SimpleValue;
 using vespalib::eval::TensorSpec;
 using vespalib::eval::ValueType;
 using vespalib::GateCallback;
+using vespalib::HwInfo;
 using vespalib::Slime;
 using vespalib::geo::ZCurve;
 using namespace vespalib::slime;

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -6,7 +6,6 @@
 #include <vespa/searchcore/proton/attribute/imported_attributes_repo.h>
 #include <vespa/searchcore/proton/bucketdb/bucketdbhandler.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/feedoperation/operations.h>
 #include <vespa/searchcore/proton/initializer/task_runner.h>
 #include <vespa/searchcore/proton/matching/querylimiter.h>
@@ -43,6 +42,7 @@
 #include <vespa/vespalib/testkit/test_kit.h>
 #include <vespa/vespalib/util/destructor_callbacks.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/lambdatask.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/testclock.h>
@@ -74,6 +74,7 @@ using storage::spi::Timestamp;
 using vespa::config::search::core::ProtonConfig;
 using vespa::config::content::core::BucketspacesConfig;
 using vespalib::datastore::CompactionStrategy;
+using vespalib::HwInfo;
 using proton::index::IndexConfig;
 
 using StoreOnlyConfig = StoreOnlyDocSubDB::Config;

--- a/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/documentdb_test.cpp
@@ -56,6 +56,7 @@ using searchcorespi::IFlushTarget;
 using searchcorespi::index::IndexFlushTarget;
 using vespa::config::search::core::ProtonConfig;
 using vespa::config::content::core::BucketspacesConfig;
+using vespalib::HwInfo;
 using vespalib::Slime;
 
 namespace {

--- a/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/fileconfigmanager/fileconfigmanager_test.cpp
@@ -37,6 +37,7 @@ using search::fef::RankingExpressions;
 using DBCM = DocumentDBConfigHelper;
 using DocumenttypesConfigSP = DocumentDBConfig::DocumenttypesConfigSP;
 using vespalib::nbostream;
+using vespalib::HwInfo;
 
 vespalib::string myId("myconfigid");
 

--- a/searchcore/src/tests/proton/documentdb/threading_service_config/threading_service_config_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/threading_service_config/threading_service_config_test.cpp
@@ -1,9 +1,9 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/config-proton.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/server/threading_service_config.h>
 #include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("threading_service_config_test");

--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -6,7 +6,6 @@
 #include <vespa/searchcore/proton/bucketdb/checksumaggregators.h>
 #include <vespa/searchcore/proton/bucketdb/bucket_db_owner.h>
 #include <vespa/searchcore/proton/bucketdb/i_bucket_create_listener.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/documentmetastore/documentmetastore.h>
 #include <vespa/searchcore/proton/documentmetastore/operation_listener.h>
 #include <vespa/searchcore/proton/flushengine/shrink_lid_space_flush_target.h>
@@ -23,6 +22,7 @@
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/size_literals.h>
 #include <vespa/vespalib/util/threadstackexecutor.h>
 #include <filesystem>
@@ -59,6 +59,7 @@ using storage::spi::BucketInfo;
 using storage::spi::Timestamp;
 using vespalib::GenerationHandler;
 using vespalib::GenerationHolder;
+using vespalib::HwInfo;
 using namespace std::literals;
 
 namespace proton {

--- a/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
+++ b/searchcore/src/tests/proton/proton_config_fetcher/proton_config_fetcher_test.cpp
@@ -17,12 +17,12 @@
 #include <vespa/searchcore/proton/server/proton_config_snapshot.h>
 #include <vespa/searchcore/proton/server/i_proton_configurer.h>
 #include <vespa/searchcore/proton/common/alloc_config.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/subdbtype.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>
 #include <vespa/document/repo/documenttyperepo.h>
 #include <vespa/fileacquirer/config-filedistributorrpc.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/varholder.h>
 #include <vespa/vespalib/testkit/testapp.h>
 #include <map>
@@ -45,6 +45,7 @@ using std::map;
 using vespalib::VarHolder;
 using search::GrowStrategy;
 using vespalib::datastore::CompactionStrategy;
+using vespalib::HwInfo;
 
 struct DoctypeFixture {
     using UP = std::unique_ptr<DoctypeFixture>;

--- a/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
+++ b/searchcore/src/tests/proton/proton_configurer/proton_configurer_test.cpp
@@ -43,6 +43,7 @@ using search::index::Schema;
 using search::fef::OnnxModels;
 using search::fef::RankingConstants;
 using search::fef::RankingExpressions;
+using vespalib::HwInfo;
 
 struct DBConfigFixture {
     using UP = std::unique_ptr<DBConfigFixture>;

--- a/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
+++ b/searchcore/src/tests/proton/reprocessing/attribute_reprocessing_initializer/attribute_reprocessing_initializer_test.cpp
@@ -5,7 +5,6 @@
 #include <vespa/searchcore/proton/attribute/attributedisklayout.h>
 #include <vespa/searchcore/proton/attribute/attributemanager.h>
 #include <vespa/searchcore/proton/attribute/document_field_populator.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/i_indexschema_inspector.h>
 #include <vespa/searchcore/proton/reprocessing/attribute_reprocessing_initializer.h>
 #include <vespa/searchcore/proton/reprocessing/i_reprocessing_handler.h>
@@ -20,6 +19,7 @@
 #include <vespa/vespalib/test/insertion_operators.h>
 #include <vespa/vespalib/util/foreground_thread_executor.h>
 #include <vespa/vespalib/util/foregroundtaskexecutor.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("attribute_reprocessing_initializer_test");
@@ -35,6 +35,7 @@ using search::index::schema::DataType;
 using search::test::DirectoryHandler;
 using vespalib::ForegroundTaskExecutor;
 using vespalib::ForegroundThreadExecutor;
+using vespalib::HwInfo;
 
 const vespalib::string TEST_DIR = "test_output";
 const SerialNum INIT_SERIAL_NUM = 10;

--- a/searchcore/src/tests/proton/server/disk_mem_usage_filter/disk_mem_usage_filter_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_filter/disk_mem_usage_filter_test.cpp
@@ -1,11 +1,12 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/server/disk_mem_usage_filter.h>
 #include <vespa/searchcore/proton/server/resource_usage_state.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 using namespace proton;
+using vespalib::HwInfo;
 
 namespace fs = std::filesystem;
 

--- a/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
+++ b/searchcore/src/tests/proton/server/disk_mem_usage_sampler/disk_mem_usage_sampler_test.cpp
@@ -1,11 +1,11 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/scheduledexecutor.h>
 #include <vespa/searchcore/proton/common/i_transient_resource_usage_provider.h>
 #include <vespa/searchcore/proton/server/disk_mem_usage_sampler.h>
 #include <vespa/searchcore/proton/test/transport_helper.h>
 #include <vespa/vespalib/gtest/gtest.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <thread>
 
 #include <vespa/log/log.h>
@@ -13,6 +13,7 @@ LOG_SETUP("disk_mem_usage_sampler_test");
 
 using namespace proton;
 using namespace std::chrono_literals;
+using vespalib::HwInfo;
 
 constexpr uint64_t disk_size_bytes = 200000;
 constexpr uint64_t memory_size_bytes = 100000;

--- a/searchcore/src/tests/proton/server/initialize_threads_calculator/initialize_threads_calculator_test.cpp
+++ b/searchcore/src/tests/proton/server/initialize_threads_calculator/initialize_threads_calculator_test.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/util/threadstackexecutor.h>
 
 using namespace proton;
+using vespalib::HwInfo;
 using vespalib::ThreadStackExecutor;
 
 class InitializeThreadsCalculatorTest : public search::test::DirectoryHandler, public testing::Test {

--- a/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
+++ b/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
@@ -6,6 +6,7 @@
 
 using namespace proton;
 using vespa::config::search::core::ProtonConfig;
+using vespalib::HwInfo;
 
 ProtonConfig::Flush::Memory
 getConfig(int64_t maxMemory, int64_t eachMaxMemory, int64_t maxTlsSize,

--- a/searchcore/src/tests/proton/server/shared_threading_service/shared_threading_service_test.cpp
+++ b/searchcore/src/tests/proton/server/shared_threading_service/shared_threading_service_test.cpp
@@ -13,6 +13,7 @@ using ProtonConfig = vespa::config::search::core::ProtonConfig;
 using ProtonConfigBuilder = vespa::config::search::core::ProtonConfigBuilder;
 using namespace proton;
 using storage::spi::dummy::DummyBucketExecutor;
+using vespalib::HwInfo;
 using vespalib::ISequencedTaskExecutor;
 using vespalib::SequencedTaskExecutor;
 

--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -87,7 +87,6 @@ using proton::BootstrapConfig;
 using proton::DocTypeName;
 using proton::DocumentDB;
 using proton::DocumentDBConfig;
-using proton::HwInfo;
 using search::index::Schema;
 using search::transactionlog::TransLogServer;
 using storage::MergeThrottler;
@@ -120,6 +119,7 @@ using vespa::config::search::core::ProtonConfig;
 using vespa::config::search::core::ProtonConfigBuilder;
 using vespa::config::search::summary::JuniperrcConfig;
 using vespalib::compression::CompressionConfig;
+using vespalib::HwInfo;
 
 namespace search::bmcluster {
 

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.cpp
@@ -249,7 +249,7 @@ AttributeManager::AttributeManager(const vespalib::string &baseDir,
                                    std::shared_ptr<search::attribute::Interlock> interlock,
                                    vespalib::ISequencedTaskExecutor &attributeFieldWriter,
                                    vespalib::Executor& shared_executor,
-                                   const HwInfo &hwInfo)
+                                   const vespalib::HwInfo &hwInfo)
     : proton::IAttributeManager(),
       _attributes(),
       _flushables(),
@@ -275,7 +275,7 @@ AttributeManager::AttributeManager(const vespalib::string &baseDir,
                                    vespalib::ISequencedTaskExecutor &attributeFieldWriter,
                                    vespalib::Executor& shared_executor,
                                    IAttributeFactory::SP factory,
-                                   const HwInfo &hwInfo)
+                                   const vespalib::HwInfo &hwInfo)
     : proton::IAttributeManager(),
       _attributes(),
       _flushables(),

--- a/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attributemanager.h
@@ -7,7 +7,7 @@
 #include <set>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/vespalib/stllike/hash_map.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace search::attribute { class Interlock; }
 
@@ -88,7 +88,7 @@ private:
     std::shared_ptr<search::attribute::Interlock> _interlock;
     vespalib::ISequencedTaskExecutor &_attributeFieldWriter;
     vespalib::Executor& _shared_executor;
-    HwInfo _hwInfo;
+    vespalib::HwInfo _hwInfo;
     std::unique_ptr<ImportedAttributesRepo> _importedAttributes;
 
     AttributeVectorSP internalAddAttribute(AttributeSpec && spec, uint64_t serialNum, const IAttributeFactory &factory);
@@ -108,7 +108,7 @@ public:
                      std::shared_ptr<search::attribute::Interlock> interlock,
                      vespalib::ISequencedTaskExecutor &attributeFieldWriter,
                      vespalib::Executor& shared_executor,
-                     const HwInfo &hwInfo);
+                     const vespalib::HwInfo &hwInfo);
 
     AttributeManager(const vespalib::string &baseDir,
                      const vespalib::string &documentSubDbName,
@@ -118,7 +118,7 @@ public:
                      vespalib::ISequencedTaskExecutor &attributeFieldWriter,
                      vespalib::Executor& shared_executor,
                      std::shared_ptr<IAttributeFactory> factory,
-                     const HwInfo &hwInfo);
+                     const vespalib::HwInfo &hwInfo);
 
     AttributeManager(const AttributeManager &currMgr, Spec && newSpec,
                      IAttributeInitializerRegistry &initializerRegistry);

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.cpp
@@ -154,7 +154,7 @@ FlushableAttribute::FlushableAttribute(AttributeVectorSP attr,
                                        fileHeaderContext,
                                        vespalib::ISequencedTaskExecutor &
                                        attributeFieldWriter,
-                                       const HwInfo &hwInfo)
+                                       const vespalib::HwInfo &hwInfo)
     : LeafFlushTarget(make_string("attribute.flush.%s", attr->getName().c_str()), Type::SYNC, Component::ATTRIBUTE),
       _attr(attr),
       _cleanUpAfterFlush(true),

--- a/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
+++ b/searchcore/src/vespa/searchcore/proton/attribute/flushableattribute.h
@@ -2,9 +2,9 @@
 
 #pragma once
 
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcorespi/flush/iflushtarget.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace search { class AttributeVector; }
 
@@ -35,7 +35,7 @@ private:
     const search::TuneFileAttributes         _tuneFileAttributes;
     const search::common::FileHeaderContext &_fileHeaderContext;
     vespalib::ISequencedTaskExecutor        &_attributeFieldWriter;
-    HwInfo                                   _hwInfo;
+    vespalib::HwInfo                         _hwInfo;
     std::shared_ptr<AttributeDirectory>      _attrDir;
     double                                   _replay_operation_cost;
 
@@ -56,7 +56,7 @@ public:
                        const search::common::FileHeaderContext &
                        fileHeaderContext,
                        vespalib::ISequencedTaskExecutor &attributeFieldWriter,
-                       const HwInfo &hwInfo);
+                       const vespalib::HwInfo &hwInfo);
 
     virtual ~FlushableAttribute();
 

--- a/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.cpp
@@ -22,6 +22,7 @@ using config::FileSpec;
 using vespa::config::search::core::HwinfoConfig;
 using vespa::config::search::core::HwinfoConfigBuilder;
 using vespalib::alloc::Alloc;
+using vespalib::HwInfo;
 
 using Clock = std::chrono::system_clock;
 

--- a/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/common/hw_info_sampler.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "hw_info.h"
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <chrono>
 
 namespace proton {
@@ -43,19 +43,19 @@ public:
     };
 
 private:
-    HwInfo _hwInfo;
+    vespalib::HwInfo _hwInfo;
     using Clock = std::chrono::system_clock;
     Clock::time_point _sampleTime;
     double _diskWriteSpeed;
 
-    void setup(const HwInfo::Disk &disk, const HwInfo::Memory &memory, const HwInfo::Cpu &cpu);
+    void setup(const vespalib::HwInfo::Disk &disk, const vespalib::HwInfo::Memory &memory, const vespalib::HwInfo::Cpu &cpu);
     void setDiskWriteSpeed(const vespalib::string &path, const Config &config);
     void sampleDiskWriteSpeed(const vespalib::string &path, const Config &config);
 public:
     HwInfoSampler(const vespalib::string &path, const Config &config);
     ~HwInfoSampler();
 
-    const HwInfo &hwInfo() const { return _hwInfo; }
+    const vespalib::HwInfo &hwInfo() const { return _hwInfo; }
     std::chrono::time_point<Clock> sampleTime() const { return _sampleTime; }
     double diskWriteSpeed() const { return _diskWriteSpeed; }
 };

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.cpp
@@ -149,7 +149,7 @@ DocumentMetaStoreFlushTarget::Flusher::run()
 DocumentMetaStoreFlushTarget::
 DocumentMetaStoreFlushTarget(const DocumentMetaStore::SP dms, ITlsSyncer &tlsSyncer,
                              const vespalib::string & baseDir, const TuneFileAttributes &tuneFileAttributes,
-                             const FileHeaderContext &fileHeaderContext, const HwInfo &hwInfo)
+                             const FileHeaderContext &fileHeaderContext, const vespalib::HwInfo &hwInfo)
     : LeafFlushTarget("documentmetastore.flush", Type::SYNC, Component::ATTRIBUTE),
       _dms(dms),
       _tlsSyncer(tlsSyncer),

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/documentmetastoreflushtarget.h
@@ -4,7 +4,7 @@
 
 #include <vespa/searchcorespi/flush/iflushtarget.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace search::common { class FileHeaderContext; }
 
@@ -36,7 +36,7 @@ private:
     FlushStats                               _lastStats;
     const search::TuneFileAttributes         _tuneFileAttributes;
     const search::common::FileHeaderContext &_fileHeaderContext;
-    HwInfo                                   _hwInfo;
+    vespalib::HwInfo                         _hwInfo;
     std::shared_ptr<AttributeDiskLayout>     _diskLayout;
     std::shared_ptr<AttributeDirectory>      _dmsDir;
 
@@ -49,7 +49,7 @@ public:
      **/
     DocumentMetaStoreFlushTarget(const DocumentMetaStoreSP dms, ITlsSyncer &tlsSyncer,
                                  const vespalib::string &baseDir, const search::TuneFileAttributes &tuneFileAttributes,
-                                 const search::common::FileHeaderContext &fileHeaderContext, const HwInfo &hwInfo);
+                                 const search::common::FileHeaderContext &fileHeaderContext, const vespalib::HwInfo &hwInfo);
 
     ~DocumentMetaStoreFlushTarget() override;
 

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.cpp
@@ -30,7 +30,7 @@ BootstrapConfig::BootstrapConfig(
                const FiledistributorrpcConfigSP &filedistRpcConfSP,
                const BucketspacesConfigSP &bucketspaces,
                const search::TuneFileDocumentDB::SP &tuneFileDocumentDB,
-               const HwInfo & hwInfo)
+               const vespalib::HwInfo & hwInfo)
     : _documenttypes(documenttypes),
       _repo(repo),
       _proton(protonConfig),

--- a/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
+++ b/searchcore/src/vespa/searchcore/proton/server/bootstrapconfig.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #include <vespa/config-proton.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/document/config/config-documenttypes.h>
 #include <vespa/document/config/documenttypes_config_fwd.h>
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/config/retriever/configsnapshot.h>
 #include <vespa/fileacquirer/config-filedistributorrpc.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace vespa::config::content::core::internal { class InternalBucketspacesType; }
 
@@ -38,7 +38,7 @@ private:
     FiledistributorrpcConfigSP     _fileDistributorRpc;
     BucketspacesConfigSP           _bucketspaces;
     search::TuneFileDocumentDB::SP _tuneFileDocumentDB;
-    HwInfo                         _hwInfo;
+    vespalib::HwInfo               _hwInfo;
     int64_t                        _generation;
 
 public:
@@ -49,7 +49,7 @@ public:
                     const FiledistributorrpcConfigSP &filedistRpcConfSP,
                     const BucketspacesConfigSP &bucketspaces,
                     const search::TuneFileDocumentDB::SP &_tuneFileDocumentDB,
-                    const HwInfo & hwInfo);
+                    const vespalib::HwInfo & hwInfo);
     ~BootstrapConfig();
 
     const document::config::DocumenttypesConfig &getDocumenttypesConfig() const { return *_documenttypes; }
@@ -62,7 +62,7 @@ public:
     const BucketspacesConfigSP &getBucketspacesConfigSP() const { return _bucketspaces; }
     const search::TuneFileDocumentDB::SP &getTuneFileDocumentDBSP() const { return _tuneFileDocumentDB; }
     int64_t getGeneration() const { return _generation; }
-    const HwInfo & getHwInfo() const { return _hwInfo; }
+    const vespalib::HwInfo & getHwInfo() const { return _hwInfo; }
 
     /**
      * Shared pointers are checked for identity, not equality.

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.cpp
@@ -2,7 +2,7 @@
 
 #include "disk_mem_usage_filter.h"
 #include "i_disk_mem_usage_listener.h"
-#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <sstream>
 
 #include <vespa/log/log.h>
@@ -45,7 +45,7 @@ void
 makeDiskStatsMessage(std::ostream &os,
                      double diskUsed,
                      double diskLimit,
-                     const HwInfo &hwInfo,
+                     const vespalib::HwInfo &hwInfo,
                      uint64_t usedDiskSizeBytes)
 {
     os << "stats: { ";
@@ -59,7 +59,7 @@ void
 makeDiskLimitMessage(std::ostream &os,
                      double diskUsed,
                      double diskLimit,
-                     const HwInfo &hwInfo,
+                     const vespalib::HwInfo &hwInfo,
                      uint64_t usedDiskSizeBytes)
 {
     os << "diskLimitReached: { ";
@@ -73,7 +73,7 @@ vespalib::string
 makeUnblockingMessage(double memoryUsed,
                       double memoryLimit,
                       const vespalib::ProcessMemoryStats &memoryStats,
-                      const HwInfo &hwInfo,
+                      const vespalib::HwInfo &hwInfo,
                       double diskUsed,
                       double diskLimit,
                       uint64_t usedDiskSizeBytes)
@@ -163,7 +163,7 @@ DiskMemUsageFilter::get_relative_transient_disk_usage(const Guard&) const
     return  static_cast<double>(_transient_usage.disk()) / _hwInfo.disk().sizeBytes();
 }
 
-DiskMemUsageFilter::DiskMemUsageFilter(const HwInfo &hwInfo)
+DiskMemUsageFilter::DiskMemUsageFilter(const vespalib::HwInfo &hwInfo)
     : _lock(),
       _hwInfo(hwInfo),
       _acceptWrite(true),

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_filter.h
@@ -5,9 +5,9 @@
 #include "i_disk_mem_usage_notifier.h"
 #include "disk_mem_usage_state.h"
 #include "disk_mem_usage_metrics.h"
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/common/i_transient_resource_usage_provider.h>
 #include <vespa/searchcore/proton/persistenceengine/i_resource_write_filter.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/process_memory_stats.h>
 #include <atomic>
 #include <filesystem>
@@ -48,7 +48,7 @@ public:
 
 private:
     mutable Mutex                _lock;
-    HwInfo                       _hwInfo;
+    vespalib::HwInfo             _hwInfo;
     std::atomic<bool>            _acceptWrite;
     // Following member variables are protected by _lock
     vespalib::ProcessMemoryStats _memoryStats;
@@ -68,7 +68,7 @@ private:
     void notifyDiskMemUsage(const Guard &guard, DiskMemUsageState state);
 
 public:
-    DiskMemUsageFilter(const HwInfo &hwInfo);
+    DiskMemUsageFilter(const vespalib::HwInfo &hwInfo);
     ~DiskMemUsageFilter() override;
     void set_resource_usage(const TransientResourceUsage& transient_usage, vespalib::ProcessMemoryStats memoryStats, uint64_t diskUsedSizeBytes);
     [[nodiscard]] bool setConfig(Config config);
@@ -76,7 +76,7 @@ public:
     uint64_t getDiskUsedSize() const;
     TransientResourceUsage get_transient_resource_usage() const;
     Config getConfig() const;
-    const HwInfo &getHwInfo() const { return _hwInfo; }
+    const vespalib::HwInfo &getHwInfo() const { return _hwInfo; }
     DiskMemUsageState usageState() const;
     DiskMemUsageMetrics get_metrics() const;
     bool acceptWriteOperation() const override;

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.cpp
@@ -11,7 +11,7 @@ using vespalib::makeLambdaTask;
 
 namespace proton {
 
-DiskMemUsageSampler::DiskMemUsageSampler(const std::string &path_in, const HwInfo &hwInfo)
+DiskMemUsageSampler::DiskMemUsageSampler(const std::string &path_in, const vespalib::HwInfo &hwInfo)
     : _filter(hwInfo),
       _path(path_in),
       _sampleInterval(60s),
@@ -77,7 +77,7 @@ constexpr uint64_t symlink_disk_usage = 4_Ki;
 constexpr uint64_t directory_disk_usage = 4_Ki;
 
 uint64_t
-sampleDiskUsageOnFileSystem(const fs::path &path, const HwInfo::Disk &disk)
+sampleDiskUsageOnFileSystem(const fs::path &path, const vespalib::HwInfo::Disk &disk)
 {
     auto space_info = fs::space(path);
     uint64_t result = (space_info.capacity - space_info.available);

--- a/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
+++ b/searchcore/src/vespa/searchcore/proton/server/disk_mem_usage_sampler.h
@@ -32,7 +32,7 @@ public:
     struct Config {
         DiskMemUsageFilter::Config filterConfig;
         vespalib::duration sampleInterval;
-        HwInfo hwInfo;
+        vespalib::HwInfo hwInfo;
 
         Config()
             : filterConfig(),
@@ -43,14 +43,14 @@ public:
         Config(double memoryLimit_in,
                double diskLimit_in,
                vespalib::duration sampleInterval_in,
-               const HwInfo &hwInfo_in)
+               const vespalib::HwInfo &hwInfo_in)
             : filterConfig(memoryLimit_in, diskLimit_in),
               sampleInterval(sampleInterval_in),
               hwInfo(hwInfo_in)
         { }
     };
 
-    DiskMemUsageSampler(const std::string &path_in, const HwInfo &config);
+    DiskMemUsageSampler(const std::string &path_in, const vespalib::HwInfo &config);
     ~DiskMemUsageSampler();
     void close();
 

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.cpp
@@ -153,7 +153,7 @@ DocumentDB::create(const vespalib::string &baseDir,
                    std::shared_ptr<search::attribute::Interlock> attribute_interlock,
                    ConfigStore::UP config_store,
                    InitializeThreads initializeThreads,
-                   const HwInfo &hwInfo)
+                   const vespalib::HwInfo &hwInfo)
 {
     return DocumentDB::SP(
             new DocumentDB(baseDir, std::move(currentSnapshot), tlsSpec, queryLimiter, docTypeName, bucketSpace,
@@ -176,7 +176,7 @@ DocumentDB::DocumentDB(const vespalib::string &baseDir,
                        std::shared_ptr<search::attribute::Interlock> attribute_interlock,
                        ConfigStore::UP config_store,
                        InitializeThreads initializeThreads,
-                       const HwInfo &hwInfo)
+                       const vespalib::HwInfo &hwInfo)
     : DocumentDBConfigOwner(),
       IReplayConfig(),
       IFeedHandlerOwner(),

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -229,7 +229,7 @@ private:
                std::shared_ptr<search::attribute::Interlock> attribute_interlock,
                ConfigStore::UP config_store,
                InitializeThreads initializeThreads,
-               const HwInfo &hwInfo);
+               const vespalib::HwInfo &hwInfo);
 public:
     using SP = std::shared_ptr<DocumentDB>;
 
@@ -259,7 +259,7 @@ public:
            std::shared_ptr<search::attribute::Interlock> attribute_interlock,
            ConfigStore::UP config_store,
            InitializeThreads initializeThreads,
-           const HwInfo &hwInfo);
+           const vespalib::HwInfo &hwInfo);
 
     /**
      * Frees any allocated resources. This will also stop the internal thread

--- a/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdbconfigmanager.cpp
@@ -16,11 +16,11 @@
 #include <vespa/config/helper/legacy.h>
 #include <vespa/searchcommon/common/schemaconfigurer.h>
 #include <vespa/searchcore/proton/common/alloc_config.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchlib/fef/ranking_assets_builder.h>
 #include <vespa/searchlib/index/schemautil.h>
 #include <vespa/searchsummary/config/config-juniperrc.h>
 #include <vespa/config/retriever/configsnapshot.hpp>
+#include <vespa/vespalib/util/hw_info.h>
 #include <thread>
 #include <cassert>
 #include <cinttypes>
@@ -165,7 +165,7 @@ derive(ProtonConfig::Summary::Cache::UpdateStrategy strategy) {
 }
 
 DocumentStore::Config
-getStoreConfig(const ProtonConfig::Summary::Cache & cache, const HwInfo & hwInfo)
+getStoreConfig(const ProtonConfig::Summary::Cache & cache, const vespalib::HwInfo & hwInfo)
 {
     size_t maxBytes = (cache.maxbytes < 0)
                       ? (hwInfo.memory().sizeBytes()*std::min(INT64_C(50), -cache.maxbytes))/100l
@@ -175,7 +175,7 @@ getStoreConfig(const ProtonConfig::Summary::Cache & cache, const HwInfo & hwInfo
 }
 
 LogDocumentStore::Config
-deriveConfig(const ProtonConfig::Summary & summary, const HwInfo & hwInfo) {
+deriveConfig(const ProtonConfig::Summary & summary, const vespalib::HwInfo & hwInfo) {
     DocumentStore::Config config(getStoreConfig(summary.cache, hwInfo));
     const ProtonConfig::Summary::Log & log(summary.log);
     const ProtonConfig::Summary::Log::Chunk & chunk(log.chunk);
@@ -189,7 +189,7 @@ deriveConfig(const ProtonConfig::Summary & summary, const HwInfo & hwInfo) {
     return {config, logConfig};
 }
 
-search::LogDocumentStore::Config buildStoreConfig(const ProtonConfig & proton, const HwInfo & hwInfo) {
+search::LogDocumentStore::Config buildStoreConfig(const ProtonConfig & proton, const vespalib::HwInfo & hwInfo) {
     return deriveConfig(proton.summary, hwInfo);
 }
 
@@ -223,7 +223,7 @@ find_document_db_config_entry(const ProtonConfig::DocumentdbVector& document_dbs
 }
 
 AllocConfig
-build_alloc_config(const HwInfo & hwInfo, const ProtonConfig& proton_config, const vespalib::string& doc_type_name)
+build_alloc_config(const vespalib::HwInfo & hwInfo, const ProtonConfig& proton_config, const vespalib::string& doc_type_name)
 {
     // This is an approximate number based on observation of a node using 33G memory with 765M docs
     constexpr uint64_t MIN_MEMORY_COST_PER_DOCUMENT = 46;

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.cpp
@@ -37,7 +37,7 @@ DocumentSubDBCollection::DocumentSubDBCollection(
         const vespalib::Clock &clock,
         std::mutex &configMutex,
         const vespalib::string &baseDir,
-        const HwInfo &hwInfo)
+        const vespalib::HwInfo &hwInfo)
     : _subDBs(),
       _owner(owner),
       _calc(),

--- a/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentsubdbcollection.h
@@ -3,17 +3,18 @@
 
 #include <vespa/searchcore/proton/reprocessing/reprocessingrunner.h>
 #include <vespa/searchcore/proton/bucketdb/bucketdbhandler.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/searchcore/proton/persistenceengine/i_document_retriever.h>
 #include <vespa/searchlib/common/serialnum.h>
 #include <vespa/vespalib/util/varholder.h>
 #include <vespa/vespalib/util/idestructorcallback.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <mutex>
 #include <optional>
 
 namespace vespalib {
     class Clock;
     class Executor;
+    class HwInfo;
     class ThreadStackExecutorBase;
 }
 
@@ -34,7 +35,6 @@ class DocTypeName;
 class DocumentDBConfig;
 class DocumentDBReconfig;
 class FeedHandler;
-class HwInfo;
 class IDocumentRetriever;
 class IDocumentSubDB;
 class IDocumentSubDBOwner;
@@ -76,7 +76,7 @@ private:
     ReprocessingRunner _reprocessingRunner;
     std::shared_ptr<bucketdb::BucketDBOwner> _bucketDB;
     std::unique_ptr<bucketdb::BucketDBHandler> _bucketDBHandler;
-    HwInfo _hwInfo;
+    vespalib::HwInfo _hwInfo;
 
 public:
     DocumentSubDBCollection(
@@ -94,7 +94,7 @@ public:
             const vespalib::Clock &clock,
             std::mutex &configMutex,
             const vespalib::string &baseDir,
-            const HwInfo &hwInfo);
+            const vespalib::HwInfo &hwInfo);
     ~DocumentSubDBCollection();
 
     void setBucketStateCalculator(const IBucketStateCalculatorSP &calc, OnDone onDone);

--- a/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.cpp
@@ -5,7 +5,7 @@
 
 namespace proton {
 
-HwInfoExplorer::HwInfoExplorer(const HwInfo& info)
+HwInfoExplorer::HwInfoExplorer(const vespalib::HwInfo& info)
     : _info(info)
 {
 }

--- a/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.h
+++ b/searchcore/src/vespa/searchcore/proton/server/hw_info_explorer.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/vespalib/net/http/state_explorer.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace proton {
 
@@ -13,10 +13,10 @@ namespace proton {
 class HwInfoExplorer : public vespalib::StateExplorer
 {
 private:
-    HwInfo _info;
+    vespalib::HwInfo _info;
 
 public:
-    HwInfoExplorer(const HwInfo& info);
+    HwInfoExplorer(const vespalib::HwInfo& info);
 
     void get_state(const vespalib::slime::Inserter& inserter, bool full) const override;
 };

--- a/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.cpp
@@ -39,7 +39,7 @@ const vespalib::string file_name = "initialize-threads.txt";
 
 namespace proton {
 
-InitializeThreadsCalculator::InitializeThreadsCalculator(const HwInfo::Cpu & cpu_info,
+InitializeThreadsCalculator::InitializeThreadsCalculator(const vespalib::HwInfo::Cpu & cpu_info,
                                                          const vespalib::string& base_dir,
                                                          uint32_t configured_num_threads)
     : _path(base_dir + "/" + file_name),

--- a/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/initialize_threads_calculator.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/vespalib/stllike/string.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/threadexecutor.h>
 #include <filesystem>
 #include <memory>
@@ -26,7 +26,7 @@ namespace proton {
      InitializeThreads _threads;
 
  public:
-     InitializeThreadsCalculator(const HwInfo::Cpu & cpu_info, const vespalib::string& base_dir, uint32_t configured_num_threads);
+     InitializeThreadsCalculator(const vespalib::HwInfo::Cpu & cpu_info, const vespalib::string& base_dir, uint32_t configured_num_threads);
      ~InitializeThreadsCalculator();
      uint32_t num_threads() const { return _num_threads; }
      InitializeThreads threads() const { return _threads; }

--- a/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.cpp
@@ -92,7 +92,7 @@ MemoryFlushConfigUpdater::updateFlushStrategy(const LockGuard &guard, const char
 
 MemoryFlushConfigUpdater::MemoryFlushConfigUpdater(const MemoryFlush::SP &flushStrategy,
                                                    const ProtonConfig::Flush::Memory &config,
-                                                   const HwInfo::Memory &memory)
+                                                   const vespalib::HwInfo::Memory &memory)
     : _mutex(),
       _flushStrategy(flushStrategy),
       _currConfig(config),
@@ -131,7 +131,7 @@ MemoryFlushConfigUpdater::setNodeRetired(bool nodeRetired)
 namespace {
 
 size_t
-getHardMemoryLimit(const HwInfo::Memory &memory)
+getHardMemoryLimit(const vespalib::HwInfo::Memory &memory)
 {
     return memory.sizeBytes() / 4;
 }
@@ -139,7 +139,7 @@ getHardMemoryLimit(const HwInfo::Memory &memory)
 }
 
 MemoryFlush::Config
-MemoryFlushConfigUpdater::convertConfig(const ProtonConfig::Flush::Memory &config, const HwInfo::Memory &memory)
+MemoryFlushConfigUpdater::convertConfig(const ProtonConfig::Flush::Memory &config, const vespalib::HwInfo::Memory &memory)
 {
     const size_t hardMemoryLimit = getHardMemoryLimit(memory);
     size_t totalMaxMemory = config.maxmemory;

--- a/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.h
+++ b/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.h
@@ -5,7 +5,7 @@
 #include "i_disk_mem_usage_listener.h"
 #include "memoryflush.h"
 #include <vespa/config-proton.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <mutex>
 
 namespace proton {
@@ -24,7 +24,7 @@ private:
     Mutex                       _mutex;
     MemoryFlush::SP             _flushStrategy;
     ProtonConfig::Flush::Memory _currConfig;
-    HwInfo::Memory              _memory;
+    vespalib::HwInfo::Memory    _memory;
     DiskMemUsageState           _currState;
     bool                        _useConservativeDiskMode;
     bool                        _useConservativeMemoryMode;
@@ -41,13 +41,13 @@ public:
 
     MemoryFlushConfigUpdater(const MemoryFlush::SP &flushStrategy,
                              const ProtonConfig::Flush::Memory &config,
-                             const HwInfo::Memory &memory);
+                             const vespalib::HwInfo::Memory &memory);
     void setConfig(const ProtonConfig::Flush::Memory &newConfig);
     void setNodeRetired(bool nodeRetired);
     void notifyDiskMemUsage(DiskMemUsageState newState) override;
 
     static MemoryFlush::Config convertConfig(const ProtonConfig::Flush::Memory &config,
-                                             const HwInfo::Memory &memory);
+                                             const vespalib::HwInfo::Memory &memory);
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -114,7 +114,7 @@ setFS4Compression(const ProtonConfig & proton)
 }
 
 DiskMemUsageSampler::Config
-diskMemUsageSamplerConfig(const ProtonConfig &proton, const HwInfo &hwInfo)
+diskMemUsageSamplerConfig(const ProtonConfig &proton, const vespalib::HwInfo &hwInfo)
 {
     return { proton.writefilter.memorylimit,
              proton.writefilter.disklimit,
@@ -123,7 +123,7 @@ diskMemUsageSamplerConfig(const ProtonConfig &proton, const HwInfo &hwInfo)
 }
 
 uint32_t
-computeRpcTransportThreads(const ProtonConfig & cfg, const HwInfo::Cpu &cpuInfo) {
+computeRpcTransportThreads(const ProtonConfig & cfg, const vespalib::HwInfo::Cpu &cpuInfo) {
     bool areSearchAndDocsumAsync = cfg.docsum.async && cfg.search.async;
     return (cfg.rpc.transportthreads > 0)
             ? cfg.rpc.transportthreads
@@ -291,7 +291,7 @@ Proton::init(const BootstrapConfig::SP & configSnapshot)
     assert( _initStarted && ! _initComplete );
     const ProtonConfig &protonConfig = configSnapshot->getProtonConfig();
     ensureWritableDir(protonConfig.basedir);
-    const HwInfo & hwInfo = configSnapshot->getHwInfo();
+    const vespalib::HwInfo & hwInfo = configSnapshot->getHwInfo();
     _hw_info = hwInfo;
     _numThreadsPerSearch = std::min(hwInfo.cpu().cores(), uint32_t(protonConfig.numthreadspersearch));
 

--- a/searchcore/src/vespa/searchcore/proton/server/proton.h
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.h
@@ -87,7 +87,7 @@ private:
     };
 
     vespalib::CpuUtil                      _cpu_util;
-    HwInfo                                 _hw_info;
+    vespalib::HwInfo                       _hw_info;
     FNET_Transport                       & _transport;
     const config::ConfigUri                _configUri;
     mutable std::shared_mutex              _mutex;

--- a/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/resource_usage_explorer.cpp
@@ -11,7 +11,7 @@ using storage::spi::AttributeResourceUsage;
 namespace proton {
 
 void
-convertDiskStatsToSlime(const HwInfo &hwInfo, uint64_t diskUsedSizeBytes, Cursor &object)
+convertDiskStatsToSlime(const vespalib::HwInfo &hwInfo, uint64_t diskUsedSizeBytes, Cursor &object)
 {
     object.setLong("capacity", hwInfo.disk().sizeBytes());
     object.setLong("used", diskUsedSizeBytes);

--- a/searchcore/src/vespa/searchcore/proton/server/shared_threading_service_config.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/shared_threading_service_config.cpp
@@ -26,7 +26,7 @@ SharedThreadingServiceConfig::SharedThreadingServiceConfig(uint32_t shared_threa
 namespace {
 
 uint32_t
-derive_shared_threads(const ProtonConfig& cfg, const HwInfo::Cpu& cpu_info)
+derive_shared_threads(const ProtonConfig& cfg, const vespalib::HwInfo::Cpu& cpu_info)
 {
     uint32_t scaled_cores = uint32_t(std::ceil(cpu_info.cores() * cfg.feeding.concurrency));
 
@@ -35,12 +35,12 @@ derive_shared_threads(const ProtonConfig& cfg, const HwInfo::Cpu& cpu_info)
 }
 
 uint32_t
-derive_warmup_threads(const HwInfo::Cpu& cpu_info) {
+derive_warmup_threads(const vespalib::HwInfo::Cpu& cpu_info) {
     return std::max(1u, std::min(4u, cpu_info.cores()/8));
 }
 
 uint32_t
-derive_field_writer_threads(const ProtonConfig& cfg, const HwInfo::Cpu& cpu_info)
+derive_field_writer_threads(const ProtonConfig& cfg, const vespalib::HwInfo::Cpu& cpu_info)
 {
     uint32_t scaled_cores = size_t(std::ceil(cpu_info.cores() * cfg.feeding.concurrency));
     uint32_t field_writer_threads = std::max(scaled_cores, uint32_t(cfg.indexing.threads));
@@ -56,7 +56,7 @@ derive_field_writer_threads(const ProtonConfig& cfg, const HwInfo::Cpu& cpu_info
 
 SharedThreadingServiceConfig
 SharedThreadingServiceConfig::make(const proton::SharedThreadingServiceConfig::ProtonConfig& cfg,
-                                   const proton::HwInfo::Cpu& cpu_info)
+                                   const vespalib::HwInfo::Cpu& cpu_info)
 {
     uint32_t shared_threads = derive_shared_threads(cfg, cpu_info);
     uint32_t field_writer_threads = derive_field_writer_threads(cfg, cpu_info);

--- a/searchcore/src/vespa/searchcore/proton/server/shared_threading_service_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/shared_threading_service_config.h
@@ -2,7 +2,7 @@
 #pragma once
 
 #include "threading_service_config.h"
-#include <vespa/searchcore/proton/common/hw_info.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace vespa::config::search::core::internal { class InternalProtonType; }
 
@@ -31,7 +31,7 @@ public:
                                  double feed_niceness_in,
                                  const ThreadingServiceConfig& field_writer_config_in);
 
-    static SharedThreadingServiceConfig make(const ProtonConfig& cfg, const HwInfo::Cpu& cpu_info);
+    static SharedThreadingServiceConfig make(const ProtonConfig& cfg, const vespalib::HwInfo::Cpu& cpu_info);
 
     uint32_t shared_threads() const { return _shared_threads; }
     uint32_t shared_task_limit() const { return _shared_task_limit; }

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.cpp
@@ -74,7 +74,7 @@ StoreOnlyDocSubDB::Context::Context(IDocumentSubDBOwner &owner,
                                     bucketdb::IBucketDBHandlerInitializer & bucketDBHandlerInitializer,
                                     DocumentDBTaggedMetrics &metrics,
                                     std::mutex &configMutex,
-                                    const HwInfo &hwInfo)
+                                    const vespalib::HwInfo &hwInfo)
     : _owner(owner),
       _tlSyncer(tlSyncer),
       _getSerialNum(getSerialNum),

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -106,7 +106,7 @@ public:
         bucketdb::IBucketDBHandlerInitializer &_bucketDBHandlerInitializer;
         DocumentDBTaggedMetrics &_metrics;
         std::mutex &_configMutex;
-        const HwInfo &_hwInfo;
+        const vespalib::HwInfo &_hwInfo;
 
         Context(IDocumentSubDBOwner &owner,
                 search::transactionlog::SyncProxy &tlSyncer,
@@ -118,7 +118,7 @@ public:
                 bucketDBHandlerInitializer,
                 DocumentDBTaggedMetrics &metrics,
                 std::mutex &configMutex,
-                const HwInfo &hwInfo);
+                const vespalib::HwInfo &hwInfo);
         ~Context();
     };
 
@@ -145,7 +145,7 @@ protected:
     vespalib::VarHolder<ISearchHandler::SP> _iSearchView;
     vespalib::VarHolder<IFeedView::SP>      _iFeedView;
     std::mutex                             &_configMutex;
-    HwInfo                                  _hwInfo;
+    vespalib::HwInfo                        _hwInfo;
     const IGetSerialNum                    &_getSerialNum;
 private:
     TlsSyncer                                  _tlsSyncer;

--- a/searchcore/src/vespa/searchcore/proton/server/threading_service_config.h
+++ b/searchcore/src/vespa/searchcore/proton/server/threading_service_config.h
@@ -2,8 +2,8 @@
 #pragma once
 
 #include <vespa/config-proton.h>
-#include <vespa/searchcore/proton/common/hw_info.h>
 #include <vespa/vespalib/util/executor.h>
+#include <vespa/vespalib/util/hw_info.h>
 #include <vespa/vespalib/util/time.h>
 #include <cstdint>
 

--- a/vespalib/src/vespa/vespalib/util/hw_info.h
+++ b/vespalib/src/vespa/vespalib/util/hw_info.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 
 namespace vespalib {
 
@@ -16,15 +16,15 @@ public:
     class Disk {
     private:
         uint64_t _sizeBytes;
-        bool _slow;
-        bool _shared;
+        bool     _slow;
+        bool     _shared;
     public:
-        Disk(uint64_t sizeBytes_, bool slow_, bool shared_)
+        Disk(uint64_t sizeBytes_, bool slow_, bool shared_) noexcept
             : _sizeBytes(sizeBytes_), _slow(slow_), _shared(shared_) {}
-        uint64_t sizeBytes() const { return _sizeBytes; }
-        bool slow() const { return _slow; }
-        bool shared() const { return _shared; }
-        bool operator == (const Disk & rhs) const {
+        uint64_t sizeBytes() const noexcept { return _sizeBytes; }
+        [[nodiscard]] bool slow() const noexcept { return _slow; }
+        [[nodiscard]] bool shared() const noexcept { return _shared; }
+        bool operator == (const Disk & rhs) const noexcept {
             return (_sizeBytes == rhs._sizeBytes) && (_slow == rhs._slow) && (_shared == rhs._shared);
         }
     };
@@ -33,27 +33,27 @@ public:
     private:
         uint64_t _sizeBytes;
     public:
-        Memory(uint64_t sizeBytes_) : _sizeBytes(sizeBytes_) {}
-        uint64_t sizeBytes() const { return _sizeBytes; }
-        bool operator == (const Memory & rhs) const { return _sizeBytes == rhs._sizeBytes; }
+        Memory(uint64_t sizeBytes_) noexcept : _sizeBytes(sizeBytes_) {}
+        uint64_t sizeBytes() const noexcept { return _sizeBytes; }
+        bool operator == (const Memory & rhs) const noexcept { return _sizeBytes == rhs._sizeBytes; }
     };
 
     class Cpu {
     private:
         uint32_t _cores;
     public:
-        Cpu(uint32_t cores_) : _cores(std::max(1u, cores_)) { }
-        uint32_t cores() const { return _cores; }
-        bool operator == (const Cpu & rhs) const { return _cores == rhs._cores; }
+        Cpu(uint32_t cores_) noexcept : _cores(std::max(1u, cores_)) { }
+        uint32_t cores() const noexcept { return _cores; }
+        bool operator == (const Cpu & rhs) const noexcept { return _cores == rhs._cores; }
     };
 
 private:
-    Disk _disk;
+    Disk   _disk;
     Memory _memory;
-    Cpu _cpu;
+    Cpu    _cpu;
 
 public:
-    HwInfo()
+    HwInfo() noexcept
         : _disk(0, false, false),
           _memory(0),
           _cpu(1)
@@ -62,17 +62,17 @@ public:
 
     HwInfo(const Disk &disk_,
            const Memory &memory_,
-           const Cpu &cpu_)
+           const Cpu &cpu_) noexcept
         : _disk(disk_),
           _memory(memory_),
           _cpu(cpu_)
     {
     }
 
-    const Disk &disk() const { return _disk; }
-    const Memory &memory() const { return _memory; }
-    const Cpu &cpu() const { return _cpu; }
-    bool operator == (const HwInfo & rhs) const {
+    const Disk &disk() const noexcept { return _disk; }
+    const Memory &memory() const noexcept { return _memory; }
+    const Cpu &cpu() const noexcept { return _cpu; }
+    bool operator == (const HwInfo & rhs) const noexcept {
         return (_cpu == rhs._cpu) && (_disk == rhs._disk) && (_memory == rhs._memory);
     }
 };

--- a/vespalib/src/vespa/vespalib/util/hw_info.h
+++ b/vespalib/src/vespa/vespalib/util/hw_info.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <algorithm>
 
-namespace proton {
+namespace vespalib {
 
 /*
  * Class describing some hardware on the machine.


### PR DESCRIPTION
@baldersheim please review. Moving this out so that we can propagate this information from the Proton bootstrap config into the storage-specific modules during process init.
@geirst @toregge FYI

This is information that is valuable to many different components, not just the search core internals.

Will initially be used when auto-deducing merge memory limits, but we should also change existing non-cgroups-aware thread pool setups in the persistence code to use this information when no explicit config is provided.