### PR TITLE
Avoid injecting Exclusivity

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SharedHosts.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SharedHosts.java
@@ -11,12 +11,10 @@ public interface SharedHosts {
     /** Whether there are any shared hosts specifically for the given cluster type. */
     boolean hasClusterType(ClusterSpec.Type clusterType);
 
-    static SharedHosts empty() { return ofConstant(false, false); }
-
-    static SharedHosts ofConstant(boolean supportsClusterType, boolean hasClusterType) {
+    static SharedHosts empty() {
         return new SharedHosts() {
-            @Override public boolean supportsClusterType(ClusterSpec.Type clusterType) { return supportsClusterType; }
-            @Override public boolean hasClusterType(ClusterSpec.Type clusterType) { return hasClusterType; }
+            @Override public boolean supportsClusterType(ClusterSpec.Type clusterType) { return false; }
+            @Override public boolean hasClusterType(ClusterSpec.Type clusterType) { return false; }
         };
     }
 

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/testutils/MockNodeRepository.java
@@ -92,7 +92,6 @@ public class MockNodeRepository extends NodeRepository {
               curator,
               Clock.fixed(Instant.ofEpochMilli(123), ZoneId.of("Z")),
               zone,
-              new Exclusivity(zone, SharedHosts.empty()),
               new MockNameResolver().mockAnyLookup(),
               DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
               Optional.empty(),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/NodeRepositoryTester.java
@@ -42,18 +42,16 @@ public class NodeRepositoryTester {
         clock = new ManualClock();
         curator = new MockCurator();
         curator.setZooKeeperEnsembleConnectionSpec("server1:1234,server2:5678");
-        var flagSource = new InMemoryFlagSource();
         nodeRepository = new NodeRepository(nodeFlavors,
                                             new EmptyProvisionServiceProvider(),
                                             curator,
                                             clock,
                                             zone,
-                                            new Exclusivity(zone, SharedHosts.empty()),
                                             new MockNameResolver().mockAnyLookup(),
                                             DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
                                             Optional.empty(),
                                             Optional.empty(),
-                                            flagSource,
+                                            new InMemoryFlagSource(),
                                             new MemoryMetricsDb(clock),
                                             new OrchestratorMock(),
                                             true,

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/autoscale/Fixture.java
@@ -15,6 +15,9 @@ import com.yahoo.config.provision.SharedHosts;
 import com.yahoo.config.provision.SystemName;
 import com.yahoo.config.provision.Zone;
 import com.yahoo.vespa.flags.InMemoryFlagSource;
+import com.yahoo.vespa.flags.PermanentFlags;
+import com.yahoo.vespa.flags.custom.HostResources;
+import com.yahoo.vespa.flags.custom.SharedHost;
 import com.yahoo.vespa.hosted.provision.Node;
 import com.yahoo.vespa.hosted.provision.NodeList;
 import com.yahoo.vespa.hosted.provision.applications.Application;
@@ -49,7 +52,7 @@ public class Fixture {
         applicationId = builder.application;
         clusterSpec = builder.cluster;
         capacity = builder.capacity;
-        tester = new DynamicProvisioningTester(builder.zone, builder.resourceCalculator, builder.hostFlavors, builder.flagSource, builder.sharedHosts, hostCount);
+        tester = new DynamicProvisioningTester(builder.zone, builder.resourceCalculator, builder.hostFlavors, builder.flagSource, hostCount);
         var deployCapacity = initialResources.isPresent() ? Capacity.from(initialResources.get()) : capacity;
         tester.deploy(builder.application, builder.cluster, deployCapacity);
         this.loader = new Loader(this);
@@ -176,7 +179,6 @@ public class Fixture {
         HostResourcesCalculator resourceCalculator = new DynamicProvisioningTester.MockHostResourcesCalculator(zone);
         final InMemoryFlagSource flagSource = new InMemoryFlagSource();
         int hostCount = 0;
-        SharedHosts sharedHosts = SharedHosts.empty();
 
         public Fixture.Builder zone(Zone zone) {
             this.zone = zone;
@@ -283,7 +285,8 @@ public class Fixture {
         }
 
         public Fixture.Builder hostSharing() {
-            sharedHosts = SharedHosts.ofConstant(true, false);
+            var resources = new HostResources(8.0, 32.0, 100.0, 10.0, "fast", "local", null, 6, "x86_64");
+            flagSource.withJacksonFlag(PermanentFlags.SHARED_HOST.id(), new SharedHost(List.of(resources)), SharedHost.class);
             return this;
         }
 

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityCheckerTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/CapacityCheckerTester.java
@@ -70,7 +70,6 @@ public class CapacityCheckerTester {
                                             curator,
                                             clock,
                                             zone,
-                                            new Exclusivity(zone, SharedHosts.empty()),
                                             new MockNameResolver().mockAnyLookup(),
                                             DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
                                             Optional.empty(),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainerTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/maintenance/SpareCapacityMaintainerTest.java
@@ -260,13 +260,11 @@ public class SpareCapacityMaintainerTest {
         private SpareCapacityMaintainerTester(int maxIterations) {
             NodeFlavors flavors = new NodeFlavors(new FlavorConfigBuilder().build());
             ManualClock clock = new ManualClock();
-            var zone = new Zone(Environment.prod, RegionName.from("us-east-3"));
             nodeRepository = new NodeRepository(flavors,
                                                 new EmptyProvisionServiceProvider(),
                                                 new MockCurator(),
                                                 clock,
-                                                zone,
-                                                new Exclusivity(zone, SharedHosts.empty()),
+                                                new Zone(Environment.prod, RegionName.from("us-east-3")),
                                                 new MockNameResolver().mockAnyLookup(),
                                                 DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa"),
                                                 Optional.empty(),

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTest.java
@@ -208,8 +208,9 @@ public class DynamicProvisioningTest {
     private void assertHostSharing(Environment environment, ClusterSpec.Type clusterType, boolean expectShared) {
         Zone zone = new Zone(Cloud.builder().dynamicProvisioning(true).allowHostSharing(false).build(), SystemName.Public, environment, RegionName.defaultName());
         MockHostProvisioner hostProvisioner = new MockHostProvisioner(new NodeFlavors(ProvisioningTester.createConfig()).getFlavors(), nameResolver, 0);
-        ProvisioningTester tester = new ProvisioningTester.Builder().zone(zone).hostProvisioner(hostProvisioner).nameResolver(nameResolver).sharedHosts(SharedHosts.ofConstant(true, false)).build();
+        ProvisioningTester tester = new ProvisioningTester.Builder().zone(zone).hostProvisioner(hostProvisioner).nameResolver(nameResolver).build();
         tester.makeReadyHosts(2, new NodeResources(12, 12, 200, 12));
+        tester.flagSource().withJacksonFlag(PermanentFlags.SHARED_HOST.id(), new SharedHost(List.of(new HostResources(4.0, 16.0, 50.0, 0.3, "fast", "local", null, 10, "x86_64"))), SharedHost.class);
 
         ApplicationId application = applicationId();
         ClusterSpec cluster = ClusterSpec.request(clusterType, ClusterSpec.Id.from("default")).vespaVersion("6.42").build();

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/DynamicProvisioningTester.java
@@ -54,14 +54,14 @@ public class DynamicProvisioningTester {
     private final Autoscaler autoscaler;
     private final HostResourcesCalculator hostResourcesCalculator;
 
-    public DynamicProvisioningTester(Zone zone, HostResourcesCalculator resourcesCalculator, List<Flavor> hostFlavors, InMemoryFlagSource flagSource, SharedHosts sharedHosts, int hostCount) {
-        this(zone, hostFlavors, resourcesCalculator, flagSource, sharedHosts);
+    public DynamicProvisioningTester(Zone zone, HostResourcesCalculator resourcesCalculator, List<Flavor> hostFlavors, InMemoryFlagSource flagSource, int hostCount) {
+        this(zone, hostFlavors, resourcesCalculator, flagSource);
         for (Flavor flavor : hostFlavors)
             provisioningTester.makeReadyNodes(hostCount, flavor.name(), NodeType.host, 8);
         provisioningTester.activateTenantHosts();
     }
 
-    private DynamicProvisioningTester(Zone zone, List<Flavor> flavors, HostResourcesCalculator resourcesCalculator, InMemoryFlagSource flagSource, SharedHosts sharedHosts) {
+    private DynamicProvisioningTester(Zone zone, List<Flavor> flavors, HostResourcesCalculator resourcesCalculator, InMemoryFlagSource flagSource) {
         MockHostProvisioner hostProvisioner = null;
         if (zone.cloud().dynamicProvisioning()) {
             hostProvisioner = new MockHostProvisioner(flavors);
@@ -74,7 +74,6 @@ public class DynamicProvisioningTester {
                                                              .resourcesCalculator(resourcesCalculator)
                                                              .flagSource(flagSource)
                                                              .hostProvisioner(hostProvisioner)
-                                                             .sharedHosts(sharedHosts)
                                                              .build();
 
         hostResourcesCalculator = resourcesCalculator;

--- a/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
+++ b/node-repository/src/test/java/com/yahoo/vespa/hosted/provision/provisioning/ProvisioningTester.java
@@ -112,8 +112,7 @@ public class ProvisioningTester {
                                LoadBalancerServiceMock loadBalancerService,
                                FlagSource flagSource,
                                int spareCount,
-                               ManualClock clock,
-                               SharedHosts sharedHosts) {
+                               ManualClock clock) {
         this.curator = curator;
         this.nodeFlavors = nodeFlavors;
         this.clock = clock;
@@ -124,7 +123,6 @@ public class ProvisioningTester {
                                                  curator,
                                                  clock,
                                                  zone,
-                                                 new Exclusivity(zone, sharedHosts),
                                                  nameResolver,
                                                  containerImage,
                                                  Optional.empty(),
@@ -663,7 +661,6 @@ public class ProvisioningTester {
         private int spareCount = 0;
         private ManualClock clock = new ManualClock();
         private DockerImage defaultImage = DockerImage.fromString("docker-registry.domain.tld:8080/dist/vespa");
-        private SharedHosts sharedHosts = SharedHosts.empty();
 
         public Builder curator(Curator curator) {
             this.curator = curator;
@@ -745,11 +742,6 @@ public class ProvisioningTester {
             return this;
         }
 
-        public Builder sharedHosts(SharedHosts sharedHosts) {
-            this.sharedHosts = sharedHosts;
-            return this;
-        }
-
         private FlagSource defaultFlagSource() {
             return new InMemoryFlagSource();
         }
@@ -766,8 +758,7 @@ public class ProvisioningTester {
                                           new LoadBalancerServiceMock(),
                                           Optional.ofNullable(flagSource).orElse(defaultFlagSource()),
                                           spareCount,
-                                          clock,
-                                          sharedHosts);
+                                          clock);
         }
 
         private static FlavorsConfig asConfig(List<Flavor> flavors) {


### PR DESCRIPTION
Fixes

```
        Failed to set up first component graph
        exception=
        java.lang.RuntimeException: When resolving dependencies of 'NodeRepository' of type 'com.yahoo.vespa.hosted.provision.NodeRepository'
        Caused by: java.lang.IllegalStateException: No global component of class com.yahoo.config.provision.Exclusivity to inject into component 'NodeRepository' of type 'com.yahoo.vespa.hosted.provision.NodeRepository'.
```

Introduced with https://github.com/vespa-engine/vespa/pull/31241.
