### PR TITLE
Add test showing that inheriting a non-existent document summary give…

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/documentmodel/DocumentSummary.java
+++ b/config-model/src/main/java/com/yahoo/vespa/documentmodel/DocumentSummary.java
@@ -124,10 +124,9 @@ public class DocumentSummary extends FieldView {
             if (inheritedSummary == null) {
                 // TODO Vespa 9: Throw IllegalArgumentException instead
                 logger.logApplicationPackage(Level.WARNING,
-                                             this + " inherits '" + inheritedName + "' but this" + " is not present in " + owner);
+                                             this + " inherits '" + inheritedName + "' but this is not present in " + owner);
             }
         }
-
     }
 
 }

--- a/config-model/src/test/java/com/yahoo/schema/processing/SummaryConsistencyTestCase.java
+++ b/config-model/src/test/java/com/yahoo/schema/processing/SummaryConsistencyTestCase.java
@@ -5,6 +5,7 @@ import com.yahoo.schema.Schema;
 import com.yahoo.schema.ApplicationBuilder;
 import com.yahoo.schema.parser.ParseException;
 import com.yahoo.vespa.documentmodel.SummaryTransform;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static com.yahoo.config.model.test.TestUtil.joinLines;
@@ -42,4 +43,26 @@ public class SummaryConsistencyTestCase {
         Schema schema = ApplicationBuilder.createFromString(sd).getSchema();
         assertEquals(SummaryTransform.ATTRIBUTECOMBINER, schema.getSummaryField("elem_array_unfiltered").getTransform());
     }
+
+    @Test
+    @Disabled
+    void testDocumentTypesWithInheritanceOfNonExistingField() throws ParseException {
+        String schemaString = """
+                schema foo {
+                  document foo {
+                    field foo type string {
+                        indexing: summary
+                    }
+                  }
+                  document-summary foo_summary inherits non-existent {
+                    summary foo {
+                        source: foo
+                    }
+                  }
+                }
+                """;
+        var schema = ApplicationBuilder.createFromString(schemaString).getSchema();
+        schema.getSummaryField("foo_summary");
+    }
+
 }


### PR DESCRIPTION
…s NullPointerException

Today we give a warning and plan to fix this in Vespa 9. This test shows that we might as well throw as we get a NullPointerException and config server returns and internal server error when this happens, which is worse.

@baldersheim the fix is easy, but it is marked for change in Vespa 9, any objections to changing it now?