### PR TITLE
- Always inhibit_default_merges_when_global_merges_pending

### DIFF
--- a/storage/src/tests/common/teststorageapp.cpp
+++ b/storage/src/tests/common/teststorageapp.cpp
@@ -3,6 +3,8 @@
 #include "teststorageapp.h"
 #include <vespa/storage/common/content_bucket_db_options.h>
 #include <vespa/storage/config/config-stor-server.h>
+#include <vespa/storage/config/config-stor-distributormanager.h>
+#include <vespa/storage/config/config-stor-visitordispatcher.h>
 #include <vespa/config-stor-distribution.h>
 #include <vespa/config-fleetcontroller.h>
 #include <vespa/persistence/dummyimpl/dummypersistence.h>

--- a/storage/src/tests/common/teststorageapp.h
+++ b/storage/src/tests/common/teststorageapp.h
@@ -22,6 +22,7 @@
 #include <vespa/document/bucket/fixed_bucket_spaces.h>
 #include <vespa/persistence/spi/types.h>
 #include <vespa/storage/bucketdb/storbucketdb.h>
+#include <vespa/storage/bucketdb/bucketdatabase.h>
 #include <vespa/storage/common/doneinitializehandler.h>
 #include <vespa/storage/common/hostreporter/hostinfo.h>
 #include <vespa/storage/common/node_identity.h>
