### PR TITLE
Avoid static_assert(false, ...) in portion of function that is elimin…

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/flow.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow.h
@@ -53,12 +53,11 @@ concept DirectAdaptable = requires(const T &t) {
 
 auto make_adapter(const auto &children) {
     using type = std::remove_cvref_t<decltype(children)>::value_type;
+    static_assert(DefaultAdaptable<type> || DirectAdaptable<type>, "unable to resolve children adapter");
     if constexpr (DefaultAdaptable<type>) {
         return DefaultAdapter();
-    } else if constexpr (DirectAdaptable<type>) {
-        return DirectAdapter();
     } else {
-        static_assert(false, "unable to resolve children adapter");
+        return DirectAdapter();
     }
 }
 


### PR DESCRIPTION
…ated

due to 'if constexpr' since this is not well handled by old compilers. 'if constexpr' in templated functions.

@havardpe : please review
