### PR TITLE
Add rendering of hits (and trace and timing etc) in llm rendering

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -9227,7 +9227,7 @@
     "methods" : [
       "public void <init>(ai.vespa.search.llm.LlmSearcherConfig, com.yahoo.component.provider.ComponentRegistry)",
       "public com.yahoo.search.Result search(com.yahoo.search.Query, com.yahoo.search.searchchain.Execution)",
-      "protected com.yahoo.search.Result complete(com.yahoo.search.Query, ai.vespa.llm.completion.Prompt)",
+      "protected com.yahoo.search.Result complete(com.yahoo.search.Query, ai.vespa.llm.completion.Prompt, com.yahoo.search.Result, com.yahoo.search.searchchain.Execution)",
       "public java.lang.String getPrompt(com.yahoo.search.Query)",
       "public java.lang.String getPropertyPrefix()",
       "public java.lang.String lookupProperty(java.lang.String, com.yahoo.search.Query)",

--- a/container-search/src/main/java/ai/vespa/search/llm/RAGSearcher.java
+++ b/container-search/src/main/java/ai/vespa/search/llm/RAGSearcher.java
@@ -37,7 +37,7 @@ public class RAGSearcher extends LLMSearcher {
     public Result search(Query query, Execution execution) {
         Result result = execution.search(query);
         execution.fill(result);
-        return complete(query, buildPrompt(query, result));
+        return complete(query, buildPrompt(query, result), result, execution);
     }
 
     protected Prompt buildPrompt(Query query, Result result) {

--- a/container-search/src/main/java/com/yahoo/search/rendering/EventRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/EventRenderer.java
@@ -79,13 +79,16 @@ public class EventRenderer extends AsynchronousSectionedRenderer<Result> {
                 generator.writeRaw("event: " + event.type() + "\n");
             }
             generator.writeRaw("data: ");
-            generator.writeStartObject();
-            generator.writeStringField(event.type(), event.toString());
-            generator.writeEndObject();
+            if (event.type().equals("hits")) {
+                generator.writeRaw(event.toString());
+            } else {
+                generator.writeStartObject();
+                generator.writeStringField(event.type(), event.toString());
+                generator.writeEndObject();
+            }
             generator.writeRaw("\n\n");
             generator.flush();
         }
-        // Todo: support other types of data such as search results (hits), timing and trace
     }
 
     @Override

--- a/container-search/src/test/java/ai/vespa/search/llm/RAGSearcherTest.java
+++ b/container-search/src/test/java/ai/vespa/search/llm/RAGSearcherTest.java
@@ -115,7 +115,7 @@ public class RAGSearcherTest {
         return execution.search(query);
     }
 
-    private static Searcher createRAGSearcher(Map<String, LanguageModel> llms) {
+    static Searcher createRAGSearcher(Map<String, LanguageModel> llms) {
         var config = new LlmSearcherConfig.Builder().stream(false).build();
         ComponentRegistry<LanguageModel> models = new ComponentRegistry<>();
         llms.forEach((key, value) -> models.register(ComponentId.fromString(key), value));

--- a/container-search/src/test/java/ai/vespa/search/llm/RAGWithEventRendererTest.java
+++ b/container-search/src/test/java/ai/vespa/search/llm/RAGWithEventRendererTest.java
@@ -1,0 +1,77 @@
+package ai.vespa.search.llm;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yahoo.search.Result;
+import com.yahoo.search.rendering.EventRenderer;
+import com.yahoo.search.searchchain.Execution;
+import com.yahoo.text.Utf8;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RAGWithEventRendererTest {
+
+    @Test
+    public void testPromptAndHitsAreRendered() throws Exception {
+        var params = Map.of(
+                "query", "why are ducks better than cats?",
+                "llm.stream", "false",
+                "llm.includePrompt", "true",
+                "llm.includeHits", "true"
+        );
+        var llm = LLMSearcherTest.createLLMClient();
+        var searcher = RAGSearcherTest.createRAGSearcher(Map.of("mock", llm));
+        var results = RAGSearcherTest.runMockSearch(searcher, params);
+
+        var result = render(results);
+
+        var promptEvent = extractEvent(result, "prompt");
+        assertNotNull(promptEvent);
+        assertTrue(promptEvent.has("prompt"));
+
+        var resultsEvent = extractEvent(result, "hits");
+        assertNotNull(resultsEvent);
+        assertTrue(resultsEvent.has("root"));
+        assertEquals(2, resultsEvent.get("root").get("children").size());
+    }
+
+    private JsonNode extractEvent(String result, String eventName) throws JsonProcessingException {
+        var lines = result.split("\n");
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith("event: " + eventName)) {
+                var data = lines[i + 1].substring("data: ".length()).trim();
+                ObjectMapper objectMapper = new ObjectMapper();
+                return objectMapper.readTree(data);
+            }
+        }
+        return null;
+    }
+
+    private String render(Result r) throws InterruptedException, ExecutionException {
+        var execution = new Execution(Execution.Context.createContextStub());
+        return render(execution, r);
+    }
+
+    private String render(Execution execution, Result r) throws ExecutionException, InterruptedException {
+        var renderer = new EventRenderer();
+        try {
+            renderer.init();
+            ByteArrayOutputStream bs = new ByteArrayOutputStream();
+            CompletableFuture<Boolean> f = renderer.renderResponse(bs, r, execution, null);
+            assertTrue(f.get());
+            return Utf8.toString(bs.toByteArray());
+        } finally {
+            renderer.deconstruct();
+        }
+    }
+
+}

--- a/container-search/src/test/java/com/yahoo/search/rendering/EventRendererTestCase.java
+++ b/container-search/src/test/java/com/yahoo/search/rendering/EventRendererTestCase.java
@@ -232,7 +232,7 @@ public class EventRendererTestCase {
 
                 event: end
                 """;
-        assertEquals(expected, result);  // Todo: support other types of data such as search results (hits), timing and trace
+        assertEquals(expected, result);
     }
 
     static HitGroup newHitGroup(EventStream eventStream, String id) {


### PR DESCRIPTION
@hmusum Please review.

Rather than making extensive changes to the `EventRenderer` and `JsonRenderer` we make the `LLMSearcher` put the events in the `EventStream` if requested.