### PR TITLE
- Hardcode enable_metadata_only_fetch_phase_for_inconsistent_updates …

### DIFF
--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -144,10 +144,6 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         });
     }
 
-    void configure_update_fast_path_restart_enabled() {
-        configure_stripe_with([&](auto& builder) { (void) builder; });
-    }
-
     void configure_merge_operations_disabled(bool disabled) {
         configure_stripe_with([&](auto& builder) {
             builder.mergeOperationsDisabled = disabled;
@@ -158,10 +154,6 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         configure_stripe_with([&](auto& builder) {
             builder.useWeakInternalReadConsistencyForClientGets = use_weak;
         });
-    }
-
-    void configure_metadata_update_phase_enabled() {
-        configure_stripe_with([&](auto& builder) { (void) builder; });
     }
 
     void configure_max_activation_inhibited_out_of_sync_groups(uint32_t n_groups) {

--- a/storage/src/tests/distributor/distributor_stripe_test.cpp
+++ b/storage/src/tests/distributor/distributor_stripe_test.cpp
@@ -144,10 +144,8 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         });
     }
 
-    void configure_update_fast_path_restart_enabled(bool enabled) {
-        configure_stripe_with([&](auto& builder) {
-            builder.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent = enabled;
-        });
+    void configure_update_fast_path_restart_enabled() {
+        configure_stripe_with([&](auto& builder) { (void) builder; });
     }
 
     void configure_merge_operations_disabled(bool disabled) {
@@ -162,10 +160,8 @@ struct DistributorStripeTest : Test, DistributorStripeTestUtil {
         });
     }
 
