### PR TITLE
Do not setup API authenticator when using concrete URL

### DIFF
--- a/client/go/internal/cli/cmd/curl.go
+++ b/client/go/internal/cli/cmd/curl.go
@@ -10,14 +10,12 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vespa-engine/vespa/client/go/internal/curl"
-	"github.com/vespa-engine/vespa/client/go/internal/vespa"
 )
 
 func newCurlCmd(cli *CLI) *cobra.Command {
 	var (
-		waitSecs    int
-		dryRun      bool
-		curlService string
+		waitSecs int
+		dryRun   bool
 	)
 	cmd := &cobra.Command{
 		Use:   "curl [curl-options] path",
@@ -39,17 +37,8 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 			if err != nil {
 				return err
 			}
-			var service *vespa.Service
-			useDeploy := curlService == "deploy"
 			waiter := cli.waiter(time.Duration(waitSecs) * time.Second)
-			if useDeploy {
-				if cli.config.cluster() != "" {
-					return fmt.Errorf("cannot specify cluster for service %s", curlService)
-				}
-				service, err = target.DeployService()
-			} else {
-				service, err = waiter.Service(target, cli.config.cluster())
-			}
+			service, err := waiter.Service(target, cli.config.cluster())
 			if err != nil {
 				return err
 			}
@@ -59,16 +48,9 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 			if err != nil {
 				return err
 			}
-			// TODO(mpolden): Support issuing request to deploy service
-			if useDeploy {
-				if err := addAccessToken(c, target); err != nil {
-					return err
-				}
-			} else {
-				c.CaCertificate = service.TLSOptions.CACertificateFile
-				c.PrivateKey = service.TLSOptions.PrivateKeyFile
-				c.Certificate = service.TLSOptions.CertificateFile
-			}
+			c.CaCertificate = service.TLSOptions.CACertificateFile
+			c.PrivateKey = service.TLSOptions.PrivateKeyFile
+			c.Certificate = service.TLSOptions.CertificateFile
 			if dryRun {
 				log.Print(c.String())
 			} else {
@@ -80,17 +62,8 @@ $ vespa curl -- -v --data-urlencode "yql=select * from music where album contain
 		},
 	}
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Print the curl command that would be executed")
-	cmd.Flags().StringVarP(&curlService, "service", "s", "container", "Which service to query. Must be \"deploy\" or \"container\"")
 	cli.bindWaitFlag(cmd, 0, &waitSecs)
 	return cmd
-}
-
-func addAccessToken(cmd *curl.Command, target vespa.Target) error {
-	if target.Type() != vespa.TargetCloud {
-		return nil
-	}
-	cmd.Header("Authorization", "secret")
-	return nil
 }
 
 func joinURL(baseURL, path string) string {

--- a/client/go/internal/cli/cmd/curl_test.go
+++ b/client/go/internal/cli/cmd/curl_test.go
@@ -25,12 +25,4 @@ func TestCurl(t *testing.T) {
 		filepath.Join(cli.config.homeDir, "t1.a1.i1", "data-plane-private-key.pem"),
 		filepath.Join(cli.config.homeDir, "t1.a1.i1", "data-plane-public-cert.pem"))
 	assert.Equal(t, expected, stdout.String())
-
-	assert.Nil(t, cli.Run("config", "set", "target", "local"))
-
-	stdout.Reset()
-	err = cli.Run("curl", "-a", "t1.a1.i1", "-s", "deploy", "-n", "/application/v4/tenant/foo")
-	assert.Nil(t, err)
-	expected = "curl http://127.0.0.1:19071/application/v4/tenant/foo\n"
-	assert.Equal(t, expected, stdout.String())
 }


### PR DESCRIPTION
Avoids the need to setup API key or `vespa auth login` when you simply want to
interact directly with a deployment.

@jonmv