### PR TITLE
Support hash filter iterator in DirectMultiTermBlueprint.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.cpp
@@ -6,12 +6,12 @@
 #include <vespa/searchlib/common/bitvector.h>
 #include <vespa/searchlib/fef/matchdatalayout.h>
 #include <vespa/searchlib/query/query_term_ucs4.h>
-#include <vespa/searchlib/queryeval/weighted_set_term_search.h>
-#include <vespa/vespalib/objects/visit.h>
-#include <vespa/vespalib/util/stringfmt.h>
-#include <vespa/vespalib/stllike/hash_map.hpp>
 #include <vespa/searchlib/queryeval/filter_wrapper.h>
 #include <vespa/searchlib/queryeval/orsearch.h>
+#include <vespa/searchlib/queryeval/weighted_set_term_search.h>
+#include <vespa/vespalib/objects/visit.h>
+#include <vespa/vespalib/stllike/hash_map.hpp>
+#include <vespa/vespalib/util/stringfmt.h>
 
 
 namespace search {
@@ -38,6 +38,7 @@ class StringEnumWrapper : public AttrWrapper
 {
 public:
     using TokenT = uint32_t;
+    static constexpr bool unpack_weights = true;
     explicit StringEnumWrapper(const IAttributeVector & attr)
         : AttrWrapper(attr) {}
     auto mapToken(const ISearchContext &context) const {
@@ -52,6 +53,7 @@ class IntegerWrapper : public AttrWrapper
 {
 public:
     using TokenT = uint64_t;
+    static constexpr bool unpack_weights = true;
     explicit IntegerWrapper(const IAttributeVector & attr) : AttrWrapper(attr) {}
     std::vector<int64_t> mapToken(const ISearchContext &context) const {
         std::vector<int64_t> result;

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
@@ -35,6 +35,8 @@ private:
     using IteratorType = typename PostingStoreType::IteratorType;
     using IteratorWeights = std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>>;
 
+    bool use_hash_filter(bool strict) const;
+
     IteratorWeights create_iterators(std::vector<IteratorType>& btree_iterators,
                                      std::vector<std::unique_ptr<queryeval::SearchIterator>>& bitvectors,
                                      bool use_bitvector_when_available,

--- a/searchlib/src/vespa/searchlib/attribute/multi_term_hash_filter.h
+++ b/searchlib/src/vespa/searchlib/attribute/multi_term_hash_filter.h
@@ -23,6 +23,7 @@ class MultiTermHashFilter final : public queryeval::SearchIterator
 public:
     using Key = typename WrapperType::TokenT;
     using TokenMap = vespalib::hash_map<Key, int32_t, vespalib::hash<Key>, std::equal_to<Key>, vespalib::hashtable_base::and_modulator>;
+    static constexpr bool unpack_weights = WrapperType::unpack_weights;
 
 private:
     fef::TermFieldMatchData& _tfmd;

--- a/searchlib/src/vespa/searchlib/attribute/multi_term_hash_filter.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multi_term_hash_filter.hpp
@@ -42,10 +42,14 @@ template <typename WrapperType>
 void
 MultiTermHashFilter<WrapperType>::doUnpack(uint32_t docId)
 {
-    _tfmd.reset(docId);
-    fef::TermFieldMatchDataPosition pos;
-    pos.setElementWeight(_weight);
-    _tfmd.appendPosition(pos);
+    if constexpr (unpack_weights) {
+        _tfmd.reset(docId);
+        fef::TermFieldMatchDataPosition pos;
+        pos.setElementWeight(_weight);
+        _tfmd.appendPosition(pos);
+    } else {
+        _tfmd.resetOnlyDocId(docId);
+    }
 }
     
 }

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_search.h
@@ -27,6 +27,7 @@ protected:
 public:
     static constexpr bool filter_search = false;
     static constexpr bool require_btree_iterators = true;
+    static constexpr bool supports_hash_filter = false;
 
     // TODO: use MultiSearch::Children to pass ownership
     static SearchIterator::UP create(const std::vector<SearchIterator*> &children,

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_search.h
@@ -11,6 +11,8 @@
 #include <variant>
 #include <vector>
 
+namespace search::attribute { class IAttributeVector; }
+
 namespace search::fef { class TermFieldMatchData; }
 
 namespace search::queryeval {
@@ -30,6 +32,8 @@ public:
     static constexpr bool filter_search = false;
     // Whether this iterator requires btree iterators for all tokens/terms used by the operator.
     static constexpr bool require_btree_iterators = false;
+    // Whether this supports creating a hash filter iterator;
+    static constexpr bool supports_hash_filter = true;
 
     // TODO: pass ownership with unique_ptr
     static SearchIterator::UP create(const std::vector<SearchIterator *> &children,
@@ -47,6 +51,14 @@ public:
                                      bool is_filter_search,
                                      std::variant<std::reference_wrapper<const std::vector<int32_t>>, std::vector<int32_t>> weights,
                                      std::vector<DocidWithWeightIterator> &&iterators);
+
+    static SearchIterator::UP create_hash_filter(search::fef::TermFieldMatchData& tmd,
+                                                 bool is_filter_search,
+                                                 const std::vector<int32_t>& weights,
+                                                 const std::vector<IDirectPostingStore::LookupResult>& terms,
+                                                 const attribute::IAttributeVector& attr,
+                                                 const IDirectPostingStore& posting_store,
+                                                 vespalib::datastore::EntryRef dictionary_snapshot);
 
     // used during docsum fetching to identify matching elements
     // initRange must be called before use.


### PR DESCRIPTION
This is used in some non-strict cases, and should improve IN operator performance: https://github.com/vespa-engine/system-test/tree/master/tests/performance/in_operator.

@toregge please review
@baldersheim FYI