### PR TITLE
No need to have more than 1s shutdownIdleTimeout as default. Running …

### DIFF
--- a/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
+++ b/container-core/src/main/resources/configdefinitions/jdisc.http.jdisc.http.connector.def
@@ -34,7 +34,7 @@ reuseAddress                        bool     default=true
 idleTimeout                         double   default=180.0
 
 # The idle timeout that takes effect during graceful shutdown of Jetty
-shutdownIdleTimeout                 double   default=5.0
+shutdownIdleTimeout                 double   default=1.0
 
 # TODO Vespa 9 Remove
 # Has no effect since Jetty 11 upgrade


### PR DESCRIPTION
…tests takes a lot longer with high timeout.

@bjorncs PR