### PR TITLE
- Put the inner loops in separate methods. This improves ability to i…

### DIFF
--- a/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
+++ b/model-integration/src/test/java/ai/vespa/embedding/SpladeEmbedderTest.java
@@ -49,7 +49,7 @@ public class SpladeEmbedderTest {
         String text = "what was the manhattan project in this context it was a secret project to develop a nuclear weapon in world war" +
                 " ii the project was led by the united states with the support of the united kingdom and canada";
         Long now = System.currentTimeMillis();
-        int n = 1000; // Takes around 8s on Intel core i9 2.4Ghz (macbook pro, 2019)
+        int n = 1000; // Takes around 7s on Intel core i9 2.4Ghz (macbook pro, 2019)
         for (int i = 0; i < n; i++) {
             assertEmbed("tensor<float>(t{})", text, indexingContext);
         }


### PR DESCRIPTION
…nline.

- Use Buffer.get(int index) instead of Buffer.get(). That avoids a write.
- Use int as loop variable.
- This brings the splade perfoamnce test down from 8s to 7s
- TensorConverter.toVespaTensor more than doubled speed.

@bratseth @jobergum PR