### PR TITLE
Export cluster controller `cluster-buckets-out-of-sync-ratio` metric

### DIFF
--- a/metrics/src/main/java/ai/vespa/metrics/ClusterControllerMetrics.java
+++ b/metrics/src/main/java/ai/vespa/metrics/ClusterControllerMetrics.java
@@ -13,6 +13,7 @@ public enum ClusterControllerMetrics implements VespaMetrics {
     STOPPING_COUNT("cluster-controller.stopping.count", Unit.NODE, "Number of content nodes currently stopping"),
     UP_COUNT("cluster-controller.up.count", Unit.NODE, "Number of content nodes up"),
     CLUSTER_STATE_CHANGE_COUNT("cluster-controller.cluster-state-change.count", Unit.NODE, "Number of nodes changing state"),
+    CLUSTER_BUCKETS_OUT_OF_SYNC_RATIO("cluster-buckets-out-of-sync-ratio", Unit.FRACTION, "Ratio of buckets in the cluster currently in need of syncing"),
     BUSY_TICK_TIME_MS("cluster-controller.busy-tick-time-ms", Unit.MILLISECOND, "Time busy"),
     IDLE_TICK_TIME_MS("cluster-controller.idle-tick-time-ms", Unit.MILLISECOND, "Time idle"),
     WORK_MS("cluster-controller.work-ms", Unit.MILLISECOND, "Time used for actual work"),

--- a/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
+++ b/metrics/src/main/java/ai/vespa/metrics/set/VespaMetricSet.java
@@ -258,6 +258,7 @@ public class VespaMetricSet {
         addMetric(metrics, ClusterControllerMetrics.STOPPING_COUNT.last());
         addMetric(metrics, ClusterControllerMetrics.UP_COUNT, EnumSet.of(max, last)); // TODO: Vespa 9: Remove last
         addMetric(metrics, ClusterControllerMetrics.CLUSTER_STATE_CHANGE_COUNT.baseName());
+        addMetric(metrics, ClusterControllerMetrics.CLUSTER_BUCKETS_OUT_OF_SYNC_RATIO.max());
         addMetric(metrics, ClusterControllerMetrics.BUSY_TICK_TIME_MS, EnumSet.of(last, max, sum, count)); // TODO: Vespa 9: Remove last
         addMetric(metrics, ClusterControllerMetrics.IDLE_TICK_TIME_MS, EnumSet.of(last, max, sum, count)); // TODO: Vespa 9: Remove last
 


### PR DESCRIPTION
@yngveaasheim please review. Using the `max` aggregate here seems to be in line with the other metrics.
