### PR TITLE
Revert "- Use default compilerArgs where we turn on linting and enable warnin…"

### DIFF
--- a/zkfacade/pom.xml
+++ b/zkfacade/pom.xml
@@ -74,6 +74,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Xlint:-serial</arg>
+            <arg>-Xlint:-try</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/NodeCacheWrapper.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/NodeCacheWrapper.java
@@ -15,10 +15,8 @@ import java.io.IOException;
  */
 class NodeCacheWrapper implements Curator.FileCache {
 
-    @SuppressWarnings("deprecation")
     private final NodeCache wrapped;
 
-    @SuppressWarnings("deprecation")
     public NodeCacheWrapper(CuratorFramework curatorFramework, String path, boolean dataIsCompressed) {
         wrapped = new NodeCache(curatorFramework, path, dataIsCompressed);
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/PathChildrenCacheWrapper.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/PathChildrenCacheWrapper.java
@@ -18,15 +18,12 @@ import java.util.concurrent.ExecutorService;
  */
 class PathChildrenCacheWrapper implements Curator.DirectoryCache {
 
-    @SuppressWarnings("deprecation")
     private final PathChildrenCache wrapped;
 
-    @SuppressWarnings("deprecation")
     public PathChildrenCacheWrapper(CuratorFramework curatorFramework, String path, boolean cacheData, boolean dataIsCompressed, ExecutorService executorService) {
         wrapped = new PathChildrenCache(curatorFramework, path, cacheData, dataIsCompressed, executorService);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void start() {
         try {

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/SingletonManager.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/SingletonManager.java
@@ -100,7 +100,7 @@ class SingletonManager {
     }
 
     public synchronized CompletableFuture<?> shutdown() {
-        CompletableFuture<?>[] futures = new CompletableFuture<?>[registrations.size()];
+        CompletableFuture<?>[] futures = new CompletableFuture[registrations.size()];
         int i = 0;
         for (SingletonWorker singleton : List.copyOf(registrations.keySet())) {
             String id = registrations.get(singleton);

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCuratorFramework.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/mock/MockCuratorFramework.java
@@ -210,7 +210,6 @@ public class MockCuratorFramework implements CuratorFramework  {
     @Override
     public GetConfigBuilder getConfig() { throw new UnsupportedOperationException("Not implemented in MockCurator"); }
 
-    @Deprecated
     @Override
     public CuratorTransaction inTransaction() {
         return new MockCuratorTransactionFinal();
@@ -222,7 +221,6 @@ public class MockCuratorFramework implements CuratorFramework  {
     @Override
     public TransactionOp transactionOp() { throw new UnsupportedOperationException("Not implemented in MockCurator"); }
 
-    @Deprecated
     @Override
     public RemoveWatchesBuilder watches() { throw new UnsupportedOperationException("Not implemented in MockCurator"); }
 
@@ -311,7 +309,6 @@ public class MockCuratorFramework implements CuratorFramework  {
         return new EnsurePath(path);
     }
 
-    @Deprecated
     @Override
     public void clearWatcherReferences(Watcher watcher) {
         throw new UnsupportedOperationException("Not implemented in MockCurator");

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorCreateOperation.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorCreateOperation.java
@@ -34,7 +34,6 @@ class CuratorCreateOperation implements CuratorOperation {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public CuratorTransaction and(CuratorTransaction transaction) throws Exception {
         if (data.isPresent()) {
             return transaction.create().forPath(path, data.get()).and();

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorDeleteOperation.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorDeleteOperation.java
@@ -33,7 +33,6 @@ class CuratorDeleteOperation implements CuratorOperation {
         return false;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public CuratorTransaction and(CuratorTransaction transaction) throws Exception {
         return transaction.delete().forPath(path).and();

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorOperation.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorOperation.java
@@ -20,7 +20,6 @@ public interface CuratorOperation extends Transaction.Operation {
      * @return the transaction, for chaining.
      * @throws Exception if unable to create transaction for this operation.
      */
-    @SuppressWarnings("deprecation")
     CuratorTransaction and(CuratorTransaction transaction) throws Exception;
 
     /**

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorSetDataOperation.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorSetDataOperation.java
@@ -28,7 +28,6 @@ class CuratorSetDataOperation implements CuratorOperation {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public CuratorTransaction and(CuratorTransaction transaction) throws Exception {
         return transaction.setData().forPath(path, data).and();
     }

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorTransaction.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/transaction/CuratorTransaction.java
@@ -52,7 +52,6 @@ public class CuratorTransaction extends AbstractTransaction {
 
     /** Commits this transaction. If it is not already prepared this will prepare it first */
     @Override
-    @SuppressWarnings("deprecation")
     public void commit() {
         try {
             if ( ! prepared)

--- a/zookeeper-server/pom.xml
+++ b/zookeeper-server/pom.xml
@@ -35,6 +35,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-server/zookeeper-server-3.9.2/pom.xml
+++ b/zookeeper-server/zookeeper-server-3.9.2/pom.xml
@@ -66,18 +66,17 @@
       <artifactId>snappy-java</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <!-- Included to suppress warning on missing annotation 'edu.umd.cs.findbugs.annotations.SuppressFBWarnings' at compile time -->
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-server/zookeeper-server-3.9.2/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
+++ b/zookeeper-server/zookeeper-server-3.9.2/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
@@ -26,8 +26,6 @@ public class VespaZooKeeperAdminImpl implements VespaZooKeeperAdmin {
 
     private static final Logger log = java.util.logging.Logger.getLogger(VespaZooKeeperAdminImpl.class.getName());
 
-
-    @SuppressWarnings("try")
     @Override
     public void reconfigure(String connectionSpec, String servers) throws ReconfigException {
         try (ZooKeeperAdmin zooKeeperAdmin = createAdmin(connectionSpec)) {
@@ -60,7 +58,6 @@ public class VespaZooKeeperAdminImpl implements VespaZooKeeperAdmin {
     }
 
     /** Creates a node in zookeeper, with hostname as part of node name, this ensures that server is up and working before returning */
-    @SuppressWarnings("try")
     void createDummyNode(ZookeeperServerConfig zookeeperServerConfig) {
         int sleepTime = 2_000;
         try (ZooKeeperAdmin zooKeeperAdmin = createAdmin(localConnectionSpec(zookeeperServerConfig))) {

--- a/zookeeper-server/zookeeper-server-common/pom.xml
+++ b/zookeeper-server/zookeeper-server-common/pom.xml
@@ -29,6 +29,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+            <arg>-Werror</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-server/zookeeper-server/pom.xml
+++ b/zookeeper-server/zookeeper-server/pom.xml
@@ -66,18 +66,17 @@
       <artifactId>snappy-java</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <!-- Included to suppress warning on missing annotation 'edu.umd.cs.findbugs.annotations.SuppressFBWarnings' at compile time -->
-      <groupId>com.github.spotbugs</groupId>
-      <artifactId>spotbugs-annotations</artifactId>
-      <scope>compile</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/zookeeper-server/zookeeper-server/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
+++ b/zookeeper-server/zookeeper-server/src/main/java/com/yahoo/vespa/zookeeper/VespaZooKeeperAdminImpl.java
@@ -26,7 +26,6 @@ public class VespaZooKeeperAdminImpl implements VespaZooKeeperAdmin {
 
     private static final Logger log = java.util.logging.Logger.getLogger(VespaZooKeeperAdminImpl.class.getName());
 
-    @SuppressWarnings("try")
     @Override
     public void reconfigure(String connectionSpec, String servers) throws ReconfigException {
         try (ZooKeeperAdmin zooKeeperAdmin = createAdmin(connectionSpec)) {
@@ -59,7 +58,6 @@ public class VespaZooKeeperAdminImpl implements VespaZooKeeperAdmin {
     }
 
     /** Creates a node in zookeeper, with hostname as part of node name, this ensures that server is up and working before returning */
-    @SuppressWarnings("try")
     void createDummyNode(ZookeeperServerConfig zookeeperServerConfig) {
         int sleepTime = 2_000;
         try (ZooKeeperAdmin zooKeeperAdmin = createAdmin(localConnectionSpec(zookeeperServerConfig))) {


### PR DESCRIPTION
Reverts vespa-engine/vespa#30836

Controller fails to start:

 Caused by: org.osgi.framework.BundleException: Unable to resolve controller-clients [37](R 37.0): missing requirement [controller-clients [37](R 37.0)] osgi.wiring.package; (osgi.wiring.package=edu.umd.cs.findbugs.annotations) Unresolved requirements: [[controller-clients [37](R 37.0)] osgi.wiring.package; (osgi.wiring.package=edu.umd.cs.findbugs.annotations)]