### PR TITLE
Use readonly scores heap in parallel weak and search iterators during

### DIFF
--- a/searchlib/src/tests/queryeval/weak_and/wand_bench_setup.hpp
+++ b/searchlib/src/tests/queryeval/weak_and/wand_bench_setup.hpp
@@ -156,7 +156,7 @@ struct VespaParallelWandFactory : public WandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::create(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true);
+                        PWRankParams(rootMatchData, {}), true, false);
     }
 };
 
@@ -169,7 +169,7 @@ struct VespaParallelArrayWandFactory : public VespaParallelWandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::createArrayWand(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true);
+                        PWRankParams(rootMatchData, {}), true, false);
     }
 };
 
@@ -182,7 +182,7 @@ struct VespaParallelHeapWandFactory : public VespaParallelWandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::createHeapWand(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true);
+                        PWRankParams(rootMatchData, {}), true, false);
     }
 };
 

--- a/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_blueprint_factory.cpp
@@ -81,6 +81,7 @@ using search::queryeval::FieldSpecBase;
 using search::queryeval::FieldSpecBaseList;
 using search::queryeval::FilterWrapper;
 using search::queryeval::IRequestContext;
+using search::queryeval::MatchingPhase;
 using search::queryeval::NoUnpack;
 using search::queryeval::OrLikeSearch;
 using search::queryeval::OrSearch;
@@ -451,6 +452,7 @@ private:
     std::vector<IDirectPostingStore::LookupResult> _terms;
     const IDocidWithWeightPostingStore            &_attr;
     vespalib::datastore::EntryRef                  _dictionary_snapshot;
+    MatchingPhase                                  _matching_phase;
 
 
 public:
@@ -465,7 +467,8 @@ public:
           _weights(),
           _terms(),
           _attr(attr),
-          _dictionary_snapshot(_attr.get_dictionary_snapshot())
+          _dictionary_snapshot(_attr.get_dictionary_snapshot()),
+          _matching_phase(MatchingPhase::FIRST_PHASE)
     {
         _weights.reserve(size_hint);
         _terms.reserve(size_hint);
@@ -509,13 +512,15 @@ public:
         if (_terms.empty()) {
             return std::make_unique<queryeval::EmptySearch>();
         }
+        bool readonly_scores_heap = (_matching_phase != MatchingPhase::FIRST_PHASE);
         return queryeval::ParallelWeakAndSearch::create(*tfmda[0],
                 queryeval::ParallelWeakAndSearch::MatchParams(*_scores, _scoreThreshold, _thresholdBoostFactor,
                                                               _scoresAdjustFrequency, get_docid_limit()),
-                                                        _weights, _terms, _attr, strict());
+                                                        _weights, _terms, _attr, strict(), readonly_scores_heap);
     }
     std::unique_ptr<SearchIterator> createFilterSearch(FilterConstraint constraint) const override;
     bool always_needs_unpack() const override { return true; }
+    void set_matching_phase(MatchingPhase matching_phase) noexcept override;
 };
 
 DirectWandBlueprint::~DirectWandBlueprint() = default;
