### PR TITLE
Handle cluster state bundle with distribution config on content node

### DIFF
--- a/storage/src/tests/common/testnodestateupdater.h
+++ b/storage/src/tests/common/testnodestateupdater.h
@@ -1,11 +1,4 @@
 // Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
-/**
- * \class storage::TestNodeStateUpdater
- * \ingroup common
- *
- * \brief Test implementation of the node state updater.
- */
-
 #pragma once
 
 #include <vespa/storage/common/nodestateupdater.h>
@@ -14,6 +7,7 @@
 namespace storage::lib {
     class ClusterState;
     class ClusterStateBundle;
+    class Distribution;
 }
 namespace storage {
 
@@ -53,6 +47,7 @@ public:
         _current = std::make_shared<lib::NodeState>(state);
     }
 
+    void patch_distribution(std::shared_ptr<const lib::Distribution> distribution);
     void setClusterState(std::shared_ptr<const lib::ClusterState> c);
     void setClusterStateBundle(std::shared_ptr<const lib::ClusterStateBundle> clusterStateBundle);
 

--- a/storage/src/tests/common/teststorageapp.cpp
+++ b/storage/src/tests/common/teststorageapp.cpp
@@ -6,10 +6,10 @@
 #include <vespa/storage/config/config-stor-distributormanager.h>
 #include <vespa/storage/config/config-stor-visitordispatcher.h>
 #include <vespa/config-stor-distribution.h>
-#include <vespa/config-fleetcontroller.h>
 #include <vespa/persistence/dummyimpl/dummypersistence.h>
 #include <vespa/vdslib/distribution/distribution.h>
 #include <vespa/vdslib/state/clusterstate.h>
+#include <vespa/vdslib/state/cluster_state_bundle.h>
 #include <vespa/vespalib/util/exceptions.h>
 #include <vespa/vespalib/util/time.h>
 #include <vespa/config/subscription/configuri.h>
@@ -59,6 +59,7 @@ TestStorageApp::TestStorageApp(StorageComponentRegisterImpl::UP compReg,
     auto distr = std::make_shared<lib::Distribution>(
             lib::Distribution::getDefaultDistributionConfig(redundancy, nodeCount));
     _compReg.setDistribution(distr);
+    _nodeStateUpdater.patch_distribution(distr);
 }
 
 TestStorageApp::~TestStorageApp() = default;
@@ -69,6 +70,7 @@ TestStorageApp::setDistribution(Redundancy redundancy, NodeCount nodeCount)
     auto distr = std::make_shared<lib::Distribution>(
             lib::Distribution::getDefaultDistributionConfig(redundancy, nodeCount));
     _compReg.setDistribution(distr);
+    _nodeStateUpdater.patch_distribution(distr);
 }
 
 void
