### PR TITLE
Make replica selection for Puts and bucket activation symmetric

### DIFF
--- a/storage/src/vespa/storage/config/distributorconfiguration.cpp
+++ b/storage/src/vespa/storage/config/distributorconfiguration.cpp
@@ -46,6 +46,7 @@ DistributorConfiguration::DistributorConfiguration(StorageComponent& component)
       _use_weak_internal_read_consistency_for_client_gets(false),
       _enable_metadata_only_fetch_phase_for_inconsistent_updates(true),
       _enable_operation_cancellation(false),
+      _symmetric_put_and_activate_replica_selection(false),
       _minimumReplicaCountingMode(ReplicaCountingMode::TRUSTED)
 {
 }
@@ -150,6 +151,7 @@ DistributorConfiguration::configure(const DistributorManagerConfig & config)
     _max_activation_inhibited_out_of_sync_groups = config.maxActivationInhibitedOutOfSyncGroups;
     _enable_operation_cancellation = config.enableOperationCancellation;
     _minimumReplicaCountingMode = deriveReplicaCountingMode(config.minimumReplicaCountingMode);
+    _symmetric_put_and_activate_replica_selection = config.symmetricPutAndActivateReplicaSelection;
 
     if (config.maxClusterClockSkewSec >= 0) {
         _maxClusterClockSkew = std::chrono::seconds(config.maxClusterClockSkewSec);

--- a/storage/src/vespa/storage/config/distributorconfiguration.h
+++ b/storage/src/vespa/storage/config/distributorconfiguration.h
@@ -234,8 +234,11 @@ public:
     [[nodiscard]] bool enable_operation_cancellation() const noexcept {
         return _enable_operation_cancellation;
     }
+    [[nodiscard]] bool symmetric_put_and_activate_replica_selection() const noexcept {
+        return _symmetric_put_and_activate_replica_selection;
+    }
 
-    bool containsTimeStatement(const std::string& documentSelection) const;
+    [[nodiscard]] bool containsTimeStatement(const std::string& documentSelection) const;
     
 private:
     StorageComponent& _component;
@@ -276,6 +279,7 @@ private:
     bool _use_weak_internal_read_consistency_for_client_gets;
     bool _enable_metadata_only_fetch_phase_for_inconsistent_updates; //TODO Rewrite tests and GC
     bool _enable_operation_cancellation;
+    bool _symmetric_put_and_activate_replica_selection;
 
     ReplicaCountingMode _minimumReplicaCountingMode;
 };

--- a/storage/src/vespa/storage/config/stor-distributormanager.def
+++ b/storage/src/vespa/storage/config/stor-distributormanager.def
@@ -159,6 +159,13 @@ num_distributor_stripes int default=0 restart
 ## requests partially or fully "invalidated" by such a change.
 enable_operation_cancellation bool default=false
 
+## Iff true there will be an 1-1 symmetry between the replicas chosen as feed targets
+## for Put operations and the replica selection logic for bucket activation. In particular,
+## the most preferred replica for feed will be the most preferred bucket for activation.
+## This helps ensure that new versions of documents are routed to replicas that are most
+## likely to reflect these changes as part of visible search results.
+symmetric_put_and_activate_replica_selection bool default=false
+
 ## TODO GC very soon, it has no effect.
 priority_merge_out_of_sync_copies int default=120
 

