### PR TITLE
Use fake ZooKeeper database implementation for subset of CC tests

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -8,7 +8,6 @@ import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
-import com.yahoo.vespa.clustercontroller.core.database.ZooKeeperDatabaseFactory;
 import com.yahoo.vespa.clustercontroller.core.hostinfo.HostInfo;
 import com.yahoo.vespa.clustercontroller.core.listeners.NodeListener;
 import com.yahoo.vespa.clustercontroller.core.listeners.SlobrokListener;
@@ -152,7 +151,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                 options.nodeStateRequestTimeoutEarliestPercentage(),
                 options.nodeStateRequestTimeoutLatestPercentage(),
                 options.nodeStateRequestRoundTripTimeMaxSeconds());
-        var database = new DatabaseHandler(context, new ZooKeeperDatabaseFactory(context), timer, options.zooKeeperServerAddress(), timer);
+        var database = new DatabaseHandler(context, options.dbFactoryFn().apply(context), timer, options.zooKeeperServerAddress(), timer);
         var lookUp = new SlobrokClient(context, timer, options.slobrokConnectionSpecs());
         var stateGenerator = new StateChangeHandler(context, timer, log);
         var stateBroadcaster = new SystemStateBroadcaster(context, timer, timer);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseFactory.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/database/DatabaseFactory.java
