### PR TITLE
Explicitly use HEAD serializer for document update instances

### DIFF
--- a/document/src/main/java/com/yahoo/document/DocumentUpdate.java
+++ b/document/src/main/java/com/yahoo/document/DocumentUpdate.java
@@ -347,6 +347,7 @@ public class DocumentUpdate extends DocumentOperation implements Iterable<FieldP
     }
 
     public final void serialize(GrowableByteBuffer buf) {
+        // TODO shouldn't this be createHead()?!
         serialize(DocumentSerializerFactory.create6(buf));
     }
 

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
@@ -19,6 +19,7 @@ import com.yahoo.document.TestAndSetCondition;
 import com.yahoo.document.serialization.DocumentDeserializer;
 import com.yahoo.document.serialization.DocumentDeserializerFactory;
 import com.yahoo.document.serialization.DocumentSerializer;
+import com.yahoo.document.serialization.DocumentSerializerFactory;
 import com.yahoo.io.GrowableByteBuffer;
 import com.yahoo.messagebus.Routable;
 import com.yahoo.vdslib.DocumentSummary;
@@ -225,7 +226,7 @@ abstract class RoutableFactories80 {
 
     private static ByteBuffer serializeUpdate(DocumentUpdate update) {
         var buf = new GrowableByteBuffer();
-        update.serialize(buf);
+        update.serialize(DocumentSerializerFactory.createHead(buf));
         buf.flip();
         return buf.getByteBuffer();
     }


### PR DESCRIPTION
@bjorncs please review

For some assuredly exciting reason, `DocumentUpdate.serialize()` by default uses the v6 protocol version instead of the HEAD version. This caused tensor updates (which are only available on the HEAD version) to fail serialization.

