### PR TITLE
- Drop the optimization from long to int and just use long throughout.

### DIFF
--- a/document/src/main/java/com/yahoo/document/update/TensorModifyUpdate.java
+++ b/document/src/main/java/com/yahoo/document/update/TensorModifyUpdate.java
@@ -119,7 +119,7 @@ public class TensorModifyUpdate extends ValueUpdate<TensorFieldValue> {
         for (int i = 0; i < type.dimensions().size(); ++i) {
             var dim = type.dimensions().get(i);
             if (dim.isMapped()) {
-                builder.add(dim.name(), (int) address.numericLabel(i));
+                builder.add(dim.name(), address.numericLabel(i));
             }
         }
         return builder.build();

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/UnpackBitsNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/UnpackBitsNode.java
@@ -121,7 +121,7 @@ public class UnpackBitsNode extends CompositeNode {
                         long newIdx = oldAddr.numericLabel(i) * 8 + bitIdx;
                         addrBuilder.add(dim.name(), newIdx);
                     } else {
-                        addrBuilder.add(dim.name(), (int) oldAddr.numericLabel(i));
+                        addrBuilder.add(dim.name(), oldAddr.numericLabel(i));
                     }
                 }
                 var newAddr = addrBuilder.build();

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1281,8 +1281,8 @@
       "public void <init>(com.yahoo.tensor.TensorType)",
       "public com.yahoo.tensor.TensorAddress$Builder add(java.lang.String)",
       "public com.yahoo.tensor.TensorAddress$Builder add(java.lang.String, java.lang.String)",
-      "public com.yahoo.tensor.TensorAddress$Builder add(java.lang.String, long)",
       "public com.yahoo.tensor.TensorAddress$Builder add(java.lang.String, int)",
+      "public com.yahoo.tensor.TensorAddress$Builder add(java.lang.String, long)",
       "public com.yahoo.tensor.TensorAddress$Builder copy()",
       "public com.yahoo.tensor.TensorType type()",
       "public com.yahoo.tensor.TensorAddress build()"

--- a/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/TensorAddress.java
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.tensor;
 
-import com.yahoo.tensor.impl.Convert;
 import com.yahoo.tensor.impl.Label;
 import com.yahoo.tensor.impl.TensorAddressAny;
 
@@ -105,16 +104,16 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
 
     /** Returns an address with only some of the dimension. Ordering will also be according to indexMap */
     public TensorAddress partialCopy(int[] indexMap) {
-        int[] labels = new int[indexMap.length];
+        long[] labels = new long[indexMap.length];
         for (int i = 0; i < labels.length; ++i) {
-            labels[i] = (int)numericLabel(indexMap[i]);
+            labels[i] = numericLabel(indexMap[i]);
         }
         return TensorAddressAny.ofUnsafe(labels);
     }
 
     /** Creates a complete address by taking the mapped dimmensions from this and the indexed from the indexedPart */
     public TensorAddress fullAddressOf(List<TensorType.Dimension> dimensions, int[] densePart) {
-        int[] labels = new int[dimensions.size()];
+        long[] labels = new long[dimensions.size()];
         int mappedIndex = 0;
         int indexedIndex = 0;
         for (int i = 0; i < labels.length; i++) {
@@ -123,7 +122,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
                 labels[i] = densePart[indexedIndex];
                 indexedIndex++;
             } else {
-                labels[i] = (int)numericLabel(mappedIndex);
+                labels[i] = numericLabel(mappedIndex);
                 mappedIndex++;
             }
         }
@@ -144,7 +143,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
         for (int i = 0; i < dimensions.size(); ++i) {
             TensorType.Dimension dimension = dimensions.get(i);
             if ( ! dimension.isIndexed())
-                builder.add(dimension.name(), (int)numericLabel(i));
+                builder.add(dimension.name(), numericLabel(i));
         }
         return builder.build();
     }
