### PR TITLE
Reduce CC unit test ZooKeeper WAL file preallocations by three orders of magnitude

### DIFF
--- a/clustercontroller-core/pom.xml
+++ b/clustercontroller-core/pom.xml
@@ -137,6 +137,10 @@
                 <configuration>
                     <forkCount>4</forkCount>
                     <rerunFailingTestsCount>5</rerunFailingTestsCount>
+                    <systemPropertyVariables>
+                        <!-- Avoid 64 MiB default in favor of just 64 KiB -->
+                        <zookeeper.preAllocSize>64</zookeeper.preAllocSize>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
@jonmv please review.
@baldersheim FYI. Maybe we should ponder setting something like this for our system tests too...

ZK will by default preallocate 65536 * 1024 bytes (i.e. 64 MiB) for its write-ahead log file. This will happen for every test instantiation of the ZooKeeper database. Now, I like wearing out SSD flash cells as much as the next guy, but this just feels silly.

Input number is always multiplied by 1024, so reduce down to 64 to get a much more manageable 64 _KiB_ preallocation instead.

Preallocation is done by padding with null-bytes, so it's possible a clever FS will elide actual disk writes for this in favor of just extending the file area and pretending it wrote all zeroes, but this is hard to rely on.
