### PR TITLE
Support TermFieldMatchData where doUnpack() sets docid.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/multi_term_or_filter_search.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_term_or_filter_search.h
@@ -18,7 +18,9 @@ protected:
     MultiTermOrFilterSearch() = default;
 public:
     static std::unique_ptr<SearchIterator> create(std::vector<DocidIterator>&& children);
+    static std::unique_ptr<SearchIterator> create(std::vector<DocidIterator>&& children, fef::TermFieldMatchData& tfmd);
     static std::unique_ptr<SearchIterator> create(std::vector<DocidWithWeightIterator>&& children);
+    static std::unique_ptr<SearchIterator> create(std::vector<DocidWithWeightIterator>&& children, fef::TermFieldMatchData& tfmd);
     static std::unique_ptr<SearchIterator> create(const std::vector<SearchIterator *>& children,
                                                   std::unique_ptr<fef::MatchData> md);
 };


### PR DESCRIPTION
This will be needed for an InTerm used for ranking, e.g. the matches rank feature.

@baldersheim please review