### PR TITLE
Add metric for number of nodes not converged to the latest cluster state version

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/MetricUpdater.java
@@ -10,6 +10,7 @@ import com.yahoo.vespa.clustercontroller.utils.util.ComponentMetricReporter;
 import com.yahoo.vespa.clustercontroller.utils.util.MetricReporter;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedSet;
@@ -19,15 +20,25 @@ import java.util.function.BooleanSupplier;
 public class MetricUpdater {
 
     private final ComponentMetricReporter metricReporter;
+    private final Timer timer;
+    // Publishing and converging on a cluster state version is never instant nor atomic, but
+    // it usually completes within a few seconds. If convergence does not happen for more than
+    // 30 seconds, it's a sign something has stalled.
+    private Duration stateVersionConvergenceGracePeriod = Duration.ofSeconds(30);
 
-    public MetricUpdater(MetricReporter metricReporter, int controllerIndex, String clusterName) {
+    public MetricUpdater(MetricReporter metricReporter, Timer timer, int controllerIndex, String clusterName) {
         this.metricReporter = new ComponentMetricReporter(metricReporter, "cluster-controller.");
         this.metricReporter.addDimension("controller-index", String.valueOf(controllerIndex));
         this.metricReporter.addDimension("clusterid", clusterName);
+        this.timer = timer;
     }
 
     public MetricReporter.Context createContext(Map<String, String> dimensions) {
         return metricReporter.createContext(dimensions);
+    }
+
+    public void setStateVersionConvergenceGracePeriod(Duration gracePeriod) {
+        stateVersionConvergenceGracePeriod = gracePeriod;
     }
 
     private static int nodesInAvailableState(Map<State, Integer> nodeCounts) {
@@ -39,10 +50,13 @@ public class MetricUpdater {
                 + nodeCounts.getOrDefault(State.MAINTENANCE, 0);
     }
 
-    public void updateClusterStateMetrics(ContentCluster cluster, ClusterState state, ResourceUsageStats resourceUsage) {
+    public void updateClusterStateMetrics(ContentCluster cluster, ClusterState state,
+                                          ResourceUsageStats resourceUsage, Instant lastStateBroadcastTimePoint) {
         Map<String, String> dimensions = new HashMap<>();
         dimensions.put("cluster", cluster.getName());
         dimensions.put("clusterid", cluster.getName());
+        Instant now = timer.getCurrentWallClockTime();
+        boolean convergenceDeadlinePassed = lastStateBroadcastTimePoint.plus(stateVersionConvergenceGracePeriod).isBefore(now);
         for (NodeType type : NodeType.getTypes()) {
             dimensions.put("node-type", type.toString().toLowerCase());
             MetricReporter.Context context = createContext(dimensions);
@@ -50,10 +64,18 @@ public class MetricUpdater {
             for (State s : State.values()) {
                 nodeCounts.put(s, 0);
             }
+            int nodesNotConverged = 0;
             for (Integer i : cluster.getConfiguredNodes().keySet()) {
-                NodeState s = state.getNodeState(new Node(type, i));
+                var node = new Node(type, i);
+                NodeState s = state.getNodeState(node);
                 Integer count = nodeCounts.get(s.getState());
                 nodeCounts.put(s.getState(), count + 1);
+                var info = cluster.getNodeInfo(node);
+                if (info != null && convergenceDeadlinePassed && s.getState().oneOf("uir")) {
+                    if (info.getClusterStateVersionBundleAcknowledged() != state.getVersion()) {
+                        nodesNotConverged++;
+                    }
+                }
             }
             for (State s : State.values()) {
                 String name = s.toString().toLowerCase() + ".count";
@@ -63,6 +85,7 @@ public class MetricUpdater {
             final int availableNodes = nodesInAvailableState(nodeCounts);
             final int totalNodes = Math.max(cluster.getConfiguredNodes().size(), 1); // Assumes 1-1 between distributor and storage
             metricReporter.set("available-nodes.ratio", (double)availableNodes / totalNodes, context);
+            metricReporter.set("nodes-not-converged", nodesNotConverged, context);
         }
         dimensions.remove("node-type");
         MetricReporter.Context context = createContext(dimensions);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RealTimer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/RealTimer.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -10,8 +11,9 @@ import java.util.TimeZone;
  */
 public class RealTimer implements Timer {
 
-    public long getCurrentTimeInMillis() {
-        return System.currentTimeMillis();
+    @Override
+    public Instant getCurrentWallClockTime() {
+        return Instant.now();
     }
 
     public static String printDuration(long time) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/SystemStateBroadcaster.java
@@ -8,6 +8,7 @@ import com.yahoo.vdslib.state.NodeState;
 import com.yahoo.vdslib.state.State;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseHandler;
 
+import java.time.Instant;
 import java.util.logging.Level;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,6 +30,7 @@ public class SystemStateBroadcaster {
     private final static long minTimeBetweenNodeErrorLogging = 10 * 60 * 1000;
     private final Map<Node, Long> lastErrorReported = new TreeMap<>();
 
+    private Instant lastStateBroadcastTimePoint = Instant.EPOCH;
     private int lastOfficialStateVersion = -1;
     private int lastStateVersionBundleAcked = 0;
     private int lastClusterStateVersionConverged = 0;
@@ -45,6 +47,7 @@ public class SystemStateBroadcaster {
 
     public void handleNewClusterStates(ClusterStateBundle state) {
         clusterStateBundle = state;
+        lastStateBroadcastTimePoint = Instant.ofEpochMilli(timer.getCurrentTimeInMillis());
     }
 
     public ClusterState getClusterState() {
@@ -65,6 +68,10 @@ public class SystemStateBroadcaster {
 
     public ClusterStateBundle getLastClusterStateBundleConverged() {
         return lastClusterStateBundleConverged;
+    }
+
+    public Instant getLastStateBroadcastTimePoint() {
+        return lastStateBroadcastTimePoint;
     }
 
     private void reportNodeError(boolean nodeOk, NodeInfo info, String message) {

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/Timer.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/Timer.java
@@ -1,12 +1,18 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import java.time.Instant;
+
 /**
  * Interface used to get time. This is separated into its own class, such that unit tests can fake timing to do timing related
  * tests without relying on the speed of the unit test processing.
  */
 public interface Timer {
 
-    long getCurrentTimeInMillis();
+    Instant getCurrentWallClockTime();
+
+    default long getCurrentTimeInMillis() {
+        return getCurrentWallClockTime().toEpochMilli();
+    }
 
 }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentClusterHtmlRendererTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ContentClusterHtmlRendererTest.java
@@ -30,8 +30,9 @@ public class ContentClusterHtmlRendererTest {
         ClusterStateBundle stateBundle = ClusterStateBundle.ofBaselineOnly(
                 AnnotatedClusterState.withoutAnnotations(
                         ClusterState.stateFromString("version:34633 bits:24 distributor:211 storage:211")));
-        var metricUpdater = new MetricUpdater(new NoMetricReporter(), 0, clusterName);
-        EventLog eventLog = new EventLog(new FakeTimer(), metricUpdater);
+        var timer = new FakeTimer();
+        var metricUpdater = new MetricUpdater(new NoMetricReporter(), timer, 0, clusterName);
+        EventLog eventLog = new EventLog(timer, metricUpdater);
         VdsClusterHtmlRenderer.Table table = renderer.createNewClusterHtmlTable(clusterName, slobrokGeneration);
         ContentCluster contentCluster = mock(ContentCluster.class);
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FakeTimer.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FakeTimer.java
@@ -1,6 +1,7 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 package com.yahoo.vespa.clustercontroller.core;
 
+import java.time.Instant;
 import java.util.logging.Level;
 import com.yahoo.vespa.clustercontroller.core.testutils.LogFormatter;
 
@@ -22,8 +23,9 @@ public class FakeTimer implements Timer {
     // Don't start at zero. Clock users may initialize a 'last run' entry with 0, and we want first time to always look like a timeout
     private long currentTime = (long) 30 * 365 * 24 * 60 * 60 * 1000;
 
-    public synchronized long getCurrentTimeInMillis() {
-        return currentTime;
+    @Override
+    public synchronized Instant getCurrentWallClockTime() {
+        return Instant.ofEpochMilli(currentTime);
     }
 
     public synchronized void advanceTime(long time) {

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
@@ -120,7 +120,7 @@ public abstract class FleetControllerTest implements Waiter {
                                           RpcServer rpcServer,
                                           boolean start) {
         waiter = createWaiter(timer);
-        var metricUpdater = new MetricUpdater(new NoMetricReporter(), options.fleetControllerIndex(), options.clusterName());
+        var metricUpdater = new MetricUpdater(new NoMetricReporter(), timer, options.fleetControllerIndex(), options.clusterName());
         var log = new EventLog(timer, metricUpdater);
         var cluster = new ContentCluster(options.clusterName(), options.nodes(), options.storageDistribution());
         var stateGatherer = new NodeStateGatherer(timer, timer, log);


### PR DESCRIPTION
@hakonhall please review

There is a grace period (currently hard-coded to 30s) between the time a new state version is published and before nodes are counted as not converging. This state is not sticky for a given node, so if the state keeps changing constantly it's possible that we under- count the number of non-converging nodes. But this can be improved over time; for now it's primarily a source from which we can generate alerts, as failures to converge can manifest itself as other failures in the content cluster.

Also move out of sync ratio computations to the periodic metric update functionality and reset it if the current controller is not the believed cluster leader.

Start moving some CC timer code to use `Instant` instead of implicit units with `long`s.

This relates to #29861 but does not add any API etc to communicate the _set_ of nodes that are not converging (this will—however—be visible through the cluster controller status page).
