### PR TITLE
Revert "Specifically set number of threads to use in llama unit test"

### DIFF
--- a/model-integration/src/test/java/ai/vespa/llm/clients/LocalLLMTest.java
+++ b/model-integration/src/test/java/ai/vespa/llm/clients/LocalLLMTest.java
@@ -6,6 +6,7 @@ import ai.vespa.llm.completion.Completion;
 import ai.vespa.llm.completion.Prompt;
 import ai.vespa.llm.completion.StringPrompt;
 import com.yahoo.config.ModelReference;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -32,10 +33,10 @@ public class LocalLLMTest {
     private static Prompt prompt = StringPrompt.from("A random prompt");
 
     @Test
+    @Disabled
     public void testGeneration() {
         var config = new LlmLocalClientConfig.Builder()
                 .parallelRequests(1)
-                .threads(1)
                 .model(ModelReference.valueOf(model));
         var llm = new LocalLLM(config.build());
 
@@ -49,12 +50,12 @@ public class LocalLLMTest {
     }
 
     @Test
+    @Disabled
     public void testAsyncGeneration() {
         var sb = new StringBuilder();
         var tokenCount = new AtomicInteger(0);
         var config = new LlmLocalClientConfig.Builder()
                 .parallelRequests(1)
-                .threads(1)
                 .model(ModelReference.valueOf(model));
         var llm = new LocalLLM(config.build());
 
@@ -77,6 +78,7 @@ public class LocalLLMTest {
     }
 
     @Test
+    @Disabled
     public void testParallelGeneration() {
         var prompts = testPrompts();
         var promptsToUse = prompts.size();
@@ -88,7 +90,6 @@ public class LocalLLMTest {
 
         var config = new LlmLocalClientConfig.Builder()
                 .parallelRequests(parallelRequests)
-                .threads(1)
                 .model(ModelReference.valueOf(model));
         var llm = new LocalLLM(config.build());
 
@@ -116,6 +117,7 @@ public class LocalLLMTest {
     }
 
     @Test
+    @Disabled
     public void testRejection() {
         var prompts = testPrompts();
         var promptsToUse = prompts.size();
@@ -128,7 +130,6 @@ public class LocalLLMTest {
 
         var config = new LlmLocalClientConfig.Builder()
                 .parallelRequests(parallelRequests)
-                .threads(1)
                 .maxQueueSize(additionalQueue)
                 .model(ModelReference.valueOf(model));
         var llm = new LocalLLM(config.build());


### PR DESCRIPTION
Reverts vespa-engine/vespa#30989

Test failed for one of the builds:

21:11:58 [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
21:11:58 [ERROR] Command was /bin/sh -c cd '/wd/vespa/model-integration' && '/usr/lib/jvm/java-17-openjdk-17.0.10.0.7-2.el8.aarch64/bin/java' '-Djava.io.tmpdir=/wd/vespa/model-integration/target' '-jar' '/wd/vespa/model-integration/target/surefire/surefirebooter-20240422191013331_678.jar' '/wd/vespa/model-integration/target/surefire' '2024-04-22T19-08-50_137-jvmRun4' 'surefire-20240422191013331_676tmp' 'surefire_29-20240422191013331_677tmp'
21:11:58 [ERROR] Error occurred in starting fork, check output in log
21:11:58 [ERROR] Process Exit Code: 134
21:11:58 [ERROR] Crashed tests:
21:11:58 [ERROR] ai.vespa.llm.clients.LocalLLMTest
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.fork(ForkStarter.java:643)
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:285)
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.booterclient.ForkStarter.run(ForkStarter.java:250)
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeProvider(AbstractSurefireMojo.java:1241)
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.executeAfterPreconditionsChecked(AbstractSurefireMojo.java:1090)
21:11:58 [ERROR] 	at org.apache.maven.plugin.surefire.AbstractSurefireMojo.execute(AbstractSurefireMojo.java:910)
21:11:58 [ERROR] 	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2(MojoExecutor.java:370)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute(MojoExecutor.java:351)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:215)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:171)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:163)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:210)
21:11:58 [ERROR] 	at org.apache.maven.lifecycle.internal.builder.multithreaded.MultiThreadedBuilder$1.call(MultiThreadedBuilder.java:195)
21:11:58 [ERROR] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
21:11:58 [ERROR] 	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
21:11:58 [ERROR] 	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
21:11:58 [ERROR] 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
21:11:58 [ERROR] 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
21:11:58 [ERROR] 	at java.base/java.lang.Thread.run(Thread.java:840)
21:11:58 [ERROR] -> [Help 1]