### PR TITLE
Add env var for setting `no_new_privs` process bit on Linux

### DIFF
--- a/configd/src/apps/sentinel/CMakeLists.txt
+++ b/configd/src/apps/sentinel/CMakeLists.txt
@@ -14,6 +14,7 @@ vespa_add_executable(configd_config-sentinel_app
     output-connection.cpp
     outward-check.cpp
     peer-check.cpp
+    platform-specific.cpp
     report-connectivity.cpp
     rpchooks.cpp
     rpcserver.cpp

--- a/configd/src/apps/sentinel/platform-specific.cpp
+++ b/configd/src/apps/sentinel/platform-specific.cpp
@@ -1,0 +1,45 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "platform-specific.h"
+#include <vespa/vespalib/util/error.h>
+#include <cstdlib>
+#include <string_view>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
+
+#include <vespa/log/log.h>
+LOG_SETUP(".sentinel.platform-specific");
+
+using namespace std::string_view_literals;
+
+namespace config::platform_specific {
+
+namespace {
+
+[[maybe_unused]] [[nodiscard]]
+bool is_env_toggled(const char* var_name) {
+    const char* maybe_toggled = getenv(var_name);
+    return (maybe_toggled && (maybe_toggled == "true"sv || maybe_toggled == "yes"sv));
+}
+
+}
+
+void pledge_no_new_privileges_if_env_configured() {
+#ifdef __linux__
+    if (is_env_toggled("VESPA_PR_SET_NO_NEW_PRIVS")) {
+        // One-way toggle to prevent any subprocess from possibly getting extra privileges via
+        // setuid/setgid executables (modulo exciting things like kernel bugs or a small, trained
+        // rat that climbs into your computer and pulls an adorably tiny lever labeled "root access").
+        // Helps mitigate a certain class of vulnerabilities, and also allows processes to install
+        // their own seccomp filters.
+        // See https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt
+        if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0) {
+            LOG(warning, "Failed to invoke prctl(PR_SET_NO_NEW_PRIVS): %s", vespalib::getErrorString(errno).c_str());
+        } else {
+            LOG(debug, "Successfully invoked prctl(PR_SET_NO_NEW_PRIVS)");
+        }
+    }
+#endif
+}
+
+}

--- a/configd/src/apps/sentinel/platform-specific.h
+++ b/configd/src/apps/sentinel/platform-specific.h
@@ -1,0 +1,16 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+namespace config::platform_specific {
+
+/**
+ * If running on Linux, sets the `no_new_privs` process bit, which amongst other
+ * things prevents all launched sub-process(es) from acquiring more privileges
+ * through setuid/setgid executables.
+ *
+ * Only takes effect if the `VESPA_PR_SET_NO_NEW_PRIVS` environment variable is
+ * set to "true" or "yes".
+ */
+void pledge_no_new_privileges_if_env_configured();
+
+}

--- a/configd/src/apps/sentinel/sentinel.cpp
+++ b/configd/src/apps/sentinel/sentinel.cpp
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "manager.h"
+#include "platform-specific.h"
 #include <vespa/config/common/exceptions.h>
 #include <vespa/vespalib/util/signalhandler.h>
 #include <vespa/vespalib/util/exceptions.h>
@@ -57,6 +58,8 @@ main(int argc, char **argv)
         return EXIT_FAILURE;
     }
     setlocale(LC_ALL, "C");
+
+    platform_specific::pledge_no_new_privileges_if_env_configured(); // Affects all launched subprocesses
 
     sentinel::Env environment;
     LOG(debug, "Reading configuration");


### PR DESCRIPTION
@arnej27959 please review

If set, this will apply to all processes launched by the config sentinel, directly or transitively. This is a one-way toggle.

From https://www.kernel.org/doc/Documentation/prctl/no_new_privs.txt:

> The `no_new_privs` bit (since Linux 3.5) is a new, generic mechanism to make it safe for a process to modify its
execution environment in a manner that persists across `execve`. Any task can set `no_new_privs`. Once the bit is set, it is inherited across `fork`, `clone`, and `execve` and cannot be unset. With `no_new_privs` set, `execve` promises not to grant the privilege to do anything that could not have been done without the `execve` call. For example, the `setuid` and `setgid` bits will no longer change the uid or gid; file capabilities will not add to the permitted set, and LSMs will not relax constraints after `execve`.

