### PR TITLE
Skip check of OS version availability in node response MERGEOK

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsVersions.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/os/OsVersions.java
@@ -159,13 +159,9 @@ public class OsVersions {
         }
     }
 
-    /** Returns whether node can be upgraded now */
-    public boolean canUpgrade(Node node) {
-        Optional<Version> wantedVersion = node.status().osVersion().wanted();
-        if (wantedVersion.isEmpty()) {
-            return false;
-        }
-        return chooseUpgrader(node.type(), Optional.empty()).canUpgradeTo(wantedVersion.get(), nodeRepository.clock().instant(), node);
+    /** Returns whether node is currently deferring its upgrade */
+    public boolean deferringUpgrade(Node node) {
+        return chooseUpgrader(node.type(), Optional.empty()).deferringUpgrade(node, nodeRepository.clock().instant());
     }
 
     /** Returns the upgrader to use when upgrading given node type to target */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -167,7 +167,7 @@ class NodesResponse extends SlimeJsonResponse {
         node.status().osVersion().current().ifPresent(version -> object.setString("currentOsVersion", version.toFullString()));
         node.status().osVersion().wanted().ifPresent(version -> object.setString("wantedOsVersion", version.toFullString()));
         if (node.type().isHost()) {
-            object.setBool("deferOsUpgrade", !nodeRepository.osVersions().canUpgrade(node));
+            object.setBool("deferOsUpgrade", nodeRepository.osVersions().deferringUpgrade(node));
         }
         node.status().firmwareVerifiedAt().ifPresent(instant -> object.setLong("currentFirmwareCheck", instant.toEpochMilli()));
         if (node.type().isHost())


### PR DESCRIPTION
Unavailability is logged, and we don't want that for every response.

@jonmv