### PR TITLE
Move UTF8StringFieldSearcherBase tokenize member function to Tokenize…

### DIFF
--- a/streamingvisitors/src/vespa/vsm/searcher/tokenizereader.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/tokenizereader.cpp
@@ -4,6 +4,19 @@
 
 namespace vsm {
 
+namespace {
+
+template <bool exact_match> inline bool is_word_char(ucs4_t c);
+
+template <>
+inline bool is_word_char<false>(ucs4_t c) { return Fast_UnicodeUtil::IsWordChar(c); }
+
+// All characters are treated as word characters for exact match
+template <>
+inline constexpr bool is_word_char<true>(ucs4_t) { return true; }
+
+}
+
 void
 TokenizeReader::fold(ucs4_t c) {
     const char *repl = Fast_NormalizeWordFolder::ReplacementString(c);
@@ -17,5 +30,25 @@ TokenizeReader::fold(ucs4_t c) {
         *_q++ = c;
     }
 }
+
+template <bool exact_match>
+size_t
+TokenizeReader::tokenize_helper(Normalizing norm_mode)
+{
+    ucs4_t c(0);
+    while (hasNext()) {
+        if (is_word_char<exact_match>(c = next())) {
+            normalize(c, norm_mode);
+            while (hasNext() && is_word_char<exact_match>(c = next())) {
+                normalize(c, norm_mode);
+            }
+            break;
+        }
+    }
+    return complete();
+}
+
+template size_t TokenizeReader::tokenize_helper<false>(Normalizing);
+template size_t TokenizeReader::tokenize_helper<true>(Normalizing);
 
 }

--- a/streamingvisitors/src/vespa/vsm/searcher/tokenizereader.h
+++ b/streamingvisitors/src/vespa/vsm/searcher/tokenizereader.h
@@ -43,6 +43,10 @@ public:
         _q = _q_start;
         return token_len;
     }
+    template <bool exact_match>
+    size_t tokenize_helper(Normalizing norm_mode);
+    size_t tokenize(Normalizing norm_mode) { return tokenize_helper<false>(norm_mode); }
+    size_t tokenize_exact_match(Normalizing norm_mode) { return tokenize_helper<true>(norm_mode); }
 private:
     void fold(ucs4_t c);
     const byte *_p;

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8strchrfieldsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8strchrfieldsearcher.cpp
@@ -26,8 +26,7 @@ UTF8StrChrFieldSearcher::matchTerms(const FieldRef & f, size_t mintsz)
 
     TokenizeReader reader(reinterpret_cast<const byte *> (f.data()), f.size(), fn);
     while ( reader.hasNext() ) {
-        tokenize(reader);
-        size_t fl = reader.complete();
+        size_t fl = reader.tokenize(normalize_mode());
         for (auto qt : _qtl) {
             const cmptype_t * term;
             termsize_t tsz = qt->term(term);

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.h
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8stringfieldsearcherbase.h
@@ -60,9 +60,6 @@ public:
 protected:
     SharedSearcherBuf _buf;
 
-    template<typename Reader>
-    void tokenize(Reader & reader);
-
     /**
      * Matches the given query term against the words in the given field reference
      * using exact or prefix match strategy.

--- a/streamingvisitors/src/vespa/vsm/searcher/utf8suffixstringfieldsearcher.cpp
+++ b/streamingvisitors/src/vespa/vsm/searcher/utf8suffixstringfieldsearcher.cpp
@@ -26,8 +26,7 @@ UTF8SuffixStringFieldSearcher::matchTerms(const FieldRef & f, size_t mintsz)
 
     TokenizeReader reader(reinterpret_cast<const byte *> (f.data()), f.size(), dstbuf);
     while ( reader.hasNext() ) {
-        tokenize(reader);
-        size_t tokenlen = reader.complete();
+        size_t tokenlen = reader.tokenize(normalize_mode());
         for (auto qt : _qtl) {
             const cmptype_t * term;
             termsize_t tsz = qt->term(term);

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -273,16 +273,17 @@ buildFieldSet(const VsmfieldsConfig::Documenttype::Index & ci, const FieldSearch
     return ifm;
 }
 
+}
+
 search::Normalizing
-normalize_mode(VsmfieldsConfig::Fieldspec::Normalize normalize_mode) {
+FieldSearchSpecMap::convert_normalize_mode(VsmfieldsConfig::Fieldspec::Normalize normalize_mode)
+{
     switch (normalize_mode) {
         case VsmfieldsConfig::Fieldspec::Normalize::NONE: return search::Normalizing::NONE;
         case VsmfieldsConfig::Fieldspec::Normalize::LOWERCASE: return search::Normalizing::LOWERCASE;
         case VsmfieldsConfig::Fieldspec::Normalize::LOWERCASE_AND_FOLD: return search::Normalizing::LOWERCASE_AND_FOLD;
     }
     return search::Normalizing::LOWERCASE_AND_FOLD;
-}
-
 }
 
 void
@@ -292,7 +293,7 @@ FieldSearchSpecMap::buildFromConfig(const VsmfieldsHandle & conf, const search::
     for(const VsmfieldsConfig::Fieldspec & cfs : conf->fieldspec) {
         LOG(spam, "Parsing %s", cfs.name.c_str());
         FieldIdT fieldId = specMap().size();
-        FieldSearchSpec fss(fieldId, cfs.name, cfs.searchmethod, normalize_mode(cfs.normalize), cfs.arg1, cfs.maxlength);
+        FieldSearchSpec fss(fieldId, cfs.name, cfs.searchmethod, convert_normalize_mode(cfs.normalize), cfs.arg1, cfs.maxlength);
         _specMap[fieldId] = std::move(fss);
         _nameIdMap.add(cfs.name, fieldId);
         LOG(spam, "M in %d = %s", fieldId, cfs.name.c_str());

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.h
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.h
@@ -101,6 +101,7 @@ public:
 
     static vespalib::string stripNonFields(vespalib::stringref rawIndex);
     search::attribute::DistanceMetric get_distance_metric(const vespalib::string& name) const;
+    static search::Normalizing convert_normalize_mode(VsmfieldsConfig::Fieldspec::Normalize normalize_mode);
 
 private:
     FieldSearchSpecMapT         _specMap;         // mapping from field id to field search spec


### PR DESCRIPTION
…Reader.

Move anonymous normalize_mode funtion to a public static FieldSearchSpecMap::convert_normalize_mode member function.

@geirst : please review