@@ -532,6 +537,27 @@ DirectWandBlueprint::createFilterSearch(FilterConstraint constraint) const
         return attribute::MultiTermOrFilterSearch::create(std::move(iterators));
     } else {
         return std::make_unique<queryeval::EmptySearch>();
+    }
+}
+
+void
+DirectWandBlueprint::set_matching_phase(MatchingPhase matching_phase) noexcept
+{
+    _matching_phase = matching_phase;
+    if (matching_phase != MatchingPhase::FIRST_PHASE) {
+        /*
+         * During first phase matching, the scores heap is adjusted by
+         * the iterators. The minimum score is increased when the
+         * scores heap is full while handling a matching document with
+         * a higher score than the worst existing one.
+         *
+         * During later matching phases, only the original minimum
+         * score is used, and the heap is not updated by the
+         * iterators. This ensures that all documents considered a hit
+         * by the first phase matching will also be considered as hits
+         * by the later matching phases.
+         */
+        _scores->set_min_score(_scoreThreshold);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
@@ -26,6 +26,7 @@ private:
     fef::MatchDataLayout                  _layout;
     std::vector<int32_t>                  _weights;
     std::vector<Blueprint::UP>            _terms;
+    MatchingPhase                         _matching_phase;
 
 public:
     ParallelWeakAndBlueprint(const ParallelWeakAndBlueprint &) = delete;
@@ -60,6 +61,7 @@ public:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     bool always_needs_unpack() const override;
+    void set_matching_phase(MatchingPhase matching_phase) noexcept override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.cpp
@@ -32,6 +32,7 @@ private:
     score_t                        _boostedThreshold;
     const MatchParams              _matchParams;
     std::vector<score_t>           _localScores;
+    const bool                     _readonly_scores_heap;
 
     void updateThreshold(score_t newThreshold) {
         if (newThreshold > _threshold) {
@@ -67,7 +68,8 @@ private:
 public:
     ParallelWeakAndSearchImpl(fef::TermFieldMatchData &tfmd,
                               VectorizedTerms &&terms,
-                              const MatchParams &matchParams)
+                              const MatchParams &matchParams,
+                              bool readonly_scores_heap)
         : _tfmd(tfmd),
           _terms(std::move(terms)),
           _heaps(DocIdOrder(_terms.docId()), _terms.size()),
@@ -75,7 +77,8 @@ public:
           _threshold(matchParams.scoreThreshold),
           _boostedThreshold(_threshold * matchParams.thresholdBoostFactor),
           _matchParams(matchParams),
-          _localScores()
+          _localScores(),
+          _readonly_scores_heap(readonly_scores_heap)
     {
         _localScores.reserve(_matchParams.scoresAdjustFrequency);
     }
@@ -94,10 +97,12 @@ public:
     }
     void doUnpack(uint32_t docid) override {
         score_t score = _algo.get_full_score(_terms, _heaps, DotProductScorer());
-        _localScores.push_back(score);
-        if (_localScores.size() == _matchParams.scoresAdjustFrequency) {
-            _matchParams.scores.adjust(&_localScores[0], &_localScores[0] + _localScores.size());
-            _localScores.clear();
+        if (!_readonly_scores_heap) {
+            _localScores.push_back(score);
+            if (_localScores.size() == _matchParams.scoresAdjustFrequency) {
+                _matchParams.scores.adjust(&_localScores[0], &_localScores[0] + _localScores.size());
+                _localScores.clear();
+            }
         }
         _tfmd.setRawScore(docid, score);
     }
@@ -130,7 +135,8 @@ template <typename FutureHeap, typename PastHeap, bool IS_STRICT>
 SearchIterator::UP
 createWand(const wand::Terms &terms,
            const ParallelWeakAndSearch::MatchParams &matchParams,
-           ParallelWeakAndSearch::RankParams &&rankParams)
+           ParallelWeakAndSearch::RankParams &&rankParams,
+           bool readonly_scores_heap)
 {
     using WandType = ParallelWeakAndSearchImpl<VectorizedIteratorTerms, FutureHeap, PastHeap, IS_STRICT>;
     if (should_monitor_wand()) {
@@ -144,7 +150,7 @@ createWand(const wand::Terms &terms,
                                                                    DotProductScorer(),
                                                                    matchParams.docIdLimit,
                                                                    std::move(rankParams.childrenMatchData)),
-                                           matchParams),
+                                           matchParams, readonly_scores_heap),
                 false);
         return std::make_unique<MonitoringDumpIterator>(std::move(monitoringIterator));
     }
@@ -153,7 +159,7 @@ createWand(const wand::Terms &terms,
                                                               DotProductScorer(),
                                                               matchParams.docIdLimit,
                                                               std::move(rankParams.childrenMatchData)),
-                                      matchParams);
+                                      matchParams, readonly_scores_heap);
 }
 
 } // namespace search::queryeval::wand::<unnamed>
