### PR TITLE
Set fixed vespa-build-dependencies version

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -42,7 +42,7 @@ License:        Commercial
 URL:            http://vespa.ai
 Source0:        vespa-%{version}.tar.gz
 
-BuildRequires: vespa-build-dependencies >= 1.2.7
+BuildRequires: vespa-build-dependencies = 1.2.7
 
 Requires: %{name}-base             = %{version}-%{release}
 Requires: %{name}-base-libs        = %{version}-%{release}


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Because we have fixed runtime deps like vespa-onnxruntime we must use exact version for vespa-build-dependencies. If not we risk getting a newer version in the develop/build environment compared to the runtime environment.

FYI, @toregge 
