### PR TITLE
Support fuzzy term matching in streaming search

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/CMakeLists.txt
+++ b/searchlib/src/vespa/searchlib/query/streaming/CMakeLists.txt
@@ -2,6 +2,7 @@
 vespa_add_library(searchlib_query_streaming OBJECT
     SOURCES
     dot_product_term.cpp
+    fuzzy_term.cpp
     in_term.cpp
     multi_term.cpp
     nearest_neighbor_query_node.cpp

--- a/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.cpp
@@ -1,0 +1,43 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "fuzzy_term.h"
+
+namespace search::streaming {
+
+namespace {
+
+constexpr bool normalizing_implies_cased(Normalizing norm) noexcept {
+    return (norm == Normalizing::NONE);
+}
+
+}
+
+FuzzyTerm::FuzzyTerm(std::unique_ptr<QueryNodeResultBase> result_base, stringref term,
+                     const string& index, Type type, Normalizing normalizing,
+                     uint8_t max_edits, uint32_t prefix_size)
+    : QueryTerm(std::move(result_base), term, index, type, normalizing),
+      _dfa_matcher(),
+      _fallback_matcher()
+{
+    setFuzzyMaxEditDistance(max_edits);
+    setFuzzyPrefixLength(prefix_size);
+
+    std::string_view term_view(term.data(), term.size());
+    const bool cased = normalizing_implies_cased(normalizing);
+    if (attribute::DfaFuzzyMatcher::supports_max_edits(max_edits)) {
+        _dfa_matcher = std::make_unique<attribute::DfaFuzzyMatcher>(term_view, max_edits, prefix_size, cased);
+    } else {
+        _fallback_matcher = std::make_unique<vespalib::FuzzyMatcher>(term_view, max_edits, prefix_size, cased);
+    }
+}
+
+FuzzyTerm::~FuzzyTerm() = default;
+
+bool FuzzyTerm::is_match(std::string_view term) const {
+    if (_dfa_matcher) {
+        return _dfa_matcher->is_match(term);
+    } else {
+        return _fallback_matcher->isMatch(term);
+    }
+}
+
+}

--- a/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.h
@@ -1,0 +1,34 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "queryterm.h"
+#include <vespa/searchlib/attribute/dfa_fuzzy_matcher.h>
+#include <vespa/vespalib/fuzzy/fuzzy_matcher.h>
+#include <memory>
+#include <string_view>
+
+namespace search::streaming {
+
+/**
+ * Query term that matches candidate field terms that are within a query-specified
+ * maximum number of edits (add, delete or substitute a character), with case
+ * sensitivity controlled by the provided Normalizing mode.
+ *
+ * Optionally, terms may be prefixed-locked, which enforces field terms to have a
+ * particular prefix and where edits are only counted for the remaining term suffix.
+ */
+class FuzzyTerm : public QueryTerm {
+    std::unique_ptr<attribute::DfaFuzzyMatcher> _dfa_matcher;
+    std::unique_ptr<vespalib::FuzzyMatcher>     _fallback_matcher;
+public:
+    FuzzyTerm(std::unique_ptr<QueryNodeResultBase> result_base, stringref term,
+              const string& index, Type type, Normalizing normalizing,
+              uint8_t max_edits, uint32_t prefix_size);
+    ~FuzzyTerm() override;
+
+    [[nodiscard]] FuzzyTerm* as_fuzzy_term() noexcept override { return this; }
+
+    [[nodiscard]] bool is_match(std::string_view term) const;
+};
+
+}

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.cpp
@@ -185,4 +185,10 @@ QueryTerm::as_regexp_term() noexcept
     return nullptr;
 }
 