@@ -164,33 +170,36 @@ SearchIterator::UP
 ParallelWeakAndSearch::createArrayWand(const Terms &terms,
                                        const MatchParams &matchParams,
                                        RankParams &&rankParams,
-                                       bool strict)
+                                       bool strict,
+                                       bool readonly_scores_heap)
 {
     return strict
-        ? wand::createWand<vespalib::LeftArrayHeap, vespalib::RightArrayHeap, true>(terms, matchParams, std::move(rankParams))
-        : wand::createWand<vespalib::LeftArrayHeap, vespalib::RightArrayHeap, false>(terms, matchParams, std::move(rankParams));
+        ? wand::createWand<vespalib::LeftArrayHeap, vespalib::RightArrayHeap, true>(terms, matchParams, std::move(rankParams), readonly_scores_heap)
+        : wand::createWand<vespalib::LeftArrayHeap, vespalib::RightArrayHeap, false>(terms, matchParams, std::move(rankParams), readonly_scores_heap);
 }
 
 SearchIterator::UP
 ParallelWeakAndSearch::createHeapWand(const Terms &terms,
                                       const MatchParams &matchParams,
                                       RankParams &&rankParams,
-                                      bool strict)
+                                      bool strict,
+                                      bool readonly_scores_heap)
 {
     return strict
-        ? wand::createWand<vespalib::LeftHeap, vespalib::RightHeap, true>(terms, matchParams, std::move(rankParams))
-        : wand::createWand<vespalib::LeftHeap, vespalib::RightHeap, false>(terms, matchParams, std::move(rankParams));
+        ? wand::createWand<vespalib::LeftHeap, vespalib::RightHeap, true>(terms, matchParams, std::move(rankParams), readonly_scores_heap)
+        : wand::createWand<vespalib::LeftHeap, vespalib::RightHeap, false>(terms, matchParams, std::move(rankParams), readonly_scores_heap);
 }
 
 SearchIterator::UP
 ParallelWeakAndSearch::create(const Terms &terms,
                               const MatchParams &matchParams,
                               RankParams &&rankParams,
-                              bool strict)
+                              bool strict,
+                              bool readonly_scores_heap)
 {
     return (terms.size() < 128)
-        ? createArrayWand(terms, matchParams, std::move(rankParams), strict)
-        : createHeapWand(terms, matchParams, std::move(rankParams), strict);
+        ? createArrayWand(terms, matchParams, std::move(rankParams), strict, readonly_scores_heap)
+        : createHeapWand(terms, matchParams, std::move(rankParams), strict, readonly_scores_heap);
 }
 
 //-----------------------------------------------------------------------------
