### PR TITLE
- Having expensive asserts during shutdown is not worthwhile. It does…

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdb.cpp
+++ b/searchcore/src/vespa/searchcore/proton/bucketdb/bucketdb.cpp
@@ -62,7 +62,6 @@ BucketDB::checkActiveCount() const {
 void
 BucketDB::unloadBucket(BucketId bucket, const BucketState &delta)
 {
-    checkActiveCount();
     BucketState *state = getBucketStatePtr(bucket);
     assert(state);
     *state -= delta;


### PR DESCRIPTION
… not prevent persisting any errors,

  nor does it provide any information about what went wrong.

@toregge @geirst PR