### PR TITLE
Don't make elevated CC "events last week" column render as error if high

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/status/statuspage/VdsClusterHtmlRenderer.java
@@ -308,9 +308,7 @@ public class VdsClusterHtmlRenderer {
             int nodeEvents = eventLog.getNodeEventsSince(nodeInfo.getNode(),
                     currentTime - eventLog.getRecentTimePeriod());
             row.addCell(new HtmlTable.Cell("" + nodeEvents));
-            if (nodeEvents > 20) {
-                row.getLastCell().addProperties(ERROR_PROPERTY);
-            } else if (nodeEvents > 3) {
+            if (nodeEvents > 3) {
                 row.getLastCell().addProperties(WARNING_PROPERTY);
             }
         }


### PR DESCRIPTION
@hakonhall please review

The cluster controller has no notion of the nature of these events (could just be a benign upgrade cycle), so don't paint it with a scary red color that implies something is wrong in the cluster.

