### PR TITLE
Align flow stats calculation for leaf blueprints.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -223,11 +223,6 @@ public:
         setEstimate(HitEstimate(_activeLids.size(), false));
     }
 
-    FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
-        auto est = abs_to_rel_est(getState().estimate().estHits, docid_limit);
-        return {est, 1.0, est};
-    }
-
     bool isWhiteList() const noexcept final { return true; }
 
     SearchIterator::UP createFilterSearch(bool strict, FilterConstraint) const override {

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -718,14 +718,7 @@ FlowStats
 LeafBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 {
     double rel_est = abs_to_rel_est(_state.estimate().estHits, docid_limit);
-    if (rel_est > 0.9) {
-        // Assume we do not really know how much we are matching when
-        // we claim to match 'everything'. Also assume we are not able
-        // to skip documents efficiently when strict.
-        return {0.5, 1.0, 1.0};
-    } else {
-        return {rel_est, 1.0, rel_est};
-    }
+    return {rel_est, 1.0, rel_est};
 }
 
 void


### PR DESCRIPTION
A special case is added for attributes without a known hit estimate, instead of trying to deduce this based on the size of the (legacy) absolute hit estimate.

@havardpe please review