### PR TITLE
Avoid running ctest and make install together.

### DIFF
--- a/.buildkite/Makefile
+++ b/.buildkite/Makefile
@@ -53,7 +53,7 @@ cpp: bootstrap-cmake
 cpp-test: cpp
 	@$(TOP)/execute.sh $@
 
-install: cpp java
+install: cpp java cpp-test
 	@$(TOP)/execute.sh $@
 
 build-rpms: install


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

`ctest3` is not happy when `make install` strips the running test.
