### PR TITLE
- Complete dumping of 1 index field before progressing to the next.

### DIFF
--- a/searchcore/src/tests/proton/feed_and_search/feed_and_search_test.cpp
+++ b/searchcore/src/tests/proton/feed_and_search/feed_and_search_test.cpp
@@ -176,12 +176,14 @@ void Test::requireThatMemoryIndexCanBeDumpedAndSearched() {
     const string index_dir = "test_index";
     const uint32_t docIdLimit = memory_index.getDocIdLimit();
     const uint64_t num_words = memory_index.getNumWords();
-    IndexBuilder index_builder(schema, index_dir, docIdLimit);
     search::TuneFileIndexing tuneFileIndexing;
     DummyFileHeaderContext fileHeaderContext;
-    index_builder.open(num_words, MockFieldLengthInspector(), tuneFileIndexing, fileHeaderContext);
-    memory_index.dump(index_builder);
-    index_builder.close();
+    {
+        MockFieldLengthInspector fieldLengthInspector;
+        IndexBuilder index_builder(schema, index_dir, docIdLimit, num_words,
+                                   fieldLengthInspector, tuneFileIndexing, fileHeaderContext);
+        memory_index.dump(index_builder);
+    }
 
     // Fusion test.  Keep all documents to get an "indentical" copy.
     const string index_dir2 = "test_index2";

--- a/searchcore/src/vespa/searchcore/proton/index/memoryindexwrapper.cpp
+++ b/searchcore/src/vespa/searchcore/proton/index/memoryindexwrapper.cpp
@@ -36,11 +36,10 @@ MemoryIndexWrapper::flushToDisk(const vespalib::string &flushDir, uint32_t docId
 {
     const uint64_t numWords = _index.getNumWords();
     _index.freeze(); // TODO(geirst): is this needed anymore?
-    IndexBuilder indexBuilder(_index.getSchema(), flushDir, docIdLimit);
     SerialNumFileHeaderContext fileHeaderContext(_fileHeaderContext, serialNum);
-    indexBuilder.open(numWords, *this, _tuneFileIndexing, fileHeaderContext);
+    IndexBuilder indexBuilder(_index.getSchema(), flushDir, docIdLimit,
+                              numWords, *this, _tuneFileIndexing, fileHeaderContext);
     _index.dump(indexBuilder);
-    indexBuilder.close();
 }
 
 search::SerialNum

--- a/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
+++ b/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
@@ -382,7 +382,8 @@ DiskIndexTest::build_index(const IOSettings& io_settings, const EmptySettings& e
     if (empty_settings._empty_word) {
         name << "we";
     }
-    openIndex(name.str(), io_settings._use_directio, io_settings._use_mmap, empty_settings._empty_field, empty_settings._empty_doc, empty_settings._empty_word);
+    openIndex(name.str(), io_settings._use_directio, io_settings._use_mmap, empty_settings._empty_field,
+              empty_settings._empty_doc, empty_settings._empty_word);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/diskindex.cpp
@@ -81,8 +81,7 @@ bool
 DiskIndex::openDictionaries(const TuneFileSearch &tuneFileSearch)
 {
     for (SchemaUtil::IndexIterator itr(_schema); itr.isValid(); ++itr) {
-        vespalib::string dictName =
-            _indexDir + "/" + itr.getName() + "/dictionary";
+        vespalib::string dictName = _indexDir + "/" + itr.getName() + "/dictionary";
         auto dict = std::make_unique<PageDict4RandRead>();
         if (!dict->open(dictName, tuneFileSearch._read)) {
             LOG(warning, "Could not open disk dictionary '%s'", dictName.c_str());
@@ -152,7 +151,10 @@ DiskIndex::openField(const vespalib::string &fieldDir,
 bool
 DiskIndex::setup(const TuneFileSearch &tuneFileSearch)
 {
-    if (!loadSchema() || !openDictionaries(tuneFileSearch)) {
+    if (!loadSchema() ) {
+        return false;
+    }
+    if (!openDictionaries(tuneFileSearch)) {
         return false;
     }
     for (SchemaUtil::IndexIterator itr(_schema); itr.isValid(); ++itr) {

--- a/searchlib/src/vespa/searchlib/diskindex/indexbuilder.h
+++ b/searchlib/src/vespa/searchlib/diskindex/indexbuilder.h
@@ -22,43 +22,26 @@ class BitVectorCandidate;
 class IndexBuilder : public index::IndexBuilder {
 public:
     // Schema argument must live until IndexBuilder has been deleted.
-    IndexBuilder(const index::Schema &schema, vespalib::stringref prefix, uint32_t docIdLimit);
+    IndexBuilder(const index::Schema &schema, vespalib::stringref prefix, uint32_t docIdLimit,
+                 uint64_t numWordIds, const index::IFieldLengthInspector &field_length_inspector,
+                 const TuneFileIndexing &tuneFileIndexing, const search::common::FileHeaderContext &fileHeaderContext);
     ~IndexBuilder() override;
 
-    void startField(uint32_t fieldId) override;
-    void endField() override;
-    void startWord(vespalib::stringref word) override;
-    void endWord() override;
-    void add_document(const index::DocIdAndFeatures &features) override;
+    std::unique_ptr<index::FieldIndexBuilder> startField(uint32_t fieldId) override;
     vespalib::string appendToPrefix(vespalib::stringref name) const;
-
-    void open(uint64_t numWordIds, const index::IFieldLengthInspector &field_length_inspector,
-              const TuneFileIndexing &tuneFileIndexing,
-              const common::FileHeaderContext &fileHandleContext);
-
-    void close();
 private:
-    class FieldHandle;
     const index::Schema      &_schema;
-    std::vector<FieldHandle>  _fields;
+    std::vector<int>          _fields;
     const vespalib::string    _prefix;
-    vespalib::string          _curWord;
     const uint32_t            _docIdLimit;
-    int32_t                   _curFieldId;
-    uint32_t                  _lowestOKFieldId;
-    uint32_t                  _curDocId;
-    bool                      _inWord;
-
-    static std::vector<IndexBuilder::FieldHandle> extractFields(const index::Schema &schema, IndexBuilder & builder);
-
-    static uint32_t noDocId() {
-        return std::numeric_limits<uint32_t>::max();
-    }
+    const uint32_t            _numWordIds;
+    const index::IFieldLengthInspector       &_field_length_inspector;
+    const TuneFileIndexing                   &_tuneFileIndexing;
+    const search::common::FileHeaderContext  &_fileHeaderContext;
 
     static uint64_t noWordNumHigh() {
         return std::numeric_limits<uint64_t>::max();
     }
-    FieldHandle & currentField();
 };
 
 }

--- a/searchlib/src/vespa/searchlib/index/indexbuilder.h
+++ b/searchlib/src/vespa/searchlib/index/indexbuilder.h
@@ -2,12 +2,21 @@
 #pragma once
 
 #include <vespa/vespalib/stllike/string.h>
+#include <memory>
 
 namespace search::index {
 
 class DocIdAndFeatures;
 class Schema;
 class WordDocElementWordPosFeatures;
+
+class FieldIndexBuilder {
+public:
+    virtual ~FieldIndexBuilder() = default;
+    virtual void startWord(vespalib::stringref word) = 0;
+    virtual void endWord() = 0;
+    virtual void add_document(const DocIdAndFeatures &features) = 0;
+};
 
 /**
  * Interface used to build an index for the set of index fields specified in a schema.
@@ -22,14 +31,9 @@ protected:
     const Schema &_schema;
 
 public:
-    IndexBuilder(const Schema &schema);
-
+    explicit IndexBuilder(const Schema &schema);
     virtual ~IndexBuilder();
-    virtual void startField(uint32_t fieldId) = 0;
-    virtual void endField() = 0;
-    virtual void startWord(vespalib::stringref word) = 0;
-    virtual void endWord() = 0;
-    virtual void add_document(const DocIdAndFeatures &features) = 0;
+    virtual std::unique_ptr<FieldIndexBuilder> startField(uint32_t fieldId) = 0;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -149,7 +149,7 @@ FieldIndex<interleaved_features>::compactFeatures()
 
 template <bool interleaved_features>
 void
-FieldIndex<interleaved_features>::dump(search::index::IndexBuilder & indexBuilder)
+FieldIndex<interleaved_features>::dump(search::index::FieldIndexBuilder & indexBuilder)
 {
     vespalib::stringref word;
     FeatureStore::DecodeContextCooked decoder(nullptr);

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.h
@@ -82,7 +82,7 @@ public:
 
     void compactFeatures() override;
 
-    void dump(search::index::IndexBuilder & indexBuilder) override;
+    void dump(search::index::FieldIndexBuilder & indexBuilder) override;
 
     vespalib::MemoryUsage getMemoryUsage() const override;
     PostingListStore &getPostingListStore() { return _postingListStore; }
@@ -98,8 +98,7 @@ public:
     /**
      * Should only by used by unit tests.
      */
-    queryeval::SearchIterator::UP make_search_iterator(const vespalib::string& term,
-                                                       uint32_t field_id,
+    queryeval::SearchIterator::UP make_search_iterator(const vespalib::string& term, uint32_t field_id,
                                                        fef::TermFieldMatchDataArray match_data) const;
 
     std::unique_ptr<queryeval::SimpleLeafBlueprint> make_term_blueprint(const vespalib::string& term,

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.cpp
@@ -6,13 +6,9 @@
 #include <vespa/searchlib/bitcompression/posocccompression.h>
 #include <vespa/searchlib/index/i_field_length_inspector.h>
 #include <vespa/searchcommon/common/schema.h>
-#include <vespa/vespalib/btree/btree.hpp>
 #include <vespa/vespalib/btree/btreeiterator.hpp>
-#include <vespa/vespalib/btree/btreenode.hpp>
 #include <vespa/vespalib/btree/btreenodeallocator.hpp>
 #include <vespa/vespalib/btree/btreenodestore.hpp>
-#include <vespa/vespalib/btree/btreeroot.hpp>
-#include <vespa/vespalib/btree/btreestore.hpp>
 #include <vespa/vespalib/util/exceptions.h>
 
 namespace search {
@@ -46,9 +42,10 @@ void
 FieldIndexCollection::dump(search::index::IndexBuilder &indexBuilder)
 {
     for (uint32_t fieldId = 0; fieldId < _numFields; ++fieldId) {
-        indexBuilder.startField(fieldId);
-        _fieldIndexes[fieldId]->dump(indexBuilder);
-        indexBuilder.endField();
+        auto fieldIndexBuilder = indexBuilder.startField(fieldId);
+        if (fieldIndexBuilder) {
+            _fieldIndexes[fieldId]->dump(*fieldIndexBuilder);
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index_collection.h
@@ -10,6 +10,7 @@
 namespace search::index {
     class IFieldLengthInspector;
     class Schema;
+    class IndexBuilder;
 }
 
 namespace search::memoryindex {

--- a/searchlib/src/vespa/searchlib/memoryindex/i_field_index.h
+++ b/searchlib/src/vespa/searchlib/memoryindex/i_field_index.h
@@ -12,7 +12,7 @@ namespace search::queryeval {
 }
 namespace search::index {
 class FieldLengthCalculator;
-class IndexBuilder;
+class FieldIndexBuilder;
 }
 
 namespace search::memoryindex {
@@ -37,7 +37,7 @@ public:
     virtual FieldIndexRemover& getDocumentRemover() = 0;
     virtual index::FieldLengthCalculator& get_calculator() = 0;
     virtual void compactFeatures() = 0;
-    virtual void dump(search::index::IndexBuilder& indexBuilder) = 0;
+    virtual void dump(search::index::FieldIndexBuilder& builder) = 0;
 
     virtual std::unique_ptr<queryeval::SimpleLeafBlueprint> make_term_blueprint(const vespalib::string& term,
                                                                                 const queryeval::FieldSpec& field,

--- a/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
+++ b/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
@@ -79,27 +79,29 @@ TestDiskIndex::buildIndex(const std::string & dir, bool directio,
 {
     Builder b(dir, _schema, docEmpty ? 1 : 32, wordEmpty ? 0 : 2, directio);
 
-    // f1
-    auto fb = b._ib.startField(0);
-    if (!wordEmpty && !fieldEmpty && !docEmpty) {
-        fb->startWord("w1");
-        b.addDoc(*fb, 1);
-        b.addDoc(*fb, 3);
-        fb->endWord();
-    }
-    fb = b._ib.startField(1);
-    if (!wordEmpty && !fieldEmpty && !docEmpty) {
-        // f2
-        fb->startWord("w1");
-        b.addDoc(*fb, 2);
-        b.addDoc(*fb, 4);
-        b.addDoc(*fb, 6);
-        fb->endWord();
-        fb->startWord("w2");
-        for (uint32_t docId = 1; docId < 18; ++docId) {
-            b.addDoc(*fb, docId);
+    if (!fieldEmpty) {
+        // f1
+        auto fb = b._ib.startField(0);
+        if (!wordEmpty && !docEmpty) {
+            fb->startWord("w1");
+            b.addDoc(*fb, 1);
+            b.addDoc(*fb, 3);
+            fb->endWord();
         }
-        fb->endWord();
+        fb = b._ib.startField(1);
+        if (!wordEmpty && !docEmpty) {
+            // f2
+            fb->startWord("w1");
+            b.addDoc(*fb, 2);
+            b.addDoc(*fb, 4);
+            b.addDoc(*fb, 6);
+            fb->endWord();
+            fb->startWord("w2");
+            for (uint32_t docId = 1; docId < 18; ++docId) {
+                b.addDoc(*fb, docId);
+            }
+            fb->endWord();
+        }
     }
 }
 

--- a/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
+++ b/searchlib/src/vespa/searchlib/test/diskindex/testdiskindex.cpp
@@ -35,39 +35,30 @@ class MockFieldLengthInspector : public IFieldLengthInspector {
 
 struct Builder
 {
-    search::diskindex::IndexBuilder _ib;
     MockFieldLengthInspector        _mock_field_length_inspector;
     TuneFileIndexing                _tuneFileIndexing;
     DummyFileHeaderContext          _fileHeaderContext;
+    search::diskindex::IndexBuilder _ib;
     DocIdAndFeatures                _features;
 
-    Builder(const std::string &dir,
-            const Schema &s,
-            uint32_t docIdLimit,
-            uint64_t numWordIds,
-            bool directio)
-        : _ib(s, dir, docIdLimit),
-          _tuneFileIndexing(),
+    Builder(const std::string &dir, const Schema &s, uint32_t docIdLimit, uint64_t numWordIds, bool directio)
+        : _tuneFileIndexing(),
           _fileHeaderContext(),
+          _ib(s, dir, docIdLimit,numWordIds, _mock_field_length_inspector, _tuneFileIndexing, _fileHeaderContext),
           _features()
     {
         if (directio) {
             _tuneFileIndexing._read.setWantDirectIO();
             _tuneFileIndexing._write.setWantDirectIO();
         }
-        _ib.open(numWordIds, _mock_field_length_inspector, _tuneFileIndexing, _fileHeaderContext);
     }
 
-    void addDoc(uint32_t docId) {
+    void addDoc(index::FieldIndexBuilder & fb, uint32_t docId) {
         _features.clear(docId);
         _features.elements().emplace_back(0, 1, 1);
         _features.elements().back().setNumOccs(1);
         _features.word_positions().emplace_back(0);
-        _ib.add_document(_features);
-    }
-
-    void close() {
-        _ib.close();
+        fb.add_document(_features);
     }
 };
 
@@ -84,37 +75,37 @@ TestDiskIndex::buildSchema()
 
 void
 TestDiskIndex::buildIndex(const std::string & dir, bool directio,
-                 bool fieldEmpty, bool docEmpty, bool wordEmpty)
+                          bool fieldEmpty, bool docEmpty, bool wordEmpty)
 {
     Builder b(dir, _schema, docEmpty ? 1 : 32, wordEmpty ? 0 : 2, directio);
+
+    // f1
+    auto fb = b._ib.startField(0);
     if (!wordEmpty && !fieldEmpty && !docEmpty) {
-        // f1
-        b._ib.startField(0);
-        b._ib.startWord("w1");
-        b.addDoc(1);
-        b.addDoc(3);
-        b._ib.endWord();
-        b._ib.endField();
-        // f2
-        b._ib.startField(1);
-        b._ib.startWord("w1");
-        b.addDoc(2);
-        b.addDoc(4);
-        b.addDoc(6);
-        b._ib.endWord();
-        b._ib.startWord("w2");
-        for (uint32_t docId = 1; docId < 18; ++docId) {
-            b.addDoc(docId);
-        }
-        b._ib.endWord();
-        b._ib.endField();
+        fb->startWord("w1");
+        b.addDoc(*fb, 1);
+        b.addDoc(*fb, 3);
+        fb->endWord();
     }
-    b.close();
+    fb = b._ib.startField(1);
+    if (!wordEmpty && !fieldEmpty && !docEmpty) {
+        // f2
+        fb->startWord("w1");
+        b.addDoc(*fb, 2);
+        b.addDoc(*fb, 4);
+        b.addDoc(*fb, 6);
+        fb->endWord();
+        fb->startWord("w2");
+        for (uint32_t docId = 1; docId < 18; ++docId) {
+            b.addDoc(*fb, docId);
+        }
+        fb->endWord();
+    }
 }
 
 void
 TestDiskIndex::openIndex(const std::string &dir, bool directio, bool readmmap,
-                bool fieldEmpty, bool docEmpty, bool wordEmpty)
+                         bool fieldEmpty, bool docEmpty, bool wordEmpty)
 {
     buildIndex(dir, directio, fieldEmpty, docEmpty, wordEmpty);
     TuneFileRandRead    tuneFileRead;


### PR DESCRIPTION
- This prevents allocating memory buffers, and file descriptors for all fields concurrently.
- It will reduce memory footprint during flush if there are many fields.

@toregge or @geirst PR