### PR TITLE
Wire Prometheus metric export to state V1 APIs

### DIFF
--- a/metrics/src/vespa/metrics/state_api_adapter.cpp
+++ b/metrics/src/vespa/metrics/state_api_adapter.cpp
@@ -1,30 +1,45 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "jsonwriter.h"
-#include "state_api_adapter.h"
 #include "metricmanager.h"
+#include "prometheus_writer.h"
+#include "state_api_adapter.h"
 #include <vespa/vespalib/stllike/asciistream.h>
 
 namespace metrics {
 
 vespalib::string
-StateApiAdapter::getMetrics(const vespalib::string &consumer)
+StateApiAdapter::getMetrics(const vespalib::string &consumer, ExpositionFormat format)
 {
     MetricLockGuard guard(_manager.getMetricLock());
     auto periods = _manager.getSnapshotPeriods(guard);
     if (periods.empty() || !_manager.any_snapshots_taken(guard)) {
         return ""; // no configuration or snapshots yet
     }
-    const MetricSnapshot &snapshot(_manager.getMetricSnapshot(guard, periods[0]));
-    vespalib::asciistream json;
-    vespalib::JsonStream stream(json);
-    metrics::JsonWriter metricJsonWriter(stream);
-    _manager.visit(guard, snapshot, metricJsonWriter, consumer);
-    stream.finalize();
-    return json.str();
+    const MetricSnapshot& snapshot(_manager.getMetricSnapshot(guard, periods[0]));
+    vespalib::asciistream out;
+    // Using `switch` instead of `if` so that we fail with a compiler warning -> error if
+    // we add another enum value and forget to add a case for it here.
+    switch (format) {
+    case ExpositionFormat::JSON:
+        {
+            vespalib::JsonStream stream(out);
+            JsonWriter metricJsonWriter(stream);
+            _manager.visit(guard, snapshot, metricJsonWriter, consumer);
+            stream.finalize();
+            break;
+        }
+    case ExpositionFormat::Prometheus:
+        {
+            PrometheusWriter writer(out);
+            _manager.visit(guard, snapshot, writer, consumer);
+            break;
+        }
+    }
+    return out.str();
 }
 
 vespalib::string
-StateApiAdapter::getTotalMetrics(const vespalib::string &consumer)
+StateApiAdapter::getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format)
 {
     _manager.updateMetrics();
     MetricLockGuard guard(_manager.getMetricLock());
@@ -34,13 +49,26 @@ StateApiAdapter::getTotalMetrics(const vespalib::string &consumer)
                                                       _manager.getTotalMetricSnapshot(guard).getMetrics(), true);
     _manager.getActiveMetrics(guard).addToSnapshot(*generated, false, currentTime);
     generated->setFromTime(_manager.getTotalMetricSnapshot(guard).getFromTime());
-    const MetricSnapshot &snapshot = *generated;
-    vespalib::asciistream json;
-    vespalib::JsonStream stream(json);
-    metrics::JsonWriter metricJsonWriter(stream);
-    _manager.visit(guard, snapshot, metricJsonWriter, consumer);
-    stream.finalize();
-    return json.str();
+    const MetricSnapshot& snapshot = *generated;
+    vespalib::asciistream out;
+    switch (format) {
+    case ExpositionFormat::JSON:
+        {
+            vespalib::JsonStream stream(out);
+            metrics::JsonWriter metricJsonWriter(stream);
+            _manager.visit(guard, snapshot, metricJsonWriter, consumer);
+            stream.finalize();
+            break;
+        }
+    case ExpositionFormat::Prometheus:
+        {
+            PrometheusWriter writer(out);
+            _manager.visit(guard, snapshot, writer, consumer);
+            break;
+        }
+    }
+
+    return out.str();
 }
 
 } // namespace metrics

