### PR TITLE
Balder/restart with fast update path and metadata only fetch phase

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -144,12 +144,6 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         });
     }
 
-    void configure_update_fast_path_restart_enabled(bool enabled) {
-        configure_stripe_with([&](auto& builder) {
-            builder.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent = enabled;
-        });
-    }
-
     void configure_merge_operations_disabled(bool disabled) {
         configure_stripe_with([&](auto& builder) {
             builder.mergeOperationsDisabled = disabled;
@@ -797,19 +791,6 @@ TEST_F(DistributorStripeTest, stale_reads_config_is_propagated_to_external_opera
 
     configure_stale_reads_enabled(false);
     EXPECT_FALSE(getExternalOperationHandler().concurrent_gets_enabled());
-}
-
-TEST_F(DistributorStripeTest, fast_path_on_consistent_gets_config_is_propagated_to_internal_config)
-{
-    setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
-
-    EXPECT_TRUE(getConfig().update_fast_path_restart_enabled()); // Enabled by default
-
-    configure_update_fast_path_restart_enabled(true);
-    EXPECT_TRUE(getConfig().update_fast_path_restart_enabled());
-
-    configure_update_fast_path_restart_enabled(false);
-    EXPECT_FALSE(getConfig().update_fast_path_restart_enabled());
 }
 
 TEST_F(DistributorStripeTest, merge_disabling_config_is_propagated_to_internal_config)

--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -162,12 +162,6 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         });
     }
 
