### PR TITLE
PublicCdMigration is a hosted vespa system

### DIFF
--- a/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
+++ b/config-provisioning/src/main/java/com/yahoo/config/provision/SystemName.java
@@ -78,6 +78,6 @@ public enum SystemName {
         return Stream.of(values()).filter(predicate).collect(Collectors.toUnmodifiableSet());
     }
 
-    public static Set<SystemName> hostedVespa() { return EnumSet.of(main, cd, Public, PublicCd); }
+    public static Set<SystemName> hostedVespa() { return EnumSet.of(main, cd, Public, PublicCd, PublicCdMigration); }
 
 }


### PR DESCRIPTION
It's currently not possible to add publicmt as a flag deployment target, as it fails in FlagsTarget.filenameForSystem(FlagsTarget.java:100) .