@@ -81,6 +83,12 @@ void
 TestStorageApp::setClusterState(const lib::ClusterState& c)
 {
     _nodeStateUpdater.setClusterState(std::make_shared<lib::ClusterState>(c));
+}
+
+void
+TestStorageApp::set_cluster_state_bundle(std::shared_ptr<const lib::ClusterStateBundle> state_bundle)
+{
+    _nodeStateUpdater.setClusterStateBundle(std::move(state_bundle));
 }
 
 namespace {

--- a/storage/src/tests/common/teststorageapp.h
+++ b/storage/src/tests/common/teststorageapp.h
@@ -73,6 +73,7 @@ public:
     void setDistribution(Redundancy, NodeCount);
     void setTypeRepo(std::shared_ptr<const document::DocumentTypeRepo> repo);
     void setClusterState(const lib::ClusterState&);
+    void set_cluster_state_bundle(std::shared_ptr<const lib::ClusterStateBundle>);
 
     // Utility functions for getting a hold of currently used bits. Practical
     // to avoid adding extra components in the tests.
@@ -81,7 +82,7 @@ public:
     std::shared_ptr<const document::DocumentTypeRepo> getTypeRepo() { return _compReg.getTypeRepo(); }
     const document::BucketIdFactory& getBucketIdFactory() { return _compReg.getBucketIdFactory(); }
     TestNodeStateUpdater& getStateUpdater() { return _nodeStateUpdater; }
-    std::shared_ptr<lib::Distribution> & getDistribution() { return _compReg.getDistribution(); }
+    std::shared_ptr<const lib::Distribution> getDistribution() { return _compReg.getDistribution(); }
     TestNodeStateUpdater& getNodeStateUpdater() { return _nodeStateUpdater; }
     uint16_t getIndex() const { return _compReg.getIndex(); }
     const NodeIdentity& node_identity() const noexcept { return _node_identity; }

--- a/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
+++ b/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
@@ -53,6 +53,7 @@ struct ChangedBucketOwnershipHandlerTest : Test {
 
     void applyDistribution(Redundancy, NodeCount);
     void applyClusterState(const lib::ClusterState&);
+    void apply_cluster_state_bundle(std::shared_ptr<const lib::ClusterStateBundle>);
 
     document::BucketId nextOwnedBucket(
             uint16_t wantedOwner,
@@ -82,6 +83,21 @@ struct ChangedBucketOwnershipHandlerTest : Test {
 
     static lib::ClusterState getStorageDownTestClusterState() {
         return lib::ClusterState("distributor:4 storage:1 .0.s:d");
+    }
+
+    static std::shared_ptr<const lib::DistributionConfigBundle> make_distr_bundle(uint16_t node_count) {
+        return lib::DistributionConfigBundle::of(lib::Distribution::getDefaultDistributionConfig(1, node_count));
+    }
+
+    static std::shared_ptr<const lib::ClusterStateBundle> make_state_bundle_with_config(
+            vespalib::stringref state_str, uint16_t node_count)
+    {
+        return std::make_shared<const lib::ClusterStateBundle>(
+                std::make_shared<const lib::ClusterState>(state_str),
+                lib::ClusterStateBundle::BucketSpaceStateMapping{},
+                std::nullopt,
+                make_distr_bundle(node_count),
+                false);
     }
 
     void SetUp() override;
@@ -194,6 +210,7 @@ hasOnlySetSystemStateCmdQueued(DummyStorageLink& link) {
 void
 ChangedBucketOwnershipHandlerTest::applyDistribution(Redundancy redundancy, NodeCount nodeCount)
 {
+    // TODO set distribution via state bundle instead
     _app->setDistribution(redundancy, nodeCount);
     _handler->storageDistributionChanged();
 }
@@ -202,6 +219,13 @@ void
 ChangedBucketOwnershipHandlerTest::applyClusterState(const lib::ClusterState& state)
 {
     _app->setClusterState(state);
+    _handler->reloadClusterState();
+}
+
+void
+ChangedBucketOwnershipHandlerTest::apply_cluster_state_bundle(std::shared_ptr<const lib::ClusterStateBundle> state_bundle)
+{
+    _app->set_cluster_state_bundle(std::move(state_bundle));
     _handler->reloadClusterState();
 }
 
@@ -225,7 +249,7 @@ TEST_F(ChangedBucketOwnershipHandlerTest, enumerate_buckets_belonging_on_changed
     EXPECT_TRUE(hasAbortedNoneOf(cmd, node2Buckets));
 
     // Handler must swallow abort replies
-    _bottom->sendUp(api::StorageMessage::SP(cmd->makeReply().release()));
+    _bottom->sendUp(api::StorageMessage::SP(cmd->makeReply()));
     EXPECT_EQ(size_t(0), _top->getNumReplies());
 }
 
@@ -312,7 +336,7 @@ TEST_F(ChangedBucketOwnershipHandlerTest, ownership_changed_on_distributor_up_ed
     EXPECT_TRUE(hasAbortedNoneOf(cmd, node2Buckets));
 
     // Handler must swallow abort replies
-    _bottom->sendUp(api::StorageMessage::SP(cmd->makeReply().release()));
+    _bottom->sendUp(api::StorageMessage::SP(cmd->makeReply()));
     EXPECT_EQ(0, _top->getNumReplies());
 }
 
@@ -342,6 +366,32 @@ TEST_F(ChangedBucketOwnershipHandlerTest, distribution_config_change_updates_own
     // Apply new distribution config containing only 1 distributor, meaning
     // any messages sent from >1 must be aborted.
     applyDistribution(Redundancy(1), NodeCount(1));
+    sendAndExpectAbortedCreateBucket(2);
+}
+
+TEST_F(ChangedBucketOwnershipHandlerTest, distribution_config_via_state_bundle_change_updates_ownership) {
+    apply_cluster_state_bundle(make_state_bundle_with_config("version:2 distributor:3 storage:1", 3));
+    // Apply new distribution config containing only 1 distributor, meaning
+    // any messages sent from >1 must be aborted.
+    // This test case is a bit dodgy since the CC should never send a state with more nodes in it than
+    // the distribution config allows for when _it_ is responsible for also sending the config.
+    apply_cluster_state_bundle(make_state_bundle_with_config("version:3 distributor:3 storage:1", 1));
+    sendAndExpectAbortedCreateBucket(2);
+}
+
+TEST_F(ChangedBucketOwnershipHandlerTest, ignore_internal_config_once_state_bundle_with_config_received) {
+    apply_cluster_state_bundle(make_state_bundle_with_config("version:2 distributor:1 storage:3", 1));
+    applyDistribution(Redundancy(1), NodeCount(3));
+    // Bundle config says 1 node, internal config says 3. Trust the bundle(tm).
+    sendAndExpectAbortedCreateBucket(2);
+}
+
+TEST_F(ChangedBucketOwnershipHandlerTest, revert_to_internal_config_if_distribution_no_longer_received_in_state_bundle) {
+    apply_cluster_state_bundle(make_state_bundle_with_config("version:2 distributor:1 storage:3", 3));
+
+    applyDistribution(Redundancy(1), NodeCount(1)); // not yet used
+    applyClusterState(lib::ClusterState("version:3 distributor:3 storage:3")); // no bundle config; revert to internal
+
     sendAndExpectAbortedCreateBucket(2);
 }
 

--- a/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
+++ b/storage/src/tests/storageserver/changedbucketownershiphandlertest.cpp
@@ -380,7 +380,7 @@ TEST_F(ChangedBucketOwnershipHandlerTest, distribution_config_via_state_bundle_c
 }
 
 TEST_F(ChangedBucketOwnershipHandlerTest, ignore_internal_config_once_state_bundle_with_config_received) {
-    apply_cluster_state_bundle(make_state_bundle_with_config("version:2 distributor:1 storage:3", 1));
+    apply_cluster_state_bundle(make_state_bundle_with_config("version:2 distributor:3 storage:3", 1));
     applyDistribution(Redundancy(1), NodeCount(3));
     // Bundle config says 1 node, internal config says 3. Trust the bundle(tm).
     sendAndExpectAbortedCreateBucket(2);

--- a/storage/src/tests/storageserver/statemanagertest.cpp
+++ b/storage/src/tests/storageserver/statemanagertest.cpp
@@ -10,6 +10,7 @@
 #include <vespa/vdslib/state/clusterstate.h>
 #include <vespa/storage/storageserver/statemanager.h>
 #include <vespa/vespalib/data/slime/slime.h>
+#include <vespa/config-stor-distribution.h>
 #include <vespa/vespalib/gtest/gtest.h>
 
 using storage::lib::NodeState;
@@ -38,6 +39,23 @@ struct StateManagerTest : Test, NodeStateReporter {
         return cmd;
     }
 
+    static std::shared_ptr<const lib::ClusterStateBundle> make_state_bundle_with_config(
+            vespalib::stringref state_str, uint16_t num_nodes)
+    {
+        auto state = std::make_shared<const ClusterState>(state_str);
+        auto distr = lib::DistributionConfigBundle::of(lib::Distribution::getDefaultDistributionConfig(1, num_nodes));
+        return std::make_shared<lib::ClusterStateBundle>(std::move(state),
+                                                         lib::ClusterStateBundle::BucketSpaceStateMapping{},
+                                                         std::nullopt, std::move(distr), false);
+    }
+
+
+    static std::shared_ptr<api::SetSystemStateCommand> make_set_state_cmd_with_config(
+            vespalib::stringref state_str, uint16_t num_nodes)
+    {
+        return std::make_shared<api::SetSystemStateCommand>(make_state_bundle_with_config(state_str, num_nodes));
+    }
+
     void get_single_reply(std::shared_ptr<api::StorageReply>& reply_out);
     void get_only_ok_reply(std::shared_ptr<api::StorageReply>& reply_out);
     void force_current_cluster_state_version(uint32_t version, uint16_t cc_index);
@@ -56,6 +74,10 @@ struct StateManagerTest : Test, NodeStateReporter {
     void report(vespalib::JsonStream &) const override {}
 
     void extract_cluster_state_version_from_host_info(uint32_t& version_out);
+
+    static vespalib::string to_string(const lib::Distribution::DistributionConfig& cfg) {
+        return lib::Distribution(cfg).serialized();
+    }
 };
 
 StateManagerTest::StateManagerTest()
@@ -148,26 +170,107 @@ StateManagerTest::extract_cluster_state_version_from_host_info(uint32_t& version
     version_out = clusterStateVersionCursor.asLong();
 }
 
-TEST_F(StateManagerTest, cluster_state) {
-    std::shared_ptr<api::StorageReply> reply;
-    // Verify initial state on startup
-    auto currentState = _manager->getClusterStateBundle()->getBaselineClusterState();
+TEST_F(StateManagerTest, cluster_state_and_config_has_expected_values_at_bootstrap) {
+    auto initial_bundle = _manager->getClusterStateBundle();
+    auto currentState = initial_bundle->getBaselineClusterState();
     EXPECT_EQ("cluster:d", currentState->toString(false));
     EXPECT_EQ(currentState->getVersion(), 0);
 
+    // Distribution config should be equal to the config the node is running with.
+    ASSERT_TRUE(initial_bundle->has_distribution_config());
+    EXPECT_EQ(to_string(initial_bundle->distribution_config_bundle()->config()),
+              _node->getComponentRegister().getDistribution()->serialized());
+
     auto currentNodeState = _manager->getCurrentNodeState();
     EXPECT_EQ("s:d", currentNodeState->toString(false));
+}
 
-    ClusterState sendState("storage:4 .2.s:m");
-    auto cmd = std::make_shared<api::SetSystemStateCommand>(sendState);
+TEST_F(StateManagerTest, can_receive_state_bundle_without_distribution_config) {
+    ClusterState send_state("version:2 distributor:1 storage:4 .2.s:m");
+    auto cmd = std::make_shared<api::SetSystemStateCommand>(send_state);
     _upper->sendDown(cmd);
+    std::shared_ptr<api::StorageReply> reply;
     ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
 
-    currentState = _manager->getClusterStateBundle()->getBaselineClusterState();
-    EXPECT_EQ(sendState, *currentState);
+    auto current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(send_state, *current_bundle->getBaselineClusterState());
+    // Distribution config should be unchanged from boostrap.
+    ASSERT_TRUE(current_bundle->has_distribution_config());
+    EXPECT_EQ(to_string(current_bundle->distribution_config_bundle()->config()),
+              _node->getComponentRegister().getDistribution()->serialized());
 
-    currentNodeState = _manager->getCurrentNodeState();
-    EXPECT_EQ("s:m", currentNodeState->toString(false));
+    auto current_node_state = _manager->getCurrentNodeState();
+    EXPECT_EQ("s:m", current_node_state->toString(false));
+}
+
+TEST_F(StateManagerTest, can_receive_state_bundle_with_distribution_config) {
+    auto cmd = make_set_state_cmd_with_config("version:2 distributor:1 storage:4 .2.s:m", 5);
+    EXPECT_NE(to_string(cmd->getClusterStateBundle().distribution_config_bundle()->config()),
+              _node->getComponentRegister().getDistribution()->serialized());
+    _upper->sendDown(cmd);
+    std::shared_ptr<api::StorageReply> reply;
+    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
+
+    auto current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(*current_bundle, cmd->getClusterStateBundle()); // also compares distribution configs
+}
+
+TEST_F(StateManagerTest, receiving_cc_bundle_with_distribution_config_disables_node_distribution_config_propagation) {
+    auto cmd = make_set_state_cmd_with_config("version:2 distributor:1 storage:4 .2.s:m", 5);
+    _upper->sendDown(cmd);
+    std::shared_ptr<api::StorageReply> reply;
+    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
+    // Explicitly setting distribution config should not propagate to the active state bundle
+    // since we've flipped to expecting config from the cluster controllers instead.
+    auto distr = std::make_shared<lib::Distribution>(lib::Distribution::getDefaultDistributionConfig(2, 7));
+    _node->getComponentRegister().setDistribution(distr);
+
+    auto current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(*current_bundle, cmd->getClusterStateBundle()); // unchanged
+}
+
+TEST_F(StateManagerTest, internal_distribution_config_is_propagated_if_none_yet_received_from_cc) {
+    _upper->sendDown(make_set_state_cmd("version:10 distributor:1 storage:4", 0));
+    std::shared_ptr<api::StorageReply> reply;
+    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
+
+    auto expected_bundle = make_state_bundle_with_config("version:10 distributor:1 storage:4", 7);
+    // Explicitly set internal config
+    _node->getComponentRegister().setDistribution(expected_bundle->distribution_config_bundle()->default_distribution_sp());
+    _manager->storageDistributionChanged();
+
+    auto current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(*current_bundle, *expected_bundle);
+}
+
+TEST_F(StateManagerTest, revert_to_internal_config_if_cc_no_longer_sends_distribution_config) {
+    // Initial state bundle _with_ distribution config
+    auto cmd = make_set_state_cmd_with_config("version:2 distributor:1 storage:4 .2.s:m", 5);
+    _upper->sendDown(cmd);
+    std::shared_ptr<api::StorageReply> reply;
+    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
+
+    auto current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(to_string(current_bundle->distribution_config_bundle()->config()),
+              to_string(cmd->getClusterStateBundle().distribution_config_bundle()->config()));
+
+    // CC then sends a new bundle _without_ config
+    _upper->sendDown(make_set_state_cmd("version:3 distributor:1 storage:4", 0));
+    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
+
+    // Config implicitly reverted to the active internal config
+    current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(to_string(current_bundle->distribution_config_bundle()->config()),
+              _node->getComponentRegister().getDistribution()->serialized());
+
+    // Explicitly set internal config
+    auto expected_bundle = make_state_bundle_with_config("version:3 distributor:1 storage:4", 7);
+    _node->getComponentRegister().setDistribution(expected_bundle->distribution_config_bundle()->default_distribution_sp());
+    _manager->storageDistributionChanged();
+
+    // Internal config shall have taken effect, overriding that of the initial bundle
+    current_bundle = _manager->getClusterStateBundle();
+    EXPECT_EQ(*current_bundle, *expected_bundle);
 }
 
 TEST_F(StateManagerTest, accept_lower_state_versions_if_strict_requirement_disabled) {

--- a/storage/src/tests/storageserver/statemanagertest.cpp
+++ b/storage/src/tests/storageserver/statemanagertest.cpp
@@ -194,7 +194,7 @@ TEST_F(StateManagerTest, can_receive_state_bundle_without_distribution_config) {
 
     auto current_bundle = _manager->getClusterStateBundle();
     EXPECT_EQ(send_state, *current_bundle->getBaselineClusterState());
-    // Distribution config should be unchanged from boostrap.
+    // Distribution config should be unchanged from bootstrap.
     ASSERT_TRUE(current_bundle->has_distribution_config());
     EXPECT_EQ(to_string(current_bundle->distribution_config_bundle()->config()),
               _node->getComponentRegister().getDistribution()->serialized());

--- a/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
+++ b/storage/src/vespa/storage/bucketdb/bucketmanager.cpp
@@ -526,12 +526,12 @@ BucketManager::processRequestBucketInfoCommands(document::BucketSpace bucketSpac
     using RBISP = std::shared_ptr<api::RequestBucketInfoCommand>;
     std::map<uint16_t, RBISP> requests;
 
-    // TODO fetch distribution from bundle as well
-    auto distribution(_component.getBucketSpaceRepo().get(bucketSpace).getDistribution());
-    auto clusterStateBundle(_component.getStateUpdater().getClusterStateBundle());
-    assert(clusterStateBundle);
-    lib::ClusterState::CSP clusterState(clusterStateBundle->getDerivedClusterState(bucketSpace));
-    assert(clusterState.get());
+    auto clusterStateBundle = _component.getStateUpdater().getClusterStateBundle();
+    assert(clusterStateBundle && clusterStateBundle->has_distribution_config());
+    auto clusterState = clusterStateBundle->getDerivedClusterState(bucketSpace);
+    assert(clusterState);
+    const auto distribution = clusterStateBundle->bucket_space_distribution_or_nullptr(bucketSpace);
+    assert(distribution);
 
     const auto our_hash = distribution->getNodeGraph().getDistributionConfigHash();
 

--- a/storage/src/vespa/storage/common/content_bucket_space.cpp
+++ b/storage/src/vespa/storage/common/content_bucket_space.cpp
@@ -10,6 +10,7 @@ ClusterStateAndDistribution::ClusterStateAndDistribution(
     : _cluster_state(std::move(cluster_state)),
       _distribution(std::move(distribution))
 {
+    assert(_cluster_state && _distribution);
 }
 
 ClusterStateAndDistribution::~ClusterStateAndDistribution() = default;
@@ -46,34 +47,6 @@ std::shared_ptr<const ClusterStateAndDistribution>
 ContentBucketSpace::state_and_distribution() const noexcept {
     std::lock_guard guard(_lock);
     return _state_and_distribution;
-}
-
-void
-ContentBucketSpace::setClusterState(std::shared_ptr<const lib::ClusterState> clusterState)
-{
-    std::lock_guard guard(_lock);
-    _state_and_distribution = _state_and_distribution->with_new_state(std::move(clusterState));
-}
-
-std::shared_ptr<const lib::ClusterState>
-ContentBucketSpace::getClusterState() const
-{
-    std::lock_guard guard(_lock);
-    return _state_and_distribution->_cluster_state;
-}
-
-void
-ContentBucketSpace::setDistribution(std::shared_ptr<const lib::Distribution> distribution)
-{
-    std::lock_guard guard(_lock);
-    _state_and_distribution = _state_and_distribution->with_new_distribution(std::move(distribution));
-}
-
-std::shared_ptr<const lib::Distribution>
-ContentBucketSpace::getDistribution() const
-{
-    std::lock_guard guard(_lock);
-    return _state_and_distribution->_distribution;
 }
 
 bool

--- a/storage/src/vespa/storage/common/content_bucket_space.h
+++ b/storage/src/vespa/storage/common/content_bucket_space.h
@@ -54,14 +54,6 @@ public:
 
     void set_state_and_distribution(std::shared_ptr<const ClusterStateAndDistribution> state_and_distr) noexcept;
     [[nodiscard]] std::shared_ptr<const ClusterStateAndDistribution> state_and_distribution() const noexcept;
-    // TODO deprecate; only use atomic state+distribution setter
-    void setClusterState(std::shared_ptr<const lib::ClusterState> clusterState);
-    // TODO deprecate; only use atomic state+distribution getter
-    std::shared_ptr<const lib::ClusterState> getClusterState() const;
-    // TODO deprecate; only use atomic state+distribution setter
-    void setDistribution(std::shared_ptr<const lib::Distribution> distribution);
-    // TODO deprecate; only use atomic state+distribution getter
-    std::shared_ptr<const lib::Distribution> getDistribution() const;
 
     bool getNodeUpInLastNodeStateSeenByProvider() const;
     void setNodeUpInLastNodeStateSeenByProvider(bool nodeUpInLastNodeStateSeenByProvider);

--- a/storage/src/vespa/storage/common/storagecomponent.h
+++ b/storage/src/vespa/storage/common/storagecomponent.h
@@ -61,7 +61,7 @@ public:
         const std::shared_ptr<const document::FieldSetRepo> fieldSetRepo;
     };
     using UP = std::unique_ptr<StorageComponent>;
-    using DistributionSP = std::shared_ptr<lib::Distribution>;
+    using DistributionSP = std::shared_ptr<const lib::Distribution>;
 
     /**
      * Node type is supposed to be set immediately, and never be updated.

--- a/storage/src/vespa/storage/frameworkimpl/component/servicelayercomponentregisterimpl.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/component/servicelayercomponentregisterimpl.cpp
@@ -23,11 +23,9 @@ ServiceLayerComponentRegisterImpl::registerServiceLayerComponent(ServiceLayerMan
 }
 
 void
-ServiceLayerComponentRegisterImpl::setDistribution(std::shared_ptr<lib::Distribution> distribution)
+ServiceLayerComponentRegisterImpl::setDistribution(std::shared_ptr<const lib::Distribution> distribution)
 {
-    _bucketSpaceRepo.get(document::FixedBucketSpaces::default_space()).setDistribution(distribution);
-    auto global_distr = lib::GlobalBucketSpaceDistributionConverter::convert_to_global(*distribution);
-    _bucketSpaceRepo.get(document::FixedBucketSpaces::global_space()).setDistribution(global_distr);
+    // TODO remove this override entirely?
     StorageComponentRegisterImpl::setDistribution(distribution);
 }
 

--- a/storage/src/vespa/storage/frameworkimpl/component/servicelayercomponentregisterimpl.h
+++ b/storage/src/vespa/storage/frameworkimpl/component/servicelayercomponentregisterimpl.h
@@ -34,7 +34,7 @@ public:
     }
 
     void registerServiceLayerComponent(ServiceLayerManagedComponent&) override;
-    void setDistribution(std::shared_ptr<lib::Distribution> distribution) override;
+    void setDistribution(std::shared_ptr<const lib::Distribution> distribution) override;
 };
 
 } // storage

--- a/storage/src/vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.cpp
+++ b/storage/src/vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.cpp
@@ -91,7 +91,7 @@ StorageComponentRegisterImpl::setBucketIdFactory(const document::BucketIdFactory
 }
 
 void
-StorageComponentRegisterImpl::setDistribution(std::shared_ptr<lib::Distribution> distribution)
+StorageComponentRegisterImpl::setDistribution(std::shared_ptr<const lib::Distribution> distribution)
 {
     std::lock_guard lock(_componentLock);
     _distribution = distribution;

--- a/storage/src/vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.h
+++ b/storage/src/vespa/storage/frameworkimpl/component/storagecomponentregisterimpl.h
@@ -21,16 +21,16 @@ class StorageComponentRegisterImpl
 {
     using BucketspacesConfig = vespa::config::content::core::internal::InternalBucketspacesType;
 
-    std::mutex _componentLock;
-    std::vector<StorageComponent*> _components;
-    vespalib::string _clusterName;
-    const lib::NodeType* _nodeType;
-    uint16_t _index;
+    std::mutex                                        _componentLock;
+    std::vector<StorageComponent*>                    _components;
+    vespalib::string                                  _clusterName;
+    const lib::NodeType*                              _nodeType;
+    uint16_t                                          _index;
     std::shared_ptr<const document::DocumentTypeRepo> _docTypeRepo;
-    document::BucketIdFactory _bucketIdFactory;
-    std::shared_ptr<lib::Distribution> _distribution;
-    NodeStateUpdater* _nodeStateUpdater;
-    BucketspacesConfig _bucketSpacesConfig;
+    document::BucketIdFactory                         _bucketIdFactory;
+    std::shared_ptr<const lib::Distribution>          _distribution;
+    NodeStateUpdater*                                 _nodeStateUpdater;
+    BucketspacesConfig                                _bucketSpacesConfig;
 
 public:
     using UP = std::unique_ptr<StorageComponentRegisterImpl>;
@@ -38,12 +38,12 @@ public:
     StorageComponentRegisterImpl();
     ~StorageComponentRegisterImpl() override;
 
-    const lib::NodeType& getNodeType() const { return *_nodeType; }
-    uint16_t getIndex() const { return _index; }
-    std::shared_ptr<const document::DocumentTypeRepo> getTypeRepo() { return _docTypeRepo; }
-    const document::BucketIdFactory& getBucketIdFactory() { return _bucketIdFactory; }
-    std::shared_ptr<lib::Distribution> & getDistribution() { return _distribution; }
-    NodeStateUpdater& getNodeStateUpdater() { return *_nodeStateUpdater; }
+    [[nodiscard]] const lib::NodeType& getNodeType() const noexcept { return *_nodeType; }
+    [[nodiscard]] uint16_t getIndex() const noexcept { return _index; }
+    [[nodiscard]] std::shared_ptr<const document::DocumentTypeRepo> getTypeRepo() const noexcept { return _docTypeRepo; }
+    [[nodiscard]] const document::BucketIdFactory& getBucketIdFactory() const noexcept { return _bucketIdFactory; }
+    [[nodiscard]] const std::shared_ptr<const lib::Distribution>& getDistribution() const noexcept { return _distribution; }
+    [[nodiscard]] NodeStateUpdater& getNodeStateUpdater() noexcept { return *_nodeStateUpdater; }
 
     void registerStorageComponent(StorageComponent&) override;
 
@@ -51,7 +51,7 @@ public:
     virtual void setNodeStateUpdater(NodeStateUpdater& updater);
     virtual void setDocumentTypeRepo(std::shared_ptr<const document::DocumentTypeRepo>);
     virtual void setBucketIdFactory(const document::BucketIdFactory&);
-    virtual void setDistribution(std::shared_ptr<lib::Distribution>);
+    virtual void setDistribution(std::shared_ptr<const lib::Distribution>);
     virtual void setBucketSpacesConfig(const BucketspacesConfig&);
 };
 

--- a/storage/src/vespa/storage/persistence/bucketownershipnotifier.h
+++ b/storage/src/vespa/storage/persistence/bucketownershipnotifier.h
@@ -11,29 +11,29 @@ namespace storage {
 
 class BucketOwnershipNotifier
 {
-    const ServiceLayerComponent & _component;
-    MessageSender               & _sender;
+    const ServiceLayerComponent& _component;
+    MessageSender&               _sender;
 public:
     BucketOwnershipNotifier(const ServiceLayerComponent& component, MessageSender& sender)
         : _component(component),
           _sender(sender)
     {}
 
-    bool distributorOwns(uint16_t distributor, const document::Bucket &bucket) const;
-    void notifyIfOwnershipChanged(const document::Bucket &bucket, uint16_t sourceIndex, const api::BucketInfo& infoToSend);
-    void sendNotifyBucketToCurrentOwner(const document::Bucket &bucket, const api::BucketInfo& infoToSend);
+    [[nodiscard]] bool distributorOwns(uint16_t distributor, const document::Bucket& bucket) const;
+    void notifyIfOwnershipChanged(const document::Bucket& bucket, uint16_t sourceIndex, const api::BucketInfo& infoToSend);
+    void sendNotifyBucketToCurrentOwner(const document::Bucket& bucket, const api::BucketInfo& infoToSend);
 private:
     enum IndexMeta {
         FAILED_TO_RESOLVE = 0xffff
     };
 
-    void sendNotifyBucketToDistributor(uint16_t distributorIndex, const document::Bucket &bucket,
+    void sendNotifyBucketToDistributor(uint16_t distributorIndex, const document::Bucket& bucket,
                                        const api::BucketInfo& infoToSend);
 
     // Returns either index or FAILED_TO_RESOLVE
     uint16_t getOwnerDistributorForBucket(const document::Bucket &bucket) const;
 
-    void logNotification(const document::Bucket &bucket, uint16_t sourceIndex,
+    void logNotification(const document::Bucket& bucket, uint16_t sourceIndex,
                          uint16_t currentOwnerIndex, const api::BucketInfo& newInfo);
 };
 
@@ -60,7 +60,7 @@ class NotificationGuard
     BucketOwnershipNotifier& _notifier;
     std::vector<BucketToCheck> _bucketsToCheck;
 public:
-    NotificationGuard(BucketOwnershipNotifier& notifier)
+    explicit NotificationGuard(BucketOwnershipNotifier& notifier)
         : _notifier(notifier),
           _bucketsToCheck()
     {}
@@ -69,8 +69,8 @@ public:
 
     ~NotificationGuard();
 
-    void notifyIfOwnershipChanged(const document::Bucket &bucket, uint16_t sourceIndex, const api::BucketInfo& infoToSend);
-    void notifyAlways(const document::Bucket &bucket, const api::BucketInfo& infoToSend);
+    void notifyIfOwnershipChanged(const document::Bucket& bucket, uint16_t sourceIndex, const api::BucketInfo& infoToSend);
+    void notifyAlways(const document::Bucket& bucket, const api::BucketInfo& infoToSend);
 };
 
 } // storage

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -887,9 +887,9 @@ bool
 FileStorManager::maintenance_in_all_spaces(const lib::Node& node) const noexcept
 {
     for (const auto& elem :  _component.getBucketSpaceRepo()) {
-        const ContentBucketSpace& bucket_space = *elem.second;
-        auto derived_cluster_state = bucket_space.getClusterState();
-        if (!derived_cluster_state->getNodeState(node).getState().oneOf("m")) {
+        const auto space_state_and_distr = elem.second->state_and_distribution();
+        const auto& derived_cluster_state = space_state_and_distr->cluster_state();
+        if (!derived_cluster_state.getNodeState(node).getState().oneOf("m")) {
             return false;
         }
     }
@@ -915,8 +915,7 @@ FileStorManager::maybe_log_received_cluster_state()
 {
     if (LOG_WOULD_LOG(debug)) {
         auto cluster_state_bundle = _component.getStateUpdater().getClusterStateBundle();
-        auto baseline_state = cluster_state_bundle->getBaselineClusterState();
-        LOG(debug, "FileStorManager received baseline cluster state '%s'", baseline_state->toString().c_str());
+        LOG(debug, "FileStorManager received baseline cluster state '%s'", cluster_state_bundle->toString().c_str());
     }
 }
 
@@ -951,16 +950,17 @@ FileStorManager::updateState()
 void
 FileStorManager::storageDistributionChanged()
 {
-    updateState();
 }
 
 void
 FileStorManager::propagateClusterStates()
 {
     auto clusterStateBundle = _component.getStateUpdater().getClusterStateBundle();
-    for (const auto &elem : _component.getBucketSpaceRepo()) {
-        // TODO also distribution! bundle and repo must be 1-1
-        elem.second->setClusterState(clusterStateBundle->getDerivedClusterState(elem.first));
+    assert(clusterStateBundle->has_distribution_config());
+    for (const auto& elem : _component.getBucketSpaceRepo()) {
+        elem.second->set_state_and_distribution(std::make_shared<ClusterStateAndDistribution>(
+                clusterStateBundle->getDerivedClusterState(elem.first),
+                clusterStateBundle->bucket_space_distribution_or_nullptr(elem.first)));
     }
 }
 

--- a/storage/src/vespa/storage/storageserver/statemanager.h
+++ b/storage/src/vespa/storage/storageserver/statemanager.h
@@ -55,6 +55,7 @@ class StateManager : public NodeStateUpdater,
     std::mutex                                _listenerLock;
     std::shared_ptr<lib::NodeState>           _nodeState;
     std::shared_ptr<lib::NodeState>           _nextNodeState;
+    std::shared_ptr<const lib::Distribution>  _configured_distribution; // From config system, not from CC
     std::shared_ptr<const ClusterStateBundle> _systemState;
     std::shared_ptr<const ClusterStateBundle> _nextSystemState;
     uint32_t                                  _reported_host_info_cluster_state_version;
@@ -78,6 +79,7 @@ class StateManager : public NodeStateUpdater,
     bool                                      _noThreadTestMode;
     bool                                      _grabbedExternalLock;
     bool                                      _require_strictly_increasing_cluster_state_versions;
+    bool                                      _receiving_distribution_config_from_cc;
     std::atomic<bool>                         _notifyingListeners;
     std::atomic<bool>                         _requested_almost_immediate_node_state_replies;
 
@@ -101,6 +103,8 @@ public:
     lib::NodeState::CSP getReportedNodeState() const override;
     lib::NodeState::CSP getCurrentNodeState() const override;
     std::shared_ptr<const ClusterStateBundle> getClusterStateBundle() const override;
+
+    void storageDistributionChanged() override;
 
     void addStateListener(StateListener&) override;
     void removeStateListener(StateListener&) override;

--- a/vdslib/src/vespa/vdslib/distribution/bucket_space_distribution_configs.h
+++ b/vdslib/src/vespa/vdslib/distribution/bucket_space_distribution_configs.h
@@ -21,6 +21,11 @@ struct BucketSpaceDistributionConfigs {
         return (iter != space_configs.end()) ? iter->second : std::shared_ptr<const Distribution>();
     }
 
+    [[nodiscard]] const Distribution* get_or_nullptr_raw(document::BucketSpace space) const noexcept {
+        auto iter = space_configs.find(space);
+        return (iter != space_configs.end()) ? iter->second.get() : nullptr;
+    }
+
     static BucketSpaceDistributionConfigs from_default_distribution(std::shared_ptr<const Distribution>);
 };
 

--- a/vdslib/src/vespa/vdslib/distribution/distribution_config_bundle.h
+++ b/vdslib/src/vespa/vdslib/distribution/distribution_config_bundle.h
@@ -33,6 +33,9 @@ public:
     [[nodiscard]] std::shared_ptr<const Distribution> bucket_space_distribution_or_nullptr(document::BucketSpace space) const noexcept {
         return _bucket_space_distributions.get_or_nullptr(space);
     }
+    [[nodiscard]] const Distribution* bucket_space_distribution_or_nullptr_raw(document::BucketSpace space) const noexcept {
+        return _bucket_space_distributions.get_or_nullptr_raw(space);
+    }
     [[nodiscard]] const BucketSpaceDistributionConfigs& bucket_space_distributions() const noexcept {
         return _bucket_space_distributions;
     }

--- a/vdslib/src/vespa/vdslib/state/cluster_state_bundle.cpp
+++ b/vdslib/src/vespa/vdslib/state/cluster_state_bundle.cpp
@@ -22,13 +22,17 @@ ClusterStateBundle::FeedBlock::operator==(const FeedBlock& rhs) const noexcept
             (_description == rhs._description);
 }
 
-// TODO implement with ctor fwd
-ClusterStateBundle::ClusterStateBundle(const ClusterState& baselineClusterState)
-    : _baselineClusterState(std::make_shared<const ClusterState>(baselineClusterState)),
+ClusterStateBundle::ClusterStateBundle(std::shared_ptr<const ClusterState> baseline_cluster_state)
+    : _baselineClusterState(std::move(baseline_cluster_state)),
       _derivedBucketSpaceStates(),
       _feed_block(),
       _distribution_bundle(),
       _deferredActivation(false)
+{
+}
+
+ClusterStateBundle::ClusterStateBundle(const ClusterState& baselineClusterState)
+    : ClusterStateBundle(std::make_shared<const ClusterState>(baselineClusterState))
 {
 }
 
@@ -106,6 +110,14 @@ ClusterStateBundle::getDerivedClusterState(document::BucketSpace bucketSpace) co
         return itr->second;
     }
     return _baselineClusterState;
+}
+
+std::shared_ptr<const Distribution>
+ClusterStateBundle::bucket_space_distribution_or_nullptr(document::BucketSpace space) const noexcept {
+    if (!_distribution_bundle) {
+        return {};
+    }
+    return _distribution_bundle->bucket_space_distribution_or_nullptr(space);
 }
 
 uint32_t

--- a/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
+++ b/vdslib/src/vespa/vdslib/state/cluster_state_bundle.h
@@ -52,6 +52,7 @@ public:
     std::shared_ptr<const DistributionConfigBundle> _distribution_bundle;
     bool                                            _deferredActivation;
 public:
+    explicit ClusterStateBundle(std::shared_ptr<const ClusterState> baseline_cluster_state);
     explicit ClusterStateBundle(const ClusterState& baselineClusterState);
     ClusterStateBundle(const ClusterState& baselineClusterState,
                        BucketSpaceStateMapping derivedBucketSpaceStates);
@@ -98,6 +99,7 @@ public:
     [[nodiscard]] const std::shared_ptr<const DistributionConfigBundle>& distribution_config_bundle() const noexcept {
         return _distribution_bundle;
     }
+    [[nodiscard]] std::shared_ptr<const Distribution> bucket_space_distribution_or_nullptr(document::BucketSpace space) const noexcept;
     [[nodiscard]] const std::optional<FeedBlock>& feed_block() const { return _feed_block; }
     [[nodiscard]] uint32_t getVersion() const;
     [[nodiscard]] bool deferredActivation() const noexcept { return _deferredActivation; }


### PR DESCRIPTION
@geirst please review 🎣

If a cluster state bundle contains distribution config, this is internally propagated via the `StateManager` component to all registered state listeners. One such state listener is `FileStorManager`, which updates the content node-internal bucket space repository.

All `SetSystemStateCommand` and internal config-aware components (`StateManager` and `ChangedBucketOwnershipHandler`) now explicitly track whether the cluster controller provides distribution config, or if the internally provided config should be used (including fallback to internal config if necessary). This logic duplication is not optimal, but will go away once the only way to get distribution config is via the cluster controller.
