### PR TITLE
Disable OmitStackTraceInFastThrow everywhere

### DIFF
--- a/client/go/internal/admin/jvm/standalone_container.go
+++ b/client/go/internal/admin/jvm/standalone_container.go
@@ -37,7 +37,6 @@ func (a *StandaloneContainer) configureOptions() {
 	opts := a.jvmOpts
 	opts.ConfigureCpuCount(0)
 	opts.AddCommonXX()
-	opts.AddOption("-XX:-OmitStackTraceInFastThrow")
 	opts.AddCommonOpens()
 	opts.AddCommonJdkProperties()
 	a.addJdiscProperties()

--- a/client/go/internal/admin/jvm/xx_options.go
+++ b/client/go/internal/admin/jvm/xx_options.go
@@ -19,5 +19,5 @@ func (opts *Options) AddCommonXX() {
 	// not common after all:
 	opts.AddOption("-XX:MaxJavaStackTraceDepth=1000000")
 	// Aid debugging for slight cost in performance
-	opts.AddOption("-XX:+OmitStackTraceInFastThrow")
+	opts.AddOption("-XX:-OmitStackTraceInFastThrow")
 }


### PR DESCRIPTION
Removes the need to control this with a feature flag. Comment in AddCommonXX not touched, as it is now actually correct.
