### PR TITLE
Fail immediately when `Content-Length` is present

### DIFF
--- a/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
+++ b/container-core/src/test/java/com/yahoo/jdisc/http/server/jetty/HttpServerTest.java
@@ -160,6 +160,20 @@ public class HttpServerTest {
     }
 
     @Test
+    void requireThatTooLargePayloadFailsWith413() throws Exception {
+        final JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(
+                new EchoRequestHandler(),
+                new ServerConfig.Builder(),
+                new ConnectorConfig.Builder()
+                        .maxContentSize(100));
+        driver.client().newPost("/status.html")
+                .setBinaryContent(new byte[200])
+                .execute()
+                .expectStatusCode(is(REQUEST_TOO_LONG));
+        assertTrue(driver.close());
+    }
+
+    @Test
     void requireThatMultipleHostHeadersReturns400() throws Exception {
         var metricConsumer = new MetricConsumerMock();
         JettyTestDriver driver = JettyTestDriver.newConfiguredInstance(


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