--- a/metrics/src/vespa/metrics/state_api_adapter.h
+++ b/metrics/src/vespa/metrics/state_api_adapter.h
@@ -11,7 +11,7 @@ class MetricManager;
 /**
  * This is an adapter class that implements the metrics producer
  * interface defined by the state api implementation in vespalib by
- * extracting metrics in json format from a metric manager.
+ * extracting metrics in JSON or Prometheus format from a metric manager.
  **/
 class StateApiAdapter : public vespalib::MetricsProducer
 {
@@ -19,10 +19,10 @@ private:
     MetricManager &_manager;
 
 public:
-    StateApiAdapter(MetricManager &manager) : _manager(manager) {}
+    explicit StateApiAdapter(MetricManager &manager) : _manager(manager) {}
 
-    vespalib::string getMetrics(const vespalib::string &consumer) override;
-    vespalib::string getTotalMetrics(const vespalib::string &consumer) override;
+    vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
+    vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
 };
 
 } // namespace metrics

--- a/slobrok/src/vespa/slobrok/server/metrics_producer.h
+++ b/slobrok/src/vespa/slobrok/server/metrics_producer.h
@@ -4,6 +4,7 @@
 #include "rpchooks.h"
 #include <vespa/vespalib/net/http/metrics_producer.h>
 #include <vespa/vespalib/net/http/simple_metrics_producer.h>
+#include <chrono>
 
 class FNET_Transport;
 
@@ -15,13 +16,13 @@ private:
     const RPCHooks &_rpcHooks;
     RPCHooks::Metrics _lastMetrics;
     vespalib::SimpleMetricsProducer _producer;
-    uint32_t _startTime;
-    uint32_t _lastSnapshotStart;
+    std::chrono::system_clock::time_point _startTime;
+    std::chrono::system_clock::time_point _lastSnapshotStart;
     std::unique_ptr<FNET_Task> _snapshotter;
 
 public:
-    vespalib::string getMetrics(const vespalib::string &consumer) override;
-    vespalib::string getTotalMetrics(const vespalib::string &consumer) override;
+    vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
+    vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
 
     void snapshot();
 

--- a/storage/src/vespa/storage/storageserver/statereporter.h
+++ b/storage/src/vespa/storage/storageserver/statereporter.h
@@ -57,8 +57,8 @@ private:
     ApplicationGenerationFetcher& _generationFetcher;
     std::string _name;
 
-    vespalib::string getMetrics(const vespalib::string &consumer) override;
-    vespalib::string getTotalMetrics(const vespalib::string &consumer) override;
+    vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
+    vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
     Health getHealth() const override;
     void getComponentConfig(Consumer &consumer) override;
 };

--- a/vespalib/src/vespa/vespalib/metrics/producer.cpp
+++ b/vespalib/src/vespa/vespalib/metrics/producer.cpp
@@ -4,15 +4,16 @@
 #include "metrics_manager.h"
 #include "json_formatter.h"
 
-namespace vespalib {
-namespace metrics {
+namespace vespalib::metrics {
 
 Producer::Producer(std::shared_ptr<MetricsManager> m)
-    : _manager(m)
+    : _manager(std::move(m))
 {}
 
+Producer::~Producer() = default;
+
 vespalib::string
-Producer::getMetrics(const vespalib::string &)
+Producer::getMetrics(const vespalib::string &, ExpositionFormat /*ignored*/)
 {
     Snapshot snap = _manager->snapshot();
     JsonFormatter fmt(snap);
@@ -20,14 +21,11 @@ Producer::getMetrics(const vespalib::string &)
 }
 
 vespalib::string
-Producer::getTotalMetrics(const vespalib::string &)
+Producer::getTotalMetrics(const vespalib::string &, ExpositionFormat /*ignored*/)
 {
     Snapshot snap = _manager->totalSnapshot();
     JsonFormatter fmt(snap);
     return fmt.asString();
 }
 
-
-
 } // namespace vespalib::metrics
-} // namespace vespalib

--- a/vespalib/src/vespa/vespalib/metrics/producer.h
+++ b/vespalib/src/vespa/vespalib/metrics/producer.h
@@ -15,9 +15,10 @@ class Producer : public vespalib::MetricsProducer {
 private:
     std::shared_ptr<MetricsManager> _manager;
 public:
-    Producer(std::shared_ptr<MetricsManager> m);
-    vespalib::string getMetrics(const vespalib::string &consumer) override;
-    vespalib::string getTotalMetrics(const vespalib::string &consumer) override;
+    explicit Producer(std::shared_ptr<MetricsManager> m);
+    ~Producer() override;
+    vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
+    vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
 };
 
 }

