### PR TITLE
Add feature flag for enforcing strictly increasing cluster state versions

### DIFF
--- a/config-model-api/abi-spec.json
+++ b/config-model-api/abi-spec.json
@@ -1329,7 +1329,8 @@
       "public boolean logserverOtelCol()",
       "public com.yahoo.config.provision.SharedHosts sharedHosts()",
       "public com.yahoo.config.provision.NodeResources$Architecture adminClusterArchitecture()",
-      "public boolean symmetricPutAndActivateReplicaSelection()"
+      "public boolean symmetricPutAndActivateReplicaSelection()",
+      "public boolean enforceStrictlyIncreasingClusterStateVersions()"
     ],
     "fields" : [ ]
   },

--- a/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
+++ b/config-model-api/src/main/java/com/yahoo/config/model/api/ModelContext.java
@@ -120,6 +120,7 @@ public interface ModelContext {
         @ModelFeatureFlag(owners = {"bratseth"}) default SharedHosts sharedHosts() { return SharedHosts.empty(); }
         @ModelFeatureFlag(owners = {"bratseth"}) default Architecture adminClusterArchitecture() { return Architecture.x86_64; }
         @ModelFeatureFlag(owners = {"vekterli"}) default boolean symmetricPutAndActivateReplicaSelection() { return false; }
+        @ModelFeatureFlag(owners = {"vekterli"}) default boolean enforceStrictlyIncreasingClusterStateVersions() { return false; }
     }
 
     /** Warning: As elsewhere in this package, do not make backwards incompatible changes that will break old config models! */

--- a/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
+++ b/config-model/src/main/java/com/yahoo/config/model/deploy/TestProperties.java
@@ -84,6 +84,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     private int persistenceThreadMaxFeedOpBatchSize = 1;
     private boolean logserverOtelCol = false;
     private boolean symmetricPutAndActivateReplicaSelection = false;
+    private boolean enforceStrictlyIncreasingClusterStateVersions = false;
 
     @Override public ModelContext.FeatureFlags featureFlags() { return this; }
     @Override public boolean multitenant() { return multitenant; }
@@ -142,6 +143,7 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
     @Override public int persistenceThreadMaxFeedOpBatchSize() { return persistenceThreadMaxFeedOpBatchSize; }
     @Override public boolean logserverOtelCol() { return logserverOtelCol; }
     @Override public boolean symmetricPutAndActivateReplicaSelection() { return symmetricPutAndActivateReplicaSelection; }
+    @Override public boolean enforceStrictlyIncreasingClusterStateVersions() { return enforceStrictlyIncreasingClusterStateVersions; }
 
     public TestProperties sharedStringRepoNoReclaim(boolean sharedStringRepoNoReclaim) {
         this.sharedStringRepoNoReclaim = sharedStringRepoNoReclaim;
@@ -379,6 +381,11 @@ public class TestProperties implements ModelContext.Properties, ModelContext.Fea
 
     public TestProperties setSymmetricPutAndActivateReplicaSelection(boolean symmetricReplicaSelection) {
         this.symmetricPutAndActivateReplicaSelection = symmetricReplicaSelection;
+        return this;
+    }
+
+    public TestProperties setEnforceStrictlyIncreasingClusterStateVersions(boolean enforce) {
+        this.enforceStrictlyIncreasingClusterStateVersions = enforce;
         return this;
     }
 

--- a/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/content/DistributorCluster.java
@@ -36,6 +36,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
     private final int maxActivationInhibitedOutOfSyncGroups;
     private final int contentLayerMetadataFeatureLevel;
     private final boolean symmetricPutAndActivateReplicaSelection;
+    private final boolean enforceStrictlyIncreasingClusterStateVersions;
 
     public static class Builder extends VespaDomBuilder.DomConfigProducerBuilderBase<DistributorCluster> {
 
@@ -100,13 +101,15 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
             int maxInhibitedGroups = featureFlags.maxActivationInhibitedOutOfSyncGroups();
             int contentLayerMetadataFeatureLevel = featureFlags.contentLayerMetadataFeatureLevel();
             boolean symmetricPutAndActivateReplicaSelection = featureFlags.symmetricPutAndActivateReplicaSelection();
+            boolean enforceStrictlyIncreasingClusterStateVersions = featureFlags.enforceStrictlyIncreasingClusterStateVersions();
 
             return new DistributorCluster(parent,
                     new BucketSplitting.Builder().build(new ModelElement(producerSpec)), gc,
                     hasIndexedDocumentType,
                     maxInhibitedGroups,
                     contentLayerMetadataFeatureLevel,
-                    symmetricPutAndActivateReplicaSelection);
+                    symmetricPutAndActivateReplicaSelection,
+                    enforceStrictlyIncreasingClusterStateVersions);
         }
     }
 
@@ -114,7 +117,8 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
                                GcOptions gc, boolean hasIndexedDocumentType,
                                int maxActivationInhibitedOutOfSyncGroups,
                                int contentLayerMetadataFeatureLevel,
-                               boolean symmetricPutAndActivateReplicaSelection)
+                               boolean symmetricPutAndActivateReplicaSelection,
+                               boolean enforceStrictlyIncreasingClusterStateVersions)
     {
         super(parent, "distributor");
         this.parent = parent;
@@ -124,6 +128,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         this.maxActivationInhibitedOutOfSyncGroups = maxActivationInhibitedOutOfSyncGroups;
         this.contentLayerMetadataFeatureLevel = contentLayerMetadataFeatureLevel;
         this.symmetricPutAndActivateReplicaSelection = symmetricPutAndActivateReplicaSelection;
+        this.enforceStrictlyIncreasingClusterStateVersions = enforceStrictlyIncreasingClusterStateVersions;
     }
 
     @Override
