### PR TITLE
Rename metric context "job" due to overlap with prometheus

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintainer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/maintenance/ConfigServerMaintainer.java
@@ -47,7 +47,7 @@ public abstract class ConfigServerMaintainer extends Maintainer {
 
         @Override
         public void completed(String job, double successFactorDeviation, long durationMs) {
-            var context = metric.createContext(Map.of("job", job));
+            var context = metric.createContext(Map.of("maintainer", job));
             metric.set("maintenance.successFactorDeviation", successFactorDeviation, context);
             metric.set("maintenance.duration", durationMs, context);
         }

--- a/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintainer.java
+++ b/node-repository/src/main/java/com/yahoo/vespa/hosted/provision/maintenance/NodeRepositoryMaintainer.java
@@ -58,7 +58,7 @@ public abstract class NodeRepositoryMaintainer extends Maintainer {
 
         @Override
         public void completed(String job, double successFactor, long duration) {
-            var context = metric.createContext(Map.of("job", job));
+            var context = metric.createContext(Map.of("maintainer", job));
             metric.set("maintenance.successFactorDeviation", successFactor, context);
             metric.set("maintenance.duration", duration, context);
         }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