--- a/vespalib/src/vespa/vespalib/net/http/http_server.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/http_server.cpp
@@ -13,7 +13,7 @@ HttpServer::get(Portal::GetRequest req)
     if (response.failed()) {
         req.respond_with_error(response.status_code(), response.status_message());
     } else {
-        req.respond_with_content("application/json", response.payload());
+        req.respond_with_content(response.content_type(), response.payload());
     }
 }
 

--- a/vespalib/src/vespa/vespalib/net/http/json_get_handler.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/json_get_handler.cpp
@@ -4,14 +4,18 @@
 
 namespace vespalib {
 
-JsonGetHandler::Response::Response(int status_code, vespalib::string status_or_payload)
+JsonGetHandler::Response::Response(int status_code,
+                                   vespalib::string status_or_payload,
+                                   vespalib::string content_type_override)
     : _status_code(status_code),
-      _status_or_payload(std::move(status_or_payload))
+      _status_or_payload(std::move(status_or_payload)),
+      _content_type_override(std::move(content_type_override))
 {}
 
 JsonGetHandler::Response::Response()
     : _status_code(500),
-      _status_or_payload("Internal Server Error")
+      _status_or_payload("Internal Server Error"),
+      _content_type_override()
 {}
 
 JsonGetHandler::Response::~Response() = default;
@@ -24,19 +28,25 @@ JsonGetHandler::Response& JsonGetHandler::Response::operator=(Response&&) noexce
 JsonGetHandler::Response
 JsonGetHandler::Response::make_ok_with_json(vespalib::string json)
 {
-    return {200, std::move(json)};
+    return {200, std::move(json), {}};
+}
+
+JsonGetHandler::Response
+JsonGetHandler::Response::make_ok_with_content_type(vespalib::string payload, vespalib::string content_type)
+{
+    return {200, std::move(payload), std::move(content_type)};
 }
 
 JsonGetHandler::Response
 JsonGetHandler::Response::make_failure(int status_code, vespalib::string status_message)
 {
-    return {status_code, std::move(status_message)};
+    return {status_code, std::move(status_message), {}};
 }
 
 JsonGetHandler::Response
 JsonGetHandler::Response::make_not_found()
 {
-    return {404, "Not Found"};
+    return {404, "Not Found", {}};
 }
 
 }

--- a/vespalib/src/vespa/vespalib/net/http/json_get_handler.h
+++ b/vespalib/src/vespa/vespalib/net/http/json_get_handler.h
@@ -13,8 +13,11 @@ struct JsonGetHandler {
     class Response {
         int              _status_code;
         vespalib::string _status_or_payload;
+        vespalib::string _content_type_override;
 
-        Response(int status_code, vespalib::string status_or_payload);
+        Response(int status_code,
+                 vespalib::string status_or_payload,
+                 vespalib::string content_type_override);
     public:
         Response(); // By default, 500 Internal Server Error
         ~Response();
@@ -40,8 +43,16 @@ struct JsonGetHandler {
                 return {};
             }
         }
+        [[nodiscard]] vespalib::stringref content_type() const noexcept {
+            if (_content_type_override.empty()) {
+                return "application/json";
+            } else {
+                return _content_type_override;
+            }
+        }
 
         [[nodiscard]] static Response make_ok_with_json(vespalib::string json);
+        [[nodiscard]] static Response make_ok_with_content_type(vespalib::string payload, vespalib::string content_type);
         [[nodiscard]] static Response make_failure(int status_code, vespalib::string status_message);
         [[nodiscard]] static Response make_not_found();
     };

--- a/vespalib/src/vespa/vespalib/net/http/metrics_producer.h
+++ b/vespalib/src/vespa/vespalib/net/http/metrics_producer.h
@@ -7,8 +7,13 @@
 namespace vespalib {
 
 struct MetricsProducer {
-    virtual vespalib::string getMetrics(const vespalib::string &consumer) = 0;
-    virtual vespalib::string getTotalMetrics(const vespalib::string &consumer) = 0;
+    enum class ExpositionFormat {
+        JSON,
+        Prometheus
+    };
+
+    virtual vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) = 0;
+    virtual vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) = 0;
     virtual ~MetricsProducer() = default;
 };
 

