### PR TITLE
Add configurable soft limiting of memory used by merge operations on a content node

### DIFF
--- a/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
+++ b/searchcore/src/vespa/searchcore/bmcluster/bm_node.cpp
@@ -243,7 +243,7 @@ public:
 MyServiceLayerProcess::MyServiceLayerProcess(const config::ConfigUri&  configUri,
                                              PersistenceProvider& provider,
                                              std::unique_ptr<storage::IStorageChainBuilder> chain_builder)
-    : ServiceLayerProcess(configUri),
+    : ServiceLayerProcess(configUri, vespalib::HwInfo()),
       _provider(provider)
 {
     if (chain_builder) {

--- a/storage/src/tests/storageserver/mergethrottlertest.cpp
+++ b/storage/src/tests/storageserver/mergethrottlertest.cpp
@@ -1,17 +1,18 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-#include <tests/common/testhelper.h>
 #include <tests/common/dummystoragelink.h>
+#include <tests/common/testhelper.h>
 #include <tests/common/teststorageapp.h>
 #include <vespa/config/helper/configgetter.hpp>
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/messagebus/dynamicthrottlepolicy.h>
-#include <vespa/storage/storageserver/mergethrottler.h>
 #include <vespa/storage/persistence/messages.h>
+#include <vespa/storage/storageserver/mergethrottler.h>
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageapi/message/state.h>
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <vespa/vespalib/util/exceptions.h>
+#include <vespa/vespalib/util/size_literals.h>
 #include <unordered_set>
 #include <memory>
 #include <iterator>
@@ -34,18 +35,22 @@ using StorServerConfig = vespa::config::content::core::StorServerConfig;
 vespalib::string _storage("storage");
 
 struct MergeBuilder {
-    document::BucketId _bucket;
-    api::Timestamp _maxTimestamp;
-    std::vector<uint16_t> _nodes;
-    std::vector<uint16_t> _chain;
+    document::BucketId           _bucket;
+    api::Timestamp               _maxTimestamp;
+    std::vector<uint16_t>        _nodes;
+    std::vector<uint16_t>        _chain;
     std::unordered_set<uint16_t> _source_only;
-    uint64_t _clusterStateVersion;
+    uint64_t                     _clusterStateVersion;
+    uint32_t                     _memory_usage;
+    bool                         _unordered;
 
-    MergeBuilder(const document::BucketId& bucket)
+    explicit MergeBuilder(const document::BucketId& bucket)
         : _bucket(bucket),
           _maxTimestamp(1234),
           _chain(),
-          _clusterStateVersion(1)
+          _clusterStateVersion(1),
+          _memory_usage(0),
+          _unordered(false)
     {
         nodes(0, 1, 2);
     }
@@ -100,6 +105,14 @@ struct MergeBuilder {
         _source_only.insert(node);
         return *this;
     }
+    MergeBuilder& memory_usage(uint32_t usage_bytes) {
+        _memory_usage = usage_bytes;
+        return *this;
+    }
+    MergeBuilder& unordered(bool is_unordered) {
+        _unordered = is_unordered;
+        return *this;
+    }
 
     api::MergeBucketCommand::SP create() const {
         std::vector<api::MergeBucketCommand::Node> n;
@@ -112,6 +125,8 @@ struct MergeBuilder {
                 makeDocumentBucket(_bucket), n, _maxTimestamp,
                 _clusterStateVersion, _chain);
         cmd->setAddress(StorageMessageAddress::create(&_storage, lib::NodeType::STORAGE, _nodes[0]));
+        cmd->set_estimated_memory_footprint(_memory_usage);
+        cmd->set_use_unordered_forwarding(_unordered);
         return cmd;
     }
 };
@@ -137,20 +152,21 @@ struct MergeThrottlerTest : Test {
     std::vector<DummyStorageLink*> _bottomLinks;
 
     MergeThrottlerTest();
-    ~MergeThrottlerTest();
+    ~MergeThrottlerTest() override;
 
     void SetUp() override;
     void TearDown() override;
 
     api::MergeBucketCommand::SP sendMerge(const MergeBuilder&);
 
-    void sendAndExpectReply(
+    void send_and_expect_reply(
         const std::shared_ptr<api::StorageMessage>& msg,
         const api::MessageType& expectedReplyType,
         api::ReturnCode::Result expectedResultCode);
 
+    std::shared_ptr<api::StorageMessage> send_and_expect_forwarding(const std::shared_ptr<api::StorageMessage>& msg);
+
     void fill_throttler_queue_with_n_commands(uint16_t throttler_index, size_t queued_count);
-    void fill_up_throttler_active_window_and_queue(uint16_t node_idx);
     void receive_chained_merge_with_full_queue(bool disable_queue_limits, bool unordered_fwd = false);
 
     std::shared_ptr<api::MergeBucketCommand> peek_throttler_queue_top(size_t throttler_idx) {
@@ -180,10 +196,10 @@ MergeThrottlerTest::SetUp()
         std::unique_ptr<DummyStorageLink> top;
 
         top = std::make_unique<DummyStorageLink>();
-        MergeThrottler* throttler = new MergeThrottler(*config, server->getComponentRegister());
+        auto* throttler = new MergeThrottler(*config, server->getComponentRegister());
         // MergeThrottler will be sandwiched in between two dummy links
         top->push_back(std::unique_ptr<StorageLink>(throttler));
-        DummyStorageLink* bottom = new DummyStorageLink;
+        auto* bottom = new DummyStorageLink;
         throttler->push_back(std::unique_ptr<StorageLink>(bottom));
 
         _servers.push_back(std::shared_ptr<TestServiceLayerApp>(server.release()));
@@ -291,6 +307,7 @@ TEST_F(MergeThrottlerTest, chain) {
         cmd->setAddress(StorageMessageAddress::create(&_storage, lib::NodeType::STORAGE, 0));
         const uint16_t distributorIndex = 123;
         cmd->setSourceIndex(distributorIndex); // Dummy distributor index that must be forwarded
+        cmd->set_estimated_memory_footprint(456'789);
 
         StorageMessage::SP fwd = cmd;
         StorageMessage::SP fwdToExec;
@@ -322,10 +339,12 @@ TEST_F(MergeThrottlerTest, chain) {
                 }
                 EXPECT_TRUE(checkChain(fwd, chain.begin(), chain.end()));
             }
-            // Ensure priority, cluster state version and timeout is correctly forwarded
+            // Ensure operation properties are forwarded as expected
             EXPECT_EQ(7, static_cast<int>(fwd->getPriority()));
-            EXPECT_EQ(123, dynamic_cast<const MergeBucketCommand&>(*fwd).getClusterStateVersion());
-            EXPECT_EQ(54321ms, dynamic_cast<const StorageCommand&>(*fwd).getTimeout());
+            auto& as_merge = dynamic_cast<const MergeBucketCommand&>(*fwd);
+            EXPECT_EQ(as_merge.getClusterStateVersion(), 123);
+            EXPECT_EQ(as_merge.getTimeout(), 54321ms);
+            EXPECT_EQ(as_merge.estimated_memory_footprint(), 456'789);
         }
 
         _topLinks[lastNodeIdx]->sendDown(fwd);
@@ -1350,7 +1369,7 @@ TEST_F(MergeThrottlerTest, broken_cycle) {
 }
 
 void
-MergeThrottlerTest::sendAndExpectReply(
+MergeThrottlerTest::send_and_expect_reply(
         const std::shared_ptr<api::StorageMessage>& msg,
         const api::MessageType& expectedReplyType,
         api::ReturnCode::Result expectedResultCode)
@@ -1362,13 +1381,22 @@ MergeThrottlerTest::sendAndExpectReply(
     ASSERT_EQ(expectedResultCode, storageReply.getResult().getResult());
 }
 
+std::shared_ptr<api::StorageMessage>
+MergeThrottlerTest::send_and_expect_forwarding(const std::shared_ptr<api::StorageMessage>& msg)
+{
+    _topLinks[0]->sendDown(msg);
+    _topLinks[0]->waitForMessage(MessageType::MERGEBUCKET, _messageWaitTime);
+    return _topLinks[0]->getAndRemoveMessage(MessageType::MERGEBUCKET);
+}
+
 TEST_F(MergeThrottlerTest, get_bucket_diff_command_not_in_active_set_is_rejected) {
     document::BucketId bucket(16, 1234);
     std::vector<api::GetBucketDiffCommand::Node> nodes;
     auto getDiffCmd = std::make_shared<api::GetBucketDiffCommand>(
             makeDocumentBucket(bucket), nodes, api::Timestamp(1234));
 
-    ASSERT_NO_FATAL_FAILURE(sendAndExpectReply(getDiffCmd,
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+            getDiffCmd,
             api::MessageType::GETBUCKETDIFF_REPLY,
             api::ReturnCode::ABORTED));
     ASSERT_EQ(0, _bottomLinks[0]->getNumCommands());
@@ -1379,7 +1407,8 @@ TEST_F(MergeThrottlerTest, apply_bucket_diff_command_not_in_active_set_is_reject
     std::vector<api::GetBucketDiffCommand::Node> nodes;
     auto applyDiffCmd = std::make_shared<api::ApplyBucketDiffCommand>(makeDocumentBucket(bucket), nodes);
 
-    ASSERT_NO_FATAL_FAILURE(sendAndExpectReply(applyDiffCmd,
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+            applyDiffCmd,
             api::MessageType::APPLYBUCKETDIFF_REPLY,
             api::ReturnCode::ABORTED));
     ASSERT_EQ(0, _bottomLinks[0]->getNumCommands());
@@ -1411,7 +1440,8 @@ TEST_F(MergeThrottlerTest, new_cluster_state_aborts_all_outdated_active_merges) 
         auto getDiffCmd = std::make_shared<api::GetBucketDiffCommand>(
                 makeDocumentBucket(bucket), std::vector<api::GetBucketDiffCommand::Node>(), api::Timestamp(123));
 
-        ASSERT_NO_FATAL_FAILURE(sendAndExpectReply(getDiffCmd,
+        ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+                getDiffCmd,
                 api::MessageType::GETBUCKETDIFF_REPLY,
                 api::ReturnCode::ABORTED));
     }
@@ -1428,7 +1458,8 @@ TEST_F(MergeThrottlerTest, backpressure_busy_bounces_merges_for_configured_durat
     EXPECT_EQ(0, _throttlers[0]->getMetrics().bounced_due_to_back_pressure.getValue());
     EXPECT_EQ(uint64_t(0), _throttlers[0]->getMetrics().local.failures.busy.getValue());
 
-    ASSERT_NO_FATAL_FAILURE(sendAndExpectReply(MergeBuilder(bucket).create(),
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+            MergeBuilder(bucket).create(),
             api::MessageType::MERGEBUCKET_REPLY,
             api::ReturnCode::BUSY));
 
@@ -1479,6 +1510,91 @@ TEST_F(MergeThrottlerTest, backpressure_evicts_all_queued_merges) {
     auto reply = _topLinks[0]->getAndRemoveMessage(MessageType::MERGEBUCKET_REPLY);
     EXPECT_EQ(ReturnCode::BUSY, dynamic_cast<const MergeBucketReply&>(*reply).getResult().getResult());
 }
+
+TEST_F(MergeThrottlerTest, exceeding_memory_soft_limit_rejects_merges_even_with_available_active_window_slots) {
+    ASSERT_GT(throttler_max_merges_pending(0), 1); // Sanity check for the test itself
+
+    _throttlers[0]->set_max_merge_memory_usage_bytes(10_Mi);
+
+    ASSERT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 0);
+
+    std::shared_ptr<api::StorageMessage> fwd_cmd;
+    ASSERT_NO_FATAL_FAILURE(fwd_cmd = send_and_expect_forwarding(
+            MergeBuilder(document::BucketId(16, 0)).nodes(0, 1, 2).memory_usage(5_Mi).create()));
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 5_Mi);
+
+    // Accepting this merge would exceed memory limits. It is sent as part of a forwarded unordered
+    // merge and can therefore NOT be enqueued; it must be bounced immediately.
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+            MergeBuilder(document::BucketId(16, 1))
+                    .nodes(2, 1, 0).chain(2, 1).unordered(true)
+                    .memory_usage(8_Mi).create(),
+            MessageType::MERGEBUCKET_REPLY, ReturnCode::BUSY));
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 5_Mi); // Unchanged
+
+    // Fail the forwarded merge. This shall immediately free up the memory usage, allowing a new merge in.
+    auto fwd_reply = dynamic_cast<api::MergeBucketCommand&>(*fwd_cmd).makeReply();
+    fwd_reply->setResult(ReturnCode(ReturnCode::ABORTED, "node stumbled into a ravine"));
+
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_reply(
+            std::shared_ptr<api::StorageReply>(std::move(fwd_reply)),
+            MessageType::MERGEBUCKET_REPLY, ReturnCode::ABORTED)); // Unwind reply for failed merge
+
+    ASSERT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 0);
+
+    // New merge is accepted
+    _topLinks[0]->sendDown(MergeBuilder(document::BucketId(16, 2)).nodes(0, 1, 2).unordered(true).memory_usage(9_Mi).create());
+    _topLinks[0]->waitForMessage(MessageType::MERGEBUCKET, _messageWaitTime); // Forwarded to node 1
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 9_Mi);
+}
+
+TEST_F(MergeThrottlerTest, exceeding_memory_soft_limit_can_enqueue_unordered_merge_sent_directly_from_distributor) {
+    _throttlers[0]->set_max_merge_memory_usage_bytes(10_Mi);
+
+    ASSERT_NO_FATAL_FAILURE(send_and_expect_forwarding(
+            MergeBuilder(document::BucketId(16, 0)).nodes(0, 1, 2).memory_usage(5_Mi).create()));
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 5_Mi);
+
+    // Accepting this merge would exceed memory limits. It is sent directly from a distributor and
+    // can therefore be enqueued.
+    _topLinks[0]->sendDown(MergeBuilder(document::BucketId(16, 1)).nodes(0, 1, 2).unordered(true).memory_usage(8_Mi).create());
+    waitUntilMergeQueueIs(*_throttlers[0], 1, _messageWaitTime); // Should end up in queue
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 5_Mi); // Unchanged
+}
+
+TEST_F(MergeThrottlerTest, at_least_one_merge_is_accepted_even_if_exceeding_memory_soft_limit) {
+    _throttlers[0]->set_max_merge_memory_usage_bytes(5_Mi);
+
+    _topLinks[0]->sendDown(MergeBuilder(document::BucketId(16, 0)).nodes(0, 1, 2).unordered(true).memory_usage(100_Mi).create());
+    _topLinks[0]->waitForMessage(MessageType::MERGEBUCKET, _messageWaitTime); // Forwarded, _not_ bounced
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 100_Mi);
+}
+
+TEST_F(MergeThrottlerTest, queued_merges_are_not_counted_towards_memory_usage) {
+    // Our utility function for filling queues uses bucket IDs {16, x} where x is increasing
+    // from 0 to the max pending. Ensure we don't accidentally overlap with the bucket ID we
+    // send for below in the test code.
+    ASSERT_LT(throttler_max_merges_pending(0), 1000);
+
+    _throttlers[0]->set_max_merge_memory_usage_bytes(50_Mi);
+    // Fill up active window on node 0. Note: these merges do not have any associated memory cost.
+    fill_throttler_queue_with_n_commands(0, 0);
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 0_Mi);
+
+    _topLinks[0]->sendDown(MergeBuilder(document::BucketId(16, 1000)).nodes(0, 1, 2).unordered(true).memory_usage(10_Mi).create());
+    waitUntilMergeQueueIs(*_throttlers[0], 1, _messageWaitTime); // Should end up in queue
+
+    EXPECT_EQ(_throttlers[0]->getMetrics().estimated_merge_memory_usage.getLast(), 0_Mi);
+}
+
+// TODO define and test auto-deduced max memory usage
 
 // TODO test message queue aborting (use rendezvous functionality--make guard)
 

