### PR TITLE
Support minimum-required-vespa-version attribute

### DIFF
--- a/config-model/src/main/resources/schema/services.rnc
+++ b/config-model/src/main/resources/schema/services.rnc
@@ -7,6 +7,7 @@ include "containercluster.rnc"
 
 start = element services {
    attribute version { "1.0" }? &
+   attribute minimum-required-vespa-version { text }? &
    attribute application-type { "hosted-infrastructure" }? &
    element legacy { element v7-geo-positions { xsd:boolean } }? &
    GenericConfig* &

--- a/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilderTest.java
@@ -17,6 +17,7 @@ import java.io.StringReader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * @author gjoranv
@@ -97,6 +98,20 @@ public class VespaDomBuilderTest {
         HostResource host = hostSystem.getHosts().get(0);
         assertNotNull(hostSystem.getHost("node1"));
         assertEquals("hosts [" + host.getHostname() + "]", hostSystem.toString());
+    }
+
+    @Test
+    void testMinimumRequiredVespaVersion() {
+        var exception = assertThrows(IllegalArgumentException.class,
+                     () -> createModel(hosts, """
+                             <services minimum-required-vespa-version='1.0.1' >
+                             </services>"""));
+        assertEquals("Cannot deploy application, minimum required Vespa version is specified as 1.0.1 in services.xml, this Vespa version is 1.0.0.",
+                     exception.getMessage());
+
+        createModel(hosts, """
+                <services minimum-required-vespa-version='1.0.0' >
+                </services>""");
     }
 
     private VespaModel createModel(String hosts, String services) {

--- a/config-model/src/test/schema-test-files/services-hosted-infrastructure.xml
+++ b/config-model/src/test/schema-test-files/services-hosted-infrastructure.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root. -->
-<services version="1.0" application-type="hosted-infrastructure">
+<services version="1.0" application-type="hosted-infrastructure" minimum-required-vespa-version="8.0.0">
 
   <admin version="4.0">
     <slobroks><nodes count="3" flavor="small"/></slobroks>


### PR DESCRIPTION
If attribute is set and the running Vespa version is lower than the specified version deployment will fail with invalid application package error.