### PR TITLE
Avoid compiling gbdt models with many conditions

### DIFF
--- a/eval/src/vespa/eval/eval/gbdt.cpp
+++ b/eval/src/vespa/eval/eval/gbdt.cpp
@@ -154,6 +154,9 @@ Optimize::select_best(const ForestStats &stats,
     if ((stats.tree_sizes.back().size > 12) && (path_len > 2500.0)) {
         return apply_chain(VMForest::optimize_chain, stats, trees);
     }
+    if (stats.total_size > 25000) {
+        return apply_chain(VMForest::optimize_chain, stats, trees);
+    }
     return Optimize::Result();
 }
 


### PR DESCRIPTION
The average path length grows slower with larger trees (you need to traverse a smaller part of the total model). This makes it harder(slower) for llvm to compile and run the code compared to the VMForest option.

@baldersheim please review
@andreer FYI