--- a/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
+++ b/storage/src/tests/storageserver/service_layer_error_listener_test.cpp
@@ -40,7 +40,8 @@ struct Fixture {
     vdstestlib::DirConfig config{getStandardConfig(true)};
     TestServiceLayerApp app;
     ServiceLayerComponent component{app.getComponentRegister(), "dummy"};
-    MergeThrottler merge_throttler{*config_from<StorServerConfig>(config::ConfigUri(config.getConfigId())), app.getComponentRegister()};
+    MergeThrottler merge_throttler{*config_from<StorServerConfig>(config::ConfigUri(config.getConfigId())),
+                                   app.getComponentRegister(), vespalib::HwInfo()};
     TestShutdownListener shutdown_listener;
     ServiceLayerErrorListener error_listener{component, merge_throttler};
 

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -46,6 +46,18 @@ merge_throttling_policy.min_window_size int default=16
 merge_throttling_policy.max_window_size int default=128
 merge_throttling_policy.window_size_increment double default=2.0
 
+## If positive, nodes enforce a soft limit on the estimated amount of memory that
+## can be used by merges touching a particular content node. If a merge arrives
+## to the node that would violate the soft limit, it will be bounced with BUSY.
+## Note that this also counts merges where the node is part of the source-only set,
+## since these use memory when/if data is read from the local node.
+##
+## Semantics:
+##    > 0  explicit limit in bytes
+##   == 0  limit automatically derived by content node
+##    < 0  unlimited (legacy behavior)
+max_merge_memory_usage_bytes long default=-1
+
 ## If the persistence provider indicates that it has exhausted one or more
 ## of its internal resources during a mutating operation, new merges will
 ## be bounced for this duration. Not allowing further merges helps take

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -54,9 +54,29 @@ merge_throttling_policy.window_size_increment double default=2.0
 ##
 ## Semantics:
 ##    > 0  explicit limit in bytes
-##   == 0  limit automatically derived by content node
+##   == 0  limit automatically deduced by content node
 ##    < 0  unlimited (legacy behavior)
-max_merge_memory_usage_bytes long default=-1
+merge_throttling_memory_limit.max_usage_bytes long default=-1
+
+## If merge_throttling_memory_limit.max_usage_bytes == 0, this factor is used
+## as a multiplier to automatically deduce a memory limit for merges on the
+## content node. Note that the result of this multiplication is capped at both
+## ends by the auto_(lower|upper)_bound_bytes config values.
+##
+## Default: 3% of physical memory
+merge_throttling_memory_limit.auto_phys_mem_scale_factor double default=0.03
+
+## The absolute minimum memory limit that can be set when automatically
+## deducing the limit from physical memory on the node.
+##
+## Default: 128MiB
+merge_throttling_memory_limit.auto_lower_bound_bytes long default=134217728
+
+## The absolute maximum memory limit that can be set when automatically
+## deducing the limit from physical memory on the node.
+##
+## Default: 2GiB
+merge_throttling_memory_limit.auto_upper_bound_bytes long default=2147483648
 
 ## If the persistence provider indicates that it has exhausted one or more
 ## of its internal resources during a mutating operation, new merges will

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -140,7 +140,7 @@ MergeOperation::onStart(DistributorStripeMessageSender& sender)
         _mnodes.emplace_back(node._nodeIndex, node._sourceOnly);
     }
 
