### PR TITLE
Emit single metric for how out of sync the cluster data is

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/AggregatedClusterStats.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/AggregatedClusterStats.java
@@ -10,4 +10,6 @@ public interface AggregatedClusterStats {
 
     ContentClusterStats getStats();
 
+    ContentNodeStats getGlobalStats();
+
 }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculator.java
@@ -1,0 +1,39 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import java.util.Optional;
+
+/**
+ * @author vekterli
+ */
+public class GlobalBucketSyncStatsCalculator {
+
+    /**
+     * Compute a value in [0, 1] representing how much of the cluster's data space is currently
+     * out of sync, i.e. pending merging. In other words, if the value is 1 all buckets are out
+     * of sync, and conversely if it's 0 all buckets are in sync. This number applies across bucket
+     * spaces.
+     *
+     * @param globalStats Globally aggregated content node statistics for the entire cluster.
+     * @return Optional containing a value [0, 1] representing the ratio of buckets pending merge
+     *         in relation to the total number of buckets in the cluster, or an empty optional if
+     *         the underlying global statistics contains invalid/incomplete information.
+     */
+    public static Optional<Double> clusterBucketsOutOfSyncRatio(ContentNodeStats globalStats) {
+        long totalBuckets = 0;
+        long pendingBuckets = 0;
+        for (var space : globalStats.getBucketSpaces().values()) {
+            if (!space.valid()) {
+                return Optional.empty();
+            }
+            totalBuckets   += space.getBucketsTotal();
+            pendingBuckets += space.getBucketsPending();
+        }
+        pendingBuckets = Math.min(pendingBuckets, totalBuckets);
+        if (totalBuckets <= 0) {
+            return Optional.of(0.0); // No buckets; cannot be out of sync by definition
+        }
+        return Optional.of((double)pendingBuckets / (double)totalBuckets);
+    }
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculator.java
@@ -29,6 +29,12 @@ public class GlobalBucketSyncStatsCalculator {
             totalBuckets   += space.getBucketsTotal();
             pendingBuckets += space.getBucketsPending();
         }
+        // It's currently possible for the reported number of pending buckets to be greater than
+        // the number of total buckets. Example: this can happen if a bucket is present on a single
+        // node, but should have been replicated to 9 more nodes. Since counts are not normalized
+        // across content nodes for a given bucket, this will be counted as 9 pending and 1 total.
+        // Eventually this will settle as 0 pending and 10 total.
+        // TODO report node-normalized pending/total counts from distributors and use these.
         pendingBuckets = Math.min(pendingBuckets, totalBuckets);
         if (totalBuckets <= 0) {
             return Optional.of(0.0); // No buckets; cannot be out of sync by definition

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -93,6 +93,10 @@ public class MetricUpdater {
         metricReporter.set("is-master", isMaster ? 1 : 0);
     }
 
+    public void updateClusterBucketsOutOfSyncRatio(double ratio) {
+        metricReporter.set("cluster-buckets-out-of-sync-ratio", ratio);
+    }
+
     public void addTickTime(long millis, boolean didWork) {
         if (didWork) {
             metricReporter.set("busy-tick-time-ms", millis);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RemoteClusterControllerTask.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RemoteClusterControllerTask.java
@@ -17,6 +17,7 @@ public abstract class RemoteClusterControllerTask {
         public MasterInterface masterInfo;
         public NodeListener nodeListener;
         public SlobrokListener slobrokListener;
+        public AggregatedClusterStats aggregatedClusterStats;
     }
 
     private final Object monitor = new Object();

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Response.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/Response.java
@@ -76,7 +76,7 @@ public class Response {
     {
         protected final Map<String, String> attributes = new LinkedHashMap<>();
         protected final Map<String, SubUnitList> subUnits = new LinkedHashMap<>();
-        protected final Map<String, Long> metrics = new LinkedHashMap<>();
+        protected final Map<String, Number> metrics = new LinkedHashMap<>();
         protected final Map<String, UnitState> stateMap = new LinkedHashMap<>();
         protected DistributionState publishedState = null;
 
@@ -94,7 +94,7 @@ public class Response {
         }
 
         @Override
-        public Map<String, Long> getMetricMap() { return metrics; }
+        public Map<String, Number> getMetricMap() { return metrics; }
         @Override
         public Map<String, UnitState> getStatePerType() { return stateMap; }
         @Override
@@ -122,7 +122,7 @@ public class Response {
             list.addUnit(unit, response);
             return this;
         }
-        public EmptyResponse<T> addMetric(String name, Long value) {
+        public EmptyResponse<T> addMetric(String name, Number value) {
             metrics.put(name, value);
             return this;
         }

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/ClusterStateRequest.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/restapiv2/requests/ClusterStateRequest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core.restapiv2.requests;
 
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
+import com.yahoo.vespa.clustercontroller.core.GlobalBucketSyncStatsCalculator;
 import com.yahoo.vespa.clustercontroller.core.RemoteClusterControllerTask;
 import com.yahoo.vespa.clustercontroller.core.restapiv2.Id;
 import com.yahoo.vespa.clustercontroller.core.restapiv2.Request;
@@ -36,6 +37,11 @@ public class ClusterStateRequest extends Request<Response.ClusterResponse> {
             }
         }
         result.setPublishedState(bundleToDistributionState(context.publishedClusterStateBundle));
+        if (context.aggregatedClusterStats.hasUpdatesFromAllDistributors()) {
+            var stats = context.aggregatedClusterStats.getGlobalStats();
+            var maybeRatio = GlobalBucketSyncStatsCalculator.clusterBucketsOutOfSyncRatio(stats);
+            maybeRatio.ifPresent(r -> result.addMetric("cluster-buckets-out-of-sync-ratio", r));
+        }
         return result;
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStatsBuilder.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentNodeStatsBuilder.java
@@ -13,7 +13,7 @@ public class ContentNodeStatsBuilder {
         this.nodeIndex = nodeIndex;
     }
 
-    static ContentNodeStatsBuilder forNode(int nodeIndex) {
+    public static ContentNodeStatsBuilder forNode(int nodeIndex) {
         return new ContentNodeStatsBuilder(nodeIndex);
     }
 
@@ -21,12 +21,16 @@ public class ContentNodeStatsBuilder {
         return add(bucketSpace, ContentNodeStats.BucketSpaceStats.of(bucketsTotal, bucketsPending));
     }
 
+    public ContentNodeStatsBuilder addInvalid(String bucketSpace, long bucketsTotal, long bucketsPending) {
+        return add(bucketSpace, ContentNodeStats.BucketSpaceStats.invalid(bucketsTotal, bucketsPending));
+    }
+
     public ContentNodeStatsBuilder add(String bucketSpace, ContentNodeStats.BucketSpaceStats bucketSpaceStats) {
         stats.put(bucketSpace, bucketSpaceStats);
         return this;
     }
 
-    ContentNodeStats build() {
+    public ContentNodeStats build() {
         return new ContentNodeStats(nodeIndex, stats);
     }
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculatorTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GlobalBucketSyncStatsCalculatorTest.java
@@ -1,0 +1,59 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class GlobalBucketSyncStatsCalculatorTest {
+
+    private static ContentNodeStatsBuilder globalStatsBuilder() {
+        return ContentNodeStatsBuilder.forNode(-1);
+    }
+
+    private static void assertComputedRatio(double expected, ContentNodeStatsBuilder statsBuilder) {
+        var maybeRatio = GlobalBucketSyncStatsCalculator.clusterBucketsOutOfSyncRatio(statsBuilder.build());
+        if (maybeRatio.isEmpty()) {
+            throw new IllegalArgumentException("Expected calculation to yield a value, but was empty");
+        }
+        assertEquals(expected, maybeRatio.get(), 0.00001);
+    }
+
+    private static void assertEmptyComputedRatio(ContentNodeStatsBuilder statsBuilder) {
+        var maybeRatio = GlobalBucketSyncStatsCalculator.clusterBucketsOutOfSyncRatio(statsBuilder.build());
+        assertTrue(maybeRatio.isEmpty());
+    }
+
+    @Test
+    void no_buckets_imply_fully_in_sync() {
+        // Can't have anything out of sync if you don't have anything to be out of sync with *taps side of head*
+        assertComputedRatio(0.0, globalStatsBuilder().add("default", 0, 0));
+    }
+
+    @Test
+    void no_pending_buckets_implies_fully_in_sync() {
+        assertComputedRatio(0.0, globalStatsBuilder().add("default", 100, 0));
+        assertComputedRatio(0.0, globalStatsBuilder().add("default", 100, 0).add("global", 50, 0));
+    }
+
+    @Test
+    void invalid_stats_returns_empty() {
+        assertEmptyComputedRatio(globalStatsBuilder().add("default", ContentNodeStats.BucketSpaceStats.invalid()));
+        assertEmptyComputedRatio(globalStatsBuilder()
+                .add("default", 100, 0)
+                .add("global", ContentNodeStats.BucketSpaceStats.invalid()));
+    }
+
+    @Test
+    void pending_buckets_return_expected_ratio() {
+        assertComputedRatio(0.50, globalStatsBuilder().add("default", 10, 5));
+        assertComputedRatio(0.80, globalStatsBuilder().add("default", 10, 8));
+        assertComputedRatio(0.10, globalStatsBuilder().add("default", 100, 10));
+        assertComputedRatio(0.01, globalStatsBuilder().add("default", 100, 1));
+        assertComputedRatio(0.05, globalStatsBuilder().add("default", 50, 5).add("global", 50, 0));
+        assertComputedRatio(0.05, globalStatsBuilder().add("default", 50, 0).add("global", 50, 5));
+        assertComputedRatio(0.10, globalStatsBuilder().add("default", 50, 5).add("global", 50, 5));
+    }
+
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/ClusterControllerMock.java
@@ -15,6 +15,8 @@ public class ClusterControllerMock implements RemoteClusterControllerTaskSchedul
     private final int fleetControllerIndex;
     Integer fleetControllerMaster;
     private final StringBuilder events = new StringBuilder();
+    ContentNodeStats globalClusterStats = new ContentNodeStats(-1);
+    boolean enableGlobalStatsReporting = false;
 
     ClusterControllerMock(ContentCluster cluster, ClusterState state,
                           ClusterStateBundle publishedClusterStateBundle,
@@ -87,6 +89,22 @@ public class ClusterControllerMock implements RemoteClusterControllerTaskSchedul
                 events.append("returnedRpcAddress(").append(node.getNode()).append(")\n");
             }
 
+        };
+        context.aggregatedClusterStats = new AggregatedClusterStats() {
+            @Override
+            public boolean hasUpdatesFromAllDistributors() {
+                return enableGlobalStatsReporting;
+            }
+
+            @Override
+            public ContentClusterStats getStats() {
+                return null;
+            }
+
+            @Override
+            public ContentNodeStats getGlobalStats() {
+                return globalClusterStats;
+            }
         };
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/restapiv2/StateRestApiTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 
 public abstract class StateRestApiTest {
 
-    private ClusterControllerMock books;
+    ClusterControllerMock books;
     ClusterControllerMock music;
     StateRestAPI restAPI;
     JsonWriter jsonWriter = new JsonWriter();

--- a/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/response/UnitMetrics.java
+++ b/clustercontroller-utils/src/main/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/response/UnitMetrics.java
@@ -5,6 +5,6 @@ import java.util.Map;
 
 public interface UnitMetrics {
 
-    Map<String, Long> getMetricMap();
+    Map<String, Number> getMetricMap();
 
 }

--- a/clustercontroller-utils/src/test/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/DummyStateApi.java
+++ b/clustercontroller-utils/src/test/java/com/yahoo/vespa/clustercontroller/utils/staterestapi/DummyStateApi.java
@@ -139,8 +139,8 @@ public class DummyStateApi implements StateRestAPI {
             public UnitMetrics getMetrics() {
                 return new UnitMetrics() {
                     @Override
-                    public Map<String, Long> getMetricMap() {
-                        Map<String, Long> m = new LinkedHashMap<>();
+                    public Map<String, Number> getMetricMap() {
+                        Map<String, Number> m = new LinkedHashMap<>();
                         m.put("doc-count", (long) node.docCount);
                         return m;
                     }


### PR DESCRIPTION
@hakonhall please review. Once merged, we should observe the output of this in practice for a bit before wiring it to anything.

With these changes the cluster controller continuously maintains a global aggregate across all content nodes that represents the number of pending and total buckets per bucket space. This aggregate can be sampled in O(1) time.

An explicit metric `cluster-buckets-out-of-sync-ratio` has been added, and the value is also emitted as part of the cluster state REST API. Note: only emitted when statistics have been received from _all_ distributors for a particular cluster state version, as it would otherwise potentially represent a sample at an arbitrary time point between two or more distinct states.

