### PR TITLE
Reset downtime at resume

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/Node.java
@@ -431,20 +431,14 @@ public final class Node implements Nodelike {
         return with(history.with(new History.Event(History.Event.Type.up, agent, instant)));
     }
 
-    /** Returns true if we have positive evidence that this node is down. */
-    public boolean isDown() {
-        Optional<Instant> downAt = history().event(History.Event.Type.down).map(History.Event::at);
-        if (downAt.isEmpty()) return false;
-
-        return !history().hasEventAfter(History.Event.Type.up, downAt.get());
+    /** Returns a copy of this with a history event saying it has been suspended at instant. */
+    public Node suspendedAt(Instant instant, Agent agent) {
+        return with(history.with(new History.Event(History.Event.Type.suspended, agent, instant)));
     }
 
-    /** Returns true if we have positive evidence that this node is up. */
-    public boolean isUp() {
-        Optional<Instant> upAt = history().event(History.Event.Type.up).map(History.Event::at);
-        if (upAt.isEmpty()) return false;
-
-        return !history().hasEventAfter(History.Event.Type.down, upAt.get());
+    /** Returns a copy of this with a history event saying it has been resumed at instant. */
+    public Node resumedAt(Instant instant, Agent agent) {
+        return with(history.with(new History.Event(History.Event.Type.resumed, agent, instant)));
     }
 
     /** Returns a copy of this with allocation set as specified. <code>node.state</code> is *not* changed. */

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/NodeList.java
@@ -221,7 +221,7 @@ public class NodeList extends AbstractFilteringList<Node, NodeList> {
     }
 
     /** Returns the subset of nodes which have a record of being down */
-    public NodeList down() { return matching(Node::isDown); }
+    public NodeList down() { return matching(node -> node.history().isDown()); }
 
     /** Returns the subset of nodes which are being retired */
     public NodeList retiring() {

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporter.java
@@ -268,7 +268,7 @@ public class MetricsReporter extends NodeRepositoryMaintainer {
             boolean down = NodeHealthTracker.allDown(services);
             metric.set(ConfigServerMetrics.NODE_FAILER_BAD_NODE.baseName(), (down ? 1 : 0), context);
 
-            boolean nodeDownInNodeRepo = node.isDown();
+            boolean nodeDownInNodeRepo = node.history().isDown();;
             metric.set(ConfigServerMetrics.DOWN_IN_NODE_REPO.baseName(), (nodeDownInNodeRepo ? 1 : 0), context);
         }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/node/History.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * An immutable record of the last event of each type happening to this node, and a chronological log of the events.
@@ -79,6 +78,34 @@ public class History {
         return event(type)
                 .map(event -> event.at().isBefore(time))
                 .orElse(false);
+    }
+
+    /** Returns the instant the services went down, unless the services have been up afterward. */
+    public Optional<Instant> downSince() { return instantOf(Event.Type.down, Event.Type.up); }
+
+    /** Returns the instant the services went up, unless the services have been down afterward. */
+    public Optional<Instant> upSince() { return instantOf(Event.Type.up, Event.Type.down); }
+
+    /** Returns true if there is a down event without a later up. */
+    public boolean isDown() { return downSince().isPresent(); }
+
+    /** Returns true if there is an up event without a later down. */
+    public boolean isUp() { return upSince().isPresent(); }
+
+    /** Returns the instant the node suspended, unless the node has been resumed afterward. */
+    public Optional<Instant> suspendedSince() { return instantOf(Event.Type.suspended, Event.Type.resumed); }
+
+    /** Returns the instant the node was resumed, unless the node has been suspended afterward. */
+    public Optional<Instant> resumedSince() { return instantOf(Event.Type.resumed, Event.Type.suspended); }
+
+    /** Returns true if there is a suspended event without a later resumed. */
+    public boolean isSuspended() { return suspendedSince().isPresent(); }
+
+    /** Returns true if there is a resumed event without a later suspended. */
+    public boolean isResumed() { return resumedSince().isPresent(); }
+
+    private Optional<Instant> instantOf(History.Event.Type type, History.Event.Type sentinelType) {
+        return event(type).map(History.Event::at).filter(instant -> !hasEventAfter(sentinelType, instant));
     }
 
     /** Returns the last event of each type in this history */
@@ -180,6 +207,10 @@ public class History {
             down,
             // The active node came up according to the service monitor
             up,
+            // The node has been given permission to suspend by Orchestrator
+            suspended,
+            // The node has resumed from suspension by Orchestrator
+            resumed,
             // The node resources/flavor were changed
             resized(false),
             // The node was rebooted

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/persistence/NodeSerializer.java
@@ -428,6 +428,8 @@ public class NodeSerializer {
             case "deallocated" -> History.Event.Type.deallocated;
             case "down" -> History.Event.Type.down;
             case "up" -> History.Event.Type.up;
+            case "suspended" -> History.Event.Type.suspended;
+            case "resumed" -> History.Event.Type.resumed;
             case "resized" -> History.Event.Type.resized;
             case "rebooted" -> History.Event.Type.rebooted;
             case "osUpgraded" -> History.Event.Type.osUpgraded;
@@ -454,6 +456,8 @@ public class NodeSerializer {
             case deallocated -> "deallocated";
             case down -> "down";
             case up -> "up";
+            case suspended -> "suspended";
+            case resumed -> "resumed";
             case resized -> "resized";
             case rebooted -> "rebooted";
             case osUpgraded -> "osUpgraded";

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/restapi/NodesResponse.java
@@ -180,7 +180,7 @@ class NodesResponse extends SlimeJsonResponse {
         object.setBool("wantToDeprovision", node.status().wantToDeprovision());
         object.setBool("wantToRebuild", node.status().wantToRebuild());
         object.setBool("wantToUpgradeFlavor", node.status().wantToUpgradeFlavor());
-        object.setBool("down", node.isDown());
+        object.setBool("down", node.history().isDown());
         toSlime(node.history().events(), object.setArray("history"));
         toSlime(node.history().log(), object.setArray("log"));
         ipAddressesToSlime(node.ipConfig().primary(), object.setArray("ipAddresses"));

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/OrchestratorMock.java
@@ -1,8 +1,10 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.hosted.provision.testutils;
 
+import com.google.inject.Inject;
 import com.yahoo.component.AbstractComponent;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.jdisc.test.TestTimer;
 import com.yahoo.vespa.applicationmodel.ApplicationInstanceReference;
 import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.orchestrator.Host;
@@ -11,6 +13,7 @@ import com.yahoo.vespa.orchestrator.status.ApplicationInstanceStatus;
 import com.yahoo.vespa.orchestrator.status.HostInfo;
 import com.yahoo.vespa.orchestrator.status.HostStatus;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -28,6 +31,14 @@ public class OrchestratorMock extends AbstractComponent implements Orchestrator 
 
     private final Map<HostName, HostInfo> suspendedHosts = new HashMap<>();
     private final Set<ApplicationId> suspendedApplications = new HashSet<>();
+    private final Clock clock;
+
+    @Inject
+    public OrchestratorMock() { this(new TestTimer(Instant.EPOCH).toUtcClock()); }
+
+    public OrchestratorMock(Clock clock) {
+        this.clock = clock;
+    }
 
     @Override
     public Host getHost(HostName hostName) {
@@ -52,7 +63,13 @@ public class OrchestratorMock extends AbstractComponent implements Orchestrator 
     }
 
     @Override
-    public void setNodeStatus(HostName hostName, HostStatus state) {}
+    public void setNodeStatus(HostName hostName, HostStatus state) {
+        if (state == HostStatus.NO_REMARKS) {
+            suspendedHosts.remove(hostName);
+        } else {
+            suspendedHosts.put(hostName, HostInfo.createSuspended(state, clock.instant()));
+        }
+    }
 
     @Override
     public void resume(HostName hostName) {
@@ -61,7 +78,7 @@ public class OrchestratorMock extends AbstractComponent implements Orchestrator 
 
     @Override
     public void suspend(HostName hostName) {
-        suspendedHosts.put(hostName, HostInfo.createSuspended(HostStatus.ALLOWED_TO_BE_DOWN, Instant.EPOCH));
+        suspendedHosts.put(hostName, HostInfo.createSuspended(HostStatus.ALLOWED_TO_BE_DOWN, clock.instant()));
     }
 
     @Override

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/NodeFailerTest.java
@@ -7,6 +7,7 @@ import com.yahoo.config.provision.ClusterSpec;
 import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeType;
 import com.yahoo.slime.SlimeUtils;
+import com.yahoo.vespa.applicationmodel.HostName;
 import com.yahoo.vespa.applicationmodel.ServiceInstance;
 import com.yahoo.vespa.applicationmodel.ServiceStatus;
 import com.yahoo.vespa.hosted.provision.Node;
@@ -14,6 +15,7 @@ import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.NodeRepository;
 import com.yahoo.vespa.hosted.provision.node.Agent;
 import com.yahoo.vespa.hosted.provision.node.Report;
+import com.yahoo.vespa.orchestrator.status.HostStatus;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -170,8 +172,8 @@ public class NodeFailerTest {
         tester.clock.advance(Duration.ofMinutes(65));
         tester.runMaintainers();
 
-        assertTrue(tester.nodeRepository.nodes().node(host_from_normal_app).get().isDown());
-        assertTrue(tester.nodeRepository.nodes().node(host_from_suspended_app).get().isDown());
+        assertTrue(tester.nodeRepository.nodes().node(host_from_normal_app).get().history().isDown());
+        assertTrue(tester.nodeRepository.nodes().node(host_from_suspended_app).get().history().isDown());
         assertEquals(Node.State.failed, tester.nodeRepository.nodes().node(host_from_normal_app).get().state());
         assertEquals(Node.State.active, tester.nodeRepository.nodes().node(host_from_suspended_app).get().state());
     }
@@ -203,8 +205,10 @@ public class NodeFailerTest {
         String downHost1 = tester.nodeRepository.nodes().list(Node.State.active).owner(NodeFailTester.app1).asList().get(1).hostname();
         String downHost2 = tester.nodeRepository.nodes().list(Node.State.active).owner(NodeFailTester.app2).asList().get(3).hostname();
         // No liveness evidence yet:
-        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().isDown());
-        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().isUp());
+        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isDown());
+        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isUp());
+        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isSuspended());
+        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isResumed());
 
         // For a day all nodes work so nothing happens
         for (int minutes = 0; minutes < 24 * 60; minutes +=5 ) {
@@ -214,8 +218,10 @@ public class NodeFailerTest {
             assertEquals(0, tester.deployer.activations);
             assertEquals(8, tester.nodeRepository.nodes().list(Node.State.active).nodeType(NodeType.tenant).size());
             assertEquals(0, tester.nodeRepository.nodes().list(Node.State.failed).nodeType(NodeType.tenant).size());
-            assertFalse(tester.nodeRepository.nodes().node(downHost1).get().isDown());
-            assertTrue(tester.nodeRepository.nodes().node(downHost1).get().isUp());
+            assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isDown());
+            assertTrue(tester.nodeRepository.nodes().node(downHost1).get().history().isUp());
+            assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isSuspended());
+            assertTrue(tester.nodeRepository.nodes().node(downHost1).get().history().isResumed());
         }
 
         tester.serviceMonitor.setHostDown(downHost1);
@@ -227,16 +233,16 @@ public class NodeFailerTest {
             assertEquals(0, tester.deployer.activations);
             assertEquals(8, tester.nodeRepository.nodes().list(Node.State.active).nodeType(NodeType.tenant).size());
             assertEquals(0, tester.nodeRepository.nodes().list(Node.State.failed).nodeType(NodeType.tenant).size());
-            assertTrue(tester.nodeRepository.nodes().node(downHost1).get().isDown());
-            assertFalse(tester.nodeRepository.nodes().node(downHost1).get().isUp());
+            assertTrue(tester.nodeRepository.nodes().node(downHost1).get().history().isDown());
+            assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isUp());
         }
         tester.serviceMonitor.setHostUp(downHost1);
 
         // downHost2 should now be failed and replaced, but not downHost1
         tester.clock.advance(Duration.ofDays(1));
         tester.runMaintainers();
-        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().isDown());
-        assertTrue(tester.nodeRepository.nodes().node(downHost1).get().isUp());
+        assertFalse(tester.nodeRepository.nodes().node(downHost1).get().history().isDown());
+        assertTrue(tester.nodeRepository.nodes().node(downHost1).get().history().isUp());
         assertEquals(1, tester.deployer.activations);
         assertEquals(8, tester.nodeRepository.nodes().list(Node.State.active).nodeType(NodeType.tenant).size());
         assertEquals(1, tester.nodeRepository.nodes().list(Node.State.failed).nodeType(NodeType.tenant).size());
