### PR TITLE
Use attributes when evaluating selection expression on full documents 

### DIFF
--- a/document/src/vespa/document/select/branch.cpp
+++ b/document/src/vespa/document/select/branch.cpp
@@ -39,6 +39,10 @@ namespace {
     ResultList traceAndValue(const T& value, std::ostream& out,
                          const Node& leftNode, const Node& rightNode)
     {
+        out << "And (lhs):\n";
+        (void)leftNode.trace(value, out);
+        out << "And (rhs):\n";
+        (void)rightNode.trace(value, out);
         out << "And - Left branch returned " << leftNode.contains(value) << ".\n";
         out << "And - Right branch returned " << rightNode.contains(value) << ".\n";
         return leftNode.contains(value) && rightNode.contains(value);
@@ -83,6 +87,10 @@ namespace {
     ResultList traceOrValue(const T& value, std::ostream& out,
                          const Node& leftNode, const Node& rightNode)
     {
+        out << "Or (lhs):\n";
+        (void)leftNode.trace(value, out);
+        out << "Or (rhs):\n";
+        (void)rightNode.trace(value, out);
         out << "Or - Left branch returned " << leftNode.contains(value) << ".\n";
         out << "Or - Right branch returned " << rightNode.contains(value) << ".\n";
         return leftNode.contains(value) || rightNode.contains(value);
@@ -122,6 +130,8 @@ namespace {
     template<typename T>
     ResultList traceNotValue(const T& value, std::ostream& out, const Node& node)
     {
+        out << "Not:\n";
+        (void)node.trace(value, out);
         out << "Not - Child returned " << node.contains(value)
             << ". Returning opposite.\n";
         return !node.contains(value);

--- a/searchcore/src/tests/proton/common/selectpruner_test.cpp
+++ b/searchcore/src/tests/proton/common/selectpruner_test.cpp
@@ -799,6 +799,12 @@ TEST_F("Imported fields with matching attribute names are supported", TestFixtur
                 "test.my_imported_field > 0");
 }
 
+TEST_F("Imported fields can be used alongside non-attribute fields", TestFixture)
+{
+    f.testPrune("test.my_imported_field > 0 and id.namespace != \"foo\"",
+                "test.my_imported_field > 0 and id.namespace != \"foo\"");
+}
+
 // Edge case: document type reconfigured but attribute not yet visible in Proton
 TEST_F("Imported fields without matching attribute are mapped to constant NullValue", TestFixture)
 {

--- a/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.cpp
+++ b/searchcore/src/vespa/searchcore/proton/common/attributefieldvaluenode.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<document::select::Value>
 AttributeFieldValueNode::
 getValue(const Context &context) const
 {
-    const auto &sc(static_cast<const SelectContext &>(context));
+    const auto &sc(dynamic_cast<const SelectContext &>(context));
     uint32_t docId(sc._docId); 
     assert(docId != 0u);
     const auto& v = sc.guarded_attribute_at_index(_attr_guard_index);

--- a/searchcore/src/vespa/searchcore/proton/common/cachedselect.h
+++ b/searchcore/src/vespa/searchcore/proton/common/cachedselect.h
@@ -42,9 +42,10 @@ public:
         Session(std::unique_ptr<document::select::Node> docSelect,
                 std::unique_ptr<document::select::Node> preDocOnlySelect,
                 std::unique_ptr<document::select::Node> preDocSelect);
-        bool contains(const SelectContext &context) const;
-        bool contains(const document::Document &doc) const;
-        const document::select::Node &selectNode() const;
+        [[nodiscard]] bool contains_pre_doc(const SelectContext &context) const;
+        // Precondition: context must have non-nullptr _doc
+        [[nodiscard]] bool contains_doc(const SelectContext &context) const;
+        [[nodiscard]] const document::select::Node &selectNode() const;
     };
 
     using AttributeVectors = std::vector<std::shared_ptr<search::attribute::ReadableAttributeVector>>;

--- a/searchcore/src/vespa/searchcore/proton/common/selectpruner.h
+++ b/searchcore/src/vespa/searchcore/proton/common/selectpruner.h
@@ -36,7 +36,7 @@ public:
 
 
 class SelectPruner : public document::select::CloningVisitor,
-                      public SelectPrunerBase
+                     public SelectPrunerBase
 {
 public:
 private:
@@ -53,16 +53,16 @@ public:
                  bool hasFields,
                  bool hasDocuments);
 
-    SelectPruner(const SelectPruner *rhs);
-    virtual ~SelectPruner();
+    explicit SelectPruner(const SelectPruner *rhs);
+    ~SelectPruner() override;
 
-    uint32_t getFieldNodes() const { return _fieldNodes; }
-    uint32_t getAttrFieldNodes() const { return _attrFieldNodes; }
-    const document::select::ResultSet & getResultSet() const { return _resultSet; }
-    bool isFalse() const;
-    bool isTrue() const;
-    bool isInvalid() const;
-    bool isConst() const;
+    [[nodiscard]] uint32_t getFieldNodes() const noexcept { return _fieldNodes; }
+    [[nodiscard]] uint32_t getAttrFieldNodes() const noexcept { return _attrFieldNodes; }
+    [[nodiscard]] const document::select::ResultSet & getResultSet() const noexcept { return _resultSet; }
+    [[nodiscard]] bool isFalse() const;
+    [[nodiscard]] bool isTrue() const;
+    [[nodiscard]] bool isInvalid() const;
+    [[nodiscard]] bool isConst() const;
     void trace(std::ostream &t);
     void process(const document::select::Node &node);
 private:
@@ -83,8 +83,8 @@ private:
     void setTernaryConst(bool val);
     void set_null_value_node();
     void resolveTernaryConst(bool wantInverted);
-    bool isInvalidVal() const;
-    bool isNullVal() const;
+    [[nodiscard]] bool isInvalidVal() const;
+    [[nodiscard]] bool isNullVal() const;
     void swap(SelectPruner &rhs);
 };
 

--- a/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/persistenceengine/document_iterator.cpp
@@ -171,28 +171,31 @@ public:
         }
     }
 
-    bool willAlwaysFail() const { return _willAlwaysFail; }
+    [[nodiscard]] bool willAlwaysFail() const noexcept { return _willAlwaysFail; }
 
-    bool match(const search::DocumentMetaData & meta) const {
+    [[nodiscard]] bool match(const search::DocumentMetaData & meta) const {
         if (meta.lid >= _docidLimit) {
             return false;
         }
         if (_dscTrue || _metaOnly) {
             return true;
         }
-        if (_selectCxt) {
-            _selectCxt->_docId = meta.lid;
-        }
         if (!_gidFilter.gid_might_match_selection(meta.gid)) {
             return false;
         }
-        return _selectSession->contains(*_selectCxt);
+        assert(_selectCxt);
+        _selectCxt->_docId = meta.lid;
+        _selectCxt->_doc = nullptr;
+        return _selectSession->contains_pre_doc(*_selectCxt);
     }
-    bool match(const search::DocumentMetaData & meta, const Document * doc) const {
+    [[nodiscard]] bool match(const search::DocumentMetaData & meta, const Document * doc) const {
         if (_dscTrue || _metaOnly) {
             return true;
         }
-        return (doc && (doc->getId().getGlobalId() == meta.gid) && _selectSession->contains(*doc));
+        assert(_selectCxt);
+        _selectCxt->_docId = meta.lid;
+        _selectCxt->_doc = doc;
+        return (doc && (doc->getId().getGlobalId() == meta.gid) && _selectSession->contains_doc(*_selectCxt));
     }
 private:
     bool                           _dscTrue;


### PR DESCRIPTION
@toregge please review

This addresses an unintended shortcoming in our handling of imported fields, as these are exposed _only_ through attributes.

Document selection evaluation is automatically optimized in the backend by pre-filtering documents that can be fully evaluated by exclusively looking at attribute values (this goes for both selection matching and mismatching). This is done by cloning the selection AST and replacing all applicable field value nodes with corresponding attribute references.

However, if a document _cannot_ be evaluated from attributes alone, we fall back to reading it fully from the doc store, after which the original selection is evaluated on it. This is the crux of the problem, and prior to this commit an expression using both an imported field and a non-attribute field would fail to be evaluated since the full document evaluation would not have any knowledge of the attribute.

This commit makes it so that also the full document evaluation will use a "patched" AST with all possible field references replaced with attribute lookups. Since we reuse an existing patched AST that was not otherwise used in this code path, there is no added overhead with this approach.