### PR TITLE
Enforce document timestamp requirements for updates in backend

### DIFF
--- a/storage/src/vespa/storage/persistence/asynchandler.cpp
+++ b/storage/src/vespa/storage/persistence/asynchandler.cpp
@@ -349,9 +349,17 @@ AsyncHandler::handleUpdate(api::UpdateCommand& cmd, MessageTracker::UP trackerUP
         metrics.test_and_set_failed.inc();
         return trackerUP;
     }
-
     spi::Bucket bucket = _env.getBucket(cmd.getDocumentId(), cmd.getBucket());
 
+    if ((cmd.getOldTimestamp() != 0) &&
+        (fetch_existing_document_timestamp(cmd.getDocumentId(), bucket, tracker.context()) != cmd.getOldTimestamp()))
+    {
+        metrics.notFound.inc();
+        // It's debatable if this should be OK or a TaS failure, but OK is the legacy behavior, i.e. what
+        // the distributor already does as part of a multiphase update where the expected timestamp is set.
+        tracker.fail(api::ReturnCode::OK, "No document with requested timestamp found");
+        return trackerUP;
+    }
     // Note that the &cmd capture is OK since its lifetime is guaranteed by the tracker
     auto task = makeResultTask([&cmd, tracker = std::move(trackerUP)](spi::Result::UP responseUP) {
         auto & response = dynamic_cast<const spi::UpdateResult &>(*responseUP);
@@ -396,6 +404,12 @@ AsyncHandler::handleRemove(api::RemoveCommand& cmd, MessageTracker::UP trackerUP
     _spi.removeIfFoundAsync(bucket, spi::Timestamp(cmd.getTimestamp()), cmd.getDocumentId(),
                             std::make_unique<ResultTaskOperationDone>(_sequencedExecutor, cmd.getBucketId(), std::move(task)));
     return trackerUP;
+}
+
+api::Timestamp
+AsyncHandler::fetch_existing_document_timestamp(const document::DocumentId& id, const spi::Bucket& bucket, spi::Context& ctx) const
+{
+    return _spi.get(bucket, document::NoFields(), id, ctx).getTimestamp();
 }
 
 bool

--- a/storage/src/vespa/storage/persistence/asynchandler.h
+++ b/storage/src/vespa/storage/persistence/asynchandler.h
@@ -37,9 +37,12 @@ public:
     static bool is_async_unconditional_message(const api::StorageMessage& cmd) noexcept;
 private:
     [[nodiscard]] bool checkProviderBucketInfoMatches(const spi::Bucket&, const api::BucketInfo&) const;
-    static bool tasConditionExists(const api::TestAndSetCommand& cmd);
-    bool tasConditionMatches(const api::TestAndSetCommand& cmd, MessageTracker& tracker,
-                             spi::Context& context, bool missingDocumentImpliesMatch = false) const;
+    [[nodiscard]] static bool tasConditionExists(const api::TestAndSetCommand& cmd);
+    [[nodiscard]] bool tasConditionMatches(const api::TestAndSetCommand& cmd, MessageTracker& tracker,
+                                           spi::Context& context, bool missingDocumentImpliesMatch = false) const;
+    [[nodiscard]] api::Timestamp fetch_existing_document_timestamp(const document::DocumentId& id,
+                                                                   const spi::Bucket& bucket,
+                                                                   spi::Context& ctx) const;
     void on_delete_bucket_complete(const document::Bucket& bucket) const;
     const PersistenceUtil            & _env;
     spi::PersistenceProvider         & _spi;


### PR DESCRIPTION
@geirst please review

The document API has long since had a special field for update operations where an optional expected _existing_ backend timestamp can be specified, and where the update should only go through iff there is a timestamp match.

This has been supported on the distributor all along, but only when write-repair is taking place (i.e. rarely), but the actual backend support has been lacking. No one has complained yet since this is very much not an advertised feature, but if we want to e.g. use this feature for improvements to batch updates we should ensure that it works as expected.

With this commit, a non-zero "old timestamp" field is cross-checked against the existing document, and the update is only applied if the actual and expected timestamps match.

Note: this is a replica-level decision, but  if replicas are out of sync this shall be transparently (and equivalently) handled on the distributor as part of write-repair.

