### PR TITLE
Retire if there are shared hosts dedicated to cluster type

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/custom/SharedHost.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/custom/SharedHost.java
@@ -41,9 +41,16 @@ public class SharedHost {
         return resources.isEmpty() ? null : resources;
     }
 
+    /** Whether there are any shared hosts specifically for the given cluster type, or without a cluster type restriction. */
     @JsonIgnore
-    public boolean isEnabled(String clusterType) {
-        return resources.stream().anyMatch(hr -> hr.satisfiesClusterType(clusterType));
+    public boolean supportsClusterType(String clusterType) {
+        return resources.stream().anyMatch(resource -> resource.clusterType().map(clusterType::equalsIgnoreCase).orElse(true));
+    }
+
+    /** Whether there are any shared hosts specifically for the given cluster type. */
+    @JsonIgnore
+    public boolean hasClusterType(String clusterType) {
+        return resources.stream().anyMatch(resource -> resource.clusterType().map(clusterType::equalsIgnoreCase).orElse(false));
     }
 
     @JsonIgnore

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -201,6 +201,11 @@ public class NodeRepository extends AbstractComponent {
     /** The number of nodes we should ensure has free capacity for node failures whenever possible */
     public int spareCount() { return spareCount; }
 
+    /** Returns whether nodes must be allocated to hosts that are exclusive to the cluster type. */
+    public boolean exclusiveClusterType(ClusterSpec cluster) {
+        return sharedHosts.value().hasClusterType(cluster.type().name());
+    }
+
     /**
      * Returns whether nodes are allocated exclusively in this instance given this cluster spec.
      * Exclusive allocation requires that the wanted node resources matches the advertised resources of the node
@@ -209,7 +214,7 @@ public class NodeRepository extends AbstractComponent {
     public boolean exclusiveAllocation(ClusterSpec clusterSpec) {
         return clusterSpec.isExclusive() ||
                ( clusterSpec.type().isContainer() && zone.system().isPublic() && !zone.environment().isTest() ) ||
-               ( !zone().cloud().allowHostSharing() && !sharedHosts.value().isEnabled(clusterSpec.type().name()));
+               ( !zone().cloud().allowHostSharing() && !sharedHosts.value().supportsClusterType(clusterSpec.type().name()));
     }
 
     /** Whether the nodes of this cluster must be running on hosts that are specifically provisioned for the application. */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/HostCapacityMaintainer.java
@@ -301,6 +301,7 @@ public class HostCapacityMaintainer extends NodeRepositoryMaintainer {
                                                         .stream()
                                                         .filter(node -> node.violatesExclusivity(cluster,
                                                                                                  application,
+                                                                                                 nodeRepository().exclusiveClusterType(cluster),
                                                                                                  nodeRepository().exclusiveAllocation(cluster),
                                                                                                  false,
                                                                                                  nodeRepository().zone().cloud().allowHostSharing(),

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeAllocation.java
@@ -198,6 +198,7 @@ class NodeAllocation {
 
     private NodeCandidate.ExclusivityViolation violatesExclusivity(NodeCandidate candidate) {
         return candidate.violatesExclusivity(cluster, application,
+                                             nodeRepository.exclusiveClusterType(cluster),
                                              nodeRepository.exclusiveAllocation(cluster),
                                              nodeRepository.exclusiveProvisioning(cluster),
                                              nodeRepository.zone().cloud().allowHostSharing(), allNodes, makeExclusive);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/NodeCandidate.java
@@ -595,7 +595,7 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
     }
 
     public ExclusivityViolation violatesExclusivity(ClusterSpec cluster, ApplicationId application,
-                                                    boolean exclusiveAllocation, boolean exclusiveProvisioning,
+                                                    boolean exclusiveClusterType, boolean exclusiveAllocation, boolean exclusiveProvisioning,
                                                     boolean hostSharing, NodeList allNodes, boolean makeExclusive) {
         if (parentHostname().isEmpty()) return ExclusivityViolation.NONE;
         if (type() != NodeType.tenant) return ExclusivityViolation.NONE;
@@ -612,6 +612,10 @@ public abstract class NodeCandidate implements Nodelike, Comparable<NodeCandidat
         } else {
             // the parent is exclusive to another cluster type
             if ( ! emptyOrEqual(parent.flatMap(Node::exclusiveToClusterType), cluster.type()))
+                return ExclusivityViolation.YES;
+
+            // this cluster requires a parent that was provisioned exclusively for this cluster type
+            if (exclusiveClusterType && parent.flatMap(Node::exclusiveToClusterType).isEmpty() && makeExclusive)
                 return ExclusivityViolation.YES;
 
             // the parent is provisioned for another application


### PR DESCRIPTION
Violate exclusivity if shared-host contains a shared host for the cluster type being allocated.  When an "admin" shared host is defined for a zone, this ensures that all admin nodes will be put on these "admin" shared hosts.  As it is now, this should only affect CD prod.aws-us-east-1a, main AWS test and staging, and public CD AWS. 

This is a no-op if make-exclusive is disabled, which it is in main and public systems, currently.