### PR TITLE
Store onnx model info after deciding if we need to restart on deploy

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1465,7 +1465,8 @@
       "public abstract void registerModel(java.net.URI, com.yahoo.config.model.api.OnnxModelOptions)",
       "public abstract java.util.Map models()",
       "public abstract void setRestartOnDeploy()",
-      "public abstract boolean restartOnDeploy()"
+      "public abstract boolean restartOnDeploy()",
+      "public abstract void store()"
     ],
     "fields" : [ ]
   },
@@ -1488,7 +1489,8 @@
       "public void registerModel(java.net.URI, com.yahoo.config.model.api.OnnxModelOptions)",
       "public java.util.Map models()",
       "public void setRestartOnDeploy()",
-      "public boolean restartOnDeploy()"
+      "public boolean restartOnDeploy()",
+      "public void store()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelCost.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelCost.java
@@ -25,6 +25,7 @@ public interface OnnxModelCost {
         Map<String, ModelInfo> models();
         void setRestartOnDeploy();
         boolean restartOnDeploy();
+        void store();
     }
 
     record ModelInfo(String modelId, long estimatedCost, long hash, Optional<OnnxModelOptions> onnxModelOptions) {}
@@ -41,6 +42,7 @@ public interface OnnxModelCost {
         @Override public Map<String, ModelInfo> models() { return Map.of(); }
         @Override public void setRestartOnDeploy() {}
         @Override public boolean restartOnDeploy() { return false; }
+        @Override public void store() {}
     }
 
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidator.java
@@ -99,6 +99,7 @@ public class RestartOnDeployForOnnxModelChangesValidator implements ChangeValida
     private static void setRestartOnDeployAndAddRestartAction(List<ConfigChangeAction> actions, ApplicationContainerCluster cluster, String message) {
         log.log(INFO, message);
         cluster.onnxModelCostCalculator().setRestartOnDeploy();
+        cluster.onnxModelCostCalculator().store();
         actions.add(new VespaRestartAction(cluster.id(), message));
     }
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/JvmHeapSizeValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/JvmHeapSizeValidatorTest.java
@@ -124,6 +124,7 @@ class JvmHeapSizeValidatorTest {
         @Override public Map<String, ModelInfo> models() { return Map.of(); }
         @Override public void setRestartOnDeploy() {}
         @Override public boolean restartOnDeploy() { return false;}
+        @Override public void store() {}
         @Override public long aggregatedModelCostInBytes() { return totalCost.get(); }
         @Override public void registerModel(ApplicationFile path) {}
         @Override public void registerModel(ApplicationFile path, OnnxModelOptions onnxModelOptions) {}

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RestartOnDeployForOnnxModelChangesValidatorTest.java
@@ -110,6 +110,9 @@ public class RestartOnDeployForOnnxModelChangesValidatorTest {
 
             @Override
             public boolean restartOnDeploy() { return restartOnDeploy; }
+
+            @Override
+            public void store() {}
         };
     }
 


### PR DESCRIPTION
Need to store (in ZK) so that info is available on all config servers

Depends on change in internal repo.
Please review only, I'll merge when we have a release candidate