### PR TITLE
More graceful reporting of Protobuf protocol decode errors

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
@@ -73,7 +73,7 @@ abstract class RoutableFactories80 {
                 protoStream.checkNoSpaceLeft();
                 return buf;
             } catch (IOException | RuntimeException e) {
-                logCodecError("encoding", e);
+                log.severe("Error during Protobuf encoding of message type %s: %s".formatted(apiClass.getSimpleName(), e.getMessage()));
                 return null;
             }
         }
@@ -89,17 +89,11 @@ abstract class RoutableFactories80 {
             try {
                 return decoderFn.apply(in);
             } catch (RuntimeException e) {
-                logCodecError("decoding", e);
-                return null;
+                throw new RuntimeException("Error during Protobuf decoding of message type %s: %s"
+                        .formatted(apiClass.getSimpleName(), e.getMessage()), e);
             }
         }
 
-        private void logCodecError(String op, Throwable t) {
-            // TODO ideally we'd print the peer address here, but that information is Abstracted Away(tm)
-            //  and we can't safely propagate the exception to a lower-level component which _does_ know this
-            //  information, as it's not necessarily exception safe.
-            log.severe("Error during Protobuf %s for message type %s: %s".formatted(op, apiClass.getSimpleName(), t.getMessage()));
-        }
     }
 
     private static class ProtobufCodecBuilder<DocApiT extends Routable, ProtoT extends AbstractMessage> {


### PR DESCRIPTION
@geirst please review. This should address the protocol-related system test failure (which fails due to errors in the Vespa log).

If a message fails decoding due to e.g. a missing document type during document decode, that will be reported as a protocol-level decode error, even if that message itself is perfectly compliant. Report such exceptions as warnings instead (by propagating an exception up to the `DocumentProcotol` caller), but add more context to the exception message to make it clear that it happened in a decode-context.

Example of old (and rather confusing) message in logs:
```
WARNING distributor  vds.documentprotocol  Document type foo not found
```
Now becomes:
```
WARNING distributor  vds.documentprotocol Failed decoding message of type PutDocumentRequest: Document type foo not found
```
