### PR TITLE
Accept distribution config from cluster controller on distributor

### DIFF
--- a/config/src/vespa/config/print/asciiconfigreader.h
+++ b/config/src/vespa/config/print/asciiconfigreader.h
@@ -3,6 +3,8 @@
 
 #include "configreader.h"
 
+namespace vespalib { class asciistream; }
+
 namespace config {
 
 class ConfigFormatter;

--- a/config/src/vespa/config/print/asciiconfigreader.hpp
+++ b/config/src/vespa/config/print/asciiconfigreader.hpp
@@ -5,6 +5,7 @@
 #include "asciiconfigreader.h"
 #include <vespa/config/common/types.h>
 #include <vespa/config/common/configvalue.h>
+#include <vespa/vespalib/stllike/asciistream.h>
 
 namespace config {
 

--- a/storage/src/tests/distributor/top_level_distributor_test_util.cpp
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.cpp
@@ -444,6 +444,12 @@ TopLevelDistributorTestUtil::trigger_distribution_change(std::shared_ptr<lib::Di
 {
     _node->getComponentRegister().setDistribution(std::move(distr));
     _distributor->storageDistributionChanged();
+    enable_next_distribution_if_changed();
+}
+
+void
+TopLevelDistributorTestUtil::enable_next_distribution_if_changed()
+{
     _distributor->enable_next_distribution_if_changed();
 }
 

--- a/storage/src/tests/distributor/top_level_distributor_test_util.h
+++ b/storage/src/tests/distributor/top_level_distributor_test_util.h
@@ -135,6 +135,7 @@ public:
     bool handle_top_level_message(const std::shared_ptr<api::StorageMessage>& msg);
 
     void trigger_distribution_change(std::shared_ptr<lib::Distribution> distr);
+    void enable_next_distribution_if_changed();
 
     const lib::ClusterStateBundle& current_cluster_state_bundle() const;
 

--- a/storage/src/vespa/storage/common/storagecomponent.h
+++ b/storage/src/vespa/storage/common/storagecomponent.h
@@ -91,6 +91,8 @@ public:
 
     std::shared_ptr<Repos> getTypeRepo() const;
     const document::BucketIdFactory& getBucketIdFactory() const { return _bucketIdFactory; }
+    // Must NOT be used by lower-level components, as it may out of sync with distribution
+    // config propagated from the cluster controller.
     DistributionSP getDistribution() const;
     NodeStateUpdater& getStateUpdater() const;
     uint64_t getGeneration() const { return _generation.load(std::memory_order_relaxed); }

--- a/storage/src/vespa/storage/common/storagecomponent.h
+++ b/storage/src/vespa/storage/common/storagecomponent.h
@@ -91,7 +91,7 @@ public:
 
     std::shared_ptr<Repos> getTypeRepo() const;
     const document::BucketIdFactory& getBucketIdFactory() const { return _bucketIdFactory; }
-    // Must NOT be used by lower-level components, as it may out of sync with distribution
+    // Must NOT be used by lower-level components, as it may be out of sync with distribution
     // config propagated from the cluster controller.
     DistributionSP getDistribution() const;
     NodeStateUpdater& getStateUpdater() const;

--- a/storage/src/vespa/storage/distributor/distributor_interface.h
+++ b/storage/src/vespa/storage/distributor/distributor_interface.h
@@ -14,9 +14,27 @@ class DistributorMetricSet;
  */
 class DistributorInterface : public DistributorMessageSender {
 public:
-    virtual ~DistributorInterface() = default;
-    virtual DistributorMetricSet& metrics() = 0;
-    virtual const DistributorConfiguration& config() const = 0;
+    ~DistributorInterface() override = default;
+    [[nodiscard]] virtual DistributorMetricSet& metrics() = 0;
+    [[nodiscard]] virtual const DistributorConfiguration& config() const = 0;
+    // Called from our own bucket DB updater when a cluster state bundle with embedded distribution
+    // config is received. Once at least one such embedded config has been received, config from
+    // the storage component should be _ignored_, as the cluster controller is the lone source of
+    // truth for distribution config.
+    // Returns true iff `distribution` differs from the existing config.
+    [[nodiscard]] virtual bool receive_distribution_from_cluster_controller(std::shared_ptr<const lib::Distribution> distribution) = 0;
+
+    // Whether this distributor treats the CC as the source of truth for distribution config, and
+    // thus ignores node-internal distribution config changes.
+    [[nodiscard]] virtual bool cluster_controller_is_distribution_source_of_truth() const noexcept = 0;
+
+    // Indicates that we are no longer receiving distribution config from the cluster controller,
+    // and that the process' own distribution config should be used. This is a safety valve in
+    // the case the cluster controller is rolled back or reconfigured to not send distribution
+    // config as part of state bundles.
+    // This may trigger a distribution change on the next tick if internal distribution differs
+    // from that previously received from the cluster controller.
+    virtual void revert_distribution_source_of_truth_to_node_internal_config() = 0;
 };
 
 }

--- a/storage/src/vespa/storage/distributor/pendingclusterstate.h
+++ b/storage/src/vespa/storage/distributor/pendingclusterstate.h
@@ -66,11 +66,12 @@ public:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             const BucketSpaceStateMap& bucket_space_states,
-            api::Timestamp creationTimestamp)
+            api::Timestamp creationTimestamp,
+            bool inhibit_request_sending)
     {
         // Naked new due to private constructor
         return std::unique_ptr<PendingClusterState>(new PendingClusterState(
-                clock, clusterInfo, sender, bucket_space_states, creationTimestamp));
+                clock, clusterInfo, sender, bucket_space_states, creationTimestamp, inhibit_request_sending));
     }
 
     PendingClusterState(const PendingClusterState &) = delete;
