### PR TITLE
Propagate normalizing mode and max field length to new searcher

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.cpp
@@ -3,4 +3,22 @@
 
 namespace search::streaming {
 
+namespace {
+
+const char* to_str(Normalizing norm) noexcept {
+    switch (norm) {
+    case Normalizing::NONE:               return "NONE";
+    case Normalizing::LOWERCASE:          return "LOWERCASE";
+    case Normalizing::LOWERCASE_AND_FOLD: return "LOWERCASE_AND_FOLD";
+    }
+    abort();
+}
+
+}
+
+std::ostream& operator<<(std::ostream& os, Normalizing n) {
+    os << to_str(n);
+    return os;
+}
+
 }

--- a/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <vespa/vespalib/stllike/string.h>
+#include <iosfwd>
 #include <memory>
 
 namespace search::streaming {
@@ -23,6 +24,8 @@ enum class Normalizing {
     LOWERCASE,
     LOWERCASE_AND_FOLD
 };
+
+std::ostream& operator<<(std::ostream&, Normalizing);
 
 class QueryNodeResultFactory {
 public:

--- a/streamingvisitors/src/tests/searcher/searcher_test.cpp
+++ b/streamingvisitors/src/tests/searcher/searcher_test.cpp
@@ -832,6 +832,18 @@ TEST("FieldSearchSpec construction") {
     }
 }
 
+TEST("FieldSearchSpec reconfiguration preserves match/normalization properties for new searcher") {
+    FieldSearchSpec f(7, "f0", Searchmethod::AUTOUTF8, Normalizing::NONE, "substring", 789);
+    QueryNodeResultFactory qnrf;
+    QueryTerm qt(qnrf.create(), "foo", "index", TermType::EXACTSTRINGTERM, Normalizing::LOWERCASE_AND_FOLD);
+    // Match type, normalization mode and max length are all properties of the original spec
+    // and should be propagated to the new searcher.
+    f.reconfig(qt);
+    EXPECT_EQUAL(f.searcher().match_type(), FieldSearcher::MatchType::SUBSTRING);
+    EXPECT_EQUAL(f.searcher().normalize_mode(), Normalizing::NONE);
+    EXPECT_EQUAL(f.searcher().maxFieldLength(), 789u);
+}
+
 TEST("snippet modifier manager") {
     FieldSearchSpecMapT specMap;
     specMap[0] = FieldSearchSpec(0, "f0", Searchmethod::AUTOUTF8, Normalizing::LOWERCASE, "substring", 1000);

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -114,9 +114,7 @@ FieldSearchSpec::FieldSearchSpec(const FieldIdT & fid, const vespalib::string & 
         break;
     }
     if (_searcher) {
-        setMatchType(_searcher, _arg1);
-        _searcher->maxFieldLength(maxLength());
-        _searcher->normalize_mode(_normalize_mode);
+        propagate_settings_to_searcher();
     }
 }
 
@@ -138,8 +136,7 @@ FieldSearchSpec::reconfig(const QueryTerm & term)
             term.isRegex())
         {
             _searcher = std::make_unique<UTF8FlexibleStringFieldSearcher>(id());
-            // preserve the basic match property of the searcher
-            setMatchType(_searcher, _arg1);
+            propagate_settings_to_searcher();
             LOG(debug, "Reconfigured to use UTF8FlexibleStringFieldSearcher (%s) for field '%s' with id '%d'",
                 _searcher->prefix() ? "prefix" : "regular", name().c_str(), id());
             _reconfigured = true;
@@ -148,6 +145,15 @@ FieldSearchSpec::reconfig(const QueryTerm & term)
     default:
         break;
     }
+}
+
+void
+FieldSearchSpec::propagate_settings_to_searcher()
+{
+    // preserve the basic match property and normalization mode of the searcher
+    setMatchType(_searcher, _arg1);
+    _searcher->maxFieldLength(maxLength());
+    _searcher->normalize_mode(_normalize_mode);
 }
 
 vespalib::asciistream &

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.h
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.h
@@ -42,6 +42,8 @@ public:
     friend vespalib::asciistream & operator <<(vespalib::asciistream & os, const FieldSearchSpec & f);
 
 private:
+    void propagate_settings_to_searcher();
+
     FieldIdT               _id;
     vespalib::string       _name;
     size_t                 _maxLength;


### PR DESCRIPTION
@baldersheim please review

Needed to avoid default normalizing mode/max field length being used in the reconfigured searcher instance.

