### PR TITLE
Suppress more protobuf related valgrind warnings MERGEOK

### DIFF
--- a/valgrind-suppressions.txt
+++ b/valgrind-suppressions.txt
@@ -521,3 +521,36 @@
    fun:_dl_init
    obj:/usr/lib64/ld-2.28.so
 }
+{
+   Protobuf 5.26.1 suppression 4
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN6google8protobuf14DescriptorPool6TablesC1Ev
+   fun:_ZN6google8protobuf14DescriptorPoolC1EPNS0_18DescriptorDatabaseEPNS1_14ErrorCollectorE
+   fun:_ZN6google8protobuf14DescriptorPool23internal_generated_poolEv
+   fun:_ZN6google8protobuf14DescriptorPool24InternalAddGeneratedFileEPKvi
+   fun:_ZN6google8protobuf8internal14AddDescriptorsEPKNS1_15DescriptorTableE
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.28.so
+}
+{
+   Protobuf 5.26.1 suppression 5
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4absl12lts_2024011618container_internal19HashSetResizeHelper15InitializeSlotsISaIcELm40ELb0ELm8EEEbRNS1_12CommonFieldsEPvT_.isra.0
+   fun:_ZN4absl12lts_2024011618container_internal12raw_hash_setINS1_17FlatHashMapPolicyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN6google8protobuf10Descriptor13WellKnownTypeEEENS1_10StringHashENS1_8StringEqESaISt4pairIKS9_SD_EEE6resizeEm
+   fun:_ZN4absl12lts_2024011618container_internal12raw_hash_setINS1_17FlatHashMapPolicyINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEN6google8protobuf10Descriptor13WellKnownTypeEEENS1_10StringHashENS1_8StringEqESaISt4pairIKS9_SD_EEE14prepare_insertEm
+   fun:_ZN6google8protobuf14DescriptorPool6TablesC1Ev
+   fun:_ZN6google8protobuf14DescriptorPoolC1EPNS0_18DescriptorDatabaseEPNS1_14ErrorCollectorE
+   fun:_ZN6google8protobuf14DescriptorPool23internal_generated_poolEv
+   fun:_ZN6google8protobuf14DescriptorPool24InternalAddGeneratedFileEPKvi
+   fun:_ZN6google8protobuf8internal14AddDescriptorsEPKNS1_15DescriptorTableE
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:/usr/lib64/ld-2.28.so
+}


### PR DESCRIPTION
systems without debuginfo libraries installed.

@vekterli : please review
