### PR TITLE
Remove unused member variable from search::streaming::WeightedSetTerm.

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/weighted_set_term.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/weighted_set_term.h
@@ -10,7 +10,6 @@ namespace search::streaming {
  * A weighted set query term for streaming search.
  */
 class WeightedSetTerm : public MultiTerm {
-    double _score_threshold;
 public:
     WeightedSetTerm(std::unique_ptr<QueryNodeResultBase> result_base, const string& index, uint32_t num_terms);
     ~WeightedSetTerm() override;


### PR DESCRIPTION
@geirst : please review
