### PR TITLE
expose dense subspace blocks for serializing

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1002,6 +1002,22 @@
     ],
     "fields" : [ ]
   },
+  "com.yahoo.tensor.MixedTensor$DenseSubspace" : {
+    "superClass" : "java.lang.Object",
+    "interfaces" : [ ],
+    "attributes" : [
+      "public",
+      "final"
+    ],
+    "methods" : [
+      "public int hashCode()",
+      "public boolean equals(java.lang.Object)"
+    ],
+    "fields" : [
+      "public final com.yahoo.tensor.TensorAddress sparseAddr",
+      "public final double[] cells"
+    ]
+  },
   "com.yahoo.tensor.MixedTensor" : {
     "superClass" : "java.lang.Object",
     "interfaces" : [
@@ -1011,6 +1027,7 @@
       "public"
     ],
     "methods" : [
+      "public java.util.List getInternalDenseSubspaces()",
       "public com.yahoo.tensor.TensorType type()",
       "public long size()",
       "public double get(com.yahoo.tensor.TensorAddress)",

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1014,7 +1014,7 @@
       "public boolean equals(java.lang.Object)"
     ],
     "fields" : [
-      "public final com.yahoo.tensor.TensorAddress sparseAddr",
+      "public final com.yahoo.tensor.TensorAddress sparseAddress",
       "public final double[] cells"
     ]
   },