@@ -310,6 +316,64 @@ public class NodeFailerTest {
         tester.clock.advance(Duration.ofMinutes(45));
         tester.runMaintainers();
         assertEquals(1, tester.nodeRepository.nodes().list(Node.State.failed).nodeType(NodeType.tenant).size());
+        assertEquals(Node.State.failed, tester.nodeRepository.nodes().node(downNode).get().state());
+    }
+
+    @Test
+    public void suspension_extends_grace_period() {
+        NodeFailTester tester = NodeFailTester.withTwoApplications();
+        String downNode = tester.nodeRepository.nodes().list(Node.State.active).owner(NodeFailTester.app1).asList().get(1).hostname();
+
+        // host down, but within 1h timeout
+        tester.serviceMonitor.setHostDown(downNode);
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // 30m is still within 1h timeout
+        tester.clock.advance(Duration.ofMinutes(30));
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // suspend
+        tester.clock.advance(Duration.ofSeconds(5));
+        tester.nodeRepository.orchestrator().setNodeStatus(new HostName(downNode), HostStatus.ALLOWED_TO_BE_DOWN);
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // the timeout should now be 4h, so still ~3:30 left.
+        tester.clock.advance(Duration.ofHours(3));
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // advancing another hour takes us beyond the 4h timeout
+        tester.clock.advance(Duration.ofHours(1));
+        tester.runMaintainers();
+        assertEquals(Node.State.failed, tester.nodeRepository.nodes().node(downNode).get().state());
+    }
+
+    @Test
+    public void suspension_defers_downtime() {
+        NodeFailTester tester = NodeFailTester.withTwoApplications();
+        String downNode = tester.nodeRepository.nodes().list(Node.State.active).owner(NodeFailTester.app1).asList().get(1).hostname();
+
+        // host suspends and goes down
+        tester.nodeRepository.orchestrator().setNodeStatus(new HostName(downNode), HostStatus.ALLOWED_TO_BE_DOWN);
+        tester.serviceMonitor.setHostDown(downNode);
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // host resumes after 30m
+        tester.clock.advance(Duration.ofMinutes(30));
+        tester.nodeRepository.orchestrator().setNodeStatus(new HostName(downNode), HostStatus.NO_REMARKS);
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+
+        // the host should fail 1h after resume, not when the node goes down. Verify this
+        tester.clock.advance(Duration.ofMinutes(45));
+        tester.runMaintainers();
+        assertEquals(Node.State.active, tester.nodeRepository.nodes().node(downNode).get().state());
+        tester.clock.advance(Duration.ofMinutes(30));
+        tester.runMaintainers();
         assertEquals(Node.State.failed, tester.nodeRepository.nodes().node(downNode).get().state());
     }
 