+FuzzyTerm*
+QueryTerm::as_fuzzy_term() noexcept
+{
+    return nullptr;
+}
+
 }

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
@@ -11,6 +11,7 @@
 
 namespace search::streaming {
 
+class FuzzyTerm;
 class NearestNeighborQueryNode;
 class MultiTerm;
 class RegexpTerm;
@@ -95,6 +96,7 @@ public:
     virtual NearestNeighborQueryNode* as_nearest_neighbor_query_node() noexcept;
     virtual MultiTerm* as_multi_term() noexcept;
     virtual RegexpTerm* as_regexp_term() noexcept;
+    virtual FuzzyTerm* as_fuzzy_term() noexcept;
 protected:
     using QueryNodeResultBaseContainer = std::unique_ptr<QueryNodeResultBase>;
     string                       _index;

--- a/streamingvisitors/src/vespa/vsm/searcher/fieldsearcher.h
+++ b/streamingvisitors/src/vespa/vsm/searcher/fieldsearcher.h
@@ -46,7 +46,7 @@ public:
     explicit FieldSearcher(FieldIdT fId) noexcept : FieldSearcher(fId, false) {}
     FieldSearcher(FieldIdT fId, bool defaultPrefix) noexcept;
     ~FieldSearcher() override;
-    virtual std::unique_ptr<FieldSearcher> duplicate() const = 0;
+    [[nodiscard]] virtual std::unique_ptr<FieldSearcher> duplicate() const = 0;
     bool search(const StorageDocument & doc);
     virtual void prepare(search::streaming::QueryTermList& qtl, const SharedSearcherBuf& buf,
                          const vsm::FieldPathMapT& field_paths, search::fef::IQueryEnvironment& query_env);

--- a/streamingvisitors/src/vespa/vsm/searcher/strchrfieldsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/strchrfieldsearcher.cpp
@@ -34,7 +34,7 @@ bool StrChrFieldSearcher::matchDoc(const FieldRef & fieldRef)
     }
   } else {
     for (auto qt : _qtl) {
-      if (fieldRef.size() >= qt->termLen() || qt->isRegex()) {
+      if (fieldRef.size() >= qt->termLen() || qt->isRegex() || qt->isFuzzy()) {
         _words += matchTerm(fieldRef, *qt);
       } else {
         _words += countWords(fieldRef);
@@ -49,8 +49,8 @@ size_t StrChrFieldSearcher::shortestTerm() const
   size_t mintsz(_qtl.front()->termLen());
   for (auto it=_qtl.begin()+1, mt=_qtl.end(); it != mt; it++) {
     const QueryTerm & qt = **it;
-    if (qt.isRegex()) {
-        return 0; // Must avoid "too short query term" optimization when using regex
+    if (qt.isRegex() || qt.isFuzzy()) {
+        return 0; // Must avoid "too short query term" optimization when using regex or fuzzy
     }
     mintsz = std::min(mintsz, qt.termLen());
   }

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.h
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8flexiblestringfieldsearcher.h
@@ -25,6 +25,7 @@ private:
     size_t matchTerms(const FieldRef & f, size_t shortestTerm) override;
 
     size_t match_regexp(const FieldRef & f, search::streaming::QueryTerm & qt);
+    size_t match_fuzzy(const FieldRef & f, search::streaming::QueryTerm & qt);
 
 public:
     std::unique_ptr<FieldSearcher> duplicate() const override;

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -133,7 +133,7 @@ FieldSearchSpec::reconfig(const QueryTerm & term)
             (term.isSuffix() && _arg1 != "suffix") ||
             (term.isExactstring() && _arg1 != "exact") ||
             (term.isPrefix() && _arg1 == "suffix") ||
-            term.isRegex())
+            (term.isRegex() || term.isFuzzy()))
         {
             _searcher = std::make_unique<UTF8FlexibleStringFieldSearcher>(id());
             propagate_settings_to_searcher();


### PR DESCRIPTION
@geirst please review
@toregge FYI

Uses a DFA-based matcher for max edits $`k \in \{ 1, 2 \}`$ and falls back to the legacy non-DFA matcher for all other values (including 0).

Currently only supports fuzzy matching across the full field string, i.e. there's no implicit tokenization or whitespace removal. This matches the semantics we currently have for fuzzy search over attributes in a non-streaming case