@@ -188,7 +189,8 @@ private:
             const ClusterInformation::CSP& clusterInfo,
             DistributorMessageSender& sender,
             const BucketSpaceStateMap& bucket_space_states,
-            api::Timestamp creationTimestamp);
+            api::Timestamp creationTimestamp,
+            bool inhibit_request_sending);
 
     struct BucketSpaceAndNode {
         document::BucketSpace bucketSpace;
@@ -200,7 +202,9 @@ private:
         }
     };
 
-    void initializeBucketSpaceTransitions(bool distributionChanged, const OutdatedNodesMap& outdatedNodesMap);
+    void initializeBucketSpaceTransitions(bool distributionChanged,
+                                          const OutdatedNodesMap& outdatedNodesMap,
+                                          bool inhibit_request_sending);
     void logConstructionInformation() const;
     void requestNode(BucketSpaceAndNode bucketSpaceAndNode);
     void requestNodes();

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.h
@@ -94,6 +94,10 @@ private:
     void ensure_transition_timer_started();
     void complete_transition_timer();
 
+    void storage_distribution_changed_impl(StripeAccessGuard& guard,
+                                           const lib::BucketSpaceDistributionConfigs& configs,
+                                           bool inhibit_request_sending);
+
     void remove_superfluous_buckets(StripeAccessGuard& guard,
                                     const lib::ClusterStateBundle& new_state,
                                     bool is_distribution_config_change);

--- a/storage/src/vespa/storage/distributor/top_level_distributor.h
+++ b/storage/src/vespa/storage/distributor/top_level_distributor.h
@@ -99,7 +99,12 @@ public:
     int getDistributorIndex() const override { return _component.node_index(); }
     const ClusterContext& cluster_context() const override { return _component.cluster_context(); }
 
+    // Called from top-level storage component when config is updated from config server
     void storageDistributionChanged() override;
+
+    bool receive_distribution_from_cluster_controller(std::shared_ptr<const lib::Distribution> distribution) override;
+    bool cluster_controller_is_distribution_source_of_truth() const noexcept override;
+    void revert_distribution_source_of_truth_to_node_internal_config() override;
 
     // StatusReporter implementation
     vespalib::string getReportContentType(const framework::HttpUrlPath&) const override;
