### PR TITLE
Less aggressive smoothing, and readjust a bit less often

### DIFF
--- a/client/go/internal/vespa/document/throttler.go
+++ b/client/go/internal/vespa/document/throttler.go
@@ -59,7 +59,7 @@ func NewThrottler(connections int) Throttler { return newThrottler(connections, 
 func (t *dynamicThrottler) Sent() {
 	currentInflight := t.TargetInflight()
 	t.sent++
-	if t.sent*t.sent*t.sent < 100*currentInflight*currentInflight {
+	if t.sent*t.sent*t.sent < 1000*currentInflight*currentInflight {
 		return
 	}
 	t.sent = 0
@@ -94,7 +94,7 @@ func (t *dynamicThrottler) Sent() {
 		if j != -1 {
 			u := t.throughputs[j]
 			if k != -1 {
-				t.throughputs[j] = (2*u + t.throughputs[i] + s) / 4
+				t.throughputs[j] = (18*u + t.throughputs[i] + s) / 20
 			}
 			s = u
 		}

--- a/client/go/internal/vespa/document/throttler_test.go
+++ b/client/go/internal/vespa/document/throttler_test.go
@@ -13,7 +13,7 @@ func TestThrottler(t *testing.T) {
 	if got, want := tr.TargetInflight(), int64(16); got != want {
 		t.Errorf("got TargetInflight() = %d, but want %d", got, want)
 	}
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 65; i++ {
 		tr.Sent()
 		tr.Success()
 	}

--- a/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
+++ b/vespa-feed-client/src/main/java/ai/vespa/feed/client/impl/DynamicThrottler.java
@@ -34,7 +34,7 @@ public class DynamicThrottler extends StaticThrottler {
     @Override
     public void sent(long __, CompletableFuture<HttpResponse> ___) {
         double currentInflight = targetInflight();
-        if (++sent * sent * sent < 1e2 * currentInflight * currentInflight)
+        if (++sent * sent * sent < 1e3 * currentInflight * currentInflight)
             return;
 
         sent = 0;
@@ -63,7 +63,7 @@ public class DynamicThrottler extends StaticThrottler {
             // Additionally, smooth the throughput values, to reduce the impact of noise, and reduce jumpiness.
             if (j != -1) {
                 double t = throughputs[j];
-                if (k != -1) throughputs[j] = (2 * t + throughputs[i] + s) / 4;
+                if (k != -1) throughputs[j] = (18 * t + throughputs[i] + s) / 20;
                 s = t;
             }
             k = j;

--- a/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/DynamicThrottlerTest.java
+++ b/vespa-feed-client/src/test/java/ai/vespa/feed/client/impl/DynamicThrottlerTest.java
@@ -17,7 +17,7 @@ class DynamicThrottlerTest {
         DynamicThrottler throttler = new DynamicThrottler(new FeedClientBuilderImpl(List.of(URI.create("http://localhost:8080"))));
         assertEquals(16, throttler.targetInflight());
 
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 65; i++) {
             throttler.sent(1, null);
             throttler.success();
         }


### PR DESCRIPTION
@baldersheim I believe the very aggressive smoothing is the reason for the recent drop in throughput: hiccups will give a much more persistent dent in the throughput graph with aggressive smoothing. Worth a shot imo. 