### PR TITLE
Remove legacy storage node root directory IO in unit tests

### DIFF
--- a/storage/src/tests/common/metricstest.cpp
+++ b/storage/src/tests/common/metricstest.cpp
@@ -67,16 +67,12 @@ MetricsTest::~MetricsTest() = default;
 
 void MetricsTest::SetUp() {
     _config = std::make_unique<vdstestlib::DirConfig>(getStandardConfig(true, "metricstest"));
-    std::filesystem::remove_all(std::filesystem::path(getRootFolder(*_config)));
-    try {
-        _node = std::make_unique<TestServiceLayerApp>(NodeIndex(0), _config->getConfigId());
-        _node->setupDummyPersistence();
-        _clock = &_node->getClock();
-        _clock->setAbsoluteTimeInSeconds(1000000);
-        _top = std::make_unique<DummyStorageLink>();
-    } catch (config::InvalidConfigException& e) {
-        fprintf(stderr, "%s\n", e.what());
-    }
+    _node = std::make_unique<TestServiceLayerApp>(NodeIndex(0), _config->getConfigId());
+    _node->setupDummyPersistence();
+    _clock = &_node->getClock();
+    _clock->setAbsoluteTimeInSeconds(1000000);
+    _top = std::make_unique<DummyStorageLink>();
+
     _metricManager = std::make_unique<metrics::MetricManager>(std::make_unique<MetricClock>(*_clock));
     _topSet.reset(new metrics::MetricSet("vds", {}, ""));
     {

--- a/storage/src/tests/common/testhelper.cpp
+++ b/storage/src/tests/common/testhelper.cpp
@@ -68,6 +68,7 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode, const std::string & ro
     rootFolder += (storagenode ? "vdsroot" : "vdsroot.distributor");
     config->set("root_folder", rootFolder);
     config->set("is_distributor", (storagenode ? "false" : "true"));
+    config->set("write_pid_file_on_startup", "false");
     config = &dc.addConfig("stor-devices");
     config->set("root_folder", rootFolder);
     config = &dc.addConfig("stor-status");

--- a/storage/src/tests/persistence/persistencetestutils.cpp
+++ b/storage/src/tests/persistence/persistencetestutils.cpp
@@ -26,11 +26,7 @@ namespace storage {
 namespace {
 
 vdstestlib::DirConfig initialize(const std::string & rootOfRoot) {
-    vdstestlib::DirConfig config(getStandardConfig(true, rootOfRoot));
-    std::string rootFolder = getRootFolder(config);
-    std::filesystem::remove_all(std::filesystem::path(rootFolder));
-    std::filesystem::create_directories(std::filesystem::path(vespalib::make_string("%s/disks/d0", rootFolder.c_str())));
-    return config;
+    return getStandardConfig(true, rootOfRoot);
 }
 
 template<typename T>

--- a/storage/src/tests/storageserver/statereportertest.cpp
+++ b/storage/src/tests/storageserver/statereportertest.cpp
@@ -69,7 +69,6 @@ StateReporterTest::~StateReporterTest() = default;
 
 void StateReporterTest::SetUp() {
     _config = std::make_unique<vdstestlib::DirConfig>(getStandardConfig(true, "statereportertest"));
-    assert(system(("rm -rf " + getRootFolder(*_config)).c_str()) == 0);
 
     _node = std::make_unique<TestServiceLayerApp>(NodeIndex(0), _config->getConfigId());
     _node->setupDummyPersistence();

--- a/storage/src/tests/visiting/visitortest.cpp
+++ b/storage/src/tests/visiting/visitortest.cpp
@@ -155,13 +155,6 @@ VisitorTest::initializeTest(const TestParams& params)
             "visitor_memory_usage_limit",
             std::to_string(params._maxVisitorMemoryUsage));
 
-    std::string rootFolder = getRootFolder(config);
-
-    ::chmod(rootFolder.c_str(), 0755);
-    std::filesystem::remove_all(std::filesystem::path(rootFolder));
-    std::filesystem::create_directories(std::filesystem::path(vespalib::make_string("%s/disks/d0", rootFolder.c_str())));
-    std::filesystem::create_directories(std::filesystem::path(vespalib::make_string("%s/disks/d1", rootFolder.c_str())));
-
     _messageSessionFactory = std::make_unique<TestVisitorMessageSessionFactory>();
     if (params._autoReplyError.getCode() != mbus::ErrorCode::NONE) {
         _messageSessionFactory->_autoReplyError = params._autoReplyError;
@@ -217,14 +210,12 @@ VisitorTest::initializeTest(const TestParams& params)
     _documents.clear();
     for (uint32_t i=0; i<docCount; ++i) {
         std::ostringstream uri;
-        uri << "id:test:testdoctype1:n=" << i % 10 << ":http://www.ntnu.no/"
-            << i << ".html";
+        uri << "id:test:testdoctype1:n=" << i % 10 << ":http://www.ntnu.no/" << i << ".html";
 
         _documents.push_back(Document::SP(
                 _node->getTestDocMan().createDocument(content, uri.str())));
         const document::DocumentType& type(_documents.back()->getType());
-        _documents.back()->setValue(type.getField("headerval"),
-                                    document::IntFieldValue(i % 4));
+        _documents.back()->setValue(type.getField("headerval"), document::IntFieldValue(i % 4));
     }
 }
 

--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -114,3 +114,7 @@ simulated_bucket_request_latency_msec int default=0
 ## a disjoint subset of the node's buckets, in order to reduce locking contention.
 ## Max value is unspecified, but will be clamped internally.
 content_node_bucket_db_stripe_bits int default=4 restart
+
+## Iff set, a special `pidfile` file is written under the node's root directory upon
+## startup containing the PID of the running process.
+write_pid_file_on_startup bool default=true

--- a/storageserver/src/tests/testhelper.cpp
+++ b/storageserver/src/tests/testhelper.cpp
@@ -62,13 +62,11 @@ vdstestlib::DirConfig getStandardConfig(bool storagenode) {
     config->set("enable_dead_lock_detector_warnings", "false");
     config->set("max_merges_per_node", "25");
     config->set("max_merge_queue_size", "20");
-    config->set("root_folder",
-                    (storagenode ? "vdsroot" : "vdsroot.distributor"));
-    config->set("is_distributor",
-                    (storagenode ? "false" : "true"));
+    config->set("root_folder", (storagenode ? "vdsroot" : "vdsroot.distributor"));
+    config->set("is_distributor", (storagenode ? "false" : "true"));
+    config->set("write_pid_file_on_startup", "false");
     config = &dc.addConfig("stor-devices");
-    config->set("root_folder",
-                    (storagenode ? "vdsroot" : "vdsroot.distributor"));
+    config->set("root_folder", (storagenode ? "vdsroot" : "vdsroot.distributor"));
     config = &dc.addConfig("stor-status");
     config->set("httpport", "0");
     config = &dc.addConfig("stor-visitor");


### PR DESCRIPTION
@baldersheim please review

Once upon a time, VDS roamed the lands 🦖. It used real disk IO as part of tests. Then came the meteor and in-memory dummy persistence took over. Now it is time for the fossils to be moved into a museum where they belong.

Also make PID file writing conditional on a config that is set to `false` during unit testing (but `true` as default).

