### PR TITLE
Control resource usage when node in maintenance

### DIFF
--- a/searchcore/src/tests/proton/documentdb/clusterstatehandler/CMakeLists.txt
+++ b/searchcore/src/tests/proton/documentdb/clusterstatehandler/CMakeLists.txt
@@ -10,5 +10,6 @@ vespa_add_executable(searchcore_clusterstatehandler_test_app TEST
     searchcore_attribute
     searchcore_pcommon
     searchcore_grouping
+    GTest::GTest
 )
 vespa_add_test(NAME searchcore_clusterstatehandler_test_app COMMAND searchcore_clusterstatehandler_test_app)

--- a/searchcore/src/tests/proton/documentdb/clusterstatehandler/clusterstatehandler_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/clusterstatehandler/clusterstatehandler_test.cpp
@@ -30,8 +30,14 @@ BucketId bucket1(1);
 BucketId bucket2(2);
 BucketId bucket3(3);
 Distribution distribution(Distribution::getDefaultDistributionConfig(3, 3));
-storage::lib::ClusterState rawClusterState("version:1 storage:3 distributor:3");
-ClusterState clusterState(rawClusterState, 0, distribution);
+
+ClusterState make_cluster_state(const vespalib::string& state, uint16_t node_index, bool maintenance_in_all_spaces = false) {
+    return ClusterState(storage::lib::ClusterState(state), node_index, distribution, maintenance_in_all_spaces);
+}
+
+ClusterState basic_state = make_cluster_state("distributor:3 storage:3", 0);
+ClusterState node_retired_state = make_cluster_state("distributor:3 .1.s:d storage:3 .1.s:r", 1);
+ClusterState node_maintenance_state = make_cluster_state("distributor:3 storage:3", 1, true);
 
 struct ClusterStateHandlerTest : testing::Test {
     vespalib::ThreadStackExecutor   _exec;
@@ -51,18 +57,44 @@ struct ClusterStateHandlerTest : testing::Test {
     ~ClusterStateHandlerTest() {
         _stateHandler.removeClusterStateChangedHandler(&_changedHandler);
     }
+    const IBucketStateCalculator& set_cluster_state(const ClusterState& state) {
+        _stateHandler.handleSetClusterState(state, _genericHandler);
+        _exec.sync();
+        EXPECT_TRUE(_changedHandler._calc);
+        return *_changedHandler._calc;
+    }
 };
 
 TEST_F(ClusterStateHandlerTest, cluster_state_change_is_notified)
 {
-    _stateHandler.handleSetClusterState(clusterState, _genericHandler);
-    _exec.sync();
-    EXPECT_TRUE(_changedHandler._calc);
+    const auto& calc = set_cluster_state(basic_state);
+    EXPECT_TRUE(calc.clusterUp());
+    EXPECT_TRUE(calc.nodeUp());
+    EXPECT_FALSE(calc.nodeInitializing());
+    EXPECT_FALSE(calc.nodeRetired());
+    EXPECT_FALSE(calc.nodeMaintenance());
+    EXPECT_FALSE(calc.node_retired_or_maintenance());
+}
+
+TEST_F(ClusterStateHandlerTest, node_in_retired_state)
+{
+    const auto &calc = set_cluster_state(node_retired_state);
+    EXPECT_TRUE(calc.nodeRetired());
+    EXPECT_FALSE(calc.nodeMaintenance());
+    EXPECT_TRUE(calc.node_retired_or_maintenance());
+}
+
+TEST_F(ClusterStateHandlerTest, node_in_maintenance_state)
+{
+    const auto &calc = set_cluster_state(node_maintenance_state);
+    EXPECT_FALSE(calc.nodeRetired());
+    EXPECT_TRUE(calc.nodeMaintenance());
+    EXPECT_TRUE(calc.node_retired_or_maintenance());
 }
 
 TEST_F(ClusterStateHandlerTest, modified_buckets_are_returned)
 {
-    _stateHandler.handleSetClusterState(clusterState, _genericHandler);
+    _stateHandler.handleSetClusterState(basic_state, _genericHandler);
     _exec.sync();
 
     // notify 2 buckets

--- a/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
+++ b/searchcore/src/tests/proton/documentdb/document_subdbs/document_subdbs_test.cpp
@@ -620,30 +620,35 @@ TEST_F("require that attribute manager can be reconfigured", SearchableFixture)
     requireThatAttributeManagerCanBeReconfigured(f);
 }
 
-TEST_F("require that subdb reflect retirement", FastAccessFixture)
+TEST_F("require that subdb reflect retirement or maintenance", FastAccessFixture)
 {
     CompactionStrategy cfg(0.1, 0.3);
 
-    EXPECT_FALSE(f._subDb.isNodeRetired());
+    EXPECT_FALSE(f._subDb.is_node_retired_or_maintenance());
     auto unretired_cfg = f._subDb.computeCompactionStrategy(cfg);
     EXPECT_TRUE(cfg == unretired_cfg);
 
     auto calc = std::make_shared<proton::test::BucketStateCalculator>();
     calc->setNodeRetired(true);
     f.setBucketStateCalculator(calc);
-    EXPECT_TRUE(f._subDb.isNodeRetired());
+    EXPECT_TRUE(f._subDb.is_node_retired_or_maintenance());
     auto retired_cfg = f._subDb.computeCompactionStrategy(cfg);
     EXPECT_TRUE(cfg != retired_cfg);
     EXPECT_TRUE(CompactionStrategy(0.5, 0.5) == retired_cfg);
 
     calc->setNodeRetired(false);
+    calc->setNodeMaintenance(true);
     f.setBucketStateCalculator(calc);
-    EXPECT_FALSE(f._subDb.isNodeRetired());
+    EXPECT_TRUE(f._subDb.is_node_retired_or_maintenance());
+
+    calc->setNodeMaintenance(false);
+    f.setBucketStateCalculator(calc);
+    EXPECT_FALSE(f._subDb.is_node_retired_or_maintenance());
     unretired_cfg = f._subDb.computeCompactionStrategy(cfg);
     EXPECT_TRUE(cfg == unretired_cfg);
 }
 
-TEST_F("require that attribute compaction config reflect retirement", FastAccessFixture) {
+TEST_F("require that attribute compaction config reflect retirement or maintenance", FastAccessFixture) {
     CompactionStrategy default_cfg(0.05, 0.2);
     CompactionStrategy retired_cfg(0.5, 0.5);
 

--- a/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
+++ b/searchcore/src/tests/proton/documentdb/lid_space_compaction/lid_space_jobtest.cpp
@@ -44,7 +44,7 @@ JobTestBase::init(uint32_t allowedLidBloat,
           double allowedLidBloatFactor,
           double resourceLimitFactor,
           vespalib::duration interval,
-          bool nodeRetired,
+          bool node_retired_or_maintenance,
           uint32_t maxOutstandingMoveOps)
 {
     _handler = std::make_shared<MyHandler>(maxOutstandingMoveOps != MAX_OUTSTANDING_MOVE_OPS, true);
@@ -57,7 +57,7 @@ JobTestBase::init(uint32_t allowedLidBloat,
     _master = std::make_unique<proton::SyncableExecutorThreadService> (*_singleExecutor);
     _bucketExecutor = std::make_unique<storage::spi::dummy::DummyBucketExecutor>(4);
     _job = lidspace::CompactionJob::create(compactCfg, RetainGuard(_refCount), _handler, _storer, *_master, *_bucketExecutor,
-                                           _diskMemUsageNotifier, blockableCfg, _clusterStateHandler, nodeRetired,
+                                           _diskMemUsageNotifier, blockableCfg, _clusterStateHandler, node_retired_or_maintenance,
                                            document::BucketSpace::placeHolder());
 }
 
@@ -180,10 +180,10 @@ JobTest::init(uint32_t allowedLidBloat,
               double allowedLidBloatFactor,
               double resourceLimitFactor,
               vespalib::duration interval,
-              bool nodeRetired,
+              bool node_retired_or_maintenance,
               uint32_t maxOutstandingMoveOps)
 {
-    JobTestBase::init(allowedLidBloat, allowedLidBloatFactor, resourceLimitFactor, interval, nodeRetired, maxOutstandingMoveOps);
+    JobTestBase::init(allowedLidBloat, allowedLidBloatFactor, resourceLimitFactor, interval, node_retired_or_maintenance, maxOutstandingMoveOps);
     _jobRunner = std::make_unique<MyDirectJobRunner>(*_job);
 }
 

--- a/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
+++ b/searchcore/src/tests/proton/server/memory_flush_config_updater/memory_flush_config_updater_test.cpp
@@ -69,8 +69,8 @@ struct Fixture
     void notifyDiskMemUsage(const ResourceUsageState &diskState, const ResourceUsageState &memoryState) {
         updater.notifyDiskMemUsage(DiskMemUsageState(diskState, memoryState));
     }
-    void setNodeRetired(bool nodeRetired) {
-        updater.setNodeRetired(nodeRetired);
+    void set_node_retired_or_maintenance(bool value) {
+        updater.set_node_retired_or_maintenance(value);
     }
 };
 
@@ -226,12 +226,12 @@ TEST_F("require that we must go below low watermark for memory usage before usin
     TEST_DO(f.assertStrategyConfig(4, 1, 20));
 }
 
-TEST_F("require that more disk bloat is allowed while node state is retired", Fixture)
+TEST_F("require that more disk bloat is allowed while node state is retired or maintenance", Fixture)
 {
     constexpr double DEFAULT_DISK_BLOAT = 0.25;
     f.notifyDiskMemUsage(ResourceUsageState(0.7, 0.3), belowLimit());
     TEST_DO(f.assertStrategyDiskConfig(DEFAULT_DISK_BLOAT, DEFAULT_DISK_BLOAT));
-    f.setNodeRetired(true);
+    f.set_node_retired_or_maintenance(true);
     TEST_DO(f.assertStrategyDiskConfig((0.8 - ((0.3/0.7)*(1 - DEFAULT_DISK_BLOAT))) / 0.8, 1.0));
     f.notifyDiskMemUsage(belowLimit(), belowLimit());
     TEST_DO(f.assertStrategyDiskConfig(DEFAULT_DISK_BLOAT, DEFAULT_DISK_BLOAT));

--- a/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/clusterstatehandler.cpp
@@ -47,6 +47,7 @@ public:
     bool nodeInitializing() const override { return _nodeInitializing; }
     bool nodeRetired() const override { return _nodeRetired; }
     bool nodeMaintenance() const noexcept override { return _nodeMaintenance; }
+    bool node_retired_or_maintenance() const noexcept override { return _nodeRetired || _nodeMaintenance; }
 };
 
 }

--- a/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/fast_access_doc_subdb.cpp
@@ -272,7 +272,7 @@ FastAccessDocSubDB::applyConfig(const DocumentDBConfig &newConfigSnapshot, const
             reconfigureAttributeMetrics(*newMgr, *oldMgr);
         }
         _iFeedView.set(_fastAccessFeedView.get());
-        if (isNodeRetired()) {
+        if (is_node_retired_or_maintenance()) {
             // TODO Should probably ahve a similar OnDone callback to applyConfig too.
             vespalib::Gate gate;
             reconfigureAttributesConsideringNodeState(std::make_shared<vespalib::GateCallback>(gate));

--- a/searchcore/src/vespa/searchcore/proton/server/ibucketstatecalculator.h
+++ b/searchcore/src/vespa/searchcore/proton/server/ibucketstatecalculator.h
@@ -16,6 +16,7 @@ struct IBucketStateCalculator
     virtual bool nodeInitializing() const = 0;
     virtual bool nodeRetired() const = 0;
     virtual bool nodeMaintenance() const noexcept = 0;
+    virtual bool node_retired_or_maintenance() const noexcept = 0;
     virtual ~IBucketStateCalculator() = default;
 };
 

--- a/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/maintenance_jobs_injector.cpp
@@ -37,7 +37,7 @@ injectLidSpaceCompactionJobs(MaintenanceController &controller,
         auto job = lidspace::CompactionJob::create(config.getLidSpaceCompactionConfig(), controller.retainDB(),
                                                    std::move(lidHandler), opStorer, controller.masterThread(),
                                                    bucketExecutor, diskMemUsageNotifier,config.getBlockableJobConfig(),
-                                                   clusterStateChangedNotifier, calc && calc->nodeRetired(), bucketSpace);
+                                                   clusterStateChangedNotifier, calc && calc->node_retired_or_maintenance(), bucketSpace);
         controller.registerJob(trackJob(tracker, std::move(job)));
     }
 }

--- a/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.h
+++ b/searchcore/src/vespa/searchcore/proton/server/memory_flush_config_updater.h
@@ -28,7 +28,7 @@ private:
     DiskMemUsageState           _currState;
     bool                        _useConservativeDiskMode;
     bool                        _useConservativeMemoryMode;
-    bool                        _nodeRetired;
+    bool                        _node_retired_or_maintenance;
 
 
     void considerUseConservativeDiskMode(const LockGuard &guard, MemoryFlush::Config &newConfig);
@@ -43,7 +43,7 @@ public:
                              const ProtonConfig::Flush::Memory &config,
                              const vespalib::HwInfo::Memory &memory);
     void setConfig(const ProtonConfig::Flush::Memory &newConfig);
-    void setNodeRetired(bool nodeRetired);
+    void set_node_retired_or_maintenance(bool value);
     void notifyDiskMemUsage(DiskMemUsageState newState) override;
 
     static MemoryFlush::Config convertConfig(const ProtonConfig::Flush::Memory &config,

--- a/searchcore/src/vespa/searchcore/proton/server/proton.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/proton.cpp
@@ -925,12 +925,13 @@ Proton::setClusterState(BucketSpace bucketSpace, const storage::spi::ClusterStat
     // about whether node is supposed to be up or not.  Match engine
     // needs to know this in order to stop serving queries.
     bool nodeUpInBucketSpace(calc.nodeUp()); // TODO rename calculator function to imply bucket space affinity
-    bool nodeRetired(calc.nodeRetired());
+    bool nodeRetired = calc.nodeRetired();
+    bool nodeMaintenance = calc.nodeMaintenance();
     bool nodeUp = updateNodeUp(bucketSpace, nodeUpInBucketSpace);
     _matchEngine->setNodeUp(nodeUp);
-    _matchEngine->setNodeMaintenance(calc.nodeMaintenance()); // Note: _all_ bucket spaces in maintenance
+    _matchEngine->setNodeMaintenance(nodeMaintenance); // Note: _all_ bucket spaces in maintenance
     if (_memoryFlushConfigUpdater) {
-        _memoryFlushConfigUpdater->setNodeRetired(nodeRetired);
+        _memoryFlushConfigUpdater->set_node_retired_or_maintenance(nodeRetired || nodeMaintenance);
     }
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/searchabledocsubdb.cpp
@@ -183,7 +183,7 @@ SearchableDocSubDB::applyFlushConfig(const DocumentDBFlushConfig &flushConfig)
 void
 SearchableDocSubDB::propagateFlushConfig()
 {
-    uint32_t maxFlushed = isNodeRetired() ? _flushConfig.getMaxFlushedRetired() : _flushConfig.getMaxFlushed();
+    uint32_t maxFlushed = is_node_retired_or_maintenance() ? _flushConfig.getMaxFlushedRetired() : _flushConfig.getMaxFlushed();
     _indexMgr->setMaxFlushed(maxFlushed);
 }
 

--- a/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
+++ b/searchcore/src/vespa/searchcore/proton/server/storeonlydocsubdb.h
@@ -152,7 +152,7 @@ private:
     DocumentMetaStoreFlushTarget::SP           _dmsFlushTarget;
     std::shared_ptr<ShrinkLidSpaceFlushTarget> _dmsShrinkTarget;
     std::shared_ptr<PendingLidTrackerBase>     _pendingLidsForCommit;
-    bool                                       _nodeRetired;
+    bool                                       _node_retired_or_maintenance;
     vespalib::datastore::CompactionStrategy    _lastConfiguredCompactionStrategy;
 
     IFlushTargetList getFlushTargets() override;
@@ -239,7 +239,7 @@ public:
     void tearDownReferences(IDocumentDBReferenceResolver &resolver) override;
     PendingLidTrackerBase & getUncommittedLidsTracker() override { return *_pendingLidsForCommit; }
     vespalib::datastore::CompactionStrategy computeCompactionStrategy(vespalib::datastore::CompactionStrategy strategy) const;
-    bool isNodeRetired() const { return _nodeRetired; }
+    bool is_node_retired_or_maintenance() const { return _node_retired_or_maintenance; }
     TransientResourceUsage get_transient_resource_usage() const override;
 
 };

--- a/searchcore/src/vespa/searchcore/proton/test/bucketstatecalculator.h
+++ b/searchcore/src/vespa/searchcore/proton/test/bucketstatecalculator.h
@@ -83,6 +83,7 @@ public:
     bool nodeRetired() const override { return _nodeRetired; }
     bool nodeInitializing() const override { return false; }
     bool nodeMaintenance() const noexcept override { return _nodeMaintenance; }
+    bool node_retired_or_maintenance() const noexcept override { return _nodeRetired || _nodeMaintenance; }
 };
 
 }


### PR DESCRIPTION
Previously the following has been adjusted when the content node is retired:
    1) Lid space compaction - turned off.
    2) Flush engine strategy - tuned to reduce disk and CPU usage.
    3) Attribute vector compaction - tuned to reduce memory allocations and CPU usage.

In a node retirement scenario documents are being removed from the node, and eventually the node is deleted.
Without the adjustments above a lot of resources are spent "fixing" the results of removing documents,
and the process just takes a lot longer.

A similar set of challenges can occur when a node is set in maintenance,
especially if the node transitions from retired to maintenance.
E.g. this happens when the Vespa version is upgraded in Vespa Cloud.

With this change the resource usage of background jobs are kept in check
for both a retired node and a node in maintenance.

@baldersheim and @toregge please review
@vekterli FYI