@@ -653,21 +717,21 @@ public class NodeFailerTest {
         tester.serviceMonitor.setHostDown(downHost);
         tester.runMaintainers();
         node = tester.nodeRepository.nodes().node(downHost).get();
-        assertTrue(node.isDown());
+        assertTrue(node.history().isDown());
         assertEquals(Node.State.active, node.state());
 
         // CMR still ongoing, don't fail yet
         clock.advance(Duration.ofHours(1));
         tester.runMaintainers();
         node = tester.nodeRepository.nodes().node(downHost).get();
-        assertTrue(node.isDown());
+        assertTrue(node.history().isDown());
         assertEquals(Node.State.active, node.state());
 
         // No ongoing CMR anymore, host should be failed
         clock.advance(Duration.ofHours(1));
         tester.runMaintainers();
         node = tester.nodeRepository.nodes().node(downHost).get();
-        assertTrue(node.isDown());
+        assertTrue(node.history().isDown());
         assertEquals(Node.State.failed, node.state());
     }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/RetiredExpirerTest.java
@@ -73,7 +73,7 @@ public class RetiredExpirerTest {
     public void setup() throws OrchestrationException {
         // By default, orchestrator should deny all request for suspension so we can test expiration
         doThrow(new RuntimeException()).when(orchestrator).acquirePermissionToRemove(any());
-        when(orchestrator.getNodeStatus(any())).thenReturn(HostStatus.NO_REMARKS);
+        when(orchestrator.getNodeStatus(any(HostName.class))).thenReturn(HostStatus.NO_REMARKS);
     }
 
     @Test

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -4,6 +4,7 @@ package com.yahoo.vespa.hosted.provision.provisioning;
 import com.yahoo.component.Version;
 import com.yahoo.config.provision.ActivationContext;
 import com.yahoo.config.provision.ApplicationId;
+import com.yahoo.config.provision.ApplicationMutex;
 import com.yahoo.config.provision.ApplicationName;
 import com.yahoo.config.provision.ApplicationTransaction;
 import com.yahoo.config.provision.Capacity;
@@ -22,7 +23,6 @@ import com.yahoo.config.provision.NodeResources;
 import com.yahoo.config.provision.NodeResources.DiskSpeed;
 import com.yahoo.config.provision.NodeResources.StorageType;
 import com.yahoo.config.provision.NodeType;
-import com.yahoo.config.provision.ApplicationMutex;
 import com.yahoo.config.provision.RegionName;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.TenantName;
@@ -100,19 +100,20 @@ public class ProvisioningTester {
     private int nextIP = 0;
 
     private ProvisioningTester(Curator curator,
-                              NodeFlavors nodeFlavors,
-                              HostResourcesCalculator resourcesCalculator,
-                              Zone zone,
-                              NameResolver nameResolver,
-                              DockerImage containerImage,
-                              Orchestrator orchestrator,
-                              HostProvisioner hostProvisioner,
-                              LoadBalancerServiceMock loadBalancerService,
-                              FlagSource flagSource,
-                              int spareCount) {
+                               NodeFlavors nodeFlavors,
+                               HostResourcesCalculator resourcesCalculator,
+                               Zone zone,
+                               NameResolver nameResolver,
+                               DockerImage containerImage,
+                               Orchestrator orchestrator,
+                               HostProvisioner hostProvisioner,
+                               LoadBalancerServiceMock loadBalancerService,
+                               FlagSource flagSource,
+                               int spareCount,
+                               ManualClock clock) {
         this.curator = curator;
         this.nodeFlavors = nodeFlavors;
-        this.clock = new ManualClock();
+        this.clock = clock;
         this.hostProvisioner = hostProvisioner;
         ProvisionServiceProvider provisionServiceProvider = new MockProvisionServiceProvider(loadBalancerService, hostProvisioner, resourcesCalculator);
         this.nodeRepository = new NodeRepository(nodeFlavors,
@@ -658,6 +659,7 @@ public class ProvisioningTester {
         private HostProvisioner hostProvisioner;
         private FlagSource flagSource;
         private int spareCount = 0;
+        private ManualClock clock = new ManualClock();
         private DockerImage defaultImage = DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa");
 
         public Builder curator(Curator curator) {
@@ -735,6 +737,11 @@ public class ProvisioningTester {
             return this;
         }
 
+        public Builder clock(ManualClock clock) {
+            this.clock = clock;
+            return this;
+        }
+
         private FlagSource defaultFlagSource() {
             return new InMemoryFlagSource();
         }
@@ -746,11 +753,12 @@ public class ProvisioningTester {
                                           Optional.ofNullable(zone).orElseGet(Zone::defaultZone),
                                           Optional.ofNullable(nameResolver).orElseGet(() -> new MockNameResolver().mockAnyLookup()),
                                           defaultImage,
-                                          Optional.ofNullable(orchestrator).orElseGet(OrchestratorMock::new),
+                                          Optional.ofNullable(orchestrator).orElseGet(() -> new OrchestratorMock(clock)),
                                           hostProvisioner,
                                           new LoadBalancerServiceMock(),
                                           Optional.ofNullable(flagSource).orElse(defaultFlagSource()),
-                                          spareCount);
+                                          spareCount,
+                                          clock);
         }
 
         private static FlavorsConfig asConfig(List<Flavor> flavors) {

--- a/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
+++ b/orchestrator/src/main/java/com/yahoo/vespa/orchestrator/Orchestrator.java
@@ -49,6 +49,14 @@ public interface Orchestrator {
      */
     HostStatus getNodeStatus(HostName hostName) throws HostNameNotFoundException;
 
+    default Optional<HostStatus> getOptionalNodeStatus(String hostname) {
+        try {
+            return Optional.of(getNodeStatus(new HostName(hostname)));
+        } catch (HostNameNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
     /** Get host info for hostname in application, returning no-remarks if not in application. */
     HostInfo getHostInfo(ApplicationInstanceReference reference, HostName hostname);
 


### PR DESCRIPTION
* Defines 2 new node history events: suspended and resumed.  AFAIK this should be handled transparently by any/all clients.
* The NodeFailer measures the time a node has been down from the latest of the following events: the node went down, the node was activated, the node was resumed.  The last one (resumed) is new with this PR.
* Whether a node is down or not is now based on the node's history instead of asking the Orchestrator directly.  It is the NodeHealthTracker maintainer that queries the Orchestrator and adds up and down events.
