### PR TITLE
Add Vespa 9 deprecation comment for lazy deserialization

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetDocumentReply.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/GetDocumentReply.java
@@ -11,9 +11,10 @@ import java.nio.ByteBuffer;
  */
 public class GetDocumentReply extends DocumentAcceptedReply {
 
-    private DocumentDeserializer buffer = null;
     private Document document = null;
     private long lastModified = 0;
+    // TODO Vespa 9: remove. Inherently tied to legacy protocol version.
+    private DocumentDeserializer buffer = null;
     private LazyDecoder decoder = null;
 
     /**

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/PutDocumentMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/PutDocumentMessage.java
@@ -14,9 +14,10 @@ import java.util.Arrays;
  */
 public class PutDocumentMessage extends TestAndSetMessage {
 
-    private DocumentDeserializer buffer = null;
     private DocumentPut put = null;
     private long time = 0;
+    // TODO Vespa 9: remove. Inherently tied to legacy protocol version.
+    private DocumentDeserializer buffer = null;
     private LazyDecoder decoder = null;
 
     /**

--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/UpdateDocumentMessage.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/UpdateDocumentMessage.java
@@ -13,10 +13,11 @@ import java.util.Arrays;
  */
 public class UpdateDocumentMessage extends TestAndSetMessage {
 
-    private DocumentDeserializer buffer = null;
     private DocumentUpdate update = null;
     private long oldTime = 0;
     private long newTime = 0;
+    // TODO Vespa 9: remove. Inherently tied to legacy protocol version.
+    private DocumentDeserializer buffer = null;
     private LazyDecoder decoder = null;
 
     /**


### PR DESCRIPTION
@baldersheim please review

Since the lazy deserialization captures the entire message payload, it's not independent of the protocol version used and it's therefore not safe to set or use it from any other protocol than the legacy version.

