### PR TITLE
Explicitly print backtrace on bucket space invariant violation

### DIFF
--- a/storage/src/vespa/storage/distributor/distributor_bucket_space_repo.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_bucket_space_repo.cpp
@@ -5,6 +5,7 @@
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/document/bucket/fixed_bucket_spaces.h>
+#include <vespa/vespalib/util/backtrace.h>
 #include <cassert>
 
 #include <vespa/log/log.h>
@@ -34,7 +35,10 @@ DistributorBucketSpace &
 DistributorBucketSpaceRepo::get(BucketSpace bucketSpace)
 {
     auto itr = _map.find(bucketSpace);
-    assert(itr != _map.end());
+    if (itr == _map.end()) [[unlikely]] {
+        LOG(error, "Bucket space %zu does not have a valid mapping. %s", bucketSpace.getId(), vespalib::getStackTrace(0).c_str());
+        abort();
+    }
     return *itr->second;
 }
 
@@ -42,7 +46,10 @@ const DistributorBucketSpace &
 DistributorBucketSpaceRepo::get(BucketSpace bucketSpace) const
 {
     auto itr = _map.find(bucketSpace);
-    assert(itr != _map.end());
+    if (itr == _map.end()) [[unlikely]] {
+        LOG(error, "Bucket space %zu does not have a valid mapping. %s", bucketSpace.getId(), vespalib::getStackTrace(0).c_str());
+        abort();
+    }
     return *itr->second;
 }
 


### PR DESCRIPTION
@geirst please review

This is to help catch an unknown edge case that can happen if distributor operation cancellation is enabled (note: not enabled by default). Will be removed once the edge case is found+fixed.
