### PR TITLE
- Or and SourceBlender inherits max cost tier of children.

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -298,7 +298,7 @@ class IntermediateBlueprint : public blueprint::StateCache
 private:
     Children _children;
     HitEstimate calculateEstimate() const;
-    uint8_t calculate_cost_tier() const;
+    virtual uint8_t calculate_cost_tier() const;
     uint32_t calculate_tree_size() const;
     bool infer_allow_termwise_eval() const;
     bool infer_want_global_filter() const;

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
@@ -355,6 +355,16 @@ OrBlueprint::createFilterSearch(bool strict, FilterConstraint constraint) const
     return create_or_filter(get_children(), strict, constraint);
 }
 
+uint8_t
+OrBlueprint::calculate_cost_tier() const
+{
+    uint8_t cost_tier = State::COST_TIER_NORMAL;
+    for (const Blueprint::UP &child : get_children()) {
+        cost_tier = std::max(cost_tier, child->getState().cost_tier());
+    }
+    return cost_tier;
+}
+
 //-----------------------------------------------------------------------------
 WeakAndBlueprint::~WeakAndBlueprint() = default;
 
@@ -661,6 +671,16 @@ bool
 SourceBlenderBlueprint::isCompatibleWith(const SourceBlenderBlueprint &other) const
 {
     return (&_selector == &other._selector);
+}
+
+uint8_t
+SourceBlenderBlueprint::calculate_cost_tier() const
+{
+    uint8_t cost_tier = State::COST_TIER_NORMAL;
+    for (const Blueprint::UP &child : get_children()) {
+        cost_tier = std::max(cost_tier, child->getState().cost_tier());
+    }
+    return cost_tier;
 }
 
 //-----------------------------------------------------------------------------

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
@@ -28,6 +28,9 @@ public:
     SearchIterator::UP
     createFilterSearch(bool strict, FilterConstraint constraint) const override;
 private:
+    uint8_t calculate_cost_tier() const override {
+        return (childCnt() > 0) ? get_children()[0]->getState().cost_tier() : State::COST_TIER_NORMAL;
+    }
     bool isPositive(size_t index) const override { return index == 0; }
 };
 
@@ -76,6 +79,7 @@ public:
     createFilterSearch(bool strict, FilterConstraint constraint) const override;
 private:
     double computeNextHitRate(const Blueprint & child, double hitRate) const override;
+    uint8_t calculate_cost_tier() const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -168,6 +172,9 @@ public:
                              bool strict, fef::MatchData &md) const override;
     SearchIterator::UP
     createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    uint8_t calculate_cost_tier() const override {
+        return (childCnt() > 0) ? get_children()[0]->getState().cost_tier() : State::COST_TIER_NORMAL;
+    }
 };
 
 //-----------------------------------------------------------------------------
@@ -193,6 +200,7 @@ public:
     /** check if this blueprint has the same source selector as the other */
     bool isCompatibleWith(const SourceBlenderBlueprint &other) const;
     bool isSourceBlender() const override { return true; }
+    uint8_t calculate_cost_tier() const override;
 };
 
 }


### PR DESCRIPTION
- Rank and AndNot inherits cost tier for first child.
- And and the others inherits minimum cost tier of children as it already does.

Tests are missing.