@@ -9,9 +9,9 @@ package com.yahoo.vespa.clustercontroller.core.database;
 public interface DatabaseFactory {
 
     class Params {
-        String dbAddress;
-        int dbSessionTimeout;
-        Database.DatabaseListener listener;
+        public String dbAddress;
+        public int dbSessionTimeout;
+        public Database.DatabaseListener listener;
 
         Params databaseAddress(String address) { this.dbAddress = address; return this; }
         Params databaseSessionTimeout(int timeout) { this.dbSessionTimeout = timeout; return this; }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionBitCountTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionBitCountTest.java
@@ -14,8 +14,11 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@ExtendWith(CleanupZookeeperLogsOnSuccess.class)
 public class DistributionBitCountTest extends FleetControllerTest {
+
+    DistributionBitCountTest() {
+        useRealZooKeeperInTest(false);
+    }
 
     private FleetControllerOptions setUpSystem() throws Exception {
         List<ConfiguredNode> configuredNodes = new ArrayList<>();

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FakeZooKeeperDatabase.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FakeZooKeeperDatabase.java
@@ -1,0 +1,136 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.state.Node;
+import com.yahoo.vdslib.state.NodeState;
+import com.yahoo.vespa.clustercontroller.core.database.Database;
+import com.yahoo.vespa.clustercontroller.core.database.DatabaseFactory;
+
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Memory-backed fake DB implementation that tries to mirror the semantics of the
+ * (synchronous) ZooKeeper DB implementation. By itself this fake acts as if a quorum
+ * with a _single_, local ZK instance has been configured. This DB instance cannot be
+ * used across multiple cluster controller instances.
+ *
+ * Threading note: we expect all invocations on this instance to happen from the
+ * main cluster controller thread (i.e. "as-if" single threaded), but we wrap everything
+ * in a mutex to stay on the safe side since this isn't explicitly documented as
+ * part of the API,
+ */
+public class FakeZooKeeperDatabase extends Database {
+
+    public static class Factory implements DatabaseFactory {
+        private final FleetControllerContext context;
+        public Factory(FleetControllerContext context) {
+            this.context = context;
+        }
+        @Override
+        public Database create(Params params) {
+            return new FakeZooKeeperDatabase(context, params.listener);
+        }
+    }
+
+    private final FleetControllerContext context;
+    private final Database.DatabaseListener listener;
+
+    private final Object mutex = new Object();
+    private boolean closed = false;
+    private Integer persistedLatestStateVersion = null;
+    private Map<Integer, Integer> persistedLeaderVotes = new TreeMap<>();
+    private Map<Node, NodeState> persistedWantedStates = new TreeMap<>();
+    private Map<Node, Long> persistedStartTimestamps = new TreeMap<>();
+    private ClusterStateBundle persistedBundle = ClusterStateBundle.ofBaselineOnly(AnnotatedClusterState.emptyState());
+
+    public FakeZooKeeperDatabase(FleetControllerContext context, DatabaseListener listener) {
+        this.context = context;
+        this.listener = listener;
+    }
+
+    @Override
+    public void close() {
+        synchronized (mutex) {
+            closed = true;
+        }
+    }
+
+    @Override
+    public boolean isClosed() {
+        synchronized (mutex) {
+            return closed;
+        }
+    }
+
+    @Override
+    public boolean storeMasterVote(int voteForNode) {
+        Map<Integer, Integer> voteState;
+        synchronized (mutex) {
+            persistedLeaderVotes.put(context.id().index(), voteForNode);
+            voteState = Map.copyOf(persistedLeaderVotes);
+        }
+        listener.handleMasterData(voteState);
+        return true;
+    }
+
+    @Override
+    public boolean storeLatestSystemStateVersion(int version) {
+        synchronized (mutex) {
+            persistedLatestStateVersion = version;
+            return true;
+        }
+    }
+
+    @Override
+    public Integer retrieveLatestSystemStateVersion() {
+        synchronized (mutex) {
+            return persistedLatestStateVersion;
+        }
+    }
+
+    @Override
+    public boolean storeWantedStates(Map<Node, NodeState> states) {
+        synchronized (mutex) {
+            persistedWantedStates = Map.copyOf(states);
+        }
+        return true;
+    }
+
+    @Override
+    public Map<Node, NodeState> retrieveWantedStates() {
+        synchronized (mutex) {
+            return Map.copyOf(persistedWantedStates);
+        }
+    }
+
+    @Override
+    public boolean storeStartTimestamps(Map<Node, Long> timestamps) {
+        synchronized (mutex) {
+            persistedStartTimestamps = Map.copyOf(timestamps);
+            return true;
+        }
+    }
+
+    @Override
+    public Map<Node, Long> retrieveStartTimestamps() {
+        synchronized (mutex) {
+            return Map.copyOf(persistedStartTimestamps);
+        }
+    }
+
+    @Override
+    public boolean storeLastPublishedStateBundle(ClusterStateBundle stateBundle) {
+        synchronized (mutex) {
+            persistedBundle = stateBundle;
+            return true;
+        }
+    }
+
+    @Override
+    public ClusterStateBundle retrieveLastPublishedStateBundle() {
+        synchronized (mutex) {
+            return persistedBundle;
+        }
+    }
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/StateChangeTest.java
@@ -9,7 +9,6 @@ import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.testutils.StateWaiter;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -23,13 +22,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@ExtendWith(CleanupZookeeperLogsOnSuccess.class)
 public class StateChangeTest extends FleetControllerTest {
 
     private final FakeTimer timer = new FakeTimer();
 
     private FleetController ctrl;
     private DummyCommunicator communicator;
+
+    StateChangeTest() {
+        useRealZooKeeperInTest(false);
+    }
 
     private void initialize(FleetControllerOptions.Builder builder) throws Exception {
         List<Node> nodes = new ArrayList<>();
@@ -38,7 +40,7 @@ public class StateChangeTest extends FleetControllerTest {
             nodes.add(new Node(NodeType.DISTRIBUTOR, i));
         }
 
-        setUpZooKeeperServer(builder);
+        builder.setDbFactoryFn(FakeZooKeeperDatabase.Factory::new);
         communicator = new DummyCommunicator(nodes, timer);
         boolean start = false;
         FleetControllerOptions options = builder.build();


### PR DESCRIPTION
@hmusum please review
@jonmv FYI

The fake impl acts "as if" a single-node ZK quorum is present, so it cannot be directly used with most multi-node tests that require multiple nodes to actually participate in leader elections. Though we could probably expand the fake to handle this if desired.
