### PR TITLE
test and adjust some stuff

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
+++ b/searchlib/src/vespa/searchlib/queryeval/flow_tuning.h
@@ -90,7 +90,7 @@ inline double lookup_strict_cost(size_t num_indirections) {
  * as the latency (time) penalty is higher if choosing wrong.
  */
 inline double non_strict_cost_of_strict_iterator(double estimate, double strict_cost) {
-    return strict_cost + strict_cost_diff(estimate, 1.0);
+    return 2.0 * (strict_cost + strict_cost_diff(estimate, 0.5));
 }
 
 // Strict cost of matching in a btree posting list (e.g. fast-search attribute or memory index field).

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.cpp
@@ -758,7 +758,18 @@ SourceBlenderBlueprint::calculate_flow_stats(uint32_t) const {
         my_cost = std::max(my_cost, child->cost());
         my_strict_cost = std::max(my_strict_cost, child->strict_cost());
     }
-    return {OrFlow::estimate_of(get_children()), my_cost, my_strict_cost};
+    double my_est = OrFlow::estimate_of(get_children());
+    return {my_est, my_cost + 1.0, my_strict_cost + my_est};
+}
+
+double
+SourceBlenderBlueprint::estimate_self_cost(InFlow in_flow) const noexcept
+{
+    if (in_flow.strict()) {
+        return estimate();
+    } else {
+        return in_flow.rate();
+    }
 }
 
 Blueprint::HitEstimate

--- a/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
+++ b/searchlib/src/vespa/searchlib/queryeval/intermediate_blueprints.h
@@ -201,6 +201,7 @@ public:
     explicit SourceBlenderBlueprint(const ISourceSelector &selector) noexcept;
     ~SourceBlenderBlueprint() override;
     FlowStats calculate_flow_stats(uint32_t docid_limit) const final;
+    double estimate_self_cost(InFlow in_flow) const noexcept override;
     HitEstimate combine(const std::vector<HitEstimate> &data) const override;
     FieldSpecBaseList exposeFields() const override;
     void sort(Children &children, InFlow in_flow) const override;

--- a/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/leaf_blueprints.cpp
@@ -11,9 +11,9 @@ namespace search::queryeval {
 //-----------------------------------------------------------------------------
 
 FlowStats
-EmptyBlueprint::calculate_flow_stats(uint32_t docid_limit) const
+EmptyBlueprint::calculate_flow_stats(uint32_t) const
 {
-    return default_flow_stats(docid_limit, 0, 0);
+    return {0.0, 0.2, 0.0};
 }
 
 SearchIterator::UP


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

- reduce empty blueprint cost since it starts at end
- adjust source blender cost to account for vector lookup
- tweak nonstrict strict cost to place crossover point at 0.5 in_flow

we talked about increasing the strict cost of the whitelist to avoid it being put first, but I think that might break the IN performance test since IN is not doing reverse-lookup in strict mode.