--- a/vespajlib/src/main/java/com/yahoo/tensor/MixedTensor.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/MixedTensor.java
@@ -33,18 +33,18 @@ public class MixedTensor implements Tensor {
     // XXX consider using "record" instead
     /** only exposed for internal use; subject to change without notice */
     public static final class DenseSubspace {
-        public final TensorAddress sparseAddr;
+        public final TensorAddress sparseAddress;
         public final double[] cells;
-        DenseSubspace(TensorAddress sparseAddr, double[] cells) {
-            this.sparseAddr = sparseAddr;
+        DenseSubspace(TensorAddress sparseAddress, double[] cells) {
+            this.sparseAddress = sparseAddress;
             this.cells = cells;
         }
         @Override public int hashCode() {
-            return Objects.hash(sparseAddr, cells[0]);
+            return Objects.hash(sparseAddress, cells[0]);
         }
         @Override public boolean equals(Object other) {
             if (other instanceof DenseSubspace o) {
-                return sparseAddr.equals(o.sparseAddr) && Arrays.equals(cells, o.cells);
+                return sparseAddress.equals(o.sparseAddress) && Arrays.equals(cells, o.cells);
             }
             return false;
         }
@@ -69,11 +69,11 @@ public class MixedTensor implements Tensor {
         }
         long count = 0;
         for (var block : this.denseSubspaces) {
-            if (index.sparseMap.get(block.sparseAddr) != count) {
+            if (index.sparseMap.get(block.sparseAddress) != count) {
                 throw new IllegalStateException("map vs list mismatch: block #"
                                                 + count
                                                 + " address maps to #"
-                                                + index.sparseMap.get(block.sparseAddr));
+                                                + index.sparseMap.get(block.sparseAddress));
             }
             if (block.cells.length != denseSubspaceSize) {
                 throw new IllegalStateException("dense subspace size mismatch, expected "
@@ -148,7 +148,7 @@ public class MixedTensor implements Tensor {
                     currBlock = blockIterator.next();
                     currOffset = 0;
                 }
-                TensorAddress fullAddr = index.fullAddressOf(currBlock.sparseAddr, currOffset);
+                TensorAddress fullAddr = index.fullAddressOf(currBlock.sparseAddress, currOffset);
                 double value = currBlock.cells[currOffset++];
                 return new Cell(fullAddr, value);
             }
@@ -205,8 +205,8 @@ public class MixedTensor implements Tensor {
         var indexBuilder = new Index.Builder(type);
         List<DenseSubspace> list = new ArrayList<>();
         for (var block : denseSubspaces) {
-            if ( ! addresses.contains(block.sparseAddr)) {  // assumption: addresses only contain the sparse part
-                indexBuilder.addBlock(block.sparseAddr, list.size());
+            if ( ! addresses.contains(block.sparseAddress)) {  // assumption: addresses only contain the sparse part
+                indexBuilder.addBlock(block.sparseAddress, list.size());
                 list.add(block);
             }
         }

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorType.java
@@ -90,6 +90,7 @@ public class TensorType {
     private final TensorType mappedSubtype;
     private final TensorType indexedSubtype;
 
+    // only used to initialize the "empty" instance
     private TensorType() {
         this.valueType = Value.DOUBLE;
         this.dimensions = List.of();

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -151,22 +151,14 @@ public class JsonFormat {
 
         // Create tensor type for mapped dimensions subtype
         TensorType mappedSubType = new TensorType.Builder(mappedDimensions).build();
-
-        // Find all unique indices for the mapped dimensions
-        Set<TensorAddress> denseSubSpaceAddresses = new HashSet<>();
-        tensor.cellIterator().forEachRemaining((cell) -> {
-            denseSubSpaceAddresses.add(subAddress(cell.getKey(), mappedSubType, tensor.type()));
-        });
-
-        // Slice out dense subspace of each and encode dense subspace as a list
-        for (TensorAddress denseSubSpaceAddress : denseSubSpaceAddresses) {
-            IndexedTensor denseSubspace = (IndexedTensor) sliceSubAddress(tensor, denseSubSpaceAddress, mappedSubType);
-
+        TensorType denseSubType = tensor.type().indexedSubtype();
+        for (var subspace : tensor.getInternalDenseSubspaces()) {
+            IndexedTensor denseSubspace = IndexedTensor.Builder.of(denseSubType, subspace.cells).build();
             if (mappedDimensions.size() == 1) {
-                encodeValues(denseSubspace, cursor.setArray(denseSubSpaceAddress.label(0)), new long[denseSubspace.dimensionSizes().dimensions()], 0);
+                encodeValues(denseSubspace, cursor.setArray(subspace.sparseAddr.label(0)), new long[denseSubspace.dimensionSizes().dimensions()], 0);
             } else {
                 Cursor block = cursor.addObject();
-                encodeAddress(mappedSubType, denseSubSpaceAddress, block.setObject("address"));
+                encodeAddress(mappedSubType, subspace.sparseAddr, block.setObject("address"));
                 encodeValues(denseSubspace, block.setArray("values"), new long[denseSubspace.dimensionSizes().dimensions()], 0);
             }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/JsonFormat.java
@@ -155,10 +155,10 @@ public class JsonFormat {
         for (var subspace : tensor.getInternalDenseSubspaces()) {
             IndexedTensor denseSubspace = IndexedTensor.Builder.of(denseSubType, subspace.cells).build();
             if (mappedDimensions.size() == 1) {
-                encodeValues(denseSubspace, cursor.setArray(subspace.sparseAddr.label(0)), new long[denseSubspace.dimensionSizes().dimensions()], 0);
+                encodeValues(denseSubspace, cursor.setArray(subspace.sparseAddress.label(0)), new long[denseSubspace.dimensionSizes().dimensions()], 0);
             } else {
                 Cursor block = cursor.addObject();
-                encodeAddress(mappedSubType, subspace.sparseAddr, block.setObject("address"));
+                encodeAddress(mappedSubType, subspace.sparseAddress, block.setObject("address"));
                 encodeValues(denseSubspace, block.setArray("values"), new long[denseSubspace.dimensionSizes().dimensions()], 0);
             }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/MixedBinaryFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/MixedBinaryFormat.java
@@ -78,8 +78,8 @@ class MixedBinaryFormat implements BinaryFormat {
             buffer.putInt1_4Bytes(denseSubspaces.size());
         }
         for (var subspace : denseSubspaces) {
-            for (int index = 0; index < subspace.sparseAddr.size(); index++) {
-                buffer.putUtf8String(subspace.sparseAddr.label(index));
+            for (int index = 0; index < subspace.sparseAddress.size(); index++) {
+                buffer.putUtf8String(subspace.sparseAddress.label(index));
             }
             for (double val : subspace.cells) {
                 consumer.accept(val);

--- a/vespajlib/src/main/java/com/yahoo/tensor/serialization/MixedBinaryFormat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/serialization/MixedBinaryFormat.java
@@ -73,20 +73,16 @@ class MixedBinaryFormat implements BinaryFormat {
     private void encodeCells(GrowableByteBuffer buffer, MixedTensor tensor, Consumer<Double> consumer) {
         List<TensorType.Dimension> sparseDimensions = tensor.type().dimensions().stream().filter(d -> !d.isIndexed()).toList();
         long denseSubspaceSize = tensor.denseSubspaceSize();
+        var denseSubspaces = tensor.getInternalDenseSubspaces();
         if (sparseDimensions.size() > 0) {
-            buffer.putInt1_4Bytes((int)(tensor.size() / denseSubspaceSize));  // XXX: Size truncation
+            buffer.putInt1_4Bytes(denseSubspaces.size());
         }
-        Iterator<Tensor.Cell> cellIterator = tensor.cellIterator();
-        while (cellIterator.hasNext()) {
-            Tensor.Cell cell = cellIterator.next();
-            for (TensorType.Dimension dimension : sparseDimensions) {
-                int index = tensor.type().indexOfDimension(dimension.name()).orElseThrow(() ->
-                    new IllegalStateException("Dimension not found in address."));
-                buffer.putUtf8String(cell.getKey().label(index));
+        for (var subspace : denseSubspaces) {
+            for (int index = 0; index < subspace.sparseAddr.size(); index++) {
+                buffer.putUtf8String(subspace.sparseAddr.label(index));
             }
-            consumer.accept(cell.getValue());
-            for (int i = 1; i < denseSubspaceSize; ++i ) {
-                consumer.accept(cellIterator.next().getValue());
+            for (double val : subspace.cells) {
+                consumer.accept(val);
             }
         }
     }


### PR DESCRIPTION
this simplifies serialization by exposing the internal representation;
we probably want to do more redesign (to allow float cells etc at least)
so this API should only be used internally.

@lesters or @bratseth please review
@jonmv @geirst  @havardpe FYI
