### PR TITLE
Add lucene-linguistics to platform bundles

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
@@ -59,6 +59,7 @@ public class PlatformBundles {
             SEARCH_AND_DOCPROC_BUNDLE,
             "docprocs",
             LINGUISTICS_BUNDLE_NAME,
+            "lucene-linguistics",
             EVALUATION_BUNDLE_NAME,
             INTEGRATION_BUNDLE_NAME,
             ONNXRUNTIME_BUNDLE_NAME


### PR DESCRIPTION
Allow customers to specify LuceneLinguistics as a component without specifying bundle (so that Vespa's provided lucene-linguistics bundle will be used)