### PR TITLE
Explicitly shut down Protobuf library prior to distributor process exit

### DIFF
--- a/storageserver/src/apps/storaged/CMakeLists.txt
+++ b/storageserver/src/apps/storaged/CMakeLists.txt
@@ -9,4 +9,6 @@ vespa_add_executable(storageserver_storaged_app
     storageserver_storageapp
 )
 
+vespa_add_target_package_dependency(storageserver_storaged_app Protobuf)
+
 install_absolute_symlink(vespa-storaged-bin sbin/vespa-distributord-bin)

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -20,6 +20,7 @@
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/config/helper/configgetter.hpp>
 #include <vespa/vespalib/util/signalhandler.h>
+#include <google/protobuf/message_lite.h>
 #include <iostream>
 #include <csignal>
 #include <cstdlib>
@@ -203,6 +204,8 @@ int StorageApp::main(int argc, char **argv)
     vespalib::ShutdownGuard shutdownGuard(getMaxShutDownTime());
     LOG(debug, "Attempting proper shutdown");
     _process.reset();
+    // Clean up Protobuf library globals to avoid false positive leak warnings from Valgrind et al.
+    google::protobuf::ShutdownProtobufLibrary();
     LOG(debug, "Completed controlled shutdown.");
     return 0;
 }


### PR DESCRIPTION
@geirst please review

This avoids false positives from Valgrind et al about memory leaks.

The distributor is most susceptible to this false positive since error reporting in the DocumentAPI protocol may cause Protobuf descriptors to be lazily loaded when an incoming message fails to be decoded (usually due to a missing document type).

