### PR TITLE
Remove ancient, non-functional distributor init node state from tests

### DIFF
--- a/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
+++ b/storage/src/tests/distributor/top_level_bucket_db_updater_test.cpp
@@ -646,7 +646,7 @@ TopLevelBucketDBUpdaterTest::verify_state_bundle_propagated_to_stripes(const lib
 //  longer supported (>= Vespa 9).
 
 TEST_F(TopLevelBucketDBUpdaterTest, normal_usage) {
-    set_cluster_state(lib::ClusterState("distributor:2 .0.s:i .1.s:i storage:3")); // FIXME init mode why?
+    set_cluster_state(lib::ClusterState("distributor:2 storage:3"));
 
     ASSERT_EQ(message_count(3), _sender.commands().size());
 
@@ -654,21 +654,21 @@ TEST_F(TopLevelBucketDBUpdaterTest, normal_usage) {
     ASSERT_EQ(_component->getDistribution()->getNodeGraph().getDistributionConfigHash(),
               dynamic_cast<const RequestBucketInfoCommand&>(*_sender.command(0)).getDistributionHash());
 
-    ASSERT_NO_FATAL_FAILURE(fake_bucket_reply(lib::ClusterState("distributor:2 .0.s:i .1.s:i storage:3"), // FIXME init mode why?
+    ASSERT_NO_FATAL_FAILURE(fake_bucket_reply(lib::ClusterState("distributor:2 storage:3"),
                                               *_sender.command(0), 10));
 
     _sender.clear();
 
     // Optimization for not refetching unneeded data after cluster state
     // change is only implemented after completion of previous cluster state
-    set_cluster_state("distributor:2 .0.s:i storage:3"); // FIXME init mode why?
+    set_cluster_state("distributor:2 storage:3");
 
     ASSERT_EQ(message_count(3), _sender.commands().size());
     // Expect reply of first set SystemState request.
     ASSERT_EQ(size_t(1), _sender.replies().size());
 
     ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(
-            lib::ClusterState("distributor:2 .0.s:i .1.s:i storage:3"), // FIXME init mode why?
+            lib::ClusterState("distributor:2 storage:3"),
             message_count(3), 10));
     ASSERT_NO_FATAL_FAILURE(assert_correct_buckets(10, "distributor:2 storage:3"));
 }
@@ -677,9 +677,9 @@ TEST_F(TopLevelBucketDBUpdaterTest, distributor_change) {
     int num_buckets = 100;
 
     // First sends request
-    set_cluster_state("distributor:2 .0.s:i .1.s:i storage:3"); // FIXME init mode why?
+    set_cluster_state("distributor:2 storage:3");
     ASSERT_EQ(message_count(3), _sender.commands().size());
-    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:2 .0.s:i .1.s:i storage:3"), // FIXME init mode why?
+    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:2 storage:3"),
                                                            message_count(3), num_buckets));
     _sender.clear();
 
@@ -734,14 +734,14 @@ TEST_F(TopLevelBucketDBUpdaterTest, distributor_change_with_grouping) {
 }
 
 TEST_F(TopLevelBucketDBUpdaterTest, normal_usage_initializing) {
-    set_cluster_state("distributor:1 .0.s:i storage:1 .0.s:i"); // FIXME init mode why?
+    set_cluster_state("distributor:1 storage:1 .0.s:i");
 
     ASSERT_EQ(_bucket_spaces.size(), _sender.commands().size());
 
     // Not yet passing on system state.
     ASSERT_EQ(size_t(0), _sender_down.commands().size());
 
-    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:1 .0.s:i storage:1"), // FIXME init mode why?
+    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:1 storage:1"),
                                                            _bucket_spaces.size(), 10, 10));
 
     ASSERT_NO_FATAL_FAILURE(assert_correct_buckets(10, "distributor:1 storage:1"));
@@ -756,12 +756,12 @@ TEST_F(TopLevelBucketDBUpdaterTest, normal_usage_initializing) {
     _sender.clear();
     _sender_down.clear();
 
-    set_cluster_state("distributor:1 .0.s:i storage:1"); // FIXME init mode why?
+    set_cluster_state("distributor:1 storage:1");
 
     // Send a new request bucket info up.
     ASSERT_EQ(_bucket_spaces.size(), _sender.commands().size());
 
-    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:1 .0.s:i storage:1"), // FIXME init mode why?
+    ASSERT_NO_FATAL_FAILURE(complete_bucket_info_gathering(lib::ClusterState("distributor:1 storage:1"),
                                                            _bucket_spaces.size(), 20));
 
     // Pass on cluster state and recheck buckets now.
@@ -771,7 +771,7 @@ TEST_F(TopLevelBucketDBUpdaterTest, normal_usage_initializing) {
 }
 
 TEST_F(TopLevelBucketDBUpdaterTest, failed_request_bucket_info) {
-    set_cluster_state("distributor:1 .0.s:i storage:1"); // FIXME init mode why?
+    set_cluster_state("distributor:1 storage:1");
 
     // 2 messages sent up: 1 to the nodes, and one reply to the setsystemstate.
     ASSERT_EQ(_bucket_spaces.size(), _sender.commands().size());


### PR DESCRIPTION
@geirst please review.

This has not been anything more than a no-op at best, as there is no (and to the best of my knowledge—never has been) an init state for distributors.

🦖🧹💨