### PR TITLE
Re-enable async LLM test

### DIFF
--- a/container-search/src/test/java/ai/vespa/llm/search/LLMSearcherTest.java
+++ b/container-search/src/test/java/ai/vespa/llm/search/LLMSearcherTest.java
@@ -18,7 +18,6 @@ import com.yahoo.search.Result;
 import com.yahoo.search.Searcher;
 import com.yahoo.search.result.EventStream;
 import com.yahoo.search.searchchain.Execution;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.net.URLEncoder;
@@ -123,7 +122,6 @@ public class LLMSearcherTest {
     }
 
     @Test
-    @Disabled
     public void testAsyncGeneration() {
         var executor = Executors.newFixedThreadPool(2);
         var sb = new StringBuilder();


### PR DESCRIPTION
@hmusum Please review.

In https://github.com/vespa-engine/vespa/pull/30779 I added a stealth change: upping fixed thread pool count to 2. When testing this at 1, locally on my computer I had maybe 10 tests failing out of 10000. With 2, 0 out of 10000. This should fix the instability.