### PR TITLE
Disable valgrind for generation handler stress tests.

### DIFF
--- a/vespalib/src/tests/util/generationhandler_stress/CMakeLists.txt
+++ b/vespalib/src/tests/util/generationhandler_stress/CMakeLists.txt
@@ -6,4 +6,4 @@ vespa_add_executable(vespalib_generation_handler_stress_test_app
     vespalib
     GTest::GTest
 )
-vespa_add_test(NAME vespalib_generation_handler_stress_test_app COMMAND vespalib_generation_handler_stress_test_app --smoke-test)
+vespa_add_test(NAME vespalib_generation_handler_stress_test_app NO_VALGRIND COMMAND vespalib_generation_handler_stress_test_app --smoke-test)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
