### PR TITLE
Revert "Revert "Go back to commons-logging 1.2""

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -33,7 +33,7 @@
 
         <!-- DO NOT UPGRADE THESE TO A NEW MAJOR VERSION WITHOUT CHECKING FOR BINARY COMPATIBILITY -->
         <aopalliance.vespa.version>1.0</aopalliance.vespa.version>
-        <commons-logging.vespa.version>1.3.0</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
+        <commons-logging.vespa.version>1.2</commons-logging.vespa.version>  <!-- This version is exported by jdisc via jcl-over-slf4j. -->
         <error-prone-annotations.vespa.version>2.23.0</error-prone-annotations.vespa.version>
         <guava.vespa.version>32.1.3-jre</guava.vespa.version>
         <guice.vespa.version>6.0.0</guice.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#29553

@jonmv has the exact details.

```
java.lang.NoClassDefFoundError: org/apache/logging/log4j/spi/LoggerAdapter
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:375)
	at org.apache.commons.logging.LogFactory.createFactory(LogFactory.java:419)
	at org.apache.commons.logging.LogFactory.lambda$newFactory$3(LogFactory.java:1432)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:318)
	at org.apache.commons.logging.LogFactory.newFactory(LogFactory.java:1431)
	at org.apache.commons.logging.LogFactory.getFactory(LogFactory.java:928)
	at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:987)
```