### PR TITLE
Use better non-strict cost estimates for btree and disk index iterators.

### DIFF
--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -166,7 +166,7 @@ public:
             return {0.5, lookup_cost(indirections), lookup_strict_cost(indirections)};
         } else {
             double rel_est = abs_to_rel_est(_hit_estimate.est_hits(), docid_limit);
-            return {rel_est, btree_cost(), btree_strict_cost(rel_est)};
+            return {rel_est, btree_cost(rel_est), btree_strict_cost(rel_est)};
         }
     }
 
@@ -519,8 +519,9 @@ public:
             double estimate(const IDirectPostingStore::LookupResult &term) const noexcept {
                 return abs_to_rel_est(term.posting_size, docid_limit);
             }
-            double cost(const IDirectPostingStore::LookupResult &) const noexcept {
-                return btree_cost();
+            double cost(const IDirectPostingStore::LookupResult &term) const noexcept {
+                double rel_est = abs_to_rel_est(term.posting_size, docid_limit);
+                return btree_cost(rel_est);
             }
             double strict_cost(const IDirectPostingStore::LookupResult &term) const noexcept {
                 double rel_est = abs_to_rel_est(term.posting_size, docid_limit);

--- a/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
+++ b/searchlib/src/vespa/searchlib/attribute/direct_multi_term_blueprint.hpp
@@ -192,8 +192,9 @@ DirectMultiTermBlueprint<PostingStoreType, SearchType>::calculate_flow_stats(uin
         double estimate(const IDirectPostingStore::LookupResult &term) const noexcept {
             return abs_to_rel_est(term.posting_size, docid_limit);
         }
-        double cost(const IDirectPostingStore::LookupResult &) const noexcept {
-            return search::queryeval::flow::btree_cost();
+        double cost(const IDirectPostingStore::LookupResult &term) const noexcept {
+            double rel_est = abs_to_rel_est(term.posting_size, docid_limit);
+            return search::queryeval::flow::btree_cost(rel_est);
         }
         double strict_cost(const IDirectPostingStore::LookupResult &term) const noexcept {
             double rel_est = abs_to_rel_est(term.posting_size, docid_limit);

--- a/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/disktermblueprint.cpp
@@ -72,7 +72,7 @@ queryeval::FlowStats
 DiskTermBlueprint::calculate_flow_stats(uint32_t docid_limit) const
 {
     double rel_est = abs_to_rel_est(_lookupRes->counts._numDocs, docid_limit);
-    return {rel_est, disk_index_cost(), disk_index_strict_cost(rel_est)};
+    return {rel_est, disk_index_cost(rel_est), disk_index_strict_cost(rel_est)};
 }
 
 SearchIterator::UP

--- a/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
+++ b/searchlib/src/vespa/searchlib/memoryindex/field_index.cpp
@@ -261,7 +261,7 @@ public:
 
     queryeval::FlowStats calculate_flow_stats(uint32_t docid_limit) const override {
         double rel_est = abs_to_rel_est(_posting_itr.size(), docid_limit);
-        return {rel_est, btree_cost(), btree_strict_cost(rel_est)};
+        return {rel_est, btree_cost(rel_est), btree_strict_cost(rel_est)};
     }
     
     SearchIterator::UP createLeafSearch(const TermFieldMatchDataArray& tfmda) const override {

--- a/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
@@ -7,58 +7,85 @@
 namespace search::queryeval::flow {
 
 /**
- * This function is used when calculating the strict cost of
- * intermediate and complex leaf blueprints that use a heap for their strict iterator implementation.
- *
- * Iterator benchmarking has shown the need to increase the strict cost
- * of complex blueprints, to avoid that they are forced strict too early.
- * The 5.0 multiplier reflects this.
- *
- * Program used: searchlib/src/tests/queryeval/iterator_benchmark
- * Tests used: analyze_and_with_filter_vs_*
- */
-inline double heap_cost(double my_est, size_t num_children) {
-    return 5.0 * my_est * std::log2(std::max(size_t(1), num_children));
-}
-
-/**
- * The following constants and formulas were derived after analyzing term search over attributes
- * (with and without fast-search) and disk index by using the iterator benchmark program:
+ * The following constants and formulas were derived after benchmarking and analyzing
+ * using the following benchmark program:
  * searchlib/src/tests/queryeval/iterator_benchmark
  *
- * The following tests were executed on a machine with an Intel Xeon 2.5 GHz CPU with 48 cores and 256 Gb of memory:
- * ./searchlib_iterator_benchmark_test_app --gtest_filter='*analyze_term_search*'
- *
- * TODO: Add details on OR benchmarking.
+ * The tests were executed on:
+ *   - Machine with an Intel Xeon 2.5 GHz CPU with 48 cores and 256 Gb of memory.
+ *   - Apple M1 MacBook Pro (2021) 32 GB.
  *
  * The benchmark summary shows the 'average ms per cost' of the different benchmark cases.
- * The following constants and formulas were derived to balance 'average ms per cost' to be similar
+ * The constants and formulas are adjusted to balance 'average ms per cost' to be similar
  * across the different benchmark cases.
+ *
+ * The AND benchmark cases outputs the ratio (esti/forc) of the time_ms used by two query planning algorithms:
+ * 'estimate' (legacy) and 'cost with allowed force strict' (new).
+ * 'max_speedup' indicates the gain of using the new cost model, while 'min_speedup' indicates the loss.
+ * The constants and formulas are also adjusted to maximize speedup, while reducing loss.
+ * Tests used:
+ *   - IteratorBenchmark::analyze_AND_filter_vs_IN
+ *   - IteratorBenchmark::analyze_AND_filter_vs_OR
+ *   - IteratorBenchmark::analyze_AND_filter_vs_IN_array
+ *   - IteratorBenchmark::analyze_AND_bitvector_vs_IN
  */
 
+/**
+ * This function is used when calculating the strict cost of
+ * intermediate and complex leaf blueprints that use a heap for their strict iterator implementation.
+ * Tests used:
+ *   - IteratorBenchmark::analyze_IN_strict
+ *   - IteratorBenchmark::analyze_OR_strict
+ */
+inline double heap_cost(double my_est, size_t num_children) {
+    return my_est * std::log2(std::max(size_t(1), num_children));
+}
+
 // Non-strict cost of lookup based matching in an attribute (not fast-search).
+// Test used: IteratorBenchmark::analyze_term_search_in_attributes_non_strict
 inline double lookup_cost(size_t num_indirections) {
     return 1.0 + (num_indirections * 1.0);
 }
 
 // Non-strict cost of reverse lookup into a hash table (containing terms from a multi-term operator).
+// Test used: IteratorBenchmark::analyze_IN_non_strict
 inline double reverse_hash_lookup() {
-    return 5.0;
+    return 1.0;
 }
 
 // Strict cost of lookup based matching in an attribute (not fast-search).
+// IteratorBenchmark::analyze_term_search_in_attributes_strict
 inline double lookup_strict_cost(size_t num_indirections) {
     return lookup_cost(num_indirections);
 }
 
-// Non-strict cost of matching in a btree posting list (e.g. fast-search attribute or memory index field).
-inline double btree_cost() {
-    return 1.0;
+/**
+ * Estimates the cost of evaluating an always strict iterator (e.g. btree) in a non-strict context.
+ *
+ * When the estimate and strict cost is low, this models the cost of checking whether
+ * the seek docid matches the docid the iterator is already positioned at (the 0.2 factor).
+ *
+ * The resulting non-strict cost is most accurate when the inflow is 1.0.
+ * The resulting non-strict cost is highly underestimated when the inflow goes to 0.0.
+ * It is important to have a better estimate at higher inflows,
+ * as the latency (time) penalty is higher if choosing wrong.
+ *
+ * Note: This formula is equal to forced_strict_cost() in flow.h.
+ */
+inline double non_strict_cost_of_strict_iterator(double estimate, double strict_cost) {
+    return 0.2 * (1.0 - estimate) + strict_cost;
 }
 
 // Strict cost of matching in a btree posting list (e.g. fast-search attribute or memory index field).
+// Test used: IteratorBenchmark::analyze_term_search_in_fast_search_attributes
 inline double btree_strict_cost(double my_est) {
     return my_est;
+}
+
+// Non-strict cost of matching in a btree posting list (e.g. fast-search attribute or memory index field).
+// Test used: IteratorBenchmark::analyze_btree_iterator_non_strict
+inline double btree_cost(double my_est) {
+    return non_strict_cost_of_strict_iterator(my_est, btree_strict_cost(my_est));
 }
 
 // Non-strict cost of matching in a bitvector.
@@ -72,14 +99,16 @@ inline double bitvector_strict_cost(double my_est) {
     return 1.5 * my_est;
 }
 
-// Non-strict cost of matching in a disk index posting list.
-inline double disk_index_cost() {
-    return 1.5;
-}
-
 // Strict cost of matching in a disk index posting list.
+// Test used: IteratorBenchmark::analyze_term_search_in_disk_index
 inline double disk_index_strict_cost(double my_est) {
     return 1.5 * my_est;
+}
+
+// Non-strict cost of matching in a disk index posting list.
+// Test used: IteratorBenchmark::analyze_term_search_in_disk_index
+inline double disk_index_cost(double my_est) {
+    return non_strict_cost_of_strict_iterator(my_est, disk_index_strict_cost(my_est));
 }
 
 }


### PR DESCRIPTION
We previously increased the strict cost of heap-based complex blueprints (e.g OR) to avoid the problem of them being forced strict too early. More benchmarking however has shown that its better address the real problem, which is the non-strict cost of btree iterators that are childen of the ORs. Its important that the non-strict cost is most accurate with high inflows (moving towards 1.0), as the time penalty of choosing wrong is at its highest then.

This adds additional benchmarks needed for analysis and updates/adjusts the parameters and formulas in flow_tuning.h to match observations.

@havardpe please review