### PR TITLE
preserve value type

### DIFF
--- a/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
+++ b/indexinglanguage/src/main/java/com/yahoo/vespa/indexinglanguage/expressions/EmbedExpression.java
@@ -125,7 +125,7 @@ public class EmbedExpression extends Expression  {
         String innerMappedDimension = targetType.mappedSubtype().dimensionNames().stream().filter(d -> !d.equals(outerMappedDimension)).findFirst().get();
         String indexedDimension = targetType.indexedSubtype().dimensions().get(0).name();
         long indexedDimensionSize = targetType.indexedSubtype().dimensions().get(0).size().get();
-        var innerType = new TensorType.Builder().mapped(innerMappedDimension).indexed(indexedDimension,indexedDimensionSize).build();
+        var innerType = new TensorType.Builder(targetType.valueType()).mapped(innerMappedDimension).indexed(indexedDimension,indexedDimensionSize).build();
         int innerMappedDimensionIndex = innerType.indexOfDimensionAsInt(innerMappedDimension);
         int indexedDimensionIndex = innerType.indexOfDimensionAsInt(indexedDimension);
         for (int i = 0; i < input.size(); i++) {


### PR DESCRIPTION
The colbert embedder uses the type as the signal for compression, goes with https://github.com/vespa-engine/system-test/pull/3323

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
