### PR TITLE
Skip upgrade when OS version is unavailable

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeRepository.java
@@ -137,7 +137,7 @@ public class NodeRepository extends AbstractComponent implements HealthCheckerPr
         this.resourcesCalculator = provisionServiceProvider.getHostResourcesCalculator();
         this.nodeResourceLimits = new NodeResourceLimits(this);
         this.nameResolver = nameResolver;
-        this.osVersions = new OsVersions(this);
+        this.osVersions = new OsVersions(this, provisionServiceProvider.getHostProvisioner());
         this.infrastructureVersions = new InfrastructureVersions(db);
         this.firmwareChecks = new FirmwareChecks(db, clock);
         this.containerImages = new ContainerImages(containerImage, tenantContainerImage, tenantGpuContainerImage);

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/CompositeOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/CompositeOsUpgrader.java
@@ -3,8 +3,10 @@ package com.yahoo.vespa.hosted.provision.os;
 
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * An implementation of {@link OsUpgrader} that delegates calls to multiple implementations.
@@ -15,8 +17,8 @@ public class CompositeOsUpgrader extends OsUpgrader {
 
     private final List<OsUpgrader> upgraders;
 
-    public CompositeOsUpgrader(NodeRepository nodeRepository, List<OsUpgrader> upgraders) {
-        super(nodeRepository);
+    public CompositeOsUpgrader(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner, List<OsUpgrader> upgraders) {
+        super(nodeRepository, hostProvisioner);
         this.upgraders = List.copyOf(upgraders);
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/DelegatingOsUpgrader.java
@@ -6,6 +6,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -23,8 +24,8 @@ public class DelegatingOsUpgrader extends OsUpgrader {
 
     private static final Logger LOG = Logger.getLogger(DelegatingOsUpgrader.class.getName());
 
-    public DelegatingOsUpgrader(NodeRepository nodeRepository) {
-        super(nodeRepository);
+    public DelegatingOsUpgrader(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner) {
+        super(nodeRepository, hostProvisioner);
     }
 
     @Override
@@ -35,7 +36,7 @@ public class DelegatingOsUpgrader extends OsUpgrader {
                                              // This upgrader cannot downgrade nodes. We therefore consider only nodes
                                              // on a lower version than the target
                                              .osVersionIsBefore(target.version())
-                                             .matching(node -> canUpgradeAt(now, node))
+                                             .matching(node -> canUpgradeTo(target.version(), now, node))
                                              .byIncreasingOsVersion()
                                              .first(upgradeSlots(target, activeNodes));
         if (nodesToUpgrade.size() == 0) return;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsUpgrader.java
@@ -1,15 +1,28 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.os;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.yahoo.component.Version;
+import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.vespa.flags.IntFlag;
 import com.yahoo.vespa.flags.PermanentFlags;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
+import com.yahoo.yolean.Exceptions;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Interface for an OS upgrader.
@@ -18,13 +31,23 @@ import java.time.Instant;
  */
 public abstract class OsUpgrader {
 
+    private final Logger LOG = Logger.getLogger(OsUpgrader.class.getName());
+
     private final IntFlag maxActiveUpgrades;
+    private final Optional<HostProvisioner> hostProvisioner;
+    // Supported versions is queried for each host to upgrade, so we cache the results for a while to avoid excessive
+    // API calls to the host provisioner
+    private final Cache<CloudAccount, Set<Version>> supportedVersions = CacheBuilder.newBuilder()
+                                                                                    .expireAfterWrite(10, TimeUnit.MINUTES)
+                                                                                    .build();
 
     final NodeRepository nodeRepository;
 
-    public OsUpgrader(NodeRepository nodeRepository) {
-        this.nodeRepository = nodeRepository;
+
+    public OsUpgrader(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner) {
+        this.nodeRepository = Objects.requireNonNull(nodeRepository);
         this.maxActiveUpgrades = PermanentFlags.MAX_OS_UPGRADES.bindTo(nodeRepository.flagSource());
+        this.hostProvisioner = Objects.requireNonNull(hostProvisioner);
     }
 
     /** Trigger upgrade to given target */
@@ -43,10 +66,31 @@ public abstract class OsUpgrader {
         return Math.max(0, max - upgrading);
     }
 
-    /** Returns whether node can change version at given instant */
-    final boolean canUpgradeAt(Instant instant, Node node) {
-        return node.status().osVersion().downgrading() || // Fast-track downgrades
-               node.history().age(instant).compareTo(gracePeriod()) > 0;
+    /** Returns whether node can upgrade to version at given instant */
+    final boolean canUpgradeTo(Version version, Instant instant, Node node) {
+        Set<Version> versions = supportedVersions(node, version);
+        boolean versionAvailable = versions.contains(version);
+        if (!versionAvailable) {
+            LOG.log(Level.WARNING, "Want to upgrade host " + node.hostname() + " to OS version " +
+                                   version.toFullString() + ", but this version does not exist in " +
+                                   node.cloudAccount() + ". Found " + versions.stream().sorted().toList());
+        }
+        return versionAvailable &&
+               (node.status().osVersion().downgrading() || // Fast-track downgrades
+                node.history().age(instant).compareTo(gracePeriod()) > 0);
+    }
+
+    private Set<Version> supportedVersions(Node host, Version requestedVersion) {
+        if (hostProvisioner.isEmpty()) {
+            return Set.of(requestedVersion);
+        }
+        try {
+            return supportedVersions.get(host.cloudAccount(),
+                                         () -> hostProvisioner.get().osVersions(host, requestedVersion.getMajor()));
+        } catch (ExecutionException e) {
+            LOG.log(Level.WARNING, "Failed to list supported OS versions in " + host.cloudAccount() + ": " + Exceptions.toMessageString(e));
+            return Set.of();
+        }
     }
 
     /** The duration this leaves new nodes alone before scheduling any upgrade */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RebuildingOsUpgrader.java
@@ -9,6 +9,7 @@ import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.ClusterId;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -35,8 +36,8 @@ public class RebuildingOsUpgrader extends OsUpgrader {
 
     private final boolean softRebuild;
 
-    public RebuildingOsUpgrader(NodeRepository nodeRepository, boolean softRebuild) {
-        super(nodeRepository);
+    public RebuildingOsUpgrader(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner, boolean softRebuild) {
+        super(nodeRepository, hostProvisioner);
         this.softRebuild = softRebuild;
     }
 
@@ -71,7 +72,7 @@ public class RebuildingOsUpgrader extends OsUpgrader {
         List<Node> hostsToRebuild = new ArrayList<>(rebuildLimit);
         NodeList candidates = hosts.not().rebuilding(softRebuild)
                                    .not().onOsVersion(target.version())
-                                   .matching(node -> canUpgradeAt(now, node))
+                                   .matching(node -> canUpgradeTo(target.version(), now, node))
                                    .byIncreasingOsVersion();
         for (Node host : candidates) {
             if (hostsToRebuild.size() == rebuildLimit) break;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/RetiringOsUpgrader.java
@@ -8,6 +8,7 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.filter.NodeListFilter;
+import com.yahoo.vespa.hosted.provision.provisioning.HostProvisioner;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -26,8 +27,8 @@ public class RetiringOsUpgrader extends OsUpgrader {
 
     private final boolean softRebuild;
 
-    public RetiringOsUpgrader(NodeRepository nodeRepository, boolean softRebuild) {
-        super(nodeRepository);
+    public RetiringOsUpgrader(NodeRepository nodeRepository, Optional<HostProvisioner> hostProvisioner, boolean softRebuild) {
+        super(nodeRepository, hostProvisioner);
         this.softRebuild = softRebuild;
     }
 
@@ -54,7 +55,7 @@ public class RetiringOsUpgrader extends OsUpgrader {
         }
         return nodes.not().deprovisioning()
                     .not().onOsVersion(target.version())
-                    .matching(node -> canUpgradeAt(instant, node))
+                    .matching(node -> canUpgradeTo(target.version(), instant, node))
                     .byIncreasingOsVersion()
                     .first(upgradeSlots(target, nodes.deprovisioning()));
     }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/provisioning/HostProvisioner.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.provisioning;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.HostEvent;
@@ -11,6 +12,7 @@ import com.yahoo.vespa.hosted.provision.Node;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
@@ -93,6 +95,9 @@ public interface HostProvisioner {
 
     /** Returns whether flavor for given host can be upgraded to a newer generation */
     boolean canUpgradeFlavor(Node host, Node child, Predicate<NodeResources> realHostResourcesWithinLimits);
+
+    /** Returns all OS versions available to host for the given major version */
+    Set<Version> osVersions(Node host, int majorVersion);
 
     /** Updates the given hosts to indicate that they are allocated to the given application. */
     default void updateAllocation(Collection<Node> hosts, ApplicationId owner) { }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockHostProvisioner.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.testutils;
 
+import com.yahoo.component.Version;
 import com.yahoo.config.provision.CloudAccount;
 import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.Flavor;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.yahoo.config.provision.NodeType.host;
@@ -50,6 +52,7 @@ public class MockHostProvisioner implements HostProvisioner {
     private final Map<ClusterSpec.Type, Flavor> hostFlavors = new HashMap<>();
     private final Set<String> upgradableFlavors = new HashSet<>();
     private final Map<Behaviour, Integer> behaviours = new HashMap<>();
+    private final Set<Version> osVersions = new HashSet<>();
 
     private int deprovisionedHosts = 0;
 
@@ -146,6 +149,11 @@ public class MockHostProvisioner implements HostProvisioner {
         return upgradableFlavors.contains(host.flavor().name());
     }
 
+    @Override
+    public Set<Version> osVersions(Node host, int majorVersion) {
+        return osVersions.stream().filter(v -> v.getMajor() == majorVersion).collect(Collectors.toUnmodifiableSet());
+    }
+
     /** Returns the hosts that have been provisioned by this  */
     public List<ProvisionedHost> provisionedHosts() {
         return Collections.unmodifiableList(provisionedHosts);
@@ -211,6 +219,11 @@ public class MockHostProvisioner implements HostProvisioner {
 
     public MockHostProvisioner addEvent(HostEvent event) {
         hostEvents.add(event);
+        return this;
+    }
+
+    public MockHostProvisioner addOsVersion(Version version) {
+        osVersions.add(version);
         return this;
     }
 


### PR DESCRIPTION
Merge together with internal PR.

Previously we assumed that the requested OS version was always available, but
that may not be true for a number of reasons:

- Image publishing is broken
- Image is GC-ed due to age
- Cloud account is incorrectly setup and lacks the expected images

This adds a check that verifies whether the wanted OS version is available,
before triggering an upgrade. In case an image disappears immediately after
checking, the host provisioner will still fall back to a different image, but
we'll avoid retrying the upgrade in a loop.

@bratseth