### PR TITLE
Stop using MultiTermOrFilterSearch for InTerm and WeightedSetTerm.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
@@ -44,7 +44,7 @@ private:
                                                                  std::vector<std::unique_ptr<queryeval::SearchIterator>>&& bitvectors,
                                                                  bool strict) const;
 
-    template <bool filter_search, bool need_match_data>
+    template <bool filter_search>
     std::unique_ptr<queryeval::SearchIterator> create_search_helper(const fef::TermFieldMatchDataArray& tfmda,
                                                                     bool strict) const;
 

--- a/searchlib/src/vespa/searchlib/attribute/in_term_search.h
+++ b/searchlib/src/vespa/searchlib/attribute/in_term_search.h
@@ -2,14 +2,20 @@
 
 #pragma once
 
+#include <vespa/searchlib/queryeval/weighted_set_term_search.h>
+
 namespace search::attribute {
 
 /**
- * Class used as template argument in DirectMultiTermBlueprint to configure it for the InTerm query operator.
+ * Search iterator for an InTerm, sharing the implementation with WeightedSetTerm.
+ *
+ * The only difference is that an InTerm never requires unpacking of weights.
  */
-struct InTermSearch {
+class InTermSearch : public queryeval::WeightedSetTermSearch {
+public:
+    // Whether this iterator is considered a filter, independent of attribute vector settings (ref. rank: filter).
+    // Setting this to true ensures that weights are never unpacked.
     static constexpr bool filter_search = true;
-    static constexpr bool require_btree_iterators = false;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/attribute/multi_term_or_filter_search.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_term_or_filter_search.h
@@ -9,8 +9,7 @@ namespace search::attribute {
 /**
  * Filter iterator on top of low-level posting list iterators or regular search iterators with OR semantics.
  *
- * Used during calculation of global filter for InTerm, WeightedSetTerm, DotProduct and WandTerm,
- * or when ranking is not needed for InTerm and WeightedSetTerm.
+ * Used during calculation of global filter for DotProduct and WandTerm.
  */
 class MultiTermOrFilterSearch : public queryeval::SearchIterator
 {

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.cpp
@@ -14,7 +14,13 @@ using vespalib::ObjectVisitor;
 
 namespace search::queryeval {
 
-template <typename HEAP, typename IteratorPack>
+enum class UnpackType {
+    DocidAndWeights,
+    Docid,
+    None
+};
+
+template <UnpackType unpack_type, typename HEAP, typename IteratorPack>
 class WeightedSetTermSearchImpl : public WeightedSetTermSearch
 {
 private:
@@ -47,7 +53,6 @@ private:
     ref_t                                         *_data_stash;
     ref_t                                         *_data_end;
     IteratorPack                                   _children;
-    bool                                           _need_match_data;
 
     void seek_child(ref_t child, uint32_t docId) {
         _termPos[child] = _children.seek(child, docId);
@@ -64,7 +69,6 @@ private:
 
 public:
     WeightedSetTermSearchImpl(fef::TermFieldMatchData &tmd,
-                              bool field_is_filter,
                               std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                               IteratorPack &&iteratorPack)
         : _tmd(tmd),
@@ -77,8 +81,7 @@ public:
           _data_begin(nullptr),
           _data_stash(nullptr),
           _data_end(nullptr),
-          _children(std::move(iteratorPack)),
-          _need_match_data(!field_is_filter && !_tmd.isNotNeeded())
+          _children(std::move(iteratorPack))
     {
         HEAP::require_left_heap();
         assert(_children.size() > 0);
@@ -89,7 +92,7 @@ public:
         }
         _data_begin = &_data_space[0];
         _data_end = _data_begin + _data_space.size();
-        if (_need_match_data) {
+        if constexpr (unpack_type == UnpackType::DocidAndWeights) {
             _tmd.reservePositions(_children.size());
         }
     }
@@ -115,7 +118,7 @@ public:
     }
 
     void doUnpack(uint32_t docId) override {
-        if (_need_match_data) {
+        if constexpr (unpack_type == UnpackType::DocidAndWeights) {
             _tmd.reset(docId);
             pop_matching_children(docId);
             std::sort(_data_stash, _data_end, _cmpWeight);
@@ -124,7 +127,7 @@ public:
                 pos.setElementWeight(_weights[*ptr]);
                 _tmd.appendPosition(pos);
             }
-        } else {
+        } else if constexpr (unpack_type == UnpackType::Docid) {
             _tmd.resetOnlyDocId(docId);
         }
     }
@@ -162,68 +165,76 @@ public:
     }
 };
 
-//-----------------------------------------------------------------------------
+template <typename HeapType, typename IteratorPackType>
+SearchIterator::UP
+create_helper(fef::TermFieldMatchData& tmd,
+              bool is_filter_search,
+              std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
+              IteratorPackType&& pack)
+{
+    bool match_data_needed = !tmd.isNotNeeded();
+    if (is_filter_search && match_data_needed) {
+        return std::make_unique<WeightedSetTermSearchImpl<UnpackType::Docid, HeapType, IteratorPackType>>
+            (tmd, std::move(weights), std::move(pack));
+    } else if (!is_filter_search && match_data_needed) {
+        return std::make_unique<WeightedSetTermSearchImpl<UnpackType::DocidAndWeights, HeapType, IteratorPackType>>
+                (tmd, std::move(weights), std::move(pack));
+    } else {
+        return std::make_unique<WeightedSetTermSearchImpl<UnpackType::None, HeapType, IteratorPackType>>
+                (tmd, std::move(weights), std::move(pack));
+    }
+}
 
 SearchIterator::UP
 WeightedSetTermSearch::create(const std::vector<SearchIterator *> &children,
                               TermFieldMatchData &tmd,
-                              bool field_is_filter,
+                              bool is_filter_search,
                               const std::vector<int32_t> &weights,
                               fef::MatchData::UP match_data)
 {
-    using ArrayHeapImpl = WeightedSetTermSearchImpl<vespalib::LeftArrayHeap, SearchIteratorPack>;
-    using HeapImpl = WeightedSetTermSearchImpl<vespalib::LeftHeap, SearchIteratorPack>;
-
-    if (tmd.isNotNeeded()) {
-        return attribute::MultiTermOrFilterSearch::create(children, std::move(match_data));
-    }
-
     if (children.size() < 128) {
-        return SearchIterator::UP(new ArrayHeapImpl(tmd, field_is_filter, std::cref(weights), SearchIteratorPack(children, std::move(match_data))));
+        return create_helper<vespalib::LeftArrayHeap, SearchIteratorPack>(tmd, is_filter_search, std::cref(weights),
+                                                                          SearchIteratorPack(children, std::move(match_data)));
     }
-    return SearchIterator::UP(new HeapImpl(tmd, field_is_filter, std::cref(weights), SearchIteratorPack(children, std::move(match_data))));
+    return create_helper<vespalib::LeftHeap, SearchIteratorPack>(tmd, is_filter_search, std::cref(weights),
+                                                                 SearchIteratorPack(children, std::move(match_data)));
 }
-
-//-----------------------------------------------------------------------------
 
 namespace {
 
 template <typename IteratorType, typename IteratorPackType>
 SearchIterator::UP
-create_helper(fef::TermFieldMatchData& tmd,
-              bool field_is_filter,
-              std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
-              std::vector<IteratorType>&& iterators)
+create_helper_resolve_pack(fef::TermFieldMatchData& tmd,
+                           bool is_filter_search,
+                           std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
+                           std::vector<IteratorType>&& iterators)
 {
-    using ArrayHeapImpl = WeightedSetTermSearchImpl<vespalib::LeftArrayHeap, IteratorPackType>;
-    using HeapImpl = WeightedSetTermSearchImpl<vespalib::LeftHeap, IteratorPackType>;
-
     if (iterators.size() < 128) {
-        return SearchIterator::UP(new ArrayHeapImpl(tmd, field_is_filter, std::move(weights), IteratorPackType(std::move(iterators))));
+        return create_helper<vespalib::LeftArrayHeap, IteratorPackType>(tmd, is_filter_search, std::move(weights),
+                                                                        IteratorPackType(std::move(iterators)));
     }
-    return SearchIterator::UP(new HeapImpl(tmd, field_is_filter, std::move(weights), IteratorPackType(std::move(iterators))));
+    return create_helper<vespalib::LeftHeap, IteratorPackType>(tmd, is_filter_search, std::move(weights),
+                                                               IteratorPackType(std::move(iterators)));
 }
 
 }
 
 SearchIterator::UP
 WeightedSetTermSearch::create(fef::TermFieldMatchData& tmd,
-                              bool field_is_filter,
+                              bool is_filter_search,
                               std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                               std::vector<DocidIterator>&& iterators)
 {
-    return create_helper<DocidIterator, DocidIteratorPack>(tmd, field_is_filter, std::move(weights), std::move(iterators));
+    return create_helper_resolve_pack<DocidIterator, DocidIteratorPack>(tmd, is_filter_search, std::move(weights), std::move(iterators));
 }
 
 SearchIterator::UP
 WeightedSetTermSearch::create(fef::TermFieldMatchData &tmd,
-                              bool field_is_filter,
+                              bool is_filter_search,
                               std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                               std::vector<DocidWithWeightIterator> &&iterators)
 {
-    return create_helper<DocidWithWeightIterator, DocidWithWeightIteratorPack>(tmd, field_is_filter, std::move(weights), std::move(iterators));
+    return create_helper_resolve_pack<DocidWithWeightIterator, DocidWithWeightIteratorPack>(tmd, is_filter_search, std::move(weights), std::move(iterators));
 }
-
-//-----------------------------------------------------------------------------
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
@@ -18,8 +18,7 @@ namespace search::queryeval {
 class Blueprint;
 
 /**
- * Search iterator for a weighted set, based on a set of child search
- * iterators.
+ * Search iterator for a WeightedSetTerm, based on a set of child search iterators.
  */
 class WeightedSetTermSearch : public SearchIterator
 {
@@ -27,23 +26,25 @@ protected:
     WeightedSetTermSearch() = default;
 
 public:
+    // Whether this iterator is considered a filter, independent of attribute vector settings (ref rank: filter).
     static constexpr bool filter_search = false;
+    // Whether this iterator requires btree iterators for all tokens/terms used by the operator.
     static constexpr bool require_btree_iterators = false;
 
     // TODO: pass ownership with unique_ptr
     static SearchIterator::UP create(const std::vector<SearchIterator *> &children,
                                      search::fef::TermFieldMatchData &tmd,
-                                     bool field_is_filter,
+                                     bool is_filter_search,
                                      const std::vector<int32_t> &weights,
                                      fef::MatchData::UP match_data);
 
     static SearchIterator::UP create(search::fef::TermFieldMatchData& tmd,
-                                     bool field_is_filter,
+                                     bool is_filter_search,
                                      std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                                      std::vector<DocidIterator>&& iterators);
 
     static SearchIterator::UP create(search::fef::TermFieldMatchData &tmd,
-                                     bool field_is_filter,
+                                     bool is_filter_search,
                                      std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                                      std::vector<DocidWithWeightIterator> &&iterators);
 


### PR DESCRIPTION
Benchmarking the IN operator (https://github.com/vespa-engine/system-test/tree/master/tests/performance/in_operator) has shown that the heap-based implementation in WeightedSetTermSearchImpl is on par when having fewer than 10 tokens/terms, and significantly better the more tokens/terms the operator contains.

@toregge please review
@baldersheim FYI