### PR TITLE
Reapply Support IDocidWithWeightPostingStore for more attribute data types.

### DIFF
--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -430,7 +430,8 @@ BitVectorTest::test(BasicType bt, CollectionType ct, const vespalib::string &pre
     sc = getSearch<VectorType>(tv, filter);
     checkSearch(v, std::move(sc), 2, 1022, 205, !filter, true);
     const auto* dww = v->as_docid_with_weight_posting_store();
-    if (dww != nullptr) {
+    if ((dww != nullptr) && (bt == BasicType::STRING)) {
+        // This way of doing lookup is only supported by string attributes.
         auto lres = dww->lookup(getSearchStr<VectorType>(), dww->get_dictionary_snapshot());
         using DWSI = search::queryeval::DocidWithWeightSearchIterator;
         TermFieldMatchData md;

--- a/searchlib/src/tests/attribute/direct_posting_store/direct_posting_store_test.cpp
+++ b/searchlib/src/tests/attribute/direct_posting_store/direct_posting_store_test.cpp
@@ -142,7 +142,11 @@ TEST(DirectPostingStoreApiTest, attributes_do_not_support_IDocidPostingStore_int
 
 TEST(DirectPostingStoreApiTest, attributes_support_IDocidWithWeightPostingStore_interface) {
     expect_docid_with_weight_posting_store(BasicType::INT64, CollectionType::WSET, true);
+    expect_docid_with_weight_posting_store(BasicType::INT32, CollectionType::WSET, true);
     expect_docid_with_weight_posting_store(BasicType::STRING, CollectionType::WSET, true);
+    expect_docid_with_weight_posting_store(BasicType::INT64, CollectionType::ARRAY, true);
+    expect_docid_with_weight_posting_store(BasicType::INT32, CollectionType::ARRAY, true);
+    expect_docid_with_weight_posting_store(BasicType::STRING, CollectionType::ARRAY, true);
 }
 
 TEST(DirectPostingStoreApiTest, attributes_do_not_support_IDocidWithWeightPostingStore_interface) {
@@ -150,13 +154,11 @@ TEST(DirectPostingStoreApiTest, attributes_do_not_support_IDocidWithWeightPostin
     expect_not_docid_with_weight_posting_store(BasicType::INT64, CollectionType::ARRAY, false);
     expect_not_docid_with_weight_posting_store(BasicType::INT64, CollectionType::WSET, false);
     expect_not_docid_with_weight_posting_store(BasicType::INT64, CollectionType::SINGLE, true);
-    expect_not_docid_with_weight_posting_store(BasicType::INT64, CollectionType::ARRAY, true);
     expect_not_docid_with_weight_posting_store(BasicType::STRING, CollectionType::SINGLE, false);
     expect_not_docid_with_weight_posting_store(BasicType::STRING, CollectionType::ARRAY, false);
     expect_not_docid_with_weight_posting_store(BasicType::STRING, CollectionType::WSET, false);
     expect_not_docid_with_weight_posting_store(BasicType::STRING, CollectionType::SINGLE, true);
-    expect_not_docid_with_weight_posting_store(BasicType::STRING, CollectionType::ARRAY, true);
-    expect_not_docid_with_weight_posting_store(BasicType::INT32, CollectionType::WSET, true);
+    expect_not_docid_with_weight_posting_store(BasicType::DOUBLE, CollectionType::ARRAY, true);
     expect_not_docid_with_weight_posting_store(BasicType::DOUBLE, CollectionType::WSET, true);
 }
 

--- a/searchlib/src/vespa/searchcommon/attribute/basictype.cpp
+++ b/searchlib/src/vespa/searchcommon/attribute/basictype.cpp
@@ -35,4 +35,13 @@ BasicType::asType(const vespalib::string &t)
     return NONE;
 }
 
+bool
+BasicType::is_integer_type() const noexcept
+{
+    return (_type == INT8) ||
+           (_type == INT16) ||
+           (_type == INT32) ||
+           (_type == INT64);
+}
+
 }

--- a/searchlib/src/vespa/searchcommon/attribute/basictype.h
+++ b/searchlib/src/vespa/searchcommon/attribute/basictype.h
@@ -36,6 +36,7 @@ class BasicType
     Type type() const noexcept { return _type; }
     const char * asString() const noexcept { return asString(_type); }
     size_t fixedSize() const noexcept { return fixedSize(_type); }
+    bool is_integer_type() const noexcept;
     static BasicType fromType(bool) noexcept { return BOOL; }
     static BasicType fromType(int8_t)  noexcept { return INT8; }
     static BasicType fromType(int16_t) noexcept { return INT16; }

--- a/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multinumericpostattribute.hpp
@@ -89,7 +89,7 @@ template <typename B, typename M>
 const IDocidWithWeightPostingStore*
 MultiValueNumericPostingAttribute<B, M>::as_docid_with_weight_posting_store() const
 {
-    if (this->hasWeightedSetType() && (this->getBasicType() == AttributeVector::BasicType::INT64)) {
+    if (this->getConfig().basicType().is_integer_type()) {
         return &_posting_store_adapter;
     }
     return nullptr;

--- a/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/multistringpostattribute.hpp
@@ -108,8 +108,7 @@ template <typename B, typename T>
 const IDocidWithWeightPostingStore*
 MultiValueStringPostingAttributeT<B, T>::as_docid_with_weight_posting_store() const
 {
-    // TODO: Add support for handling bit vectors too, and lift restriction on isFilter.
-    if (this->hasWeightedSetType() && this->isStringType()) {
+    if (this->isStringType()) {
         return &_posting_store_adapter;
     }
     return nullptr;

--- a/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/singlenumericpostattribute.hpp
@@ -150,22 +150,11 @@ SingleValueNumericPostingAttribute<B>::getSearch(QueryTermSimple::UP qTerm,
     return std::make_unique<SC>(std::move(base_sc), params, *this);
 }
 
-namespace {
-
-bool is_integer_type(attribute::BasicType type) {
-    return (type == attribute::BasicType::INT8) ||
-           (type == attribute::BasicType::INT16) ||
-           (type == attribute::BasicType::INT32) ||
-           (type == attribute::BasicType::INT64);
-}
-
-}
-
 template <typename B>
 const IDocidPostingStore*
 SingleValueNumericPostingAttribute<B>::as_docid_posting_store() const
 {
-    if (is_integer_type(this->getBasicType())) {
+    if (this->getConfig().basicType().is_integer_type()) {
         return &_posting_store_adapter;
     }
     return nullptr;


### PR DESCRIPTION
This includes array types (in addition to weighted set) and all integer types. This change also aligns the blueprint and iterator implementations used for WeightedSetTerm and InTerm, making the performance of WeightedSetTerm more similar to InTerm. In particular an attribute with "rank: filter" uses a more optimal search iterator for WeightedSetTerm.

This re-applies https://github.com/vespa-engine/vespa/pull/30014.
This is made possible by first merging https://github.com/vespa-engine/vespa/pull/30030.

@baldersheim please review