### PR TITLE
Support enforcing strictly increasing state versions across cluster controllers

### DIFF
--- a/storage/src/vespa/storage/config/stor-server.def
+++ b/storage/src/vespa/storage/config/stor-server.def
@@ -118,3 +118,11 @@ content_node_bucket_db_stripe_bits int default=4 restart
 ## Iff set, a special `pidfile` file is written under the node's root directory upon
 ## startup containing the PID of the running process.
 write_pid_file_on_startup bool default=true
+
+## Iff true, received cluster state versions that are lower than the current active
+## (or pending to be active) version on the node will be explicitly rejected. This
+## prevents race conditions caused by multiple cluster controllers believing they
+## are the leader during overlapping time intervals, as only the most recent leader
+## is able to increment the current state version in ZooKeeper, but the old controller
+## may still attempt to publish its old state.
+require_strictly_increasing_cluster_state_versions bool default=false

--- a/storage/src/vespa/storage/storageserver/storagenode.h
+++ b/storage/src/vespa/storage/storageserver/storagenode.h
@@ -135,6 +135,10 @@ private:
     // Depends on metric manager
     std::unique_ptr<StateReporter>             _stateReporter;
     std::unique_ptr<StateManager>              _stateManager;
+    // Node subclasses may take ownership of _stateManager in order to infuse it into
+    // their own storage link chain, but they MUST ensure its lifetime is maintained.
+    // We need to remember the original pointer in order to update its config.
+    StateManager*                              _state_manager_ptr;
 
     // The storage chain can depend on anything.
     std::unique_ptr<StorageLink>               _chain;

--- a/storage/src/vespa/storageapi/message/state.h
+++ b/storage/src/vespa/storageapi/message/state.h
@@ -9,12 +9,6 @@
 
 namespace storage::api {
 
-/**
- * @class GetNodeStateCommand
- * @ingroup message
- *
- * @brief Command for setting node state. No payload
- */
 class GetNodeStateCommand : public StorageCommand {
     lib::NodeState::UP _expectedState;
 
@@ -27,12 +21,6 @@ public:
     DECLARE_STORAGECOMMAND(GetNodeStateCommand, onGetNodeState)
 };
 
-/**
- * @class GetNodeStateReply
- * @ingroup message
- *
- * @brief Reply to GetNodeStateCommand
- */
 class GetNodeStateReply : public StorageReply {
     lib::NodeState::UP _state;
     std::string _nodeInfo;
@@ -53,12 +41,9 @@ public:
 };
 
 /**
- * @class SetSystemStateCommand
- * @ingroup message
- *
- * @brief Command for telling a node about the system state - state of each node
- *  in the system and state of the system (all ok, no merging, block
- *  put/get/remove etx)
+ * Command for telling a node about the cluster state - state of each node
+ * in the cluster and state of the cluster itself (all ok, no merging, block
+ * put/get/remove etx)
  */
 class SetSystemStateCommand : public StorageCommand {
     std::shared_ptr<const lib::ClusterStateBundle> _state;
@@ -79,12 +64,6 @@ public:
     DECLARE_STORAGECOMMAND(SetSystemStateCommand, onSetSystemState)
 };
 
-/**
- * @class SetSystemStateReply
- * @ingroup message
- *
- * @brief Reply received after a SetSystemStateCommand.
- */
 class SetSystemStateReply : public StorageReply {
     std::shared_ptr<const lib::ClusterStateBundle> _state;
 


### PR DESCRIPTION
@baldersheim please review
@geirst FYI

Adds a (live) config that specifies if content nodes and distributors shall reject cluster state versions that are lower than the one that is currently active on the node. This prevents "last write wins" ordering problems when multiple cluster controllers have partially overlapping leadership periods.

In the name of pragmatism, we try to auto-detect the case where ZooKeeper state must have been lost on the cluster controller cluster, and accept the state even with lower version number. Otherwise, the content cluster would be effectively stalled until all its processes had been manually restarted.

Adds wiring of live config to the `StateManager` component on both content and distributor nodes.
