### PR TITLE
Simplify

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1500,15 +1500,13 @@
     ],
     "methods" : [
       "public void <init>(java.lang.String, long, long, com.yahoo.config.model.api.OnnxModelOptions)",
-      "public void <init>(java.lang.String, long, long, java.util.Optional)",
-      "public com.yahoo.config.model.api.OnnxModelOptions options()",
       "public final java.lang.String toString()",
       "public final int hashCode()",
       "public final boolean equals(java.lang.Object)",
       "public java.lang.String modelId()",
       "public long estimatedCost()",
       "public long hash()",
-      "public java.util.Optional onnxModelOptions()"
+      "public com.yahoo.config.model.api.OnnxModelOptions onnxModelOptions()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelCost.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/OnnxModelCost.java
@@ -8,10 +8,10 @@ import com.yahoo.config.provision.ClusterSpec;
 
 import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * @author bjorncs
+ * @author hmusum
  */
 public interface OnnxModelCost {
 
@@ -31,17 +31,7 @@ public interface OnnxModelCost {
         void store();
     }
 
-    record ModelInfo(String modelId, long estimatedCost, long hash, Optional<OnnxModelOptions> onnxModelOptions) {
-
-        public ModelInfo(String modelId, long estimatedCost, long hash, OnnxModelOptions onnxModelOptions) {
-            this(modelId, estimatedCost, hash, Optional.of(onnxModelOptions));
-        }
-
-        public OnnxModelOptions options() {
-            return onnxModelOptions.orElseThrow(() -> new IllegalStateException("No onnxModelOptions exist"));
-        }
-
-    }
+    record ModelInfo(String modelId, long estimatedCost, long hash, OnnxModelOptions onnxModelOptions) {}
 
     static OnnxModelCost disabled() { return new DisabledOnnxModelCost(); }
 


### PR DESCRIPTION
Constructor with optional onnxmodeloptions is not used anymore. Needs an update in internal repo at the same time, please review only.