--- a/vespalib/src/vespa/vespalib/net/http/simple_metrics_producer.cpp
+++ b/vespalib/src/vespa/vespalib/net/http/simple_metrics_producer.cpp
@@ -7,38 +7,38 @@ namespace vespalib {
 SimpleMetricsProducer::SimpleMetricsProducer()
     : _lock(),
       _metrics(),
-      _totalMetrics()
+      _total_metrics()
 {
 }
 
 SimpleMetricsProducer::~SimpleMetricsProducer() = default;
 
 void
-SimpleMetricsProducer::setMetrics(const vespalib::string &metrics)
+SimpleMetricsProducer::setMetrics(const vespalib::string &metrics, ExpositionFormat format)
 {
     std::lock_guard guard(_lock);
-    _metrics = metrics;
+    _metrics[format] = metrics;
 }
 
 vespalib::string
-SimpleMetricsProducer::getMetrics(const vespalib::string &)
+SimpleMetricsProducer::getMetrics(const vespalib::string &, ExpositionFormat format)
 {
     std::lock_guard guard(_lock);
-    return _metrics;
+    return _metrics[format]; // May implicitly create entry, but that's fine here.
 }
 
 void
-SimpleMetricsProducer::setTotalMetrics(const vespalib::string &metrics)
+SimpleMetricsProducer::setTotalMetrics(const vespalib::string &metrics, ExpositionFormat format)
 {
     std::lock_guard guard(_lock);
-    _totalMetrics = metrics;
+    _total_metrics[format] = metrics;
 }
 
 vespalib::string
-SimpleMetricsProducer::getTotalMetrics(const vespalib::string &)
+SimpleMetricsProducer::getTotalMetrics(const vespalib::string &, ExpositionFormat format)
 {
     std::lock_guard guard(_lock);
-    return _totalMetrics;
+    return _total_metrics[format];
 }
 
 } // namespace vespalib

--- a/vespalib/src/vespa/vespalib/net/http/simple_metrics_producer.h
+++ b/vespalib/src/vespa/vespalib/net/http/simple_metrics_producer.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "metrics_producer.h"
+#include <map>
 #include <mutex>
 
 namespace vespalib {
@@ -11,16 +12,16 @@ class SimpleMetricsProducer : public MetricsProducer
 {
 private:
     std::mutex _lock;
-    vespalib::string _metrics;
-    vespalib::string _totalMetrics;
+    std::map<ExpositionFormat, vespalib::string> _metrics;
+    std::map<ExpositionFormat, vespalib::string> _total_metrics;
 
 public:
     SimpleMetricsProducer();
     ~SimpleMetricsProducer() override;
-    void setMetrics(const vespalib::string &metrics);
-    vespalib::string getMetrics(const vespalib::string &consumer) override;
-    void setTotalMetrics(const vespalib::string &metrics);
-    vespalib::string getTotalMetrics(const vespalib::string &consumer) override;
+    void setMetrics(const vespalib::string &metrics, ExpositionFormat format);
+    vespalib::string getMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
+    void setTotalMetrics(const vespalib::string &metrics, ExpositionFormat format);
+    vespalib::string getTotalMetrics(const vespalib::string &consumer, ExpositionFormat format) override;
 };
 
 } // namespace vespalib


### PR DESCRIPTION
@baldersheim please review
@havardpe FYI changes to the state API serving
@arnej27959 FYI changes to Slobrok metric reporting

Extends metric producer classes with the requested exposition format. As a consequence, the State API server has been changed to allow emitting other content types than just `application/json`.

... We might want to consider renaming `JsonGetHandler` to something else since it's now technically polymorphic.

Add custom Prometheus rendering for Slobrok, as it does its own domain-specific metric tracking. However, since it has non-destructive sampling properties, we can actually use proper `counter` types.

