### PR TITLE
Remove default value for proton::matching::MatchParams constructor.

### DIFF
--- a/searchcore/src/vespa/searchcore/proton/matching/match_params.h
+++ b/searchcore/src/vespa/searchcore/proton/matching/match_params.h
@@ -26,7 +26,7 @@ struct MatchParams {
                 uint32_t          offset_in,
                 uint32_t          hits_in,
                 bool              hasFinalRank,
-                bool              needRanking=true);
+                bool              needRanking);
     bool save_rank_scores() const noexcept { return (arraySize != 0); }
     bool has_rank_drop_limit() const;
 };


### PR DESCRIPTION
@geirst : please review
