### PR TITLE
Use `poll` instead of `select` in config sentinel work loop

### DIFF
--- a/configd/src/apps/sentinel/manager.cpp
+++ b/configd/src/apps/sentinel/manager.cpp
@@ -170,16 +170,16 @@ Manager::handleChildDeaths()
 }
 
 void
-Manager::updateActiveFdset(fd_set *fds, int *maxNum)
+Manager::updateActiveFdset(std::vector<pollfd> &fds)
 {
-    // ### _Possibly put an assert here if fd is > 1023???
-    for (OutputConnection *c : _outputConnections) {
+    for (const OutputConnection *c : _outputConnections) {
         int fd = c->fd();
         if (fd >= 0) {
-            FD_SET(fd, fds);
-            if (fd >= *maxNum) {
-                *maxNum = fd + 1;
-            }
+            fds.emplace_back();
+            auto &ev = fds.back();
+            ev.fd = fd;
+            ev.events = POLLIN;
+            ev.revents = 0;
         }
     }
 }

--- a/configd/src/apps/sentinel/manager.cpp
+++ b/configd/src/apps/sentinel/manager.cpp
@@ -172,6 +172,7 @@ Manager::handleChildDeaths()
 void
 Manager::updateActiveFdset(std::vector<pollfd> &fds)
 {
+    fds.clear();
     for (const OutputConnection *c : _outputConnections) {
         int fd = c->fd();
         if (fd >= 0) {

--- a/configd/src/apps/sentinel/manager.h
+++ b/configd/src/apps/sentinel/manager.h
@@ -9,6 +9,7 @@
 #include "state-api.h"
 #include <vespa/config-sentinel.h>
 #include <vespa/vespalib/net/http/state_server.h>
+#include <poll.h>
 #include <sys/types.h>
 #include <sys/select.h>
 
@@ -54,7 +55,7 @@ public:
     virtual ~Manager();
     bool terminate();
     bool doWork();
-    void updateActiveFdset(fd_set *fds, int *maxNum);
+    void updateActiveFdset(std::vector<pollfd> &fds);
 };
 
 }

--- a/configd/src/apps/sentinel/sentinel.cpp
+++ b/configd/src/apps/sentinel/sentinel.cpp
@@ -10,7 +10,6 @@
 #include <clocale>
 #include <string>
 #include <unistd.h>
-#include <sys/time.h>
 
 #include <vespa/log/log.h>
 LOG_SETUP("sentinel.config-sentinel");
@@ -84,6 +83,7 @@ main(int argc, char **argv)
     }
 
     sentinel::Manager manager(environment);
+    std::vector<pollfd> fds;
     vespalib::steady_time lastTime = vespalib::steady_clock::now();
     while (!stop()) {
         try {
@@ -103,16 +103,11 @@ main(int argc, char **argv)
         if (vespalib::SignalHandler::CHLD.check()) {
             continue;
         }
-        int maxNum = 0;
-        fd_set fds;
-        FD_ZERO(&fds);
-        manager.updateActiveFdset(&fds, &maxNum);
+        fds.clear();
+        manager.updateActiveFdset(fds);
+        constexpr int poll_timeout_ms = 100;
 
-        struct timeval tv;
-        tv.tv_sec = 0;
-        tv.tv_usec = 100000;  //0.1s
-
-        select(maxNum, &fds, nullptr, nullptr, &tv);
+        poll(fds.data(), fds.size(), poll_timeout_ms);
 
         vespalib::steady_time now = vespalib::steady_clock::now();
         if ((now - lastTime) < 10ms) {

--- a/configd/src/apps/sentinel/sentinel.cpp
+++ b/configd/src/apps/sentinel/sentinel.cpp
@@ -103,7 +103,6 @@ main(int argc, char **argv)
         if (vespalib::SignalHandler::CHLD.check()) {
             continue;
         }
-        fds.clear();
         manager.updateActiveFdset(fds);
         constexpr int poll_timeout_ms = 100;
 


### PR DESCRIPTION
@havardpe please review
@baldersheim @toregge @arnej27959 FYI

`select` on glibc is not well-defined when the highest file descriptor _number_ (not count) is > 1023. Use `poll` instead, which does not have this limitation (and also is pleasantly _O(|fds|)_ instead of _O(highest fd number)_...).

