### PR TITLE
Empty exclusive host metric considers deallocation time

### DIFF
--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/MetricsReporterTest.java
@@ -360,6 +360,14 @@ public class MetricsReporterTest {
         metricsReporter.maintain();
         assertEquals(hosts.size(), metric.values.get("nodes.emptyExclusive").intValue());
 
+        // Hosts are not considered empty if children were just deallocated
+        tester.patchNodes(hosts, (host) -> host.withHostEmptyAt(tester.clock().instant()));
+        metricsReporter.maintain();
+        assertEquals(0, metric.values.get("nodes.emptyExclusive").intValue());
+        tester.clock().advance(Duration.ofMinutes(10));
+        metricsReporter.maintain();
+        assertEquals(hosts.size(), metric.values.get("nodes.emptyExclusive").intValue());
+
         // Deploy application
         ClusterSpec spec = ClusterSpec.request(ClusterSpec.Type.container, ClusterSpec.Id.from("c1")).vespaVersion("1").build();
         Capacity capacity = Capacity.from(new ClusterResources(4, 1, resources));


### PR DESCRIPTION
There can be a brief moment between an app node is deallocated and parent host is removed. This is fine.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
