### PR TITLE
Require a higher bar to take groups in rotation

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/InvokerFactory.java
@@ -79,7 +79,7 @@ public abstract class InvokerFactory {
                     success.add(node);
                 }
             }
-            if ( ! cluster.isPartialGroupCoverageSufficient(success) && !acceptIncompleteCoverage) {
+            if ( ! cluster.isPartialGroupCoverageSufficient(group.hasSufficientCoverage(), success) && !acceptIncompleteCoverage) {
                 return Optional.empty();
             }
             if (invokers.isEmpty()) {

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/Group.java
@@ -23,7 +23,7 @@ public class Group {
 
     // Using volatile to ensure visibility for reader.
     // All updates are done in a single writer thread
-    private volatile boolean hasSufficientCoverage = true;
+    private volatile boolean hasSufficientCoverage = false;
     private volatile boolean hasFullCoverage = true;
     private volatile long activeDocuments = 0;
     private volatile long targetActiveDocuments = 0;

--- a/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
+++ b/container-search/src/main/java/com/yahoo/search/dispatch/searchcluster/SearchGroups.java
@@ -13,21 +13,30 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * Simple interface for groups and their nodes in the content cluster
+ * Simple interface for groups and their nodes in the content cluster.
+ *
  * @author baldersheim
  */
 public interface SearchGroups {
+
     Group get(int id);
+
     Set<Integer> keys();
+
     Collection<Group> groups();
+
     default boolean isEmpty() {
         return size() == 0;
     }
+
     default Set<Node> nodes() {
         return groups().stream().flatMap(group -> group.nodes().stream())
                        .sorted(comparingInt(Node::key))
                        .collect(toCollection(LinkedHashSet::new));
     }
+
     int size();
-    boolean isPartialGroupCoverageSufficient(Collection<Node> nodes);
+
+    boolean isPartialGroupCoverageSufficient(boolean currentCoverageSufficient, Collection<Node> nodes);
+
 }

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterCoverageTest.java
@@ -48,6 +48,19 @@ public class SearchClusterCoverageTest {
     }
 
     @Test
+    void three_groups_of_which_two_were_just_added() {
+        var tester =  new SearchClusterTester(3, 3);
+
+        tester.setDocsPerNode(100, 0);
+        tester.setDocsPerNode(80, 1);
+        tester.setDocsPerNode(80, 2);
+        tester.pingIterationCompleted();
+        assertTrue(tester.group(0).hasSufficientCoverage());
+        assertFalse(tester.group(1).hasSufficientCoverage());
+        assertFalse(tester.group(2).hasSufficientCoverage());
+    }
+
+    @Test
     void three_groups_one_missing_docs_but_too_few() {
         var tester =  new SearchClusterTester(3, 3);
 
@@ -64,6 +77,10 @@ public class SearchClusterCoverageTest {
     void three_groups_one_has_too_many_docs() {
         var tester =  new SearchClusterTester(3, 3);
 
+        tester.setDocsPerNode(100, 0);
+        tester.setDocsPerNode(100, 1);
+        tester.setDocsPerNode(100, 2);
+        tester.pingIterationCompleted();
         tester.setDocsPerNode(100, 0);
         tester.setDocsPerNode(150, 1);
         tester.setDocsPerNode(100, 2);

--- a/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
+++ b/container-search/src/test/java/com/yahoo/search/dispatch/searchcluster/SearchClusterTest.java
@@ -200,8 +200,6 @@ public class SearchClusterTest {
     @Test
     void requireThatVipStatusIsDefaultDownWithLocalDispatch() {
         try (State test = new State("cluster.1", 1, HostName.getLocalhost(), "b")) {
-            assertTrue(test.searchCluster.localCorpusDispatchTarget().isPresent());
-
             assertFalse(test.vipStatus.isInRotation());
             test.waitOneFullPingRound();
             assertTrue(test.vipStatus.isInRotation());
@@ -211,8 +209,6 @@ public class SearchClusterTest {
     @Test
     void requireThatVipStatusStaysUpWithLocalDispatchAndClusterSize1() {
         try (State test = new State("cluster.1", 1, HostName.getLocalhost())) {
-            assertTrue(test.searchCluster.localCorpusDispatchTarget().isPresent());
-
             assertFalse(test.vipStatus.isInRotation());
             test.waitOneFullPingRound();
             assertTrue(test.vipStatus.isInRotation());
@@ -225,8 +221,6 @@ public class SearchClusterTest {
     @Test
     void requireThatVipStatusIsDefaultDownWithLocalDispatchAndClusterSize2() {
         try (State test = new State("cluster.1", 1, HostName.getLocalhost(), "otherhost")) {
-            assertTrue(test.searchCluster.localCorpusDispatchTarget().isPresent());
-
             assertFalse(test.vipStatus.isInRotation());
             test.waitOneFullPingRound();
             assertTrue(test.vipStatus.isInRotation());


### PR DESCRIPTION
If a majority of groups have been recently added, avoid taking any that are indexing a slightly faster than the rest in rotation before it has 97% of the content.

Notice that to achieve this we have to keep groups out of rotation until we get positive info from the groups. I'm not quite sure if that may have any negative consequences.

