### PR TITLE
Amdahl's law needs due respect. By allocating bitvector and zero init…

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -76,7 +76,8 @@ struct PostingListSearchContextT<DataT>::FillPart : public vespalib::Runnable {
           _bv(bv),
           _docIdLimit(limit),
           _from(from),
-          _to(from)
+          _to(from),
+          _owned_bv()
     {
         _to += count;
     }


### PR DESCRIPTION
…ializing it in the producing thread we achieve:

  - Shift work from sequential path to parallell path.
  - Avoid filling master threads cache during bitvector creation.
  - Pull directly into correct workers cache.
  - And increase the chance the memory is allocated in a numa region close to you.

@havardpe @geirst PR
This contains the first half of #29647. I want to see effect them separately.