### PR TITLE
Disable thread sanitizer instrumentation for anonymous get function

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <vespa/config.h>
 #include <vespa/vespalib/util/optimized.h>
 #include <cstring>
 
@@ -23,6 +24,11 @@ populationCount(const uint64_t *a, size_t sz) {
     }
     return count;
 }
+
+#ifdef VESPA_USE_THREAD_SANITIZER
+template<typename T, unsigned ChunkSize>
+T get(const void * base, bool invert)__attribute__((no_sanitize("thread")));
+#endif
 
 template<typename T, unsigned ChunkSize>
 T get(const void * base, bool invert) {

--- a/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
@@ -26,6 +26,9 @@ populationCount(const uint64_t *a, size_t sz) {
 }
 
 #ifdef VESPA_USE_THREAD_SANITIZER
+/*
+ * Source bitvectors might be modified due to feeding during search.
+ */
 template<typename T, unsigned ChunkSize>
 T get(const void * base, bool invert)__attribute__((no_sanitize("thread")));
 #endif


### PR DESCRIPTION
used by accelerated bitwise and/or. Source bitvectors might be modified due to feeding during search.

@vekterli : please review
