### PR TITLE
tag blueprints with strictness

### DIFF
--- a/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
+++ b/searchcore/src/tests/proton/documentmetastore/documentmetastore_test.cpp
@@ -187,10 +187,10 @@ assertWhiteList(const SimpleResult &exp, Blueprint::UP whiteListBlueprint, bool 
 {
     MatchDataLayout mdl;
     MatchData::UP md = mdl.createMatchData();
-    whiteListBlueprint->fetchPostings(search::queryeval::ExecuteInfo::createForTest(strict));
-    whiteListBlueprint->setDocIdLimit(docIdLimit);
+    whiteListBlueprint->basic_plan(strict, docIdLimit);
+    whiteListBlueprint->fetchPostings(search::queryeval::ExecuteInfo::FULL);
 
-    SearchIterator::UP sb = whiteListBlueprint->createSearch(*md, strict);
+    SearchIterator::UP sb = whiteListBlueprint->createSearch(*md);
     SimpleResult act;
     act.searchStrict(*sb, docIdLimit);
     EXPECT_EQ(exp, act);

--- a/searchcore/src/tests/proton/feed_and_search/feed_and_search_test.cpp
+++ b/searchcore/src/tests/proton/feed_and_search/feed_and_search_test.cpp
@@ -100,8 +100,9 @@ testSearch(Searchable &source, const string &term, uint32_t doc_id)
     SimpleStringTerm node(term, field_name, 0, search::query::Weight(0));
     Blueprint::UP result = source.createBlueprint(requestContext,
             FieldSpecList().add(FieldSpec(field_name, 0, handle)), node);
-    result->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-    SearchIterator::UP search_iterator = result->createSearch(*match_data, true);
+    result->basic_plan(true, 1000);
+    result->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+    SearchIterator::UP search_iterator = result->createSearch(*match_data);
     search_iterator->initFullRange();
     ASSERT_TRUE(search_iterator.get());
     ASSERT_TRUE(search_iterator->seek(doc_id));

--- a/searchcore/src/tests/proton/index/fusionrunner_test.cpp
+++ b/searchcore/src/tests/proton/index/fusionrunner_test.cpp
@@ -240,8 +240,9 @@ FusionRunnerTest::checkResults(uint32_t fusion_id, const uint32_t *ids, size_t s
     search::queryeval::Searchable &searchable = disk_index;
     SimpleStringTerm node(term, field_name, fieldId, search::query::Weight(0));
     Blueprint::UP blueprint = searchable.createBlueprint(requestContext, fields, node);
-    blueprint->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-    SearchIterator::UP search = blueprint->createSearch(*match_data, true);
+    blueprint->basic_plan(true, 1000);
+    blueprint->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+    SearchIterator::UP search = blueprint->createSearch(*match_data);
     search->initFullRange();
     for (size_t i = 0; i < size; ++i) {
         EXPECT_TRUE(search->seek(ids[i]));

--- a/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
+++ b/searchcore/src/tests/proton/matching/match_phase_limiter/match_phase_limiter_test.cpp
@@ -78,18 +78,18 @@ struct MockBlueprint : SimpleLeafBlueprint {
     search::queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
         return default_flow_stats(docid_limit, 756, 0);
     }
-    SearchIterator::UP createLeafSearch(const TermFieldMatchDataArray &tfmda, bool strict) const override
+    SearchIterator::UP createLeafSearch(const TermFieldMatchDataArray &tfmda) const override
     {
         if (postings_fetched) {
-            EXPECT_EQUAL(postings_strict, strict);
+            EXPECT_EQUAL(postings_strict, strict());
         }
-        return std::make_unique<MockSearch>(spec, term, strict, tfmda, postings_fetched);
+        return std::make_unique<MockSearch>(spec, term, strict(), tfmda, postings_fetched);
     }
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
-    void fetchPostings(const search::queryeval::ExecuteInfo &execInfo) override {
-        postings_strict = execInfo.is_strict();
+    void fetchPostings(const search::queryeval::ExecuteInfo &) override {
+        postings_strict = strict();
         postings_fetched = true;
     }
 };

--- a/searchcore/src/tests/proton/matching/query_test.cpp
+++ b/searchcore/src/tests/proton/matching/query_test.cpp
@@ -145,9 +145,9 @@ Fixture::getIterator(Node &node, ISearchContext &context) {
     _match_data = mdl.createMatchData();
 
     _blueprint = BlueprintBuilder::build(_requestContext, node, context);
-
-    _blueprint->fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP search(_blueprint->createSearch(*_match_data, true));
+    _blueprint->basic_plan(true, 1000);
+    _blueprint->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search(_blueprint->createSearch(*_match_data));
     search->initFullRange();
     return search;
 }
@@ -652,8 +652,8 @@ TEST("requireThatQueryGluesEverythingTogether") {
     MatchData::UP md = mdl.createMatchData();
     EXPECT_EQUAL(1u, md->getNumTermFields());
 
-    query.optimize(true);
-    query.fetchPostings(ExecuteInfo::TRUE);
+    query.optimize(true, true);
+    query.fetchPostings(ExecuteInfo::FULL);
     SearchIterator::UP search = query.createSearch(*md);
     ASSERT_TRUE(search);
 }
@@ -685,7 +685,8 @@ checkQueryAddsLocation(const string &loc_in, const string &loc_out) {
     MatchData::UP md = mdl.createMatchData();
     EXPECT_EQUAL(2u, md->getNumTermFields());
 
-    query.fetchPostings(ExecuteInfo::TRUE);
+    // query.optimize(true, true);
+    query.fetchPostings(ExecuteInfo::FULL);
     SearchIterator::UP search = query.createSearch(*md);
     ASSERT_TRUE(search);
     if (!EXPECT_NOT_EQUAL(string::npos, search->asString().find(loc_out))) {
@@ -788,15 +789,20 @@ TEST("requireThatFakeFieldSearchDumpsDiffer")
     Blueprint::UP l3(a.createBlueprint(requestContext, fields2, n3)); // field
     Blueprint::UP l4(b.createBlueprint(requestContext, fields1, n1)); // tag
 
-    l1->fetchPostings(ExecuteInfo::TRUE);
-    l2->fetchPostings(ExecuteInfo::TRUE);
-    l3->fetchPostings(ExecuteInfo::TRUE);
-    l4->fetchPostings(ExecuteInfo::TRUE);
+    l1->basic_plan(true, 1000);
+    l2->basic_plan(true, 1000);
+    l3->basic_plan(true, 1000);
+    l4->basic_plan(true, 1000);
+    
+    l1->fetchPostings(ExecuteInfo::FULL);
+    l2->fetchPostings(ExecuteInfo::FULL);
+    l3->fetchPostings(ExecuteInfo::FULL);
+    l4->fetchPostings(ExecuteInfo::FULL);
 
-    SearchIterator::UP s1(l1->createSearch(*match_data, true));
-    SearchIterator::UP s2(l2->createSearch(*match_data, true));
-    SearchIterator::UP s3(l3->createSearch(*match_data, true));
-    SearchIterator::UP s4(l4->createSearch(*match_data, true));
+    SearchIterator::UP s1(l1->createSearch(*match_data));
+    SearchIterator::UP s2(l2->createSearch(*match_data));
+    SearchIterator::UP s3(l3->createSearch(*match_data));
+    SearchIterator::UP s4(l4->createSearch(*match_data));
 
     EXPECT_NOT_EQUAL(s1->asString(), s2->asString());
     EXPECT_NOT_EQUAL(s1->asString(), s3->asString());
@@ -904,8 +910,8 @@ TEST("requireThatWhiteListBlueprintCanBeUsed")
     query.reserveHandles(requestContext, context, mdl);
     MatchData::UP md = mdl.createMatchData();
 
-    query.optimize(true);
-    query.fetchPostings(ExecuteInfo::TRUE);
+    query.optimize(true, true);
+    query.fetchPostings(ExecuteInfo::FULL);
     SearchIterator::UP search = query.createSearch(*md);
     SimpleResult exp = SimpleResult().addHit(1).addHit(5).addHit(7).addHit(11);
     SimpleResult act;

--- a/searchcore/src/tests/proton/matching/querynodes_test.cpp
+++ b/searchcore/src/tests/proton/matching/querynodes_test.cpp
@@ -205,8 +205,9 @@ public:
         MatchData::UP match_data = mdl.createMatchData();
 
         Blueprint::UP blueprint = BlueprintBuilder::build(requestContext, node, context);
-        blueprint->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-        return blueprint->createSearch(*match_data, true)->asString();
+        blueprint->basic_plan(true, 1000);
+        blueprint->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+        return blueprint->createSearch(*match_data)->asString();
     }
 
     template <typename Tag> string getIteratorAsString();

--- a/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
+++ b/searchcore/src/vespa/searchcore/proton/documentmetastore/lid_allocator.cpp
@@ -209,11 +209,11 @@ private:
         return default_flow_stats(docid_limit, _activeLids.size(), 0);
     }
     SearchIterator::UP
-    createLeafSearch(const TermFieldMatchDataArray &tfmda, bool strict) const override
+    createLeafSearch(const TermFieldMatchDataArray &tfmda) const override
     {
         assert(tfmda.size() == 0);
         (void) tfmda;
-        return create_search_helper(strict);
+        return create_search_helper(strict());
     }
 public:
     WhiteListBlueprint(const search::BitVector &activeLids, bool all_lids_active)
@@ -228,11 +228,11 @@ public:
 
     bool isWhiteList() const noexcept final { return true; }
 
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint) const override {
+    SearchIterator::UP createFilterSearch(FilterConstraint) const override {
         if (_all_lids_active) {
             return std::make_unique<FullSearch>();
         }
-        return create_search_helper(strict);
+        return create_search_helper(strict());
     }
 
     ~WhiteListBlueprint() override {

--- a/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/attribute_limiter.cpp
@@ -99,9 +99,11 @@ AttributeLimiter::create_match_data(size_t want_hits, size_t max_group_size, dou
         FieldSpecList field; // single field API is protected
         field.add(FieldSpec(_attribute_name, my_field_id, my_handle));
         _blueprint = _searchable_attributes.createBlueprint(_requestContext, field, node);
+        uint32_t dummy_docid_limit = 1337;
+        _blueprint->basic_plan(strictSearch, dummy_docid_limit);
         //TODO use_estimate must be switched to true quite soon
         //TODO Use thread_bundle once verified(soon), _requestContext.thread_bundle()
-        auto execInfo = ExecuteInfo::create(strictSearch, strictSearch ? 1.0 : hit_rate, _requestContext.getDoom(),
+        auto execInfo = ExecuteInfo::create(strictSearch ? 1.0 : hit_rate, _requestContext.getDoom(),
                                             vespalib::ThreadBundle::trivial());
         _blueprint->fetchPostings(execInfo);
         _estimatedHits.store(_blueprint->getState().estimate().estHits, std::memory_order_relaxed);
@@ -114,7 +116,7 @@ AttributeLimiter::create_match_data(size_t want_hits, size_t max_group_size, dou
 std::unique_ptr<SearchIterator>
 AttributeLimiter::create_search(size_t want_hits, size_t max_group_size, double hit_rate, bool strictSearch) {
     auto [blueprint, match_data] = create_match_data(want_hits, max_group_size, hit_rate, strictSearch);
-    return blueprint.createSearch(match_data, strictSearch);
+    return blueprint.createSearch(match_data);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/docsum_matcher.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/docsum_matcher.cpp
@@ -58,7 +58,7 @@ const T *as(const Blueprint &bp) { return dynamic_cast<const T *>(&bp); }
 
 void find_matching_elements(const std::vector<uint32_t> &docs, const SameElementBlueprint &same_element, MatchingElements &result) {
     search::fef::TermFieldMatchData dummy_tfmd;
-    auto search = same_element.create_same_element_search(dummy_tfmd, false);
+    auto search = same_element.create_same_element_search(dummy_tfmd);
     search->initRange(docs.front(), docs.back()+1);
     std::vector<uint32_t> matches;
     for (uint32_t doc : docs) {

--- a/searchcore/src/vespa/searchcore/proton/matching/query.cpp
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.cpp
@@ -198,10 +198,11 @@ Query::reserveHandles(const IRequestContext & requestContext, ISearchContext &co
 }
 
 void
-Query::optimize(bool sort_by_cost)
+Query::optimize(InFlow in_flow, bool sort_by_cost)
 {
-    auto opts = Blueprint::Options::all().sort_by_cost(sort_by_cost);
-    _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), true, opts);
+    _in_flow = in_flow;
+    auto opts = Blueprint::Options().sort_by_cost(sort_by_cost);
+    _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), in_flow, opts);
     LOG(debug, "optimized blueprint:\n%s\n", _blueprint->asString().c_str());
 }
 
@@ -223,11 +224,11 @@ Query::handle_global_filter(const IRequestContext & requestContext, uint32_t doc
     }
     // optimized order may change after accounting for global filter:
     trace.addEvent(5, "Optimize query execution plan to account for global filter");
-    auto opts = Blueprint::Options::all().sort_by_cost(sort_by_cost);
-    _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), true, opts);
+    auto opts = Blueprint::Options().sort_by_cost(sort_by_cost);
+    _blueprint = Blueprint::optimize_and_sort(std::move(_blueprint), _in_flow, opts);
     LOG(debug, "blueprint after handle_global_filter:\n%s\n", _blueprint->asString().c_str());
     // strictness may change if optimized order changed:
-    fetchPostings(ExecuteInfo::create(true, 1.0, requestContext.getDoom(), requestContext.thread_bundle()));
+    fetchPostings(ExecuteInfo::create(_in_flow.rate(), requestContext.getDoom(), requestContext.thread_bundle()));
 }
 
 bool
@@ -288,7 +289,7 @@ Query::estimate() const
 SearchIterator::UP
 Query::createSearch(MatchData &md) const
 {
-    return _blueprint->createSearch(md, true);
+    return _blueprint->createSearch(md);
 }
 
 }

--- a/searchcore/src/vespa/searchcore/proton/matching/query.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/query.h
@@ -26,7 +26,9 @@ private:
     using ExecuteInfo = search::queryeval::ExecuteInfo;
     using IRequestContext = search::queryeval::IRequestContext;
     using GeoLocationSpec = search::common::GeoLocationSpec;
+    using InFlow = search::queryeval::InFlow;
     search::query::Node::UP      _query_tree;
+    InFlow                       _in_flow = InFlow(true);
     Blueprint::UP                _blueprint;
     Blueprint::UP                _whiteListBlueprint;
     std::vector<GeoLocationSpec> _locations;
@@ -103,8 +105,8 @@ public:
      * testing becomes harder. Not calling this function enables the
      * test to verify the original query without optimization.
      **/
-    void optimize(bool sort_by_cost);
-    void fetchPostings(const ExecuteInfo & executeInfo) ;
+    void optimize(InFlow in_flow, bool sort_by_cost);
+    void fetchPostings(const ExecuteInfo & executeInfo);
 
     void handle_global_filter(const IRequestContext & requestContext, uint32_t docid_limit,
                               double global_filter_lower_limit, double global_filter_upper_limit,

--- a/searchcore/src/vespa/searchcorespi/index/warmupindexcollection.cpp
+++ b/searchcore/src/vespa/searchcorespi/index/warmupindexcollection.cpp
@@ -298,8 +298,10 @@ WarmupTask::run()
 {
     if (_warmup->warmupEndTime() != vespalib::steady_time()) {
         LOG(debug, "Warming up %s", _bluePrint->asString().c_str());
-        _bluePrint->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-        SearchIterator::UP it(_bluePrint->createSearch(*_matchData, true));
+        uint32_t dummy_docid_limit = 1337;
+        _bluePrint->basic_plan(true, dummy_docid_limit);
+        _bluePrint->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+        SearchIterator::UP it(_bluePrint->createSearch(*_matchData));
         it->initFullRange();
         for (uint32_t docId = it->seekFirst(1); !it->isAtEnd(); docId = it->seekNext(docId+1)) {
             if (_warmup->doUnpack()) {

--- a/searchlib/src/apps/tests/memoryindexstress_test.cpp
+++ b/searchlib/src/apps/tests/memoryindexstress_test.cpp
@@ -63,7 +63,7 @@ const vespalib::string bar("bar");
 const vespalib::string doc_type_name = "test";
 const vespalib::string header_name = doc_type_name + ".header";
 const vespalib::string body_name = doc_type_name + ".body";
-
+uint32_t docid_limit = 100; // needed for relative estimates
 
 Schema
 makeSchema()
@@ -332,13 +332,14 @@ Fixture::readWork(uint32_t cnt)
             LOG(error, "Did not get blueprint");
             break;
         }
+        result->basic_plan(true, docid_limit);
         if (result->getState().estimate().empty) {
             ++emptyCount;
         } else {
             ++nonEmptyCount;
         }
-        result->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP search = result->createSearch(*match_data, true);
+        result->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = result->createSearch(*match_data);
         if (!EXPECT_TRUE(search)) {
             LOG(error, "Did not get search iterator");
             break;
@@ -429,11 +430,12 @@ verifyResult(const FakeResult &expect,
     if (!EXPECT_TRUE(result.get() != 0)) {
         return false;
     }
+    result->basic_plan(true, docid_limit);
     EXPECT_EQUAL(expect.inspect().size(), result->getState().estimate().estHits);
     EXPECT_EQUAL(expect.inspect().empty(), result->getState().estimate().empty);
 
-    result->fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP search = result->createSearch(*match_data, true);
+    result->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = result->createSearch(*match_data);
     if (!EXPECT_TRUE(search.get() != 0)) {
         return false;
     }

--- a/searchlib/src/tests/attribute/benchmark/attributesearcher.h
+++ b/searchlib/src/tests/attribute/benchmark/attributesearcher.h
@@ -140,7 +140,7 @@ AttributeFindSearcher<T>::doRun()
             _attrPtr->getSearch(vespalib::stringref(&_query[0], _query.size()),
                                 attribute::SearchContextParams());
 
-        searchContext->fetchPostings(queryeval::ExecuteInfo::TRUE);
+        searchContext->fetchPostings(queryeval::ExecuteInfo::FULL, true);
         std::unique_ptr<queryeval::SearchIterator> iterator = searchContext->createIterator(nullptr, true);
         std::unique_ptr<ResultSet> results = performSearch(*iterator, _attrPtr->getNumDocs());
 
@@ -218,7 +218,7 @@ AttributeRangeSearcher::doRun()
             _attrPtr->getSearch(vespalib::stringref(&_query[0], _query.size()),
                                 attribute::SearchContextParams());
 
-        searchContext->fetchPostings(queryeval::ExecuteInfo::TRUE);
+        searchContext->fetchPostings(queryeval::ExecuteInfo::FULL, true);
         std::unique_ptr<queryeval::SearchIterator> iterator = searchContext->createIterator(nullptr, true);
         std::unique_ptr<ResultSet> results = performSearch(*iterator, _attrPtr->getNumDocs());
 
@@ -257,7 +257,7 @@ AttributePrefixSearcher::doRun()
             _attrPtr->getSearch(vespalib::stringref(&_query[0], _query.size()),
                                 attribute::SearchContextParams());
 
-        searchContext->fetchPostings(queryeval::ExecuteInfo::TRUE);
+        searchContext->fetchPostings(queryeval::ExecuteInfo::FULL, true);
         std::unique_ptr<queryeval::SearchIterator> iterator = searchContext->createIterator(nullptr, true);
         std::unique_ptr<ResultSet> results = performSearch(*iterator, _attrPtr->getNumDocs());
 

--- a/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
+++ b/searchlib/src/tests/attribute/bitvector/bitvector_test.cpp
@@ -426,7 +426,7 @@ BitVectorTest::checkSearch(AttributePtr v,
                            bool checkStride)
 {
     TermFieldMatchData md;
-    sc->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(search::queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     checkSearch(std::move(v), std::move(sb), md,
                 expFirstDocId, expLastDocId, expDocFreq, weights,

--- a/searchlib/src/tests/attribute/direct_multi_term_blueprint/direct_multi_term_blueprint_test.cpp
+++ b/searchlib/src/tests/attribute/direct_multi_term_blueprint/direct_multi_term_blueprint_test.cpp
@@ -222,7 +222,6 @@ public:
         } else {
             validate_posting_lists<StringKey>(*store);
         }
-        blueprint->setDocIdLimit(doc_id_limit);
         if (need_term_field_match_data) {
             tfmd.needs_normal_features();
         } else {
@@ -263,8 +262,9 @@ public:
             add_term(value);
         }
     }
-    std::unique_ptr<SearchIterator> create_leaf_search(bool strict = true) const {
-        return blueprint->createLeafSearch(tfmda, strict);
+    std::unique_ptr<SearchIterator> create_leaf_search(bool strict = true) {
+        blueprint->basic_plan(strict, doc_id_limit);
+        return blueprint->createLeafSearch(tfmda);
     }
     vespalib::string resolve_iterator_with_unpack() const {
         if (in_operator) {

--- a/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
+++ b/searchlib/src/tests/attribute/enumeratedsave/enumeratedsave_test.cpp
@@ -665,7 +665,7 @@ EnumeratedSaveTest::testReload(AttributePtr v0,
 
     TermFieldMatchData md;
     SearchContextPtr sc = getSearch<VectorType>(as<VectorType>(v));
-    sc->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(search::queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     sb->initFullRange();
     sb->seek(1u);

--- a/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
+++ b/searchlib/src/tests/attribute/imported_search_context/imported_search_context_test.cpp
@@ -271,7 +271,7 @@ TEST_F("Non-strict iterator unpacks target match data for weighted set hit", Wse
 
 TEST_F("Strict iterator is marked as strict", Fixture) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -280,7 +280,7 @@ TEST_F("Strict iterator is marked as strict", Fixture) {
 
 TEST_F("Non-strict blueprint with high hit rate is strict", Fixture(false, FastSearchConfig::ExplicitlyEnabled)) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::createForTest(false, 0.02));
+    ctx->fetchPostings(queryeval::ExecuteInfo::createForTest(0.02), false);
     TermFieldMatchData match;
     auto iter = f.create_iterator(*ctx, match, false);
 
@@ -289,7 +289,7 @@ TEST_F("Non-strict blueprint with high hit rate is strict", Fixture(false, FastS
 
 TEST_F("Non-strict blueprint with low hit rate is non-strict", Fixture(false, FastSearchConfig::ExplicitlyEnabled)) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::createForTest(false, 0.01));
+    ctx->fetchPostings(queryeval::ExecuteInfo::createForTest(0.01), false);
     TermFieldMatchData match;
     auto iter = f.create_iterator(*ctx, match, false);
 
@@ -314,7 +314,7 @@ SingleValueFixture::~SingleValueFixture() = default;
 
 TEST_F("Strict iterator seeks to first available hit LID", SingleValueFixture) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -340,7 +340,7 @@ TEST_F("Strict iterator seeks to first available hit LID", SingleValueFixture) {
 
 TEST_F("Strict iterator unpacks target match data for single value hit", SingleValueFixture) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -352,7 +352,7 @@ TEST_F("Strict iterator unpacks target match data for single value hit", SingleV
 
 TEST_F("Strict iterator unpacks target match data for array hit", ArrayValueFixture) {
     auto ctx = f.create_context(word_term("1234"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -364,7 +364,7 @@ TEST_F("Strict iterator unpacks target match data for array hit", ArrayValueFixt
 
 TEST_F("Strict iterator unpacks target match data for weighted set hit", WsetValueFixture) {
     auto ctx = f.create_context(word_term("foo"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -375,7 +375,7 @@ TEST_F("Strict iterator unpacks target match data for weighted set hit", WsetVal
 
 TEST_F("Strict iterator handles seek outside of LID space", ArrayValueFixture) {
     auto ctx = f.create_context(word_term("1234"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
 
@@ -407,7 +407,7 @@ TEST_F("matches(weight) performs GID mapping and forwards to target attribute", 
 
 TEST_F("Multiple iterators can be created from the same context", SingleValueFixture) {
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
 
     TermFieldMatchData match1;
     auto iter1 = f.create_strict_iterator(*ctx, match1);
@@ -490,7 +490,7 @@ TEST_F("Bit vector from search cache is used if found", SearchCacheFixture)
     f.imported_attr->getSearchCache()->insert("5678",
                                               makeSearchCacheEntry({2, 6}, f.get_imported_attr()->getNumDocs()));
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
     TEST_DO(f.assertSearch({2, 6}, *iter)); // Note: would be {3, 5} if cache was not used
@@ -509,7 +509,7 @@ TEST_F("Entry is inserted into search cache if bit vector posting list is used",
 {
     EXPECT_EQUAL(0u, f.imported_attr->getSearchCache()->size());
     auto ctx = f.create_context(word_term("5678"));
-    ctx->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    ctx->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     TermFieldMatchData match;
     auto iter = f.create_strict_iterator(*ctx, match);
     TEST_DO(f.assertSearch({3, 5}, *iter));

--- a/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
+++ b/searchlib/src/tests/attribute/postinglistattribute/postinglistattribute_test.cpp
@@ -378,7 +378,7 @@ PostingListAttributeTest::assertSearch(const std::string &exp, StringAttribute &
 {
     TermFieldMatchData md;
     SearchContextPtr sc = getSearch<StringAttribute>(sa);
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     bool retval = true;
     EXPECT_TRUE(assertIterator(exp, *sb)) << (retval = false, "");
@@ -391,7 +391,7 @@ PostingListAttributeTest::assertSearch(const std::string &exp, StringAttribute &
 {
     TermFieldMatchData md;
     SearchContextPtr sc = getSearch<StringAttribute, std::string>(sa, key, false);
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     bool retval = true;
     EXPECT_TRUE(assertIterator(exp, *sb, &md)) << (retval = false, "");
@@ -403,7 +403,7 @@ PostingListAttributeTest::assertSearch(const std::string &exp, IntegerAttribute 
 {
     TermFieldMatchData md;
     SearchContextPtr sc = getSearch<IntegerAttribute, int32_t>(ia, key, false);
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     bool retval = true;
     EXPECT_TRUE(assertIterator(exp, *sb, &md)) << (retval = false, "");
@@ -497,7 +497,7 @@ PostingListAttributeTest::checkSearch(bool useBitVector, bool need_unpack, bool 
 {
     SearchContextPtr sc = getSearch(vec, term, false, attribute::SearchContextParams().useBitVector(useBitVector));
     EXPECT_FALSE( ! sc );
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     auto est = sc->calc_hit_estimate();
     uint32_t est_hits = est.est_hits();
     EXPECT_FALSE(est.is_unknown());
@@ -912,7 +912,7 @@ PostingListAttributeTest::testMinMax(AttributePtr &ptr1, uint32_t trimmed)
 {
     TermFieldMatchData md;
     SearchContextPtr sc = getSearch<VectorType>(as<VectorType>(ptr1));
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     SearchBasePtr sb = sc->createIterator(&md, true);
     sb->initFullRange();
 
@@ -937,7 +937,7 @@ PostingListAttributeTest::testMinMax(AttributePtr &ptr1, uint32_t trimmed)
     EXPECT_EQ(1u, sb->getDocId());
 
     sc = getSearch2<VectorType>(as<VectorType>(ptr1));
-    sc->fetchPostings(queryeval::ExecuteInfo::TRUE);
+    sc->fetchPostings(queryeval::ExecuteInfo::FULL, true);
     sb = sc->createIterator(&md, true);
     sb->initFullRange();
 

--- a/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_searchable_adapter_test.cpp
@@ -223,8 +223,9 @@ Result do_search(IAttributeManager &attribute_manager, const Node &node, bool st
     Blueprint::UP bp = source.createBlueprint(requestContext, FieldSpec(field, fieldId, handle), node);
     ASSERT_TRUE(bp);
     Result result(bp->getState().estimate().estHits, bp->getState().estimate().empty);
-    bp->fetchPostings(queryeval::ExecuteInfo::createForTest(strict));
-    SearchIterator::UP iterator = bp->createSearch(*match_data, strict);
+    bp->basic_plan(strict, 100);
+    bp->fetchPostings(queryeval::ExecuteInfo::FULL);
+    SearchIterator::UP iterator = bp->createSearch(*match_data);
     ASSERT_TRUE(iterator);
     iterator->initRange(1, num_docs);
     extract_posting_info(result, iterator->getPostingInfo());

--- a/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attribute_weighted_set_blueprint_test.cpp
@@ -111,8 +111,9 @@ struct WS {
         FieldSpecList fields;
         fields.add(FieldSpec(field, fieldId, handle, ac.getAttribute(field)->getIsFilter()));
         queryeval::Blueprint::UP bp = searchable.createBlueprint(requestContext, fields, *node);
-        bp->fetchPostings(queryeval::ExecuteInfo::createForTest(strict));
-        SearchIterator::UP sb = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(queryeval::ExecuteInfo::FULL);
+        SearchIterator::UP sb = bp->createSearch(*md);
         return sb;
     }
     bool isWeightedSetTermSearch(Searchable &searchable, const std::string &field, bool strict) const {
@@ -127,8 +128,9 @@ struct WS {
         FieldSpecList fields;
         fields.add(FieldSpec(field, fieldId, handle));
         queryeval::Blueprint::UP bp = searchable.createBlueprint(requestContext, fields, *node);
-        bp->fetchPostings(queryeval::ExecuteInfo::createForTest(strict));
-        SearchIterator::UP sb = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(queryeval::ExecuteInfo::FULL);
+        SearchIterator::UP sb = bp->createSearch(*md);
         FakeResult result;
         sb->initRange(1, 10);
         for (uint32_t docId = 1; docId < 10; ++docId) {

--- a/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
+++ b/searchlib/src/tests/attribute/searchable/attributeblueprint_test.cpp
@@ -127,9 +127,9 @@ do_search(const Node &node, IAttributeManager &attribute_manager, bool expect_at
     } else {
         EXPECT_TRUE(result->get_attribute_search_context() == nullptr);
     }
-    result->fetchPostings(queryeval::ExecuteInfo::TRUE);
-    result->setDocIdLimit(DOCID_LIMIT);
-    SearchIterator::UP iterator = result->createSearch(*md, true);
+    result->basic_plan(true, DOCID_LIMIT);
+    result->fetchPostings(queryeval::ExecuteInfo::FULL);
+    SearchIterator::UP iterator = result->createSearch(*md);
     assert((bool)iterator);
     iterator->initRange(1, DOCID_LIMIT);
     EXPECT_TRUE(!iterator->seek(1));
@@ -313,8 +313,8 @@ public:
     ~BlueprintFactoryFixture() {}
     Blueprint::UP create_blueprint(const Node& term) {
         auto result = source.createBlueprint(request_ctx, FieldSpec(attr_name, 0, 0), term);
-        result->fetchPostings(queryeval::ExecuteInfo::TRUE);
-        result->setDocIdLimit(DOCID_LIMIT);
+        result->basic_plan(true, DOCID_LIMIT);
+        result->fetchPostings(queryeval::ExecuteInfo::FULL);
         return result;
     }
     void expect_document_weight_attribute() {
@@ -325,14 +325,14 @@ public:
     }
     void expect_filter_search(const SimpleResult& upper, const SimpleResult& lower, const Node& term) {
         auto blueprint = create_blueprint(term);
-        auto upper_itr = blueprint->createFilterSearch(true, BFC::UPPER_BOUND);
-        auto lower_itr = blueprint->createFilterSearch(true, BFC::LOWER_BOUND);
+        auto upper_itr = blueprint->createFilterSearch(BFC::UPPER_BOUND);
+        auto lower_itr = blueprint->createFilterSearch(BFC::LOWER_BOUND);
         EXPECT_EQ(upper, SimpleResult().search(*upper_itr, DOCID_LIMIT));
         EXPECT_EQ(lower, SimpleResult().search(*lower_itr, DOCID_LIMIT));
     }
     void expect_filter_wrapper(const Node& term) {
         auto blueprint = create_blueprint(term);
-        auto itr = blueprint->createFilterSearch(true, BFC::UPPER_BOUND);
+        auto itr = blueprint->createFilterSearch(BFC::UPPER_BOUND);
         downcast<FilterWrapper>(*itr);
     }
 };

--- a/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
+++ b/searchlib/src/tests/diskindex/diskindex/diskindex_test.cpp
@@ -313,49 +313,53 @@ DiskIndexTest::requireThatBlueprintCanCreateSearchIterators()
     auto upper_bound = Blueprint::FilterConstraint::UPPER_BOUND;
     { // bit vector due to isFilter
         b = _index->createBlueprint(_requestContext, FieldSpec("f2", 0, 0, true), makeTerm("w2"));
-        b->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
+        b->basic_plan(true, 1000);
+        b->fetchPostings(search::queryeval::ExecuteInfo::FULL);
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
-        s = leaf_b.createLeafSearch(mda, true);
+        s = leaf_b.createLeafSearch(mda);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(true, upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
     { // bit vector due to no ranking needed
         b = _index->createBlueprint(_requestContext, FieldSpec("f2", 0, 0, false), makeTerm("w2"));
-        b->fetchPostings(ExecuteInfo::TRUE);
+        b->basic_plan(true, 1000);
+        b->fetchPostings(ExecuteInfo::FULL);
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
-        s = leaf_b.createLeafSearch(mda, true);
+        s = leaf_b.createLeafSearch(mda);
         EXPECT_FALSE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
         TermFieldMatchData md2;
         md2.tagAsNotNeeded();
         TermFieldMatchDataArray mda2;
         mda2.add(&md2);
         EXPECT_TRUE(mda2[0]->isNotNeeded());
-        s = (dynamic_cast<LeafBlueprint *>(b.get()))->createLeafSearch(mda2, true);
+        s = (dynamic_cast<LeafBlueprint *>(b.get()))->createLeafSearch(mda2);
         EXPECT_TRUE(dynamic_cast<BitVectorIterator *>(s.get()) != NULL);
         EXPECT_EQ(result_f2_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(true, upper_bound)));
+        EXPECT_EQ(result_f2_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
     { // fake bit vector
         b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0, true), makeTerm("w2"));
 //        std::cerr << "BP = " << typeid(*b).name() << std::endl;
-        b->fetchPostings(ExecuteInfo::TRUE);
+        b->basic_plan(true, 1000);
+        b->fetchPostings(ExecuteInfo::FULL);
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
-        s = leaf_b.createLeafSearch(mda, true);
+        s = leaf_b.createLeafSearch(mda);
 //        std::cerr << "SI = " << typeid(*s).name() << std::endl;
         EXPECT_TRUE((dynamic_cast<BooleanMatchIteratorWrapper *>(s.get()) != NULL) ||
                     dynamic_cast<EmptySearch *>(s.get()));
         EXPECT_EQ(result_f1_w2, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w2, SimpleResult().search(*leaf_b.createFilterSearch(true, upper_bound)));
+        EXPECT_EQ(result_f1_w2, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
     { // posting list iterator
         b = _index->createBlueprint(_requestContext, FieldSpec("f1", 0, 0), makeTerm("w1"));
-        b->fetchPostings(ExecuteInfo::TRUE);
+        b->basic_plan(true, 1000);
+        b->fetchPostings(ExecuteInfo::FULL);
         auto& leaf_b = dynamic_cast<LeafBlueprint&>(*b);
-        s = leaf_b.createLeafSearch(mda, true);
+        s = leaf_b.createLeafSearch(mda);
         ASSERT_TRUE((dynamic_cast<ZcRareWordPosOccIterator<true, false> *>(s.get()) != NULL));
         EXPECT_EQ(result_f1_w1, SimpleResult().search(*s));
-        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(true, upper_bound)));
+        EXPECT_EQ(result_f1_w1, SimpleResult().search(*leaf_b.createFilterSearch(upper_bound)));
     }
 }
 

--- a/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
+++ b/searchlib/src/tests/memoryindex/memory_index/memory_index_test.cpp
@@ -228,8 +228,9 @@ verifyResult(const FakeResult &expect,
     EXPECT_EQ(expect.inspect().size(), result->getState().estimate().estHits);
     EXPECT_EQ(expect.inspect().empty(), result->getState().estimate().empty);
 
-    result->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-    SearchIterator::UP search = result->createSearch(*match_data, true);
+    result->basic_plan(true, 100);
+    result->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+    SearchIterator::UP search = result->createSearch(*match_data);
     bool valid_search = search.get() != 0;
     EXPECT_TRUE(valid_search);
     if (!valid_search) {
@@ -256,7 +257,7 @@ verifyResult(const FakeResult &expect,
     using FilterConstraint = Blueprint::FilterConstraint;
     for (auto constraint : { FilterConstraint::LOWER_BOUND, FilterConstraint::UPPER_BOUND }) {
         constexpr uint32_t docid_limit = 10u;
-        auto filter_search = result->createFilterSearch(true, constraint);
+        auto filter_search = result->createFilterSearch(constraint);
         auto act_simple = SimpleResult().search(*filter_search, docid_limit);
         if (constraint == FilterConstraint::LOWER_BOUND) {
             EXPECT_TRUE(exp_simple.contains(act_simple)) << (success = false, "");
@@ -522,8 +523,9 @@ TEST(MemoryIndexTest, require_that_we_can_fake_bit_vector)
         Blueprint::UP res = searchable.createBlueprint(requestContext, fields, makeTerm(foo));
         EXPECT_TRUE(res);
 
-        res->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
-        SearchIterator::UP search = res->createSearch(*match_data, true);
+        res->basic_plan(true, 100);
+        res->fetchPostings(search::queryeval::ExecuteInfo::FULL);
+        SearchIterator::UP search = res->createSearch(*match_data);
         EXPECT_TRUE(search);
         EXPECT_TRUE(dynamic_cast<BooleanMatchIteratorWrapper *>(search.get()) != nullptr);
         search->initFullRange();

--- a/searchlib/src/tests/nearsearch/nearsearch_test.cpp
+++ b/searchlib/src/tests/nearsearch/nearsearch_test.cpp
@@ -229,11 +229,10 @@ Test::testNearSearch(MyQuery &query, uint32_t matchId)
         near_b->addChild(query.getTerm(i).make_blueprint(fieldId, i));
     }
     bp->setDocIdLimit(1000);
-    auto opts = search::queryeval::Blueprint::Options::all();
-    bp = search::queryeval::Blueprint::optimize_and_sort(std::move(bp), true, opts);
-    bp->fetchPostings(search::queryeval::ExecuteInfo::TRUE);
+    bp = search::queryeval::Blueprint::optimize_and_sort(std::move(bp));
+    bp->fetchPostings(search::queryeval::ExecuteInfo::FULL);
     search::fef::MatchData::UP md(layout.createMatchData());
-    search::queryeval::SearchIterator::UP near = bp->createSearch(*md, true);
+    search::queryeval::SearchIterator::UP near = bp->createSearch(*md);
     near->initFullRange();
     bool foundMatch = false;
     for (near->seek(1u); ! near->isAtEnd(); near->seek(near->getDocId() + 1)) {

--- a/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
+++ b/searchlib/src/tests/queryeval/blueprint/leaf_blueprints_test.cpp
@@ -29,8 +29,9 @@ Test::testEmptyBlueprint()
     EXPECT_EQUAL(1u, empty.getState().field(0).getFieldId());
     EXPECT_EQUAL(11u, empty.getState().field(0).getHandle());
 
-    empty.fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP search = empty.createSearch(*md, true);
+    empty.basic_plan(true, 100);
+    empty.fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = empty.createSearch(*md);
 
     SimpleResult res;
     res.search(*search);
@@ -47,8 +48,9 @@ Test::testSimpleBlueprint()
     SimpleBlueprint simple(a);
     simple.tag("tag");
     EXPECT_EQUAL("tag", simple.tag());
-    simple.fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP search = simple.createSearch(*md, true);
+    simple.basic_plan(true, 100);
+    simple.fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = simple.createSearch(*md);
 
     SimpleResult res;
     res.search(*search);
@@ -69,8 +71,9 @@ Test::testFakeBlueprint()
     TermFieldHandle handle = 0;
     FakeBlueprint orig(FieldSpec("<field>", fieldId, handle), fake);
 
-    orig.fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP search = orig.createSearch(*md, true);
+    orig.basic_plan(true, 100);
+    orig.fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = orig.createSearch(*md);
     search->initFullRange();
     EXPECT_TRUE(!search->seek(1u));
     EXPECT_EQUAL(10u, search->getDocId());

--- a/searchlib/src/tests/queryeval/blueprint/mysearch.h
+++ b/searchlib/src/tests/queryeval/blueprint/mysearch.h
@@ -109,9 +109,9 @@ class MyLeaf : public SimpleLeafBlueprint
 
 public:
     SearchIterator::UP
-    createLeafSearch(const TFMDA &tfmda, bool strict) const override
+    createLeafSearch(const TFMDA &tfmda) const override
     {
-        return std::make_unique<MySearch>("leaf", tfmda, strict);
+        return std::make_unique<MySearch>("leaf", tfmda, strict());
     }
 
     MyLeaf() : SimpleLeafBlueprint() {}
@@ -141,8 +141,8 @@ public:
     // make public
     using LeafBlueprint::set_want_global_filter;
 
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
 };
 

--- a/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
+++ b/searchlib/src/tests/queryeval/dot_product/dot_product_test.cpp
@@ -74,8 +74,9 @@ struct DP {
         FieldSpecList fields;
         fields.add(FieldSpec(field, fieldId, handle, field_is_filter));
         queryeval::Blueprint::UP bp = searchable.createBlueprint(requestContext, fields, *node);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP sb = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 10);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP sb = bp->createSearch(*md);
         EXPECT_TRUE(dynamic_cast<DotProductSearch*>(sb.get()) != 0);
         sb->initFullRange();
         FakeResult result;

--- a/searchlib/src/tests/queryeval/equiv/equiv_test.cpp
+++ b/searchlib/src/tests/queryeval/equiv/equiv_test.cpp
@@ -59,8 +59,9 @@ EquivTest::test_equiv(bool strict, bool unpack_normal_features, bool unpack_inte
         data.setNeedNormalFeatures(unpack_normal_features);
         data.setNeedInterleavedFeatures(unpack_interleaved_features);
     }
-    bp->fetchPostings(ExecuteInfo::createForTest(strict));
-    SearchIterator::UP search = bp->createSearch(*md, strict);
+    bp->basic_plan(strict, 100);
+    bp->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = bp->createSearch(*md);
     search->initFullRange();
 
     EXPECT_TRUE(!search->seek(3));

--- a/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
+++ b/searchlib/src/tests/queryeval/fake_searchable/fake_searchable_test.cpp
@@ -62,8 +62,9 @@ TEST_F(FakeSearchableTest, require_that_term_search_works) {
         bool strict = (i == 0);
         SCOPED_TRACE(strict ? "strict" : "non-strict");
         MatchData::UP md = MatchData::makeTestInstance(100, 10);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
 
         EXPECT_TRUE(!search->seek(3));
@@ -116,8 +117,9 @@ TEST_F(FakeSearchableTest, require_that_phrase_search_works) {
         bool strict = (i == 0);
         SCOPED_TRACE(strict ? "strict" : "non-strict");
         MatchData::UP md = MatchData::makeTestInstance(100, 10);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
 
         EXPECT_TRUE(!search->seek(3));
@@ -167,8 +169,9 @@ TEST_F(FakeSearchableTest, require_that_weigheted_set_search_works) {
         bool strict = (i == 0);
         SCOPED_TRACE(strict ? "strict" : "non-strict");
         MatchData::UP md = MatchData::makeTestInstance(100, 10);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
 
         EXPECT_TRUE(!search->seek(2));
@@ -238,8 +241,9 @@ TEST_F(FakeSearchableTest, require_that_multi_field_search_works) {
         bool strict = (i == 0);
         SCOPED_TRACE(strict ? "strict" : "non-strict");
         MatchData::UP md = MatchData::makeTestInstance(100, 10);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
 
         EXPECT_TRUE(!search->seek(3));
@@ -322,8 +326,9 @@ TEST_F(FakeSearchableTest, require_that_phrase_with_empty_child_works) {
         bool strict = (i == 0);
         SCOPED_TRACE(strict ? "strict" : "non-strict");
         MatchData::UP md = MatchData::makeTestInstance(100, 10);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
 
         EXPECT_TRUE(!search->seek(3));
@@ -342,8 +347,9 @@ TEST_F(FakeSearchableTest, require_that_match_data_is_compressed_for_attributes)
     fields.add(FieldSpec("attrfoo", 1, 1));
     Blueprint::UP bp = source.createBlueprint(req_ctx, fields, termNode);
     MatchData::UP md = MatchData::makeTestInstance(100, 10);
-    bp->fetchPostings(ExecuteInfo::FALSE);
-    SearchIterator::UP search = bp->createSearch(*md, false);
+    bp->basic_plan(false, 100);
+    bp->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = bp->createSearch(*md);
     search->initFullRange();
     EXPECT_TRUE(search->seek(5));
     search->unpack(5u);
@@ -369,8 +375,9 @@ TEST_F(FakeSearchableTest, require_that_relevant_data_can_be_obtained_from_fake_
     fields.add(FieldSpec("attrfoo", 1, 1));
     Blueprint::UP bp = source.createBlueprint(req_ctx, fields, termNode);
     MatchData::UP md = MatchData::makeTestInstance(100, 10);
-    bp->fetchPostings(ExecuteInfo::FALSE);
-    SearchIterator::UP search = bp->createSearch(*md, false);
+    bp->basic_plan(false, 100);
+    bp->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP search = bp->createSearch(*md);
     EXPECT_TRUE(bp->get_attribute_search_context() != nullptr);
     const auto *attr_ctx = bp->get_attribute_search_context();
     ASSERT_TRUE(attr_ctx);

--- a/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
+++ b/searchlib/src/tests/queryeval/filter_search/filter_search_test.cpp
@@ -36,27 +36,14 @@ constexpr auto upper_bound = Constraint::UPPER_BOUND;
 const uint32_t docid_limit = 100;
 
 template <typename T>
-concept FilterFactory = requires(const T &a, bool strict, Constraint constraint) {
-    { a.createFilterSearch(strict, constraint) } -> std::same_as<std::unique_ptr<SearchIterator>>;
+concept FilterFactory = requires(const T &a, T &ma, InFlow in_flow, uint32_t my_docid_limit, bool strict, Constraint constraint) {
+    ma.basic_plan(in_flow, my_docid_limit);
+    { a.createFilterSearch(constraint) } -> std::same_as<std::unique_ptr<SearchIterator>>;
 };
 
 template <typename T>
 concept ChildCollector = requires(T a, std::unique_ptr<Blueprint> bp) {
     a.addChild(std::move(bp));
-};
-
-// inherit Blueprint to capture the default filter factory
-struct DefaultBlueprint : Blueprint {
-    FlowStats calculate_flow_stats(uint32_t) const override { abort(); }
-    void optimize(Blueprint* &, OptimizePass) override { abort(); }
-    double sort(InFlow, const Options &) override { abort(); }
-    const State &getState() const override { abort(); }
-    void fetchPostings(const ExecuteInfo &) override { abort(); }
-    void freeze() override { abort(); }
-    SearchIteratorUP createSearch(MatchData &, bool) const override { abort(); }
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
-    }
 };
 
 // proxy class used to make various decorators for leaf blueprints
@@ -71,10 +58,20 @@ struct LeafProxy : SimpleLeafBlueprint {
       : SimpleLeafBlueprint(), child(std::move(child_in)) { init(); }
     LeafProxy(FieldSpecBase field, std::unique_ptr<Blueprint> child_in)
       : SimpleLeafBlueprint(field), child(std::move(child_in)) { init(); }
-    FlowStats calculate_flow_stats(uint32_t) const override { abort(); }
-    SearchIteratorUP createLeafSearch(const TermFieldMatchDataArray &, bool) const override { abort(); }
-    SearchIteratorUP createFilterSearch(bool strict, Constraint constraint) const override {
-        return child->createFilterSearch(strict, constraint);
+    void each_node_post_order(const std::function<void(Blueprint&)> &f) override {
+        child->each_node_post_order(f);
+        f(*this);
+    }
+    FlowStats calculate_flow_stats(uint32_t my_docid_limit) const override {
+        return child->calculate_flow_stats(my_docid_limit);
+    }
+    void sort(InFlow in_flow, const Options &opts) override {
+        strict(in_flow.strict());
+        child->sort(in_flow, opts);
+    }
+    SearchIteratorUP createLeafSearch(const TermFieldMatchDataArray &) const override { abort(); }
+    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
+        return child->createFilterSearch(constraint);
     }
 };
 
@@ -82,15 +79,22 @@ struct LeafProxy : SimpleLeafBlueprint {
 struct CheckParamsProxy : LeafProxy {
     static bool current_strict;           // <- changed by test
     static Constraint current_constraint; // <- changed by test
+    bool expect_forced_strict = false;
     bool expect_inherit_strict;
     bool expect_same_constraint;
     CheckParamsProxy(std::unique_ptr<Blueprint> child_in, bool expect_inherit_strict_in, bool expect_same_constraint_in)
       : LeafProxy(std::move(child_in)),
         expect_inherit_strict(expect_inherit_strict_in), expect_same_constraint(expect_same_constraint_in) {}
-    SearchIteratorUP createFilterSearch(bool strict, Constraint constraint) const override {
-        EXPECT_EQ(strict, (current_strict && expect_inherit_strict));
+    CheckParamsProxy(std::unique_ptr<Blueprint> child_in)
+      : LeafProxy(std::move(child_in)), expect_forced_strict(true), expect_inherit_strict(false), expect_same_constraint(true) {}
+    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
+        if (expect_forced_strict) {
+            EXPECT_EQ(strict(), true);
+        } else {
+            EXPECT_EQ(strict(), (current_strict && expect_inherit_strict));
+        }
         EXPECT_EQ((constraint == current_constraint), expect_same_constraint);
-        return child->createFilterSearch(strict, constraint);
+        return child->createFilterSearch(constraint);
     }
 };
 bool CheckParamsProxy::current_strict = false;
@@ -101,9 +105,9 @@ struct CheckDroppedProxy : LeafProxy {
     mutable bool used;
     CheckDroppedProxy(std::unique_ptr<Blueprint> child_in)
       : LeafProxy(std::move(child_in)), used(false) {}
-    SearchIteratorUP createFilterSearch(bool strict, Constraint constraint) const override {
+    SearchIteratorUP createFilterSearch(Constraint constraint) const override {
         used = true;
-        return child->createFilterSearch(strict, constraint);
+        return child->createFilterSearch(constraint);
     }
     ~CheckDroppedProxy() override {
         EXPECT_EQ(used, false);
@@ -162,6 +166,10 @@ std::unique_ptr<Blueprint> check(std::unique_ptr<Blueprint> child, bool expect_i
     return std::make_unique<CheckParamsProxy>(std::move(child), expect_inherit_strict, expect_same_constraint);
 }
 
+std::unique_ptr<Blueprint> check_forced(std::unique_ptr<Blueprint> child) {
+    return std::make_unique<CheckParamsProxy>(std::move(child));
+}
+
 // check that create filter is not called
 std::unique_ptr<Blueprint> dropped(std::unique_ptr<Blueprint> child) {
     return std::make_unique<CheckDroppedProxy>(std::move(child));
@@ -191,6 +199,11 @@ struct Children {
         list.back() = [=](){ return ::check(old_factory(), expect_inherit_strict, expect_same_constraint); };
         return *this;
     }
+    Children &check_forced() {
+        Factory old_factory = list.back();
+        list.back() = [=](){ return ::check_forced(old_factory()); };
+        return *this;
+    }
     Children &dropped() {
         Factory old_factory = list.back();
         list.back() = [=](){ return ::dropped(old_factory()); };
@@ -204,29 +217,44 @@ struct Children {
     }
 };
 
+struct NoFlow {
+    NoFlow(InFlow) noexcept {}
+    void add(double) noexcept {};
+    bool strict() noexcept { return false; }
+    double flow() noexcept { return 0.0; }
+};
+
 // Combine children blueprints using a shared filter creation
 // algorithm. Satisfies the FilterFactory concept.
+template <typename Flow>
 struct Combine {
     using factory_fun = std::function<std::unique_ptr<SearchIterator>(const Blueprint::Children &, bool, Constraint)>;
     factory_fun fun;
+    bool strict;
     Blueprint::Children list;
-    Combine(factory_fun fun_in, const Children &child_list);
+    Combine(factory_fun fun_in, const Children &child_list)
+      : fun(fun_in), strict(false), list()
+    {
+        child_list.apply(*this);
+    }
     ~Combine();
     void addChild(std::unique_ptr<Blueprint> child) {
         list.push_back(std::move(child));
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        strict = in_flow.strict();
+        Flow flow(in_flow);
+        for (auto &child: list) {
+            child->basic_plan(InFlow(flow.strict(), flow.flow()), my_docid_limit);
+            flow.add(child->estimate());
+        }
+    }
+    auto createFilterSearch(Constraint constraint) const {
         return fun(list, strict, constraint);
     }
 };
-
-Combine::Combine(factory_fun fun_in, const Children &child_list)
-    : fun(fun_in), list()
-{
-    child_list.apply(*this);
-}
-
-Combine::~Combine() = default;
+template <typename Flow>
+Combine<Flow>::~Combine() = default;
 
 // enable Make-ing source blender
 struct SourceBlenderAdapter {
@@ -236,8 +264,11 @@ struct SourceBlenderAdapter {
     void addChild(std::unique_ptr<Blueprint> child) {
         blueprint.addChild(std::move(child));
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -251,8 +282,11 @@ struct SimplePhraseAdapter {
         auto term = std::make_unique<LeafProxy>(child_field, std::move(child));
         blueprint.addTerm(std::move(term));
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -264,8 +298,11 @@ struct EquivAdapter {
     void addChild(std::unique_ptr<Blueprint> child) {
         blueprint.addTerm(std::move(child), 1.0);
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -280,8 +317,11 @@ struct WeightedSetTermAdapter {
         blueprint.addTerm(std::move(child), 100, estimate);
         blueprint.complete(estimate);
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -301,8 +341,11 @@ struct DotProductAdapter {
         blueprint.addTerm(std::move(term), 100, estimate);
         blueprint.complete(estimate);
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -321,8 +364,11 @@ struct ParallelWeakAndAdapter {
         blueprint.addTerm(std::move(term), 100, estimate);
         blueprint.complete(estimate);
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -337,8 +383,11 @@ struct SameElementAdapter {
         auto term = std::make_unique<LeafProxy>(child_field, std::move(child));
         blueprint.addTerm(std::move(term));
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -355,8 +404,11 @@ struct Make {
     Make(const Children &child_list, Args && ... args) : blueprint(std::forward<Args>(args)...) {
         child_list.apply(blueprint);
     }
-    auto createFilterSearch(bool strict, Constraint constraint) const {
-        return blueprint.createFilterSearch(strict, constraint);
+    void basic_plan(InFlow in_flow, uint32_t my_docid_limit) {
+        blueprint.basic_plan(in_flow, my_docid_limit);
+    }
+    auto createFilterSearch(Constraint constraint) const {
+        return blueprint.createFilterSearch(constraint);
     }
 };
 
@@ -381,10 +433,11 @@ struct Expect {
 };
 
 template <FilterFactory Blueprint>
-void verify(const Blueprint &blueprint, bool strict, Constraint constraint, const Expect &expect) {
+void verify(Blueprint &&blueprint, bool strict, Constraint constraint, const Expect &expect) {
     CheckParamsProxy::current_strict = strict;
     CheckParamsProxy::current_constraint = constraint;
-    auto filter = blueprint.createFilterSearch(strict, constraint);
+    blueprint.basic_plan(strict, docid_limit);
+    auto filter = blueprint.createFilterSearch(constraint);
     if (expect.children >  0) {
         ASSERT_EQ(filter->isMultiSearch(), true);
         EXPECT_EQ(static_cast<MultiSearch*>(filter.get())->getChildren().size(), expect.children);
@@ -409,14 +462,14 @@ void verify(const Blueprint &blueprint, bool strict, Constraint constraint, cons
 }
 
 template <FilterFactory Blueprint>
-void verify(const Blueprint &blueprint, bool strict, const Expect &expect) {
+void verify(Blueprint &&blueprint, bool strict, const Expect &expect) {
     for (auto constraint: {lower_bound, upper_bound}) {
         verify(blueprint, strict, constraint, expect);
     }
 }
 
 template <FilterFactory Blueprint>
-void verify(const Blueprint &blueprint, const Expect &upper, const Expect &lower) {
+void verify(Blueprint &&blueprint, const Expect &upper, const Expect &lower) {
     for (auto constraint: {lower_bound, upper_bound}) {
         const Expect &expect = (constraint == upper_bound) ? upper : lower;
         for (bool strict: {false, true}) {
@@ -426,7 +479,7 @@ void verify(const Blueprint &blueprint, const Expect &upper, const Expect &lower
 }
 
 template <FilterFactory Blueprint>
-void verify(const Blueprint &blueprint, const Expect &upper_and_lower) {
+void verify(Blueprint &&blueprint, const Expect &upper_and_lower) {
     verify(blueprint, upper_and_lower, upper_and_lower);
 }
 
@@ -443,12 +496,12 @@ TEST(FilterSearchTest, custom_leaf) {
 }
 
 TEST(FilterSearchTest, default_filter) {
-    verify(DefaultBlueprint(), Expect::full(), Expect::empty());
-    auto adapter = [](const auto &ignore_children, bool strict, Constraint constraint) {
+    auto adapter = [](const auto &ignore_children, bool ignore_strict, Constraint constraint) {
                        (void) ignore_children;
-                       return Blueprint::create_default_filter(strict, constraint);
+                       (void) ignore_strict;
+                       return Blueprint::create_default_filter(constraint);
                    };
-    verify(Combine(adapter, Children()), Expect::full(), Expect::empty());
+    verify(Combine<NoFlow>(adapter, Children()), Expect::full(), Expect::empty());
 }
 
 TEST(FilterSearchTest, simple_or) {
@@ -457,30 +510,46 @@ TEST(FilterSearchTest, simple_or) {
         .hits({7}).check(true, true)
         .hits({3, 11}).check(true, true);
     auto expected = Expect::hits({3, 5, 7, 10, 11});
-    verify(Combine(Blueprint::create_or_filter, child_list), expected);
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, child_list), expected);
     verify(Make<OrBlueprint>(child_list), expected);
     verify(Make<EquivAdapter>(child_list), expected);
-    verify(Make<WeightedSetTermAdapter>(child_list), expected);
-    verify(Make<DotProductAdapter>(child_list), expected);
-    verify(Combine(Blueprint::create_atmost_or_filter, child_list), expected, Expect::empty());
+    verify(Combine<OrFlow>(Blueprint::create_atmost_or_filter, child_list), expected, Expect::empty());
     verify(Make<WeakAndBlueprint>(child_list, 100), expected, Expect::empty());
     verify(Make<SourceBlenderAdapter>(child_list), expected, Expect::empty());
     verify(Make<ParallelWeakAndAdapter>(child_list), expected, Expect::empty());
 }
 
+TEST(FilterSearchTest, forced_or) {
+    auto child_list = Children()
+        .hits({5, 10}).check_forced()
+        .hits({7}).check_forced()
+        .hits({3, 11}).check_forced();
+    auto expected = Expect::hits({3, 5, 7, 10, 11});
+    verify(Make<WeightedSetTermAdapter>(child_list), expected);
+    verify(Make<DotProductAdapter>(child_list), expected);
+}
+
 TEST(FilterSearchTest, simple_and) {
     auto child_list = Children()
-        .hits({1, 2, 3, 4, 5, 6}).check(true, true)
-        .hits({2, 4, 6, 7}).check(false, true)
-        .hits({1, 4, 6, 7, 10}).check(false, true);
+        .hits({2, 4, 6, 7}).check(true, true)
+        .hits({1, 4, 6, 7, 10}).check(false, true)
+        .hits({1, 2, 3, 4, 5, 6}).check(false, true);
     auto expected = Expect::hits({4, 6});
-    verify(Combine(Blueprint::create_and_filter, child_list), expected);
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list), expected);
     verify(Make<AndBlueprint>(child_list), expected);
-    verify(Combine(Blueprint::create_atmost_and_filter, child_list), expected, Expect::empty());
+    verify(Combine<AndFlow>(Blueprint::create_atmost_and_filter, child_list), expected, Expect::empty());
     verify(Make<NearBlueprint>(child_list, 3), expected, Expect::empty());
     verify(Make<ONearBlueprint>(child_list, 3), expected, Expect::empty());
-    verify(Make<SimplePhraseAdapter>(child_list), expected, Expect::empty());
     verify(Make<SameElementAdapter>(child_list), expected, Expect::empty());
+}
+
+TEST(FilterSearchTest, eager_and) {
+    auto child_list = Children()
+        .hits({2, 4, 6, 7}).check(true, true)
+        .hits({1, 4, 6, 7, 10}).check(true, true)
+        .hits({1, 2, 3, 4, 5, 6}).check(true, true);
+    auto expected = Expect::hits({4, 6});
+    verify(Make<SimplePhraseAdapter>(child_list), expected, Expect::empty());
 }
 
 TEST(FilterSearchTest, simple_andnot) {
@@ -489,7 +558,7 @@ TEST(FilterSearchTest, simple_andnot) {
         .hits({2, 4, 6}).check(false, false)
         .hits({4, 6, 7}).check(false, false);
     auto expected = Expect::hits({1, 3, 5});
-    verify(Combine(Blueprint::create_andnot_filter, child_list), expected);
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list), expected);
     verify(Make<AndNotBlueprint>(child_list), expected);
 }
 
@@ -497,9 +566,13 @@ TEST(FilterSearchTest, rank_filter) {
     auto child_list1 = Children().hits({1,2,3}).empty().full();
     auto child_list2 = Children().empty().hits({1,2,3}).full();
     auto child_list3 = Children().full().hits({1,2,3}).empty();
-    verify(Combine(Blueprint::create_first_child_filter, child_list1), Expect::hits({1,2,3}));
-    verify(Combine(Blueprint::create_first_child_filter, child_list2), Expect::empty());
-    verify(Combine(Blueprint::create_first_child_filter, child_list3), Expect::full());
+    auto adapter = [](const auto &children, bool ignore_strict, Constraint constraint) {
+                       (void) ignore_strict;
+                       return Blueprint::create_first_child_filter(children, constraint);
+                   };
+    verify(Combine<RankFlow>(adapter, child_list1), Expect::hits({1,2,3}));
+    verify(Combine<RankFlow>(adapter, child_list2), Expect::empty());
+    verify(Combine<RankFlow>(adapter, child_list3), Expect::full());
     verify(Make<RankBlueprint>(child_list1), Expect::hits({1,2,3}));
     verify(Make<RankBlueprint>(child_list2), Expect::empty());
     verify(Make<RankBlueprint>(child_list3), Expect::full());
@@ -510,7 +583,7 @@ TEST(FilterSearchTest, or_short_circuit) {
         .hits({5, 10}).check(true, true)
         .full().check(true, true)
         .hits({3, 11}).check(true, true).dropped();
-    verify(Combine(Blueprint::create_or_filter, child_list),
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, child_list),
            Expect::full());
 }
 
@@ -519,7 +592,7 @@ TEST(FilterSearchTest, or_pruning) {
         .empty().check(true, true)
         .empty().check(true, true)
         .empty().check(true, true);
-    verify(Combine(Blueprint::create_or_filter, child_list),
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, child_list),
            Expect::empty());
 }
 
@@ -528,7 +601,7 @@ TEST(FilterSearchTest, or_partial_pruning) {
         .hits({5, 10}).check(true, true)
         .empty().check(true, true)
         .hits({3, 11}).check(true, true);
-    verify(Combine(Blueprint::create_or_filter, child_list),
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, child_list),
            Expect::hits({3, 5, 10, 11}).child_count(2));
 }
 
@@ -537,7 +610,7 @@ TEST(FilterSearchTest, and_short_circuit) {
         .hits({1, 2, 3}).check(true, true)
         .empty().check(false, true)
         .hits({2, 3, 4}).check(false, true).dropped();
-    verify(Combine(Blueprint::create_and_filter, child_list),
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list),
            Expect::empty());
 }
 
@@ -546,7 +619,7 @@ TEST(FilterSearchTest, and_pruning) {
         .full().check(true, true)
         .full().check(false, true)
         .full().check(false, true);
-    verify(Combine(Blueprint::create_and_filter, child_list),
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list),
            Expect::full());
 }
 
@@ -555,7 +628,7 @@ TEST(FilterSearchTest, and_partial_pruning) {
         .hits({1, 2, 3}).check(true, true)
         .full().check(false, true)
         .hits({2, 3, 4}).check(false, true);
-    verify(Combine(Blueprint::create_and_filter, child_list),
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list),
            Expect::hits({2, 3}).child_count(2));
 }
 
@@ -563,7 +636,7 @@ TEST(FilterSearchTest, andnot_positive_short_circuit) {
     auto child_list = Children()
         .empty().check(true, true)
         .hits({1, 2, 3}).check(false, false).dropped();
-    verify(Combine(Blueprint::create_andnot_filter, child_list),
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list),
            Expect::empty());
 }
 
@@ -573,7 +646,7 @@ TEST(FilterSearchTest, andnot_negative_short_circuit) {
         .hits({1}).check(false, false)
         .full().check(false, false)
         .hits({3}).check(false, false).dropped();
-    verify(Combine(Blueprint::create_andnot_filter, child_list),
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list),
            Expect::empty());
 }
 
@@ -583,7 +656,7 @@ TEST(FilterSearchTest, andnot_negative_pruning) {
         .empty().check(false, false)
         .empty().check(false, false)
         .empty().check(false, false);
-    verify(Combine(Blueprint::create_andnot_filter, child_list),
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list),
            Expect::full());
 }
 
@@ -593,7 +666,7 @@ TEST(FilterSearchTest, andnot_partial_negative_pruning) {
         .hits({1}).check(false, false)
         .empty().check(false, false)
         .hits({3}).check(false, false);
-    verify(Combine(Blueprint::create_andnot_filter, child_list),
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list),
            Expect::hits({2}).child_count(3));
 }
 
@@ -602,7 +675,7 @@ TEST(FilterSearchTest, first_or_child_can_be_partially_pruned) {
         .empty().check(true, true)
         .hits({5, 10}).check(true, true)
         .hits({3, 11}).check(true, true);
-    verify(Combine(Blueprint::create_or_filter, child_list),
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, child_list),
            Expect::hits({3, 5, 10, 11}).child_count(2));
 }
 
@@ -611,9 +684,9 @@ TEST(FilterSearchTest, first_and_child_can_only_be_partially_pruned_when_nonstri
         .full().check(true, true)
         .hits({1, 2, 3}).check(false, true)
         .hits({2, 3, 4}).check(false, true);
-    verify(Combine(Blueprint::create_and_filter, child_list), true,
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list), true,
            Expect::hits({2, 3}).child_count(3));
-    verify(Combine(Blueprint::create_and_filter, child_list), false,
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, child_list), false,
            Expect::hits({2, 3}).child_count(2));
 }
 
@@ -623,19 +696,19 @@ TEST(FilterSearchTest, first_negative_andnot_child_can_be_partially_pruned) {
         .empty().check(false, false)
         .hits({1}).check(false, false)
         .hits({3}).check(false, false);
-    verify(Combine(Blueprint::create_andnot_filter, child_list),
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, child_list),
            Expect::hits({2}).child_count(3));
 }
 
 TEST(FilterSearchTest, need_atleast_one_child) {
-    verify(Combine(Blueprint::create_and_filter, Children().full()), Expect::full());
-    verify(Combine(Blueprint::create_or_filter, Children().empty()), Expect::empty());
-    verify(Combine(Blueprint::create_andnot_filter, Children().full()), Expect::full());
-    EXPECT_THROW(verify(Combine(Blueprint::create_and_filter, Children()), Expect::empty()),
+    verify(Combine<AndFlow>(Blueprint::create_and_filter, Children().full()), Expect::full());
+    verify(Combine<OrFlow>(Blueprint::create_or_filter, Children().empty()), Expect::empty());
+    verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, Children().full()), Expect::full());
+    EXPECT_THROW(verify(Combine<AndFlow>(Blueprint::create_and_filter, Children()), Expect::empty()),
                  vespalib::RequireFailedException);
-    EXPECT_THROW(verify(Combine(Blueprint::create_or_filter, Children()), Expect::empty()),
+    EXPECT_THROW(verify(Combine<OrFlow>(Blueprint::create_or_filter, Children()), Expect::empty()),
                  vespalib::RequireFailedException);
-    EXPECT_THROW(verify(Combine(Blueprint::create_andnot_filter, Children()), Expect::empty()),
+    EXPECT_THROW(verify(Combine<AndNotFlow>(Blueprint::create_andnot_filter, Children()), Expect::empty()),
                  vespalib::RequireFailedException);
 }
 

--- a/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
@@ -179,9 +179,9 @@ struct WandBlueprintSpec
         Node::UP term = createNode();
         Blueprint::UP bp = blueprint(searchable, field, *term);
         MatchData::UP md(MatchData::makeTestInstance(1, 1));
-        bp->fetchPostings(ExecuteInfo::TRUE);
-        bp->setDocIdLimit(docIdLimit);
-        SearchIterator::UP sb = bp->createSearch(*md, true);
+        bp->basic_plan(true, docIdLimit);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP sb = bp->createSearch(*md);
         EXPECT_TRUE(dynamic_cast<ParallelWeakAndSearch*>(sb.get()) != 0);
         return sb;
     }
@@ -194,9 +194,9 @@ struct WandBlueprintSpec
     FakeResult search(Searchable &searchable, const std::string &field, const search::query::Node &term) const {
         Blueprint::UP bp = blueprint(searchable, field, term);
         MatchData::UP md(MatchData::makeTestInstance(1, 1));
-        bp->fetchPostings(ExecuteInfo::TRUE);
-        bp->setDocIdLimit(docIdLimit);
-        SearchIterator::UP sb = bp->createSearch(*md, true);
+        bp->basic_plan(true, docIdLimit);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP sb = bp->createSearch(*md);
         EXPECT_TRUE(dynamic_cast<ParallelWeakAndSearch*>(sb.get()) != 0);
         return doSearch(*sb, *md->resolveTermField(handle));
     }

--- a/searchlib/src/tests/queryeval/predicate/predicate_blueprint_test.cpp
+++ b/searchlib/src/tests/queryeval/predicate/predicate_blueprint_test.cpp
@@ -128,13 +128,14 @@ TEST_F("require that blueprint with zstar-compressed estimates non-empty.", Fixt
 void
 runQuery(Fixture & f, std::vector<uint32_t> expected, bool expectCachedSize, uint32_t expectedKV) {
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
-    blueprint.fetchPostings(ExecuteInfo::TRUE);
+    blueprint.basic_plan(true, 100);
+    blueprint.fetchPostings(ExecuteInfo::FULL);
     EXPECT_EQUAL(expectCachedSize, blueprint.getCachedFeatures().size());
     for (uint32_t docId : expected) {
         EXPECT_EQUAL(expectedKV, uint32_t(blueprint.getKV()[docId]));
     }
     TermFieldMatchDataArray tfmda;
-    SearchIterator::UP it = blueprint.createLeafSearch(tfmda, true);
+    SearchIterator::UP it = blueprint.createLeafSearch(tfmda);
     ASSERT_TRUE(it.get());
     it->initFullRange();
     EXPECT_EQUAL(SearchIterator::beginId(), it->getDocId());
@@ -172,9 +173,10 @@ TEST_F("require that blueprint can create more advanced search", Fixture) {
     f.indexEmptyDocument(doc_id + 2);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
-    blueprint.fetchPostings(ExecuteInfo::TRUE);
+    blueprint.basic_plan(true, 100);
+    blueprint.fetchPostings(ExecuteInfo::FULL);
     TermFieldMatchDataArray tfmda;
-    SearchIterator::UP it = blueprint.createLeafSearch(tfmda, true);
+    SearchIterator::UP it = blueprint.createLeafSearch(tfmda);
     ASSERT_TRUE(it.get());
     it->initFullRange();
     EXPECT_EQUAL(SearchIterator::beginId(), it->getDocId());
@@ -195,9 +197,10 @@ TEST_F("require that blueprint can create NOT search", Fixture) {
     f.indexDocument(doc_id, annotations);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
-    blueprint.fetchPostings(ExecuteInfo::TRUE);
+    blueprint.basic_plan(true, 100);
+    blueprint.fetchPostings(ExecuteInfo::FULL);
     TermFieldMatchDataArray tfmda;
-    SearchIterator::UP it = blueprint.createLeafSearch(tfmda, true);
+    SearchIterator::UP it = blueprint.createLeafSearch(tfmda);
     ASSERT_TRUE(it.get());
     it->initFullRange();
     EXPECT_TRUE(it->seek(doc_id));
@@ -211,9 +214,10 @@ TEST_F("require that blueprint can create compressed NOT search", Fixture) {
     f.indexDocument(doc_id, annotations);
 
     PredicateBlueprint blueprint(f.field, f.guard(), f.query);
-    blueprint.fetchPostings(ExecuteInfo::TRUE);
+    blueprint.basic_plan(true, 100);
+    blueprint.fetchPostings(ExecuteInfo::FULL);
     TermFieldMatchDataArray tfmda;
-    SearchIterator::UP it = blueprint.createLeafSearch(tfmda, true);
+    SearchIterator::UP it = blueprint.createLeafSearch(tfmda);
     ASSERT_TRUE(it.get());
     it->initFullRange();
     EXPECT_TRUE(it->seek(doc_id));
@@ -235,9 +239,10 @@ TEST_F("require that blueprint can set up search with subqueries", Fixture) {
     query.getTerm()->addFeature("key2", "value", 2);
 
     PredicateBlueprint blueprint(f.field, f.guard(), query);
-    blueprint.fetchPostings(ExecuteInfo::TRUE);
+    blueprint.basic_plan(true, 100);
+    blueprint.fetchPostings(ExecuteInfo::FULL);
     TermFieldMatchDataArray tfmda;
-    SearchIterator::UP it = blueprint.createLeafSearch(tfmda, true);
+    SearchIterator::UP it = blueprint.createLeafSearch(tfmda);
     ASSERT_TRUE(it.get());
     it->initFullRange();
     EXPECT_FALSE(it->seek(doc_id));

--- a/searchlib/src/tests/queryeval/queryeval_test.cpp
+++ b/searchlib/src/tests/queryeval/queryeval_test.cpp
@@ -220,8 +220,9 @@ TEST(QueryEvalTest, test_and) {
     auto and_b = std::make_unique<AndBlueprint>();
     and_b->addChild(std::make_unique<SimpleBlueprint>(a));
     and_b->addChild(std::make_unique<SimpleBlueprint>(b));
-    and_b->fetchPostings(ExecuteInfo::TRUE);
-    SearchIterator::UP and_ab = and_b->createSearch(*md, true);
+    and_b->basic_plan(true, 1000);
+    and_b->fetchPostings(ExecuteInfo::FULL);
+    SearchIterator::UP and_ab = and_b->createSearch(*md);
 
     EXPECT_TRUE(dynamic_cast<const AndSearch *>(and_ab.get()) != nullptr);
     EXPECT_EQ(4u, dynamic_cast<AndSearch &>(*and_ab).estimate());
@@ -231,14 +232,16 @@ TEST(QueryEvalTest, test_and) {
     expect.addHit(5).addHit(30);
     EXPECT_EQ(res, expect);
 
-    SearchIterator::UP filter_ab = and_b->createFilterSearch(true, upper_bound);
+    SearchIterator::UP filter_ab = and_b->createFilterSearch(upper_bound);
     SimpleResult filter_res;
     filter_res.search(*filter_ab);
     EXPECT_EQ(res, expect);
     std::string dump = filter_ab->asString();
     expect_match(dump, "upper");
     expect_match(dump, "AndSearchStrict.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
-    filter_ab = and_b->createFilterSearch(false, lower_bound);
+    and_b->basic_plan(false, 1000);
+    and_b->fetchPostings(ExecuteInfo::FULL);
+    filter_ab = and_b->createFilterSearch(lower_bound);
     dump = filter_ab->asString();
     expect_match(dump, "lower");
     expect_match(dump, "AndSearchNoStrict.*NoUnpack.*SimpleSearch.*lower.*SimpleSearch.*lower");
@@ -256,8 +259,9 @@ TEST(QueryEvalTest, test_or)
         auto or_b = std::make_unique<OrBlueprint>();
         or_b->addChild(std::make_unique<SimpleBlueprint>(a));
         or_b->addChild(std::make_unique<SimpleBlueprint>(b));
-        or_b->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP or_ab = or_b->createSearch(*md, true);
+        or_b->basic_plan(true, 1000);
+        or_b->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP or_ab = or_b->createSearch(*md);
 
         SimpleResult res;
         res.search(*or_ab);
@@ -265,14 +269,16 @@ TEST(QueryEvalTest, test_or)
         expect.addHit(5).addHit(10).addHit(17).addHit(30);
         EXPECT_EQ(res, expect);
 
-        SearchIterator::UP filter_ab = or_b->createFilterSearch(true, upper_bound);
+        SearchIterator::UP filter_ab = or_b->createFilterSearch(upper_bound);
         SimpleResult filter_res;
         filter_res.search(*filter_ab);
         EXPECT_EQ(res, expect);
         std::string dump = filter_ab->asString();
         expect_match(dump, "upper");
         expect_match(dump, "StrictHeapOrSearch.*NoUnpack.*SimpleSearch.*upper.*SimpleSearch.*upper");
-        filter_ab = or_b->createFilterSearch(false, lower_bound);
+        or_b->basic_plan(false, 1000);
+        or_b->fetchPostings(ExecuteInfo::FULL);
+        filter_ab = or_b->createFilterSearch(lower_bound);
         dump = filter_ab->asString();
         expect_match(dump, "lower");
         expect_match(dump, "OrLikeSearch.false.*NoUnpack.*SimpleSearch.*lower.*SimpleSearch.*lower");
@@ -365,13 +371,13 @@ public:
             : default_flow_stats(docid_limit, est.est_hits(), 0);
     }
     SearchIterator::UP
-    createLeafSearch(const TermFieldMatchDataArray &tfmda, bool strict) const override
+    createLeafSearch(const TermFieldMatchDataArray &tfmda) const override
     {
         (void) tfmda;
-        return _sc->createIterator(&_tfmd, strict);
+        return _sc->createIterator(&_tfmd, strict());
     }
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
 private:
     search::SingleBoolAttribute     _a;
@@ -392,8 +398,9 @@ TEST(QueryEvalTest, test_andnot)
         auto andnot_b = std::make_unique<AndNotBlueprint>();
         andnot_b->addChild(std::make_unique<SimpleBlueprint>(a));
         andnot_b->addChild(std::make_unique<SimpleBlueprint>(b));
-        andnot_b->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP andnot_ab = andnot_b->createSearch(*md, true);
+        andnot_b->basic_plan(true, 1000);
+        andnot_b->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP andnot_ab = andnot_b->createSearch(*md);
 
         SimpleResult res;
         res.search(*andnot_ab);
@@ -401,14 +408,16 @@ TEST(QueryEvalTest, test_andnot)
         expect.addHit(10);
         EXPECT_EQ(res, expect);
 
-        SearchIterator::UP filter_ab = andnot_b->createFilterSearch(true, upper_bound);
+        SearchIterator::UP filter_ab = andnot_b->createFilterSearch(upper_bound);
         SimpleResult filter_res;
         filter_res.search(*filter_ab);
         EXPECT_EQ(res, expect);
         std::string dump = filter_ab->asString();
         expect_match(dump, "upper");
         expect_match(dump, "AndNotSearch.*SimpleSearch.*<strict,upper>.*SimpleSearch.*<nostrict,lower>");
-        filter_ab = andnot_b->createFilterSearch(false, lower_bound);
+        andnot_b->basic_plan(false, 1000);
+        andnot_b->fetchPostings(ExecuteInfo::FULL);
+        filter_ab = andnot_b->createFilterSearch(lower_bound);
         dump = filter_ab->asString();
         expect_match(dump, "lower");
         expect_match(dump, "AndNotSearch.*SimpleSearch.*<nostrict,lower>.*SimpleSearch.*<nostrict,upper>");
@@ -423,8 +432,9 @@ TEST(QueryEvalTest, test_andnot)
         auto andnot_b = std::make_unique<AndNotBlueprint>();
         andnot_b->addChild(std::make_unique<SimpleBlueprint>(a));
         andnot_b->addChild(std::make_unique<DummySingleValueBitNumericAttributeBlueprint>(b));
-        andnot_b->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP andnot_ab = andnot_b->createSearch(*md, true);
+        andnot_b->basic_plan(true, 1000);
+        andnot_b->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP andnot_ab = andnot_b->createSearch(*md);
 
         SimpleResult res;
         res.search(*andnot_ab);
@@ -449,8 +459,9 @@ TEST(QueryEvalTest, test_andnot)
         auto and_b = std::make_unique<AndBlueprint>();
         and_b->addChild(std::make_unique<SimpleBlueprint>(c));
         and_b->addChild(std::move(andnot_b));
-        and_b->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP and_cab = and_b->createSearch(*md, true);
+        and_b->basic_plan(true, 1000);
+        and_b->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP and_cab = and_b->createSearch(*md);
 
         SimpleResult res;
         res.search(*and_cab);
@@ -475,8 +486,9 @@ TEST(QueryEvalTest, test_rank)
         auto rank_b = std::make_unique<RankBlueprint>();
         rank_b->addChild(std::make_unique<SimpleBlueprint>(a));
         rank_b->addChild(std::make_unique<SimpleBlueprint>(b));
-        rank_b->fetchPostings(ExecuteInfo::TRUE);
-        SearchIterator::UP rank_ab = rank_b->createSearch(*md, true);
+        rank_b->basic_plan(true, 1000);
+        rank_b->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP rank_ab = rank_b->createSearch(*md);
 
         SimpleResult res;
         res.search(*rank_ab);

--- a/searchlib/src/tests/queryeval/sourceblender/sourceblender_test.cpp
+++ b/searchlib/src/tests/queryeval/sourceblender/sourceblender_test.cpp
@@ -76,8 +76,9 @@ TEST(SourceBlenderTest, test_strictness)
         blend_b->addChild(std::move(a_b));
         blend_b->addChild(std::move(b_b));
         Blueprint::UP bp(blend_b);
-        bp->fetchPostings(ExecuteInfo::createForTest(strict));
-        SearchIterator::UP search = bp->createSearch(*md, strict);
+        bp->basic_plan(strict, 100);
+        bp->fetchPostings(ExecuteInfo::FULL);
+        SearchIterator::UP search = bp->createSearch(*md);
         search->initFullRange();
         SearchIterator &blend = *search;
 

--- a/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
+++ b/searchlib/src/vespa/searchcommon/attribute/i_search_context.h
@@ -48,7 +48,7 @@ public:
      * Create temporary posting lists.
      * Should be called before createIterator() is called.
      */
-    virtual void fetchPostings(const queryeval::ExecuteInfo &execInfo) = 0;
+    virtual void fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) = 0;
 
     virtual bool valid() const = 0;
     virtual Int64Range getAsIntegerTerm() const = 0;

--- a/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_weighted_set_blueprint.h
@@ -31,9 +31,10 @@ public:
     AttributeWeightedSetBlueprint(const queryeval::FieldSpec &field, const IAttributeVector & attr);
     ~AttributeWeightedSetBlueprint();
     void addToken(std::unique_ptr<ISearchContext> context, int32_t weight);
+    void sort(queryeval::InFlow in_flow, const Options &opts) override;
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    queryeval::SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    queryeval::SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    queryeval::SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    queryeval::SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 };

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.h
@@ -72,6 +72,10 @@ public:
         setEstimate(estimate);
     }
 
+    void sort(queryeval::InFlow in_flow, const Options &) override {
+        strict(in_flow.strict());
+    }
+
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
         using OrFlow = search::queryeval::OrFlow;
         struct MyAdapter {
@@ -93,9 +97,9 @@ public:
                 OrFlow::cost_of(MyAdapter(docid_limit), _terms, true) + queryeval::flow::heap_cost(est, _terms.size())};
     }
 
-    std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool) const override;
+    std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
 
-    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
     std::unique_ptr<queryeval::MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override {
         if (fields.has_field(_iattr.getName())) {
             return queryeval::MatchingElementsSearch::create(_iattr, _dictionary_snapshot, vespalib::ConstArrayRef<IDirectPostingStore::LookupResult>(_terms));

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
@@ -164,20 +164,20 @@ DirectMultiTermBlueprint<PostingStoreType, SearchType>::create_search_helper(con
 
 template <typename PostingStoreType, typename SearchType>
 std::unique_ptr<queryeval::SearchIterator>
-DirectMultiTermBlueprint<PostingStoreType, SearchType>::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const
+DirectMultiTermBlueprint<PostingStoreType, SearchType>::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const
 {
     assert(tfmda.size() == 1);
     assert(getState().numFields() == 1);
-    return create_search_helper<SearchType::filter_search>(tfmda, strict);
+    return create_search_helper<SearchType::filter_search>(tfmda, strict());
 }
 
 template <typename PostingStoreType, typename SearchType>
 std::unique_ptr<queryeval::SearchIterator>
-DirectMultiTermBlueprint<PostingStoreType, SearchType>::createFilterSearch(bool strict, FilterConstraint) const
+DirectMultiTermBlueprint<PostingStoreType, SearchType>::createFilterSearch(FilterConstraint) const
 {
     assert(getState().numFields() == 1);
     auto wrapper = std::make_unique<FilterWrapper>(getState().numFields());
-    wrapper->wrap(create_search_helper<true>(wrapper->tfmda(), strict));
+    wrapper->wrap(create_search_helper<true>(wrapper->tfmda(), strict()));
     return wrapper;
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.cpp
@@ -41,7 +41,7 @@ EnumHintSearchContext::lookupRange(const vespalib::datastore::EntryComparator &l
 }
 
 void
-EnumHintSearchContext::fetchPostings(const queryeval::ExecuteInfo &)
+EnumHintSearchContext::fetchPostings(const queryeval::ExecuteInfo &, bool)
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/enumhintsearchcontext.h
@@ -39,7 +39,7 @@ protected:
     std::unique_ptr<queryeval::SearchIterator>
     createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) override;
 
-    void fetchPostings(const queryeval::ExecuteInfo & execInfo) override;
+    void fetchPostings(const queryeval::ExecuteInfo & execInfo, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
     uint32_t get_committed_docid_limit() const noexcept { return _docIdLimit; }
 };

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.cpp
@@ -305,10 +305,10 @@ ImportedSearchContext::considerAddSearchCacheEntry()
 }
 
 void
-ImportedSearchContext::fetchPostings(const queryeval::ExecuteInfo &execInfo) {
+ImportedSearchContext::fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) {
     if (!_searchCacheLookup) {
-        _target_search_context->fetchPostings(execInfo);
-        if (!_merger.merge_done() && (execInfo.is_strict() || (_target_attribute.getIsFastSearch() && execInfo.hit_rate() > 0.01))) {
+        _target_search_context->fetchPostings(execInfo, strict);
+        if (!_merger.merge_done() && (strict || (_target_attribute.getIsFastSearch() && execInfo.hit_rate() > 0.01))) {
                 makeMergedPostings(_target_attribute.getIsFilter());
                 considerAddSearchCacheEntry();
         }

--- a/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/imported_search_context.h
@@ -66,7 +66,7 @@ public:
     std::unique_ptr<queryeval::SearchIterator>
     createIterator(fef::TermFieldMatchData* matchData, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
-    void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
+    void fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) override;
     bool valid() const override;
     Int64Range getAsIntegerTerm() const override;
     DoubleRange getAsDoubleTerm() const override;

--- a/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/ipostinglistsearchcontext.h
@@ -29,7 +29,7 @@ protected:
     virtual ~IPostingListSearchContext() { }
 
 public:
-    virtual void fetchPostings(const queryeval::ExecuteInfo & execInfo) = 0;
+    virtual void fetchPostings(const queryeval::ExecuteInfo & execInfo, bool strict) = 0;
     virtual std::unique_ptr<queryeval::SearchIterator> createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) = 0;
     virtual HitEstimate calc_hit_estimate() const = 0;
 };

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.h
@@ -110,7 +110,7 @@ protected:
     virtual void fillArray();
     virtual void fillBitVector(const ExecuteInfo &);
 
-    void fetchPostings(const ExecuteInfo & strict) override;
+    void fetchPostings(const ExecuteInfo &exec, bool strict) override;
     // this will be called instead of the fetchPostings function in some cases
     void diversify(bool forward, size_t wanted_hits, const IAttributeVector &diversity_attr,
                    size_t max_per_group, size_t cutoff_groups, bool cutoff_strict);
@@ -224,7 +224,7 @@ private:
             ? HitEstimate(limit)
             : estimate;
     }
-    void fetchPostings(const ExecuteInfo & execInfo) override {
+    void fetchPostings(const ExecuteInfo & execInfo, bool strict) override {
         if (params().diversityAttribute() != nullptr) {
             bool forward = (this->getRangeLimit() > 0);
             size_t wanted_hits = std::abs(this->getRangeLimit());
@@ -232,7 +232,7 @@ private:
                                                         *(params().diversityAttribute()), this->getMaxPerGroup(),
                                                         params().diversityCutoffGroups(), params().diversityCutoffStrict());
         } else {
-            PostingListSearchContextT<DataT>::fetchPostings(execInfo);
+            PostingListSearchContextT<DataT>::fetchPostings(execInfo, strict);
         }
     }
 

--- a/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/postinglistsearchcontext.hpp
@@ -137,7 +137,7 @@ PostingListSearchContextT<DataT>::fillBitVector(const ExecuteInfo & exec_info)
 
 template <typename DataT>
 void
-PostingListSearchContextT<DataT>::fetchPostings(const ExecuteInfo & exec_info)
+PostingListSearchContextT<DataT>::fetchPostings(const ExecuteInfo & exec_info, bool strict)
 {
     // The following constant is derived after running parts of
     // the range search performance test with 10M documents on an Apple M1 Pro with 32 GB memory.
@@ -168,7 +168,7 @@ PostingListSearchContextT<DataT>::fetchPostings(const ExecuteInfo & exec_info)
     // The threshold for when to use array merging is therefore 0.0025 (0.08 / 32).
     constexpr float threshold_for_using_array = 0.0025;
     if (!_merger.merge_done() && _uniqueValues >= 2u && this->_dictionary.get_has_btree_dictionary()) {
-        if (exec_info.is_strict() || use_posting_lists_when_non_strict(exec_info)) {
+        if (strict || use_posting_lists_when_non_strict(exec_info)) {
             size_t sum = estimated_hits_in_range();
             //TODO Honour soft_doom and forward it to merge code
             if (sum < (_docIdLimit * threshold_for_using_array)) {

--- a/searchlib/src/vespa/searchlib/attribute/search_context.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/search_context.cpp
@@ -50,10 +50,10 @@ SearchContext::createFilterIterator(fef::TermFieldMatchData* matchData, bool str
 
 
 void
-SearchContext::fetchPostings(const queryeval::ExecuteInfo& execInfo)
+SearchContext::fetchPostings(const queryeval::ExecuteInfo& execInfo, bool strict)
 {
     if (_plsc != nullptr) {
-        _plsc->fetchPostings(execInfo);
+        _plsc->fetchPostings(execInfo, strict);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/search_context.h
+++ b/searchlib/src/vespa/searchlib/attribute/search_context.h
@@ -34,7 +34,7 @@ public:
 
     HitEstimate calc_hit_estimate() const override;
     std::unique_ptr<queryeval::SearchIterator> createIterator(fef::TermFieldMatchData* matchData, bool strict) override;
-    void fetchPostings(const queryeval::ExecuteInfo& execInfo) override;
+    void fetchPostings(const queryeval::ExecuteInfo& execInfo, bool strict) override;
     bool valid() const override { return false; }
     Int64Range getAsIntegerTerm() const override { return Int64Range(); }
     DoubleRange getAsDoubleTerm() const override { return DoubleRange(); }

--- a/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/singleboolattribute.cpp
@@ -130,7 +130,7 @@ public:
 
     std::unique_ptr<queryeval::SearchIterator>
     createFilterIterator(fef::TermFieldMatchData * matchData, bool strict) override;
-    void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
+    void fetchPostings(const queryeval::ExecuteInfo &execInfo, bool strict) override;
     std::unique_ptr<queryeval::SearchIterator> createPostingIterator(fef::TermFieldMatchData *matchData, bool strict) override;
     HitEstimate calc_hit_estimate() const override;
     uint32_t get_committed_docid_limit() const noexcept override;
@@ -162,7 +162,7 @@ BitVectorSearchContext::createFilterIterator(fef::TermFieldMatchData * matchData
 }
 
 void
-BitVectorSearchContext::fetchPostings(const queryeval::ExecuteInfo &) {
+BitVectorSearchContext::fetchPostings(const queryeval::ExecuteInfo &, bool) {
 }
 
 std::unique_ptr<queryeval::SearchIterator>

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
@@ -76,12 +76,12 @@ DiskTermBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 }
 
 SearchIterator::UP
-DiskTermBlueprint::createLeafSearch(const TermFieldMatchDataArray & tfmda, bool strict) const
+DiskTermBlueprint::createLeafSearch(const TermFieldMatchDataArray & tfmda) const
 {
     if (_bitVector && (_useBitVector || tfmda[0]->isNotNeeded())) {
         LOG(debug, "Return BitVectorIterator: %s, wordNum(%" PRIu64 "), docCount(%" PRIu64 ")",
             getName(_lookupRes->indexId).c_str(), _lookupRes->wordNum, _lookupRes->counts._numDocs);
-        return BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict);
+        return BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict());
     }
     SearchIterator::UP search(_postingHandle->createIterator(_lookupRes->counts, tfmda, _useBitVector));
     if (_useBitVector) {
@@ -95,12 +95,12 @@ DiskTermBlueprint::createLeafSearch(const TermFieldMatchDataArray & tfmda, bool 
 }
 
 SearchIterator::UP
-DiskTermBlueprint::createFilterSearch(bool strict, FilterConstraint) const
+DiskTermBlueprint::createFilterSearch(FilterConstraint) const
 {
     auto wrapper = std::make_unique<queryeval::FilterWrapper>(getState().numFields());
     auto & tfmda = wrapper->tfmda();
     if (_bitVector) {
-        wrapper->wrap(BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict));
+        wrapper->wrap(BitVectorIterator::create(_bitVector.get(), *tfmda[0], strict()));
     } else {
         wrapper->wrap(_postingHandle->createIterator(_lookupRes->counts, tfmda, _useBitVector));
     }

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.h
@@ -41,11 +41,11 @@ public:
     
     // Inherit doc from Blueprint.
     // For now, this DiskTermBlueprint instance must have longer lifetime than the created iterator.
-    std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray & tfmda, bool strict) const override;
+    std::unique_ptr<queryeval::SearchIterator> createLeafSearch(const fef::TermFieldMatchDataArray & tfmda) const override;
 
     void fetchPostings(const queryeval::ExecuteInfo &execInfo) override;
 
-    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(bool strict, FilterConstraint) const override;
+    std::unique_ptr<queryeval::SearchIterator> createFilterSearch(FilterConstraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
 };

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -264,7 +264,7 @@ public:
         return {rel_est, btree_cost(), btree_strict_cost(rel_est)};
     }
     
-    SearchIterator::UP createLeafSearch(const TermFieldMatchDataArray& tfmda, bool) const override {
+    SearchIterator::UP createLeafSearch(const TermFieldMatchDataArray& tfmda) const override {
         auto result = make_search_iterator<interleaved_features>(_posting_itr, _feature_store, _field_id, tfmda);
         if (_use_bit_vector) {
             LOG(debug, "Return BooleanMatchIteratorWrapper: field_id(%u), doc_count(%zu)",
@@ -276,7 +276,7 @@ public:
         return result;
     }
 
-    SearchIterator::UP createFilterSearch(bool, FilterConstraint) const override {
+    SearchIterator::UP createFilterSearch(FilterConstraint) const override {
         auto wrapper = std::make_unique<queryeval::FilterWrapper>(getState().numFields());
         auto & tfmda = wrapper->tfmda();
         wrapper->wrap(make_search_iterator<interleaved_features>(_posting_itr, _feature_store, _field_id, tfmda));

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.cpp
@@ -39,6 +39,15 @@ DotProductBlueprint::addTerm(Blueprint::UP term, int32_t weight, HitEstimate & e
     _terms.push_back(std::move(term));
 }
 
+void
+DotProductBlueprint::sort(InFlow, const Options &opts)
+{
+    strict(true);
+    for (auto &term: _terms) {
+        term->sort(true, opts);
+    }
+}
+
 FlowStats
 DotProductBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 {
@@ -51,7 +60,7 @@ DotProductBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 }
 
 SearchIterator::UP
-DotProductBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool) const
+DotProductBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const
 {
     assert(tfmda.size() == 1);
     assert(getState().numFields() == 1);
@@ -63,16 +72,16 @@ DotProductBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray
         assert(childState.numFields() == 1);
         childMatch.push_back(childState.field(0).resolve(*md));
         // TODO: pass ownership with unique_ptr
-        children[i] = _terms[i]->createSearch(*md, true).release();
+        children[i] = _terms[i]->createSearch(*md).release();
     }
     bool field_is_filter = getState().fields()[0].isFilter();
     return DotProductSearch::create(children, *tfmda[0], field_is_filter, childMatch, _weights, std::move(md));
 }
 
 SearchIterator::UP
-DotProductBlueprint::createFilterSearch(bool strict, FilterConstraint constraint) const
+DotProductBlueprint::createFilterSearch(FilterConstraint constraint) const
 {
-    return create_or_filter(_terms, strict, constraint);
+    return create_or_filter(_terms, strict(), constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/dot_product_blueprint.h
@@ -33,10 +33,11 @@ public:
         setEstimate(estimate);
     }
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
-    SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;

--- a/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/equiv_blueprint.h
@@ -22,10 +22,11 @@ public:
     // used by create visitor
     EquivBlueprint& addTerm(Blueprint::UP term, double exactness);
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
 
-    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
 
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.cpp
@@ -5,16 +5,15 @@
 using vespalib::Doom;
 namespace search::queryeval {
 
-const ExecuteInfo ExecuteInfo::TRUE(true, 1.0, Doom::never(), vespalib::ThreadBundle::trivial());
-const ExecuteInfo ExecuteInfo::FALSE(false, 1.0, Doom::never(), vespalib::ThreadBundle::trivial());
+const ExecuteInfo ExecuteInfo::FULL(1.0, Doom::never(), vespalib::ThreadBundle::trivial());
 
 ExecuteInfo::ExecuteInfo() noexcept
-    : ExecuteInfo(false, 1.0, Doom::never(), vespalib::ThreadBundle::trivial())
+    : ExecuteInfo(1.0, Doom::never(), vespalib::ThreadBundle::trivial())
 { }
 
 ExecuteInfo
-ExecuteInfo::createForTest(bool strict, double hitRate) noexcept {
-    return createForTest(strict, hitRate, Doom::never());
+ExecuteInfo::createForTest(double hitRate) noexcept {
+    return createForTest(hitRate, Doom::never());
 }
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
+++ b/searchlib/src/vespa/searchlib/queryeval/executeinfo.h
@@ -14,44 +14,40 @@ namespace search::queryeval {
 class ExecuteInfo {
 public:
     ExecuteInfo() noexcept;
-    bool is_strict() const noexcept { return _strict; }
     double hit_rate() const noexcept { return _hitRate; }
     const vespalib::Doom & doom() const noexcept { return _doom; }
     vespalib::ThreadBundle & thread_bundle() const noexcept { return _thread_bundle; }
 
-    static const ExecuteInfo TRUE;
-    static const ExecuteInfo FALSE;
-    static ExecuteInfo create(bool strict, const ExecuteInfo & org) noexcept {
-        return create(strict, org._hitRate, org);
+    static const ExecuteInfo FULL;
+    static ExecuteInfo create(const ExecuteInfo & org) noexcept {
+        return create(org._hitRate, org);
     }
-    static ExecuteInfo create(bool strict, double hitRate, const ExecuteInfo & org) noexcept {
-        return {strict, hitRate, org._doom, org.thread_bundle()};
+    static ExecuteInfo create(double hitRate, const ExecuteInfo & org) noexcept {
+        return {hitRate, org._doom, org.thread_bundle()};
     }
 
-    static ExecuteInfo create(bool strict, double hitRate, const vespalib::Doom & doom,
+    static ExecuteInfo create(double hitRate, const vespalib::Doom & doom,
                               vespalib::ThreadBundle & thread_bundle_in) noexcept
     {
-         return {strict, hitRate, doom, thread_bundle_in};
+         return {hitRate, doom, thread_bundle_in};
     }
-    static ExecuteInfo createForTest(bool strict) noexcept {
-        return createForTest(strict, 1.0);
+    static ExecuteInfo createForTest() noexcept {
+        return createForTest(1.0);
     }
-    static ExecuteInfo createForTest(bool strict, double hitRate) noexcept;
-    static ExecuteInfo createForTest(bool strict, double hitRate, const vespalib::Doom & doom) noexcept {
-        return create(strict, hitRate, doom, vespalib::ThreadBundle::trivial());
+    static ExecuteInfo createForTest(double hitRate) noexcept;
+    static ExecuteInfo createForTest(double hitRate, const vespalib::Doom & doom) noexcept {
+        return create(hitRate, doom, vespalib::ThreadBundle::trivial());
     }
 private:
-    ExecuteInfo(bool strict, double hitRate_in, const vespalib::Doom & doom,
+    ExecuteInfo(double hitRate_in, const vespalib::Doom & doom,
                 vespalib::ThreadBundle & thread_bundle_in) noexcept
         : _doom(doom),
           _thread_bundle(thread_bundle_in),
-          _hitRate(hitRate_in),
-          _strict(strict)
+          _hitRate(hitRate_in)
     { }
     const vespalib::Doom     _doom;
     vespalib::ThreadBundle & _thread_bundle;
     double                   _hitRate;
-    bool                     _strict;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/global_filter.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/global_filter.cpp
@@ -109,9 +109,8 @@ struct MakePart : Runnable {
     bool is_first_thread() const { return (begin == 1); }
     bool should_trace(int level) const { return trace && trace->shouldTrace(level); }
     void run() override {
-        bool strict = true;
         auto constraint = Blueprint::FilterConstraint::UPPER_BOUND;
-        auto filter = blueprint.createFilterSearch(strict, constraint);
+        auto filter = blueprint.createFilterSearch(constraint);
         if (is_first_thread() && should_trace(7)) {
             vespalib::slime::ObjectInserter inserter(trace->createCursor("iterator"), "optimized");
             filter->asSlime(inserter);

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
@@ -22,12 +22,11 @@ public:
     AndNotBlueprint * asAndNot() noexcept final { return this; }
     Blueprint::UP get_replacement() override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
+                             fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    createFilterSearch(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
     uint8_t calculate_cost_tier() const override {
@@ -50,12 +49,11 @@ public:
     AndBlueprint * asAnd() noexcept final { return this; }
     Blueprint::UP get_replacement() override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
+                             fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    createFilterSearch(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
 };
@@ -75,12 +73,11 @@ public:
     OrBlueprint * asOr() noexcept final { return this; }
     Blueprint::UP get_replacement() override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
+                             fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    createFilterSearch(FilterConstraint constraint) const override;
 private:
     AnyFlow my_flow(InFlow in_flow) const override;
     uint8_t calculate_cost_tier() const override;
@@ -100,13 +97,12 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, bool strict, bool sort_on_cost) const override;
-    bool inheritStrict(size_t i) const override;
     bool always_needs_unpack() const override;
     WeakAndBlueprint * asWeakAnd() noexcept final { return this; }
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+                             fef::MatchData &md) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
 
     explicit WeakAndBlueprint(uint32_t n) noexcept : _n(n) {}
     ~WeakAndBlueprint() override;
@@ -131,12 +127,11 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
-    SearchIteratorUP createSearch(fef::MatchData &md, bool strict) const override;
+    SearchIteratorUP createSearch(fef::MatchData &md) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+                             fef::MatchData &md) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
 
     explicit NearBlueprint(uint32_t window) noexcept : _window(window) {}
 };
@@ -154,12 +149,11 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
-    SearchIteratorUP createSearch(fef::MatchData &md, bool strict) const override;
+    SearchIteratorUP createSearch(fef::MatchData &md) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+                             fef::MatchData &md) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
 
     explicit ONearBlueprint(uint32_t window) noexcept : _window(window) {}
 };
@@ -175,13 +169,12 @@ public:
     void optimize_self(OptimizePass pass) override;
     Blueprint::UP get_replacement() override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
     bool isRank() const noexcept final { return true; }
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
+                             fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    createFilterSearch(FilterConstraint constraint) const override;
     uint8_t calculate_cost_tier() const override {
         return (childCnt() > 0) ? get_children()[0]->getState().cost_tier() : State::COST_TIER_NORMAL;
     }
@@ -204,12 +197,11 @@ public:
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, bool strict, bool sort_by_cost) const override;
-    bool inheritStrict(size_t i) const override;
     SearchIterator::UP
     createIntermediateSearch(MultiSearch::Children subSearches,
-                             bool strict, fef::MatchData &md) const override;
+                             fef::MatchData &md) const override;
     SearchIterator::UP
-    createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    createFilterSearch(FilterConstraint constraint) const override;
 
     /** check if this blueprint has the same source selector as the other */
     bool isCompatibleWith(const SourceBlenderBlueprint &other) const;

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
@@ -17,13 +17,13 @@ EmptyBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 }
 
 SearchIterator::UP
-EmptyBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &, bool) const
+EmptyBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &) const
 {
     return std::make_unique<EmptySearch>();
 }
 
 SearchIterator::UP
-EmptyBlueprint::createFilterSearch(bool /*strict*/, FilterConstraint /* constraint */) const
+EmptyBlueprint::createFilterSearch(FilterConstraint /* constraint */) const
 {
     return std::make_unique<EmptySearch>();
 }
@@ -40,13 +40,13 @@ AlwaysTrueBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 }
 
 SearchIterator::UP
-AlwaysTrueBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &, bool) const
+AlwaysTrueBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &) const
 {
     return std::make_unique<FullSearch>();
 }
 
 SearchIterator::UP
-AlwaysTrueBlueprint::createFilterSearch(bool /*strict*/, FilterConstraint /* constraint */) const
+AlwaysTrueBlueprint::createFilterSearch(FilterConstraint /* constraint */) const
 {
     return std::make_unique<FullSearch>();
 }
@@ -65,19 +65,19 @@ SimpleBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 }
 
 SearchIterator::UP
-SimpleBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &, bool strict) const
+SimpleBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &) const
 {
-    auto search = std::make_unique<SimpleSearch>(_result, strict);
+    auto search = std::make_unique<SimpleSearch>(_result, strict());
     search->tag(_tag);
     return search;
 }
 
 SearchIterator::UP
-SimpleBlueprint::createFilterSearch(bool strict, FilterConstraint constraint) const
+SimpleBlueprint::createFilterSearch(FilterConstraint constraint) const
 {
-    auto search = std::make_unique<SimpleSearch>(_result, strict);
+    auto search = std::make_unique<SimpleSearch>(_result, strict());
     search->tag(_tag +
-               (strict ? "<strict," : "<nostrict,") +
+               (strict() ? "<strict," : "<nostrict,") +
                (constraint == FilterConstraint::UPPER_BOUND ? "upper>" : "lower>"));
     return search;
 }
@@ -127,7 +127,7 @@ struct FakeContext : attribute::ISearchContext {
     }
     attribute::HitEstimate calc_hit_estimate() const override { return attribute::HitEstimate(0); }
     std::unique_ptr<SearchIterator> createIterator(fef::TermFieldMatchData *, bool) override { abort(); }
-    void fetchPostings(const ExecuteInfo &) override { }
+    void fetchPostings(const ExecuteInfo &, bool) override { }
     bool valid() const override { return true; }
     Int64Range getAsIntegerTerm() const override { abort(); }
     DoubleRange getAsDoubleTerm() const override { abort(); }
@@ -146,7 +146,7 @@ FakeContext::get_committed_docid_limit() const noexcept
 }
 
 SearchIterator::UP
-FakeBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool) const
+FakeBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const
 {
     auto result = std::make_unique<FakeSearch>(_tag, _field.getName(), _term, _result, tfmda);
     result->attr_ctx(_ctx.get());

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.h
@@ -14,24 +14,24 @@ namespace search::queryeval {
 class EmptyBlueprint : public SimpleLeafBlueprint
 {
 protected:
-    SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
+    SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
 public:
     EmptyBlueprint(FieldSpecBaseList fields);
     EmptyBlueprint(FieldSpecBase field) : SimpleLeafBlueprint(field) {}
     EmptyBlueprint() = default;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
     EmptyBlueprint *as_empty() noexcept final override { return this; }
 };
 
 class AlwaysTrueBlueprint : public SimpleLeafBlueprint
 {
 protected:
-    SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
+    SearchIterator::UP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
 public:
     AlwaysTrueBlueprint();
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -44,14 +44,14 @@ private:
 
 protected:
     SearchIterator::UP
-    createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
+    createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
 public:
     SimpleBlueprint(const SimpleResult &result);
     ~SimpleBlueprint() override;
     SimpleBlueprint &tag(const vespalib::string &tag);
     const vespalib::string &tag() const { return _tag; }
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
-    SearchIterator::UP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIterator::UP createFilterSearch(FilterConstraint constraint) const override;
 };
 
 //-----------------------------------------------------------------------------
@@ -67,7 +67,7 @@ private:
 
 protected:
     SearchIterator::UP
-    createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
+    createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
 
 public:
     FakeBlueprint(const FieldSpec &field, const FakeResult &result);
@@ -95,8 +95,8 @@ public:
         return default_flow_stats(docid_limit, _result.inspect().size(), 0);
     }
 
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.cpp
@@ -125,8 +125,14 @@ NearestNeighborBlueprint::perform_top_k(const search::tensor::NearestNeighborInd
     }
 }
 
+void
+NearestNeighborBlueprint::sort(InFlow in_flow, const Options &)
+{
+    strict(in_flow.strict());
+}
+
 std::unique_ptr<SearchIterator>
-NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda, bool strict) const
+NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda) const
 {
     assert(tfmda.size() == 1);
     fef::TermFieldMatchData &tfmd = *tfmda[0]; // always search in only one field
@@ -137,7 +143,7 @@ NearestNeighborBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
     default:
         ;
     }
-    return NearestNeighborIterator::create(strict, tfmd,
+    return NearestNeighborIterator::create(strict(), tfmd,
                                            std::make_unique<search::tensor::DistanceCalculator>(_attr_tensor, _query_tensor),
                                            _distance_heap, *_global_filter);
 }

--- a/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/nearest_neighbor_blueprint.h
@@ -69,14 +69,14 @@ public:
     Algorithm get_algorithm() const { return _algorithm; }
     double get_distance_threshold() const { return _distance_threshold; }
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
         return default_flow_stats(docid_limit, getState().estimate().estHits, 0);
     }
     
-    std::unique_ptr<SearchIterator> createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda,
-                                                     bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    std::unique_ptr<SearchIterator> createLeafSearch(const search::fef::TermFieldMatchDataArray& tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
     void visitMembers(vespalib::ObjectVisitor& visitor) const override;
     bool always_needs_unpack() const override;

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.cpp
@@ -279,8 +279,14 @@ PredicateBlueprint::fetchPostings(const ExecuteInfo &) {
     }
 }
 
+void
+PredicateBlueprint::sort(InFlow in_flow, const Options &)
+{
+    strict(in_flow.strict());
+}
+
 SearchIterator::UP
-PredicateBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool) const {
+PredicateBlueprint::createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const {
     const auto &attribute = predicate_attribute();
     PredicateAttribute::MinFeatureHandle mfh = attribute.getMinFeatureVector();
     auto interval_range_vector = attribute.getIntervalRangeVector();

--- a/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/predicate_blueprint.h
@@ -49,15 +49,16 @@ public:
     ~PredicateBlueprint();
     void fetchPostings(const ExecuteInfo &execInfo) override;
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t) const override {
         return default_flow_stats(_interval_btree_iterators.size() + _interval_vector_iterators.size() +
                                   _bounds_btree_iterators.size() + _bounds_vector_iterators.size() + 2);
     }
 
     SearchIterator::UP
-    createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override {
-        return create_default_filter(strict, constraint);
+    createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override {
+        return create_default_filter(constraint);
     }
 
     // Exposed for testing

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.cpp
@@ -44,6 +44,17 @@ SameElementBlueprint::addTerm(Blueprint::UP term)
     _terms.push_back(std::move(term));
 }
 
+void
+SameElementBlueprint::sort(InFlow in_flow, const Options &opts)
+{
+    strict(in_flow.strict());
+    auto flow = AndFlow(in_flow);
+    for (auto &term: _terms) {
+        term->sort(InFlow(flow.strict(), flow.flow()), opts);
+        flow.add(term->estimate());
+    }
+}
+
 FlowStats
 SameElementBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 {
@@ -75,19 +86,19 @@ SameElementBlueprint::fetchPostings(const ExecuteInfo &execInfo)
     double hit_rate = execInfo.hit_rate() * _terms[0]->estimate();
     for (size_t i = 1; i < _terms.size(); ++i) {
         Blueprint & term = *_terms[i];
-        term.fetchPostings(ExecuteInfo::create(false, hit_rate, execInfo));
+        term.fetchPostings(ExecuteInfo::create(hit_rate, execInfo));
         hit_rate = hit_rate * _terms[i]->estimate();
     }
 }
 
 std::unique_ptr<SameElementSearch>
-SameElementBlueprint::create_same_element_search(search::fef::TermFieldMatchData& tfmd, bool strict) const
+SameElementBlueprint::create_same_element_search(search::fef::TermFieldMatchData& tfmd) const
 {
     fef::MatchData::UP md = _layout.createMatchData();
     std::vector<ElementIterator::UP> children(_terms.size());
     for (size_t i = 0; i < _terms.size(); ++i) {
         const State &childState = _terms[i]->getState();
-        SearchIterator::UP child = _terms[i]->createSearch(*md, (strict && (i == 0)));
+        SearchIterator::UP child = _terms[i]->createSearch(*md);
         const attribute::ISearchContext *context = _terms[i]->get_attribute_search_context();
         if (context == nullptr) {
             children[i] = std::make_unique<ElementIteratorWrapper>(std::move(child), *childState.field(0).resolve(*md));
@@ -95,20 +106,20 @@ SameElementBlueprint::create_same_element_search(search::fef::TermFieldMatchData
             children[i] = std::make_unique<attribute::SearchContextElementIterator>(std::move(child), *context);
         }
     }
-    return std::make_unique<SameElementSearch>(tfmd, std::move(md), std::move(children), strict);
+    return std::make_unique<SameElementSearch>(tfmd, std::move(md), std::move(children), strict());
 }
 
 SearchIterator::UP
-SameElementBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda, bool strict) const
+SameElementBlueprint::createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const
 {
     assert(tfmda.size() == 1);
-    return create_same_element_search(*tfmda[0], strict);
+    return create_same_element_search(*tfmda[0]);
 }
 
 SearchIterator::UP
-SameElementBlueprint::createFilterSearch(bool strict, FilterConstraint constraint) const
+SameElementBlueprint::createFilterSearch(FilterConstraint constraint) const
 {
-    return create_atmost_and_filter(_terms, strict, constraint);
+    return create_atmost_and_filter(_terms, strict(), constraint);
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/same_element_blueprint.h
@@ -34,15 +34,15 @@ public:
     // used by create visitor
     void addTerm(Blueprint::UP term);
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
     void optimize_self(OptimizePass pass) override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
 
-    std::unique_ptr<SameElementSearch> create_same_element_search(search::fef::TermFieldMatchData& tfmd, bool strict) const;
-    SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda,
-                                      bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    std::unique_ptr<SameElementSearch> create_same_element_search(search::fef::TermFieldMatchData& tfmd) const;
+    SearchIteratorUP createLeafSearch(const search::fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     const std::vector<Blueprint::UP> &terms() const { return _terms; }
     const vespalib::string &field_name() const { return _field_name; }

--- a/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/simple_phrase_blueprint.h
@@ -30,10 +30,11 @@ public:
     // used by create visitor
     void addTerm(Blueprint::UP term);
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
-    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
 };

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
@@ -62,10 +62,11 @@ public:
         set_tree_size(_terms.size() + 1);
     }
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
     
-    SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    std::unique_ptr<SearchIterator> createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIterator::UP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    std::unique_ptr<SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     bool always_needs_unpack() const override;

--- a/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/weighted_set_term_blueprint.h
@@ -35,10 +35,11 @@ public:
         setEstimate(estimate);
     }
 
+    void sort(InFlow in_flow, const Options &opts) override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const override;
 
-    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda, bool strict) const override;
-    SearchIteratorUP createFilterSearch(bool strict, FilterConstraint constraint) const override;
+    SearchIteratorUP createLeafSearch(const fef::TermFieldMatchDataArray &tfmda) const override;
+    SearchIteratorUP createFilterSearch(FilterConstraint constraint) const override;
     std::unique_ptr<MatchingElementsSearch> create_matching_elements_search(const MatchingElementsFields &fields) const override;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
 private:


### PR DESCRIPTION
The strict-aware sort function is responsible for propagating and tagging strictness throughout the blueprint tree. Use pre-tagged strictness in fetchPostings, createSearch and createFilterSearch.

@baldersheim @geirst please review