### PR TITLE
Support populating attribute where docid sets matching terms/children…

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/attribute_ctx_builder.h
@@ -19,7 +19,7 @@ private:
 
 public:
     AttributeContextBuilder();
-    void add(const search::attribute::Config& cfg, vespalib::stringref field_name, uint32_t num_docs, const HitSpecs& hit_specs);
+    void add(const search::attribute::Config& cfg, vespalib::stringref field_name, uint32_t num_docs, const HitSpecs& hit_specs, bool disjunct_terms);
     std::unique_ptr<BenchmarkSearchable> build();
 };
 

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.cpp
@@ -42,11 +42,11 @@ calc_hits_per_term(uint32_t num_docs, double op_hit_ratio, uint32_t children, Qu
 }
 
 std::unique_ptr<BenchmarkSearchable>
-make_searchable(const FieldConfig& cfg, uint32_t num_docs, const HitSpecs& hit_specs)
+make_searchable(const FieldConfig& cfg, uint32_t num_docs, const HitSpecs& hit_specs, bool disjunct_terms)
 {
     if (cfg.is_attr()) {
         AttributeContextBuilder builder;
-        builder.add(cfg.attr_cfg(), field_name, num_docs, hit_specs);
+        builder.add(cfg.attr_cfg(), field_name, num_docs, hit_specs, disjunct_terms);
         return builder.build();
     } else {
         uint32_t docid_limit = num_docs + 1;
@@ -159,14 +159,14 @@ private:
 public:
     MyFactory(const FieldConfig& field_cfg, QueryOperator query_op,
               uint32_t num_docs, uint32_t default_values_per_document,
-              double op_hit_ratio, uint32_t children);
+              double op_hit_ratio, uint32_t children, bool disjunct_children);
 
     std::unique_ptr<Blueprint> make_blueprint() override;
 };
 
 MyFactory::MyFactory(const FieldConfig& field_cfg, QueryOperator query_op,
                      uint32_t num_docs, uint32_t default_values_per_document,
-                     double op_hit_ratio, uint32_t children)
+                     double op_hit_ratio, uint32_t children, bool disjunct_children)
     : _query_op(query_op),
       _docid_limit(num_docs + 1),
       _terms(),
@@ -174,9 +174,15 @@ MyFactory::MyFactory(const FieldConfig& field_cfg, QueryOperator query_op,
 {
     uint32_t hits_per_term = calc_hits_per_term(num_docs, op_hit_ratio, children, query_op);
     HitSpecs hit_specs(55555);
-    hit_specs.add(default_values_per_document, num_docs);
+    if (!disjunct_children) {
+        hit_specs.add(default_values_per_document, num_docs);
+    }
     _terms = hit_specs.add(children, hits_per_term);
-    _searchable = make_searchable(field_cfg, num_docs, hit_specs);
+    if (disjunct_children) {
+        uint32_t op_num_hits = num_docs * op_hit_ratio;
+        hit_specs.add(default_values_per_document, num_docs - op_num_hits);
+    }
+    _searchable = make_searchable(field_cfg, num_docs, hit_specs, disjunct_children);
 }
 
 std::unique_ptr<Blueprint>
@@ -190,9 +196,9 @@ MyFactory::make_blueprint()
 std::unique_ptr<BenchmarkBlueprintFactory>
 make_blueprint_factory(const FieldConfig& field_cfg, QueryOperator query_op,
                        uint32_t num_docs, uint32_t default_values_per_document,
-                       double op_hit_ratio, uint32_t children)
+                       double op_hit_ratio, uint32_t children, bool disjunct_children)
 {
-    return std::make_unique<MyFactory>(field_cfg, query_op, num_docs, default_values_per_document, op_hit_ratio, children);
+    return std::make_unique<MyFactory>(field_cfg, query_op, num_docs, default_values_per_document, op_hit_ratio, children, disjunct_children);
 }
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.cpp
@@ -178,9 +178,11 @@ MyFactory::MyFactory(const FieldConfig& field_cfg, QueryOperator query_op,
         hit_specs.add(default_values_per_document, num_docs);
     }
     _terms = hit_specs.add(children, hits_per_term);
-    if (disjunct_children) {
+    if (disjunct_children && default_values_per_document != 0) {
+        // This ensures that the remaining docids are populated with a "default value".
+        // Only a single default value is supported.
         uint32_t op_num_hits = num_docs * op_hit_ratio;
-        hit_specs.add(default_values_per_document, num_docs - op_num_hits);
+        hit_specs.add(1, num_docs - op_num_hits);
     }
     _searchable = make_searchable(field_cfg, num_docs, hit_specs, disjunct_children);
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/benchmark_blueprint_factory.h
@@ -21,6 +21,6 @@ public:
 std::unique_ptr<BenchmarkBlueprintFactory>
 make_blueprint_factory(const FieldConfig& field_cfg, QueryOperator query_op,
                        uint32_t num_docs, uint32_t default_values_per_document,
-                       double op_hit_ratio, uint32_t children);
+                       double op_hit_ratio, uint32_t children, bool disjunct_children);
 
 }

--- a/searchlib/src/tests/queryeval/iterator_benchmark/common.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/common.cpp
@@ -1,7 +1,6 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 #include "common.h"
-#include <random>
 #include <sstream>
 
 using search::attribute::CollectionType;
@@ -48,6 +47,8 @@ constexpr uint32_t default_seed = 1234;
 std::mt19937 gen(default_seed);
 
 }
+
+std::mt19937& get_gen() { return gen; }
 
 BitVector::UP
 random_docids(uint32_t docid_limit, uint32_t count)

--- a/searchlib/src/tests/queryeval/iterator_benchmark/common.h
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/common.h
@@ -5,6 +5,7 @@
 #include <vespa/searchcommon/attribute/config.h>
 #include <vespa/searchcommon/common/schema.h>
 #include <vespa/searchlib/common/bitvector.h>
+#include <random>
 #include <variant>
 
 namespace search::queryeval::test {
@@ -77,6 +78,8 @@ public:
     auto begin() const { return _specs.begin(); }
     auto end() const { return _specs.end(); }
 };
+
+std::mt19937& get_gen();
 
 BitVector::UP random_docids(uint32_t docid_limit, uint32_t count);
 


### PR DESCRIPTION
… are disjunct.

This also adds testing of IN operator with many tokens (up to 10k), which uses disjunct terms/children.

In addition calculation of "alternative cost" is removed, as it doesn't provide any value at the moment.

@havardpe please review