### PR TITLE
Limit amount of work in DocumentV1 Q to 4096, or 3s.

### DIFF
--- a/vespaclient-container-plugin/src/main/resources/configdefinitions/document-operation-executor.def
+++ b/vespaclient-container-plugin/src/main/resources/configdefinitions/document-operation-executor.def
@@ -7,3 +7,5 @@ resendDelayMillis     int default=10
 # Bound on number of document operations to keep in retry queue — further operations are rejected
 maxThrottled          int default=4096
 
+# Max age in seconds of message in throttled Q.
+maxThrottledAge       double default=3.0


### PR DESCRIPTION
Having only a fixed length here does no work well when throughput is low.

@jonmv or @bjorncs PR