### PR TITLE
Use temporary byte array when serializing Protobuf in Java

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
@@ -59,13 +59,10 @@ abstract class RoutableFactories80 {
         public boolean encode(Routable obj, DocumentSerializer out) {
             try {
                 var protoMsg = encoderFn.apply(apiClass.cast(obj));
-                var protoStream = CodedOutputStream.newInstance(out.getBuf().getByteBuffer()); // Not AutoCloseable...
-                try {
-                    protoMsg.writeTo(protoStream);
-                } finally {
-                    protoStream.flush();
-                }
-            } catch (IOException | UnsupportedOperationException e) {
+                // TODO avoid this buffer indirection by directly exposing an OutputStream to write into...!
+                //  ... or at the very least have a way to preallocate buffer output of protoMsg.getSerializedSize() bytes!
+                out.getBuf().put(protoMsg.toByteArray());
+            } catch (RuntimeException e) {
                 logCodecError("encoding", e);
                 return false;
             }


### PR DESCRIPTION
@jonmv please review 🫣

The previous attempt at avoiding unneeded memory allocation and copying was futile because—obviously in retrospect—the underlying byte buffer is fixed in size and not dynamically growable. This did not manifest itself in any unit tests (too little data) or the set of system tests that I ran manually.

It seems likely that we want to reconsider the encode/decode APIs in the `DocumentProtocol` to allow for more optimal memory management. I'm currently pondering this.

