### PR TITLE
Adjust strict cost of bitvector after benchmarking.

### DIFF
--- a/searchlib/src/tests/queryeval/iterator_benchmark/common.cpp
+++ b/searchlib/src/tests/queryeval/iterator_benchmark/common.cpp
@@ -20,7 +20,11 @@ to_string(const Config& attr_config)
         oss << col_type.asString() << "<" << basic_type.asString() << ">";
     }
     if (attr_config.fastSearch()) {
-        oss << "(fs)";
+        oss << "(fs";
+        if (attr_config.getIsFilter()) {
+            oss << ",rf";
+        }
+        oss << ")";
     }
     return oss.str();
 }

--- a/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
@@ -61,6 +61,17 @@ inline double btree_strict_cost(double my_est) {
     return my_est;
 }
 
+// Non-strict cost of matching in a bitvector.
+inline double bitvector_cost() {
+    return 1.0;
+}
+
+// Strict cost of matching in a bitvector.
+// Test used: IteratorBenchmark::analyze_btree_vs_bitvector_iterators_strict
+inline double bitvector_strict_cost(double my_est) {
+    return 1.5 * my_est;
+}
+
 // Non-strict cost of matching in a disk index posting list.
 inline double disk_index_cost() {
     return 1.5;


### PR DESCRIPTION
A bitvector iterator is used to track active lids and is always part of a query.

@havardpe please review