### PR TITLE
Enable automatic PRs for releases older than 14 days

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,19 +5,21 @@
   ],
   "dependencyDashboardApproval": true,
   "transitiveRemediation": true,
-  "prHourlyLimit": 10,
-  "prConcurrentLimit": 10,
+  "prHourlyLimit": 20,
+  "prConcurrentLimit": 20,
   "ignorePaths": [],
-  "ignoreDeps": [
-    "com.github.spotbugs:spotbugs-annotations",
-    "com.yahoo.vespa.bundle-plugin:test-bundles",
-    "com.yahoo.vespa.jdisc_core:test_bundles",
-    "com.yahoo.vespa:cloud-tenant-base",
-    "com.yahoo.vespa:container-dependency-versions",
-    "com.yahoo.vespa:hosted-tenant-base",
-    "com.yahoo.vespa:parent",
-    "com.yahoo.vespa:zookeeper-server-parent",
-    "github.com/go-json-experiment/json",
-    "javax.servlet:javax.servlet-api"
+  "ignoreDeps": [],
+  "schedule": ["before 6am on thursday"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^com\\.yahoo\\.vespa"],
+      "matchManagers": ["maven"],
+      "enabled": false
+    },
+    {
+      "minimumReleaseAge": "14 days",
+      "dependencyDashboardApproval": false
+    }
   ]
+}
 }


### PR DESCRIPTION
Use package pattern for ignoring Vespa artifacts instead of manually curated list. PRs for previoiusly ignored artifacts must be manually closed. The advantage now is that they will be listed in the dependency dashboard.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
