### PR TITLE
Define new default for nessus-agent-group flag

### DIFF
--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -79,17 +79,17 @@ public class Flags {
             INSTANCE_ID);
 
     public static final List<String> VALID_NESSUS_AGENT_GROUPS = List.of(
-            "",              // Skip task
-            ":legacy",       // Run legacy task.  Is a no-op outside YAHOO cloud.
+            ":default",      // Use vespa-ci in CD systems, vespa-config on cfgs in prod, and :stop elsewhere
+            ":skip",         // Skip task
             ":stop",         // Stop / shut down Nessus if it is running
             "All",           // Link to the All group.
             "vespa-ci",      // Link to the vespa-ci group.
             "vespa-config"); // Link to the vespa-config group.
 
     public static final UnboundStringFlag NESSUS_AGENT_GROUP = defineStringFlag(
-            "nessus-agent-group", ":legacy",
+            "nessus-agent-group", ":default",
             List.of("hakonhall"), "2023-11-29", "2024-02-29",
-            "Link nessusagent to the given group, or run legacy task (\":legacy\"), or disable task (\"\").",
+            "Link nessusagent to the given group, or do something special (when group start with ':').",
             "Takes effect after host admin restart",
             VALID_NESSUS_AGENT_GROUPS::contains,
             ARCHITECTURE, CLAVE, NODE_TYPE);


### PR DESCRIPTION
All systems have flag overrides, and the overrides can never resolve to "" or ":legacy" anymore, so these can safely be removed.  

This PR also introduces a new ":skip" to replace the old "", and a new ":default" which is the new flag default.