### PR TITLE
Avoid starting quest db for /nodes/v2 unit tests

### DIFF
--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MemoryMetricsDb.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/autoscale/MemoryMetricsDb.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.hosted.provision.autoscale;
 
 import com.yahoo.collections.Pair;
+import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.provision.ApplicationId;
 import com.yahoo.config.provision.ClusterSpec;
 
@@ -32,6 +33,11 @@ public class MemoryMetricsDb implements MetricsDb {
 
     /** Lock all access for now since we modify lists inside a map */
     private final Object lock = new Object();
+
+    @Inject
+    public MemoryMetricsDb() {
+        this(Clock.systemUTC());
+    }
 
     public MemoryMetricsDb(Clock clock) {
         this.clock = clock;

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/ContainerConfig.java
@@ -27,6 +27,7 @@ public class ContainerConfig {
                  <accesslog type='disabled'/>
                  <component id='com.yahoo.test.ManualClock'/>
                  <component id='com.yahoo.vespa.curator.mock.MockCurator'/>
+                 <component id='com.yahoo.vespa.hosted.provision.autoscale.MemoryMetricsDb'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.OrchestratorMock'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockDeployer'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockInfraDeployer'/>
@@ -34,7 +35,6 @@ public class ContainerConfig {
                  <component id='com.yahoo.vespa.hosted.provision.testutils.ServiceMonitorStub'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockDuperModel'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockNodeFlavors'/>
-                 <component id='com.yahoo.vespa.hosted.provision.autoscale.QuestMetricsDb'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockMetricsFetcher'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockNodeRepository'/>
                  <component id='com.yahoo.vespa.hosted.provision.testutils.MockProvisionServiceProvider'/>


### PR DESCRIPTION
Saves a few seconds for node-repository and host-admin unit tests