### PR TITLE
Avoid generic reduce to reduce gc pressure

### DIFF
--- a/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
@@ -11,6 +11,7 @@ import com.yahoo.tensor.TensorAddress;
 import com.yahoo.tensor.TensorType;
 import java.util.List;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -43,7 +44,7 @@ public class SpladeEmbedderTest {
         assertEquals(0, result.size());
     }
 
-    @Test
+    @Ignore
     public void testPerformanceNotTerrible() {
         String text = "what was the manhattan project in this context it was a secret project to develop a nuclear weapon in world war" +
                 " ii the project was led by the united states with the support of the united kingdom and canada";

--- a/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
@@ -44,6 +44,19 @@ public class SpladeEmbedderTest {
     }
 
     @Test
+    public void testPerformanceNotTerrible() {
+        String text = "what was the manhattan project in this context it was a secret project to develop a nuclear weapon in world war" +
+                " ii the project was led by the united states with the support of the united kingdom and canada";
+        Long now = System.currentTimeMillis();
+        int n = 10;
+        for (int i = 0; i < n; i++) {
+            assertEmbed("tensor<float>(t{})", text, indexingContext);
+        }
+        Long elapsed = (System.currentTimeMillis() - now)/1000;
+        System.out.println("Elapsed time: " + elapsed + " ms");
+    }
+
+    @Test
     public void throwsOnInvalidTensorType() {
         Throwable exception = assertThrows(RuntimeException.class, () -> {
             assertEmbed("tensor<float>(d[128])", "", indexingContext);
@@ -54,7 +67,7 @@ public class SpladeEmbedderTest {
 
     static final Embedder spladeEmbedder;
     static final Embedder.Context indexingContext;
-    static final Double scoreThreshold = 1.15;
+    static final Double scoreThreshold =  1.15;
 
     static {
         indexingContext = new Embedder.Context("schema.indexing");

--- a/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
@@ -68,7 +68,7 @@ public class SpladeEmbedderTest {
 
     static final Embedder spladeEmbedder;
     static final Embedder.Context indexingContext;
-    static final Double scoreThreshold =  1.15;
+    static final Double scoreThreshold = 1.15;
 
     static {
         indexingContext = new Embedder.Context("schema.indexing");


### PR DESCRIPTION
Merge the two tensor.reduce calls to a single custom reduce for the exact reduce function we need for this, significantly reduces memory allocations. 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
