### PR TITLE
Only require minimum version for jllama. The interface is C style and…

### DIFF
--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -205,7 +205,7 @@ Requires: vespa-protobuf = %{_vespa_protobuf_version}
 Requires: llvm-libs
 %endif
 Requires: vespa-onnxruntime = 1.17.3
-Requires: vespa-jllama = 3.0.1-4%{?dist}
+Requires: vespa-jllama >= 3.0.1
 
 %description libs
 


### PR DESCRIPTION
… version is not in so name.

@toregge PR