@@ -185,6 +190,7 @@ private:
     DistributorComponentRegister&         _comp_reg;
     DoneInitializeHandler&                _done_init_handler;
     bool                                  _done_initializing;
+    bool                                  _cc_is_distribution_source_of_truth;
     std::shared_ptr<DistributorTotalMetrics> _total_metrics;
     std::shared_ptr<IdealStateTotalMetrics> _ideal_state_total_metrics;
     ChainedMessageSender*                 _messageSender;
@@ -218,8 +224,8 @@ private:
     DistributorHostInfoReporter          _hostInfoReporter;
 
     mutable std::mutex                   _distribution_mutex;
-    std::shared_ptr<lib::Distribution>   _distribution;
-    std::shared_ptr<lib::Distribution>   _next_distribution;
+    std::shared_ptr<const lib::Distribution> _distribution;
+    std::shared_ptr<const lib::Distribution> _next_distribution;
 
     uint64_t                             _current_internal_config_generation;
 };

--- a/vdslib/src/tests/state/cluster_state_bundle_test.cpp
+++ b/vdslib/src/tests/state/cluster_state_bundle_test.cpp
@@ -54,7 +54,7 @@ bundle_with_feed_block(const ClusterStateBundle::FeedBlock& feed_block) {
 ClusterStateBundle
 bundle_with_distribution(Distribution::ConfigWrapper dist_cfg_wrapper) {
     auto distr_bundle = DistributionConfigBundle::of(std::move(dist_cfg_wrapper));
-    return {ClusterState("storage:2"), {}, std::nullopt, std::move(distr_bundle), false};
+    return {std::make_shared<ClusterState>("storage:2"), {}, std::nullopt, std::move(distr_bundle), false};
 }
 
 TEST(ClusterStateBundleTest, verify_equality_operator) {

--- a/vdslib/src/vespa/vdslib/distribution/distribution_config_bundle.cpp
+++ b/vdslib/src/vespa/vdslib/distribution/distribution_config_bundle.cpp
@@ -1,6 +1,8 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #include "distribution_config_bundle.h"
+#include <vespa/config/print/asciiconfigreader.hpp>
 #include <vespa/config-stor-distribution.h>
+#include <vespa/vespalib/stllike/asciistream.h>
 #include <sstream>
 
 namespace storage::lib {
@@ -18,6 +20,23 @@ void count_nodes_and_leaf_groups(const Group& g, uint16_t& node_count_inout, uin
     }
 }
 
+std::unique_ptr<Distribution::DistributionConfig> config_from_existing_distribution(const Distribution& distr) {
+    vespalib::asciistream is(distr.serialized());
+    config::AsciiConfigReader<vespa::config::content::StorDistributionConfig> reader(is);
+    return reader.read();
+}
+
+}
+
+// TODO de-dupe ctors
+DistributionConfigBundle::DistributionConfigBundle(std::shared_ptr<const Distribution> distr)
+    : _config(config_from_existing_distribution(*distr)),
+      _default_distribution(std::move(distr)),
+      _bucket_space_distributions(BucketSpaceDistributionConfigs::from_default_distribution(_default_distribution)),
+      _total_node_count(0),
+      _total_leaf_group_count(0)
+{
+    count_nodes_and_leaf_groups(_default_distribution->getNodeGraph(), _total_node_count, _total_leaf_group_count);
 }
 
 DistributionConfigBundle::DistributionConfigBundle(Distribution::ConfigWrapper config)
@@ -41,6 +60,11 @@ bool DistributionConfigBundle::operator==(const DistributionConfigBundle& rhs) c
     // Distribution caches the raw string config format internally.
     // Equality is checked using this cheap representation.
     return (*_default_distribution == *rhs._default_distribution);
+}
+
+std::shared_ptr<DistributionConfigBundle>
+DistributionConfigBundle::of(std::shared_ptr<const Distribution> distr) {
+    return std::make_shared<DistributionConfigBundle>(std::move(distr));
 }
 
 std::shared_ptr<DistributionConfigBundle>

