### PR TITLE
Don't spam log when connection is abruptly closed

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -843,7 +843,8 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
                     ackDocuments();
                 }
                 @Override public void failed(Throwable t) {
-                    log.log(WARNING, "Error writing documents", t);
+                    // This is typically caused by the client closing the connection during production of the response content.
+                    log.log(FINE, "Error writing documents", t);
                     completed();
                 }
             });


### PR DESCRIPTION
It's a somewhat common scenario (e.g strict/excessive client timeout or bad network) and the client will detect this anyway.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