-    void configure_metadata_update_phase_enabled(bool enabled) {
-        configure_stripe_with([&](auto& builder) {
-            builder.enableMetadataOnlyFetchPhaseForInconsistentUpdates = enabled;
-        });
-    }
-
     void configure_max_activation_inhibited_out_of_sync_groups(uint32_t n_groups) {
         configure_stripe_with([&](auto& builder) {
             builder.maxActivationInhibitedOutOfSyncGroups = n_groups;
@@ -827,17 +821,6 @@ TEST_F(DistributorStripeTest, merge_disabling_config_is_propagated_to_internal_c
 
     configure_merge_operations_disabled(false);
     EXPECT_FALSE(getConfig().merge_operations_disabled());
-}
-
-TEST_F(DistributorStripeTest, metadata_update_phase_config_is_propagated_to_internal_config)
-{
-    setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
-
-    configure_metadata_update_phase_enabled(true);
-    EXPECT_TRUE(getConfig().enable_metadata_only_fetch_phase_for_inconsistent_updates());
-
-    configure_metadata_update_phase_enabled(false);
-    EXPECT_FALSE(getConfig().enable_metadata_only_fetch_phase_for_inconsistent_updates());
 }
 
 TEST_F(DistributorStripeTest, weak_internal_read_consistency_config_is_propagated_to_internal_configs)

--- a/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
+++ b/storage/src/tests/distributor/twophaseupdateoperationtest.cpp
@@ -1095,9 +1095,7 @@ TEST_F(TwoPhaseUpdateOperationTest, safe_path_close_edge_sends_correct_reply) {
 
 TEST_F(TwoPhaseUpdateOperationTest, safe_path_consistent_get_reply_timestamps_restarts_with_fast_path_if_enabled) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
 
     auto cb = sendUpdate("0=1/2/3,1=2/3/4"); // Inconsistent replicas.
     cb->start(_sender);
@@ -1121,32 +1119,9 @@ TEST_F(TwoPhaseUpdateOperationTest, safe_path_consistent_get_reply_timestamps_re
     EXPECT_EQ(1, m.fast_path_restarts.getValue());
 }
 
-TEST_F(TwoPhaseUpdateOperationTest, safe_path_consistent_get_reply_timestamps_does_not_restart_with_fast_path_if_disabled) {
-    setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(false);
-    configure_stripe(cfg);
-
-    auto cb = sendUpdate("0=1/2/3,1=2/3/4"); // Inconsistent replicas.
-    cb->start(_sender);
-
-    Timestamp old_timestamp = 500;
-    ASSERT_EQ("Get => 0,Get => 1", _sender.getCommands(true));
-    replyToGet(*cb, _sender, 0, old_timestamp);
-    replyToGet(*cb, _sender, 1, old_timestamp);
-
-    // Should _not_ be restarted with fast path, as it has been config disabled
-    ASSERT_EQ("Put => 1,Put => 0", _sender.getCommands(true, false, 2));
-
-    auto& m = metrics().updates;
-    EXPECT_EQ(0, m.fast_path_restarts.getValue());
-}
-
 TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_replica_set_altered_between_get_send_and_receive) {
     setup_stripe(3, 3, "storage:3 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
 
     auto cb = sendUpdate("0=1/2/3,1=2/3/4"); // Inconsistent replicas.
     cb->start(_sender);
@@ -1170,9 +1145,7 @@ TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_replica_set_alter
 
 TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_document_not_found_on_a_replica_node) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
 
     auto cb = sendUpdate("0=1/2/3,1=2/3/4"); // Inconsistent replicas.
     cb->start(_sender);
@@ -1188,9 +1161,7 @@ TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_document_not_foun
 // Buckets must be created from scratch by Put operations, updates alone cannot do this.
 TEST_F(TwoPhaseUpdateOperationTest, fast_path_not_restarted_if_no_initial_replicas_exist) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
 
     // No replicas, technically consistent but cannot use fast path.
     auto cb = sendUpdate("", UpdateOptions().createIfNonExistent(true));
@@ -1407,9 +1378,7 @@ TEST_F(ThreePhaseUpdateTest, update_failed_with_transient_error_code_if_replica_
 
 TEST_F(ThreePhaseUpdateTest, single_full_get_cannot_restart_in_fast_path) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
     auto cb = sendUpdate("0=1/2/3,1=2/3/4"); // Inconsistent replicas.
     cb->start(_sender);
 
@@ -1524,9 +1493,7 @@ TEST_F(ThreePhaseUpdateTest, single_full_get_reply_received_after_close_is_no_op
 
 TEST_F(ThreePhaseUpdateTest, single_full_get_tombstone_is_no_op_without_auto_create) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
     auto cb = sendUpdate("0=1/2/3,1=2/3/4");
     cb->start(_sender);
 
@@ -1547,9 +1514,7 @@ TEST_F(ThreePhaseUpdateTest, single_full_get_tombstone_is_no_op_without_auto_cre
 
 TEST_F(ThreePhaseUpdateTest, single_full_get_tombstone_sends_puts_with_auto_create) {
     setup_stripe(2, 2, "storage:2 distributor:1");
-    auto cfg = make_config();
-    cfg->set_update_fast_path_restart_enabled(true);
-    configure_stripe(cfg);
+    configure_stripe(make_config());
     auto cb = sendUpdate("0=1/2/3,1=2/3/4", UpdateOptions().createIfNonExistent(true));
     cb->start(_sender);
 

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -41,7 +41,6 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _enableInconsistentJoin(false),
       _disableBucketActivation(false),
       _allowStaleReadsDuringClusterStateTransitions(false),
-      _update_fast_path_restart_enabled(false),
       _merge_operations_disabled(false),
       _use_weak_internal_read_consistency_for_client_gets(false),
       _enable_operation_cancellation(false),
@@ -57,7 +56,7 @@ class TimeVisitor : public document::select::TraversingVisitor {
 public:
     bool hasCurrentTime;
 
-    TimeVisitor() : hasCurrentTime(false) {}
+    TimeVisitor() noexcept : hasCurrentTime(false) {}
 
     void visitCurrentTimeValueNode(const document::select::CurrentTimeValueNode&) override {
         hasCurrentTime = true;
@@ -144,7 +143,6 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
 
     _disableBucketActivation = config.disableBucketActivation;
     _allowStaleReadsDuringClusterStateTransitions = config.allowStaleReadsDuringClusterStateTransitions;
-    _update_fast_path_restart_enabled = config.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent;
     _merge_operations_disabled = config.mergeOperationsDisabled;
     _use_weak_internal_read_consistency_for_client_gets = config.useWeakInternalReadConsistencyForClientGets;
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -44,7 +44,6 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _update_fast_path_restart_enabled(false),
       _merge_operations_disabled(false),
       _use_weak_internal_read_consistency_for_client_gets(false),
-      _enable_metadata_only_fetch_phase_for_inconsistent_updates(false),
       _enable_operation_cancellation(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
@@ -148,7 +147,6 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
     _update_fast_path_restart_enabled = config.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent;
     _merge_operations_disabled = config.mergeOperationsDisabled;
     _use_weak_internal_read_consistency_for_client_gets = config.useWeakInternalReadConsistencyForClientGets;
-    _enable_metadata_only_fetch_phase_for_inconsistent_updates = config.enableMetadataOnlyFetchPhaseForInconsistentUpdates;
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_operation_cancellation = config.enableOperationCancellation;
     _minimumReplicaCountingMode = deriveReplicaCountingMode(config.minimumReplicaCountingMode);

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -195,13 +195,6 @@ public:
         _allowStaleReadsDuringClusterStateTransitions = allow;
     }
 
-    bool update_fast_path_restart_enabled() const noexcept {
-        return _update_fast_path_restart_enabled;
-    }
-    void set_update_fast_path_restart_enabled(bool enabled) noexcept {
-        _update_fast_path_restart_enabled = enabled;
-    }
-
     bool merge_operations_disabled() const noexcept {
         return _merge_operations_disabled;
     }
@@ -264,7 +257,6 @@ private:
     bool _enableInconsistentJoin;
     bool _disableBucketActivation;
     bool _allowStaleReadsDuringClusterStateTransitions;
-    bool _update_fast_path_restart_enabled;
     bool _merge_operations_disabled;
     bool _use_weak_internal_read_consistency_for_client_gets;
     bool _enable_operation_cancellation;

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -213,13 +213,6 @@ public:
         return _use_weak_internal_read_consistency_for_client_gets;
     }
 
-    void set_enable_metadata_only_fetch_phase_for_inconsistent_updates(bool enable) noexcept {
-        _enable_metadata_only_fetch_phase_for_inconsistent_updates = enable;
-    }
-    bool enable_metadata_only_fetch_phase_for_inconsistent_updates() const noexcept {
-        return _enable_metadata_only_fetch_phase_for_inconsistent_updates;
-    }
-
     uint32_t max_consecutively_inhibited_maintenance_ticks() const noexcept {
         return _max_consecutively_inhibited_maintenance_ticks;
     }
@@ -274,7 +267,6 @@ private:
     bool _update_fast_path_restart_enabled;
     bool _merge_operations_disabled;
     bool _use_weak_internal_read_consistency_for_client_gets;
-    bool _enable_metadata_only_fetch_phase_for_inconsistent_updates;
     bool _enable_operation_cancellation;
 
     ReplicaCountingMode _minimumReplicaCountingMode;

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -137,15 +137,6 @@ merge_operations_disabled bool default=false
 ## This is mostly useful in a system that is effectively read-only.
 use_weak_internal_read_consistency_for_client_gets bool default=false
 
-## If true, adds an initial metadata-only fetch phase to updates that touch buckets
-## with inconsistent replicas. Metadata timestamps are compared and a single full Get
-## is sent _only_ to one node with the highest timestamp. Without a metadata phase,
-## full gets would be sent to _all_ nodes.
-## Setting this option to true always implicitly enables the fast update restart
-## feature, so it's not required to set that config to true, nor will setting it
-## to false actually disable the feature.
-enable_metadata_only_fetch_phase_for_inconsistent_updates bool default=true
-
 ## If a distributor main thread tick is constantly processing requests or responses
 ## originating from other nodes, setting this value above zero will prevent implicit
 ## maintenance scans from being done as part of the tick for up to N rounds of ticking.

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -112,17 +112,6 @@ allow_stale_reads_during_cluster_state_transitions bool default=false
 simulated_db_pruning_latency_msec int default=0
 simulated_db_merging_latency_msec int default=0
 
-## If a bucket is inconsistent and an Update operation is received, a two-phase
-## write-repair path is triggered in which a Get is sent to all diverging replicas.
-## Once received, the update is applied on the distributor and pushed out to the
-## content nodes as Puts.
-## Iff this config is set to true AND all Gets return the same timestamp from all
-## content nodes, the two-phase update path reverts back to the regular fast path.
-## Since all replicas of the document were in sync, applying the update in-place
-## shall be considered safe.
-## DEPRECATED -- always enabled with 3-phase updates.
-restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true
-
 ## If set, no merge operations may be generated for any reason by a distributor.
 ## This is ONLY intended for system testing of certain transient edge cases and
 ## MUST NOT be set to true in a production environment.

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -91,9 +91,8 @@ TwoPhaseUpdateOperation::ensureUpdateReplyCreated()
 }
 
 void
-TwoPhaseUpdateOperation::sendReply(
-        DistributorStripeMessageSender& sender,
-        std::shared_ptr<api::UpdateReply> reply)
+TwoPhaseUpdateOperation::sendReply(DistributorStripeMessageSender& sender,
+                                   const std::shared_ptr<api::UpdateReply> & reply)
 {
     assert(!_replySent);
     reply->getTrace().addChild(std::move(_trace));
@@ -560,8 +559,7 @@ TwoPhaseUpdateOperation::handleSafePathReceivedGet(DistributorStripeMessageSende
 }
 
 bool TwoPhaseUpdateOperation::may_restart_with_fast_path(const api::GetReply& reply) {
-    return (_op_ctx.distributor_config().update_fast_path_restart_enabled() &&
-            !_replicas_at_get_send_time.empty() && // To ensure we send CreateBucket+Put if no replicas exist.
+    return (!_replicas_at_get_send_time.empty() && // To ensure we send CreateBucket+Put if no replicas exist.
             reply.had_consistent_replicas() &&
             replica_set_unchanged_after_get_operation());
 }

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -92,7 +92,7 @@ private:
     static const char* stateToString(SendState) noexcept;
 
     void sendReply(DistributorStripeMessageSender&,
-                   std::shared_ptr<api::UpdateReply>);
+                   const std::shared_ptr<api::UpdateReply> &);
     void sendReplyWithResult(DistributorStripeMessageSender&, const api::ReturnCode&);
     void ensureUpdateReplyCreated();
 

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -159,7 +159,6 @@ private:
     ReplicaState                        _replicas_at_get_send_time;
     std::optional<framework::MilliSecTimer> _single_get_latency_timer;
     uint16_t                            _fast_path_repair_source_node;
-    bool                                _use_initial_cheap_metadata_fetch_phase;
     bool                                _replySent;
 };
 


### PR DESCRIPTION
@vekterli This is the combination of #30150 and #30149.
It has fewer test failures and might be a better starting point