### PR TITLE
Dry-run deployments leave no application ID, even though prepared

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ApplicationPackageMaintainer.java
@@ -69,7 +69,10 @@ public class ApplicationPackageMaintainer extends ConfigServerMaintainer {
                         continue;
                 }
 
-                var applicationId = session.getApplicationId();
+                ApplicationId applicationId = session.getOptionalApplicationId().orElse(null);
+                if (applicationId == null) // dry-run sessions have no application id
+                    continue;
+                
                 log.finest(() -> "Verifying application package for " + applicationId);
 
                 Optional<FileReference> appFileReference = session.getApplicationPackageReference();


### PR DESCRIPTION
@hmusum or @mpolden please review and mereg.