### PR TITLE
Include ostream header to get definition of std::ostream

### DIFF
--- a/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/querynoderesultbase.cpp
@@ -1,5 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "querynoderesultbase.h"
+#include <ostream>
 
 namespace search::streaming {
 


### PR DESCRIPTION
@geirst : please review
