### PR TITLE
All embedders are the same

### DIFF
--- a/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MbusRequestContext.java
+++ b/docproc/src/main/java/com/yahoo/docproc/jdisc/messagebus/MbusRequestContext.java
@@ -122,7 +122,7 @@ public class MbusRequestContext implements RequestContext, ResponseHandler {
         if (exception instanceof HandledProcessingException) {
             errorMsg.append(" Error message: ").append(exception.getMessage());
         } else if (exception != null) {
-            errorMsg.append(" Error message: ").append(exception.toString());
+            errorMsg.append(" Error message: ").append(exception);
         }
         errorMsg.append(" -- See Vespa log for details.");
         processingFailed(errorCode, errorMsg.toString());

--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
@@ -204,15 +204,11 @@ public class EmbedExpression extends Expression  {
     }
 
     @Override
-    public int hashCode() { return Objects.hash(embedder.hashCode(), embedder, embedderArguments); }
+    public int hashCode() { return EmbedExpression.class.hashCode(); }
 
     @Override
     public boolean equals(Object o) {
-        if ( ! super.equals(o)) return false;
-        if ( ! (o instanceof EmbedExpression other)) return false;
-        if ( ! Objects.equals(embedder, other.embedder)) return false;
-        if ( ! Objects.equals(embedderArguments, other.embedderArguments)) return false;
-        return true;
+        return o instanceof EmbedExpression;
     }
 
     private static String validEmbedders(Map<String, Embedder> embedders) {

--- a/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
+++ b/model-integration/src/main/java/ai/vespa/embedding/ColBertEmbedder.java
@@ -242,8 +242,8 @@ public class ColBertEmbedder extends AbstractComponent implements Embedder {
         int wantedDimensionality = type.indexedSubtype().dimensions().get(0).size().get().intValue();
         int resultDimensionality = (int)result.shape()[2];
         if (resultDimensionality != wantedDimensionality) {
-            throw new IllegalArgumentException("Not possible to map token vector embedding with " + resultDimensionality
-                    + " + dimensions into tensor with " + wantedDimensionality);
+            throw new IllegalArgumentException("Not possible to map token vector embedding with " + resultDimensionality +
+                                               " dimensions into tensor with " + wantedDimensionality);
         }
         Tensor.Builder builder = Tensor.Builder.of(type);
         for (int token = 0; token < nTokens; token++) {


### PR DESCRIPTION
This is to avoid a validation override from changed indexing expression when embedder details are changed.