@@ -36,7 +37,6 @@
 namespace storage {
 
 namespace spi { struct PersistenceProvider; }
-class StorageBucketDBInitializer;
 
 DEFINE_PRIMITIVE_WRAPPER(uint16_t, NodeIndex);
 DEFINE_PRIMITIVE_WRAPPER(uint16_t, NodeCount);

--- a/storage/src/tests/distributor/bucketdbmetricupdatertest.cpp
+++ b/storage/src/tests/distributor/bucketdbmetricupdatertest.cpp
@@ -316,8 +316,7 @@ TEST_F(BucketDBMetricUpdaterTest, min_bucket_replica_tracked_and_reported_per_no
 
 TEST_F(BucketDBMetricUpdaterTest, non_trusted_replicas_also_counted_in_mode_any) {
     BucketDBMetricUpdater metricUpdater;
-    using CountingMode = BucketDBMetricUpdater::ReplicaCountingMode;
-    metricUpdater.setMinimumReplicaCountingMode(CountingMode::ANY);
+    metricUpdater.setMinimumReplicaCountingMode(ReplicaCountingMode::ANY);
     visitBucketWith2Copies1Trusted(metricUpdater);
     visitBucketWith2CopiesBothTrusted(metricUpdater);
 
@@ -327,8 +326,7 @@ TEST_F(BucketDBMetricUpdaterTest, non_trusted_replicas_also_counted_in_mode_any)
 
 TEST_F(BucketDBMetricUpdaterTest, minimum_replica_count_returned_for_node_in_mode_any) {
     BucketDBMetricUpdater metricUpdater;
-    using CountingMode = BucketDBMetricUpdater::ReplicaCountingMode;
-    metricUpdater.setMinimumReplicaCountingMode(CountingMode::ANY);
+    metricUpdater.setMinimumReplicaCountingMode(ReplicaCountingMode::ANY);
     visitBucketWith2CopiesBothTrusted(metricUpdater);
     visitBucketWith1Copy(metricUpdater);
 

--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -8,6 +8,8 @@
 #include <vespa/storage/distributor/top_level_distributor.h>
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/distributor_stripe.h>
+#include <vespa/storage/config/distributorconfiguration.h>
+#include <vespa/storage/config/config-stor-distributormanager.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
@@ -51,7 +53,7 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
     using NodeCount = uint16_t;
     using Redundancy = uint16_t;
 
-    using ConfigBuilder = vespa::config::content::core::StorDistributormanagerConfigBuilder;
+    using ConfigBuilder = DistributorManagerConfig;
 
     auto currentReplicaCountingMode() const noexcept {
         return _stripe->_bucketDBMetricUpdater.getMinimumReplicaCountingMode();
@@ -592,7 +594,7 @@ TEST_F(DistributorStripeTest, stats_generated_for_preempted_operations)
 TEST_F(DistributorStripeTest, replica_counting_mode_is_configured_to_trusted_by_default)
 {
     setup_stripe(Redundancy(2), NodeCount(2), "storage:2 distributor:1");
-    EXPECT_EQ(ConfigBuilder::MinimumReplicaCountingMode::TRUSTED, currentReplicaCountingMode());
+    EXPECT_EQ(ReplicaCountingMode::TRUSTED, currentReplicaCountingMode());
 }
 
 TEST_F(DistributorStripeTest, replica_counting_mode_config_is_propagated_to_metric_updater)
@@ -601,7 +603,7 @@ TEST_F(DistributorStripeTest, replica_counting_mode_config_is_propagated_to_metr
     ConfigBuilder builder;
     builder.minimumReplicaCountingMode = ConfigBuilder::MinimumReplicaCountingMode::ANY;
     configure_stripe(builder);
-    EXPECT_EQ(ConfigBuilder::MinimumReplicaCountingMode::ANY, currentReplicaCountingMode());
+    EXPECT_EQ(ReplicaCountingMode::ANY, currentReplicaCountingMode());
 }
 
 TEST_F(DistributorStripeTest, max_consecutively_inhibited_maintenance_ticks_config_is_propagated_to_internal_config)
@@ -646,19 +648,6 @@ TEST_F(DistributorStripeTest, max_clock_skew_config_is_propagated_to_distributor
 
     configureMaxClusterClockSkew(5);
     EXPECT_EQ(getConfig().getMaxClusterClockSkew(), std::chrono::seconds(5));
-}
-
-TEST_F(DistributorStripeTest, inhibit_default_merge_if_global_merges_pending_config_is_propagated)
-{
-    setup_stripe(Redundancy(2), NodeCount(2), "storage:2 distributor:1");
-    ConfigBuilder builder;
-    builder.inhibitDefaultMergesWhenGlobalMergesPending = true;
-    configure_stripe(builder);
-    EXPECT_TRUE(getConfig().inhibit_default_merges_when_global_merges_pending());
-
-    builder.inhibitDefaultMergesWhenGlobalMergesPending = false;
-    configure_stripe(builder);
-    EXPECT_FALSE(getConfig().inhibit_default_merges_when_global_merges_pending());
 }
 
 namespace {

--- a/storage/src/tests/distributor/distributor_stripe_test_util.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.cpp
@@ -10,6 +10,8 @@
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/ideal_state_total_metrics.h>
 #include <vespa/storage/distributor/node_supported_features_repo.h>
+#include <vespa/storage/config/distributorconfiguration.h>
+#include <vespa/storage/config/config-stor-distributormanager.h>
 #include <vespa/storage/storageutil/utils.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/text/stringtokenizer.h>

--- a/storage/src/tests/distributor/distributor_stripe_test_util.h
+++ b/storage/src/tests/distributor/distributor_stripe_test_util.h
@@ -9,11 +9,11 @@
 #include <vespa/storage/distributor/stripe_host_info_notifier.h>
 #include <vespa/storage/storageutil/utils.h>
 
-namespace storage {
+namespace storage::framework {
+    struct TickingThreadPool;
+}
 
-namespace framework { struct TickingThreadPool; }
-
-namespace distributor {
+namespace storage::distributor {
 
 class DistributorBucketSpace;
 class DistributorBucketSpaceRepo;
@@ -179,7 +179,7 @@ public:
     void simulate_distribution_config_change(std::shared_ptr<lib::Distribution> new_config);
     static std::shared_ptr<lib::Distribution> make_default_distribution_config(uint16_t redundancy, uint16_t node_count);
 
-    using ConfigBuilder = vespa::config::content::core::StorDistributormanagerConfigBuilder;
+    using ConfigBuilder = DistributorManagerConfig;
 
     std::shared_ptr<DistributorConfiguration> make_config() const;
     void configure_stripe(std::shared_ptr<const DistributorConfiguration> config);
@@ -265,7 +265,5 @@ protected:
     void enable_cluster_state(vespalib::stringref state);
     void enable_cluster_state(const lib::ClusterStateBundle& state);
 };
-
-}
 
 }

--- a/storage/src/tests/distributor/externaloperationhandlertest.cpp
+++ b/storage/src/tests/distributor/externaloperationhandlertest.cpp
@@ -15,6 +15,7 @@
 #include <vespa/storage/distributor/externaloperationhandler.h>
 #include <vespa/storage/distributor/operations/external/getoperation.h>
 #include <vespa/storage/distributor/operations/external/read_for_write_visitor_operation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/visitor.h>
 #include <vespa/vespalib/gtest/gtest.h>

--- a/storage/src/tests/distributor/garbagecollectiontest.cpp
+++ b/storage/src/tests/distributor/garbagecollectiontest.cpp
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/idealstatemanager.h>
 #include <vespa/storage/distributor/idealstatemetricsset.h>
 #include <vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/vespalib/gtest/gtest.h>
 

--- a/storage/src/tests/distributor/joinbuckettest.cpp
+++ b/storage/src/tests/distributor/joinbuckettest.cpp
@@ -4,6 +4,7 @@
 #include <vespa/document/test/make_document_bucket.h>
 #include <vespa/storage/distributor/top_level_distributor.h>
 #include <vespa/storage/distributor/operations/idealstate/joinoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/storage/src/tests/distributor/mergeoperationtest.cpp
+++ b/storage/src/tests/distributor/mergeoperationtest.cpp
@@ -8,6 +8,7 @@
 #include <vespa/storage/distributor/idealstatemanager.h>
 #include <vespa/storage/distributor/operation_sequencer.h>
 #include <vespa/storage/distributor/operations/idealstate/mergeoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/gtest/gtest.h>

--- a/storage/src/tests/distributor/putoperationtest.cpp
+++ b/storage/src/tests/distributor/putoperationtest.cpp
@@ -8,6 +8,7 @@
 #include <vespa/storage/distributor/distributor_stripe.h>
 #include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storage/distributor/operations/external/putoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/state.h>

--- a/storage/src/tests/distributor/splitbuckettest.cpp
+++ b/storage/src/tests/distributor/splitbuckettest.cpp
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/idealstatemanager.h>
 #include <vespa/storage/distributor/operation_sequencer.h>
 #include <vespa/storage/distributor/operations/idealstate/splitoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/bucketsplitting.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/vespalib/gtest/gtest.h>

--- a/storage/src/tests/distributor/statoperationtest.cpp
+++ b/storage/src/tests/distributor/statoperationtest.cpp
@@ -6,6 +6,7 @@
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/operations/external/statbucketlistoperation.h>
 #include <vespa/storage/distributor/operations/external/statbucketoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/stat.h>
 #include <vespa/vespalib/gtest/gtest.h>
 #include <gmock/gmock.h>

--- a/storage/src/tests/distributor/top_level_distributor_test.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test.cpp
@@ -20,6 +20,7 @@
 #include <vespa/storage/distributor/distributormetricsset.h>
 #include <vespa/storage/distributor/distributor_stripe_pool.h>
 #include <vespa/storage/distributor/distributor_stripe_thread.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/vespalib/stllike/asciistream.h>
 #include <vespa/metrics/updatehook.h>
 #include <thread>

--- a/storage/src/tests/distributor/top_level_distributor_test_util.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.cpp
@@ -355,14 +355,14 @@ TopLevelDistributorTestUtil::tick(bool only_tick_top_level) {
     return did_work;
 }
 
-const DistributorConfig&
+const DistributorManagerConfig&
 TopLevelDistributorTestUtil::current_distributor_config() const
 {
     return _component->getDistributorConfig();
 }
 
 void
-TopLevelDistributorTestUtil::reconfigure(const DistributorConfig& cfg)
+TopLevelDistributorTestUtil::reconfigure(const DistributorManagerConfig& cfg)
 {
     _node->getComponentRegister().setDistributorConfig(cfg);
     tick(); // Config is propagated upon next top-level tick

--- a/storage/src/tests/distributor/top_level_distributor_test_util.h
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.h
@@ -76,8 +76,8 @@ public:
 
     bool tick(bool only_tick_top_level = false);
 
-    const DistributorConfig& current_distributor_config() const;
-    void reconfigure(const DistributorConfig&);
+    const DistributorManagerConfig& current_distributor_config() const;
+    void reconfigure(const DistributorManagerConfig&);
 
     framework::defaultimplementation::FakeClock& fake_clock() noexcept {
         return _node->getClock();

--- a/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
+++ b/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
@@ -11,6 +11,7 @@
 #include <vespa/storage/distributor/distributor_stripe.h>
 #include <vespa/storage/distributor/externaloperationhandler.h>
 #include <vespa/storage/distributor/operations/external/twophaseupdateoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storage/distributor/top_level_distributor.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <gtest/gtest.h>

--- a/storage/src/vespa/storage/common/distributorcomponent.cpp
+++ b/storage/src/vespa/storage/common/distributorcomponent.cpp
@@ -1,15 +1,18 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "distributorcomponent.h"
+#include <vespa/storage/config/distributorconfiguration.h>
+#include <vespa/storage/config/config-stor-distributormanager.h>
+#include <vespa/storage/config/config-stor-visitordispatcher.h>
 
 namespace storage {
 
 DistributorComponent::DistributorComponent(DistributorComponentRegister& compReg,
                                            vespalib::stringref name)
     : StorageComponent(compReg, name),
-      _timeCalculator(0),
-      _distributorConfig(),
-      _visitorConfig(),
+      _timeCalculator(nullptr),
+      _distributorConfig(std::make_unique<DistributorManagerConfig>()),
+      _visitorConfig(std::make_unique<VisitorDispatcherConfig>()),
       _internal_config_generation(0),
       _config_snapshot(std::make_shared<DistributorConfiguration>(*this))
 {
@@ -18,14 +21,27 @@ DistributorComponent::DistributorComponent(DistributorComponentRegister& compReg
 
 DistributorComponent::~DistributorComponent() = default;
 
-void DistributorComponent::update_config_snapshot() {
+void
+DistributorComponent::update_config_snapshot() {
     auto new_snapshot = std::make_shared<DistributorConfiguration>(*this);
-    new_snapshot->configure(_visitorConfig);
-    new_snapshot->configure(_distributorConfig);
+    new_snapshot->configure(*_visitorConfig);
+    new_snapshot->configure(*_distributorConfig);
     // TODO make thread safe if necessary; access currently synchronized by config updates
     // and checks all being routed through the same "critical tick" global lock.
     ++_internal_config_generation;
     _config_snapshot = std::move(new_snapshot);
+}
+
+void
+DistributorComponent::setDistributorConfig(const DistributorManagerConfig& cfg) {
+    _distributorConfig = std::make_unique<DistributorManagerConfig>(cfg);
+    update_config_snapshot();
+}
+
+void
+DistributorComponent::setVisitorConfig(const VisitorDispatcherConfig& cfg)  {
+    _visitorConfig = std::make_unique<VisitorDispatcherConfig>(cfg);
+    update_config_snapshot();
 }
 
 } // storage

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -1,11 +1,14 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #pragma once
 
-#include <vespa/storage/config/config-stor-distributormanager.h>
-#include <vespa/storage/config/config-stor-visitordispatcher.h>
-#include <vespa/vespalib/stllike/hash_set.h>
+#include "replica_counting_mode.h"
 #include <vespa/storage/common/storagecomponent.h>
 #include <vespa/vespalib/util/time.h>
+
+namespace vespa::config::content::core::internal {
+    class InternalStorDistributormanagerType;
+    class InternalStorVisitordispatcherType;
+}
 
 namespace storage {
 
@@ -30,12 +33,11 @@ public:
         uint8_t splitInconsistentBucket {110};
         uint8_t garbageCollection {200};
     };
+    using DistributorManagerConfig = vespa::config::content::core::internal::InternalStorDistributormanagerType;
+    using VisitorDispatcherConfig = vespa::config::content::core::internal::InternalStorVisitordispatcherType;
 
-    using DistrConfig = vespa::config::content::core::StorDistributormanagerConfig;
-    
-    void configure(const DistrConfig& config);
-    void configure(const vespa::config::content::core::StorVisitordispatcherConfig& config);
-
+    void configure(const DistributorManagerConfig& config);
+    void configure(const VisitorDispatcherConfig& config);
 
     const std::string& getGarbageCollectionSelection() const {
         return _garbageCollectionSelection;
@@ -165,8 +167,6 @@ public:
         return _enableInconsistentJoin;
     }
 
-    using ReplicaCountingMode = DistrConfig::MinimumReplicaCountingMode;
-
     ReplicaCountingMode getMinimumReplicaCountingMode() const noexcept {
         return _minimumReplicaCountingMode;
     }
@@ -240,9 +240,6 @@ public:
         return _use_unordered_merge_chaining;
     }
 
-    [[nodiscard]] bool inhibit_default_merges_when_global_merges_pending() const noexcept {
-        return _inhibit_default_merges_when_global_merges_pending;
-    }
     void set_enable_two_phase_garbage_collection(bool enable) noexcept {
         _enable_two_phase_garbage_collection = enable;
     }
@@ -303,12 +300,11 @@ private:
     bool _enable_metadata_only_fetch_phase_for_inconsistent_updates;
     bool _implicitly_clear_priority_on_schedule;
     bool _use_unordered_merge_chaining;
-    bool _inhibit_default_merges_when_global_merges_pending;
     bool _enable_two_phase_garbage_collection;
     bool _enable_condition_probing;
     bool _enable_operation_cancellation;
 
-    DistrConfig::MinimumReplicaCountingMode _minimumReplicaCountingMode;
+    ReplicaCountingMode _minimumReplicaCountingMode;
 };
 
 }

--- a/storage/src/vespa/storage/config/replica_counting_mode.h
+++ b/storage/src/vespa/storage/config/replica_counting_mode.h
@@ -1,0 +1,9 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+#pragma once
+
+namespace storage {
+
+enum class ReplicaCountingMode { TRUSTED, ANY };
+
+}

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -190,12 +190,6 @@ implicitly_clear_bucket_priority_on_schedule bool default=true
 ## that they support the unordered merge feature.
 use_unordered_merge_chaining bool default=true
 
-## If true, inhibits _all_ merges to buckets in the default bucket space if the current
-## cluster state bundle indicates that global merges are pending in the cluster, i.e.
-## one or more nodes is in maintenance mode in the default bucket space but marked up in
-## the global bucket space.
-inhibit_default_merges_when_global_merges_pending bool default=true
-
 ## If true, garbage collection is performed in two phases (metadata gathering and deletion)
 ## instead of just a single phase. Two-phase GC allows for ensuring the same set of documents
 ## is deleted across all nodes and explicitly takes write locks on the distributor to prevent

--- a/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.h
+++ b/storage/src/vespa/storage/distributor/bucketdb/bucketdbmetricupdater.h
@@ -4,7 +4,7 @@
 
 #include <vespa/storage/distributor/min_replica_provider.h>
 #include <vespa/storage/bucketdb/bucketdatabase.h>
-#include <vespa/storage/config/config-stor-distributormanager.h>
+#include <vespa/storage/config/replica_counting_mode.h>
 #include <vespa/vespalib/util/memoryusage.h>
 #include <vespa/vespalib/stllike/hash_map.h>
 
@@ -56,8 +56,6 @@ public:
          */
         void propagateMetrics(IdealStateMetricSet&, DistributorMetricSet&) const;
     };
-
-    using ReplicaCountingMode = vespa::config::content::core::StorDistributormanagerConfig::MinimumReplicaCountingMode;
 
 private:
     Stats               _workingStats;

--- a/storage/src/vespa/storage/distributor/distributor_stripe.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe.cpp
@@ -18,6 +18,7 @@
 #include <vespa/storage/distributor/maintenance/simplebucketprioritydatabase.h>
 #include <vespa/storage/distributor/operations/cancel_scope.h>
 #include <vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageframework/generic/status/xmlstatusreporter.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vespalib/util/memoryusage.h>

--- a/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
+++ b/storage/src/vespa/storage/distributor/distributor_stripe_component.cpp
@@ -5,6 +5,7 @@
 #include "distributor_bucket_space.h"
 #include "pendingmessagetracker.h"
 #include "storage_node_up_states.h"
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storage/storageutil/utils.h>
 #include <vespa/storageframework/generic/clock/clock.h>
 #include <vespa/document/select/parser.h>

--- a/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
+++ b/storage/src/vespa/storage/distributor/externaloperationhandler.cpp
@@ -18,6 +18,7 @@
 #include <vespa/storage/distributor/operations/external/statbucketoperation.h>
 #include <vespa/storage/distributor/operations/external/twophaseupdateoperation.h>
 #include <vespa/storage/distributor/operations/external/visitoroperation.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/storageapi/message/stat.h>

--- a/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/check_condition.cpp
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/distributor_node_context.h>
 #include <vespa/storage/distributor/distributor_stripe_operation_context.h>
 #include <vespa/storage/distributor/node_supported_features_repo.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <cassert>

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
@@ -8,6 +8,7 @@
 #include <vespa/storage/distributor/operationtargetresolverimpl.h>
 #include <vespa/storage/distributor/pendingmessagetracker.h>
 #include <vespa/storage/distributor/storage_node_up_states.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -11,6 +11,7 @@
 #include <vespa/document/select/parser.h>
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/distributor_bucket_space_repo.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vespalib/stllike/hash_set.hpp>

--- a/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/garbagecollectionoperation.cpp
@@ -7,6 +7,7 @@
 #include <vespa/storage/distributor/top_level_distributor.h>
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/node_supported_features_repo.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/vespalib/stllike/hash_map.hpp>
 #include <algorithm>

--- a/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/idealstate/mergeoperation.cpp
@@ -6,6 +6,7 @@
 #include <vespa/storage/distributor/distributor_bucket_space.h>
 #include <vespa/storage/distributor/node_supported_features_repo.h>
 #include <vespa/storage/distributor/pendingmessagetracker.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageframework/generic/clock/clock.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -4,13 +4,12 @@
 #include "node_supported_features.h"
 #include "pending_bucket_space_db_transition_entry.h"
 #include "clusterinformation.h"
+#include "outdated_nodes_map.h"
 #include <vespa/storageapi/message/bucket.h>
 #include <vespa/storageapi/message/state.h>
 #include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vespalib/util/xmlserializable.h>
 #include <vespa/vespalib/stllike/hash_map.h>
-#include "outdated_nodes_map.h"
-#include <unordered_map>
 #include <deque>
 
 namespace storage::framework { struct Clock; }

--- a/storage/src/vespa/storage/distributor/statechecker.cpp
+++ b/storage/src/vespa/storage/distributor/statechecker.cpp
@@ -2,6 +2,7 @@
 #include "statechecker.h"
 #include "distributor_bucket_space.h"
 #include "distributor_stripe_component.h"
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>
 #include <sstream>

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
@@ -12,6 +12,7 @@
 #include "stripe_access_guard.h"
 #include <vespa/document/bucket/fixed_bucket_spaces.h>
 #include <vespa/storage/common/global_bucket_space_distribution_converter.h>
+#include <vespa/storage/config/distributorconfiguration.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/removelocation.h>
 #include <vespa/vdslib/distribution/distribution.h>

--- a/storage/src/vespa/storage/distributor/top_level_distributor.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.cpp
@@ -21,6 +21,7 @@
 #include <vespa/storage/common/node_identity.h>
 #include <vespa/storage/common/nodestateupdater.h>
 #include <vespa/storage/config/distributorconfiguration.h>
+#include <vespa/storage/config/config-stor-distributormanager.h>
 #include <vespa/storageapi/message/persistence.h>
 #include <vespa/storageapi/message/visitor.h>
 #include <vespa/storageframework/generic/status/xmlstatusreporter.h>

--- a/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.h
+++ b/storage/src/vespa/storage/frameworkimpl/component/distributorcomponentregisterimpl.h
@@ -12,7 +12,6 @@
 #include <vespa/storage/common/nodestateupdater.h>
 
 namespace storage::lib {
-    class IdealNodeCalculatorConfigurable;
     class ClusterState;
 }
 
@@ -27,8 +26,8 @@ class DistributorComponentRegisterImpl
     std::vector<DistributorManagedComponent*> _components;
 
     UniqueTimeCalculator* _timeCalculator;
-    DistributorConfig _distributorConfig;
-    VisitorConfig _visitorConfig;
+    std::unique_ptr<DistributorManagerConfig> _distributorConfig;
+    std::unique_ptr<VisitorDispatcherConfig> _visitorConfig;
     std::shared_ptr<lib::ClusterState> _clusterState;
 
 public:
@@ -39,8 +38,8 @@ public:
 
     void registerDistributorComponent(DistributorManagedComponent&) override;
     void setTimeCalculator(UniqueTimeCalculator& calc);
-    void setDistributorConfig(const DistributorConfig&);
-    void setVisitorConfig(const VisitorConfig&);
+    void setDistributorConfig(const DistributorManagerConfig&);
+    void setVisitorConfig(const VisitorDispatcherConfig&);
 private:
     void handleNewState() noexcept override;
     void setNodeStateUpdater(NodeStateUpdater& updater) override;

--- a/storage/src/vespa/storage/storageserver/distributornode.cpp
+++ b/storage/src/vespa/storage/storageserver/distributornode.cpp
@@ -67,14 +67,14 @@ DistributorNode::initializeNodeSpecific()
 }
 
 void
-DistributorNode::handleConfigChange(vespa::config::content::core::StorDistributormanagerConfig& c)
+DistributorNode::handleConfigChange(DistributorManagerConfig & c)
 {
     framework::TickingLockGuard guard(_threadPool->freezeAllTicks());
     _context.getComponentRegister().setDistributorConfig(c);
 }
 
 void
-DistributorNode::handleConfigChange(vespa::config::content::core::StorVisitordispatcherConfig& c)
+DistributorNode::handleConfigChange(VisitorDispatcherConfig & c)
 {
     framework::TickingLockGuard guard(_threadPool->freezeAllTicks());
     _context.getComponentRegister().setVisitorConfig(c);

--- a/storage/src/vespa/storage/storageserver/distributornode.h
+++ b/storage/src/vespa/storage/storageserver/distributornode.h
@@ -52,8 +52,8 @@ public:
     const lib::NodeType& getNodeType() const override { return lib::NodeType::DISTRIBUTOR; }
     ResumeGuard pause() override;
 
-    void handleConfigChange(vespa::config::content::core::StorDistributormanagerConfig&);
-    void handleConfigChange(vespa::config::content::core::StorVisitordispatcherConfig&);
+    void handleConfigChange(DistributorManagerConfig &);
+    void handleConfigChange(VisitorDispatcherConfig&);
 
 private:
     void report(vespalib::JsonStream &) const override { /* no-op */ }

--- a/storageserver/src/vespa/storageserver/app/distributorprocess.cpp
+++ b/storageserver/src/vespa/storageserver/app/distributorprocess.cpp
@@ -2,6 +2,8 @@
 
 #include "distributorprocess.h"
 #include <vespa/config/helper/configgetter.hpp>
+#include <vespa/storage/config/config-stor-distributormanager.h>
+#include <vespa/storage/config/config-stor-visitordispatcher.h>
 #include <vespa/storage/common/bucket_stripe_utils.h>
 #include <vespa/storage/common/i_storage_chain_builder.h>
 #include <vespa/storage/common/storagelink.h>
@@ -58,11 +60,8 @@ adjusted_num_distributor_stripes(int32_t cfg_n_stripes)
 void
 DistributorProcess::setupConfig(vespalib::duration subscribeTimeout)
 {
-    using vespa::config::content::core::StorDistributormanagerConfig;
-    using vespa::config::content::core::StorVisitordispatcherConfig;
-
-    _distributorConfigHandler = _configSubscriber.subscribe<StorDistributormanagerConfig>(_configUri.getConfigId(), subscribeTimeout);
-    _visitDispatcherConfigHandler = _configSubscriber.subscribe<StorVisitordispatcherConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _distributorConfigHandler = _configSubscriber.subscribe<DistributorManagerConfig>(_configUri.getConfigId(), subscribeTimeout);
+    _visitDispatcherConfigHandler = _configSubscriber.subscribe<VisitorDispatcherConfig>(_configUri.getConfigId(), subscribeTimeout);
     Process::setupConfig(subscribeTimeout);
 }
 

--- a/storageserver/src/vespa/storageserver/app/distributorprocess.h
+++ b/storageserver/src/vespa/storageserver/app/distributorprocess.h
@@ -16,13 +16,11 @@ class IStorageChainBuilder;
 
 class DistributorProcess final : public Process {
     DistributorNodeContext _context;
-    uint32_t _num_distributor_stripes;
-    DistributorNode::UP _node;
-    config::ConfigHandle<vespa::config::content::core::StorDistributormanagerConfig>::UP
-            _distributorConfigHandler;
-    config::ConfigHandle<vespa::config::content::core::StorVisitordispatcherConfig>::UP
-            _visitDispatcherConfigHandler;
-    std::unique_ptr<IStorageChainBuilder> _storage_chain_builder;
+    uint32_t               _num_distributor_stripes;
+    DistributorNode::UP    _node;
+    config::ConfigHandle<DistributorManagerConfig>::UP _distributorConfigHandler;
+    config::ConfigHandle<VisitorDispatcherConfig>::UP  _visitDispatcherConfigHandler;
+    std::unique_ptr<IStorageChainBuilder>              _storage_chain_builder;
 
 public:
     explicit DistributorProcess(const config::ConfigUri & configUri);


### PR DESCRIPTION
- Only show config to the code that needs it.
- Avoid using config autogenerated internals around in the code.

@vekterli PR