### PR TITLE
Reapply "Update dependency org.apache.maven.plugins:maven-compiler-plugin to v3.13.0"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -160,7 +160,7 @@
         <maven-antrun-plugin.vespa.version>3.1.0</maven-antrun-plugin.vespa.version>
         <maven-assembly-plugin.vespa.version>3.7.1</maven-assembly-plugin.vespa.version>
         <maven-bundle-plugin.vespa.version>5.1.9</maven-bundle-plugin.vespa.version>
-        <maven-compiler-plugin.vespa.version>3.12.1</maven-compiler-plugin.vespa.version>
+        <maven-compiler-plugin.vespa.version>3.13.0</maven-compiler-plugin.vespa.version>
         <maven-core.vespa.version>3.9.6</maven-core.vespa.version>
         <maven-dependency-plugin.vespa.version>3.6.1</maven-dependency-plugin.vespa.version>
         <maven-deploy-plugin.vespa.version>3.1.1</maven-deploy-plugin.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#30690

Build image swapped and works with Maven 3.8.5. This should now be ok to apply.