### PR TITLE
Wire fuzzy prefix matching support through the query stack

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -555,11 +555,15 @@
       "public"
     ],
     "methods" : [
+      "public void <init>(java.lang.String, boolean, java.lang.String, int, int, boolean)",
       "public void <init>(java.lang.String, boolean, java.lang.String, int, int)",
       "public void setMaxEditDistance(int)",
       "public void setPrefixLength(int)",
       "public int getPrefixLength()",
       "public int getMaxEditDistance()",
+      "public boolean isPrefixMatch()",
+      "public void setPrefixMatch(boolean)",
+      "protected boolean hasPrefixMatchSemantics()",
       "public void setValue(java.lang.String)",
       "public java.lang.String getRawWord()",
       "public boolean isWords()",
@@ -820,6 +824,7 @@
       "public abstract java.lang.String getName()",
       "public void setFilter(boolean)",
       "public boolean isFilter()",
+      "protected boolean hasPrefixMatchSemantics()",
       "public com.yahoo.prelude.query.Item$ItemCreator getCreator()",
       "public void setCreator(com.yahoo.prelude.query.Item$ItemCreator)",
       "public void setWeight(int)",

--- a/container-search/src/main/java/com/yahoo/prelude/query/Item.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/Item.java
@@ -161,6 +161,16 @@ public abstract class Item implements Cloneable {
     }
 
     /**
+     * Indicates that a query item that does not normally match with prefix semantics
+     * should do so for this particular query item instance.
+     *
+     * False by default; should be overridden by subclasses that want to signal this behavior.
+     */
+    protected boolean hasPrefixMatchSemantics() {
+        return false;
+    }
+
+    /**
      * Returns the item creator value.
      *
      * @deprecated use isFilter(boolean)
@@ -286,6 +296,7 @@ public abstract class Item implements Cloneable {
         byte FLAGS_SPECIALTOKEN = 0x02;
         byte FLAGS_NOPOSITIONDATA = 0x04;
         byte FLAGS_ISFILTER = 0x08;
+        byte FLAGS_PREFIX_MATCH = 0x10;
 
         byte ret = 0;
         if (!isRanked()) {
@@ -299,6 +310,9 @@ public abstract class Item implements Cloneable {
         }
         if (isFilter()) {
             ret |= FLAGS_ISFILTER;
+        }
+        if (hasPrefixMatchSemantics()) {
+            ret |= FLAGS_PREFIX_MATCH;
         }
         return ret;
     }

--- a/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
+++ b/container-search/src/main/java/com/yahoo/search/query/SelectParser.java
@@ -1150,8 +1150,9 @@ public class SelectParser implements Parser {
 
         Integer maxEditDistance = getIntegerAnnotation(MAX_EDIT_DISTANCE, annotations, FuzzyItem.DEFAULT_MAX_EDIT_DISTANCE);
         Integer prefixLength = getIntegerAnnotation(PREFIX_LENGTH, annotations, FuzzyItem.DEFAULT_PREFIX_LENGTH);
+        boolean prefixMatch = getBoolAnnotation(PREFIX, annotations, Boolean.FALSE);
 
-        FuzzyItem fuzzy = new FuzzyItem(field, true, wordData, maxEditDistance, prefixLength);
+        FuzzyItem fuzzy = new FuzzyItem(field, true, wordData, maxEditDistance, prefixLength, prefixMatch);
 
         return leafStyleSettings(getAnnotations(value), fuzzy);
     }

--- a/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/VespaSerializer.java
@@ -551,24 +551,31 @@ public class VespaSerializer {
         static String fuzzyAnnotations(FuzzyItem fuzzyItem) {
             boolean isMaxEditDistanceSet = fuzzyItem.getMaxEditDistance() != FuzzyItem.DEFAULT_MAX_EDIT_DISTANCE;
             boolean isPrefixLengthSet = fuzzyItem.getPrefixLength() != FuzzyItem.DEFAULT_PREFIX_LENGTH;
-            boolean anyAnnotationSet = isMaxEditDistanceSet || isPrefixLengthSet;
+            boolean isPrefixMatch = fuzzyItem.isPrefixMatch();
+            boolean anyAnnotationSet = isMaxEditDistanceSet || isPrefixLengthSet || isPrefixMatch;
+
+            if (!anyAnnotationSet) {
+                return "";
+            }
 
             StringBuilder builder = new StringBuilder();
-            if (anyAnnotationSet) {
-                builder.append("{");
-            }
+            builder.append("{");
             if (isMaxEditDistanceSet) {
                 builder.append(MAX_EDIT_DISTANCE + ":").append(fuzzyItem.getMaxEditDistance());
-            }
-            if (isMaxEditDistanceSet && isPrefixLengthSet) {
-                builder.append(",");
+                if (isPrefixLengthSet || isPrefixMatch) {
+                    builder.append(",");
+                }
             }
             if (isPrefixLengthSet) {
                 builder.append(PREFIX_LENGTH + ":").append(fuzzyItem.getPrefixLength());
+                if (isPrefixMatch) {
+                    builder.append(",");
+                }
             }
-            if (anyAnnotationSet) {
-                builder.append("}");
+            if (isPrefixMatch) {
+                builder.append(PREFIX).append(':').append(fuzzyItem.isPrefixMatch());
             }
+            builder.append("}");
             return builder.toString();
         }
     }

--- a/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
+++ b/container-search/src/main/java/com/yahoo/search/yql/YqlParser.java
@@ -1385,7 +1385,14 @@ public class YqlParser implements Parser {
                 FuzzyItem.DEFAULT_PREFIX_LENGTH,
                 PREFIX_LENGTH_DESCRIPTION);
 
-        FuzzyItem fuzzy = new FuzzyItem(field, true, wordData, maxEditDistance, prefixLength);
+        boolean prefixMatch = getAnnotation(
+                ast,
+                PREFIX,
+                Boolean.class,
+                Boolean.FALSE,
+                "setting for whether to use prefix match of input data");
+
+        FuzzyItem fuzzy = new FuzzyItem(field, true, wordData, maxEditDistance, prefixLength, prefixMatch);
         return leafStyleSettings(ast, fuzzy);
     }
 

--- a/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/VespaSerializerTestCase.java
@@ -464,7 +464,12 @@ public class VespaSerializerTestCase {
 
     @Test
     void testFuzzyAnnotations() {
+        parseAndConfirm("foo contains ({maxEditDistance:3}fuzzy(\"a\"))");
         parseAndConfirm("foo contains ({maxEditDistance:3,prefixLength:5}fuzzy(\"a\"))");
+        parseAndConfirm("foo contains ({maxEditDistance:3,prefixLength:5,prefix:true}fuzzy(\"a\"))");
+        parseAndConfirm("foo contains ({prefixLength:5,prefix:true}fuzzy(\"a\"))");
+        parseAndConfirm("foo contains ({maxEditDistance:3,prefix:true}fuzzy(\"a\"))");
+        parseAndConfirm("foo contains ({prefix:true}fuzzy(\"a\"))");
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/yql/YqlParserTestCase.java
@@ -437,23 +437,27 @@ public class YqlParserTestCase {
         QueryTree x = parse("select foo from bar where baz contains fuzzy(\"a b\")");
         Item root = x.getRoot();
         assertSame(FuzzyItem.class, root.getClass());
-        assertEquals("baz", ((FuzzyItem) root).getIndexName());
-        assertEquals("a b", ((FuzzyItem) root).stringValue());
-        assertEquals(FuzzyItem.DEFAULT_MAX_EDIT_DISTANCE, ((FuzzyItem) root).getMaxEditDistance());
-        assertEquals(FuzzyItem.DEFAULT_PREFIX_LENGTH, ((FuzzyItem) root).getPrefixLength());
+        var fuzzy = (FuzzyItem) root;
+        assertEquals("baz", fuzzy.getIndexName());
+        assertEquals("a b", fuzzy.stringValue());
+        assertEquals(FuzzyItem.DEFAULT_MAX_EDIT_DISTANCE, fuzzy.getMaxEditDistance());
+        assertEquals(FuzzyItem.DEFAULT_PREFIX_LENGTH, fuzzy.getPrefixLength());
+        assertFalse(fuzzy.isPrefixMatch());
     }
 
     @Test
     void testFuzzyAnnotations() {
         QueryTree x = parse(
-                "select foo from bar where baz contains ({maxEditDistance: 3, prefixLength: 10}fuzzy(\"a b\"))"
+                "select foo from bar where baz contains ({maxEditDistance: 3, prefixLength: 10, prefix: true}fuzzy(\"a b\"))"
         );
         Item root = x.getRoot();
         assertSame(FuzzyItem.class, root.getClass());
-        assertEquals("baz", ((FuzzyItem) root).getIndexName());
-        assertEquals("a b", ((FuzzyItem) root).stringValue());
-        assertEquals(3, ((FuzzyItem) root).getMaxEditDistance());
-        assertEquals(10, ((FuzzyItem) root).getPrefixLength());
+        var fuzzy = (FuzzyItem) root;
+        assertEquals("baz", fuzzy.getIndexName());
+        assertEquals("a b", fuzzy.stringValue());
+        assertEquals(3, fuzzy.getMaxEditDistance());
+        assertEquals(10, fuzzy.getPrefixLength());
+        assertTrue(fuzzy.isPrefixMatch());
     }
 
     @Test

--- a/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
+++ b/container-search/src/test/java/com/yahoo/select/SelectTestCase.java
@@ -671,8 +671,39 @@ public class SelectTestCase {
         QueryTree x = parseWhere("{ \"contains\": [\"description\", { \"fuzzy\": [\"a b\"] }] }");
         Item root = x.getRoot();
         assertSame(FuzzyItem.class, root.getClass());
-        assertEquals("description", ((FuzzyItem) root).getIndexName());
-        assertEquals("a b", ((FuzzyItem) root).stringValue());
+        var fuzzy = (FuzzyItem) root;
+        assertEquals("description", fuzzy.getIndexName());
+        assertEquals("a b", fuzzy.stringValue());
+        assertEquals(FuzzyItem.DEFAULT_MAX_EDIT_DISTANCE, fuzzy.getMaxEditDistance());
+        assertEquals(FuzzyItem.DEFAULT_PREFIX_LENGTH, fuzzy.getPrefixLength());
+        assertFalse(fuzzy.isPrefixMatch());
+    }
+
+    @Test
+    void fuzzy_with_annotations() {
+        var where = """
+                {
+                  "contains": ["description", {
+                    "fuzzy": {
+                      "children": ["a b"],
+                      "attributes": {
+                        "maxEditDistance": 3,
+                        "prefixLength": 10,
+                        "prefix": true
+                      }
+                    }
+                  }]
+                }
+                """;
+        QueryTree x = parseWhere(where);
+        Item root = x.getRoot();
+        assertSame(FuzzyItem.class, root.getClass());
+        var fuzzy = (FuzzyItem) root;
+        assertEquals("description", fuzzy.getIndexName());
+        assertEquals("a b", fuzzy.stringValue());
+        assertEquals(3, fuzzy.getMaxEditDistance());
+        assertEquals(10, fuzzy.getPrefixLength());
+        assertTrue(fuzzy.isPrefixMatch());
     }
 
     //------------------------------------------------------------------- grouping tests

--- a/searchlib/src/tests/query/customtypevisitor_test.cpp
+++ b/searchlib/src/tests/query/customtypevisitor_test.cpp
@@ -37,7 +37,7 @@ struct MyRangeTerm : InitTerm<RangeTerm> {};
 struct MyStringTerm : InitTerm<StringTerm>  {};
 struct MySubstrTerm : InitTerm<SubstringTerm>  {};
 struct MySuffixTerm : InitTerm<SuffixTerm>  {};
-struct MyFuzzyTerm : FuzzyTerm { MyFuzzyTerm(): FuzzyTerm("term", "view", 0, Weight(0), 2, 0) {} };
+struct MyFuzzyTerm : FuzzyTerm { MyFuzzyTerm(): FuzzyTerm("term", "view", 0, Weight(0), 2, 0, false) {} };
 struct MyWeakAnd : WeakAnd { MyWeakAnd() : WeakAnd(1234, "view") {} };
 struct MyWeightedSetTerm : WeightedSetTerm { MyWeightedSetTerm() : WeightedSetTerm(0, "view", 0, Weight(42)) {} };
 struct MyDotProduct : DotProduct { MyDotProduct() : DotProduct(0, "view", 0, Weight(42)) {} };

--- a/searchlib/src/tests/query/query_visitor_test.cpp
+++ b/searchlib/src/tests/query/query_visitor_test.cpp
@@ -88,7 +88,7 @@ TEST("requireThatAllNodesCanBeVisited") {
     checkVisit<NearestNeighborTerm>(new SimpleNearestNeighborTerm("query_tensor", "doc_tensor", 0, Weight(0), 123, true, 321, 100100.25));
     checkVisit<TrueQueryNode>(new SimpleTrue());
     checkVisit<FalseQueryNode>(new SimpleFalse());
-    checkVisit<FuzzyTerm>(new SimpleFuzzyTerm("t", "field", 0, Weight(0), 2, 0));
+    checkVisit<FuzzyTerm>(new SimpleFuzzyTerm("t", "field", 0, Weight(0), 2, 0, false));
     checkVisit<InTerm>(new SimpleInTerm(std::make_unique<StringTermVector>(0), MultiTerm::Type::STRING, "field", 0, Weight(0)));
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.cpp
@@ -44,8 +44,12 @@ extract_suffix(std::string_view target, uint32_t prefix_size)
 
 }
 
-DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased, LevenshteinDfa::DfaType dfa_type)
-    : _dfa(vespalib::fuzzy::LevenshteinDfa::build(extract_suffix(target, prefix_size), max_edits, (cased ? LevenshteinDfa::Casing::Cased : LevenshteinDfa::Casing::Uncased), dfa_type)),
+DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size,
+                                 bool cased, bool prefix_match, LevenshteinDfa::DfaType dfa_type)
+    : _dfa(vespalib::fuzzy::LevenshteinDfa::build(extract_suffix(target, prefix_size), max_edits,
+                                                  (cased ? LevenshteinDfa::Casing::Cased : LevenshteinDfa::Casing::Uncased),
+                                                  dfa_type, // TODO reorder args
+                                                  (prefix_match ? LevenshteinDfa::Matching::Prefix : LevenshteinDfa::Matching::FullString))),
       _successor(),
       _prefix(extract_prefix(target, prefix_size, cased)),
       _prefix_size(prefix_size),
@@ -54,8 +58,8 @@ DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uin
     _successor = _prefix;
 }
 
-DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased)
-    : DfaFuzzyMatcher(target, max_edits, prefix_size, cased, LevenshteinDfa::DfaType::Table)
+DfaFuzzyMatcher::DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased, bool prefix_match)
+    : DfaFuzzyMatcher(target, max_edits, prefix_size, cased, prefix_match, LevenshteinDfa::DfaType::Table)
 {
 }
 

--- a/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
+++ b/searchlib/src/vespa/searchlib/attribute/dfa_fuzzy_matcher.h
@@ -26,8 +26,10 @@ private:
 
     const char* skip_prefix(const char* word) const;
 public:
-    DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased, vespalib::fuzzy::LevenshteinDfa::DfaType dfa_type);
-    DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased); // Defaults to table-based DFA
+    DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased, bool prefix_match,
+                    vespalib::fuzzy::LevenshteinDfa::DfaType dfa_type);
+    // Defaults to table-based DFA:
+    DfaFuzzyMatcher(std::string_view target, uint8_t max_edits, uint32_t prefix_size, bool cased, bool prefix_match);
     ~DfaFuzzyMatcher();
 
     [[nodiscard]] static constexpr bool supports_max_edits(uint8_t edits) noexcept {

--- a/searchlib/src/vespa/searchlib/attribute/string_search_helper.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/string_search_helper.cpp
@@ -49,17 +49,19 @@ StringSearchHelper::StringSearchHelper(QueryTermUCS4 & term, bool cased, vespali
                 ? vespalib::Regex::from_pattern(term.getTerm(), vespalib::Regex::Options::None)
                 : vespalib::Regex::from_pattern(term.getTerm(), vespalib::Regex::Options::IgnoreCase);
     } else if (isFuzzy()) {
-        auto max_edit_dist = term.getFuzzyMaxEditDistance();
+        const auto max_edit_dist = term.fuzzy_max_edit_distance();
         _fuzzyMatcher = std::make_unique<vespalib::FuzzyMatcher>(term.getTerm(),
                                                                  max_edit_dist,
-                                                                 term.getFuzzyPrefixLength(),
-                                                                 isCased());
+                                                                 term.fuzzy_prefix_lock_length(),
+                                                                 isCased(),
+                                                                 term.fuzzy_prefix_match());
         if ((fuzzy_matching_algorithm != FMA::BruteForce) &&
             (max_edit_dist > 0 && max_edit_dist <= 2)) {
             _dfa_fuzzy_matcher = std::make_unique<DfaFuzzyMatcher>(term.getTerm(),
                                                                    max_edit_dist,
-                                                                   term.getFuzzyPrefixLength(),
+                                                                   term.fuzzy_prefix_lock_length(),
                                                                    isCased(),
+                                                                   term.fuzzy_prefix_match(),
                                                                    to_dfa_type(fuzzy_matching_algorithm));
         }
     } else if (isCased()) {

--- a/searchlib/src/vespa/searchlib/parsequery/parse.h
+++ b/searchlib/src/vespa/searchlib/parsequery/parse.h
@@ -87,6 +87,8 @@ public:
         IFLAG_NORANK         = 0x00000001, // this term should not be ranked (not exposed to rank framework)
         IFLAG_SPECIALTOKEN   = 0x00000002,
         IFLAG_NOPOSITIONDATA = 0x00000004, // we should not use position data when ranking this term
+        IFLAG_FILTER         = 0x00000008, // see GetCreator(flags) below
+        IFLAG_PREFIX_MATCH   = 0x00000010
     };
 
     /** Extra information on each item (creator id) coded in bit 3 of flags */

--- a/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
+++ b/searchlib/src/vespa/searchlib/parsequery/stackdumpiterator.h
@@ -113,9 +113,18 @@ public:
     uint32_t getUniqueId() const noexcept { return _currUniqueId; }
 
     // Get the flags of the current item.
-    bool hasNoRankFlag() const noexcept { return (_currFlags & ParseItem::IFLAG_NORANK) != 0; }
-    bool hasSpecialTokenFlag() const noexcept { return (_currFlags & ParseItem::IFLAG_SPECIALTOKEN) != 0; }
-    bool hasNoPositionDataFlag() const noexcept { return (_currFlags & ParseItem::IFLAG_NOPOSITIONDATA) != 0; }
+    [[nodiscard]] bool hasNoRankFlag() const noexcept {
+        return (_currFlags & ParseItem::IFLAG_NORANK) != 0;
+    }
+    [[nodiscard]] bool hasSpecialTokenFlag() const noexcept {
+        return (_currFlags & ParseItem::IFLAG_SPECIALTOKEN) != 0;
+    }
+    [[nodiscard]] bool hasNoPositionDataFlag() const noexcept {
+        return (_currFlags & ParseItem::IFLAG_NOPOSITIONDATA) != 0;
+    }
+    [[nodiscard]] bool has_prefix_match_semantics() const noexcept {
+        return (_currFlags & ParseItem::IFLAG_PREFIX_MATCH) != 0;
+    }
 
     uint32_t getArity() const noexcept { return _currArity; }
 
@@ -127,9 +136,9 @@ public:
     bool getAllowApproximate() const noexcept { return (_extraIntArg2 != 0); }
     uint32_t getExploreAdditionalHits() const noexcept { return _extraIntArg3; }
 
-    // fuzzy match arguments
-    uint32_t getFuzzyMaxEditDistance() const noexcept { return _extraIntArg1; }
-    uint32_t getFuzzyPrefixLength() const noexcept { return _extraIntArg2; }
+    // fuzzy match arguments (see also: has_prefix_match_semantics() for fuzzy prefix matching)
+    [[nodiscard]] uint32_t fuzzy_max_edit_distance() const noexcept { return _extraIntArg1; }
+    [[nodiscard]] uint32_t fuzzy_prefix_lock_length() const noexcept { return _extraIntArg2; }
 
     std::unique_ptr<query::PredicateQueryTerm> getPredicateQueryTerm();
     std::unique_ptr<query::TermVector> get_terms();

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.cpp
@@ -248,10 +248,11 @@ QueryTermSimple::QueryTermSimple(const string & term_, Type type)
       _type(type),
       _diversityCutoffStrict(false),
       _valid(true),
+      _fuzzy_prefix_match(false),
       _term(term_),
       _diversityAttribute(),
-      _fuzzyMaxEditDistance(2),
-      _fuzzyPrefixLength(0)
+      _fuzzy_max_edit_distance(2),
+      _fuzzy_prefix_lock_length(0)
 {
     if (isFullRange(_term)) {
         stringref rest(_term.c_str() + 1, _term.size() - 2);

--- a/searchlib/src/vespa/searchlib/query/query_term_simple.h
+++ b/searchlib/src/vespa/searchlib/query/query_term_simple.h
@@ -44,8 +44,9 @@ public:
     size_t           getDiversityCutoffGroups() const noexcept { return _diversityCutoffGroups; }
     bool             getDiversityCutoffStrict() const noexcept { return _diversityCutoffStrict; }
     vespalib::stringref getDiversityAttribute() const noexcept { return _diversityAttribute; }
-    size_t            getFuzzyMaxEditDistance() const noexcept { return _fuzzyMaxEditDistance; }
-    size_t               getFuzzyPrefixLength() const noexcept { return _fuzzyPrefixLength; }
+    [[nodiscard]] size_t fuzzy_max_edit_distance() const noexcept { return _fuzzy_max_edit_distance; }
+    [[nodiscard]] size_t fuzzy_prefix_lock_length() const noexcept { return _fuzzy_prefix_lock_length; }
+    [[nodiscard]] bool   fuzzy_prefix_match() const noexcept { return _fuzzy_prefix_match; }
     bool getAsIntegerTerm(int64_t & lower, int64_t & upper) const noexcept;
     bool getAsFloatTerm(double & lower, double & upper) const noexcept;
     bool getAsFloatTerm(float & lower, float & upper) const noexcept;
@@ -77,14 +78,17 @@ private:
     Type        _type;
     bool        _diversityCutoffStrict;
     bool        _valid;
+protected:
+    bool        _fuzzy_prefix_match; // set in QueryTerm
+private:
     string      _term;
     stringref   _diversityAttribute;
     template <typename T, typename D>
     bool    getAsNumericTerm(T & lower, T & upper, D d) const noexcept;
 
 protected:
-    uint32_t    _fuzzyMaxEditDistance;  // set in QueryTerm
-    uint32_t    _fuzzyPrefixLength;
+    uint32_t    _fuzzy_max_edit_distance;  // set in QueryTerm
+    uint32_t    _fuzzy_prefix_lock_length;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.cpp
@@ -13,20 +13,21 @@ constexpr bool normalizing_implies_cased(Normalizing norm) noexcept {
 
 FuzzyTerm::FuzzyTerm(std::unique_ptr<QueryNodeResultBase> result_base, stringref term,
                      const string& index, Type type, Normalizing normalizing,
-                     uint8_t max_edits, uint32_t prefix_size)
+                     uint8_t max_edits, uint32_t prefix_lock_length, bool prefix_match)
     : QueryTerm(std::move(result_base), term, index, type, normalizing),
       _dfa_matcher(),
       _fallback_matcher()
 {
-    setFuzzyMaxEditDistance(max_edits);
-    setFuzzyPrefixLength(prefix_size);
+    set_fuzzy_max_edit_distance(max_edits);
+    set_fuzzy_prefix_lock_length(prefix_lock_length);
+    set_fuzzy_prefix_match(prefix_match);
 
     std::string_view term_view(term.data(), term.size());
     const bool cased = normalizing_implies_cased(normalizing);
     if (attribute::DfaFuzzyMatcher::supports_max_edits(max_edits)) {
-        _dfa_matcher = std::make_unique<attribute::DfaFuzzyMatcher>(term_view, max_edits, prefix_size, cased);
+        _dfa_matcher = std::make_unique<attribute::DfaFuzzyMatcher>(term_view, max_edits, prefix_lock_length, cased, prefix_match);
     } else {
-        _fallback_matcher = std::make_unique<vespalib::FuzzyMatcher>(term_view, max_edits, prefix_size, cased);
+        _fallback_matcher = std::make_unique<vespalib::FuzzyMatcher>(term_view, max_edits, prefix_lock_length, cased, prefix_match);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/fuzzy_term.h
@@ -23,7 +23,7 @@ class FuzzyTerm : public QueryTerm {
 public:
     FuzzyTerm(std::unique_ptr<QueryNodeResultBase> result_base, stringref term,
               const string& index, Type type, Normalizing normalizing,
-              uint8_t max_edits, uint32_t prefix_size);
+              uint8_t max_edits, uint32_t prefix_lock_length, bool prefix_match);
     ~FuzzyTerm() override;
 
     [[nodiscard]] FuzzyTerm* as_fuzzy_term() noexcept override { return this; }

--- a/searchlib/src/vespa/searchlib/query/streaming/querynode.cpp
+++ b/searchlib/src/vespa/searchlib/query/streaming/querynode.cpp
@@ -130,7 +130,8 @@ QueryNode::Build(const QueryNode * parent, const QueryNodeResultFactory & factor
                 qt = std::make_unique<RegexpTerm>(factory.create(), ssTerm, ssIndex, TermType::REGEXP, normalize_mode);
             } else if (sTerm == TermType::FUZZYTERM) {
                 qt = std::make_unique<FuzzyTerm>(factory.create(), ssTerm, ssIndex, TermType::FUZZYTERM, normalize_mode,
-                                                 queryRep.getFuzzyMaxEditDistance(), queryRep.getFuzzyPrefixLength());
+                                                 queryRep.fuzzy_max_edit_distance(), queryRep.fuzzy_prefix_lock_length(),
+                                                 queryRep.has_prefix_match_semantics());
             } else [[likely]] {
                 qt = std::make_unique<QueryTerm>(factory.create(), ssTerm, ssIndex, sTerm, normalize_mode);
             }

--- a/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
+++ b/searchlib/src/vespa/searchlib/query/streaming/queryterm.h
@@ -100,8 +100,9 @@ public:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void setIndex(const string & index_) override { _index = index_; }
     const string & getIndex() const override { return _index; }
-    void setFuzzyMaxEditDistance(uint32_t fuzzyMaxEditDistance) { _fuzzyMaxEditDistance = fuzzyMaxEditDistance; }
-    void setFuzzyPrefixLength(uint32_t fuzzyPrefixLength) { _fuzzyPrefixLength = fuzzyPrefixLength; }
+    void set_fuzzy_max_edit_distance(uint32_t fuzzy_max_edit_distance) noexcept { _fuzzy_max_edit_distance = fuzzy_max_edit_distance; }
+    void set_fuzzy_prefix_lock_length(uint32_t fuzzy_prefix_length) noexcept { _fuzzy_prefix_lock_length = fuzzy_prefix_length; }
+    void set_fuzzy_prefix_match(bool prefix_match) noexcept { _fuzzy_prefix_match = prefix_match; }
     virtual NearestNeighborQueryNode* as_nearest_neighbor_query_node() noexcept;
     virtual MultiTerm* as_multi_term() noexcept;
     virtual const MultiTerm* as_multi_term() const noexcept;

--- a/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
+++ b/searchlib/src/vespa/searchlib/query/tree/querybuilder.h
@@ -226,8 +226,8 @@ create_nearest_neighbor_term(vespalib::stringref query_tensor_name, vespalib::st
 template <class NodeTypes>
 typename NodeTypes::FuzzyTerm *
 createFuzzyTerm(vespalib::stringref term, vespalib::stringref view, int32_t id, Weight weight,
-                uint32_t maxEditDistance, uint32_t prefixLength) {
-    return new typename NodeTypes::FuzzyTerm(term, view, id, weight, maxEditDistance, prefixLength);
+                uint32_t max_edit_distance, uint32_t prefix_lock_length, bool prefix_match) {
+    return new typename NodeTypes::FuzzyTerm(term, view, id, weight, max_edit_distance, prefix_lock_length, prefix_match);
 }
 
 template <class NodeTypes>
@@ -343,9 +343,10 @@ public:
         return addTerm(createRegExpTerm<NodeTypes>(term, view, id, weight));
     }
     typename NodeTypes::FuzzyTerm &addFuzzyTerm(stringref term, stringref view, int32_t id, Weight weight,
-                                                uint32_t maxEditDistance, uint32_t prefixLength) {
+                                                uint32_t max_edit_distance, uint32_t prefix_lock_length,
+                                                bool prefix_match) {
         adjustWeight(weight);
-        return addTerm(createFuzzyTerm<NodeTypes>(term, view, id, weight, maxEditDistance, prefixLength));
+        return addTerm(createFuzzyTerm<NodeTypes>(term, view, id, weight, max_edit_distance, prefix_lock_length, prefix_match));
     }
     typename NodeTypes::NearestNeighborTerm &add_nearest_neighbor_term(stringref query_tensor_name, stringref field_name,
                                                                        int32_t id, Weight weight, uint32_t target_num_hits,

--- a/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/queryreplicator.h
@@ -201,7 +201,8 @@ private:
         replicate(node, _builder.addFuzzyTerm(
                 node.getTerm(), node.getView(),
                 node.getId(), node.getWeight(),
-                node.getMaxEditDistance(), node.getPrefixLength()));
+                node.max_edit_distance(), node.prefix_lock_length(),
+                node.prefix_match()));
     }
 
     std::unique_ptr<TermVector> replicate_subterms(const InTerm& original) {

--- a/searchlib/src/vespa/searchlib/query/tree/simplequery.h
+++ b/searchlib/src/vespa/searchlib/query/tree/simplequery.h
@@ -163,8 +163,10 @@ struct SimpleNearestNeighborTerm : NearestNeighborTerm {
 struct SimpleFuzzyTerm : FuzzyTerm {
     SimpleFuzzyTerm(const Type &term, vespalib::stringref view,
                      int32_t id, Weight weight,
-                     uint32_t maxEditDistance, uint32_t prefixLength)
-            : FuzzyTerm(term, view, id, weight, maxEditDistance, prefixLength) {
+                     uint32_t max_edit_distance, uint32_t prefix_lock_length,
+                     bool prefix_match)
+        : FuzzyTerm(term, view, id, weight, max_edit_distance, prefix_lock_length, prefix_match)
+    {
     }
     ~SimpleFuzzyTerm() override;
 };

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpcreator.cpp
@@ -225,6 +225,9 @@ class QueryNodeConverter : public QueryVisitor {
         if (!node.usePositionData()) {
             flags |= ParseItem::IFLAG_NOPOSITIONDATA;
         }
+        if (node.prefix_match()) {
+            flags |= ParseItem::IFLAG_PREFIX_MATCH;
+        }
         if (flags != 0) {
             features |= ParseItem::IF_FLAGS;
         }
@@ -289,8 +292,8 @@ class QueryNodeConverter : public QueryVisitor {
 
     void visit(FuzzyTerm &node) override {
         createTerm(node, ParseItem::ITEM_FUZZY);
-        appendCompressedPositiveNumber(node.getMaxEditDistance());
-        appendCompressedPositiveNumber(node.getPrefixLength());
+        appendCompressedPositiveNumber(node.max_edit_distance());
+        appendCompressedPositiveNumber(node.prefix_lock_length());
     }
 
     void visit(NearestNeighborTerm &node) override {

--- a/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
+++ b/searchlib/src/vespa/searchlib/query/tree/stackdumpquerycreator.h
@@ -42,6 +42,9 @@ public:
                 if (queryStack.hasNoPositionDataFlag()) {
                     t->setPositionData(false);
                 }
+                if (queryStack.has_prefix_match_semantics()) [[unlikely]] {
+                    t->set_prefix_match(true);
+                }
             }
         }
         if (builder.hasError()) {
@@ -185,9 +188,10 @@ private:
             } else if (type == ParseItem::ITEM_REGEXP) {
                 t = &builder.addRegExpTerm(term, view, id, weight);
             } else if (type == ParseItem::ITEM_FUZZY) {
-                uint32_t maxEditDistance = queryStack.getFuzzyMaxEditDistance();
-                uint32_t prefixLength = queryStack.getFuzzyPrefixLength();
-                t = &builder.addFuzzyTerm(term, view, id, weight, maxEditDistance, prefixLength);
+                uint32_t max_edit_distance  = queryStack.fuzzy_max_edit_distance();
+                uint32_t prefix_lock_length = queryStack.fuzzy_prefix_lock_length();
+                bool     prefix_match       = queryStack.has_prefix_match_semantics();
+                t = &builder.addFuzzyTerm(term, view, id, weight, max_edit_distance, prefix_lock_length, prefix_match);
             } else if (type == ParseItem::ITEM_STRING_IN) {
                 t = &builder.add_in_term(queryStack.get_terms(), MultiTerm::Type::STRING, view, id, weight);
             } else if (type == ParseItem::ITEM_NUMERIC_IN) {

--- a/searchlib/src/vespa/searchlib/query/tree/term.cpp
+++ b/searchlib/src/vespa/searchlib/query/tree/term.cpp
@@ -12,12 +12,14 @@ Term::Term(vespalib::stringref view, int32_t id, Weight weight) :
     _id(id),
     _weight(weight),
     _ranked(true),
-    _position_data(true)
+    _position_data(true),
+    _prefix_match(false)
 { }
 
 void Term::setStateFrom(const Term& other) {
     setRanked(other.isRanked());
     setPositionData(other.usePositionData());
+    set_prefix_match(other.prefix_match());
     // too late to copy this state:
     assert(_view == other.getView());
     assert(_id == other.getId());

--- a/searchlib/src/vespa/searchlib/query/tree/term.h
+++ b/searchlib/src/vespa/searchlib/query/tree/term.h
@@ -18,6 +18,7 @@ class Term
     Weight           _weight;
     bool             _ranked;
     bool             _position_data;
+    bool             _prefix_match;
 
 public:
     virtual ~Term() = 0;
@@ -25,14 +26,17 @@ public:
     void setView(const vespalib::string & view) { _view = view; }
     void setRanked(bool ranked) noexcept { _ranked = ranked; }
     void setPositionData(bool position_data) noexcept { _position_data = position_data; }
+    // Used for fuzzy prefix matching. Not to be confused with distinct Prefix query term type
+    void set_prefix_match(bool prefix_match) noexcept { _prefix_match = prefix_match; }
 
     void setStateFrom(const Term& other);
 
     const vespalib::string & getView() const noexcept { return _view; }
     Weight getWeight() const noexcept { return _weight; }
     int32_t getId() const noexcept { return _id; }
-    bool isRanked() const noexcept { return _ranked; }
-    bool usePositionData() const noexcept { return _position_data; }
+    [[nodiscard]] bool isRanked() const noexcept { return _ranked; }
+    [[nodiscard]] bool usePositionData() const noexcept { return _position_data; }
+    [[nodiscard]] bool prefix_match() const noexcept { return _prefix_match; }
 
     static bool isPossibleRangeTerm(vespalib::stringref term) noexcept {
         return (term[0] == '[' || term[0] == '<' || term[0] == '>');

--- a/searchlib/src/vespa/searchlib/query/tree/termnodes.h
+++ b/searchlib/src/vespa/searchlib/query/tree/termnodes.h
@@ -119,19 +119,22 @@ public:
 //-----------------------------------------------------------------------------
 
 class FuzzyTerm : public QueryNodeMixin<FuzzyTerm, StringBase> {
-private:
-    uint32_t _maxEditDistance;
-    uint32_t _prefixLength;
+    uint32_t _max_edit_distance;
+    uint32_t _prefix_lock_length;
+    // Prefix match mode is stored in parent Term
 public:
     FuzzyTerm(const Type &term, vespalib::stringref view,
-               int32_t id, Weight weight, uint32_t maxEditDistance, uint32_t prefixLength)
-            : QueryNodeMixinType(term, view, id, weight),
-              _maxEditDistance(maxEditDistance),
-              _prefixLength(prefixLength)
-    {}
+              int32_t id, Weight weight, uint32_t max_edit_distance,
+              uint32_t prefix_lock_length, bool prefix_match)
+        : QueryNodeMixinType(term, view, id, weight),
+          _max_edit_distance(max_edit_distance),
+          _prefix_lock_length(prefix_lock_length)
+    {
+        set_prefix_match(prefix_match);
+    }
 
-    uint32_t getMaxEditDistance() const { return _maxEditDistance; }
-    uint32_t getPrefixLength() const { return _prefixLength; }
+    [[nodiscard]] uint32_t max_edit_distance() const { return _max_edit_distance; }
+    [[nodiscard]] uint32_t prefix_lock_length() const { return _prefix_lock_length; }
 
     virtual ~FuzzyTerm() = 0;
 };

--- a/vespalib/src/tests/fuzzy/fuzzy_matcher_test.cpp
+++ b/vespalib/src/tests/fuzzy/fuzzy_matcher_test.cpp
@@ -33,7 +33,7 @@ TEST(FuzzyMatcherTest, get_suffix_edge_cases) {
 }
 
 TEST(FuzzyMatcherTest, fuzzy_match_empty_prefix) {
-    FuzzyMatcher fuzzy("abc", 2, 0, false);
+    FuzzyMatcher fuzzy("abc", 2, 0, false, false);
     EXPECT_TRUE(fuzzy.isMatch("abc"));
     EXPECT_TRUE(fuzzy.isMatch("ABC"));
     EXPECT_TRUE(fuzzy.isMatch("ab1"));
@@ -42,15 +42,15 @@ TEST(FuzzyMatcherTest, fuzzy_match_empty_prefix) {
 }
 
 TEST(FuzzyMatcherTest, fuzzy_match_cased) {
-    FuzzyMatcher fuzzy("abc", 2, 0, true);
+    FuzzyMatcher fuzzy("abc", 2, 0, true, false);
     EXPECT_TRUE(fuzzy.isMatch("abc"));
     EXPECT_TRUE(fuzzy.isMatch("abC"));
     EXPECT_TRUE(fuzzy.isMatch("aBC"));
     EXPECT_FALSE(fuzzy.isMatch("ABC"));
 }
 
-TEST(FuzzyMatcherTest, fuzzy_match_with_prefix) {
-    FuzzyMatcher fuzzy("abcdef", 2, 2, false);
+TEST(FuzzyMatcherTest, fuzzy_match_with_prefix_locking) {
+    FuzzyMatcher fuzzy("abcdef", 2, 2, false, false);
     EXPECT_TRUE(fuzzy.isMatch("abcdef"));
     EXPECT_TRUE(fuzzy.isMatch("ABCDEF"));
     EXPECT_TRUE(fuzzy.isMatch("abcde1"));
@@ -59,22 +59,43 @@ TEST(FuzzyMatcherTest, fuzzy_match_with_prefix) {
     EXPECT_FALSE(fuzzy.isMatch("12cdef"));
 }
 
-TEST(FuzzyMatcherTest, get_prefix_is_empty) {
-    FuzzyMatcher fuzzy("whatever", 2, 0, false);
+TEST(FuzzyMatcherTest, get_prefix_lock_length_is_zero) {
+    FuzzyMatcher fuzzy("whatever", 2, 0, false, false);
     EXPECT_EQ(fuzzy.getPrefix(), "");
 }
 
 TEST(FuzzyMatcherTest, term_is_empty) {
-    FuzzyMatcher fuzzy("", 2, 0, false);
+    FuzzyMatcher fuzzy("", 2, 0, false, false);
     EXPECT_TRUE(fuzzy.isMatch(""));
     EXPECT_TRUE(fuzzy.isMatch("a"));
     EXPECT_TRUE(fuzzy.isMatch("aa"));
     EXPECT_FALSE(fuzzy.isMatch("aaa"));
 }
 
-TEST(FuzzyMatcherTest, get_prefix_non_empty) {
-    FuzzyMatcher fuzzy("abcd", 2, 2, false);
+TEST(FuzzyMatcherTest, get_prefix_lock_length_non_zero) {
+    FuzzyMatcher fuzzy("abcd", 2, 2, false, false);
     EXPECT_EQ(fuzzy.getPrefix(), "ab");
+}
+
+TEST(FuzzyMatcherTest, fuzzy_prefix_matching_without_prefix_lock_length) {
+    FuzzyMatcher fuzzy("abc", 1, 0, false, true);
+    EXPECT_EQ(fuzzy.getPrefix(), "");
+    EXPECT_TRUE(fuzzy.isMatch("abc"));
+    EXPECT_TRUE(fuzzy.isMatch("abcdefgh"));
+    EXPECT_TRUE(fuzzy.isMatch("ab"));
+    EXPECT_TRUE(fuzzy.isMatch("abd"));
+    EXPECT_TRUE(fuzzy.isMatch("xabc"));
+    EXPECT_FALSE(fuzzy.isMatch("xy"));
+}
+
+TEST(FuzzyMatcherTest, fuzzy_prefix_matching_with_prefix_lock_length) {
+    FuzzyMatcher fuzzy("zoid", 1, 2, false, true);
+    EXPECT_EQ(fuzzy.getPrefix(), "zo");
+    EXPECT_TRUE(fuzzy.isMatch("zoidberg"));
+    EXPECT_TRUE(fuzzy.isMatch("zold"));
+    EXPECT_TRUE(fuzzy.isMatch("zoldberg"));
+    EXPECT_FALSE(fuzzy.isMatch("zoxx"));
+    EXPECT_FALSE(fuzzy.isMatch("loid"));
 }
 
 GTEST_MAIN_RUN_ALL_TESTS()

--- a/vespalib/src/tests/fuzzy/levenshtein_distance_test.cpp
+++ b/vespalib/src/tests/fuzzy/levenshtein_distance_test.cpp
@@ -74,7 +74,11 @@ TEST(LevenshteinDistance, prefix_match_edge_cases) {
     EXPECT_EQ(prefix_calculate("xy",  "", 2), std::optional{2});
     EXPECT_EQ(prefix_calculate("xyz", "", 2), std::nullopt);
 
-    // Max edits > 2 cases; not supported by DFA implementation.
+    // Max edits not in {1, 2} cases; not supported by DFA implementation.
+    EXPECT_EQ(prefix_calculate("", "", 0),         std::optional{0});
+    EXPECT_EQ(prefix_calculate("abc", "abc", 0),   std::optional{0});
+    EXPECT_EQ(prefix_calculate("abc", "abcde", 0), std::optional{0});
+    EXPECT_EQ(prefix_calculate("abc", "dbc", 0),   std::nullopt);
     EXPECT_EQ(prefix_calculate("abc", "", 3),      std::optional{3});
     EXPECT_EQ(prefix_calculate("abc", "xy", 3),    std::optional{3});
     EXPECT_EQ(prefix_calculate("abc", "xyz", 3),   std::optional{3});

--- a/vespalib/src/vespa/vespalib/fuzzy/fuzzy_matcher.cpp
+++ b/vespalib/src/vespa/vespalib/fuzzy/fuzzy_matcher.cpp
@@ -29,10 +29,12 @@ vespalib::FuzzyMatcher::FuzzyMatcher():
         _folded_term_codepoints_suffix()
 {}
 
-vespalib::FuzzyMatcher::FuzzyMatcher(std::string_view term, uint32_t max_edit_distance, uint32_t prefix_size, bool is_cased):
+vespalib::FuzzyMatcher::FuzzyMatcher(std::string_view term, uint32_t max_edit_distance, uint32_t prefix_size,
+                                     bool is_cased, bool is_prefix):
         _max_edit_distance(max_edit_distance),
         _prefix_size(prefix_size),
         _is_cased(is_cased),
+        _is_prefix(is_prefix),
         _folded_term_codepoints(_is_cased ? cased_convert_to_ucs4(term) : LowerCase::convert_to_ucs4(term)),
         _folded_term_codepoints_prefix(get_prefix(_folded_term_codepoints, _prefix_size)),
         _folded_term_codepoints_suffix(get_suffix(_folded_term_codepoints, _prefix_size))
@@ -73,7 +75,7 @@ bool vespalib::FuzzyMatcher::isMatch(std::string_view target) const {
     return LevenshteinDistance::calculate(
             _folded_term_codepoints_suffix,
             get_suffix(targetCodepoints, _prefix_size),
-            _max_edit_distance).has_value();
+            _max_edit_distance, _is_prefix).has_value();
 }
 
 vespalib::string vespalib::FuzzyMatcher::getPrefix() const {

--- a/vespalib/src/vespa/vespalib/fuzzy/fuzzy_matcher.h
+++ b/vespalib/src/vespa/vespalib/fuzzy/fuzzy_matcher.h
@@ -24,6 +24,7 @@ private:
     uint32_t _max_edit_distance; // max edit distance
     uint32_t _prefix_size;       // prefix of a term that is considered frozen, i.e. non-fuzzy
     bool     _is_cased;
+    bool     _is_prefix;
 
     std::vector<uint32_t> _folded_term_codepoints;
 
@@ -34,7 +35,7 @@ public:
     FuzzyMatcher();
     FuzzyMatcher(const FuzzyMatcher &) = delete;
     FuzzyMatcher & operator = (const FuzzyMatcher &) = delete;
-    FuzzyMatcher(std::string_view term, uint32_t max_edit_distance, uint32_t prefix_size, bool is_cased);
+    FuzzyMatcher(std::string_view term, uint32_t max_edit_distance, uint32_t prefix_size, bool is_cased, bool is_prefix);
     ~FuzzyMatcher();
 
     [[nodiscard]] bool isMatch(std::string_view target) const;


### PR DESCRIPTION
@geirst please review.
@toregge FYI

Adds `prefix:[true|false]` annotation support to the `fuzzy` query operator in the YQL and JSON query languages. Fuzzy prefix matching semantics are wired through to the matcher implementations for both indexed and streaming search.

Example usage:
```
  {maxEditDistance:1,prefix:true}fuzzy("foo")
```
Will match `foo`, `foobar`, `foxtrot`, `zookeeper` and so on.

It can be combined with the existing prefix locking feature:
```
  {maxEditDistance:1,prefixLength:2,prefix:true}fuzzy("foo")
```
Which will match `foo`, `foobar`, `foxtrot` etc, but _not_ `zookeeper` since the locked prefix (`fo`) does not match.

Due to the complexities involved with extending the legacy binary query stack representation, signalling prefix matching for the fuzzy term is done by pragmatically adding a new, generic "prefix matching" term-level flag. This is currently ignored for everything except fuzzy query items.

Modernizing the query stack format to make it more extensible (i.e. move encoding to Protobuf) is on the backlog...!

This relates to #30720.
