### PR TITLE
allow profiling weak and children

### DIFF
--- a/searchlib/src/vespa/searchlib/queryeval/iterator_pack.h
+++ b/searchlib/src/vespa/searchlib/queryeval/iterator_pack.h
@@ -61,6 +61,11 @@ public:
     }
     std::unique_ptr<BitVector> get_hits(uint32_t begin_id, uint32_t end_id) const;
     void or_hits_into(BitVector &result, uint32_t begin_id) const;
+    void transform_children(auto f) {
+        for (size_t i = 0; i < _children.size(); ++i) {
+            _children[i] = f(std::move(_children[i]), i);
+        }
+    }
 };
 
 using SearchIteratorPack = SearchIteratorPackT<uint16_t>;

--- a/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/profiled_iterator.cpp
@@ -6,6 +6,7 @@
 #include <vespa/vespalib/objects/visit.hpp>
 #include <vespa/vespalib/util/classname.h>
 #include <vespa/vespalib/util/stringfmt.h>
+#include "wand/weak_and_search.h"
 
 #include <typeindex>
 
@@ -54,6 +55,10 @@ void handle_leaf_node(Profiler &profiler, SearchIterator &leaf, const vespalib::
             child = ProfiledIterator::profile(profiler, std::move(child), fmt("%s%zu/", path.c_str(), i));
             source_blender.setChild(i, std::move(child));
         }
+    } else if (auto *weak_and = leaf.as_weak_and(); weak_and != nullptr) {
+        weak_and->transform_children([&](auto child, size_t i){
+                                         return ProfiledIterator::profile(profiler, std::move(child), fmt("%s%zu/", path.c_str(), i));
+                                     });
     }
 }
 

--- a/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
+++ b/searchlib/src/vespa/searchlib/queryeval/searchiterator.h
@@ -20,6 +20,8 @@ namespace search::attribute { class ISearchContext; }
 
 namespace search::queryeval {
 
+struct WeakAndSearch;
+
 /**
  * This is the abstract superclass of all search objects. Each search
  * object act as an iterator over documents that are results for the
@@ -356,6 +358,8 @@ public:
      * @return true if it is a multi search
      */
     virtual bool isMultiSearch() const { return false; }
+
+    virtual WeakAndSearch *as_weak_and() noexcept { return nullptr; }
 
     /**
      * This is used for adding an extra filter. If it is accepted it will return an empty UP.

--- a/searchlib/src/vespa/searchlib/queryeval/wand/weak_and_search.cpp
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/weak_and_search.cpp
@@ -67,6 +67,9 @@ public:
     score_t get_max_score(size_t idx) const override { return _terms.maxScore(idx); }
     const Terms &getTerms() const override { return _terms.input_terms(); }
     uint32_t getN() const override { return _n; }
+    void transform_children(std::function<SearchIterator::UP(SearchIterator::UP, size_t)> f) override {
+        _terms.transform_children(std::move(f));
+    }
     void doSeek(uint32_t docid) override {
         updateThreshold(_matchParams.scores.getMinScore());
         if (IS_STRICT) {

--- a/searchlib/src/vespa/searchlib/queryeval/wand/weak_and_search.h
+++ b/searchlib/src/vespa/searchlib/queryeval/wand/weak_and_search.h
@@ -4,6 +4,7 @@
 
 #include "wand_parts.h"
 #include <vespa/searchlib/queryeval/searchiterator.h>
+#include <functional>
 
 namespace search::queryeval {
 
@@ -15,6 +16,8 @@ struct WeakAndSearch : SearchIterator {
     virtual wand::score_t get_max_score(size_t idx) const = 0;
     virtual const Terms &getTerms() const = 0;
     virtual uint32_t getN() const = 0;
+    WeakAndSearch *as_weak_and() noexcept override { return this; }
+    virtual void transform_children(std::function<SearchIterator::UP(SearchIterator::UP, size_t)> f) = 0;
     void visitMembers(vespalib::ObjectVisitor &visitor) const override;
     template<typename Scorer>
     static SearchIterator::UP createArrayWand(const Terms &terms, const MatchParams & matchParams,


### PR DESCRIPTION
- new decoration strategy: transform_children
- track child reordering (to make profile results match the structure of the blueprint tree)

@geirst please review