### PR TITLE
- Require non-null inner expression in foreach.

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
@@ -104,9 +104,7 @@ public final class IndexingScript extends Derived implements IlscriptsConfig.Pro
     private static class DropTokenize extends ExpressionConverter {
         @Override
         protected boolean shouldConvert(Expression exp) {
-            // Handle both string and array<string>
-            return (exp instanceof TokenizeExpression) ||
-                    ((exp instanceof ForEachExpression foreach) && (foreach.getInnerExpression() instanceof TokenizeExpression));
+            return exp instanceof TokenizeExpression;
         }
 
         @Override

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/ForEachExpression.java
@@ -11,6 +11,8 @@ import com.yahoo.vespa.indexinglanguage.FieldValueConverter;
 import com.yahoo.vespa.objects.ObjectOperation;
 import com.yahoo.vespa.objects.ObjectPredicate;
 
+import java.util.Objects;
+
 /**
  * @author Simon Thoresen Hult
  */
@@ -20,7 +22,7 @@ public final class ForEachExpression extends CompositeExpression {
 
     public ForEachExpression(Expression exp) {
         super(UnresolvedDataType.INSTANCE);
-        this.exp = exp;
+        this.exp = Objects.requireNonNull(exp);
     }
 
     public Expression getInnerExpression() {
@@ -29,7 +31,8 @@ public final class ForEachExpression extends CompositeExpression {
 
     @Override
     public ForEachExpression convertChildren(ExpressionConverter converter) {
-        return new ForEachExpression(converter.convert(exp));
+        Expression converted = converter.convert(exp);
+        return converted != null ?  new ForEachExpression(converted) : null;
     }
 
     @Override


### PR DESCRIPTION
- Let null conversion bubble up.

@geirst or @bratseth PR

better fix of root issue with multivalue fields than the special handling in #29886 