### PR TITLE
Optimize Java `DocumentProtocol` encoding memory usage for Protobuf implementation

### DIFF
--- a/documentapi/abi-spec.json
+++ b/documentapi/abi-spec.json
@@ -3015,6 +3015,7 @@
     ],
     "methods" : [
       "public abstract boolean encode(com.yahoo.messagebus.Routable, com.yahoo.document.serialization.DocumentSerializer)",
+      "public byte[] encode(int, com.yahoo.messagebus.Routable)",
       "public abstract com.yahoo.messagebus.Routable decode(com.yahoo.document.serialization.DocumentDeserializer)"
     ],
     "fields" : [ ]

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableRepository.java
@@ -93,17 +93,12 @@ final class RoutableRepository {
             log.log(Level.SEVERE,"Can not encode routable type " + type + " (version " + version + "). Only major version 5 and up supported.");
             return new byte[0];
         }
-        DocumentSerializer out= DocumentSerializerFactory.createHead(new GrowableByteBuffer(8192));
-
-        out.putInt(null, type);
-        if (!factory.encode(obj, out)) {
+        byte[] ret = factory.encode(type, obj);
+        if (ret == null) {
             log.log(Level.SEVERE, "Routable factory " + factory.getClass().getName() + " failed to serialize " +
                                     "routable of type " + type + " (version " + version + ").");
             return new byte[0];
         }
-        byte[] ret = new byte[out.getBuf().position()];
-        out.getBuf().rewind();
-        out.getBuf().get(ret);
         return ret;
     }
 


### PR DESCRIPTION
@geirst please review

This commit allows protocol implementations to directly construct and return a payload byte array that contains both the message identifier and the serialized message itself _without_ having to go through a `DocumentSerializer` indirection.

A new method has been added to the `RoutableFactory` whose default implementation defers to the legacy `DocumentSerializer`-accepting method. This means the v6 protocol has the same semantics and performance characteristics as before.

The new Protobuf protocol implementation now allocates the result byte array once with the correct size and writes both the message ID header and the protobuf data into this.

This has the following performance benefits for the new protocol:

 - Reduces the number of buffer _allocations_ from 3 to 1.
 - Avoids 2 buffer _copies_ since we now directly allocate and write into the resulting array.
 - Encoding allocates the exact number of required bytes instead of always allocating 8K at a minimum. This also avoids the need for growing (by realloc and copy) the buffer during encoding.

