### PR TITLE
- Set the complete list of the config where it contains the complete …

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexInfo.java
@@ -316,6 +316,7 @@ public class IndexInfo extends Derived implements IndexInfoConfig.Producer {
 
     @Override
     public void getConfig(IndexInfoConfig.Builder builder) {
+        // Append
         IndexInfoConfig.Indexinfo.Builder iiB = new IndexInfoConfig.Indexinfo.Builder();
         iiB.name(getName());
         for (IndexCommand command : commands) {

--- a/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/IndexingScript.java
@@ -95,6 +95,7 @@ public final class IndexingScript extends Derived implements IlscriptsConfig.Pro
 
     @Override
     public void getConfig(IlscriptsConfig.Builder configBuilder) {
+        // Append
         IlscriptsConfig.Ilscript.Builder ilscriptBuilder = new IlscriptsConfig.Ilscript.Builder();
         ilscriptBuilder.doctype(getName());
         ilscriptBuilder.docfield(docFields);

--- a/config-model/src/main/java/com/yahoo/schema/derived/Juniperrc.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/Juniperrc.java
@@ -44,18 +44,21 @@ public class Juniperrc extends Derived implements JuniperrcConfig.Producer {
     @Override
     protected String getDerivedName() { return "juniperrc"; }
 
+    private static JuniperrcConfig.Override.Builder createOverride(String name) {
+        return new JuniperrcConfig.Override.Builder()
+                .fieldname(name)
+                .length(64*Mb)
+                .max_matches(1)
+                .min_length(8192)
+                .surround_max(64*Mb);
+    }
+
     @Override
     public void getConfig(JuniperrcConfig.Builder builder) {
-        if (boldingFields.size() != 0) {
+        // Replace
+        if (!boldingFields.isEmpty()) {
             builder.prefix(true);
-            for (String name : boldingFields) {
-                builder.override(new JuniperrcConfig.Override.Builder()
-                    .fieldname(name)
-                    .length(64*Mb)
-                    .max_matches(1)
-                    .min_length(8192)
-                    .surround_max(64*Mb));
-            }
+            builder.override(boldingFields.stream().map(Juniperrc::createOverride).toList());
         }
     }
 

--- a/config-model/src/main/java/com/yahoo/schema/derived/SchemaInfo.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/SchemaInfo.java
@@ -65,6 +65,7 @@ public final class SchemaInfo extends Derived implements SchemaInfoConfig.Produc
 
     @Override
     public void getConfig(SchemaInfoConfig.Builder builder) {
+        // Append
         var schemaBuilder = new SchemaInfoConfig.Schema.Builder();
         schemaBuilder.name(schema.getName());
         addFieldsConfig(schemaBuilder);

--- a/config-model/src/main/java/com/yahoo/schema/derived/Summaries.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/Summaries.java
@@ -41,11 +41,10 @@ public class Summaries extends Derived implements SummaryConfig.Producer {
 
     @Override
     public void getConfig(SummaryConfig.Builder builder) {
+        // Replace
         builder.defaultsummaryid(summaries.isEmpty() ? -1 : summaries.get(0).hashCode());
         builder.usev8geopositions(useV8GeoPositions);
-        for (SummaryClass summaryClass : summaries) {
-            builder.classes(summaryClass.getSummaryClassConfig());
-        }
+        builder.classes(summaries.stream().map(SummaryClass::getSummaryClassConfig).toList());
     }    
 
 }

--- a/config-model/src/main/java/com/yahoo/schema/derived/VsmFields.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/VsmFields.java
@@ -108,12 +108,9 @@ public class VsmFields extends Derived implements VsmfieldsConfig.Producer {
 
     @Override
     public void getConfig(VsmfieldsConfig.Builder vsB) {
-        for (StreamingField streamingField : fields.values()) {
-            vsB.fieldspec(streamingField.getFieldSpecConfig());
-        }
-        for (StreamingDocumentType streamingDocType : doctypes.values()) {
-            vsB.documenttype(streamingDocType.getDocTypeConfig());
-        }
+        // Replace
+        vsB.fieldspec(fields.values().stream().map(StreamingField::getFieldSpecConfig).toList());
+        vsB.documenttype(doctypes.values().stream().map(StreamingDocumentType::getDocTypeConfig).toList());
     }
 
     private static boolean isAttributeField(ImmutableSDField field, boolean isStructField, boolean ignoreAttributeAspect) {

--- a/config-model/src/main/java/com/yahoo/schema/derived/VsmSummary.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/VsmSummary.java
@@ -96,14 +96,14 @@ public class VsmSummary extends Derived implements VsmsummaryConfig.Producer {
 
     @Override
     public void getConfig(VsmsummaryConfig.Builder vB) {
-        for (Map.Entry<SummaryField, List<String>> entry : summaryMap.entrySet()) {
-            VsmsummaryConfig.Fieldmap.Builder fmB = new VsmsummaryConfig.Fieldmap.Builder().summary(entry.getKey().getName());
-            for (String field : entry.getValue()) {
-                fmB.document(new VsmsummaryConfig.Fieldmap.Document.Builder().field(field));
-            }
-            fmB.command(VsmsummaryConfig.Fieldmap.Command.Enum.valueOf(entry.getKey().getVsmCommand().toString()));
-            vB.fieldmap(fmB);
-        }
+        // Replace
+        vB.fieldmap(
+                summaryMap.entrySet().stream().map(entry -> new VsmsummaryConfig.Fieldmap.Builder()
+                        .summary(entry.getKey().getName())
+                        .document(entry.getValue().stream().map(field -> new VsmsummaryConfig.Fieldmap.Document.Builder().field(field)).toList())
+                        .command(VsmsummaryConfig.Fieldmap.Command.Enum.valueOf(entry.getKey().getVsmCommand().toString()))
+                ).toList()
+        );
     }
     
 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/VespaDomBuilder.java
@@ -241,7 +241,7 @@ public class VespaDomBuilder extends VespaModelBuilder {
      */
     private static int getXmlIntegerAttribute(Element spec, String attributeName) {
         String value = (spec == null) ? null : spec.getAttribute(attributeName);
-        if (value == null || value.equals("")) {
+        if (value == null || value.isEmpty()) {
             return 0;
         } else {
             try {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/search/ContainerSearch.java
@@ -173,12 +173,11 @@ public class ContainerSearch extends ContainerSubsystem<SearchChains>
     public void getConfig(QrSearchersConfig.Builder builder) {
         for (int i = 0; i < searchClusters.size(); i++) {
             SearchCluster sys = findClusterWithId(searchClusters, i);
-            QrSearchersConfig.Searchcluster.Builder scB = new QrSearchersConfig.Searchcluster.Builder().
-                    name(sys.getClusterName());
+            var scB = new QrSearchersConfig.Searchcluster.Builder().name(sys.getClusterName());
             for (SchemaInfo spec : sys.schemas().values()) {
                 scB.searchdef(spec.fullSchema().getName());
             }
-            scB.rankprofiles(new QrSearchersConfig.Searchcluster.Rankprofiles.Builder().configid(sys.getConfigId()));
+            scB.rankprofiles_configid(sys.getConfigId());
             scB.indexingmode(QrSearchersConfig.Searchcluster.Indexingmode.Enum.valueOf(sys.getIndexingModeName()));
             if ( ! (sys instanceof IndexedSearchCluster)) {
                 scB.storagecluster(new QrSearchersConfig.Searchcluster.Storagecluster.Builder().

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/xml/ContainerModelBuilder.java
@@ -425,7 +425,7 @@ public class ContainerModelBuilder extends ConfigModelBuilder<ContainerModel> {
                         cluster.addComponent(accessLogComponent);
                     });
                 }
-                if (components.size() > 0) {
+                if ( ! components.isEmpty()) {
                     cluster.removeSimpleComponent(VoidRequestLog.class);
                     cluster.addSimpleComponent(AccessLog.class);
                 }

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentDatabase.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/DocumentDatabase.java
@@ -61,18 +61,25 @@ public class DocumentDatabase extends AnyConfigProducer implements
     public DerivedConfiguration getDerivedConfiguration() {
         return derivedCfg;
     }
+    // These methods will append to the config
     @Override public void getConfig(IndexInfoConfig.Builder builder) { derivedCfg.getIndexInfo().getConfig(builder); }
     @Override public void getConfig(IlscriptsConfig.Builder builder) { derivedCfg.getIndexingScript().getConfig(builder); }
+    @Override public void getConfig(SchemaInfoConfig.Builder builder) { derivedCfg.getSchemaInfo().getConfig(builder); }
+
+    // These methods append as multiple databases join config => TODO will loose information - not good
     @Override public void getConfig(AttributesConfig.Builder builder) { derivedCfg.getConfig(builder); }
     @Override public void getConfig(RankProfilesConfig.Builder builder) { derivedCfg.getRankProfileList().getConfig(builder); }
+
+    // These methods append, TODO unknown usage and consequences
     @Override public void getConfig(RankingExpressionsConfig.Builder builder) { derivedCfg.getRankProfileList().getConfig(builder); }
     @Override public void getConfig(RankingConstantsConfig.Builder builder) { derivedCfg.getRankProfileList().getConfig(builder); }
     @Override public void getConfig(OnnxModelsConfig.Builder builder) { derivedCfg.getRankProfileList().getConfig(builder); }
+
+    // Below methods will replace config completely
     @Override public void getConfig(IndexschemaConfig.Builder builder) { derivedCfg.getIndexSchema().getConfig(builder); }
     @Override public void getConfig(JuniperrcConfig.Builder builder) { derivedCfg.getJuniperrc().getConfig(builder); }
     @Override public void getConfig(SummaryConfig.Builder builder) { derivedCfg.getSummaries().getConfig(builder); }
     @Override public void getConfig(ImportedFieldsConfig.Builder builder) { derivedCfg.getImportedFields().getConfig(builder); }
-    @Override public void getConfig(SchemaInfoConfig.Builder builder) { derivedCfg.getSchemaInfo().getConfig(builder); }
     @Override public void getConfig(VsmsummaryConfig.Builder builder) { derivedCfg.getVsmSummary().getConfig(builder); }
     @Override public void getConfig(VsmfieldsConfig.Builder builder) { derivedCfg.getVsmFields().getConfig(builder); }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/search/SearchCluster.java
@@ -60,6 +60,15 @@ public abstract class SearchCluster extends TreeConfigProducer<AnyConfigProducer
         return false;
     }
 
+    public String getConfigId(String name) {
+        for (DocumentDatabase db : documentDbs) {
+            if (db.getName().equals(name)) {
+                return db.getConfigId();
+            }
+        }
+        return "";
+    }
+
     /** Returns the schemas that should be active in this cluster. Note: These are added during processing. */
     public Map<String, SchemaInfo> schemas() { return Collections.unmodifiableMap(schemas); }
 

--- a/container-core/src/main/resources/configdefinitions/container.qr-searchers.def
+++ b/container-core/src/main/resources/configdefinitions/container.qr-searchers.def
@@ -64,7 +64,7 @@ searchcluster[].name string
 searchcluster[].searchdef[] string
 
 ## configid that may be used to get rank-profiles config for the cluster.
-searchcluster[].rankprofiles.configid reference default=""
+searchcluster[].rankprofiles_configid string default=""
 
 ## Indexing mode of search cluster.
 searchcluster[].indexingmode enum { REALTIME, STREAMING } default=REALTIME

--- a/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/cluster/ClusterSearcher.java
@@ -150,7 +150,7 @@ public class ClusterSearcher extends Searcher {
                                                searchClusterConfig.searchdef());
         ClusterParams clusterParams = makeClusterParams(searchclusterIndex);
         StreamingSearcher searcher = new StreamingSearcher(access);
-        searcher.setSearchClusterName(searchClusterConfig.rankprofiles().configid());
+        searcher.setSearchClusterName(searchClusterConfig.rankprofiles_configid());
         searcher.setDocumentType(searchClusterConfig.searchdef(0));
         searcher.setStorageClusterRouteSpec(searchClusterConfig.storagecluster().routespec());
         searcher.init(serverId, docSumParams, clusterParams, documentdbInfoConfig, schemaInfo);

--- a/container-search/src/main/java/com/yahoo/prelude/querytransform/NonPhrasingSearcher.java
+++ b/container-search/src/main/java/com/yahoo/prelude/querytransform/NonPhrasingSearcher.java
@@ -44,7 +44,7 @@ public class NonPhrasingSearcher extends Searcher {
     }
 
     private void setupAutomatonFile(String phraseAutomatonFile) {
-        if (phraseAutomatonFile == null || phraseAutomatonFile.trim().equals("")) {
+        if (phraseAutomatonFile == null || phraseAutomatonFile.trim().isEmpty()) {
             //no file, just use dummy matcher
             phraseMatcher = PhraseMatcher.getNullMatcher();
         } else {

--- a/container-search/src/main/java/com/yahoo/search/ranking/GlobalPhaseSetup.java
+++ b/container-search/src/main/java/com/yahoo/search/ranking/GlobalPhaseSetup.java
@@ -7,7 +7,13 @@ import com.yahoo.tensor.Tensor;
 import com.yahoo.tensor.TensorType;
 import com.yahoo.vespa.config.search.RankProfilesConfig;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 class GlobalPhaseSetup {
@@ -122,7 +128,7 @@ class GlobalPhaseSetup {
                 } else if (availableMatchFeatures.contains(input)) {
                     String mfName = renamedFeatures.getOrDefault(input, input);
                     fromMF.add(new MatchFeatureInput(input, mfName));
-                } else if (renamedFeatures.values().contains(input)) {
+                } else if (renamedFeatures.containsValue(input)) {
                     fromMF.add(new MatchFeatureInput(input, input));
                 } else {
                     throw new IllegalArgumentException("Bad config, missing global-phase input: " + input);
@@ -145,7 +151,7 @@ class GlobalPhaseSetup {
         String toRename = null;
         for (var prop : rp.fef().property()) {
             if (prop.name().equals("vespa.globalphase.rerankcount")) {
-                rerankCount = Integer.valueOf(prop.value());
+                rerankCount = Integer.parseInt(prop.value());
             }
             if (prop.name().equals("vespa.rank.globalphase")) {
                 functionEvaluatorSource = () -> model.evaluatorOf("globalphase");
@@ -177,7 +183,7 @@ class GlobalPhaseSetup {
             for (var input : mainResolver.usedNormalizers) {
                 var cfg = availableNormalizers.get(input);
                 String normInput = cfg.input();
-                if (matchFeatures.contains(normInput) || renameFeatures.values().contains(normInput)) {
+                if (matchFeatures.contains(normInput) || renameFeatures.containsValue(normInput)) {
                     Supplier<Evaluator> normSource = () -> new DummyEvaluator(normInput);
                     normalizers.add(makeNormalizerSetup(cfg, matchFeatures, renameFeatures, normSource, List.of(normInput), rerankCount));
                 } else {

--- a/container-search/src/main/java/com/yahoo/search/schema/SchemaInfoConfigurer.java
+++ b/container-search/src/main/java/com/yahoo/search/schema/SchemaInfoConfigurer.java
@@ -3,7 +3,6 @@ package com.yahoo.search.schema;
 
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.search.config.SchemaInfoConfig;
-import com.yahoo.tensor.TensorType;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/container-search/src/test/java/com/yahoo/search/schema/SchemaInfoTester.java
+++ b/container-search/src/test/java/com/yahoo/search/schema/SchemaInfoTester.java
@@ -3,12 +3,8 @@ package com.yahoo.search.schema;
 
 import com.yahoo.container.QrSearchersConfig;
 import com.yahoo.search.Query;
-import com.yahoo.search.config.IndexInfoConfig;
 import com.yahoo.search.config.SchemaInfoConfig;
-import com.yahoo.search.schema.RankProfile;
 import com.yahoo.search.schema.RankProfile.InputType;
-import com.yahoo.search.schema.Schema;
-import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.tensor.TensorType;
 
 import java.util.ArrayList;

--- a/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
+++ b/container-search/src/test/java/com/yahoo/vespa/streamingvisitors/StreamingSearcherTestCase.java
@@ -28,7 +28,6 @@ import com.yahoo.vespa.streamingvisitors.tracing.TraceExporter;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
…world.

- Append where it is intended. This is a workaround for not having a map type in config. Sometimes it works to have multiple producers produce the same config, sometimes not. This tries to make it more deterministic. Currently other tricks have been employed to avoid appending more to the list than intended.

@geirst PR