### PR TITLE
Use plain CentOS Stream 8 image for mirroring to avoid confusion with…

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -529,6 +529,7 @@ jobs:
           dnf install -y vespa
 
   mirror-copr-rpms-to-artifactory:
+    image: quay.io/centos/centos:stream8
     annotations:
       screwdriver.cd/cpu: LOW
       screwdriver.cd/ram: LOW
@@ -538,6 +539,8 @@ jobs:
     secrets:
       - JFROG_API_TOKEN
     steps:
+      - install: |
+          dnf install -y dnf-plugins-core
       - mirror: |
           screwdriver/publish-unpublished-rpms-to-jfrog-cloud.sh
 


### PR DESCRIPTION
… preinstalled packages.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
