### PR TITLE
Use __attribute__((noinline)) instead of glibc macro __attribute_noin…

### DIFF
--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
@@ -16,8 +16,8 @@ using search::attribute::DistanceMetric;
 
 size_t npos = std::string::npos;
 
-double run_calc(size_t iterations, TypedCells b, const BoundDistanceFunction & df) __attribute_noinline__;
-double run_calc_with_limit(size_t iterations, TypedCells b, const BoundDistanceFunction & df) __attribute_noinline__;
+double run_calc(size_t iterations, TypedCells b, const BoundDistanceFunction & df) __attribute__((noinline));
+double run_calc_with_limit(size_t iterations, TypedCells b, const BoundDistanceFunction & df) __attribute__((noinline));
 
 double
 run_calc(size_t iterations, TypedCells b, const BoundDistanceFunction & df) {
@@ -53,7 +53,7 @@ run_calc_with_limit(size_t iterations, TypedCells b, const BoundDistanceFunction
 }
 
 template<typename T>
-void benchmark(size_t iterations, size_t elems) __attribute_noinline__;
+void benchmark(size_t iterations, size_t elems) __attribute__((noinline));
 
 template<typename T>
 void benchmark(size_t iterations, size_t elems, const DistanceFunctionFactory & df) {

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.cpp
@@ -15,7 +15,7 @@ namespace {
 
 template<typename FromType, typename ToType>
 ConstArrayRef<ToType>
-convert_cells(ArrayRef<ToType> space, TypedCells cells) noexcept __attribute_noinline__;
+convert_cells(ArrayRef<ToType> space, TypedCells cells) noexcept __attribute__((noinline));
 
 template<typename FromType, typename ToType>
 ConstArrayRef<ToType>

--- a/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
+++ b/vespalib/src/vespa/vespalib/hwaccelrated/private_helpers.hpp
@@ -123,7 +123,7 @@ convert_bfloat16_to_float(const uint16_t *src, float *dest, size_t sz) noexcept 
 
 template<typename ACCUM = uint32_t>
 ACCUM
-multiplyAddT(const int8_t *a, const int8_t *b, size_t sz) noexcept __attribute_noinline__;
+multiplyAddT(const int8_t *a, const int8_t *b, size_t sz) noexcept __attribute__((noinline));
 
 template<typename ACCUM>
 ACCUM


### PR DESCRIPTION
…line__

@baldersheim : please review
