### PR TITLE
GC old and unused persistence-level metrics

### DIFF
--- a/storage/src/tests/common/metricstest.cpp
+++ b/storage/src/tests/common/metricstest.cpp
@@ -122,9 +122,6 @@ void MetricsTest::createFakeLoad()
         metrics.docs.inc(10 * n);
         metrics.bytes.inc(10240 * n);
     }
-    _filestorMetrics->directoryEvents.inc(5);
-    _filestorMetrics->partitionEvents.inc(4);
-    _filestorMetrics->diskEvents.inc(3);
     {
         FileStorMetrics& disk(*_filestorMetrics);
         disk.queueSize.addValue(4 * n);
@@ -147,18 +144,10 @@ void MetricsTest::createFakeLoad()
             thread.update.notFound.inc(1 * n);
             thread.update.latencyRead.addValue(2 * n);
             thread.update.latency.addValue(7 * n);
-            thread.revert.count.inc(2 * n);
-            thread.revert.notFound.inc(n / 2);
-            thread.revert.latency.addValue(2 * n);
             thread.visit.count.inc(6 * n);
 
             thread.deleteBuckets.count.inc(1 * n);
-            thread.repairs.count.inc(3 * n);
-            thread.repairFixed.inc(1 * n);
             thread.splitBuckets.count.inc(20 * n);
-            thread.movedBuckets.count.inc(1 * n);
-            thread.readBucketInfo.count.inc(2 * n);
-            thread.internalJoin.count.inc(3 * n);
 
             thread.mergeBuckets.count.inc(2 * n);
             thread.getBucketDiff.count.inc(4 * n);

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.cpp
@@ -154,14 +154,11 @@ FileStorThreadMetrics::FileStorThreadMetrics(const std::string& name, const std:
       removeLocation("remove_location", "Remove location", this),
       statBucket("stat_bucket", "Stat bucket", this),
       update(this),
-      revert("revert", "Revert", this),
       createIterator("createiterator", {}, this),
       visit(this),
       createBuckets("createbuckets", "Number of buckets that has been created.", this),
       deleteBuckets("deletebuckets", "Number of buckets that has been deleted.", this),
       remove_by_gid("remove_by_gid", "Internal single-document remove operations used by DeleteBucket", this),
-      repairs("bucketverified", "Number of times buckets have been checked.", this),
-      repairFixed("bucketfixed", {}, "Number of times bucket has been fixed because of corruption", this),
       recheckBucketInfo("recheckbucketinfo",
                         "Number of times bucket info has been explicitly "
                         "rechecked due to buckets being marked modified by "
@@ -170,11 +167,6 @@ FileStorThreadMetrics::FileStorThreadMetrics(const std::string& name, const std:
       splitBuckets("splitbuckets", "Number of times buckets have been split.", this),
       joinBuckets("joinbuckets", "Number of times buckets have been joined.", this),
       setBucketStates("setbucketstates", "Number of times buckets have been activated or deactivated.", this),
-      movedBuckets("movedbuckets", "Number of buckets moved between disks", this),
-      readBucketList("readbucketlist", "Number of read bucket list requests", this),
-      readBucketInfo("readbucketinfo", "Number of read bucket info requests", this),
-      internalJoin("internaljoin", "Number of joins to join buckets on multiple disks during "
-                                   "storage initialization.", this),
       mergeBuckets("mergebuckets", "Number of times buckets have been merged.", this),
       getBucketDiff("getbucketdiff", "Number of getbucketdiff commands that have been processed.", this),
       applyBucketDiff("applybucketdiff", "Number of applybucketdiff commands that have been processed.", this),
@@ -212,18 +204,11 @@ FileStorMetrics::FileStorMetrics()
       throttle_window_size("throttle_window_size", {}, "Current size of async operation throttler window size", this),
       throttle_waiting_threads("throttle_waiting_threads", {}, "Number of threads waiting to acquire a throttle token", this),
       throttle_active_tokens("throttle_active_tokens", {}, "Current number of active throttle tokens", this),
-      waitingForLockHitRate("waitingforlockrate", {},
-                            "Amount of times a filestor thread has needed to wait for "
-                            "lock to take next message in queue.", this),
       active_operations(this),
-      directoryEvents("directoryevents", {}, "Number of directory events received.", this),
-      partitionEvents("partitionevents", {}, "Number of partition events received.", this),
-      diskEvents("diskevents", {}, "Number of disk events received.", this),
       bucket_db_init_latency("bucket_db_init_latency", {}, "Time taken (in ms) to initialize bucket databases with "
                                                            "information from the persistence provider", this)
 {
     pendingMerges.unsetOnZeroValue();
-    waitingForLockHitRate.unsetOnZeroValue();
 }
 
 FileStorMetrics::~FileStorMetrics() = default;

--- a/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormetrics.h
@@ -1,11 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 /**
- * @class storage::FileStorMetrics
- * @ingroup filestorage
- *
- * @brief Metrics for the file store threads.
- *
- * @version $Id$
+ * Metrics for the peristence threads.
  */
 
 #pragma once
@@ -98,22 +93,15 @@ struct FileStorThreadMetrics : public metrics::MetricSet
     Op removeLocation;
     Op statBucket;
     Update update;
-    OpWithNotFound revert;
     Op createIterator;
     Visitor visit;
     Op createBuckets;
     Op deleteBuckets;
     Op remove_by_gid;
-    Op repairs;
-    metrics::LongCountMetric repairFixed;
     Op recheckBucketInfo;
     Op splitBuckets;
     Op joinBuckets;
     Op setBucketStates;
-    Op movedBuckets;
-    Op readBucketList;
-    Op readBucketInfo;
-    Op internalJoin;
     Op mergeBuckets;
     Op getBucketDiff;
     Op applyBucketDiff;
@@ -149,11 +137,7 @@ struct FileStorMetrics : public metrics::MetricSet
     metrics::LongAverageMetric    throttle_window_size;
     metrics::LongAverageMetric    throttle_waiting_threads;
     metrics::LongAverageMetric    throttle_active_tokens;
-    metrics::DoubleAverageMetric  waitingForLockHitRate;
     ActiveOperationsMetrics       active_operations;
-    metrics::LongCountMetric      directoryEvents;
-    metrics::LongCountMetric      partitionEvents;
-    metrics::LongCountMetric      diskEvents;
     metrics::LongAverageMetric    bucket_db_init_latency;
 
     FileStorMetrics();


### PR DESCRIPTION
These metrics are from the age of VDS and a dozen spinning disks per node 🦕

