### PR TITLE
Speed up insertion into HNSW index by referencing vector memory in mo…

### DIFF
--- a/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
+++ b/searchlib/src/tests/tensor/distance_functions/distance_functions_benchmark.cpp
@@ -75,7 +75,11 @@ void benchmark(size_t iterations, size_t elems, const DistanceFunctionFactory & 
 template<typename T>
 void benchmark(size_t iterations, size_t elems, const std::string & dist_functions) {
     if (dist_functions.find("euclid") != npos) {
-        benchmark<T>(iterations, elems, EuclideanDistanceFunctionFactory<T>());
+        if constexpr ( ! std::is_same<T, BFloat16>()) {
+            benchmark<T>(iterations, elems, EuclideanDistanceFunctionFactory<T>());
+        } else {
+            benchmark<BFloat16>(iterations, elems, EuclideanDistanceFunctionFactory<float>());
+        }
     }
     if (dist_functions.find("angular") != npos) {
         if constexpr ( ! std::is_same<T, BFloat16>()) {

--- a/searchlib/src/vespa/searchlib/tensor/angular_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/angular_distance.h
@@ -10,11 +10,19 @@ namespace search::tensor {
  * Calculates angular distance between vectors
  * Will use instruction optimal for the cpu it is running on
  * after converting both vectors to an optimal cell type.
+ *
+ * When reference_insertion_vector == true:
+ *   - Vectors passed to for_insertion_vector() and BoundDistanceFunction::calc() are assumed to have the same type as FloatType.
+ *   - The TypedCells memory is just referenced and used directly in calculations,
+ *     and thus no transformation via a temporary memory buffer occurs.
  */
 template <typename FloatType>
 class AngularDistanceFunctionFactory : public DistanceFunctionFactory {
+private:
+    bool _reference_insertion_vector;
 public:
-    AngularDistanceFunctionFactory() = default;
+    AngularDistanceFunctionFactory() noexcept : AngularDistanceFunctionFactory(false) {}
+    AngularDistanceFunctionFactory(bool reference_insertion_vector) noexcept : _reference_insertion_vector(reference_insertion_vector) {}
     BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };

--- a/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
+++ b/searchlib/src/vespa/searchlib/tensor/distance_function_factory.cpp
@@ -16,40 +16,44 @@ make_distance_function_factory(DistanceMetric variant, CellType cell_type)
     switch (variant) {
         case DistanceMetric::Angular:
             switch (cell_type) {
-                case CellType::DOUBLE: return std::make_unique<AngularDistanceFunctionFactory<double>>();
-                case CellType::INT8:   return std::make_unique<AngularDistanceFunctionFactory<Int8Float>>();
+                case CellType::DOUBLE: return std::make_unique<AngularDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<AngularDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<AngularDistanceFunctionFactory<float>>(true);
                 default:               return std::make_unique<AngularDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::Euclidean:
             switch (cell_type) {
-                case CellType::DOUBLE:   return std::make_unique<EuclideanDistanceFunctionFactory<double>>();
-                case CellType::INT8:     return std::make_unique<EuclideanDistanceFunctionFactory<Int8Float>>();
-                case CellType::BFLOAT16: return std::make_unique<EuclideanDistanceFunctionFactory<vespalib::BFloat16>>();
+                case CellType::DOUBLE:   return std::make_unique<EuclideanDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:     return std::make_unique<EuclideanDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:    return std::make_unique<EuclideanDistanceFunctionFactory<float>>(true);
                 default:                 return std::make_unique<EuclideanDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::InnerProduct:
         case DistanceMetric::PrenormalizedAngular:
             switch (cell_type) {
-                case CellType::DOUBLE: return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<double>>();
-                case CellType::INT8:   return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<Int8Float>>();
-                default:               return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<float>>();
+                case CellType::DOUBLE:   return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:     return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:    return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<float>>(true);
+                default:                 return std::make_unique<PrenormalizedAngularDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::Dotproduct:
             switch (cell_type) {
-                case CellType::DOUBLE: return std::make_unique<MipsDistanceFunctionFactory<double>>();
-                case CellType::INT8:   return std::make_unique<MipsDistanceFunctionFactory<Int8Float>>();
+                case CellType::DOUBLE: return std::make_unique<MipsDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<MipsDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<MipsDistanceFunctionFactory<float>>(true);
                 default:               return std::make_unique<MipsDistanceFunctionFactory<float>>();
             }
         case DistanceMetric::GeoDegrees:
             return std::make_unique<GeoDistanceFunctionFactory>();
         case DistanceMetric::Hamming:
             switch (cell_type) {
-                case CellType::DOUBLE: return std::make_unique<HammingDistanceFunctionFactory<double>>();
-                case CellType::INT8:   return std::make_unique<HammingDistanceFunctionFactory<Int8Float>>();
+                case CellType::DOUBLE: return std::make_unique<HammingDistanceFunctionFactory<double>>(true);
+                case CellType::INT8:   return std::make_unique<HammingDistanceFunctionFactory<Int8Float>>(true);
+                case CellType::FLOAT:  return std::make_unique<HammingDistanceFunctionFactory<float>>(true);
                 default:               return std::make_unique<HammingDistanceFunctionFactory<float>>();
             }
     }
-    // not reached:
+    // Not reached:
     return {};
 }
 

--- a/searchlib/src/vespa/searchlib/tensor/euclidean_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/euclidean_distance.h
@@ -10,11 +10,19 @@ namespace search::tensor {
  * Calculates the square of the standard Euclidean distance.
  * Will use instruction optimal for the cpu it is running on
  * after converting both vectors to an optimal cell type.
+ *
+ * When reference_insertion_vector == true:
+ *   - Vectors passed to for_insertion_vector() and BoundDistanceFunction::calc() are assumed to have the same type as FloatType.
+ *   - The TypedCells memory is just referenced and used directly in calculations,
+ *     and thus no transformation via a temporary memory buffer occurs.
  */
 template <typename FloatType>
 class EuclideanDistanceFunctionFactory : public DistanceFunctionFactory {
+private:
+    bool _reference_insertion_vector;
 public:
-    EuclideanDistanceFunctionFactory() noexcept = default;
+    EuclideanDistanceFunctionFactory() noexcept : EuclideanDistanceFunctionFactory(false) {}
+    EuclideanDistanceFunctionFactory(bool reference_insertion_vector) noexcept : _reference_insertion_vector(reference_insertion_vector) {}
     BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };

--- a/searchlib/src/vespa/searchlib/tensor/hamming_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/hamming_distance.h
@@ -7,15 +7,22 @@
 namespace search::tensor {
 
 /**
- * Calculates the Hamming distance defined as
- * "number of cells where the values are different"
- * or (for int8 cells, aka binary data only)
- * "number of bits that are different"
+ * Calculates the Hamming distance defined as "number of cells where the values are different"
+ * or (for int8 cells, aka binary data only) "number of bits that are different".
+ *
+ * When reference_insertion_vector == true:
+ *   - Vectors passed to for_insertion_vector() and BoundDistanceFunction::calc() are assumed to have the same type as FloatType.
+ *   - The TypedCells memory is referenced and used directly in calculations,
+ *     and thus no transformation via a temporary memory buffer occurs.
  */
 template <typename FloatType>
 class HammingDistanceFunctionFactory : public DistanceFunctionFactory {
+private:
+    bool _reference_insertion_vector;
 public:
-    HammingDistanceFunctionFactory() = default;
+    HammingDistanceFunctionFactory() noexcept : HammingDistanceFunctionFactory(false) {}
+    HammingDistanceFunctionFactory(bool reference_insertion_vector) noexcept : _reference_insertion_vector(reference_insertion_vector) {}
+
     BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };

--- a/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
+++ b/searchlib/src/vespa/searchlib/tensor/mips_distance_transform.h
@@ -55,11 +55,19 @@ public:
  * problem.  When inserting vectors, an extra dimension is
  * added ensuring behavior "as if" all vectors had length equal
  * to the longest vector inserted so far, or at least length 1.
+ *
+ * When reference_insertion_vector == true:
+ *   - Vectors passed to for_insertion_vector() and BoundDistanceFunction::calc() are assumed to have the same type as FloatType.
+ *   - The TypedCells memory is just referenced and used directly in calculations,
+ *     and thus no transformation via a temporary memory buffer occurs.
  */
-template<typename FloatType>
+template <typename FloatType>
 class MipsDistanceFunctionFactory : public MipsDistanceFunctionFactoryBase {
+private:
+    bool _reference_insertion_vector;
 public:
-    MipsDistanceFunctionFactory() noexcept = default;
+    MipsDistanceFunctionFactory() noexcept : MipsDistanceFunctionFactory(false) {}
+    MipsDistanceFunctionFactory(bool reference_insertion_vector) noexcept : _reference_insertion_vector(reference_insertion_vector) {}
     ~MipsDistanceFunctionFactory() override = default;
 
     BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;

--- a/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.h
+++ b/searchlib/src/vespa/searchlib/tensor/prenormalized_angular_distance.h
@@ -9,11 +9,19 @@ namespace search::tensor {
 /**
  * Calculates inner-product "distance" between vectors assuming a common norm.
  * Should give same ordering as Angular distance, but is less expensive.
+ *
+ * When reference_insertion_vector == true:
+ *   - Vectors passed to for_insertion_vector() and BoundDistanceFunction::calc() are assumed to have the same type as FloatType.
+ *   - The TypedCells memory is just referenced and used directly in calculations,
+ *     and thus no transformation via a temporary memory buffer occurs.
  */
 template <typename FloatType>
 class PrenormalizedAngularDistanceFunctionFactory : public DistanceFunctionFactory {
+private:
+    bool _reference_insertion_vector;
 public:
-    PrenormalizedAngularDistanceFunctionFactory() = default;
+    PrenormalizedAngularDistanceFunctionFactory() noexcept : PrenormalizedAngularDistanceFunctionFactory(false) {}
+    PrenormalizedAngularDistanceFunctionFactory(bool reference_insertion_vector) noexcept : _reference_insertion_vector(reference_insertion_vector) {}
     BoundDistanceFunction::UP for_query_vector(TypedCells lhs) const override;
     BoundDistanceFunction::UP for_insertion_vector(TypedCells lhs) const override;
 };

--- a/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.h
+++ b/searchlib/src/vespa/searchlib/tensor/temporary_vector_store.h
@@ -6,9 +6,13 @@
 
 namespace search::tensor {
 
-/** helper class - temporary storage of possibly-converted vector cells */
-template <typename FloatType>
+/**
+ * Helper class containing temporary memory storage for possibly converted vector cells.
+ */
+template <typename FloatTypeT>
 class TemporaryVectorStore {
+public:
+    using FloatType = FloatTypeT;
 private:
     using TypedCells = vespalib::eval::TypedCells;
     std::vector<FloatType> _tmpSpace;
@@ -24,6 +28,26 @@ public:
         } else {
             return internal_convert(cells, cells.size);
         }
+    }
+};
+
+/**
+ * Helper class used when TypedCells vector memory is just referenced,
+ * and used directly in calculations without any transforms.
+ */
+template <typename FloatTypeT>
+class ReferenceVectorStore {
+public:
+    using FloatType = FloatTypeT;
+private:
+    using TypedCells = vespalib::eval::TypedCells;
+public:
+    explicit ReferenceVectorStore(size_t vector_size) noexcept { (void) vector_size; }
+    vespalib::ConstArrayRef<FloatType> storeLhs(TypedCells cells) noexcept {
+        return cells.unsafe_typify<FloatType>();
+    }
+    vespalib::ConstArrayRef<FloatType> convertRhs(TypedCells cells) noexcept {
+        return cells.unsafe_typify<FloatType>();
     }
 };
 


### PR DESCRIPTION
…re cases.

When inserting vectors into a HnswIndex we use DistanceFunctionFactory::for_insertion_vector() to create a distance function each time distance calculations are needed for a candidate vector. All these vectors are of the same type, as given by the tensor type of the TensorAttribute. The lifetime of vectors is also handled by them either being stored in the TensorAttribute, or existing in the document being inserted.

This PR speeds up insertion for vectors of type int8, float and double. This is done by referencing the vector memory directly in the distance function, instead of copying (and transforming) into a tempory memory buffer. Vectors of type bfloat16 are still transformed to float before distance calculations.

@arnej27959 please review
@baldersheim @toregge FYI