### PR TITLE
only allow matching fields searched by all children

### DIFF
--- a/searchlib/src/tests/nearsearch/nearsearch_test.cpp
+++ b/searchlib/src/tests/nearsearch/nearsearch_test.cpp
@@ -215,7 +215,7 @@ bool
 Test::testNearSearch(MyQuery &query, uint32_t matchId)
 {
     LOG(info, "testNearSearch(%d)", matchId);
-    search::queryeval::IntermediateBlueprint *near_b = 0;
+    search::queryeval::IntermediateBlueprint *near_b = nullptr;
     if (query.isOrdered()) {
         near_b = new search::queryeval::ONearBlueprint(query.getWindow());
     } else {
@@ -228,9 +228,10 @@ Test::testNearSearch(MyQuery &query, uint32_t matchId)
         layout.allocTermField(fieldId);
         near_b->addChild(query.getTerm(i).make_blueprint(fieldId, i));
     }
-    search::fef::MatchData::UP md(layout.createMatchData());
-
+    bp->setDocIdLimit(1000);
+    bp = search::queryeval::Blueprint::optimize_and_sort(std::move(bp), true, true);
     bp->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
+    search::fef::MatchData::UP md(layout.createMatchData());
     search::queryeval::SearchIterator::UP near = bp->createSearch(*md, true);
     near->initFullRange();
     bool foundMatch = false;


### PR DESCRIPTION
this is needed since we now optimize children of near/onear which might lead to dropping non-matcing children of OR (when searching multiple fields at once).

@baldersheim please review
@arnej27959 FYI