### PR TITLE
systemd: fix service LimitSTACK configuration

### DIFF
--- a/vespabase/src/vespa-configserver.service.in
+++ b/vespabase/src/vespa-configserver.service.in
@@ -12,7 +12,7 @@ ExecStop=@CMAKE_INSTALL_PREFIX@/bin/vespa-stop-configserver
 LimitNOFILE=32768:262144
 LimitCORE=0:infinity
 LimitNPROC=32768:409600
-LimitStack=8388608:16777216
+LimitSTACK=8388608:16777216
 
 [Install]
 WantedBy=multi-user.target

--- a/vespabase/src/vespa.service.in
+++ b/vespabase/src/vespa.service.in
@@ -12,7 +12,7 @@ ExecStop=@CMAKE_INSTALL_PREFIX@/bin/vespa-stop-services
 LimitNOFILE=32768:262144
 LimitCORE=0:infinity
 LimitNPROC=32768:409600
-LimitStack=8388608:16777216
+LimitSTACK=8388608:16777216
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Error when running systemd services.

```
Apr 18 11:36:22 barerocky811699-ow-MW9F6F3V53-avvjnv3 systemd[1]: /usr/lib/systemd/system/vespa.service:15: Unknown lvalue 'LimitStack' in section 'Service'
Apr 18 11:36:23 barerocky811699-ow-MW9F6F3V53-avvjnv3 systemd[1]: /usr/lib/systemd/system/vespa.service:15: Unknown lvalue 'LimitStack' in section 'Service'
```

Documentation: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html

Correct form is  `LimitSTACK`