--- a/storage/src/vespa/storage/distributor/activecopy.cpp
+++ b/storage/src/vespa/storage/distributor/activecopy.cpp
@@ -108,6 +108,7 @@ buildNodeList(const BucketDatabase::Entry& e,vespalib::ConstArrayRef<uint16_t> n
 
 struct ActiveStateOrder {
     bool operator()(const ActiveCopy & e1, const ActiveCopy & e2) noexcept {
+        // Replica selection order should be kept in sync with OperationTargetResolverImpl's InstanceOrder.
         if (e1._ready != e2._ready) {
             return e1._ready;
         }
@@ -120,7 +121,9 @@ struct ActiveStateOrder {
         if (e1._active != e2._active) {
             return e1._active;
         }
-        return e1.nodeIndex() < e2.nodeIndex();
+        // Use _entry_ order instead of node index, as it is in ideal state order (even for retired
+        // nodes), which avoids unintentional affinities towards lower node indexes.
+        return e1.entryIndex() < e2.entryIndex();
     }
 };
 

--- a/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/putoperation.cpp
@@ -180,6 +180,8 @@ void PutOperation::start_direct_put_dispatch(DistributorStripeMessageSender& sen
                                                    _op_ctx.distributor_config().getMinimalBucketSplit(),
                                                    _bucket_space.getDistribution().getRedundancy(),
                                                    _msg->getBucket().getBucketSpace());
+        targetResolver.use_symmetric_replica_selection(
+                _op_ctx.distributor_config().symmetric_put_and_activate_replica_selection());
         OperationTargetList targets(targetResolver.getTargets(OperationTargetResolver::PUT, _doc_id_bucket_id));
 
         for (const auto& target : targets) {

--- a/storage/src/vespa/storage/distributor/operationtargetresolverimpl.h
+++ b/storage/src/vespa/storage/distributor/operationtargetresolverimpl.h
@@ -15,15 +15,17 @@ struct BucketInstance : public vespalib::AsciiPrintable {
     document::BucketId _bucket;
     api::BucketInfo    _info;
     lib::Node          _node;
-    uint16_t           _idealLocationPriority;
-    bool               _trusted;
-    bool               _exist;
+    uint16_t           _ideal_location_priority;
+    uint16_t           _db_entry_order;
+    bool               _trusted; // TODO remove
+    bool               _exists;
 
     BucketInstance() noexcept
-        : _idealLocationPriority(0xffff), _trusted(false), _exist(false) {}
+        : _ideal_location_priority(0xffff), _db_entry_order(0xffff), _trusted(false), _exists(false)
+    {}
     BucketInstance(const document::BucketId& id, const api::BucketInfo& info,
-                   lib::Node node, uint16_t idealLocationPriority, bool trusted,
-                   bool exist) noexcept;
+                   lib::Node node, uint16_t ideal_location_priority,
+                   uint16_t db_entry_order, bool trusted, bool exist) noexcept;
 
     void print(vespalib::asciistream& out, const PrintProperties&) const override;
 };
@@ -83,6 +85,7 @@ class OperationTargetResolverImpl : public OperationTargetResolver {
     uint32_t              _minUsedBucketBits;
     uint16_t              _redundancy;
     document::BucketSpace _bucketSpace;
+    bool                  _symmetric_replica_selection;
 
 public:
     OperationTargetResolverImpl(const DistributorBucketSpace& distributor_bucket_space,
@@ -94,8 +97,13 @@ public:
           _bucketDatabase(bucketDatabase),
           _minUsedBucketBits(minUsedBucketBits),
           _redundancy(redundancy),
-          _bucketSpace(bucketSpace)
+          _bucketSpace(bucketSpace),
+          _symmetric_replica_selection(true)
     {}
+
+    void use_symmetric_replica_selection(bool symmetry) noexcept {
+        _symmetric_replica_selection = symmetry;
+    }
 
     BucketInstanceList getAllInstances(OperationType type, const document::BucketId& id);
     BucketInstanceList getInstances(OperationType type, const document::BucketId& id) {


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

The legacy Put replica selection behavior may route new versions of a document to replicas that are not considered optimal for activation. This is not normally an issue, but can manifest itself as missing coverage (of new versions) when the system is in flux with replicas moving away from `retired` nodes containing ready replicas, as the existing replicas on the `retired` node would be preferred for activation (and thus be used for searches) but incoming Puts would instead be sent to non-retired nodes due to being in the ideal state.

The new replica ordering (and transitively, selection) behavior is identical between Puts and activation. This should help ensure that new versions of the document is routed to replica(s) that are most likely to be visible as part of searches.

New selection behavior for Puts is config-gated and defaults to the legacy behavior.

This also subtly changes the fallback ordering criteria for replica _activation_ to consider the replica's existing DB _entry_ order instead of its node index. Since DB entries are always ordered by their ideal state order (with `retired` nodes included), this will evenly distribute fallback activations rather than skewing them towards lower indexes. It is not expected that this has any negative effects in practice, and is therefore _not_ a config-gated change.

