### PR TITLE
Revert "Use readonly scores heap in parallel weak and search iterators during" MERGEOK

### DIFF
--- a/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
+++ b/searchlib/src/tests/queryeval/parallel_weak_and/parallel_weak_and_test.cpp
@@ -86,7 +86,6 @@ struct WandTestSpec : public WandSpec
     HeapType heap;
     TermFieldMatchData rootMatchData;
     MatchParams matchParams;
-    MatchingPhase matching_phase;
 
     explicit WandTestSpec(uint32_t scoresToTrack, uint32_t scoresAdjustFrequency = 1,
                           score_t scoreThreshold = 0, double thresholdBoostFactor = 1);
@@ -94,7 +93,6 @@ struct WandTestSpec : public WandSpec
     SearchIterator::UP create() {
         MatchData::UP childrenMatchData = createMatchData();
         MatchData *tmp = childrenMatchData.get();
-        bool readonly_scores_heap = (matching_phase != MatchingPhase::FIRST_PHASE);
         return SearchIterator::UP(
                 new TrackedSearch("PWAND", getHistory(),
                                   ParallelWeakAndSearch::create(
@@ -102,9 +100,8 @@ struct WandTestSpec : public WandSpec
                                           matchParams,
                                           RankParams(rootMatchData,
                                                      std::move(childrenMatchData)),
-                                          true, readonly_scores_heap)));
+                                          true)));
     }
-    void set_second_phase() { matching_phase = MatchingPhase::SECOND_PHASE; }
 };
 
 template <typename HeapType>
@@ -113,8 +110,7 @@ WandTestSpec<HeapType>::WandTestSpec(uint32_t scoresToTrack, uint32_t scoresAdju
     : WandSpec(),
       heap(scoresToTrack),
       rootMatchData(),
-      matchParams(heap, scoreThreshold, thresholdBoostFactor, scoresAdjustFrequency),
-      matching_phase(MatchingPhase::FIRST_PHASE)
+      matchParams(heap, scoreThreshold, thresholdBoostFactor, scoresAdjustFrequency)
 {}
 
 template <typename HeapType>
@@ -224,16 +220,7 @@ struct FixtureBase
 
 struct AlgoSimpleFixture : public FixtureBase
 {
-    AlgoSimpleFixture()
-        : AlgoSimpleFixture(false)
-    {
-    }
-    explicit AlgoSimpleFixture(bool second_phase)
-        : FixtureBase(2, 1)
-    {
-        if (second_phase) {
-            spec.set_second_phase();
-        }
+    AlgoSimpleFixture() : FixtureBase(2, 1) {
         spec.leaf(LeafSpec("A", 1).doc(1, 1).doc(2, 2).doc(3, 3).doc(4, 4).doc(5, 5).doc(6, 6));
         spec.leaf(LeafSpec("B", 4).doc(1, 1).doc(3, 3).doc(5, 5));
         prepare();
@@ -300,25 +287,12 @@ struct AlgoExhaustPastFixture : public FixtureBase
 
 TEST(ParallelWeakAndTest, require_that_algorithm_prunes_bad_hits_after_enough_good_ones_are_obtained)
 {
-    AlgoSimpleFixture f; // First phase
+    AlgoSimpleFixture f;
     FakeResult expect = FakeResult()
                         .doc(1).score(1 * 1 + 4 * 1)
                         .doc(2).score(1 * 2)
                         .doc(3).score(1 * 3 + 4 * 3)
                         .doc(5).score(1 * 5 + 4 * 5);
-    EXPECT_EQ(expect, f.result);
-}
-
-TEST(ParallelWeakAndTest, require_that_algorithm_does_not_prune_hits_in_pater_matching_phases)
-{
-    AlgoSimpleFixture f(true); // Second phase
-    FakeResult expect = FakeResult()
-                        .doc(1).score(1 * 1 + 4 * 1)
-                        .doc(2).score(1 * 2)
-                        .doc(3).score(1 * 3 + 4 * 3)
-                        .doc(4).score(1 * 4)
-                        .doc(5).score(1 * 5 + 4 * 5)
-                        .doc(6).score(1 * 6);
     EXPECT_EQ(expect, f.result);
 }
 
@@ -713,7 +687,7 @@ SearchIterator::UP create_wand(bool use_dww,
                                bool strict)
 {
     if (use_dww) {
-        return ParallelWeakAndSearch::create(tfmd, matchParams, weights, dict_entries, attr, strict, false);
+        return ParallelWeakAndSearch::create(tfmd, matchParams, weights, dict_entries, attr, strict);
     }
     // use search iterators as children
     MatchDataLayout layout;
@@ -731,7 +705,7 @@ SearchIterator::UP create_wand(bool use_dww,
                                    childrenMatchData->resolveTermField(handles[i])));
     }
     assert(terms.size() == dict_entries.size());
-    return SearchIterator::UP(ParallelWeakAndSearch::create(terms, matchParams, RankParams(tfmd, std::move(childrenMatchData)), strict, false));
+    return SearchIterator::UP(ParallelWeakAndSearch::create(terms, matchParams, RankParams(tfmd, std::move(childrenMatchData)), strict));
 }
 
 class Verifier : public search::test::DwwIteratorChildrenVerifier {

--- a/searchlib/src/tests/queryeval/weak_and/wand_bench_setup.hpp
+++ b/searchlib/src/tests/queryeval/weak_and/wand_bench_setup.hpp
@@ -156,7 +156,7 @@ struct VespaParallelWandFactory : public WandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::create(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true, false);
+                        PWRankParams(rootMatchData, {}), true);
     }
 };
 
