### PR TITLE
Handle combination of both weight iterators and bitvectors in DirectM…

### DIFF
--- a/searchlib/CMakeLists.txt
+++ b/searchlib/CMakeLists.txt
@@ -76,6 +76,7 @@ vespa_define_module(
     src/tests/attribute/changevector
     src/tests/attribute/compaction
     src/tests/attribute/dfa_fuzzy_matcher
+    src/tests/attribute/direct_multi_term_blueprint
     src/tests/attribute/document_weight_iterator
     src/tests/attribute/document_weight_or_filter_search
     src/tests/attribute/enum_attribute_compaction

--- a/searchlib/src/tests/attribute/direct_multi_term_blueprint/CMakeLists.txt
+++ b/searchlib/src/tests/attribute/direct_multi_term_blueprint/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+vespa_add_executable(searchlib_direct_multi_term_blueprint_test_app TEST
+    SOURCES
+    direct_multi_term_blueprint_test.cpp
+    DEPENDS
+    searchlib
+    searchlib_test
+    GTest::GTest
+)
+vespa_add_test(NAME searchlib_direct_multi_term_blueprint_test_app COMMAND searchlib_direct_multi_term_blueprint_test_app)

--- a/searchlib/src/tests/attribute/direct_multi_term_blueprint/direct_multi_term_blueprint_test.cpp
+++ b/searchlib/src/tests/attribute/direct_multi_term_blueprint/direct_multi_term_blueprint_test.cpp
@@ -1,0 +1,255 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#include <vespa/searchlib/attribute/direct_multi_term_blueprint.h>
+#include <vespa/searchlib/attribute/integerbase.h>
+#include <vespa/searchlib/fef/termfieldmatchdata.h>
+#include <vespa/searchlib/queryeval/orsearch.h>
+#include <vespa/searchlib/queryeval/searchiterator.h>
+#include <vespa/searchlib/queryeval/simpleresult.h>
+#include <vespa/searchlib/queryeval/weighted_set_term_search.h>
+#include <vespa/searchlib/test/attribute_builder.h>
+#include <vespa/vespalib/gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <numeric>
+
+using namespace search::attribute;
+using namespace search::queryeval;
+using namespace search;
+using testing::StartsWith;
+
+struct IntegerKey : public IDirectPostingStore::LookupKey {
+    int64_t _value;
+    IntegerKey(int64_t value_in) : _value(value_in) {}
+    vespalib::stringref asString() const override { abort(); }
+    bool asInteger(int64_t& value) const override { value = _value; return true; }
+};
+
+const vespalib::string field_name = "test";
+constexpr uint32_t field_id = 3;
+uint32_t doc_id_limit = 500;
+
+using Docids = std::vector<uint32_t>;
+
+Docids
+range(uint32_t begin, uint32_t count)
+{
+    Docids res(count);
+    std::iota(res.begin(), res.end(), begin);
+    return res;
+}
+
+Docids
+concat(const Docids& a, const Docids& b)
+{
+    std::vector<uint32_t> res;
+    res.insert(res.end(), a.begin(), a.end());
+    res.insert(res.end(), b.begin(), b.end());
+    std::sort(res.begin(), res.end());
+    return res;
+}
+
+std::shared_ptr<AttributeVector>
+make_attribute(bool field_is_filter)
+{
+    Config cfg(BasicType::INT64, CollectionType::WSET);
+    cfg.setFastSearch(true);
+    if (field_is_filter) {
+        cfg.setIsFilter(field_is_filter);
+    }
+    uint32_t num_docs = doc_id_limit - 1;
+    auto attr = test::AttributeBuilder(field_name, cfg).docs(num_docs).get();
+    IntegerAttribute& real = dynamic_cast<IntegerAttribute&>(*attr);
+
+    // Values 1 and 3 have btree (short) posting lists with weights.
+    real.append(10, 1, 1);
+    real.append(30, 3, 1);
+    real.append(31, 3, 1);
+
+    // Values 100 and 300 have bitvector posting lists.
+    // We need at least 128 documents to get bitvector posting list (see PostingStoreBase2::resizeBitVectors())
+    for (auto docid : range(100, 128)) {
+        real.append(docid, 100, 1);
+    }
+    for (auto docid : range(300, 128)) {
+        real.append(docid, 300, 1);
+    }
+    attr->commit(true);
+    return attr;
+}
+
+void
+expect_has_weight_iterator(const IDocidWithWeightPostingStore& store, int64_t term_value)
+{
+    auto snapshot = store.get_dictionary_snapshot();
+    auto res = store.lookup(IntegerKey(term_value), snapshot);
+    EXPECT_TRUE(store.has_weight_iterator(res.posting_idx));
+}
+
+void
+expect_has_bitvector_iterator(const IDocidWithWeightPostingStore& store, int64_t term_value)
+{
+    auto snapshot = store.get_dictionary_snapshot();
+    auto res = store.lookup(IntegerKey(term_value), snapshot);
+    EXPECT_TRUE(store.has_bitvector(res.posting_idx));
+}
+
+void
+validate_posting_lists(const IDocidWithWeightPostingStore& store)
+{
+    expect_has_weight_iterator(store, 1);
+    expect_has_weight_iterator(store, 3);
+    if (store.has_always_weight_iterator()) {
+        expect_has_weight_iterator(store, 100);
+        expect_has_weight_iterator(store, 300);
+    }
+    expect_has_bitvector_iterator(store, 100);
+    expect_has_bitvector_iterator(store, 300);
+}
+
+class DirectMultiTermBlueprintTest : public ::testing::Test {
+public:
+    using BlueprintType = DirectMultiTermBlueprint<WeightedSetTermSearch>;
+    std::shared_ptr<AttributeVector> attr;
+    const IDocidWithWeightPostingStore* store;
+    std::shared_ptr<BlueprintType> blueprint;
+    Blueprint::HitEstimate estimate;
+    fef::TermFieldMatchData tfmd;
+    fef::TermFieldMatchDataArray tfmda;
+    DirectMultiTermBlueprintTest()
+        : attr(),
+          store(),
+          blueprint(),
+          tfmd(),
+          tfmda()
+    {
+        tfmda.add(&tfmd);
+    }
+    void setup(bool field_is_filter, bool need_term_field_match_data) {
+        attr = make_attribute(field_is_filter);
+        store = attr->as_docid_with_weight_posting_store();
+        ASSERT_TRUE(store);
+        validate_posting_lists(*store);
+        blueprint = std::make_shared<BlueprintType>(FieldSpec(field_name, field_id, fef::TermFieldHandle(), field_is_filter), *attr, *store, 2);
+        blueprint->setDocIdLimit(doc_id_limit);
+        if (need_term_field_match_data) {
+            tfmd.needs_normal_features();
+        } else {
+            tfmd.tagAsNotNeeded();
+        }
+    }
+    void add_term(int64_t term_value) {
+        blueprint->addTerm(IntegerKey(term_value), 1, estimate);
+    }
+    std::unique_ptr<SearchIterator> create_leaf_search() const {
+        return blueprint->createLeafSearch(tfmda, true);
+    }
+};
+
+void
+expect_hits(const Docids& exp_docids, SearchIterator& itr)
+{
+    SimpleResult exp(exp_docids);
+    SimpleResult act;
+    act.search(itr);
+    EXPECT_EQ(exp, act);
+}
+
+void
+expect_or_iterator(SearchIterator& itr, size_t exp_children)
+{
+    auto& real = dynamic_cast<OrSearch&>(itr);
+    ASSERT_EQ(exp_children, real.getChildren().size());
+}
+
+void
+expect_or_child(SearchIterator& itr, size_t child, const vespalib::string& exp_child_itr)
+{
+    auto& real = dynamic_cast<OrSearch&>(itr);
+    EXPECT_THAT(real.getChildren()[child]->asString(), StartsWith(exp_child_itr));
+}
+
+TEST_F(DirectMultiTermBlueprintTest, weight_iterators_used_for_none_filter_field)
+{
+    setup(false, true);
+    add_term(1);
+    add_term(3);
+    auto itr = create_leaf_search();
+    EXPECT_THAT(itr->asString(), StartsWith("search::queryeval::WeightedSetTermSearchImpl"));
+    expect_hits({10, 30, 31}, *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, weight_iterators_used_instead_of_bitvectors_for_none_filter_field)
+{
+    setup(false, true);
+    add_term(1);
+    add_term(100);
+    auto itr = create_leaf_search();
+    EXPECT_THAT(itr->asString(), StartsWith("search::queryeval::WeightedSetTermSearchImpl"));
+    expect_hits(concat({10}, range(100, 128)), *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, bitvectors_and_weight_iterators_used_for_filter_field)
+{
+    setup(true, true);
+    add_term(1);
+    add_term(3);
+    add_term(100);
+    add_term(300);
+    auto itr = create_leaf_search();
+    expect_or_iterator(*itr, 3);
+    expect_or_child(*itr, 0, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 1, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 2, "search::queryeval::WeightedSetTermSearchImpl");
+    expect_hits(concat({10, 30, 31}, concat(range(100, 128), range(300, 128))), *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, only_bitvectors_used_for_filter_field)
+{
+    setup(true, true);
+    add_term(100);
+    add_term(300);
+    auto itr = create_leaf_search();
+    expect_or_iterator(*itr, 2);
+    expect_or_child(*itr, 0, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 1, "search::BitVectorIteratorStrictT");
+    expect_hits(concat(range(100, 128), range(300, 128)), *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, filter_iterator_used_for_filter_field_and_ranking_not_needed)
+{
+    setup(true, false);
+    add_term(1);
+    add_term(3);
+    auto itr = create_leaf_search();
+    EXPECT_THAT(itr->asString(), StartsWith("search::attribute::DocumentWeightOrFilterSearchImpl"));
+    expect_hits({10, 30, 31}, *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, bitvectors_and_filter_iterator_used_for_filter_field_and_ranking_not_needed)
+{
+    setup(true, false);
+    add_term(1);
+    add_term(3);
+    add_term(100);
+    add_term(300);
+    auto itr = create_leaf_search();
+    expect_or_iterator(*itr, 3);
+    expect_or_child(*itr, 0, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 1, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 2, "search::attribute::DocumentWeightOrFilterSearchImpl");
+    expect_hits(concat({10, 30, 31}, concat(range(100, 128), range(300, 128))), *itr);
+}
+
+TEST_F(DirectMultiTermBlueprintTest, only_bitvectors_used_for_filter_field_and_ranking_not_needed)
+{
+    setup(true, false);
+    add_term(100);
+    add_term(300);
+    auto itr = create_leaf_search();
+    expect_or_iterator(*itr, 2);
+    expect_or_child(*itr, 0, "search::BitVectorIteratorStrictT");
+    expect_or_child(*itr, 1, "search::BitVectorIteratorStrictT");
+    expect_hits(concat(range(100, 128), range(300, 128)), *itr);
+}
+
+GTEST_MAIN_RUN_ALL_TESTS()

--- a/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
+++ b/searchlib/src/tests/queryeval/weighted_set_term/weighted_set_term_test.cpp
@@ -292,7 +292,7 @@ private:
 class WeightIteratorChildrenVerifier : public search::test::DwwIteratorChildrenVerifier {
 private:
     SearchIterator::UP create(std::vector<DocidWithWeightIterator> && children) const override {
-        return WeightedSetTermSearch::create(_tfmd, false, _weights, std::move(children));
+        return WeightedSetTermSearch::create(_tfmd, false, std::cref(_weights), std::move(children));
     }
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_direct_posting_store.h
@@ -56,6 +56,7 @@ public:
     virtual void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const = 0;
     virtual bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept = 0;
     virtual std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const = 0;
+    virtual bool has_bitvector(vespalib::datastore::EntryRef idx) const noexcept = 0;
     virtual ~IDirectPostingStore() = default;
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
+++ b/searchlib/src/vespa/searchlib/attribute/i_docid_with_weight_posting_store.h
@@ -15,6 +15,13 @@ class IDocidWithWeightPostingStore : public IDirectPostingStore {
 public:
     virtual void create(vespalib::datastore::EntryRef idx, std::vector<DocidWithWeightIterator> &dst) const = 0;
     virtual DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const = 0;
+
+    /**
+     * Returns true when posting list iterators with weight are present for all terms.
+     *
+     * This means posting list iterators exist in addition to eventual bitvector posting lists.
+     */
+    virtual bool has_always_weight_iterator() const noexcept = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.h
@@ -35,7 +35,9 @@ private:
     class DocidWithWeightPostingStoreAdapter final : public IDocidWithWeightPostingStore {
     public:
         const MultiValueNumericPostingAttribute &self;
-        DocidWithWeightPostingStoreAdapter(const MultiValueNumericPostingAttribute &self_in) : self(self_in) {}
+        bool _is_filter;
+        DocidWithWeightPostingStoreAdapter(const MultiValueNumericPostingAttribute &self_in)
+            : self(self_in), _is_filter(self_in.getIsFilter()) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
@@ -43,6 +45,8 @@ private:
         DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const override;
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
+        bool has_bitvector(vespalib::datastore::EntryRef idx) const noexcept override;
+        bool has_always_weight_iterator() const noexcept override { return !_is_filter; }
     };
     DocidWithWeightPostingStoreAdapter _posting_store_adapter;
 

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -153,10 +153,17 @@ MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::has
 }
 
 template <typename B, typename M>
+bool
+MultiValueNumericPostingAttribute<B, M>::DocidWithWeightPostingStoreAdapter::has_bitvector(vespalib::datastore::EntryRef idx) const noexcept
+{
+    return self.get_posting_store().has_bitvector(idx);
+}
+
+template <typename B, typename M>
 const IDocidWithWeightPostingStore*
 MultiValueNumericPostingAttribute<B, M>::as_docid_with_weight_posting_store() const
 {
-    if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::INT64) && !this->getIsFilter()) {
+    if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::INT64)) {
         return &_posting_store_adapter;
     }
     return nullptr;

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.h
@@ -33,7 +33,9 @@ private:
     class DocidWithWeightPostingStoreAdapter final : public IDocidWithWeightPostingStore {
     public:
         const MultiValueStringPostingAttributeT &self;
-        DocidWithWeightPostingStoreAdapter(const MultiValueStringPostingAttributeT &self_in) : self(self_in) {}
+        bool _is_filter;
+        DocidWithWeightPostingStoreAdapter(const MultiValueStringPostingAttributeT &self_in)
+            : self(self_in), _is_filter(self_in.getIsFilter()) {}
         vespalib::datastore::EntryRef get_dictionary_snapshot() const override;
         LookupResult lookup(const LookupKey & key, vespalib::datastore::EntryRef dictionary_snapshot) const override;
         void collect_folded(vespalib::datastore::EntryRef enum_idx, vespalib::datastore::EntryRef dictionary_snapshot, const std::function<void(vespalib::datastore::EntryRef)>& callback) const override;
@@ -41,6 +43,8 @@ private:
         DocidWithWeightIterator create(vespalib::datastore::EntryRef idx) const override;
         std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const override;
         bool has_weight_iterator(vespalib::datastore::EntryRef idx) const noexcept override;
+        bool has_bitvector(vespalib::datastore::EntryRef idx) const noexcept override;
+        bool has_always_weight_iterator() const noexcept override { return !_is_filter; }
     };
     DocidWithWeightPostingStoreAdapter _posting_store_adapter;
 

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -166,6 +166,13 @@ MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::has
 }
 
 template <typename B, typename M>
+bool
+MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::has_bitvector(vespalib::datastore::EntryRef idx) const noexcept
+{
+    return self.get_posting_store().has_bitvector(idx);
+}
+
+template <typename B, typename M>
 std::unique_ptr<queryeval::SearchIterator>
 MultiValueStringPostingAttributeT<B, M>::DocidWithWeightPostingStoreAdapter::make_bitvector_iterator(vespalib::datastore::EntryRef idx, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const
 {
@@ -177,7 +184,7 @@ const IDocidWithWeightPostingStore*
 MultiValueStringPostingAttributeT<B, T>::as_docid_with_weight_posting_store() const
 {
     // TODO: Add support for handling bit vectors too, and lift restriction on isFilter.
-    if (this->hasWeightedSetType() && this->isStringType() && ! this->getIsFilter()) {
+    if (this->hasWeightedSetType() && this->isStringType()) {
         return &_posting_store_adapter;
     }
     return nullptr;

--- a/searchlib/src/vespa/searchlib/attribute/postingstore.h
+++ b/searchlib/src/vespa/searchlib/attribute/postingstore.h
@@ -190,6 +190,9 @@ public:
     bool has_btree(const EntryRef ref) const noexcept {
         return !ref.valid() || !isBitVector(getTypeId(RefType(ref))) || !isFilter();
     }
+    bool has_bitvector(const EntryRef ref) const noexcept {
+        return ref.valid() && isBitVector(getTypeId(RefType(ref)));
+    }
 
     std::unique_ptr<queryeval::SearchIterator> make_bitvector_iterator(RefType ref, uint32_t doc_id_limit, fef::TermFieldMatchData &match_data, bool strict) const;
 

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
@@ -8,6 +8,7 @@
 #include <vespa/searchlib/fef/termfieldmatchdataarray.h>
 #include <vespa/searchlib/attribute/posting_iterator_pack.h>
 #include <memory>
+#include <variant>
 #include <vector>
 
 namespace search::fef { class TermFieldMatchData; }
@@ -35,7 +36,7 @@ public:
 
     static SearchIterator::UP create(search::fef::TermFieldMatchData &tmd,
                                      bool field_is_filter,
-                                     const std::vector<int32_t> &weights,
+                                     std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                                      std::vector<DocidWithWeightIterator> &&iterators);
 
     // used during docsum fetching to identify matching elements


### PR DESCRIPTION
…ultiTermBlueprint.

This does not change how InTerm, WeightedSetTerm and DotProduct currently uses this blueprint. They still require that weight iterators are available for all terms / tokens, but this will soon be relaxed for InTerm and WeightedSetTerm.

@toregge please review