### PR TITLE
Revert "Explicitly track number of entries received through visiting"

### DIFF
--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -290,7 +290,7 @@ public class DocumentV1ApiTest {
             parameters.getLocalDataHandler().onMessage(new RemoveDocumentMessage(new DocumentId("id:space:music::t-square-truth")), tokens.get(3));
             VisitorStatistics statistics = new VisitorStatistics();
             statistics.setBucketsVisited(1);
-            statistics.setDocumentsVisited(123); // Ignored in favor of tracking actually emitted entries
+            statistics.setDocumentsVisited(3);
             parameters.getControlHandler().onVisitorStatistics(statistics);
             parameters.getControlHandler().onDone(VisitorControlHandler.CompletionCode.TIMEOUT, "timeout is OK");
         });
@@ -323,7 +323,7 @@ public class DocumentV1ApiTest {
                             "remove": "id:space:music::t-square-truth"
                            }
                          ],
-                         "documentCount": 4,
+                         "documentCount": 3,
                          "trace": [
                            { "message": "Tracy Chapman" },
                            {
@@ -488,7 +488,7 @@ public class DocumentV1ApiTest {
         assertSameJson("""
                        {
                          "pathId": "/document/v1/space/music/docid",
-                         "documentCount": 1
+                         "documentCount": 0
                        }""",
                        response.readAll());
         assertEquals(200, response.getStatus());
@@ -542,7 +542,7 @@ public class DocumentV1ApiTest {
         assertSameJson("""
                        {
                          "pathId": "/document/v1/space/music/docid",
-                         "documentCount": 1,
+                         "documentCount": 0,
                          "message": "boom"
                        }""",
                        response.readAll());


### PR DESCRIPTION
@jonmv please review. This broke reported statistics for visiting with a _remote_ data destination, so some further pondering is required to find a solution that works robustly regardless of visiting target.
@aressem FYI