### PR TITLE
Revert "Update platform bundles for RAG components"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/PlatformBundles.java
@@ -145,9 +145,7 @@ public class PlatformBundles {
             com.yahoo.search.searchers.CacheControlSearcher.class.getName(),
             com.yahoo.search.searchers.RateLimitingSearcher.class.getName(),
             com.yahoo.vespa.streamingvisitors.MetricsSearcher.class.getName(),
-            com.yahoo.vespa.streamingvisitors.StreamingBackend.class.getName(),
-            ai.vespa.llm.search.RAGSearcher.class.getName(),
-            ai.vespa.llm.clients.OpenAI.class.getName()
+            com.yahoo.vespa.streamingvisitors.StreamingBackend.class.getName()
     );
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#30752

Some issues with package exports I guess, controller fails to start with:

1) [Guice/ErrorInjectingConstructor]: NoClassDefFoundError: ai/vespa/llm/LanguageModel
	  at StandaloneContainerApplication.<init>(StandaloneContainerApplication.java:85)
	  while locating StandaloneContainerApplication