@@ -169,7 +169,7 @@ struct VespaParallelArrayWandFactory : public VespaParallelWandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::createArrayWand(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true, false);
+                        PWRankParams(rootMatchData, {}), true);
     }
 };
 
@@ -182,7 +182,7 @@ struct VespaParallelHeapWandFactory : public VespaParallelWandFactory {
     SearchIterator::UP create(const wand::Terms &terms) override {
         return ParallelWeakAndSearch::createHeapWand(terms,
                         PWMatchParams(scores, 0, 1, 1),
-                        PWRankParams(rootMatchData, {}), true, false);
+                        PWRankParams(rootMatchData, {}), true);
     }
 };
 

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.cpp
@@ -87,12 +87,11 @@ ParallelWeakAndBlueprint::createLeafSearch(const search::fef::TermFieldMatchData
                            childState.estimate().estHits,
                            childState.field(0).resolve(*childrenMatchData));
     }
-    bool readonly_scores_heap = (_matching_phase != MatchingPhase::FIRST_PHASE);
     return ParallelWeakAndSearch::create(terms,
                                          ParallelWeakAndSearch::MatchParams(*_scores, _scoreThreshold, _thresholdBoostFactor,
                                                                             _scoresAdjustFrequency, get_docid_limit()),
                                          ParallelWeakAndSearch::RankParams(*tfmda[0],std::move(childrenMatchData)),
-                                         strict(), readonly_scores_heap);
+                                         strict());
 }
 
 std::unique_ptr<SearchIterator>
@@ -113,27 +112,6 @@ bool
 ParallelWeakAndBlueprint::always_needs_unpack() const
 {
     return true;
-}
-
-void
-ParallelWeakAndBlueprint::set_matching_phase(MatchingPhase matching_phase) noexcept
-{
-    _matching_phase = matching_phase;
-    if (matching_phase != MatchingPhase::FIRST_PHASE) {
-        /*
-         * During first phase matching, the scores heap is adjusted by
-         * the iterators. The minimum score is increased when the
-         * scores heap is full while handling a matching document with
-         * a higher score than the worst existing one.
-         *
-         * During later matching phases, only the original minimum
-         * score is used, and the heap is not updated by the
-         * iterators. This ensures that all documents considered a hit
-         * by the first phase matching will also be considered as hits
-         * by the later matching phases.
-         */
-        _scores->set_min_score(_scoreThreshold);
-    }
 }
 
 void

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_blueprint.h
@@ -26,7 +26,6 @@ private:
     fef::MatchDataLayout                  _layout;
     std::vector<int32_t>                  _weights;
     std::vector<Blueprint::UP>            _terms;
-    MatchingPhase                         _matching_phase;
 
 public:
     ParallelWeakAndBlueprint(const ParallelWeakAndBlueprint &) = delete;
@@ -61,7 +60,6 @@ public:
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     void fetchPostings(const ExecuteInfo &execInfo) override;
     bool always_needs_unpack() const override;
-    void set_matching_phase(MatchingPhase matching_phase) noexcept override;
 };
 
 }

--- a/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/parallel_weak_and_search.h
@@ -62,15 +62,14 @@ struct ParallelWeakAndSearch : public SearchIterator
     virtual score_t get_max_score(size_t idx) const = 0;
     virtual const MatchParams &getMatchParams() const = 0;
 
