### PR TITLE
Include service status metric in prometheus output

### DIFF
--- a/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
+++ b/metrics-proxy/src/main/java/ai/vespa/metricsproxy/metric/model/prometheus/PrometheusUtil.java
@@ -13,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
 /**
  * @author yj-jtakagi
  * @author gjoranv
@@ -53,6 +56,15 @@ public class PrometheusUtil {
                     }
                     sampleList.add(new Sample(metricName, labels, labelValues, metric.getValue().doubleValue(), packet.timestamp * 1000));
                 }
+            }
+            if (!packets.isEmpty()) {
+                var firstPacket = packets.get(0);
+                var statusMetricName = serviceName + "_status";
+                // MetricsPacket status 0 means OK, but it's the opposite in Prometheus.
+                var statusMetricValue = (firstPacket.statusCode == 0) ? 1 : 0;
+                var sampleList = singletonList(new Sample(statusMetricName, emptyList(), emptyList(),
+                        statusMetricValue, firstPacket.timestamp * 1000));
+                metricFamilySamples.add(new MetricFamilySamples(statusMetricName, Collector.Type.UNKNOWN, "status of service", sampleList));
             }
         }));
 

--- a/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/prometheus/PrometheusHandlerTest.java
+++ b/metrics-proxy/src/test/java/ai/vespa/metricsproxy/http/prometheus/PrometheusHandlerTest.java
@@ -83,6 +83,12 @@ public class PrometheusHandlerTest extends HttpHandlerTestBase {
         assertTrue(dummy0.contains("vespa_service=\"vespa_dummy\""));
     }
 
+    @Test
+    public void response_contains_service_status() {
+        assertTrue(valuesResponse.contains("vespa_dummy_status 1.0"));
+        assertTrue(valuesResponse.contains("vespa_down_service_status 0.0"));
+    }
+
     // Find the first line that contains the given string
     private String getLine(String raw, String searchString) {
         for (var s : raw.split("\\n")) {


### PR DESCRIPTION
The `<service>_status` metric was wrongfully removed at some point