--- a/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
+++ b/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
@@ -46,13 +46,13 @@ public:
         std::shared_ptr<const ClusterState>,
         document::BucketSpace::hash
     >;
-    std::shared_ptr<const ClusterState> _baselineClusterState;
-    BucketSpaceStateMapping _derivedBucketSpaceStates;
-    std::optional<FeedBlock> _feed_block;
+    std::shared_ptr<const ClusterState>             _baselineClusterState;
+    BucketSpaceStateMapping                         _derivedBucketSpaceStates;
+    std::optional<FeedBlock>                        _feed_block;
     std::shared_ptr<const DistributionConfigBundle> _distribution_bundle;
-    bool _deferredActivation;
+    bool                                            _deferredActivation;
 public:
-    explicit ClusterStateBundle(const ClusterState &baselineClusterState);
+    explicit ClusterStateBundle(const ClusterState& baselineClusterState);
     ClusterStateBundle(const ClusterState& baselineClusterState,
                        BucketSpaceStateMapping derivedBucketSpaceStates);
     ClusterStateBundle(const ClusterState& baselineClusterState,
@@ -62,7 +62,7 @@ public:
                        BucketSpaceStateMapping derivedBucketSpaceStates,
                        const FeedBlock& feed_block_in,
                        bool deferredActivation);
-    ClusterStateBundle(const ClusterState& baseline_cluster_state,
+    ClusterStateBundle(std::shared_ptr<const ClusterState> baseline_cluster_state,
                        BucketSpaceStateMapping derived_bucket_space_states,
                        std::optional<FeedBlock> feed_block_in,
                        std::shared_ptr<const DistributionConfigBundle> distribution_bundle,
@@ -74,8 +74,14 @@ public:
     ClusterStateBundle& operator=(ClusterStateBundle&&) noexcept;
 
     ~ClusterStateBundle();
-    const std::shared_ptr<const ClusterState> &getBaselineClusterState() const;
-    const std::shared_ptr<const ClusterState> &getDerivedClusterState(document::BucketSpace bucketSpace) const;
+
+    // Factory function for "simulating" atomic cluster states with distribution config attached
+    // when the cluster controller is not yet on version that sends bundled config.
+    [[nodiscard]] std::shared_ptr<const ClusterStateBundle> clone_with_new_distribution(
+            std::shared_ptr<const DistributionConfigBundle>) const;
+
+    const std::shared_ptr<const ClusterState>& getBaselineClusterState() const;
+    const std::shared_ptr<const ClusterState>& getDerivedClusterState(document::BucketSpace bucketSpace) const;
     const BucketSpaceStateMapping& getDerivedClusterStates() const noexcept {
         return _derivedBucketSpaceStates;
     }
@@ -96,8 +102,8 @@ public:
     [[nodiscard]] uint32_t getVersion() const;
     [[nodiscard]] bool deferredActivation() const noexcept { return _deferredActivation; }
     [[nodiscard]] std::string toString() const;
-    bool operator==(const ClusterStateBundle &rhs) const noexcept;
-    bool operator!=(const ClusterStateBundle &rhs) const noexcept { return !operator==(rhs); }
+    bool operator==(const ClusterStateBundle& rhs) const noexcept;
+    bool operator!=(const ClusterStateBundle& rhs) const noexcept { return !operator==(rhs); }
 };
 
 std::ostream& operator<<(std::ostream&, const ClusterStateBundle&);


### PR DESCRIPTION
@geirst please review

If a received cluster state bundle contains an embedded distribution config, the distributor will act _as if_ it had atomically received and processed a distribution config change followed by a new cluster state, but where no bucket info requests are sent for the config change.

If a distributor observes a state bundle containing distribution config it will note this internally and explicitly ignore any further received distribution configs _not_ arriving from the cluster controller. To handle downgrades and rollbacks, it undoes this toggle if it later observes a state bundle _without_ distribution config, reverting to using internal node config instead.

Note: the `DistributionConfigBundle::clone_with_new_distribution()` functionality is added but not used here—it is expected to be used later for the content node work (or I'll remove it).