### PR TITLE
Remove unused member variable from search::queryeval::Blueprint

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.cpp
@@ -121,7 +121,6 @@ Blueprint::Blueprint() noexcept
       _flow_stats(0.0, 0.0, 0.0),
       _sourceId(0xffffffff),
       _docid_limit(0),
-      _force_strict(false),
       _frozen(false)
 {
 }

--- a/searchlib/src/vespa/searchlib/queryeval/blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/blueprint.h
@@ -205,7 +205,6 @@ private:
     FlowStats  _flow_stats;
     uint32_t   _sourceId;
     uint32_t   _docid_limit;
-    bool       _force_strict;
     bool       _frozen;
 
 protected:


### PR DESCRIPTION
@baldersheim : please review
