### PR TITLE
Use smaller buffers for Document(Update) serialization

### DIFF
--- a/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
+++ b/documentapi/src/main/java/com/yahoo/documentapi/messagebus/protocol/RoutableFactories80.java
@@ -193,8 +193,8 @@ abstract class RoutableFactories80 {
     }
 
     private static ByteBuffer serializeDoc(Document doc) {
-        var buf = new GrowableByteBuffer();
-        doc.serialize(buf);
+        var buf = new GrowableByteBuffer(8 * 1024, 2.0f);
+        doc.serialize(DocumentSerializerFactory.createHead(buf));
         buf.flip();
         return buf.getByteBuffer();
     }
@@ -233,7 +233,7 @@ abstract class RoutableFactories80 {
     }
 
     private static ByteBuffer serializeUpdate(DocumentUpdate update) {
-        var buf = new GrowableByteBuffer();
+        var buf = new GrowableByteBuffer(4 * 1024, 2.0f);
         update.serialize(DocumentSerializerFactory.createHead(buf));
         buf.flip();
         return buf.getByteBuffer();


### PR DESCRIPTION
@baldersheim please review

Default buffer size is 64 KiB, which adds a lot of unnecessary GC pressure when operations are small (which is often the case).

Now explicitly preallocate just 8 KiB for documents and 4 KiB for updates.

Additionally, use explicit HEAD serializer for `Document` serialization, as `serialize()` for some reason uses v6 internally
(this only has an observable effect for updates, but still good to use the most recent version).

