### PR TITLE
- Make separate path for reduction of indexed tensors.

### DIFF
--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -728,8 +728,10 @@
       "final"
     ],
     "methods" : [
+      "public static com.yahoo.tensor.DirectIndexedAddress of(com.yahoo.tensor.DimensionSizes)",
       "public void setIndex(int, int)",
       "public long getDirectIndex()",
+      "public long[] getIndexes()",
       "public long getStride(int)"
     ],
     "fields" : [ ]

--- a/vespajlib/src/main/java/com/yahoo/tensor/DirectIndexedAddress.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/DirectIndexedAddress.java
@@ -22,7 +22,7 @@ public final class DirectIndexedAddress {
         directIndex = 0;
     }
 
-    static DirectIndexedAddress of(DimensionSizes sizes) {
+    public static DirectIndexedAddress of(DimensionSizes sizes) {
         return new DirectIndexedAddress(sizes);
     }
 
@@ -38,6 +38,14 @@ public final class DirectIndexedAddress {
 
     /** Retrieve the index that can be used for direct lookup in an indexed tensor. */
     public long getDirectIndex() { return directIndex; }
+
+    public long [] getIndexes() {
+        long[] asLong = new long[indexes.length];
+        for (int i=0; i < indexes.length; i++) {
+            asLong[i] = indexes[i];
+        }
+        return asLong;
+    }
 
     /** returns the stride to be used for the given dimension */
     public long getStride(int dimension) {


### PR DESCRIPTION
- This brough down reduce time from 60s to 3.7s or a factor of 16x for the splade embedder if using reduce.
- A reduce based splade embedder now uses 8.0s vs 7.0s for a custom rolled out version, translated to 14% overhead. Please enter the commit message for your changes. Lines starting

@bratseth PR
@jobergum FYI