@@ -159,6 +164,7 @@ public class DistributorCluster extends TreeConfigProducer<Distributor> implemen
         builder.root_folder("");
         builder.cluster_name(parent.getName());
         builder.is_distributor(true);
+        builder.require_strictly_increasing_cluster_state_versions(enforceStrictlyIncreasingClusterStateVersions);
     }
 
     public String getClusterName() {

--- a/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/content/ContentClusterTest.java
@@ -1576,6 +1576,32 @@ public class ContentClusterTest extends ContentBaseTest {
         assertEquals(warnings, "");
     }
 
+    private void checkStrictlyIncreasingClusterStateVersionConfig(Boolean flagValue, boolean expected) throws Exception {
+        var props = new TestProperties();
+        if (flagValue != null) {
+            props.setEnforceStrictlyIncreasingClusterStateVersions(flagValue);
+        }
+        var cc = createOneNodeCluster(props);
+
+        // stor-server config should be the same for both distributors and storage nodes
+        var builder = new StorServerConfig.Builder();
+        cc.getStorageCluster().getConfig(builder);
+        var cfg = builder.build();
+        assertEquals(expected, cfg.require_strictly_increasing_cluster_state_versions());
+
+        builder = new StorServerConfig.Builder();
+        cc.getDistributorNodes().getConfig(builder);
+        cfg = builder.build();
+        assertEquals(expected, cfg.require_strictly_increasing_cluster_state_versions());
+    }
+
+    @Test
+    void strictly_increasing_cluster_state_versions_config_controlled_by_feature_flag() throws Exception {
+        checkStrictlyIncreasingClusterStateVersionConfig(null, false); // TODO change default
+        checkStrictlyIncreasingClusterStateVersionConfig(false, false);
+        checkStrictlyIncreasingClusterStateVersionConfig(true, true);
+    }
+
     private String servicesWithGroups(int groupCount, double minGroupUpRatio) {
         String services = String.format("<?xml version='1.0' encoding='UTF-8' ?>" +
                 "<services version='1.0'>" +

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/deploy/ModelContextImpl.java
@@ -213,6 +213,7 @@ public class ModelContextImpl implements ModelContext {
         private final SharedHosts sharedHosts;
         private final Architecture adminClusterArchitecture;
         private final boolean symmetricPutAndActivateReplicaSelection;
+        private final boolean enforceStrictlyIncreasingClusterStateVersions;
 
         public FeatureFlags(FlagSource source, ApplicationId appId, Version version) {
             this.defaultTermwiseLimit = Flags.DEFAULT_TERM_WISE_LIMIT.bindTo(source).with(appId).with(version).value();
@@ -259,6 +260,7 @@ public class ModelContextImpl implements ModelContext {
             this.sharedHosts = PermanentFlags.SHARED_HOST.bindTo(source).with( appId).with(version).value();
             this.adminClusterArchitecture = Architecture.valueOf(PermanentFlags.ADMIN_CLUSTER_NODE_ARCHITECTURE.bindTo(source).with(appId).with(version).value());
             this.symmetricPutAndActivateReplicaSelection = Flags.SYMMETRIC_PUT_AND_ACTIVATE_REPLICA_SELECTION.bindTo(source).with(appId).with(version).value();
+            this.enforceStrictlyIncreasingClusterStateVersions = Flags.ENFORCE_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS.bindTo(source).with(appId).with(version).value();
         }
 
         @Override public int heapSizePercentage() { return heapPercentage; }
@@ -311,6 +313,7 @@ public class ModelContextImpl implements ModelContext {
         @Override public SharedHosts sharedHosts() { return sharedHosts; }
         @Override public Architecture adminClusterArchitecture() { return adminClusterArchitecture; }
         @Override public boolean symmetricPutAndActivateReplicaSelection() { return symmetricPutAndActivateReplicaSelection; }
+        @Override public boolean enforceStrictlyIncreasingClusterStateVersions() { return enforceStrictlyIncreasingClusterStateVersions; }
     }
 
     public static class Properties implements ModelContext.Properties {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -451,6 +451,14 @@ public class Flags {
             "Takes effect immediately",
             INSTANCE_ID);
 
+    public static final UnboundBooleanFlag ENFORCE_STRICTLY_INCREASING_CLUSTER_STATE_VERSIONS = defineFeatureFlag(
+            "enforce-strictly-increasing-cluster-state-versions", false,
+            List.of("vekterli"), "2024-06-03", "2024-08-01",
+            "Iff true, received cluster state versions that are lower than the current active " +
+            "state version on the node will be explicitly rejected.",
+            "Takes effect immediately",
+            INSTANCE_ID);
+
     public static final UnboundBooleanFlag HUBSPOT_SYNC_CONTACTS = defineFeatureFlag(
             "hubspot-sync-contacts", false,
             List.of("bjorncs"), "2024-05-27", "2025-01-01",


### PR DESCRIPTION
@baldersheim please review.

Applies to `stor-server` config for both distributors and storage nodes.

Defaults to `false` for now.
