### PR TITLE
Refactor apis for attribute posting list access

### DIFF
--- a/searchlib/src/apps/tests/document_weight_attribute_lookup_stress_test.cpp
+++ b/searchlib/src/apps/tests/document_weight_attribute_lookup_stress_test.cpp
@@ -2,7 +2,7 @@
 
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/integerbase.h>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <random>
@@ -28,7 +28,7 @@ Config make_config(bool hash)
     return cfg;
 }
 
-class MyKey : public search::IDocumentWeightAttribute::LookupKey
+class MyKey : public search::IDirectPostingStore::LookupKey
 {
     int64_t _key;
 public:
@@ -118,7 +118,7 @@ DocumentWeightAttributeLookupStressTest::lookup_loop(AttributeVector& attr, uint
     size_t lookups = loops * _lookup_keys.size();
     std::cout << "Performing " << lookups << " " << attr.getName() << " lookups" << std::endl;
     auto before = steady_clock::now();
-    auto dwa = attr.asDocumentWeightAttribute();
+    auto dwa = attr.as_docid_with_weight_posting_store();
     uint64_t hits = 0;
     uint64_t misses = 0;
     for (uint32_t loop = 0; loop < loops; ++loop) {

--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -1,23 +1,21 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include <vespa/vespalib/testkit/testapp.h>
-
+#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/attribute/attribute.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
-#include <vespa/searchlib/util/randomgenerator.h>
-#include <vespa/vespalib/util/compress.h>
-#include <vespa/searchlib/fef/termfieldmatchdata.h>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
-#include <vespa/searchlib/queryeval/document_weight_search_iterator.h>
-#include <vespa/searchlib/test/searchiteratorverifier.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/searchlib/common/bitvectoriterator.h>
-#include <vespa/searchlib/queryeval/executeinfo.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
 #include <vespa/searchlib/parsequery/parse.h>
-#include <vespa/searchcommon/attribute/config.h>
+#include <vespa/searchlib/queryeval/document_weight_search_iterator.h>
+#include <vespa/searchlib/queryeval/executeinfo.h>
+#include <vespa/searchlib/test/searchiteratorverifier.h>
+#include <vespa/searchlib/util/randomgenerator.h>
 #include <vespa/vespalib/stllike/asciistream.h>
+#include <vespa/vespalib/testkit/testapp.h>
+#include <vespa/vespalib/util/compress.h>
 
 #include <vespa/log/log.h>
-
 LOG_SETUP("bitvector_test");
 
 using search::AttributeFactory;
@@ -431,12 +429,12 @@ BitVectorTest::test(BasicType bt, CollectionType ct, const vespalib::string &pre
     checkSearch(v, std::move(sc), 2, 1022, 205, !fastSearch && !filter, true);
     sc = getSearch<VectorType>(tv, filter);
     checkSearch(v, std::move(sc), 2, 1022, 205, !filter, true);
-    const search::IDocumentWeightAttribute *dwa = v->asDocumentWeightAttribute();
-    if (dwa != nullptr) {
-        auto lres = dwa->lookup(getSearchStr<VectorType>(), dwa->get_dictionary_snapshot());
+    const auto* dww = v->as_docid_with_weight_posting_store();
+    if (dww != nullptr) {
+        auto lres = dww->lookup(getSearchStr<VectorType>(), dww->get_dictionary_snapshot());
         using DWSI = search::queryeval::DocumentWeightSearchIterator;
         TermFieldMatchData md;
-        auto dwsi = std::make_unique<DWSI>(md, *dwa, lres);
+        auto dwsi = std::make_unique<DWSI>(md, *dww, lres);
         if (!filter) {
             TEST_DO(checkSearch(v, std::move(dwsi), md, 2, 1022, 205, !filter, true));
         } else {

--- a/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
+++ b/searchlib/src/tests/attribute/document_weight_iterator/document_weight_iterator_test.cpp
@@ -127,11 +127,11 @@ TEST_F("require string lookup works correctly", StringFixture) {
 void verify_posting(const IDocidWithWeightPostingStore &api, const char *term) {
     auto result = api.lookup(term, api.get_dictionary_snapshot());
     ASSERT_TRUE(result.posting_idx.valid());
-    std::vector<DocumentWeightIterator> itr_store;
+    std::vector<DocidWithWeightIterator> itr_store;
     api.create(result.posting_idx, itr_store);
     ASSERT_EQUAL(1u, itr_store.size());
     {
-        DocumentWeightIterator &itr = itr_store[0];
+        DocidWithWeightIterator &itr = itr_store[0];
         if (itr.valid() && itr.getKey() < 1) {
             itr.linearSeek(1);
         }

--- a/searchlib/src/tests/attribute/document_weight_or_filter_search/document_weight_or_filter_search_test.cpp
+++ b/searchlib/src/tests/attribute/document_weight_or_filter_search/document_weight_or_filter_search_test.cpp
@@ -1,7 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/vespalib/gtest/gtest.h>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_direct_posting_store.h>
 #include <vespa/searchlib/attribute/document_weight_or_filter_search.h>
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/common/bitvector.h>

--- a/searchlib/src/tests/attribute/imported_attribute_vector/imported_attribute_vector_test.cpp
+++ b/searchlib/src/tests/attribute/imported_attribute_vector/imported_attribute_vector_test.cpp
@@ -140,8 +140,8 @@ TEST_F("getFixedWidth() is inherited from target attribute vector", Fixture) {
                  f.get_imported_attr()->getFixedWidth());
 }
 
-TEST_F("asDocumentWeightAttribute() returns nullptr", Fixture) {
-    EXPECT_TRUE(f.get_imported_attr()->asDocumentWeightAttribute() == nullptr);
+TEST_F("as_docid_with_weight_posting_store() returns nullptr", Fixture) {
+    EXPECT_TRUE(f.get_imported_attr()->as_docid_with_weight_posting_store() == nullptr);
 }
 
 TEST_F("asTensorAttribute() returns nullptr", Fixture) {

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -315,7 +315,7 @@ public:
         return result;
     }
     void expect_document_weight_attribute() {
-        EXPECT_TRUE(attr->asDocumentWeightAttribute() != nullptr);
+        EXPECT_TRUE(attr->as_docid_with_weight_posting_store() != nullptr);
     }
     void expect_filter_search(const SimpleResult& upper_and_lower, const Node& term) {
         expect_filter_search(upper_and_lower, upper_and_lower, term);

--- a/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
+++ b/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
@@ -277,7 +277,7 @@ private:
 class WeightIteratorChildrenVerifier : public search::test::DwwIteratorChildrenVerifier {
 private:
     SearchIterator::UP
-    create(std::vector<DocumentWeightIterator> && children) const override {
+    create(std::vector<DocidWithWeightIterator> && children) const override {
         return DotProductSearch::create(_tfmd, false, _weights, std::move(children));
     }
 };

--- a/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
+++ b/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
@@ -274,7 +274,7 @@ private:
     }
 };
 
-class WeightIteratorChildrenVerifier : public search::test::DwaIteratorChildrenVerifier {
+class WeightIteratorChildrenVerifier : public search::test::DwwIteratorChildrenVerifier {
 private:
     SearchIterator::UP
     create(std::vector<DocumentWeightIterator> && children) const override {

--- a/searchlib/src/tests/queryeval/matching_elements_search/matching_elements_search_test.cpp
+++ b/searchlib/src/tests/queryeval/matching_elements_search/matching_elements_search_test.cpp
@@ -1,26 +1,26 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include <vespa/searchcommon/attribute/attributecontent.h>
+#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchlib/attribute/attributefactory.h>
 #include <vespa/searchlib/attribute/attributevector.h>
-#include <vespa/searchlib/attribute/stringbase.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/searchlib/attribute/integerbase.h>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/stringbase.h>
 #include <vespa/searchlib/common/matching_elements.h>
 #include <vespa/searchlib/queryeval/matching_elements_search.h>
-#include <vespa/searchcommon/attribute/config.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
+using search::AttributeFactory;
+using search::AttributeVector;
+using search::IDirectPostingStore;
+using search::IntegerAttribute;
+using search::MatchingElements;
+using search::StringAttribute;
 using search::attribute::BasicType;
 using search::attribute::CollectionType;
 using search::attribute::Config;
 using search::queryeval::MatchingElementsSearch;
-using search::AttributeFactory;
-using search::AttributeVector;
-using search::IDocumentWeightAttribute;
-using search::IntegerAttribute;
-using search::MatchingElements;
-using search::StringAttribute;
 
 std::shared_ptr<AttributeVector> make_attribute(BasicType type) {
     Config cfg(type, CollectionType::WSET);
@@ -36,8 +36,8 @@ std::shared_ptr<AttributeVector> make_attribute(BasicType type) {
 
 std::unique_ptr<MatchingElementsSearch> make_search(AttributeVector &attr, const std::vector<vespalib::string> &terms)
 {
-    using LookupResult = IDocumentWeightAttribute::LookupResult;
-    auto dwa = attr.asDocumentWeightAttribute();
+    using LookupResult = IDirectPostingStore::LookupResult;
+    auto dwa = attr.as_docid_with_weight_posting_store();
     assert(dwa != nullptr);
     auto snapshot = dwa->get_dictionary_snapshot();
     std::vector<LookupResult> dict_entries;

--- a/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
+++ b/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
@@ -289,7 +289,7 @@ private:
     }
 };
 
-class WeightIteratorChildrenVerifier : public search::test::DwaIteratorChildrenVerifier {
+class WeightIteratorChildrenVerifier : public search::test::DwwIteratorChildrenVerifier {
 private:
     SearchIterator::UP create(std::vector<DocumentWeightIterator> && children) const override {
         return WeightedSetTermSearch::create(_tfmd, false, _weights, std::move(children));

--- a/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
+++ b/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
@@ -291,7 +291,7 @@ private:
 
 class WeightIteratorChildrenVerifier : public search::test::DwwIteratorChildrenVerifier {
 private:
-    SearchIterator::UP create(std::vector<DocumentWeightIterator> && children) const override {
+    SearchIterator::UP create(std::vector<DocidWithWeightIterator> && children) const override {
         return WeightedSetTermSearch::create(_tfmd, false, _weights, std::move(children));
     }
 };

--- a/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
+++ b/searchlib/src/vespa/searchcommon/attribute/iattributevector.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 namespace search {
-    struct IDocumentWeightAttribute;
+    class IDocidWithWeightPostingStore;
     class QueryTermSimple;
 }
 
@@ -293,11 +293,11 @@ public:
                                                                 const SearchContextParams &params) const = 0;
 
     /**
-     * Type-safe down-cast to an attribute supporting direct document weight iterators.
+     * Type-safe down-cast to an attribute supporting direct access to posting lists with docid and weight.
      *
      * @return document weight attribute or nullptr if not supported.
      */
-    virtual const IDocumentWeightAttribute *asDocumentWeightAttribute() const = 0;
+    virtual const IDocidWithWeightPostingStore *as_docid_with_weight_posting_store() const = 0;
 
     /**
      * Type-safe down-cast to a tensor attribute.

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -3,6 +3,7 @@ vespa_add_library(searchlib_attribute OBJECT
     SOURCES
     address_space_components.cpp
     address_space_usage.cpp
+    array_iterator.cpp
     attribute.cpp
     attribute_blueprint_factory.cpp
     attribute_header.cpp
@@ -42,7 +43,6 @@ vespa_add_library(searchlib_attribute OBJECT
     direct_weighted_set_blueprint.cpp
     distance_metric_utils.cpp
     diversity.cpp
-    dociditerator.cpp
     document_weight_or_filter_search.cpp
     empty_search_context.cpp
     enum_store_compaction_spec.cpp

--- a/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/attribute/CMakeLists.txt
@@ -63,7 +63,7 @@ vespa_add_library(searchlib_attribute OBJECT
     fixedsourceselector.cpp
     flagattribute.cpp
     floatbase.cpp
-    i_document_weight_attribute.cpp
+    i_direct_posting_store.cpp
     i_enum_store.cpp
     iattributemanager.cpp
     iattributesavetarget.cpp

--- a/searchlib/src/vespa/searchlib/attribute/array_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/array_iterator.cpp
@@ -1,6 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "dociditerator.h"
+#include "array_iterator.h"
 
 namespace search {
 

--- a/searchlib/src/vespa/searchlib/attribute/array_iterator.h
+++ b/searchlib/src/vespa/searchlib/attribute/array_iterator.h
@@ -9,19 +9,17 @@
 namespace search {
 
 /**
- * Inner attribute iterator used for temporary posting lists (range
- * searches).
+ * Inner attribute iterator used for temporary posting lists (range searches).
  */
-
 template <typename P>
-class DocIdIterator
+class ArrayIterator
 {
 public:
-    DocIdIterator() : _cur(nullptr), _end(nullptr), _begin(nullptr) { }
+    ArrayIterator() : _cur(nullptr), _end(nullptr), _begin(nullptr) { }
 
     const P * operator->() const { return _cur; }
 
-    DocIdIterator & operator++() {
+    ArrayIterator & operator++() {
         ++_cur;
         return *this;
     }
@@ -49,7 +47,7 @@ public:
         _cur = std::lower_bound<const P *, P>(_begin, _end, keyWrap);
     }
 
-    void swap(DocIdIterator &rhs) {
+    void swap(ArrayIterator &rhs) {
         std::swap(_cur, rhs._cur);
         std::swap(_end, rhs._end);
         std::swap(_begin, rhs._begin);
@@ -62,7 +60,7 @@ protected:
 
 template <>
 inline int32_t
-DocIdIterator<AttributePosting>::getData() const
+ArrayIterator<AttributePosting>::getData() const
 {
     return 1;   // default weight 1 for single value attributes
 }
@@ -74,11 +72,11 @@ DocIdIterator<AttributePosting>::getData() const
  */
 
 template <typename P>
-class DocIdMinMaxIterator : public DocIdIterator<P>
+class DocIdMinMaxIterator : public ArrayIterator<P>
 {
 public:
     DocIdMinMaxIterator()
-        : DocIdIterator<P>()
+        : ArrayIterator<P>()
     { }
     inline vespalib::btree::MinMaxAggregated getAggregated() const { return vespalib::btree::MinMaxAggregated(1, 1); }
 };

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -463,7 +463,7 @@ std::unique_ptr<SearchIterator>
 DirectWandBlueprint::createFilterSearch(bool, FilterConstraint constraint) const
 {
     if (constraint == Blueprint::FilterConstraint::UPPER_BOUND) {
-        std::vector<DocumentWeightIterator> iterators;
+        std::vector<DocidWithWeightIterator> iterators;
         iterators.reserve(_terms.size());
         for (const IDirectPostingStore::LookupResult &r : _terms) {
             _attr.create(r.posting_idx, iterators);

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -6,7 +6,7 @@
 #include "attribute_weighted_set_blueprint.h"
 #include "direct_weighted_set_blueprint.h"
 #include "document_weight_or_filter_search.h"
-#include "i_document_weight_attribute.h"
+#include "i_direct_posting_store.h"
 #include "iterator_pack.h"
 #include "predicate_attribute.h"
 #include <vespa/eval/eval/value.h>
@@ -100,7 +100,7 @@ using vespalib::stringref;
 namespace search {
 namespace {
 
-class NodeAsKey final : public IDocumentWeightAttribute::LookupKey {
+class NodeAsKey final : public IDirectPostingStore::LookupKey {
 public:
     NodeAsKey(const Node & node, vespalib::string & scratchPad)
         : _node(node),
@@ -368,7 +368,7 @@ make_location_blueprint(const FieldSpec &field, const IAttributeVector &attribut
 
 LocationPostFilterBlueprint::~LocationPostFilterBlueprint() = default;
 
-class LookupKey : public IDocumentWeightAttribute::LookupKey {
+class LookupKey : public IDirectPostingStore::LookupKey {
 public:
     LookupKey(MultiTerm & terms, uint32_t index) : _terms(terms), _index(index) {}
 
@@ -397,17 +397,17 @@ private:
 class DirectWandBlueprint : public queryeval::ComplexLeafBlueprint
 {
 private:
-    mutable queryeval::SharedWeakAndPriorityQueue       _scores;
-    const queryeval::wand::score_t                      _scoreThreshold;
-    double                                              _thresholdBoostFactor;
-    const uint32_t                                      _scoresAdjustFrequency;
-    std::vector<int32_t>                                _weights;
-    std::vector<IDocumentWeightAttribute::LookupResult> _terms;
-    const IDocumentWeightAttribute                     &_attr;
-    vespalib::datastore::EntryRef                       _dictionary_snapshot;
+    mutable queryeval::SharedWeakAndPriorityQueue  _scores;
+    const queryeval::wand::score_t                 _scoreThreshold;
+    double                                         _thresholdBoostFactor;
+    const uint32_t                                 _scoresAdjustFrequency;
+    std::vector<int32_t>                           _weights;
+    std::vector<IDirectPostingStore::LookupResult> _terms;
+    const IDocidWithWeightPostingStore            &_attr;
+    vespalib::datastore::EntryRef                  _dictionary_snapshot;
 
 public:
-    DirectWandBlueprint(const FieldSpec &field, const IDocumentWeightAttribute &attr, uint32_t scoresToTrack,
+    DirectWandBlueprint(const FieldSpec &field, const IDocidWithWeightPostingStore &attr, uint32_t scoresToTrack,
                         queryeval::wand::score_t scoreThreshold, double thresholdBoostFactor, size_t size_hint)
         : ComplexLeafBlueprint(field),
           _scores(scoresToTrack),
@@ -425,8 +425,8 @@ public:
 
     ~DirectWandBlueprint() override;
 
-    void addTerm(const IDocumentWeightAttribute::LookupKey & key, int32_t weight, HitEstimate & estimate) {
-        IDocumentWeightAttribute::LookupResult result = _attr.lookup(key, _dictionary_snapshot);
+    void addTerm(const IDirectPostingStore::LookupKey & key, int32_t weight, HitEstimate & estimate) {
+        IDirectPostingStore::LookupResult result = _attr.lookup(key, _dictionary_snapshot);
         HitEstimate childEst(result.posting_size, (result.posting_size == 0));
         if (!childEst.empty) {
             if (estimate.empty) {
@@ -465,7 +465,7 @@ DirectWandBlueprint::createFilterSearch(bool, FilterConstraint constraint) const
     if (constraint == Blueprint::FilterConstraint::UPPER_BOUND) {
         std::vector<DocumentWeightIterator> iterators;
         iterators.reserve(_terms.size());
-        for (const IDocumentWeightAttribute::LookupResult &r : _terms) {
+        for (const IDirectPostingStore::LookupResult &r : _terms) {
             _attr.create(r.posting_idx, iterators);
         }
         return attribute::DocumentWeightOrFilterSearch::create(std::move(iterators));
@@ -498,15 +498,15 @@ AttributeFieldBlueprint::getRange(vespalib::string &from, vespalib::string &to) 
 class DirectAttributeBlueprint : public queryeval::SimpleLeafBlueprint
 {
 private:
-    const IAttributeVector                 &_iattr;
-    const IDocumentWeightAttribute         &_attr;
-    vespalib::datastore::EntryRef           _dictionary_snapshot;
-    IDocumentWeightAttribute::LookupResult  _dict_entry;
+    const IAttributeVector             &_iattr;
+    const IDocidWithWeightPostingStore &_attr;
+    vespalib::datastore::EntryRef       _dictionary_snapshot;
+    IDirectPostingStore::LookupResult   _dict_entry;
 
 public:
     DirectAttributeBlueprint(const FieldSpec &field, const IAttributeVector &iattr,
-                             const IDocumentWeightAttribute &attr,
-                             const IDocumentWeightAttribute::LookupKey & key)
+                             const IDocidWithWeightPostingStore &attr,
+                             const IDirectPostingStore::LookupKey & key)
         : SimpleLeafBlueprint(field),
           _iattr(iattr),
           _attr(attr),
@@ -547,7 +547,7 @@ public:
     }
     std::unique_ptr<queryeval::MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override {
         if (fields.has_field(_iattr.getName())) {
-            return queryeval::MatchingElementsSearch::create(_iattr, _dictionary_snapshot, vespalib::ConstArrayRef<IDocumentWeightAttribute::LookupResult>(&_dict_entry, 1));
+            return queryeval::MatchingElementsSearch::create(_iattr, _dictionary_snapshot, vespalib::ConstArrayRef<IDirectPostingStore::LookupResult>(&_dict_entry, 1));
         } else {
             return {};
         }
@@ -574,7 +574,7 @@ class CreateBlueprintVisitor : public CreateBlueprintVisitorHelper
 private:
     const FieldSpec &_field;
     const IAttributeVector &_attr;
-    const IDocumentWeightAttribute *_dwa;
+    const IDocidWithWeightPostingStore *_dww;
     vespalib::string _scratchPad;
 
 public:
@@ -583,7 +583,7 @@ public:
         : CreateBlueprintVisitorHelper(searchable, field, requestContext),
           _field(field),
           _attr(attr),
-          _dwa(attr.asDocumentWeightAttribute()),
+          _dww(attr.as_docid_with_weight_posting_store()),
           _scratchPad()
     {
     }
@@ -591,9 +591,9 @@ public:
 
     template <class TermNode>
     void visitSimpleTerm(TermNode &n) {
-        if ((_dwa != nullptr) && !_field.isFilter() && n.isRanked() && !Term::isPossibleRangeTerm(n.getTerm())) {
+        if ((_dww != nullptr) && !_field.isFilter() && n.isRanked() && !Term::isPossibleRangeTerm(n.getTerm())) {
             NodeAsKey key(n, _scratchPad);
-            setResult(std::make_unique<DirectAttributeBlueprint>(_field, _attr, *_dwa, key));
+            setResult(std::make_unique<DirectAttributeBlueprint>(_field, _attr, *_dww, key));
         } else {
             visitTerm(n);
         }
@@ -685,8 +685,8 @@ public:
             }
             setResult(std::move(ws));
         } else {
-            if (_dwa != nullptr) {
-                auto *bp = new attribute::DirectWeightedSetBlueprint<queryeval::WeightedSetTermSearch>(_field, _attr, *_dwa, n.getNumTerms());
+            if (_dww != nullptr) {
+                auto *bp = new attribute::DirectWeightedSetBlueprint<queryeval::WeightedSetTermSearch>(_field, _attr, *_dww, n.getNumTerms());
                 createDirectWeightedSet(bp, n);
             } else {
                 auto *bp = new WeightedSetTermBlueprint(_field);
@@ -696,8 +696,8 @@ public:
     }
 
     void visit(query::DotProduct &n) override {
-        if (_dwa != nullptr) {
-            auto *bp = new attribute::DirectWeightedSetBlueprint<queryeval::DotProductSearch>(_field, _attr, *_dwa, n.getNumTerms());
+        if (_dww != nullptr) {
+            auto *bp = new attribute::DirectWeightedSetBlueprint<queryeval::DotProductSearch>(_field, _attr, *_dww, n.getNumTerms());
             createDirectWeightedSet(bp, n);
         } else {
             auto *bp = new DotProductBlueprint(_field);
@@ -706,8 +706,8 @@ public:
     }
 
     void visit(query::WandTerm &n) override {
-        if (_dwa != nullptr) {
-            auto *bp = new DirectWandBlueprint(_field, *_dwa,
+        if (_dww != nullptr) {
+            auto *bp = new DirectWandBlueprint(_field, *_dww,
                                                n.getTargetNumHits(), n.getScoreThreshold(), n.getThresholdBoostFactor(),
                                                n.getNumTerms());
             createDirectWeightedSet(bp, n);

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "dociditerator.h"
+#include "array_iterator.h"
 #include "postinglisttraits.h"
 #include <vespa/searchlib/queryeval/searchiterator.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>

--- a/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributeiterators.hpp
@@ -115,7 +115,7 @@ namespace {
 template <typename> struct is_tree_iterator;
 
 template <typename P>
-struct is_tree_iterator<DocIdIterator<P>> {
+struct is_tree_iterator<ArrayIterator<P>> {
     static constexpr bool value = false;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.cpp
@@ -445,7 +445,7 @@ AttributeVector::set_reserved_doc_values()
 
 attribute::IPostingListAttributeBase *AttributeVector::getIPostingListAttributeBase() { return nullptr; }
 const attribute::IPostingListAttributeBase *AttributeVector::getIPostingListAttributeBase() const { return nullptr; }
-const IDocumentWeightAttribute * AttributeVector::asDocumentWeightAttribute() const { return nullptr; }
+const IDocidWithWeightPostingStore * AttributeVector::as_docid_with_weight_posting_store() const { return nullptr; }
 const tensor::ITensorAttribute *AttributeVector::asTensorAttribute() const { return nullptr; }
 const attribute::IMultiValueAttribute* AttributeVector::as_multi_value_attribute() const { return nullptr; }
 bool AttributeVector::hasPostings() { return getIPostingListAttributeBase() != nullptr; }

--- a/searchlib/src/vespa/searchlib/attribute/attributevector.h
+++ b/searchlib/src/vespa/searchlib/attribute/attributevector.h
@@ -47,7 +47,7 @@ namespace search {
     class AttributeSaver;
     class IEnumStore;
     class IAttributeSaveTarget;
-    struct IDocumentWeightAttribute;
+    class IDocidWithWeightPostingStore;
     class QueryTermSimple;
     class QueryTermUCS4;
 
@@ -384,8 +384,7 @@ public:
 
 ////// Search API
 
-    // type-safe down-cast to attribute supporting direct document weight iterators
-    const IDocumentWeightAttribute *asDocumentWeightAttribute() const override;
+    const IDocidWithWeightPostingStore *as_docid_with_weight_posting_store() const override;
 
     const tensor::ITensorAttribute *asTensorAttribute() const override;
     const attribute::IMultiValueAttribute* as_multi_value_attribute() const override;

--- a/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "attribute_object_visitor.h"
-#include "i_document_weight_attribute.h"
+#include "i_docid_with_weight_posting_store.h"
 #include <vespa/searchcommon/attribute/iattributevector.h>
 #include <vespa/searchlib/common/matching_elements_fields.h>
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
@@ -17,7 +17,7 @@ namespace search::attribute {
 
 /**
  * Blueprint used for WeightedSetTerm or DotProduct over a multi-value attribute
- * which supports the IDocumentWeightAttribute interface.
+ * which supports the IDirectPostingStore interface.
  *
  * This allows access to low-level posting lists, which speeds up query execution.
  */
@@ -25,18 +25,18 @@ template <typename SearchType>
 class DirectWeightedSetBlueprint : public queryeval::ComplexLeafBlueprint
 {
 private:
-    std::vector<int32_t>                                _weights;
-    std::vector<IDocumentWeightAttribute::LookupResult> _terms;
-    const IAttributeVector                             &_iattr;
-    const IDocumentWeightAttribute                     &_attr;
-    vespalib::datastore::EntryRef                       _dictionary_snapshot;
+    std::vector<int32_t>                           _weights;
+    std::vector<IDirectPostingStore::LookupResult> _terms;
+    const IAttributeVector                        &_iattr;
+    const IDocidWithWeightPostingStore            &_attr;
+    vespalib::datastore::EntryRef                  _dictionary_snapshot;
 
 public:
-    DirectWeightedSetBlueprint(const queryeval::FieldSpec &field, const IAttributeVector &iattr, const IDocumentWeightAttribute &attr, size_t size_hint);
+    DirectWeightedSetBlueprint(const queryeval::FieldSpec &field, const IAttributeVector &iattr, const IDocidWithWeightPostingStore &attr, size_t size_hint);
     ~DirectWeightedSetBlueprint() override;
 
-    void addTerm(const IDocumentWeightAttribute::LookupKey & key, int32_t weight, HitEstimate & estimate) {
-        IDocumentWeightAttribute::LookupResult result = _attr.lookup(key, _dictionary_snapshot);
+    void addTerm(const IDirectPostingStore::LookupKey & key, int32_t weight, HitEstimate & estimate) {
+        IDirectPostingStore::LookupResult result = _attr.lookup(key, _dictionary_snapshot);
         HitEstimate childEst(result.posting_size, (result.posting_size == 0));
         if (!childEst.empty) {
             if (estimate.empty) {
@@ -57,7 +57,7 @@ public:
     std::unique_ptr<queryeval::SearchIterator> createFilterSearch(bool strict, FilterConstraint constraint) const override;
     std::unique_ptr<queryeval::MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override {
         if (fields.has_field(_iattr.getName())) {
-            return queryeval::MatchingElementsSearch::create(_iattr, _dictionary_snapshot, vespalib::ConstArrayRef<IDocumentWeightAttribute::LookupResult>(_terms));
+            return queryeval::MatchingElementsSearch::create(_iattr, _dictionary_snapshot, vespalib::ConstArrayRef<IDirectPostingStore::LookupResult>(_terms));
         } else {
             return {};
         }

--- a/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.hpp
@@ -13,7 +13,7 @@ namespace search::attribute {
 template <typename SearchType>
 DirectWeightedSetBlueprint<SearchType>::DirectWeightedSetBlueprint(const queryeval::FieldSpec &field,
                                                                    const IAttributeVector &iattr,
-                                                                   const IDocumentWeightAttribute &attr,
+                                                                   const IDocidWithWeightPostingStore &attr,
                                                                    size_t size_hint)
     : ComplexLeafBlueprint(field),
       _weights(),
@@ -42,7 +42,7 @@ DirectWeightedSetBlueprint<SearchType>::createLeafSearch(const fef::TermFieldMat
     std::vector<DocumentWeightIterator> iterators;
     const size_t numChildren = _terms.size();
     iterators.reserve(numChildren);
-    for (const IDocumentWeightAttribute::LookupResult &r : _terms) {
+    for (const IDirectPostingStore::LookupResult &r : _terms) {
         _attr.create(r.posting_idx, iterators);
     }
     bool field_is_filter = getState().fields()[0].isFilter();
@@ -58,7 +58,7 @@ DirectWeightedSetBlueprint<SearchType>::createFilterSearch(bool, FilterConstrain
 {
     std::vector<DocumentWeightIterator> iterators;
     iterators.reserve(_terms.size());
-    for (const IDocumentWeightAttribute::LookupResult &r : _terms) {
+    for (const IDirectPostingStore::LookupResult &r : _terms) {
         _attr.create(r.posting_idx, iterators);
     }
     return attribute::DocumentWeightOrFilterSearch::create(std::move(iterators));

--- a/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/direct_weighted_set_blueprint.hpp
@@ -39,7 +39,7 @@ DirectWeightedSetBlueprint<SearchType>::createLeafSearch(const fef::TermFieldMat
     if (_terms.empty()) {
         return std::make_unique<queryeval::EmptySearch>();
     }
-    std::vector<DocumentWeightIterator> iterators;
+    std::vector<DocidWithWeightIterator> iterators;
     const size_t numChildren = _terms.size();
     iterators.reserve(numChildren);
     for (const IDirectPostingStore::LookupResult &r : _terms) {
@@ -56,7 +56,7 @@ template <typename SearchType>
 std::unique_ptr<queryeval::SearchIterator>
 DirectWeightedSetBlueprint<SearchType>::createFilterSearch(bool, FilterConstraint) const
 {
-    std::vector<DocumentWeightIterator> iterators;
+    std::vector<DocidWithWeightIterator> iterators;
     iterators.reserve(_terms.size());
     for (const IDirectPostingStore::LookupResult &r : _terms) {
         _attr.create(r.posting_idx, iterators);

--- a/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.cpp
@@ -86,7 +86,7 @@ DocumentWeightOrFilterSearchImpl<IteratorPack>::doSeek(uint32_t docId)
 }
 
 std::unique_ptr<queryeval::SearchIterator>
-DocumentWeightOrFilterSearch::create(std::vector<DocumentWeightIterator>&& children)
+DocumentWeightOrFilterSearch::create(std::vector<DocidWithWeightIterator>&& children)
 {
     if (children.empty()) {
         return std::make_unique<queryeval::EmptySearch>();

--- a/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.h
+++ b/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.h
@@ -15,7 +15,7 @@ class DocumentWeightOrFilterSearch : public queryeval::SearchIterator
 protected:
     DocumentWeightOrFilterSearch() = default;
 public:
-    static std::unique_ptr<SearchIterator> create(std::vector<DocumentWeightIterator>&& children);
+    static std::unique_ptr<SearchIterator> create(std::vector<DocidWithWeightIterator>&& children);
     static std::unique_ptr<SearchIterator> create(const std::vector<SearchIterator *>& children,
                                                   std::unique_ptr<fef::MatchData> md);
 };

--- a/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.h
+++ b/searchlib/src/vespa/searchlib/attribute/document_weight_or_filter_search.h
@@ -1,6 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "i_document_weight_attribute.h"
+#include "i_direct_posting_store.h"
 #include <vespa/searchlib/queryeval/searchiterator.h>
 
 namespace search::fef { class MatchData; }

--- a/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.cpp
@@ -1,11 +1,11 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
-#include "i_document_weight_attribute.h"
+#include "i_direct_posting_store.h"
 #include <charconv>
 
 namespace search {
 namespace {
-class StringAsKey final : public IDocumentWeightAttribute::LookupKey {
+class StringAsKey final : public IDirectPostingStore::LookupKey {
 public:
     StringAsKey(vespalib::stringref key)
         : _key(key)
@@ -18,15 +18,15 @@ private:
 }
 
 bool
-IDocumentWeightAttribute::LookupKey::asInteger(int64_t &value) const {
+IDirectPostingStore::LookupKey::asInteger(int64_t &value) const {
     vespalib::stringref str = asString();
     const char *end = str.data() + str.size();
     auto res = std::from_chars(str.data(), end, value);
     return res.ptr == end;
 }
 
-IDocumentWeightAttribute::LookupResult
-IDocumentWeightAttribute::lookup(vespalib::stringref term, vespalib::datastore::EntryRef dictionary_snapshot) const {
+IDirectPostingStore::LookupResult
+IDirectPostingStore::lookup(vespalib::stringref term, vespalib::datastore::EntryRef dictionary_snapshot) const {
     return lookup(StringAsKey(term), dictionary_snapshot);
 }
 }

--- a/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
@@ -10,7 +10,7 @@ namespace search::queryeval { class SearchIterator; }
 
 namespace search {
 
-using DocumentWeightIterator = attribute::PostingListTraits<int32_t>::const_iterator;
+using DocidWithWeightIterator = attribute::PostingListTraits<int32_t>::const_iterator;
 
 /**
  * Baseline interface providing access to dictionary lookups and underlying posting lists for an attribute vector.

--- a/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
@@ -12,8 +12,13 @@ namespace search {
 
 using DocumentWeightIterator = attribute::PostingListTraits<int32_t>::const_iterator;
 
-struct IDocumentWeightAttribute
-{
+/**
+ * Baseline interface providing access to dictionary lookups and underlying posting lists for an attribute vector.
+ *
+ * This is used to speedup query execution for multi-term query operators as InTerm, WeightedSetTerm, DotProduct, Wand.
+ */
+class IDirectPostingStore {
+public:
     struct LookupKey {
         virtual ~LookupKey() = default;
         // It is required that the string is zero terminated
@@ -41,11 +46,9 @@ struct IDocumentWeightAttribute
      * (e.g. lowercased) value equals the folded value for enum_idx.
      */
     virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const = 0;
-    virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
-    virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
     virtual bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept = 0;
     virtual std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const = 0;
-    virtual ~IDocumentWeightAttribute() = default;
+    virtual ~IDirectPostingStore() = default;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
@@ -13,8 +13,8 @@ namespace search {
  */
 class IDocidWithWeightPostingStore : public IDirectPostingStore {
 public:
-    virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
-    virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
+    virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const = 0;
+    virtual DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
@@ -1,0 +1,21 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+#include "i_direct_posting_store.h"
+
+namespace search {
+
+/**
+ * Interface providing access to dictionary lookups and underlying posting lists that contains {docid, weight} tuples.
+ *
+ * This posting store type is supported by multi-value attributes with fast-search.
+ */
+class IDocidWithWeightPostingStore : public IDirectPostingStore {
+public:
+    virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const = 0;
+    virtual DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
+};
+
+}
+

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<ISearchContext> ImportedAttributeVectorReadGuard::createSearchCo
     return std::make_unique<ImportedSearchContext>(std::move(term), params, _imported_attribute, _target_attribute);
 }
 
-const IDocumentWeightAttribute *ImportedAttributeVectorReadGuard::asDocumentWeightAttribute() const {
+const IDocidWithWeightPostingStore *ImportedAttributeVectorReadGuard::as_docid_with_weight_posting_store() const {
     return nullptr;
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_attribute_vector_read_guard.h
@@ -59,7 +59,7 @@ public:
     const char * getStringFromEnum(EnumHandle e) const override;
     std::unique_ptr<ISearchContext> createSearchContext(std::unique_ptr<QueryTermSimple> term,
                                                         const SearchContextParams &params) const override;
-    const IDocumentWeightAttribute *asDocumentWeightAttribute() const override;
+    const IDocidWithWeightPostingStore *as_docid_with_weight_posting_store() const override;
     const tensor::ITensorAttribute *asTensorAttribute() const override;
     const attribute::IMultiValueAttribute* as_multi_value_attribute() const override;
     BasicType::Type getBasicType() const override;

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -128,7 +128,7 @@ ImportedSearchContext::createIterator(fef::TermFieldMatchData* matchData, bool s
             return SearchIterator::UP(new EmptySearch());
         } else {
             using Posting = vespalib::btree::BTreeKeyData<uint32_t, int32_t>;
-            using DocIt = DocIdIterator<Posting>;
+            using DocIt = ArrayIterator<Posting>;
             DocIt postings;
             auto array = _merger.getArray();
             postings.set(&array[0], &array[array.size()]);

--- a/searchlib/src/vespa/searchlib/attribute/iterator_pack.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/iterator_pack.cpp
@@ -8,7 +8,7 @@ namespace search {
 
 AttributeIteratorPack::~AttributeIteratorPack() = default;
 
-AttributeIteratorPack::AttributeIteratorPack(std::vector<DocumentWeightIterator> &&children)
+AttributeIteratorPack::AttributeIteratorPack(std::vector<DocidWithWeightIterator> &&children)
     : _children(std::move(children))
 {
     assert(_children.size() <= std::numeric_limits<ref_t>::max());

--- a/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
+++ b/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "i_document_weight_attribute.h"
+#include "i_direct_posting_store.h"
 #include <vespa/searchlib/queryeval/begin_and_end_id.h>
 
 namespace search {

--- a/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
+++ b/searchlib/src/vespa/searchlib/attribute/iterator_pack.h
@@ -12,7 +12,7 @@ class BitVector;
 class AttributeIteratorPack
 {
 private:
-    std::vector<DocumentWeightIterator> _children;
+    std::vector<DocidWithWeightIterator> _children;
 
 public:
     using ref_t = uint16_t;
@@ -20,7 +20,7 @@ public:
     AttributeIteratorPack(AttributeIteratorPack &&rhs) noexcept = default;
     AttributeIteratorPack &operator=(AttributeIteratorPack &&rhs) noexcept = default;
 
-    explicit AttributeIteratorPack(std::vector<DocumentWeightIterator> &&children);
+    explicit AttributeIteratorPack(std::vector<DocidWithWeightIterator> &&children);
     ~AttributeIteratorPack();
 
     uint32_t get_docid(ref_t ref) const {

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -39,8 +39,8 @@ private:
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
-        void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
-        DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;
+        void create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const override;
+        DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const override;
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
     };

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -4,7 +4,7 @@
 
 #include "multinumericenumattribute.h"
 #include "postinglistattribute.h"
-#include "i_document_weight_attribute.h"
+#include "i_docid_with_weight_posting_store.h"
 
 namespace search {
 
@@ -32,9 +32,10 @@ public:
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
 
 private:
-    struct DocumentWeightAttributeAdapter final : IDocumentWeightAttribute {
+    class DocidWithWeightPostingStoreAdapter final : public IDocidWithWeightPostingStore {
+    public:
         const MultiValueNumericPostingAttribute &self;
-        DocumentWeightAttributeAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
+        DocidWithWeightPostingStoreAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
@@ -43,7 +44,7 @@ private:
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
     };
-    DocumentWeightAttributeAdapter _document_weight_attribute_adapter;
+    DocidWithWeightPostingStoreAdapter _posting_store_adapter;
 
     friend class PostingListAttributeTest;
     template <typename, typename, typename>
@@ -87,7 +88,7 @@ public:
     std::unique_ptr<attribute::SearchContext>
     getSearch(QueryTermSimpleUP term, const attribute::SearchContextParams & params) const override;
 
-    const IDocumentWeightAttribute *asDocumentWeightAttribute() const override;
+    const IDocidWithWeightPostingStore *as_docid_with_weight_posting_store() const override;
 
     bool onAddDoc(DocId doc) override {
         return forwardedOnAddDoc(doc, this->_mvMapping.getNumKeys(), this->_mvMapping.getCapacityKeys());

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -124,14 +124,14 @@ MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::col
 
 template <typename B, typename M>
 void
-MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const
 {
     assert(idx.valid());
     self.get_posting_store().beginFrozen(idx, dst);
 }
 
 template <typename B, typename M>
-DocumentWeightIterator
+DocidWithWeightIterator
 MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx) const
 {
     assert(idx.valid());

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -43,7 +43,7 @@ MultiValueNumericPostingAttribute<B, M>::MultiValueNumericPostingAttribute(const
                                                                            const AttributeVector::Config & cfg)
     : MultiValueNumericEnumAttribute<B, M>(name, cfg),
       PostingParent(*this, this->getEnumStore()),
-      _document_weight_attribute_adapter(*this)
+      _posting_store_adapter(*this)
 {
 }
 
@@ -86,15 +86,15 @@ MultiValueNumericPostingAttribute<B, M>::getSearch(QueryTermSimpleUP qTerm,
 
 template <typename B, typename M>
 vespalib::datastore::EntryRef
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::get_dictionary_snapshot() const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::get_dictionary_snapshot() const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
     return dictionary.get_frozen_root();
 }
 
 template <typename B, typename M>
-IDocumentWeightAttribute::LookupResult
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
+IDirectPostingStore::LookupResult
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
     int64_t int_term;
@@ -116,7 +116,7 @@ MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::lookup(
 
 template <typename B, typename M>
 void
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback)const
 {
     (void) dictionary_snapshot;
     callback(enum_idx);
@@ -124,7 +124,7 @@ MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::collect
 
 template <typename B, typename M>
 void
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
 {
     assert(idx.valid());
     self.get_posting_store().beginFrozen(idx, dst);
@@ -132,7 +132,7 @@ MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(
 
 template <typename B, typename M>
 DocumentWeightIterator
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx) const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx) const
 {
     assert(idx.valid());
     return self.get_posting_store().beginFrozen(idx);
@@ -140,27 +140,27 @@ MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::create(
 
 template <typename B, typename M>
 std::unique_ptr<queryeval::SearchIterator>
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const
 {
     return self.get_posting_store().make_bitvector_iterator(idx, doc_id_limit, match_data, strict);
 }
 
 template <typename B, typename M>
 bool
-MultiValueNumericPostingAttribute<B, M>::DocumentWeightAttributeAdapter::has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept
 {
     return self.get_posting_store().has_btree(idx);
 }
 
 template <typename B, typename M>
-const IDocumentWeightAttribute *
-MultiValueNumericPostingAttribute<B, M>::asDocumentWeightAttribute() const
+const IDocidWithWeightPostingStore*
+MultiValueNumericPostingAttribute<B, M>::as_docid_with_weight_posting_store() const
 {
     if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::INT64) && !this->getIsFilter()) {
-        return &_document_weight_attribute_adapter;
+        return &_posting_store_adapter;
     }
     return nullptr;
 }
 
-} // namespace search
+}
 

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -4,7 +4,7 @@
 
 #include "multistringattribute.h"
 #include "postinglistattribute.h"
-#include "i_document_weight_attribute.h"
+#include "i_docid_with_weight_posting_store.h"
 
 namespace search {
 
@@ -30,9 +30,10 @@ public:
     using EnumStoreBatchUpdater = typename EnumStore::BatchUpdater;
 
 private:
-    struct DocumentWeightAttributeAdapter final : IDocumentWeightAttribute {
+    class DocidWithWeightPostingStoreAdapter final : public IDocidWithWeightPostingStore {
+    public:
         const MultiValueStringPostingAttributeT &self;
-        DocumentWeightAttributeAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
+        DocidWithWeightPostingStoreAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
@@ -41,7 +42,7 @@ private:
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
     };
-    DocumentWeightAttributeAdapter _document_weight_attribute_adapter;
+    DocidWithWeightPostingStoreAdapter _posting_store_adapter;
 
     using LoadedVector = typename B::LoadedVector;
     using PostingParent = PostingListAttributeSubBase<AttributeWeightPosting,
@@ -84,7 +85,7 @@ public:
     std::unique_ptr<attribute::SearchContext>
     getSearch(QueryTermSimpleUP term, const attribute::SearchContextParams & params) const override;
 
-    const IDocumentWeightAttribute *asDocumentWeightAttribute() const override;
+    const IDocidWithWeightPostingStore *as_docid_with_weight_posting_store() const override;
 
     bool onAddDoc(DocId doc) override {
         return forwardedOnAddDoc(doc, this->_mvMapping.getNumKeys(), this->_mvMapping.getCapacityKeys());

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -37,8 +37,8 @@ private:
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
-        void create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const override;
-        DocumentWeightIterator create(vespalib::datastore::EntryRef idx) const override;
+        void create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const override;
+        DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const override;
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
     };

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -144,14 +144,14 @@ MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::col
 
 template <typename B, typename T>
 void
-MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
+MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const
 {
     assert(idx.valid());
     self.get_posting_store().beginFrozen(idx, dst);
 }
 
 template <typename B, typename M>
-DocumentWeightIterator
+DocidWithWeightIterator
 MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx) const
 {
     assert(idx.valid());

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -13,7 +13,7 @@ template <typename B, typename T>
 MultiValueStringPostingAttributeT<B, T>::MultiValueStringPostingAttributeT(const vespalib::string & name, const AttributeVector::Config & c)
     : MultiValueStringAttributeT<B, T>(name, c),
       PostingParent(*this, this->getEnumStore()),
-      _document_weight_attribute_adapter(*this)
+      _posting_store_adapter(*this)
 {
 }
 
@@ -106,15 +106,15 @@ MultiValueStringPostingAttributeT<B, T>::getSearch(QueryTermSimpleUP qTerm,
 
 template <typename B, typename T>
 vespalib::datastore::EntryRef
-MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::get_dictionary_snapshot() const
+MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::get_dictionary_snapshot() const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
     return dictionary.get_frozen_root();
 }
 
 template <typename B, typename T>
-IDocumentWeightAttribute::LookupResult
-MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
+IDirectPostingStore::LookupResult
+MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const
 {
     const IEnumStoreDictionary& dictionary = self._enumStore.get_dictionary();
     vespalib::stringref keyAsString = key.asString();
@@ -136,7 +136,7 @@ MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::lookup(
 
 template <typename B, typename T>
 void
-MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const
+MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const
 {
     const IEnumStoreDictionary &dictionary = self._enumStore.get_dictionary();
     dictionary.collect_folded(enum_idx, dictionary_snapshot, callback);
@@ -144,7 +144,7 @@ MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::collect
 
 template <typename B, typename T>
 void
-MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
+MultiValueStringPostingAttributeT<B, T>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx, std::vector<DocumentWeightIterator> &dst) const
 {
     assert(idx.valid());
     self.get_posting_store().beginFrozen(idx, dst);
@@ -152,7 +152,7 @@ MultiValueStringPostingAttributeT<B, T>::DocumentWeightAttributeAdapter::create(
 
 template <typename B, typename M>
 DocumentWeightIterator
-MultiValueStringPostingAttributeT<B, M>::DocumentWeightAttributeAdapter::create(vespalib::datastore::EntryRef idx) const
+MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::create(vespalib::datastore::EntryRef idx) const
 {
     assert(idx.valid());
     return self.get_posting_store().beginFrozen(idx);
@@ -160,28 +160,28 @@ MultiValueStringPostingAttributeT<B, M>::DocumentWeightAttributeAdapter::create(
 
 template <typename B, typename M>
 bool
-MultiValueStringPostingAttributeT<B, M>::DocumentWeightAttributeAdapter::has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept
+MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept
 {
     return self.get_posting_store().has_btree(idx);
 }
 
 template <typename B, typename M>
 std::unique_ptr<queryeval::SearchIterator>
-MultiValueStringPostingAttributeT<B, M>::DocumentWeightAttributeAdapter::make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const
+MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const
 {
     return self.get_posting_store().make_bitvector_iterator(idx, doc_id_limit, match_data, strict);
 }
 
 template <typename B, typename T>
-const IDocumentWeightAttribute *
-MultiValueStringPostingAttributeT<B, T>::asDocumentWeightAttribute() const
+const IDocidWithWeightPostingStore*
+MultiValueStringPostingAttributeT<B, T>::as_docid_with_weight_posting_store() const
 {
     // TODO: Add support for handling bit vectors too, and lift restriction on isFilter.
     if (this->hasWeightedSetType() && this->isStringType() && ! this->getIsFilter()) {
-        return &_document_weight_attribute_adapter;
+        return &_posting_store_adapter;
     }
     return nullptr;
 }
 
-} // namespace search
+}
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistattribute.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "dociditerator.h"
+#include "array_iterator.h"
 #include "enumattribute.h"
 #include "ipostinglistattributebase.h"
 #include "numericbase.h"

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "postinglistsearchcontext.h"
-#include "dociditerator.h"
+#include "array_iterator.h"
 #include "attributeiterators.h"
 #include "diversity.h"
 #include "postingstore.hpp"
@@ -156,7 +156,7 @@ createPostingIterator(fef::TermFieldMatchData *matchData, bool strict)
     if (_merger.hasArray() || _merger.hasBitVector()) { // synthetic results are available
         if (!_merger.emptyArray()) {
             assert(_merger.hasArray());
-            using DocIt = DocIdIterator<Posting>;
+            using DocIt = ArrayIterator<Posting>;
             DocIt postings;
             vespalib::ConstArrayRef<Posting> array = _merger.getArray();
             postings.set(&array[0], &array[array.size()]);

--- a/searchlib/src/vespa/searchlib/queryeval/document_weight_search_iterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/document_weight_search_iterator.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "searchiterator.h"
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/searchlib/fef/termfieldmatchdata.h>
 
 namespace search::queryeval {
@@ -18,8 +18,8 @@ private:
 
 public:
     DocumentWeightSearchIterator(fef::TermFieldMatchData &tfmd,
-                                 const IDocumentWeightAttribute &attr,
-                                 IDocumentWeightAttribute::LookupResult dict_entry)
+                                 const IDocidWithWeightPostingStore &attr,
+                                 IDirectPostingStore::LookupResult dict_entry)
         : _tfmd(tfmd),
           _matchPosition(_tfmd.populate_fixed()),
           _iterator(attr.create(dict_entry.posting_idx)),

--- a/searchlib/src/vespa/searchlib/queryeval/document_weight_search_iterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/document_weight_search_iterator.h
@@ -13,7 +13,7 @@ class DocumentWeightSearchIterator : public SearchIterator
 private:
     fef::TermFieldMatchData          &_tfmd;
     fef::TermFieldMatchDataPosition * _matchPosition;
-    DocumentWeightIterator            _iterator;
+    DocidWithWeightIterator            _iterator;
     queryeval::MinMaxPostingInfo      _postingInfo;
 
 public:

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_search.cpp
@@ -179,7 +179,7 @@ SearchIterator::UP
 DotProductSearch::create(TermFieldMatchData &tmd,
                          bool field_is_filter,
                          const std::vector<int32_t> &weights,
-                         std::vector<DocumentWeightIterator> &&iterators)
+                         std::vector<DocidWithWeightIterator> &&iterators)
 {
     using ArrayHeapImpl = DotProductSearchImpl<vespalib::LeftArrayHeap, AttributeIteratorPack>;
     using HeapImpl = DotProductSearchImpl<vespalib::LeftHeap, AttributeIteratorPack>;

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_search.h
@@ -36,7 +36,7 @@ public:
     static SearchIterator::UP create(search::fef::TermFieldMatchData &tmd,
                                      bool field_is_filter,
                                      const std::vector<int32_t> &weights,
-                                     std::vector<DocumentWeightIterator> &&iterators);
+                                     std::vector<DocidWithWeightIterator> &&iterators);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/matching_elements_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/matching_elements_search.h
@@ -5,7 +5,7 @@
 #include <vector>
 #include <cstdint>
 #include <memory>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_direct_posting_store.h>
 
 namespace search { class MatchingElements; }
 namespace search::attribute { class IAttributeVector; }
@@ -27,7 +27,7 @@ public:
     virtual void find_matching_elements(uint32_t doc_id, MatchingElements& result) = 0;
     virtual void initRange(uint32_t begin_id, uint32_t end_id) = 0;
 
-    static std::unique_ptr<MatchingElementsSearch> create(const search::attribute::IAttributeVector &attr, vespalib::datastore::EntryRef dictionary_snapshot, vespalib::ConstArrayRef<IDocumentWeightAttribute::LookupResult> dict_entries);
+    static std::unique_ptr<MatchingElementsSearch> create(const search::attribute::IAttributeVector &attr, vespalib::datastore::EntryRef dictionary_snapshot, vespalib::ConstArrayRef<IDirectPostingStore::LookupResult> dict_entries);
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.cpp
@@ -224,8 +224,8 @@ SearchIterator::UP
 ParallelWeakAndSearch::create(search::fef::TermFieldMatchData &tfmd,
                               const MatchParams &matchParams,
                               const std::vector<int32_t> &weights,
-                              const std::vector<IDocumentWeightAttribute::LookupResult> &dict_entries,
-                              const IDocumentWeightAttribute &attr,
+                              const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
+                              const IDocidWithWeightPostingStore &attr,
                               bool strict)
 {
     assert(weights.size() == dict_entries.size());

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
@@ -71,8 +71,8 @@ struct ParallelWeakAndSearch : public SearchIterator
     static SearchIterator::UP create(fef::TermFieldMatchData &tmd,
                                      const MatchParams &matchParams,
                                      const std::vector<int32_t> &weights,
-                                     const std::vector<IDocumentWeightAttribute::LookupResult> &dict_entries,
-                                     const IDocumentWeightAttribute &attr,
+                                     const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
+                                     const IDocidWithWeightPostingStore &attr,
                                      bool strict);
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/wand/wand_parts.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/wand_parts.h
@@ -273,7 +273,7 @@ struct VectorizedAttributeTerms : VectorizedState<AttributeIteratorPack> {
                              docid_t docIdLimit)
     {
         std::vector<ref_t> order = init_state<Scorer>(AttrInput(weights, dict_entries), docIdLimit);
-        std::vector<DocumentWeightIterator> iterators;
+        std::vector<DocidWithWeightIterator> iterators;
         iterators.reserve(order.size());
         for (size_t i = 0; i < order.size(); ++i) {
             attr.create(dict_entries[order[i]].posting_idx, iterators);

--- a/searchlib/src/vespa/searchlib/queryeval/wand/wand_parts.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/wand_parts.h
@@ -11,7 +11,7 @@
 #include <vespa/searchlib/attribute/iterator_pack.h>
 #include <vespa/vespalib/objects/objectvisitor.h>
 #include <vespa/vespalib/util/priority_queue.h>
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/vespalib/util/stringfmt.h>
 
 namespace search::queryeval::wand {
@@ -24,7 +24,7 @@ using score_t = int64_t;
 using docid_t = uint32_t;
 using ref_t = uint16_t;
 
-using Attr = IDocumentWeightAttribute;
+using Attr = IDirectPostingStore;
 using AttrDictEntry = Attr::LookupResult;
 using AttrDictEntries = std::vector<AttrDictEntry>;
 
@@ -94,9 +94,9 @@ struct TermInput {
 
 struct AttrInput {
     const std::vector<int32_t> &weights;
-    const std::vector<IDocumentWeightAttribute::LookupResult> &dict_entries;
+    const std::vector<IDirectPostingStore::LookupResult> &dict_entries;
     AttrInput(const std::vector<int32_t> &weights_in,
-              const std::vector<IDocumentWeightAttribute::LookupResult> &dict_entries_in)
+              const std::vector<IDirectPostingStore::LookupResult> &dict_entries_in)
         : weights(weights_in), dict_entries(dict_entries_in) {}
     size_t size() const { return weights.size(); }
     int32_t get_weight(ref_t ref) const { return weights[ref]; }
@@ -267,8 +267,8 @@ VectorizedIteratorTerms::VectorizedIteratorTerms(const Terms &t, const Scorer &,
 struct VectorizedAttributeTerms : VectorizedState<AttributeIteratorPack> {
     template <typename Scorer>
     VectorizedAttributeTerms(const std::vector<int32_t> &weights,
-                             const std::vector<IDocumentWeightAttribute::LookupResult> &dict_entries,
-                             const IDocumentWeightAttribute &attr,
+                             const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
+                             const IDocidWithWeightPostingStore &attr,
                              const Scorer &,
                              docid_t docIdLimit)
     {

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
@@ -188,7 +188,7 @@ SearchIterator::UP
 WeightedSetTermSearch::create(fef::TermFieldMatchData &tmd,
                               bool field_is_filter,
                               const std::vector<int32_t> &weights,
-                              std::vector<DocumentWeightIterator> &&iterators)
+                              std::vector<DocidWithWeightIterator> &&iterators)
 {
     using ArrayHeapImpl = WeightedSetTermSearchImpl<vespalib::LeftArrayHeap, AttributeIteratorPack>;
     using HeapImpl = WeightedSetTermSearchImpl<vespalib::LeftHeap, AttributeIteratorPack>;

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
@@ -36,7 +36,7 @@ public:
     static SearchIterator::UP create(search::fef::TermFieldMatchData &tmd,
                                      bool field_is_filter,
                                      const std::vector<int32_t> &weights,
-                                     std::vector<DocumentWeightIterator> &&iterators);
+                                     std::vector<DocidWithWeightIterator> &&iterators);
 
     // used during docsum fetching to identify matching elements
     // initRange must be called before use.

--- a/searchlib/src/vespa/searchlib/test/document_weight_attribute_helper.h
+++ b/searchlib/src/vespa/searchlib/test/document_weight_attribute_helper.h
@@ -1,7 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/searchlib/attribute/i_document_weight_attribute.h>
+#include <vespa/searchlib/attribute/i_docid_with_weight_posting_store.h>
 #include <vespa/searchlib/attribute/attributevector.h>
 #include <vespa/searchlib/attribute/multinumericattribute.h>
 #include <vespa/searchlib/attribute/multinumericpostattribute.hpp>
@@ -15,7 +15,7 @@ class DocumentWeightAttributeHelper
 private:
     AttributeVector::SP _attr;
     IntegerAttribute *_int_attr;
-    const IDocumentWeightAttribute *_dwa;
+    const IDocidWithWeightPostingStore *_dww;
 
     AttributeVector::SP make_attr();
 
@@ -23,10 +23,10 @@ public:
     DocumentWeightAttributeHelper()
         : _attr(make_attr()),
           _int_attr(dynamic_cast<IntegerAttribute *>(_attr.get())),
-          _dwa(_attr->asDocumentWeightAttribute())
+          _dww(_attr->as_docid_with_weight_posting_store())
     {
         ASSERT_TRUE(_int_attr != nullptr);
-        ASSERT_TRUE(_dwa != nullptr);
+        ASSERT_TRUE(_dww != nullptr);
     }
     ~DocumentWeightAttributeHelper();
 
@@ -45,7 +45,7 @@ public:
         _int_attr->commit();
     }
 
-    const IDocumentWeightAttribute &dwa() const { return *_dwa; }
+    const IDocidWithWeightPostingStore &dww() const { return *_dww; }
 };
 
 }

--- a/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
+++ b/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
@@ -62,7 +62,7 @@ public:
     ~DwwIteratorChildrenVerifier() override {}
     SearchIterator::UP create(bool strict) const override {
         (void) strict;
-        std::vector<DocumentWeightIterator> children;
+        std::vector<DocidWithWeightIterator> children;
         for (size_t i = 0; i < _num_children; ++i) {
             auto dict_entry = _helper.dww().lookup(vespalib::make_string("%zu", i).c_str(), _helper.dww().get_dictionary_snapshot());
             _helper.dww().create(dict_entry.posting_idx, children);
@@ -70,7 +70,7 @@ public:
         return create(std::move(children));
     }
 protected:
-    virtual SearchIterator::UP create(std::vector<DocumentWeightIterator> &&) const  {
+    virtual SearchIterator::UP create(std::vector<DocidWithWeightIterator> &&) const  {
         return {};
     }
     DocumentWeightAttributeHelper _helper;

--- a/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
+++ b/searchlib/src/vespa/searchlib/test/weightedchildrenverifiers.h
@@ -47,9 +47,9 @@ protected:
     std::vector<DocIds> _split_lists;
 };
 
-class DwaIteratorChildrenVerifier : public WeightedChildrenVerifier {
+class DwwIteratorChildrenVerifier : public WeightedChildrenVerifier {
 public:
-    DwaIteratorChildrenVerifier() :
+    DwwIteratorChildrenVerifier() :
         WeightedChildrenVerifier(),
         _helper()
     {
@@ -59,13 +59,13 @@ public:
             _helper.set_doc(full_list[i], i % _num_children, 1);
         }
     }
-    ~DwaIteratorChildrenVerifier() override {}
+    ~DwwIteratorChildrenVerifier() override {}
     SearchIterator::UP create(bool strict) const override {
         (void) strict;
         std::vector<DocumentWeightIterator> children;
         for (size_t i = 0; i < _num_children; ++i) {
-            auto dict_entry = _helper.dwa().lookup(vespalib::make_string("%zu", i).c_str(), _helper.dwa().get_dictionary_snapshot());
-            _helper.dwa().create(dict_entry.posting_idx, children);
+            auto dict_entry = _helper.dww().lookup(vespalib::make_string("%zu", i).c_str(), _helper.dww().get_dictionary_snapshot());
+            _helper.dww().create(dict_entry.posting_idx, children);
         }
         return create(std::move(children));
     }


### PR DESCRIPTION
This introduces a baseline interface IDirectPostingStore and prepares for the introduction of IDocidPostingStore
that will be implemented by single-value attributes with fast-search. Currently, only some multi-value attributes with fast-search support direct access to underlying posting lists via IDocidWithWeightPostingStore.

@toregge please review
@baldersheim FYI