### PR TITLE
Allow override of OPENBLAS_CORETYPE to allow system tests with valgrind.

### DIFF
--- a/client/go/internal/admin/envvars/env_vars.go
+++ b/client/go/internal/admin/envvars/env_vars.go
@@ -22,6 +22,7 @@ const (
 	MALLOC_ARENA_MAX                       = "MALLOC_ARENA_MAX"
 	NO_VESPAMALLOC_LIST                    = "NO_VESPAMALLOC_LIST"
 	NUM_PROCESSES_LIMIT                    = "num_processes_limit"
+	OPENBLAS_CORETYPE                      = "OPENBLAS_CORETYPE"
 	PATH                                   = "PATH"
 	PRELOAD                                = "PRELOAD"
 	ROOT                                   = "ROOT"


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
