### PR TITLE
Stop subscribing to config that is static

### DIFF
--- a/container-core/src/main/java/com/yahoo/container/Container.java
+++ b/container-core/src/main/java/com/yahoo/container/Container.java
@@ -95,18 +95,11 @@ public class Container {
     }
 
     // Only intended for use by the Server instance.
-    public void setupFileAcquirer(QrConfig.Filedistributor filedistributorConfig) {
+    public void setupFileAcquirer() {
         if (usingCustomFileAcquirer)
             return;
 
-        if (filedistributorConfig.configid().isEmpty()) {
-            if (fileAcquirer != null)
-                logger.warning("Disabling file distribution");
-            fileAcquirer = null;
-        } else {
-            fileAcquirer = FileAcquirerFactory.create(filedistributorConfig.configid());
-        }
-
+        fileAcquirer = FileAcquirerFactory.create();
         setPathAcquirer(fileAcquirer);
     }
 

--- a/container-core/src/main/resources/configdefinitions/container.qr.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr.def
@@ -5,7 +5,8 @@ namespace=container
 ### connection to the config system
 
 ## filedistributor rpc configuration
-filedistributor.configid reference default="" restart
+## TODO: Unused, remove in Vespa 9
+filedistributor.configid reference default=""
 
 ## Is RPC server enabled?
 rpc.enabled bool default=false restart

--- a/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
+++ b/container-disc/src/main/java/com/yahoo/container/jdisc/ConfiguredApplication.java
@@ -168,7 +168,7 @@ public final class ConfiguredApplication implements Application {
     public void start() {
         qrConfig = getConfig(QrConfig.class);
         reconfigure(qrConfig.shutdown());
-        hackToInitializeServer(qrConfig);
+        hackToInitializeServer();
 
         ContainerBuilder builder = createBuilderWithGuiceBindings();
         configurer = createConfigurer(builder.guiceModules().activate());
@@ -242,9 +242,9 @@ public final class ConfiguredApplication implements Application {
         }
     }
 
-    private static void hackToInitializeServer(QrConfig config) {
+    private static void hackToInitializeServer() {
         try {
-            Container.get().setupFileAcquirer(config.filedistributor());
+            Container.get().setupFileAcquirer();
             Container.get().setupUrlDownloader();
         } catch (Exception e) {
             log.log(Level.SEVERE, "Caught exception when initializing server. Exiting.", e);

--- a/fileacquirer/abi-spec.json
+++ b/fileacquirer/abi-spec.json
@@ -21,7 +21,7 @@
     ],
     "methods" : [
       "public void <init>()",
-      "public static com.yahoo.filedistribution.fileacquirer.FileAcquirer create(java.lang.String)"
+      "public static com.yahoo.filedistribution.fileacquirer.FileAcquirer create()"
     ],
     "fields" : [ ]
   },

--- a/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerFactory.java
+++ b/fileacquirer/src/main/java/com/yahoo/filedistribution/fileacquirer/FileAcquirerFactory.java
@@ -9,8 +9,8 @@ package com.yahoo.filedistribution.fileacquirer;
  */
 public class FileAcquirerFactory {
 
-    public static FileAcquirer create(String configId) {
-        return new FileAcquirerImpl(configId);
+    public static FileAcquirer create() {
+        return new FileAcquirerImpl();
     }
 
 }


### PR DESCRIPTION
File acquirer will always use localhost:19090 for getting files now, remove need for subscribing to qr config.
Will also remove restart log message when e.g. moving logserver to a new node

Please review only, will merge after release Thursday