### PR TITLE
Add feature flag for restart on deploy when onnx model changes

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -432,6 +432,13 @@ public class Flags {
             "Takes effect immediately",
             CONSOLE_USER_EMAIL);
 
+    public static final UnboundBooleanFlag RESTART_ON_DEPLOY_WHEN_ONNX_MODEL_CHANGES = defineFeatureFlag(
+            "restart-on-deploy-when-onnx-model-changes", false,
+            List.of("hmusum"), "2023-12-04", "2024-01-04",
+            "If set, restart on deploy if onnx model or onnx model options used by a container cluster change",
+            "Takes effect at redeployment",
+            INSTANCE_ID);
+
     /** WARNING: public for testing: All flags should be defined in {@link Flags}. */
     public static UnboundBooleanFlag defineFeatureFlag(String flagId, boolean defaultValue, List<String> owners,
                                                        String createdAt, String expiresAt, String description,


### PR DESCRIPTION
Controls whether we should restart on deploy when onnx or onnx model options change for a model used by a container cluster.