-    const auto estimated_memory_footprint = estimate_merge_memory_footprint_ubound(nodes);
+    const auto estimated_memory_footprint = estimate_merge_memory_footprint_upper_bound(nodes);
 
     if (_mnodes.size() > 1) {
         auto msg = std::make_shared<api::MergeBucketCommand>(getBucket(), _mnodes,
@@ -371,7 +371,7 @@ bool MergeOperation::all_involved_nodes_support_unordered_merge_chaining() const
     return true;
 }
 
-uint32_t MergeOperation::estimate_merge_memory_footprint_ubound(const std::vector<MergeMetaData>& nodes) const noexcept {
+uint32_t MergeOperation::estimate_merge_memory_footprint_upper_bound(const std::vector<MergeMetaData>& nodes) const noexcept {
     vespalib::hash_set<uint32_t> seen_checksums;
     uint32_t worst_case_footprint_across_nodes = 0;
     uint32_t largest_single_doc_contribution   = 0;

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -9,6 +9,7 @@
 #include <vespa/storageframework/generic/clock/clock.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>
+#include <vespa/vespalib/stllike/hash_set.h>
 #include <array>
 
 #include <vespa/log/bufferedlogger.h>
@@ -121,7 +122,7 @@ MergeOperation::onStart(DistributorStripeMessageSender& sender)
     }
 
     const lib::ClusterState& clusterState(_bucketSpace->getClusterState());
-    std::vector<std::unique_ptr<BucketCopy> > newCopies;
+    std::vector<std::unique_ptr<BucketCopy>> newCopies;
     std::vector<MergeMetaData> nodes;
 
     for (uint16_t node : getNodes()) {
@@ -139,6 +140,8 @@ MergeOperation::onStart(DistributorStripeMessageSender& sender)
         _mnodes.emplace_back(node._nodeIndex, node._sourceOnly);
     }
 
+    const auto estimated_memory_footprint = estimate_merge_memory_footprint_ubound(nodes);
+
     if (_mnodes.size() > 1) {
         auto msg = std::make_shared<api::MergeBucketCommand>(getBucket(), _mnodes,
                                                              _manager->operation_context().generate_unique_timestamp(),
@@ -153,6 +156,7 @@ MergeOperation::onStart(DistributorStripeMessageSender& sender)
         } else {
             msg->set_use_unordered_forwarding(true);
         }
+        msg->set_estimated_memory_footprint(estimated_memory_footprint);
 
         LOG(debug, "Sending %s to storage node %u", msg->toString().c_str(), _mnodes[0].index);
 
@@ -365,6 +369,40 @@ bool MergeOperation::all_involved_nodes_support_unordered_merge_chaining() const
         }
     }
     return true;
+}
+
+uint32_t MergeOperation::estimate_merge_memory_footprint_ubound(const std::vector<MergeMetaData>& nodes) const noexcept {
+    vespalib::hash_set<uint32_t> seen_checksums;
+    uint32_t worst_case_footprint_across_nodes = 0;
+    uint32_t largest_single_doc_contribution   = 0;
+    for (const auto& node : nodes) {
+        if (!seen_checksums.contains(node.checksum())) {
+            seen_checksums.insert(node.checksum());
+            const uint32_t replica_size = node._copy->getUsedFileSize();
+            // We don't know the overlap of document sets across replicas, so we have to assume the
+            // worst and treat the replicas as entirely disjoint. In this case, the _sum_ of all disjoint
+            // replica group footprints gives us the upper bound.
+            // Note: saturate-on-overflow check requires all types to be _unsigned_ to work.
+            if (worst_case_footprint_across_nodes + replica_size >= worst_case_footprint_across_nodes) {
+                worst_case_footprint_across_nodes += replica_size;
+            } else {
+                worst_case_footprint_across_nodes = UINT32_MAX;
+            }
+            // Special case for not bounding single massive doc replica to that of the max
+            // configured bucket size.
+            if (node._copy->getDocumentCount() == 1) {
+                largest_single_doc_contribution = std::max(replica_size, largest_single_doc_contribution);
+            }
+        }
+    }
+    // We know that simply adding up replica sizes is likely to massively over-count in the common
+    // case (due to the intersection set between replicas rarely being empty), so we cap it by the
+    // max expected merge chunk size (which is expected to be configured equal to the split limit).
+    // _Except_ if we have single-doc replicas, as these are known not to overlap, and we know that
+    // the worst case must be the max of the chunk size and the biggest single doc size.
+    const uint32_t expected_max_merge_chunk_size = _manager->operation_context().distributor_config().getSplitSize();
+    return std::max(std::min(worst_case_footprint_across_nodes, expected_max_merge_chunk_size),
+                    largest_single_doc_contribution);
 }
 
 MergeBucketMetricSet*

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -63,8 +63,9 @@ private:
 
     void deleteSourceOnlyNodes(const BucketDatabase::Entry& currentState,
                                DistributorStripeMessageSender& sender);