@@ -153,10 +152,10 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
     public static class Builder {
 
         final TensorType type;
-        final int[] labels;
+        final long[] labels;
 
-        private static int[] createEmptyLabels(int size) {
-            int[] labels = new int[size];
+        private static long[] createEmptyLabels(int size) {
+            long[] labels = new long[size];
             Arrays.fill(labels, Tensor.invalidIndex);
             return labels;
         }
@@ -165,7 +164,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
             this(type, createEmptyLabels(type.dimensions().size()));
         }
 
-        private Builder(TensorType type, int[] labels) {
+        private Builder(TensorType type, long[] labels) {
             this.type = type;
             this.labels = labels;
         }
@@ -199,10 +198,12 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
             return this;
         }
 
-        public Builder add(String dimension, long label) {
-            return add(dimension, Convert.safe2Int(label));
-        }
+        @Deprecated
         public Builder add(String dimension, int label) {
+            return add(dimension, (long) label);
+        }
+
+        public Builder add(String dimension, long label) {
             Objects.requireNonNull(dimension, "dimension cannot be null");
             int labelIndex = type.indexOfDimensionAsInt(dimension);
             if ( labelIndex < 0)
@@ -240,7 +241,7 @@ public abstract class TensorAddress implements Comparable<TensorAddress> {
             super(type);
         }
 
-        private PartialBuilder(TensorType type, int[] labels) {
+        private PartialBuilder(TensorType type, long[] labels) {
             super(type, labels);
         }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
@@ -355,16 +355,16 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
         }
 
         TensorAddress combine(TensorAddress match, TensorAddress leftOnly, TensorAddress rightOnly, int concatDimIdx) {
-            int[] labels = new int[plan.resultType.rank()];
+            long[] labels = new long[plan.resultType.rank()];
             int out = 0;
             int m = 0;
             int a = 0;
             int b = 0;
             for (var how : plan.combineHow) {
                 switch (how) {
-                    case left -> labels[out++] = (int) leftOnly.numericLabel(a++);
-                    case right -> labels[out++] = (int) rightOnly.numericLabel(b++);
-                    case both -> labels[out++] =   (int) match.numericLabel(m++);
+                    case left -> labels[out++] = leftOnly.numericLabel(a++);
+                    case right -> labels[out++] = rightOnly.numericLabel(b++);
+                    case both -> labels[out++] = match.numericLabel(m++);
                     case concat -> labels[out++] = concatDimIdx;
                     default -> throw new IllegalArgumentException("cannot handle: " + how);
                 }
@@ -399,8 +399,8 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
 
         CellVectorMapMap decompose(Tensor input, SplitHow how) {
             var iter = input.cellIterator();
-            int[] commonLabels = new int[(int)how.numCommon()];
-            int[] separateLabels = new int[(int)how.numSeparate()];
+            long[] commonLabels = new long[(int)how.numCommon()];
+            long[] separateLabels = new long[(int)how.numSeparate()];
             CellVectorMapMap result = new CellVectorMapMap();
             while (iter.hasNext()) {
                 var cell = iter.next();
@@ -410,8 +410,8 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
                 int separateIdx = 0;
                 for (int i = 0; i < how.handleDims.size(); i++) {
                     switch (how.handleDims.get(i)) {
-                        case common -> commonLabels[commonIdx++] = (int) addr.numericLabel(i);
-                        case separate -> separateLabels[separateIdx++] = (int) addr.numericLabel(i);
+                        case common -> commonLabels[commonIdx++] = addr.numericLabel(i);
+                        case separate -> separateLabels[separateIdx++] = addr.numericLabel(i);
                         case concat -> ccDimIndex = addr.numericLabel(i);
                         default -> throw new IllegalArgumentException("cannot handle: " + how.handleDims.get(i));
                     }

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Join.java
@@ -12,7 +12,6 @@ import com.yahoo.tensor.TypeResolver;
 import com.yahoo.tensor.evaluation.EvaluationContext;
 import com.yahoo.tensor.evaluation.Name;
 import com.yahoo.tensor.evaluation.TypeContext;
-import com.yahoo.tensor.impl.Convert;
 import com.yahoo.tensor.impl.TensorAddressAny;
 
 import java.util.ArrayList;
@@ -377,7 +376,7 @@ public class Join<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETYP
 
     private static TensorAddress joinAddresses(TensorAddress a, int[] aToIndexes, TensorAddress b, int[] bToIndexes,
                                                TensorType joinedType) {
-        int[] joinedLabels = new int[joinedType.dimensions().size()];
+        long[] joinedLabels = new long[joinedType.dimensions().size()];
         Arrays.fill(joinedLabels, Tensor.invalidIndex);
         mapContent(a, joinedLabels, aToIndexes);
         boolean compatible = mapContent(b, joinedLabels, bToIndexes);
@@ -391,10 +390,10 @@ public class Join<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETYP
      * @return true if the mapping was successful, false if one of the destination positions was
      *         occupied by a different value
      */
-    private static boolean mapContent(TensorAddress from, int[] to, int[] indexMap) {
+    private static boolean mapContent(TensorAddress from, long[] to, int[] indexMap) {
         for (int i = 0, size = from.size(); i < size; i++) {
             int toIndex = indexMap[i];
-            int label = Convert.safe2Int(from.numericLabel(i));
+            long label = from.numericLabel(i);
             if (to[toIndex] != Tensor.invalidIndex && to[toIndex] != label)
                 return false;
             to[toIndex] = label;

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Slice.java
@@ -52,7 +52,7 @@ public class Slice<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETY
     public List<TensorFunction<NAMETYPE>> selectorFunctions() {
         var result = new ArrayList<TensorFunction<NAMETYPE>>();
         for (var dimVal : subspaceAddress) {
-            dimVal.index().ifPresent(fun -> fun.asTensorFunction().ifPresent(tf -> result.add(tf)));
+            dimVal.index().flatMap(ScalarFunction::asTensorFunction).ifPresent(result::add);
         }
         return result;
     }
@@ -131,7 +131,7 @@ public class Slice<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMETY
         for (int i = 0; i < address.size(); i++) {
             String dimension = type.dimensions().get(i).name();
             if (subspaceType.dimension(type.dimensions().get(i).name()).isPresent())
-                b.add(dimension, (int)address.numericLabel(i));
+                b.add(dimension, address.numericLabel(i));
         }
         return b.build();
     }

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/Label.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/Label.java
@@ -18,7 +18,7 @@ public class Label {
 
     private static final String[] SMALL_INDEXES = createSmallIndexesAsStrings(1000);
 
-    private final static Map<String, Integer> string2Enum = new ConcurrentHashMap<>();
+    private final static Map<String, Long> string2Enum = new ConcurrentHashMap<>();
 
     // Index 0 is unused, that is a valid positive number
     // 1(-1) is reserved for the Tensor.INVALID_INDEX
@@ -33,7 +33,7 @@ public class Label {
         return asStrings;
     }
 
-    private static int addNewUniqueString(String s) {
+    private static long addNewUniqueString(String s) {
         synchronized (string2Enum) {
             if (numUniqeStrings >= uniqueStrings.length) {
                 uniqueStrings = Arrays.copyOf(uniqueStrings, uniqueStrings.length*2);
@@ -56,28 +56,25 @@ public class Label {
         return true;
     }
 
-    public static int toNumber(String s) {
+    public static long toNumber(String s) {
         if (s == null) { return Tensor.invalidIndex; }
         try {
             if (validNumericIndex(s)) {
-                return Integer.parseInt(s);
+                return Long.parseLong(s, 10);
             }
         } catch (NumberFormatException e) {
         }
         return string2Enum.computeIfAbsent(s, Label::addNewUniqueString);
     }
 
-    public static String fromNumber(int v) {
+    public static String fromNumber(long v) {
         if (v >= 0) {
             return asNumericString(v);
         } else {
             if (v == Tensor.invalidIndex) { return null; }
-            return uniqueStrings[-v];
+            int index = -Convert.safe2Int(v);
+            return uniqueStrings[index];
         }
-    }
-
-    public static String fromNumber(long v) {
-        return fromNumber(Convert.safe2Int(v));
     }
 
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny.java
@@ -5,7 +5,8 @@ package com.yahoo.tensor.impl;
 import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorAddress;
 
-import static com.yahoo.tensor.impl.Convert.safe2Int;
+import java.util.Arrays;
+
 import static com.yahoo.tensor.impl.Label.toNumber;
 import static com.yahoo.tensor.impl.Label.fromNumber;
 
@@ -21,7 +22,7 @@ abstract public class TensorAddressAny extends TensorAddress {
 
     @Override
     public String label(int i) {
-        return fromNumber((int)numericLabel(i));
+        return fromNumber(numericLabel(i));
     }
 
     public static TensorAddress of() {
@@ -45,11 +46,11 @@ abstract public class TensorAddressAny extends TensorAddress {
     }
 
     public static TensorAddress of(String[] labels) {
-        int[] labelsAsInt = new int[labels.length];
+        long[] labelsAsLong = new long[labels.length];
         for (int i = 0; i < labels.length; i++) {
-            labelsAsInt[i] = toNumber(labels[i]);
+            labelsAsLong[i] = toNumber(labels[i]);
         }
-        return ofUnsafe(labelsAsInt);
+        return ofUnsafe(labelsAsLong);
     }
 
     public static TensorAddress of(int label) {
@@ -71,80 +72,60 @@ abstract public class TensorAddressAny extends TensorAddress {
     public static TensorAddress of(int ... labels) {
         return switch (labels.length) {
             case 0 -> of();
-            case 1 -> new TensorAddressAny1(sanitize(labels[0]));
-            case 2 -> new TensorAddressAny2(sanitize(labels[0]), sanitize(labels[1]));
-            case 3 -> new TensorAddressAny3(sanitize(labels[0]), sanitize(labels[1]), sanitize(labels[2]));
-            case 4 -> new TensorAddressAny4(sanitize(labels[0]), sanitize(labels[1]), sanitize(labels[2]), sanitize(labels[3]));
+            case 1 -> of(labels[0]);
+            case 2 -> of(labels[0], labels[1]);
+            case 3 -> of(labels[0], labels[1], labels[2]);
+            case 4 -> of(labels[0], labels[1], labels[2], labels[3]);
             default -> {
+                long[] copy = new long[labels.length];
                 for (int i = 0; i < labels.length; i++) {
-                    sanitize(labels[i]);
+                    copy[i] = sanitize(labels[i]);
                 }
-                yield new TensorAddressAnyN(labels);
+                yield new TensorAddressAnyN(copy);
             }
         };
-    }
-
-    public static TensorAddress of(long label) {
-        return of(safe2Int(label));
-    }
-
-    public static TensorAddress of(long label0, long label1) {
-        return of(safe2Int(label0), safe2Int(label1));
-    }
-
-    public static TensorAddress of(long label0, long label1, long label2) {
-        return of(safe2Int(label0), safe2Int(label1), safe2Int(label2));
-    }
-
-    public static TensorAddress of(long label0, long label1, long label2, long label3) {
-        return of(safe2Int(label0), safe2Int(label1), safe2Int(label2), safe2Int(label3));
     }
 
     public static TensorAddress of(long ... labels) {
         return switch (labels.length) {
             case 0 -> of();
-            case 1 -> ofUnsafe(safe2Int(labels[0]));
-            case 2 -> ofUnsafe(safe2Int(labels[0]), safe2Int(labels[1]));
-            case 3 -> ofUnsafe(safe2Int(labels[0]), safe2Int(labels[1]), safe2Int(labels[2]));
-            case 4 -> ofUnsafe(safe2Int(labels[0]), safe2Int(labels[1]), safe2Int(labels[2]), safe2Int(labels[3]));
-            default -> {
-                int[] labelsAsInt = new int[labels.length];
-                for (int i = 0; i < labels.length; i++) {
-                    labelsAsInt[i] = safe2Int(labels[i]);
-                }
-                yield of(labelsAsInt);
-            }
+            case 1 -> of(labels[0]);
+            case 2 -> of(labels[0], labels[1]);
+            case 3 -> of(labels[0], labels[1], labels[2]);
+            case 4 -> of(labels[0], labels[1], labels[2], labels[3]);
+            default -> new TensorAddressAnyN(Arrays.copyOf(labels, labels.length));
+
         };
     }
 
-    private static TensorAddress ofUnsafe(int label) {
+    private static TensorAddress of(long label) {
         return new TensorAddressAny1(label);
     }
 
-    private static TensorAddress ofUnsafe(int label0, int label1) {
+    private static TensorAddress of(long label0, long label1) {
         return new TensorAddressAny2(label0, label1);
     }
 
-    private static TensorAddress ofUnsafe(int label0, int label1, int label2) {
+    public static TensorAddress of(long label0, long label1, long label2) {
         return new TensorAddressAny3(label0, label1, label2);
     }
 
-    private static TensorAddress ofUnsafe(int label0, int label1, int label2, int label3) {
+    public static TensorAddress of(long label0, long label1, long label2, long label3) {
         return new TensorAddressAny4(label0, label1, label2, label3);
     }
 
-    public static TensorAddress ofUnsafe(int ... labels) {
+    public static TensorAddress ofUnsafe(long ... labels) {
         return switch (labels.length) {
             case 0 -> of();
-            case 1 -> ofUnsafe(labels[0]);
-            case 2 -> ofUnsafe(labels[0], labels[1]);
-            case 3 -> ofUnsafe(labels[0], labels[1], labels[2]);
-            case 4 -> ofUnsafe(labels[0], labels[1], labels[2], labels[3]);
+            case 1 -> of(labels[0]);
+            case 2 -> of(labels[0], labels[1]);
+            case 3 -> of(labels[0], labels[1], labels[2]);
+            case 4 -> of(labels[0], labels[1], labels[2], labels[3]);
             default -> new TensorAddressAnyN(labels);
         };
     }
 
-    private static int sanitize(int label) {
+    private static long sanitize(long label) {
         if (label < Tensor.invalidIndex) {
             throw new IndexOutOfBoundsException("cell label " + label + " must be positive");
         }

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny1.java
@@ -11,9 +11,9 @@ import com.yahoo.tensor.TensorAddress;
  */
 final class TensorAddressAny1 extends TensorAddressAny {
 
-    private final int label;
+    private final long label;
 
-    TensorAddressAny1(int label) { this.label = label; }
+    TensorAddressAny1(long label) { this.label = label; }
 
     @Override public int size() { return 1; }
 
@@ -27,11 +27,11 @@ final class TensorAddressAny1 extends TensorAddressAny {
 
     @Override
     public TensorAddress withLabel(int labelIndex, long label) {
-        if (labelIndex == 0) return new TensorAddressAny1(Convert.safe2Int(label));
+        if (labelIndex == 0) return new TensorAddressAny1(label);
         throw new IllegalArgumentException("No label " + labelIndex);
     }
 
-    @Override public int hashCode() { return Math.abs(label); }
+    @Override public int hashCode() { return (int)Math.abs(label); }
 
     @Override
     public boolean equals(Object o) {

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny2.java
@@ -13,9 +13,9 @@ import static java.lang.Math.abs;
  */
 final class TensorAddressAny2 extends TensorAddressAny {
 
-    private final int label0, label1;
+    private final long label0, label1;
 
-    TensorAddressAny2(int label0, int label1) {
+    TensorAddressAny2(long label0, long label1) {
         this.label0 = label0;
         this.label1 = label1;
     }
@@ -34,15 +34,16 @@ final class TensorAddressAny2 extends TensorAddressAny {
     @Override
     public TensorAddress withLabel(int labelIndex, long label) {
         return switch (labelIndex) {
-            case 0 -> new TensorAddressAny2(Convert.safe2Int(label), label1);
-            case 1 -> new TensorAddressAny2(label0, Convert.safe2Int(label));
+            case 0 -> new TensorAddressAny2(label, label1);
+            case 1 -> new TensorAddressAny2(label0, label);
             default -> throw new IllegalArgumentException("No label " + labelIndex);
         };
     }
 
     @Override
     public int hashCode() {
-        return abs(label0) | (abs(label1) << 32 - Integer.numberOfLeadingZeros(abs(label0)));
+        long hash =  abs(label0) | (abs(label1) << (64 - Long.numberOfLeadingZeros(abs(label0))));
+        return (int) hash;
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny3.java
@@ -13,9 +13,9 @@ import static java.lang.Math.abs;
  */
 final class TensorAddressAny3 extends TensorAddressAny {
 
-    private final int label0, label1, label2;
+    private final long label0, label1, label2;
 
-    TensorAddressAny3(int label0, int label1, int label2) {
+    TensorAddressAny3(long label0, long label1, long label2) {
         this.label0 = label0;
         this.label1 = label1;
         this.label2 = label2;
@@ -36,18 +36,19 @@ final class TensorAddressAny3 extends TensorAddressAny {
     @Override
     public TensorAddress withLabel(int labelIndex, long label) {
         return switch (labelIndex) {
-            case 0 -> new TensorAddressAny3(Convert.safe2Int(label), label1, label2);
-            case 1 -> new TensorAddressAny3(label0, Convert.safe2Int(label), label2);
-            case 2 -> new TensorAddressAny3(label0, label1, Convert.safe2Int(label));
+            case 0 -> new TensorAddressAny3(label, label1, label2);
+            case 1 -> new TensorAddressAny3(label0, label, label2);
+            case 2 -> new TensorAddressAny3(label0, label1, label);
             default -> throw new IllegalArgumentException("No label " + labelIndex);
         };
     }
 
     @Override
     public int hashCode() {
-        return abs(label0) |
-                (abs(label1) << (1*32 - Integer.numberOfLeadingZeros(abs(label0)))) |
-                (abs(label2) << (2*32 - (Integer.numberOfLeadingZeros(abs(label0)) + Integer.numberOfLeadingZeros(abs(label1)))));
+        long hash = abs(label0) |
+                (abs(label1) << (1*64 - Long.numberOfLeadingZeros(abs(label0)))) |
+                (abs(label2) << (2*64 - (Long.numberOfLeadingZeros(abs(label0)) + Long.numberOfLeadingZeros(abs(label1)))));
+        return (int) hash;
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAny4.java
@@ -13,9 +13,9 @@ import static java.lang.Math.abs;
  */
 final class TensorAddressAny4 extends TensorAddressAny {
 
-    private final int label0, label1, label2, label3;
+    private final long label0, label1, label2, label3;
 
-    TensorAddressAny4(int label0, int label1, int label2, int label3) {
+    TensorAddressAny4(long label0, long label1, long label2, long label3) {
         this.label0 = label0;
         this.label1 = label1;
         this.label2 = label2;
@@ -38,20 +38,21 @@ final class TensorAddressAny4 extends TensorAddressAny {
     @Override
     public TensorAddress withLabel(int labelIndex, long label) {
         return switch (labelIndex) {
-            case 0 -> new TensorAddressAny4(Convert.safe2Int(label), label1, label2, label3);
-            case 1 -> new TensorAddressAny4(label0, Convert.safe2Int(label), label2, label3);
-            case 2 -> new TensorAddressAny4(label0, label1, Convert.safe2Int(label), label3);
-            case 3 -> new TensorAddressAny4(label0, label1, label2, Convert.safe2Int(label));
+            case 0 -> new TensorAddressAny4(label, label1, label2, label3);
+            case 1 -> new TensorAddressAny4(label0, label, label2, label3);
+            case 2 -> new TensorAddressAny4(label0, label1,label, label3);
+            case 3 -> new TensorAddressAny4(label0, label1, label2, label);
             default -> throw new IllegalArgumentException("No label " + labelIndex);
         };
     }
 
     @Override
     public int hashCode() {
-        return abs(label0) |
-                (abs(label1) << (1*32 - Integer.numberOfLeadingZeros(abs(label0)))) |
-                (abs(label2) << (2*32 - (Integer.numberOfLeadingZeros(abs(label0)) + Integer.numberOfLeadingZeros(abs(label1))))) |
-                (abs(label3) << (3*32 - (Integer.numberOfLeadingZeros(abs(label0)) + Integer.numberOfLeadingZeros(abs(label1)) + Integer.numberOfLeadingZeros(abs(label1)))));
+        long hash =  abs(label0) |
+                (abs(label1) << (1*64 - Long.numberOfLeadingZeros(abs(label0)))) |
+                (abs(label2) << (2*64 - (Long.numberOfLeadingZeros(abs(label0)) + Long.numberOfLeadingZeros(abs(label1))))) |
+                (abs(label3) << (3*64 - (Long.numberOfLeadingZeros(abs(label0)) + Long.numberOfLeadingZeros(abs(label1)) + Long.numberOfLeadingZeros(abs(label1)))));
+        return (int) hash;
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/impl/TensorAddressAnyN.java
@@ -15,9 +15,9 @@ import static java.lang.Math.abs;
  */
 final class TensorAddressAnyN extends TensorAddressAny {
 
-    private final int[] labels;
+    private final long[] labels;
 
-    TensorAddressAnyN(int[] labels) {
+    TensorAddressAnyN(long[] labels) {
         if (labels.length < 1) throw new IllegalArgumentException("Need at least 1 label");
         this.labels = labels;
     }
@@ -28,17 +28,17 @@ final class TensorAddressAnyN extends TensorAddressAny {
 
     @Override
     public TensorAddress withLabel(int labelIndex, long label) {
-        int[] copy = Arrays.copyOf(labels, labels.length);
-        copy[labelIndex] = Convert.safe2Int(label);
+        long[] copy = Arrays.copyOf(labels, labels.length);
+        copy[labelIndex] = label;
         return new TensorAddressAnyN(copy);
     }
 
     @Override public int hashCode() {
-        int hash = abs(labels[0]);
+        long hash = abs(labels[0]);
         for (int i = 0; i < size(); i++) {
-            hash = hash | (abs(labels[i]) << (32 - Integer.numberOfLeadingZeros(hash)));
+            hash = hash | (abs(labels[i]) << (32 - Long.numberOfLeadingZeros(hash)));
         }
-        return hash;
+        return (int) hash;
     }
 
     @Override


### PR DESCRIPTION
- That enables that numeric hashes are also handled efficiently, without resorting to strings.

@bratseth PR