-    static SearchIterator::UP createArrayWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
-    static SearchIterator::UP createHeapWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
-    static SearchIterator::UP create(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict, bool readonly_scores_heap);
+    static SearchIterator::UP createArrayWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
+    static SearchIterator::UP createHeapWand(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
+    static SearchIterator::UP create(const Terms &terms, const MatchParams &matchParams, RankParams &&rankParams, bool strict);
 
     static SearchIterator::UP create(fef::TermFieldMatchData &tmd, const MatchParams &matchParams,
                                      const std::vector<int32_t> &weights,
                                      const std::vector<IDirectPostingStore::LookupResult> &dict_entries,
-                                     const IDocidWithWeightPostingStore &attr, bool strict,
-                                     bool readonly_scores_heap);
+                                     const IDocidWithWeightPostingStore &attr, bool strict);
 };
 
 }


### PR DESCRIPTION
Reverts vespa-engine/vespa#31572

Valgrind not happy
```

024-06-14 17:27:40 UTC | ==248566== Memcheck, a memory error detector
-- | --
  | 2024-06-14 17:27:40 UTC | ==248566== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
  | 2024-06-14 17:27:40 UTC | ==248566== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
  | 2024-06-14 17:27:40 UTC | ==248566== Command: /workspace/build/buildkite/vespaai/vespa/searchlib/src/tests/attribute/searchable/searchlib_attribute_searchable_adapter_test_app
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  running test suite 'attribute_searchable_adapter_test.cpp'
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'requireThatIteratorsCanBeCreated': PASS
  | 2024-06-14 17:27:40 UTC | 1718385949.780100	localhost	248566/14419	-	attribute_searchable_adapter_test.vespalib.issue	warning	attribute not found: field
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that missing attribute produces empty search': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'requireThatRangeTermsWorkToo': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'requireThatPrefixTermsWork': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'requireThatLocationTermsWork': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'requireThatOptimizedLocationTermsWork': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that optimized location search works with wrapped bounding box (no hits)': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that attribute dot product works': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that attribute dot product can produce no hits': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that single weighted set turns filter on filter fields': PASS
  | 2024-06-14 17:27:40 UTC | ==248566== Conditional jump or move depends on uninitialised value(s)
  | 2024-06-14 17:27:40 UTC | ==248566==    at 0x5A56B26: search::queryeval::wand::ParallelWeakAndSearchImpl<search::queryeval::wand::VectorizedIteratorTerms, vespalib::LeftArrayHeap, vespalib::RightArrayHeap, false>::doUnpack(unsigned int) (parallel_weak_and_search.cpp:100)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A7B4: unpack (searchiterator.h:273)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A7B4: (anonymous namespace)::do_search(search::IAttributeManager&, search::query::Node const&, bool) (attribute_searchable_adapter_test.cpp:236)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41C256: (anonymous namespace)::(anonymous namespace)::TestKitHook499::Test::test_entry_point() (attribute_searchable_adapter_test.cpp:509)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC401E2: vespalib::TestThreadWrapper::threadEntry() (test_hook.cpp:24)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418D36: bool vespalib::TestHook::runTest<(anonymous namespace)::(anonymous namespace)::TestKitHook499::Test>((anonymous namespace)::(anonymous namespace)::TestKitHook499::Test const&, unsigned long) [clone .constprop.0] (test_hook.h:94)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418EB3: (anonymous namespace)::(anonymous namespace)::TestKitHook499::run() (attribute_searchable_adapter_test.cpp:499)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC416B6: vespalib::TestHook::runAll() (test_hook.cpp:86)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x40A00B: main (attribute_searchable_adapter_test.cpp:767)
  | 2024-06-14 17:27:40 UTC | ==248566==  Uninitialised value was created by a heap allocation
  | 2024-06-14 17:27:40 UTC | ==248566==    at 0x4C39913: operator new(unsigned long) (vg_replace_malloc.c:483)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x54665E7: search::(anonymous namespace)::CreateBlueprintVisitor::visit(search::query::WandTerm&) (attribute_blueprint_factory.cpp:747)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x546425A: search::AttributeBlueprintFactory::createBlueprint(search::queryeval::IRequestContext const&, search::queryeval::FieldSpec const&, search::query::Node const&) (attribute_blueprint_factory.cpp:834)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A4E5: (anonymous namespace)::do_search(search::IAttributeManager&, search::query::Node const&, bool) (attribute_searchable_adapter_test.cpp:223)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41C256: (anonymous namespace)::(anonymous namespace)::TestKitHook499::Test::test_entry_point() (attribute_searchable_adapter_test.cpp:509)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC401E2: vespalib::TestThreadWrapper::threadEntry() (test_hook.cpp:24)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418D36: bool vespalib::TestHook::runTest<(anonymous namespace)::(anonymous namespace)::TestKitHook499::Test>((anonymous namespace)::(anonymous namespace)::TestKitHook499::Test const&, unsigned long) [clone .constprop.0] (test_hook.h:94)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418EB3: (anonymous namespace)::(anonymous namespace)::TestKitHook499::run() (attribute_searchable_adapter_test.cpp:499)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC416B6: vespalib::TestHook::runAll() (test_hook.cpp:86)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x40A00B: main (attribute_searchable_adapter_test.cpp:767)
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | ==248566== Conditional jump or move depends on uninitialised value(s)
  | 2024-06-14 17:27:40 UTC | ==248566==    at 0x5A56DC6: search::queryeval::wand::ParallelWeakAndSearchImpl<search::queryeval::wand::VectorizedIteratorTerms, vespalib::LeftArrayHeap, vespalib::RightArrayHeap, true>::doUnpack(unsigned int) (parallel_weak_and_search.cpp:100)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A7B4: unpack (searchiterator.h:273)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A7B4: (anonymous namespace)::do_search(search::IAttributeManager&, search::query::Node const&, bool) (attribute_searchable_adapter_test.cpp:236)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41C256: (anonymous namespace)::(anonymous namespace)::TestKitHook499::Test::test_entry_point() (attribute_searchable_adapter_test.cpp:509)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC401E2: vespalib::TestThreadWrapper::threadEntry() (test_hook.cpp:24)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418D36: bool vespalib::TestHook::runTest<(anonymous namespace)::(anonymous namespace)::TestKitHook499::Test>((anonymous namespace)::(anonymous namespace)::TestKitHook499::Test const&, unsigned long) [clone .constprop.0] (test_hook.h:94)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418EB3: (anonymous namespace)::(anonymous namespace)::TestKitHook499::run() (attribute_searchable_adapter_test.cpp:499)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC416B6: vespalib::TestHook::runAll() (test_hook.cpp:86)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x40A00B: main (attribute_searchable_adapter_test.cpp:767)
  | 2024-06-14 17:27:40 UTC | ==248566==  Uninitialised value was created by a heap allocation
  | 2024-06-14 17:27:40 UTC | ==248566==    at 0x4C39913: operator new(unsigned long) (vg_replace_malloc.c:483)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x54665E7: search::(anonymous namespace)::CreateBlueprintVisitor::visit(search::query::WandTerm&) (attribute_blueprint_factory.cpp:747)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x546425A: search::AttributeBlueprintFactory::createBlueprint(search::queryeval::IRequestContext const&, search::queryeval::FieldSpec const&, search::query::Node const&) (attribute_blueprint_factory.cpp:834)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41A4E5: (anonymous namespace)::do_search(search::IAttributeManager&, search::query::Node const&, bool) (attribute_searchable_adapter_test.cpp:223)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x41C256: (anonymous namespace)::(anonymous namespace)::TestKitHook499::Test::test_entry_point() (attribute_searchable_adapter_test.cpp:509)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC401E2: vespalib::TestThreadWrapper::threadEntry() (test_hook.cpp:24)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418D36: bool vespalib::TestHook::runTest<(anonymous namespace)::(anonymous namespace)::TestKitHook499::Test>((anonymous namespace)::(anonymous namespace)::TestKitHook499::Test const&, unsigned long) [clone .constprop.0] (test_hook.h:94)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x418EB3: (anonymous namespace)::(anonymous namespace)::TestKitHook499::run() (attribute_searchable_adapter_test.cpp:499)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0xEC416B6: vespalib::TestHook::runAll() (test_hook.cpp:86)
  | 2024-06-14 17:27:40 UTC | ==248566==    by 0x40A00B: main (attribute_searchable_adapter_test.cpp:767)
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that attribute parallel wand works': PASS
  | 2024-06-14 17:27:40 UTC | DUMP: search::queryeval::WeightedSetTermSearchImpl<(search::queryeval::UnpackType)0, vespalib::LeftArrayHeap, search::PostingIteratorPack<vespalib::btree::BTreeConstIterator<unsigned int, int, vespalib::btree::MinMaxAggregated, std::less<unsigned int>, vespalib::btree::BTreeTraits<32ul, 16ul, 9ul, true> >, unsigned short> > {
  | 2024-06-14 17:27:40 UTC | }
  | 2024-06-14 17:27:40 UTC |  
  | 2024-06-14 17:27:40 UTC | DUMP: search::queryeval::WeightedSetTermSearchImpl<(search::queryeval::UnpackType)0, vespalib::LeftArrayHeap, search::PostingIteratorPack<vespalib::btree::BTreeConstIterator<unsigned int, int, vespalib::btree::MinMaxAggregated, std::less<unsigned int>, vespalib::btree::BTreeTraits<32ul, 16ul, 9ul, true> >, unsigned short> > {
  | 2024-06-14 17:27:40 UTC | }
  | 2024-06-14 17:27:40 UTC |  
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that attribute weighted set term works': PASS
  | 2024-06-14 17:27:40 UTC | DUMP: search::queryeval::WeightedSetTermSearchImpl<(search::queryeval::UnpackType)1, vespalib::LeftArrayHeap, search::PostingIteratorPack<vespalib::btree::BTreeConstIterator<unsigned int, int, vespalib::btree::MinMaxAggregated, std::less<unsigned int>, vespalib::btree::BTreeTraits<32ul, 16ul, 9ul, true> >, unsigned short> > {
  | 2024-06-14 17:27:40 UTC | }
  | 2024-06-14 17:27:40 UTC |  
  | 2024-06-14 17:27:40 UTC | DUMP: search::queryeval::WeightedSetTermSearchImpl<(search::queryeval::UnpackType)1, vespalib::LeftArrayHeap, search::PostingIteratorPack<vespalib::btree::BTreeConstIterator<unsigned int, int, vespalib::btree::MinMaxAggregated, std::less<unsigned int>, vespalib::btree::BTreeTraits<32ul, 16ul, 9ul, true> >, unsigned short> > {
  | 2024-06-14 17:27:40 UTC | }
  | 2024-06-14 17:27:40 UTC |  
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that attribute in term works': PASS
  | 2024-06-14 17:27:40 UTC | 1718385952.198477	localhost	248566/14419	-	attribute_searchable_adapter_test.vespalib.issue	warning	Trying to apply a PredicateQuery node to a non-predicate attribute.
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that predicate query in non-predicate field yields empty.': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that predicate query in predicate field yields results.': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that substring terms work': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that suffix terms work': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that diversity range searches work for various types': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that diversity also works for a single unique value': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that diversity range searches gives empty results for non-existing diversity attributes': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that loose diversity gives enough diversity and hits while doing less work': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  status_for_test 'require that strict diversity gives enough diversity and hits while doing less work, even though more than loose, but more correct than loose': PASS
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  test summary --- 22 test(s) passed --- 0 test(s) failed
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  imported 7978 passed check(s) from 1 thread(s)
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  summary --- 7978 check(s) passed --- 0 check(s) failed
  | 2024-06-14 17:27:40 UTC | attribute_searchable_adapter_test.cpp: info:  CONCLUSION: PASS
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | ==248566== HEAP SUMMARY:
  | 2024-06-14 17:27:40 UTC | ==248566==     in use at exit: 7,554 bytes in 56 blocks
  | 2024-06-14 17:27:40 UTC | ==248566==   total heap usage: 251,914 allocs, 251,858 frees, 354,102,262 bytes allocated
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | ==248566== LEAK SUMMARY:
  | 2024-06-14 17:27:40 UTC | ==248566==    definitely lost: 0 bytes in 0 blocks
  | 2024-06-14 17:27:40 UTC | ==248566==    indirectly lost: 0 bytes in 0 blocks
  | 2024-06-14 17:27:40 UTC | ==248566==      possibly lost: 0 bytes in 0 blocks
  | 2024-06-14 17:27:40 UTC | ==248566==    still reachable: 5,252 bytes in 37 blocks
  | 2024-06-14 17:27:40 UTC | ==248566==         suppressed: 2,302 bytes in 19 blocks
  | 2024-06-14 17:27:40 UTC | ==248566== Reachable blocks (those to which a pointer was found) are not shown.
  | 2024-06-14 17:27:40 UTC | ==248566== To see them, rerun with: --leak-check=full --show-leak-kinds=all
  | 2024-06-14 17:27:40 UTC | ==248566==
  | 2024-06-14 17:27:40 UTC | ==248566== For lists of detected and suppressed errors, rerun with: -s
  | 2024-06-14 17:27:40 UTC | ==248566== ERROR SUMMARY: 4 errors from 2 contexts (suppressed: 161 from 35)


```