### PR TITLE
Don't do a hex dump of messages into the log upon protocol deserialization failures

### DIFF
--- a/documentapi/src/vespa/documentapi/messagebus/routablerepository.cpp
+++ b/documentapi/src/vespa/documentapi/messagebus/routablerepository.cpp
@@ -72,10 +72,6 @@ RoutableRepository::decode(const vespalib::Version &version, mbus::BlobRef data)
     if (!ret) {
         LOG(error, "Routable factory failed to deserialize routable of type %d (version %s).",
             type, version.toString().c_str());
-
-        std::ostringstream ost;
-        document::StringUtil::printAsHex(ost, data.data(), data.size());
-        LOG(error, "%s", ost.str().c_str());
         return {};
     }
     return ret;


### PR DESCRIPTION
@geirst please review

I like my logs filled with pages and pages of assorted fluff as much as the next guy, but this is a bit on the excessive side.