-    bool is_global_bucket_merge() const noexcept;
-    bool all_involved_nodes_support_unordered_merge_chaining() const noexcept;
+    [[nodiscard]] bool is_global_bucket_merge() const noexcept;
+    [[nodiscard]] bool all_involved_nodes_support_unordered_merge_chaining() const noexcept;
+    [[nodiscard]] uint32_t estimate_merge_memory_footprint_ubound(const std::vector<MergeMetaData>& nodes) const noexcept;
     MergeBucketMetricSet* get_merge_metrics();
 };
 

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.h
@@ -65,7 +65,7 @@ private:
                                DistributorStripeMessageSender& sender);
     [[nodiscard]] bool is_global_bucket_merge() const noexcept;
     [[nodiscard]] bool all_involved_nodes_support_unordered_merge_chaining() const noexcept;
-    [[nodiscard]] uint32_t estimate_merge_memory_footprint_ubound(const std::vector<MergeMetaData>& nodes) const noexcept;
+    [[nodiscard]] uint32_t estimate_merge_memory_footprint_upper_bound(const std::vector<MergeMetaData>& nodes) const noexcept;
     MergeBucketMetricSet* get_merge_metrics();
 };
 

--- a/storage/src/vespa/storage/storageserver/servicelayernode.cpp
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.cpp
@@ -30,8 +30,9 @@ ServiceLayerNode::ServiceLayerBootstrapConfigs::ServiceLayerBootstrapConfigs(Ser
 ServiceLayerNode::ServiceLayerBootstrapConfigs&
 ServiceLayerNode::ServiceLayerBootstrapConfigs::operator=(ServiceLayerBootstrapConfigs&&) noexcept = default;
 
-ServiceLayerNode::ServiceLayerNode(const config::ConfigUri & configUri,
+ServiceLayerNode::ServiceLayerNode(const config::ConfigUri& configUri,
                                    ServiceLayerNodeContext& context,
+                                   const vespalib::HwInfo& hw_info,
                                    ServiceLayerBootstrapConfigs bootstrap_configs,
                                    ApplicationGenerationFetcher& generationFetcher,
                                    spi::PersistenceProvider& persistenceProvider,
@@ -41,6 +42,7 @@ ServiceLayerNode::ServiceLayerNode(const config::ConfigUri & configUri,
       _context(context),
       _persistenceProvider(persistenceProvider),
       _externalVisitors(externalVisitors),
+      _hw_info(hw_info),
       _persistence_bootstrap_config(std::move(bootstrap_configs.persistence_cfg)),
       _visitor_bootstrap_config(std::move(bootstrap_configs.visitor_cfg)),
       _filestor_bootstrap_config(std::move(bootstrap_configs.filestor_cfg)),
@@ -172,7 +174,7 @@ ServiceLayerNode::createChain(IStorageChainBuilder &builder)
     auto bouncer = std::make_unique<Bouncer>(compReg, bouncer_config());
     _bouncer = bouncer.get();
     builder.add(std::move(bouncer));
-    auto merge_throttler_up = std::make_unique<MergeThrottler>(server_config(), compReg);
+    auto merge_throttler_up = std::make_unique<MergeThrottler>(server_config(), compReg, _hw_info);
     _merge_throttler = merge_throttler_up.get();
     builder.add(std::move(merge_throttler_up));
     auto bucket_ownership_handler = std::make_unique<ChangedBucketOwnershipHandler>(*_persistence_bootstrap_config, compReg);

--- a/storage/src/vespa/storage/storageserver/servicelayernode.h
+++ b/storage/src/vespa/storage/storageserver/servicelayernode.h
@@ -12,6 +12,7 @@
 #include <vespa/storage/common/visitorfactory.h>
 #include <vespa/storage/visiting/config-stor-visitor.h>
 #include <vespa/storage/visiting/visitormessagesessionfactory.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace storage {
 
@@ -39,6 +40,7 @@ private:
     ServiceLayerNodeContext&            _context;
     spi::PersistenceProvider&           _persistenceProvider;
     VisitorFactory::Map                 _externalVisitors;
+    vespalib::HwInfo                    _hw_info;
     std::unique_ptr<PersistenceConfig>  _persistence_bootstrap_config;
     std::unique_ptr<StorVisitorConfig>  _visitor_bootstrap_config;
     std::unique_ptr<StorFilestorConfig> _filestor_bootstrap_config;
@@ -66,8 +68,9 @@ public:
         ServiceLayerBootstrapConfigs& operator=(ServiceLayerBootstrapConfigs&&) noexcept;
     };
 
-    ServiceLayerNode(const config::ConfigUri & configUri,
+    ServiceLayerNode(const config::ConfigUri& configUri,
                      ServiceLayerNodeContext& context,
+                     const vespalib::HwInfo& hw_info,
                      ServiceLayerBootstrapConfigs bootstrap_configs,
                      ApplicationGenerationFetcher& generationFetcher,
                      spi::PersistenceProvider& persistenceProvider,

--- a/storage/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
+++ b/storage/src/vespa/storageapi/mbusprot/protobuf/maintenance.proto
@@ -33,12 +33,13 @@ message MergeNode {
 }
 
 message MergeBucketRequest {
-    Bucket             bucket                = 1;
-    uint32             cluster_state_version = 2;
-    uint64             max_timestamp         = 3;
-    repeated MergeNode nodes                 = 4;
-    repeated uint32    node_chain            = 5;
-    bool               unordered_forwarding  = 6;
+    Bucket             bucket                     = 1;
+    uint32             cluster_state_version      = 2;
+    uint64             max_timestamp              = 3;
+    repeated MergeNode nodes                      = 4;
+    repeated uint32    node_chain                 = 5;
+    bool               unordered_forwarding       = 6;
+    uint32             estimated_memory_footprint = 7;
 }
 
 message MergeBucketResponse {

--- a/storage/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
+++ b/storage/src/vespa/storageapi/mbusprot/protocolserialization7.cpp
@@ -801,6 +801,7 @@ void ProtocolSerialization7::onEncode(GBBuf& buf, const api::MergeBucketCommand&
         req.set_max_timestamp(msg.getMaxTimestamp());
         req.set_cluster_state_version(msg.getClusterStateVersion());
         req.set_unordered_forwarding(msg.use_unordered_forwarding());
+        req.set_estimated_memory_footprint(msg.estimated_memory_footprint());
         for (uint16_t chain_node : msg.getChain()) {
             req.add_node_chain(chain_node);
         }
@@ -823,6 +824,7 @@ api::StorageCommand::UP ProtocolSerialization7::onDecodeMergeBucketCommand(BBuf&
         }
         cmd->setChain(std::move(chain));
         cmd->set_use_unordered_forwarding(req.unordered_forwarding());
+        cmd->set_estimated_memory_footprint(req.estimated_memory_footprint());
         return cmd;
     });
 }

--- a/storage/src/vespa/storageapi/message/bucket.cpp
+++ b/storage/src/vespa/storageapi/message/bucket.cpp
@@ -107,6 +107,7 @@ MergeBucketCommand::MergeBucketCommand(
       _nodes(nodes),
       _maxTimestamp(maxTimestamp),
       _clusterStateVersion(clusterStateVersion),
+      _estimated_memory_footprint(0),
       _chain(chain),
       _use_unordered_forwarding(false)
 {}
@@ -131,6 +132,9 @@ MergeBucketCommand::print(std::ostream& out, bool verbose, const std::string& in
     out << "]";
     if (_use_unordered_forwarding) {
         out << " (unordered forwarding)";
+    }
+    if (_estimated_memory_footprint > 0) {
+        out << ", estimated memory footprint: " << _estimated_memory_footprint << " bytes";
     }
     out << ", reasons to start: " << _reason;
     out << ")";

--- a/storage/src/vespa/storageapi/message/bucket.h
+++ b/storage/src/vespa/storageapi/message/bucket.h
@@ -118,6 +118,7 @@ private:
     std::vector<Node> _nodes;
     Timestamp _maxTimestamp;
     uint32_t _clusterStateVersion;
+    uint32_t _estimated_memory_footprint;
     std::vector<uint16_t> _chain;
     bool _use_unordered_forwarding;
 
@@ -140,6 +141,12 @@ public:
     }
     [[nodiscard]] bool use_unordered_forwarding() const noexcept { return _use_unordered_forwarding; }
     [[nodiscard]] bool from_distributor() const noexcept { return _chain.empty(); }
+    void set_estimated_memory_footprint(uint32_t footprint_bytes) noexcept {
+        _estimated_memory_footprint = footprint_bytes;
+    }
+    [[nodiscard]] uint32_t estimated_memory_footprint() const noexcept {
+        return _estimated_memory_footprint;
+    }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
     DECLARE_STORAGECOMMAND(MergeBucketCommand, onMergeBucket)
 };

--- a/storageserver/src/vespa/storageserver/app/dummyservicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/dummyservicelayerprocess.cpp
@@ -7,7 +7,7 @@ namespace storage {
 // DummyServiceLayerProcess implementation
 
 DummyServiceLayerProcess::DummyServiceLayerProcess(const config::ConfigUri & configUri)
-    : ServiceLayerProcess(configUri)
+    : ServiceLayerProcess(configUri, vespalib::HwInfo())
 {
 }
 

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.cpp
@@ -31,7 +31,7 @@ bucket_db_options_from_config(const config::ConfigUri& config_uri) {
 
 }
 
-ServiceLayerProcess::ServiceLayerProcess(const config::ConfigUri& configUri)
+ServiceLayerProcess::ServiceLayerProcess(const config::ConfigUri& configUri, const vespalib::HwInfo& hw_info)
     : Process(configUri),
       _externalVisitors(),
       _persistence_cfg_handle(),
@@ -39,6 +39,7 @@ ServiceLayerProcess::ServiceLayerProcess(const config::ConfigUri& configUri)
       _filestor_cfg_handle(),
       _node(),
       _storage_chain_builder(),
+      _hw_info(hw_info),
       _context(std::make_unique<framework::defaultimplementation::RealClock>(),
                bucket_db_options_from_config(configUri))
 {
@@ -106,7 +107,8 @@ ServiceLayerProcess::createNode()
     sbc.visitor_cfg     = _visitor_cfg_handle->getConfig();
     sbc.filestor_cfg    = _filestor_cfg_handle->getConfig();
 
-    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, std::move(sbc), *this, getProvider(), _externalVisitors);
+    _node = std::make_unique<ServiceLayerNode>(_configUri, _context, _hw_info, std::move(sbc),
+                                               *this, getProvider(), _externalVisitors);
     if (_storage_chain_builder) {
         _node->set_storage_chain_builder(std::move(_storage_chain_builder));
     }

--- a/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
+++ b/storageserver/src/vespa/storageserver/app/servicelayerprocess.h
@@ -7,6 +7,7 @@
 #include <vespa/storage/common/visitorfactory.h>
 #include <vespa/storage/storageserver/servicelayernodecontext.h>
 #include <vespa/storage/visiting/config-stor-visitor.h>
+#include <vespa/vespalib/util/hw_info.h>
 
 namespace config { class ConfigUri; }
 
@@ -29,14 +30,15 @@ private:
     std::unique_ptr<config::ConfigHandle<StorVisitorConfig>>  _visitor_cfg_handle;
     std::unique_ptr<config::ConfigHandle<StorFilestorConfig>> _filestor_cfg_handle;
 
-    std::unique_ptr<ServiceLayerNode> _node;
+    std::unique_ptr<ServiceLayerNode>     _node;
     std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;
 
 protected:
+    vespalib::HwInfo        _hw_info;
     ServiceLayerNodeContext _context;
 
 public:
-    explicit ServiceLayerProcess(const config::ConfigUri & configUri);
+    ServiceLayerProcess(const config::ConfigUri & configUri, const vespalib::HwInfo& hw_info);
     ~ServiceLayerProcess() override;
 
     void shutdown() override;


### PR DESCRIPTION
@baldersheim @geirst please review

This adds heuristically derived estimates of memory footprint to all merge operations sent from distributor nodes, and tracking of potential memory usage in the `MergeThrottler` component on the content nodes. If an incoming merge operation would exceed the configured limits, it is busy-bounced (or potentially enqueued, if coming directly from a distributor).

This also wires in `HwInfo` to the service layer setup code, which is used when auto-deducing memory limits based on config and available node memory.

For now, memory limiting is disabled by default. Testing and roll-out will be done gradually—it is expected that auto-deduction will be the default in the end.