### PR TITLE
Expose document type name from `IPersistenceHandler` interface

### DIFF
--- a/searchcore/src/tests/proton/persistenceengine/persistence_handler_map/persistence_handler_map_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistence_handler_map/persistence_handler_map_test.cpp
@@ -32,6 +32,7 @@ struct DummyPersistenceHandler : public IPersistenceHandler {
     RetrieversSP getDocumentRetrievers(storage::spi::ReadConsistency) override { return RetrieversSP(); }
     void handleListActiveBuckets(IBucketIdListResultHandler &) override {}
     void handlePopulateActiveBuckets(document::BucketId::List, IGenericResultHandler &) override {}
+    const DocTypeName & doc_type_name() const noexcept override { abort(); }
 };
 
 BucketSpace space_1(1);

--- a/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
+++ b/searchcore/src/tests/proton/persistenceengine/persistenceengine_test.cpp
@@ -161,8 +161,9 @@ struct MyHandler : public IPersistenceHandler, IBucketFreezer {
     const Document              *document;
     std::multiset<uint64_t>      frozen;
     std::multiset<uint64_t>      was_frozen;
+    DocTypeName                  _doc_type_name;
 
-    MyHandler()
+    MyHandler(const DocTypeName &type_name)
         : initialized(false),
           lastBucket(),
           lastTimestamp(),
@@ -180,7 +181,8 @@ struct MyHandler : public IPersistenceHandler, IBucketFreezer {
           _createBucketResult(),
           document(nullptr),
           frozen(),
-          was_frozen()
+          was_frozen(),
+          _doc_type_name(type_name)
     {
     }
 
@@ -287,6 +289,10 @@ struct MyHandler : public IPersistenceHandler, IBucketFreezer {
         resultHandler.handle(Result());
     }
 
+    const DocTypeName &doc_type_name() const noexcept override {
+        return _doc_type_name;
+    }
+
     void freezeBucket(BucketId bucket) override {
         frozen.insert(bucket.getId());
         was_frozen.insert(bucket.getId());
@@ -311,8 +317,8 @@ struct HandlerSet {
 };
 
 HandlerSet::HandlerSet()
-    : phandler1(std::make_shared<MyHandler>()),
-      phandler2(std::make_shared<MyHandler>()),
+    : phandler1(std::make_shared<MyHandler>(DocTypeName("type1"))),
+      phandler2(std::make_shared<MyHandler>(DocTypeName("type2"))),
       handler1(dynamic_cast<MyHandler &>(*phandler1.get())),
       handler2(dynamic_cast<MyHandler &>(*phandler2.get()))
 {}

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/ipersistencehandler.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/ipersistencehandler.h
@@ -13,6 +13,8 @@ namespace storage::spi { class ClusterState; }
 
 namespace proton {
 
+class DocTypeName;
+
 /**
  * This interface describes a sync persistence operation handler. It is implemented by
  * the DocumentDB and other classes, and used by the PersistenceEngine class to delegate
@@ -26,7 +28,7 @@ protected:
 public:
     using UP = std::unique_ptr<IPersistenceHandler>;
     using SP = std::shared_ptr<IPersistenceHandler>;
-    /// Note that you can not move awaythe handlers in the vector.
+    // Note that you can not move away the handlers in the vector.
     using RetrieversSP = std::shared_ptr<std::vector<IDocumentRetriever::SP> >;
     IPersistenceHandler(const IPersistenceHandler &) = delete;
     IPersistenceHandler & operator = (const IPersistenceHandler &) = delete;
@@ -74,6 +76,8 @@ public:
     virtual void handleListActiveBuckets(IBucketIdListResultHandler &resultHandler) = 0;
 
     virtual void handlePopulateActiveBuckets(document::BucketId::List buckets, IGenericResultHandler &resultHandler) = 0;
+
+    [[nodiscard]] virtual const DocTypeName &doc_type_name() const noexcept = 0;
 };
 
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/documentdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/documentdb.h
@@ -383,7 +383,7 @@ public:
 
     bool getDelayedConfig() const { return _state.getDelayedConfig(); }
     void replayConfig(SerialNum serialNum) override;
-    const DocTypeName & getDocTypeName() const { return _docTypeName; }
+    const DocTypeName & getDocTypeName() const noexcept { return _docTypeName; }
     std::unique_ptr<DocumentDBReconfig> prepare_reconfig(const DocumentDBConfig& new_config_snapshot, std::optional<SerialNum> serial_num);
     void reconfigure(DocumentDBConfigSP snapshot) override;
     int64_t getActiveGeneration() const;

--- a/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.cpp
@@ -145,4 +145,10 @@ PersistenceHandlerProxy::handlePopulateActiveBuckets(document::BucketId::List bu
     _bucketHandler.handlePopulateActiveBuckets(std::move(buckets), resultHandler);
 }
 
+const DocTypeName&
+PersistenceHandlerProxy::doc_type_name() const noexcept
+{
+    return _documentDB->getDocTypeName();
+}
+
 } // namespace proton

--- a/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.h
+++ b/searchcore/src/vespa/searchcore/proton/server/persistencehandlerproxy.h
@@ -61,6 +61,8 @@ public:
     void handleListActiveBuckets(IBucketIdListResultHandler &resultHandler) override;
 
     void handlePopulateActiveBuckets(document::BucketId::List buckets, IGenericResultHandler &resultHandler) override;
+
+    const DocTypeName &doc_type_name() const noexcept override;
 };
 
 } // namespace proton


### PR DESCRIPTION
@geirst please review

Step one of wiring document type names to metadata iteration