### PR TITLE
Install Abseil failure signal handler in distributor/proton daemons

### DIFF
--- a/searchcore/src/apps/proton/CMakeLists.txt
+++ b/searchcore/src/apps/proton/CMakeLists.txt
@@ -23,4 +23,5 @@ vespa_add_executable(searchcore_proton_app
     searchcore_grouping
     searchcore_proton_metrics
     storageserver_storageapp
+    absl::failure_signal_handler
 )

--- a/storageserver/src/apps/storaged/CMakeLists.txt
+++ b/storageserver/src/apps/storaged/CMakeLists.txt
@@ -8,6 +8,7 @@ vespa_add_executable(storageserver_storaged_app
     DEPENDS
     storageserver_storageapp
     protobuf::libprotobuf
+    absl::failure_signal_handler
 )
 
 vespa_add_target_package_dependency(storageserver_storaged_app Protobuf)

--- a/storageserver/src/apps/storaged/storage.cpp
+++ b/storageserver/src/apps/storaged/storage.cpp
@@ -21,6 +21,7 @@
 #include <vespa/config/helper/configgetter.hpp>
 #include <vespa/vespalib/util/signalhandler.h>
 #include <google/protobuf/message_lite.h>
+#include <absl/debugging/failure_signal_handler.h>
 #include <iostream>
 #include <csignal>
 #include <cstdlib>
@@ -213,8 +214,15 @@ int StorageApp::main(int argc, char **argv)
 } // storage
 
 int main(int argc, char **argv) {
+    absl::FailureSignalHandlerOptions opts;
+    // See `searchcore/src/apps/proton/proton.cpp` for parameter and handler ordering rationale.
+    opts.call_previous_handler = true;
+    opts.use_alternate_stack = false;
+    absl::InstallFailureSignalHandler(opts);
+
     vespalib::SignalHandler::PIPE.ignore();
     vespalib::SignalHandler::enable_cross_thread_stack_tracing();
+
     storage::StorageApp app;
     storage::sigtramp = &app;
     int retval = app.main(argc,argv);


### PR DESCRIPTION
@toregge and @baldersheim please review.

This will attempt to dump a stack trace for the offending thread to `stderr`, which should greatly improve crash visibility and debug-ability for everyone running Vespa on systems with core dumps disabled.

Signal handler chaining is explicitly enabled to allow sanitizer handlers to be called as expected.

Note that we install our own signal handlers _after_ the Abseil handlers to avoid noisy stack dumping on `SIGTERM`. It is considered a fatal signal by the failure handler, but the config sentinel uses it as a friendly "please shutdown now, or else 😘" nudge in the common case.

Example log output when doing a manual `kill -SEGV` of a `searchnode` process that is also TSan-instrumented:

```
WARNING searchnode       stderr       *** SIGSEGV received at time=1712753635 on cpu 2 ***
WARNING searchnode       stderr       PC: @     0xfffff235afb4  (unknown)  nanosleep
WARNING searchnode       stderr           @     0xfffff6e3a5e8        464  absl::lts_20240116::AbslFailureSignalHandler()
WARNING searchnode       stderr           @     0xfffff6ead38c       5008  (unknown)
WARNING searchnode       stderr           @     0xfffff235afa0         16  nanosleep
WARNING searchnode       stderr           @     0xfffff6ed3ef8        128  __interceptor_nanosleep
WARNING searchnode       stderr           @           0x527010        704  App::main()
WARNING searchnode       stderr           @           0x5274e0        272  main
WARNING searchnode       stderr           @     0xffffe8a6a384         48  __libc_start_main
WARNING searchnode       stderr       ThreadSanitizer:DEADLYSIGNAL
WARNING searchnode       stderr       ThreadSanitizer: nested bug in the same thread, aborting.
```
Prior to this, all we'd get (if no core dumps are enabled) is the sound of silence and an exit code log message from the config sentinel.

This mostly resolves issue #29928, but does not currently apply to _all_ C++ processes.