### PR TITLE
Include memory to get definition of std::unique_ptr.

### DIFF
--- a/vespalib/src/vespa/vespalib/util/testclock.h
+++ b/vespalib/src/vespa/vespalib/util/testclock.h
@@ -3,6 +3,7 @@
 
 #include "time.h"
 #include <atomic>
+#include <memory>
 
 namespace vespalib {
 


### PR DESCRIPTION
@baldersheim : please review
