### PR TITLE
configChangeActions is only set if prepare + activate on same Deployment

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/Deployment.java
@@ -177,7 +177,7 @@ public class Deployment implements com.yahoo.config.provision.Deployment {
                                                    nodesToRestart.size(), nodesToRestart.stream().sorted().collect(joining(", "))));
         log.info(String.format("%sWill schedule service restart of %d nodes after convergence on generation %d: %s",
                                session.logPre(), nodesToRestart.size(), session.getSessionId(), nodesToRestart.stream().sorted().collect(joining(", "))));
-        this.configChangeActions = configChangeActions.withRestartActions(new RestartActions());
+        configChangeActions = configChangeActions == null ? null : configChangeActions.withRestartActions(new RestartActions());
     }
 
     private void storeReindexing(ApplicationId applicationId) {


### PR DESCRIPTION
@hmusum please review and merge

The field isn't used for anything when activate is called on a `Deployment` created with `prepared(...)`. 