### PR TITLE
Improve error message when visiting with wrong document type

### DIFF
--- a/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
+++ b/vespaclient-container-plugin/src/main/java/com/yahoo/document/restapi/resource/DocumentV1ApiHandler.java
@@ -1621,8 +1621,8 @@ public class DocumentV1ApiHandler extends AbstractRequestHandler {
     static String resolveBucket(StorageCluster cluster, Optional<String> documentType,
                                 List<String> bucketSpaces, Optional<String> bucketSpace) {
         return documentType.map(type -> cluster.bucketOf(type)
-                                               .orElseThrow(() -> new IllegalArgumentException("Document type '" + type + "' in cluster '" + cluster.name() +
-                                                                                               "' is not mapped to a known bucket space")))
+                                               .orElseThrow(() -> new IllegalArgumentException("There is no document type '" + type + "' in cluster '" + cluster.name() +
+                                                                                               "', only '" + String.join("', '", cluster.documentBuckets.keySet()) + "'")))
                            .or(() -> bucketSpace.map(space -> {
                                if ( ! bucketSpaces.contains(space))
                                    throw new IllegalArgumentException("Bucket space '" + space + "' is not a known bucket space; expected one of " +

--- a/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
+++ b/vespaclient-container-plugin/src/test/java/com/yahoo/document/restapi/resource/DocumentV1ApiTest.java
@@ -185,8 +185,18 @@ public class DocumentV1ApiTest {
         StorageCluster cluster = DocumentV1ApiHandler.resolveCluster(Optional.of("content"), clusters);
         assertEquals(FixedBucketSpaces.defaultSpace(),
                      DocumentV1ApiHandler.resolveBucket(cluster, Optional.of("music"), List.of(), Optional.empty()));
+        assertEquals(FixedBucketSpaces.defaultSpace(),
+                     DocumentV1ApiHandler.resolveBucket(cluster, Optional.empty(), List.of(), Optional.empty()));
         assertEquals(FixedBucketSpaces.globalSpace(),
                      DocumentV1ApiHandler.resolveBucket(cluster, Optional.empty(), List.of(FixedBucketSpaces.globalSpace()), Optional.of("global")));
+        try {
+            DocumentV1ApiHandler.resolveBucket(cluster, Optional.of("musicc"), List.of(), Optional.empty());
+            fail("should fail with unknown document type");
+        }
+        catch (IllegalArgumentException e) {
+            assertEquals("There is no document type 'musicc' in cluster 'content', only 'music'",
+                         e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
@vekterli please review and merge.

Instead of complaining about missing a bucket space mapping, we instead tell the user that the document type was not found in the cluster, which is the actual cause. 