### PR TITLE
Include doc type name and GID in metadata iteration results

### DIFF
--- a/persistence/src/tests/spi/clusterstatetest.cpp
+++ b/persistence/src/tests/spi/clusterstatetest.cpp
@@ -297,7 +297,7 @@ TEST(DocEntryTest, test_doctype_and_gid) {
     DocEntry::UP e = DocEntry::create(Timestamp(9), DocumentMetaEnum::NONE, "doc_type", GlobalId::parse("gid(0xc4cef118f9f9649222750be2)"));
     EXPECT_EQ(9, e->getTimestamp());
     EXPECT_FALSE(e->isRemove());
-    EXPECT_EQ(20, e->getSize());
+    EXPECT_EQ(44, e->getSize());
     EXPECT_EQ(nullptr, e->getDocument());
     EXPECT_EQ(nullptr, e->getDocumentId());
     EXPECT_EQ("doc_type", e->getDocumentType());

--- a/persistence/src/vespa/persistence/spi/docentry.cpp
+++ b/persistence/src/vespa/persistence/spi/docentry.cpp
@@ -71,7 +71,7 @@ DocEntryWithId::DocEntryWithId(Timestamp t, DocumentMetaEnum metaEnum, const Doc
 { }
 
 DocEntryWithTypeAndGid::DocEntryWithTypeAndGid(Timestamp t, DocumentMetaEnum metaEnum, vespalib::stringref docType, GlobalId gid)
-    : DocEntry(t, metaEnum, docType.size() + sizeof(gid)),
+    : DocEntry(t, metaEnum, sizeof(DocEntry) + docType.size() + sizeof(gid)),
       _type(docType),
       _gid(gid)
 { }

--- a/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
+++ b/searchcore/src/tests/proton/document_iterator/document_iterator_test.cpp
@@ -5,7 +5,6 @@
 #include <vespa/searchcore/proton/common/pendinglidtracker.h>
 #include <vespa/searchcore/proton/persistenceengine/document_iterator.h>
 #include <vespa/searchcore/proton/persistenceengine/commit_and_wait_document_retriever.h>
-#include <vespa/searchcore/proton/persistenceengine/ipersistencehandler.h>
 #include <vespa/searchlib/attribute/attributecontext.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/test/mock_attribute_manager.h>
@@ -176,41 +175,6 @@ UnitDR::UnitDR(const document::DocumentType &dt, document::Document::UP d, Times
       docIdLimit(std::numeric_limits<uint32_t>::max())
 {}
 UnitDR::~UnitDR() = default;
-
-struct MockPersistenceHandler : IPersistenceHandler {
-    DocTypeName _doc_type_name;
-
-    explicit MockPersistenceHandler(vespalib::stringref type_name)
-        : _doc_type_name(type_name)
-    {
-    }
-    ~MockPersistenceHandler() override = default;
-
-    void initialize() override { abort(); }
-    void handlePut(FeedToken, const storage::spi::Bucket&, storage::spi::Timestamp, DocumentSP ) override { abort(); }
-    void handleUpdate(FeedToken, const storage::spi::Bucket&,
-                      storage::spi::Timestamp, DocumentUpdateSP) override { abort(); }
-    void handleRemove(FeedToken, const storage::spi::Bucket&,
-                      storage::spi::Timestamp, const document::DocumentId&) override { abort(); }
-    void handleRemoveByGid(FeedToken, const storage::spi::Bucket&, storage::spi::Timestamp,
-                           vespalib::stringref, const document::GlobalId&) override { abort(); }
-    void handleListBuckets(IBucketIdListResultHandler&) override { abort(); }
-    void handleSetClusterState(const storage::spi::ClusterState&, IGenericResultHandler&) override { abort(); }
-    void handleSetActiveState(const storage::spi::Bucket&, storage::spi::BucketInfo::ActiveState,
-                              std::shared_ptr<IGenericResultHandler>) override { abort(); }
-    void handleGetBucketInfo(const storage::spi::Bucket&, IBucketInfoResultHandler&) override { abort(); }
-    void handleCreateBucket(FeedToken, const storage::spi::Bucket&) override { abort(); };
-    void handleDeleteBucket(FeedToken, const storage::spi::Bucket&) override { abort(); }
-    void handleGetModifiedBuckets(IBucketIdListResultHandler&) override { abort(); }
-    void handleSplit(FeedToken, const storage::spi::Bucket&,
-                     const storage::spi::Bucket&, const storage::spi::Bucket&) override { abort(); }
-    void handleJoin(FeedToken, const storage::spi::Bucket&, const storage::spi::Bucket&,
-                    const storage::spi::Bucket&) override { abort(); }
-    RetrieversSP getDocumentRetrievers(storage::spi::ReadConsistency) override { abort(); }
-    void handleListActiveBuckets(IBucketIdListResultHandler&) override { abort(); }
-    void handlePopulateActiveBuckets(document::BucketId::List, IGenericResultHandler&) override { abort(); }
-    const DocTypeName &doc_type_name() const noexcept override { return _doc_type_name; }
-};
 
 struct VisitRecordingUnitDR : UnitDR {
     using VisitedLIDs = std::unordered_set<DocumentIdT>;
@@ -655,11 +619,9 @@ TEST("require that iterating all versions returns both documents and removes") {
 
 TEST("require that using an empty field set returns meta-data only") {
     DocumentIterator itr(bucket(5), std::make_shared<document::NoFields>(), selectAll(), newestV(), -1, false);
-    MockPersistenceHandler foo_handler("foo");
-    MockPersistenceHandler doc_handler("document");
-    itr.add(&foo_handler, doc_with_fields("id:ns:foo::1", Timestamp(2), bucket(5)));
-    itr.add(&doc_handler, cat(doc("id:ns:document::2", Timestamp(3), bucket(5)),
-                              rem("id:ns:document::3", Timestamp(4), bucket(5))));
+    itr.add(DocTypeName("foo"), doc_with_fields("id:ns:foo::1", Timestamp(2), bucket(5)));
+    itr.add(DocTypeName("document"), cat(doc("id:ns:document::2", Timestamp(3), bucket(5)),
+                                         rem("id:ns:document::3", Timestamp(4), bucket(5))));
     IterateResult res = itr.iterate(largeNum);
     EXPECT_TRUE(res.isCompleted());
     EXPECT_EQUAL(3u, res.getEntries().size());
@@ -708,7 +670,7 @@ TEST("require that maxBytes splits iteration results for meta-data only iteratio
     IterateResult res1 = itr.iterate(2 * sizeof(DocEntry));
     EXPECT_TRUE(!res1.isCompleted());
     EXPECT_EQUAL(2u, res1.getEntries().size());
-    // Note: empty doc types since we did not pass in a handler alongside the retrievers
+    // Note: empty doc types since we did not pass in an explicit doc type alongside the retrievers
     TEST_DO(checkEntry(res1, 0, Timestamp(2), DocumentMetaEnum::NONE, gid_of("id:ns:document::1"), ""));
     TEST_DO(checkEntry(res1, 1, Timestamp(3), DocumentMetaEnum::REMOVE_ENTRY, gid_of("id:ns:document::2"), ""));
 

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
@@ -4,6 +4,7 @@
 
 #include "i_document_retriever.h"
 #include <vespa/searchlib/common/idocumentmetastore.h>
+#include <vespa/searchcore/proton/common/doctypename.h>
 #include <vespa/persistence/spi/bucket.h>
 #include <vespa/persistence/spi/selection.h>
 #include <vespa/persistence/spi/result.h>
@@ -18,7 +19,7 @@ class DocumentIterator
 {
 private:
     using ReadConsistency = storage::spi::ReadConsistency;
-    using HandlerWithRetriever = std::pair<const IPersistenceHandler*, IDocumentRetriever::SP>;
+    using DocTypeNameAndRetriever = std::pair<DocTypeName, IDocumentRetriever::SP>;
 
     const storage::spi::Bucket            _bucket;;
     const storage::spi::Selection         _selection;
@@ -29,13 +30,13 @@ private:
     const bool                            _metaOnly;
     const bool                            _ignoreMaxBytes;
     bool                                  _fetchedData;
-    std::vector<HandlerWithRetriever>     _sources;
+    std::vector<DocTypeNameAndRetriever>  _sources;
     size_t                                _nextItem;
     storage::spi::IterateResult::List     _list;
 
 
     [[nodiscard]] bool checkMeta(const search::DocumentMetaData &meta) const;
-    void fetchCompleteSource(const IPersistenceHandler * handler,
+    void fetchCompleteSource(const DocTypeName & doc_type_name,
                              const IDocumentRetriever & source,
                              storage::spi::IterateResult::List & list);
     [[nodiscard]] bool isWeakRead() const { return _readConsistency == ReadConsistency::WEAK; }
@@ -46,7 +47,7 @@ public:
                      ssize_t defaultSerializedSize, bool ignoreMaxBytes,
                      ReadConsistency readConsistency=ReadConsistency::STRONG);
     ~DocumentIterator();
-    void add(const IPersistenceHandler *handler, IDocumentRetriever::SP retriever);
+    void add(const DocTypeName & doc_type_name, IDocumentRetriever::SP retriever);
     void add(IDocumentRetriever::SP retriever);
     storage::spi::IterateResult iterate(size_t maxBytes);
 };

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.h
@@ -12,10 +12,14 @@
 
 namespace proton {
 
+class IPersistenceHandler;
+
 class DocumentIterator
 {
 private:
     using ReadConsistency = storage::spi::ReadConsistency;
+    using HandlerWithRetriever = std::pair<const IPersistenceHandler*, IDocumentRetriever::SP>;
+
     const storage::spi::Bucket            _bucket;;
     const storage::spi::Selection         _selection;
     const storage::spi::IncludedVersions  _versions;
@@ -25,14 +29,16 @@ private:
     const bool                            _metaOnly;
     const bool                            _ignoreMaxBytes;
     bool                                  _fetchedData;
-    std::vector<IDocumentRetriever::SP>   _sources;
+    std::vector<HandlerWithRetriever>     _sources;
     size_t                                _nextItem;
     storage::spi::IterateResult::List     _list;
 
 
-    bool checkMeta(const search::DocumentMetaData &meta) const;
-    void fetchCompleteSource(const IDocumentRetriever & source, storage::spi::IterateResult::List & list);
-    bool isWeakRead() const { return _readConsistency == ReadConsistency::WEAK; }
+    [[nodiscard]] bool checkMeta(const search::DocumentMetaData &meta) const;
+    void fetchCompleteSource(const IPersistenceHandler * handler,
+                             const IDocumentRetriever & source,
+                             storage::spi::IterateResult::List & list);
+    [[nodiscard]] bool isWeakRead() const { return _readConsistency == ReadConsistency::WEAK; }
 
 public:
     DocumentIterator(const storage::spi::Bucket &bucket, document::FieldSet::SP fields,
@@ -40,6 +46,7 @@ public:
                      ssize_t defaultSerializedSize, bool ignoreMaxBytes,
                      ReadConsistency readConsistency=ReadConsistency::STRONG);
     ~DocumentIterator();
+    void add(const IPersistenceHandler *handler, IDocumentRetriever::SP retriever);
     void add(IDocumentRetriever::SP retriever);
     storage::spi::IterateResult iterate(size_t maxBytes);
 };

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
@@ -547,8 +547,7 @@ PersistenceEngine::createIterator(const Bucket &bucket, FieldSetSP fields, const
         auto *handler = snap.handlers().get();
         IPersistenceHandler::RetrieversSP retrievers = handler->getDocumentRetrievers(context.getReadConsistency());
         for (const auto & retriever : *retrievers) {
-            // Handler ptr validity and lifetime is maintained by handler snapshot owned by iterator
-            entry->it.add(handler, retriever);
+            entry->it.add(handler->doc_type_name(), retriever);
         }
     }
     entry->handler_sequence = HandlerSnapshot::release(std::move(snap));

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/persistenceengine.cpp
@@ -544,9 +544,11 @@ PersistenceEngine::createIterator(const Bucket &bucket, FieldSetSP fields, const
     auto entry = std::make_unique<IteratorEntry>(context.getReadConsistency(), bucket, std::move(fields), selection,
                                                  versions, _defaultSerializedSize, _ignoreMaxBytes);
     for (; snap.handlers().valid(); snap.handlers().next()) {
-        IPersistenceHandler::RetrieversSP retrievers = snap.handlers().get()->getDocumentRetrievers(context.getReadConsistency());
+        auto *handler = snap.handlers().get();
+        IPersistenceHandler::RetrieversSP retrievers = handler->getDocumentRetrievers(context.getReadConsistency());
         for (const auto & retriever : *retrievers) {
-            entry->it.add(retriever);
+            // Handler ptr validity and lifetime is maintained by handler snapshot owned by iterator
+            entry->it.add(handler, retriever);
         }
     }
     entry->handler_sequence = HandlerSnapshot::release(std::move(snap));


### PR DESCRIPTION
@geirst @toregge please review. In particular pay close attention to the expected semantics of handler lifetime and handler → retriever relationships.
@baldersheim FYI

Document type is fetched from the associated `IPersistenceHandler` on-demand; it is assumed the lifetime of the pointer must be valid for the entire lifetime of the iterator itself, as the latter holds a valid handler snapshot.

For simplicity, it's possible to _not_ pass in a handler, in which case the doc type name will be implicitly empty.

Some expected `DocEntry` sizes have been adjusted, as we now report the size of the document type and GID alongside the base type size.