### PR TITLE
Revert "Update dependency commons-logging:commons-logging to v1.3.0"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- DO NOT UPGRADE THESE TO A NEW MAJOR VERSION WITHOUT CHECKING FOR BINARY COMPATIBILITY -->
         <aopalliance.vespa.version>1.0</aopalliance.vespa.version>
-        <commons-logging.vespa.version>1.3.0</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
+        <commons-logging.vespa.version>1.2</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
         <error-prone-annotations.vespa.version>2.23.0</error-prone-annotations.vespa.version>
         <guava.vespa.version>32.1.3-jre</guava.vespa.version>
         <guice.vespa.version>6.0.0</guice.vespa.version>
@@ -103,7 +103,6 @@
         <icu4j.vespa.version>74.1</icu4j.vespa.version>
         <java-jjwt.vespa.version>0.11.5</java-jjwt.vespa.version>
         <java-jwt.vespa.version>4.4.0</java-jwt.vespa.version>
-        <javax.annotation.vespa.version>1.2</javax.annotation.vespa.version>
         <jaxb.runtime.vespa.version>4.0.4</jaxb.runtime.vespa.version>
         <jetty.vespa.version>11.0.18</jetty.vespa.version>
         <jetty-servlet-api.vespa.version>5.0.2</jetty-servlet-api.vespa.version>

--- a/maven-plugins/allowed-maven-dependencies.txt
+++ b/maven-plugins/allowed-maven-dependencies.txt
@@ -13,7 +13,7 @@ com.google.j2objc:j2objc-annotations:2.8
 commons-codec:commons-codec:${commons-codec.vespa.version}
 commons-io:commons-io:${commons-io.vespa.version}
 jakarta.inject:jakarta.inject-api:${jakarta.inject.vespa.version}
-javax.annotation:javax.annotation-api:${javax.annotation.vespa.version}
+javax.annotation:javax.annotation-api:${commons-logging.vespa.version}
 javax.inject:javax.inject:${javax.inject.vespa.version}
 junit:junit:${junit4.vespa.version}
 net.bytebuddy:byte-buddy-agent:${byte-buddy.vespa.version}

--- a/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
+++ b/vespa-dependencies-enforcer/allowed-maven-dependencies.txt
@@ -78,7 +78,7 @@ io.prometheus:simpleclient_tracer_otel:${prometheus.client.vespa.version}
 io.prometheus:simpleclient_tracer_otel_agent:${prometheus.client.vespa.version}
 jakarta.inject:jakarta.inject-api:${jakarta.inject.vespa.version}
 javax.activation:javax.activation-api:1.2.0
-javax.annotation:javax.annotation-api:${javax.annotation.vespa.version}
+javax.annotation:javax.annotation-api:${commons-logging.vespa.version}
 javax.inject:javax.inject:${javax.inject.vespa.version}
 javax.servlet:javax.servlet-api:${javax.servlet-api.vespa.version}
 javax.ws.rs:javax.ws.rs-api:${javax.ws.rs-api.vespa.version}


### PR DESCRIPTION
Reverts vespa-engine/vespa#29519

Looks like this broke host-admin:

	Caused by: java.lang.NoClassDefFoundError: org/slf4j/spi/LocationAwareLogger
	at org.apache.commons.logging.impl.Slf4jLogFactory.lambda$getInstance$0(Slf4jLogFactory.java:288)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at org.apache.commons.logging.impl.Slf4jLogFactory.getInstance(Slf4jLogFactory.java:286)
	at org.apache.commons.logging.impl.Slf4jLogFactory.getInstance(Slf4jLogFactory.java:281)
	at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:987)