-    void configure_metadata_update_phase_enabled(bool enabled) {
-        configure_stripe_with([&](auto& builder) {
-            builder.enableMetadataOnlyFetchPhaseForInconsistentUpdates = enabled;
-        });
+    void configure_metadata_update_phase_enabled() {
+        configure_stripe_with([&](auto& builder) { (void) builder; });
     }
 
     void configure_max_activation_inhibited_out_of_sync_groups(uint32_t n_groups) {
@@ -810,12 +806,6 @@ TEST_F(DistributorStripeTest, fast_path_on_consistent_gets_config_is_propagated_
     setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
 
     EXPECT_TRUE(getConfig().update_fast_path_restart_enabled()); // Enabled by default
-
-    configure_update_fast_path_restart_enabled(true);
-    EXPECT_TRUE(getConfig().update_fast_path_restart_enabled());
-
-    configure_update_fast_path_restart_enabled(false);
-    EXPECT_FALSE(getConfig().update_fast_path_restart_enabled());
 }
 
 TEST_F(DistributorStripeTest, merge_disabling_config_is_propagated_to_internal_config)
@@ -832,12 +822,7 @@ TEST_F(DistributorStripeTest, merge_disabling_config_is_propagated_to_internal_c
 TEST_F(DistributorStripeTest, metadata_update_phase_config_is_propagated_to_internal_config)
 {
     setup_stripe(Redundancy(1), NodeCount(1), "distributor:1 storage:1");
-
-    configure_metadata_update_phase_enabled(true);
     EXPECT_TRUE(getConfig().enable_metadata_only_fetch_phase_for_inconsistent_updates());
-
-    configure_metadata_update_phase_enabled(false);
-    EXPECT_FALSE(getConfig().enable_metadata_only_fetch_phase_for_inconsistent_updates());
 }
 
 TEST_F(DistributorStripeTest, weak_internal_read_consistency_config_is_propagated_to_internal_configs)

--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -41,10 +41,10 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _enableInconsistentJoin(false),
       _disableBucketActivation(false),
       _allowStaleReadsDuringClusterStateTransitions(false),
-      _update_fast_path_restart_enabled(false),
+      _update_fast_path_restart_enabled(true),
       _merge_operations_disabled(false),
       _use_weak_internal_read_consistency_for_client_gets(false),
-      _enable_metadata_only_fetch_phase_for_inconsistent_updates(false),
+      _enable_metadata_only_fetch_phase_for_inconsistent_updates(true),
       _enable_operation_cancellation(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
@@ -145,10 +145,8 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
 
     _disableBucketActivation = config.disableBucketActivation;
     _allowStaleReadsDuringClusterStateTransitions = config.allowStaleReadsDuringClusterStateTransitions;
-    _update_fast_path_restart_enabled = config.restartWithFastUpdatePathIfAllGetTimestampsAreConsistent;
     _merge_operations_disabled = config.mergeOperationsDisabled;
     _use_weak_internal_read_consistency_for_client_gets = config.useWeakInternalReadConsistencyForClientGets;
-    _enable_metadata_only_fetch_phase_for_inconsistent_updates = config.enableMetadataOnlyFetchPhaseForInconsistentUpdates;
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_operation_cancellation = config.enableOperationCancellation;
     _minimumReplicaCountingMode = deriveReplicaCountingMode(config.minimumReplicaCountingMode);
@@ -161,6 +159,10 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
     }
     _simulated_db_pruning_latency = std::chrono::milliseconds(std::max(0, config.simulatedDbPruningLatencyMsec));
     _simulated_db_merging_latency = std::chrono::milliseconds(std::max(0, config.simulatedDbMergingLatencyMsec));
+
+    // TODO GC
+    _update_fast_path_restart_enabled = true;
+    _enable_metadata_only_fetch_phase_for_inconsistent_updates = true;
 
     LOG(debug,
         "Distributor now using new configuration parameters. Split limits: %d docs/%d bytes. "

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -271,10 +271,10 @@ private:
     bool _enableInconsistentJoin;
     bool _disableBucketActivation;
     bool _allowStaleReadsDuringClusterStateTransitions;
-    bool _update_fast_path_restart_enabled;
+    bool _update_fast_path_restart_enabled; //TODO Rewrite tests and GC
     bool _merge_operations_disabled;
     bool _use_weak_internal_read_consistency_for_client_gets;
-    bool _enable_metadata_only_fetch_phase_for_inconsistent_updates;
+    bool _enable_metadata_only_fetch_phase_for_inconsistent_updates; //TODO Rewrite tests and GC
     bool _enable_operation_cancellation;
 
     ReplicaCountingMode _minimumReplicaCountingMode;

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -112,17 +112,6 @@ allow_stale_reads_during_cluster_state_transitions bool default=false
 simulated_db_pruning_latency_msec int default=0
 simulated_db_merging_latency_msec int default=0
 
-## If a bucket is inconsistent and an Update operation is received, a two-phase
-## write-repair path is triggered in which a Get is sent to all diverging replicas.
-## Once received, the update is applied on the distributor and pushed out to the
-## content nodes as Puts.
-## Iff this config is set to true AND all Gets return the same timestamp from all
-## content nodes, the two-phase update path reverts back to the regular fast path.
-## Since all replicas of the document were in sync, applying the update in-place
-## shall be considered safe.
-## DEPRECATED -- always enabled with 3-phase updates.
-restart_with_fast_update_path_if_all_get_timestamps_are_consistent bool default=true
-
 ## If set, no merge operations may be generated for any reason by a distributor.
 ## This is ONLY intended for system testing of certain transient edge cases and
 ## MUST NOT be set to true in a production environment.
@@ -136,15 +125,6 @@ merge_operations_disabled bool default=false
 ## consistent view of fields across document versions.
 ## This is mostly useful in a system that is effectively read-only.
 use_weak_internal_read_consistency_for_client_gets bool default=false
-
-## If true, adds an initial metadata-only fetch phase to updates that touch buckets
-## with inconsistent replicas. Metadata timestamps are compared and a single full Get
-## is sent _only_ to one node with the highest timestamp. Without a metadata phase,
-## full gets would be sent to _all_ nodes.
-## Setting this option to true always implicitly enables the fast update restart
-## feature, so it's not required to set that config to true, nor will setting it
-## to false actually disable the feature.
-enable_metadata_only_fetch_phase_for_inconsistent_updates bool default=true
 
 ## If a distributor main thread tick is constantly processing requests or responses
 ## originating from other nodes, setting this value above zero will prevent implicit

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.cpp
@@ -93,9 +93,8 @@ TwoPhaseUpdateOperation::ensureUpdateReplyCreated()
 }
 
 void
-TwoPhaseUpdateOperation::sendReply(
-        DistributorStripeMessageSender& sender,
-        std::shared_ptr<api::UpdateReply> reply)
+TwoPhaseUpdateOperation::sendReply(DistributorStripeMessageSender& sender,
+                                   const std::shared_ptr<api::UpdateReply> & reply)
 {
     assert(!_replySent);
     reply->getTrace().addChild(std::move(_trace));

--- a/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
+++ b/storage/src/vespa/storage/distributor/operations/external/twophaseupdateoperation.h
@@ -92,7 +92,7 @@ private:
     static const char* stateToString(SendState) noexcept;
 
     void sendReply(DistributorStripeMessageSender&,
-                   std::shared_ptr<api::UpdateReply>);
+                   const std::shared_ptr<api::UpdateReply> &);
     void sendReplyWithResult(DistributorStripeMessageSender&, const api::ReturnCode&);
     void ensureUpdateReplyCreated();
 


### PR DESCRIPTION
…and restart_with_fast_update_path_if_all_get_timestamps_are_consistent to true.

- The tests expecting depending on these flags specify these values explicit.

@vekterli PR