### PR TITLE
fix default cycle time in fbench-usage to 0 MERGEOK

### DIFF
--- a/fbench/README
+++ b/fbench/README
@@ -103,7 +103,7 @@ mark optional parameters and default values):
 | 		[-r restartLimit] [-k] <hostname> <port>
 | 
 |  -n <num> : run with <num> parallel clients [10]
-|  -c <num> : each client will make a request each <num> milliseconds [1000]
+|  -c <num> : each client will make a request each <num> milliseconds [0]
 | 	      ('-1' -> cycle time should be twice the response time)
 |  -l <num> : minimum response size for successful requests [0]
 |  -i <num> : do not log the <num> first results. -1 means no logging [0]

--- a/fbench/src/fbench/fbench.cpp
+++ b/fbench/src/fbench/fbench.cpp
@@ -299,7 +299,7 @@ FBench::Usage()
     printf(" -P       : use POST for requests instead of GET.\n");
     printf(" -a <str> : append string to each query\n");
     printf(" -n <num> : run with <num> parallel clients [10]\n");
-    printf(" -c <num> : each client will make a request each <num> milliseconds [1000]\n");
+    printf(" -c <num> : each client will make a request each <num> milliseconds [0]\n");
     printf("            ('-1' -> cycle time should be twice the response time)\n");
     printf(" -l <num> : minimum response size for successful requests [0]\n");
     printf(" -i <num> : do not log the <num> first results. -1 means no logging [0]\n");


### PR DESCRIPTION
Hi,

The default fbench cycle time was set to 0 in [this PR](https://github.com/vespa-engine/vespa/pull/23876). However, the corresponding usage was not updated, so fixed it.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