@@ -198,19 +207,19 @@ ParallelWeakAndSearch::create(const Terms &terms,
 namespace {
 
 template <typename VectorizedTerms, typename FutureHeap, typename PastHeap>
-SearchIterator::UP create_helper(search::fef::TermFieldMatchData &tfmd, VectorizedTerms &&terms, const MatchParams &params, bool strict) {
+SearchIterator::UP create_helper(search::fef::TermFieldMatchData &tfmd, VectorizedTerms &&terms, const MatchParams &params, bool strict, bool readonly_scores_heap) {
     if (strict) {
-        return std::make_unique<wand::ParallelWeakAndSearchImpl<VectorizedTerms, FutureHeap, PastHeap, true>>(tfmd, std::forward<VectorizedTerms>(terms), params);
+        return std::make_unique<wand::ParallelWeakAndSearchImpl<VectorizedTerms, FutureHeap, PastHeap, true>>(tfmd, std::forward<VectorizedTerms>(terms), params, readonly_scores_heap);
     } else {
-        return std::make_unique<wand::ParallelWeakAndSearchImpl<VectorizedTerms, FutureHeap, PastHeap, false>>(tfmd, std::forward<VectorizedTerms>(terms), params);
+        return std::make_unique<wand::ParallelWeakAndSearchImpl<VectorizedTerms, FutureHeap, PastHeap, false>>(tfmd, std::forward<VectorizedTerms>(terms), params, readonly_scores_heap);
     }
 }
 
 template <typename VectorizedTerms>
-SearchIterator::UP create_helper(search::fef::TermFieldMatchData &tfmd, VectorizedTerms &&terms, const MatchParams &params, bool strict, bool use_array) {
+SearchIterator::UP create_helper(search::fef::TermFieldMatchData &tfmd, VectorizedTerms &&terms, const MatchParams &params, bool strict, bool readonly_scores_heap, bool use_array) {
     return (use_array)
-        ? create_helper<VectorizedTerms, vespalib::LeftArrayHeap, vespalib::RightArrayHeap>(tfmd, std::forward<VectorizedTerms>(terms), params, strict)
-        : create_helper<VectorizedTerms, vespalib::LeftHeap, vespalib::RightHeap>(tfmd, std::forward<VectorizedTerms>(terms), params, strict);
+        ? create_helper<VectorizedTerms, vespalib::LeftArrayHeap, vespalib::RightArrayHeap>(tfmd, std::forward<VectorizedTerms>(terms), params, strict, readonly_scores_heap)
+        : create_helper<VectorizedTerms, vespalib::LeftHeap, vespalib::RightHeap>(tfmd, std::forward<VectorizedTerms>(terms), params, strict, readonly_scores_heap);
 }
 
 } // namespace search::queryeval::<unnamed>
@@ -221,12 +230,13 @@ ParallelWeakAndSearch::create(search::fef::TermFieldMatchData &tfmd,
                               const std::vector<int32_t> &weights,
                               const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
                               const IDocidWithWeightPostingStore &attr,
-                              bool strict)
+                              bool strict,
+                              bool readonly_scores_heap)
 {
     assert(weights.size() == dict_entries.size());
     if (!wand::should_monitor_wand()) {
         wand::VectorizedAttributeTerms terms(weights, dict_entries, attr, wand::DotProductScorer(), matchParams.docIdLimit);
-        return create_helper(tfmd, std::move(terms), matchParams, strict, (weights.size() < 128));
+        return create_helper(tfmd, std::move(terms), matchParams, strict, readonly_scores_heap, (weights.size() < 128));
     } else {
         // reverse-wrap direct iterators into old API to be compatible with monitoring
         fef::MatchDataLayout layout;
@@ -245,7 +255,7 @@ ParallelWeakAndSearch::create(search::fef::TermFieldMatchData &tfmd,
                                dict_entries[i].posting_size,
                                childrenMatchData->resolveTermField(handles[i]));
         }
-        return create(terms, matchParams, RankParams(tfmd, std::move(childrenMatchData)), strict);
+        return create(terms, matchParams, RankParams(tfmd, std::move(childrenMatchData)), strict, readonly_scores_heap);
     }
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
@@ -62,14 +62,15 @@ struct ParallelWeakAndSearch : public SearchIterator
     virtual score_t get_max_score(size_t idx) const = 0;
     virtual const MatchParams &getMatchParams() const = 0;
 
-    static SearchIterator::UP createArrayWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
-    static SearchIterator::UP createHeapWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
-    static SearchIterator::UP create(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
+    static SearchIterator::UP createArrayWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
+    static SearchIterator::UP createHeapWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
+    static SearchIterator::UP create(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
 
     static SearchIterator::UP create(fef::TermFieldMatchData &tmd, const MatchParams &matchParams,
                                      const std::vector<int32_t> &weights,
                                      const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
-                                     const IDocidWithWeightPostingStore &attr, bool strict);
+                                     const IDocidWithWeightPostingStore &attr, bool strict,
+                                     bool readonly_scores_heap);
 };
 
 }


### PR DESCRIPTION
later matching phases.

This ensures that all documents considered a hit by the first phase matching will also be considered as hits by the later matching phases.

@baldersheim : please review
@geirst : FYI
