### PR TITLE
Treat TLS alert as authentication failure

### DIFF
--- a/client/go/internal/vespa/crypto.go
+++ b/client/go/internal/vespa/crypto.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -219,4 +220,16 @@ func contentHash(r io.Reader) (string, io.Reader, error) {
 func randomSerialNumber() (*big.Int, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	return rand.Int(rand.Reader, serialNumberLimit)
+}
+
+// isTLSAlert returns whether err contains a TLS alert error.
+func isTLSAlert(err error) bool {
+	for ; err != nil; err = errors.Unwrap(err) {
+		// This is ugly, but alert types are currently not exposed:
+		// https://github.com/golang/go/issues/35234
+		if fmt.Sprintf("%T", err) == "tls.alert" {
+			return true
+		}
+	}
+	return false
 }

--- a/client/go/internal/vespa/target.go
+++ b/client/go/internal/vespa/target.go
@@ -153,7 +153,11 @@ func (s *Service) Do(request *http.Request, timeout time.Duration) (*http.Respon
 	if err := s.CurlWriter.print(request, s.TLSOptions, timeout); err != nil {
 		return nil, err
 	}
-	return s.httpClient.Do(request, timeout)
+	resp, err := s.httpClient.Do(request, timeout)
+	if isTLSAlert(err) {
+		return nil, fmt.Errorf("%w: %s", errAuth, err)
+	}
+	return resp, err
 }
 
 // SetClient sets a custom HTTP client that this service should use.


### PR DESCRIPTION
When a service call fails due to a TLS alert, for example "unknown certificate",
we want `--wait` to abort immediately as there is no point in retrying.

@jonmv