### PR TITLE
Less copying of cluster state bundles

### DIFF
--- a/storage/src/vespa/storage/storageserver/rpc/cluster_controller_api_rpc_service.cpp
+++ b/storage/src/vespa/storage/storageserver/rpc/cluster_controller_api_rpc_service.cpp
@@ -124,7 +124,8 @@ void ClusterControllerApiRpcService::RPC_setSystemState2(FRT_RPCRequest* req) {
                                     req->GetParams()->GetValue(0)._string._len);
     lib::ClusterState systemState(systemStateStr);
 
-    auto cmd = std::make_shared<api::SetSystemStateCommand>(lib::ClusterStateBundle(systemState));
+    auto bundle = std::make_shared<const lib::ClusterStateBundle>(systemState);
+    auto cmd = std::make_shared<api::SetSystemStateCommand>(std::move(bundle));
     cmd->setPriority(api::StorageMessage::VERYHIGH);
 
     detach_and_forward_to_enqueuer(std::move(cmd), req);
@@ -167,8 +168,7 @@ void ClusterControllerApiRpcService::RPC_setDistributionStates(FRT_RPCRequest* r
     }
     LOG(debug, "Got state bundle %s", state_bundle->toString().c_str());
 
-    // TODO add constructor taking in shared_ptr directly instead?
-    auto cmd = std::make_shared<api::SetSystemStateCommand>(*state_bundle);
+    auto cmd = std::make_shared<api::SetSystemStateCommand>(std::move(state_bundle));
     cmd->setPriority(api::StorageMessage::VERYHIGH);
 
     detach_and_forward_to_enqueuer(std::move(cmd), req);

--- a/storage/src/vespa/storageapi/message/state.h
+++ b/storage/src/vespa/storageapi/message/state.h
@@ -61,13 +61,19 @@ public:
  *  put/get/remove etx)
  */
 class SetSystemStateCommand : public StorageCommand {
-    lib::ClusterStateBundle _state;
+    std::shared_ptr<const lib::ClusterStateBundle> _state;
 
 public:
+    explicit SetSystemStateCommand(std::shared_ptr<const lib::ClusterStateBundle> state);
     explicit SetSystemStateCommand(const lib::ClusterStateBundle &state);
     explicit SetSystemStateCommand(const lib::ClusterState &state);
-    const lib::ClusterState& getSystemState() const { return *_state.getBaselineClusterState(); }
-    const lib::ClusterStateBundle& getClusterStateBundle() const { return _state; }
+    ~SetSystemStateCommand() override;
+
+    [[nodiscard]] const lib::ClusterState& getSystemState() const { return *_state->getBaselineClusterState(); }
+    [[nodiscard]] const lib::ClusterStateBundle& getClusterStateBundle() const { return *_state; }
+    [[nodiscard]] std::shared_ptr<const lib::ClusterStateBundle> cluster_state_bundle_ptr() const noexcept {
+        return _state;
+    }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 
     DECLARE_STORAGECOMMAND(SetSystemStateCommand, onSetSystemState)
@@ -80,14 +86,14 @@ public:
  * @brief Reply received after a SetSystemStateCommand.
  */
 class SetSystemStateReply : public StorageReply {
-    lib::ClusterStateBundle _state;
+    std::shared_ptr<const lib::ClusterStateBundle> _state;
 
 public:
     explicit SetSystemStateReply(const SetSystemStateCommand& cmd);
 
     // Not serialized. Available locally
-    const lib::ClusterState& getSystemState() const { return *_state.getBaselineClusterState(); }
-    const lib::ClusterStateBundle& getClusterStateBundle() const { return _state; }
+    const lib::ClusterState& getSystemState() const { return *_state->getBaselineClusterState(); }
+    const lib::ClusterStateBundle& getClusterStateBundle() const { return *_state; }
     void print(std::ostream& out, bool verbose, const std::string& indent) const override;
 
     DECLARE_STORAGEREPLY(SetSystemStateReply, onSetSystemStateReply)


### PR DESCRIPTION
@baldersheim please review.

Already decoded into a `shared_ptr` during RPC request handling; might as well use it.

