### PR TITLE
Add fundamental metrics for async "remove by GID" SPI operation

### DIFF
--- a/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
+++ b/storage/src/tests/persistence/filestorage/filestormanagertest.cpp
@@ -1421,6 +1421,14 @@ void FileStorManagerTest::do_test_delete_bucket(bool use_throttled_delete) {
         StorBucketDatabase::WrappedEntry entry(_node->getStorageBucketDatabase().get(bid, "foo"));
         EXPECT_FALSE(entry.exists());
     }
+    if (use_throttled_delete) {
+        auto& metrics = thread_metrics_of(*c.manager)->remove_by_gid;
+        EXPECT_EQ(metrics.failed.getValue(), 0);
+        EXPECT_EQ(metrics.count.getValue(), 1);
+        // We can't reliably test the actual latency here without wiring mock clock bumping into
+        // the async remove by GID execution, but we can at least test that we updated the metric.
+        EXPECT_EQ(metrics.latency.getCount(), 1);
+    }
 }
 
 // TODO remove once throttled behavior is the default

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -159,6 +159,7 @@ FileStorThreadMetrics::FileStorThreadMetrics(const std::string& name, const std:
       visit(this),
       createBuckets("createbuckets", "Number of buckets that has been created.", this),
       deleteBuckets("deletebuckets", "Number of buckets that has been deleted.", this),
+      remove_by_gid("remove_by_gid", "Internal single-document remove operations used by DeleteBucket", this),
       repairs("bucketverified", "Number of times buckets have been checked.", this),
       repairFixed("bucketfixed", {}, "Number of times bucket has been fixed because of corruption", this),
       recheckBucketInfo("recheckbucketinfo",

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -103,6 +103,7 @@ struct FileStorThreadMetrics : public metrics::MetricSet
     Visitor visit;
     Op createBuckets;
     Op deleteBuckets;
+    Op remove_by_gid;
     Op repairs;
     metrics::LongCountMetric repairFixed;
     Op recheckBucketInfo;


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

Tracks invocation count, latency and failures (although we don't expect to see any failures in this pipeline, since the remove ops logically happen atomically with the bucket iteration).
