### PR TITLE
Require Go 1.22

### DIFF
--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -17,6 +17,7 @@ GO_FLAGS := -ldflags "-X github.com/vespa-engine/vespa/client/go/internal/build.
 PROJECT_ROOT := $(shell realpath $(CURDIR)/../..)
 GO_TMPDIR := $(PROJECT_ROOT)/build/go
 DIST_TARGETS := dist-mac dist-mac-arm64 dist-linux dist-linux-arm64 dist-win32 dist-win64
+GOTOOLCHAIN := $(shell go env GOTOOLCHAIN)
 
 all: test checkfmt install
 
@@ -111,19 +112,19 @@ install-all: all manpages
 # Development targets
 #
 
-ci:
+setenv:
+# Set GOTOOLCHAIN if its default value has been changed
+	@test "$(GOTOOLCHAIN)" = auto || go env -w GOTOOLCHAIN="auto"
 ifdef CI
-# Ensure that CI systems use a proxy for downloading dependencies, and
-# automatically downloads the necessary toolchain
+# Ensure that CI systems use a proxy for downloading dependencies
 	go env -w GOPROXY="https://proxy.golang.org,direct"
-	go env -w GOTOOLCHAIN="auto"
 	go env
 endif
 
 install-brew:
 	brew install vespa-cli
 
-install: ci
+install: setenv
 	env GOBIN=$(BIN) go install $(GO_FLAGS) ./...
 
 manpages: install
@@ -135,7 +136,7 @@ clean:
 	rm -f $(BIN)/vespa $(BIN)/vespa-wrapper $(SHARE)/man/man1/vespa.1 $(SHARE)/man/man1/vespa-*.1
 	rmdir -p $(BIN) $(SHARE)/man/man1 > /dev/null 2>&1 || true
 
-test: ci
+test: setenv
 # Why custom GOTMPDIR? go builds executables for unit tests and by default these
 # end up in TMPDIR/GOTMPDIR. In some environments /tmp is mounted noexec so
 # running test executables will fail

--- a/client/go/Makefile
+++ b/client/go/Makefile
@@ -113,8 +113,10 @@ install-all: all manpages
 
 ci:
 ifdef CI
-# Ensure that CI systems use a proxy for downloading dependencies
+# Ensure that CI systems use a proxy for downloading dependencies, and
+# automatically downloads the necessary toolchain
 	go env -w GOPROXY="https://proxy.golang.org,direct"
+	go env -w GOTOOLCHAIN="auto"
 	go env
 endif
 

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/vespa-engine/vespa/client/go
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/vespa-engine/vespa/client/go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/client/go/go.mod
+++ b/client/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/vespa-engine/vespa/client/go
 
-go 1.22.0
+go 1.22.4
 
 require (
 	github.com/alessio/shellescape v1.4.2

--- a/client/go/internal/admin/jvm/mem_options_test.go
+++ b/client/go/internal/admin/jvm/mem_options_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAdjustment(t *testing.T) {
 	lastAdj := 64
-	for i := 0; i < 4096; i++ {
+	for i := range 4096 {
 		adj := adjustAvailableMemory(MegaBytesOfMemory(i)).ToMB()
 		assert.True(t, int(adj) >= lastAdj)
 		lastAdj = int(adj)

--- a/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
+++ b/client/go/internal/admin/vespa-wrapper/logfmt/tail_unix.go
@@ -85,7 +85,7 @@ func (t *unixTail) openTail() {
 	if err != nil {
 		return
 	}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if t.lineBuf[i] == '\n' {
 			sz, err = file.Seek(sz+int64(i+1), os.SEEK_SET)
 			if err == nil {

--- a/client/go/internal/cli/cmd/feed.go
+++ b/client/go/internal/cli/cmd/feed.go
@@ -136,7 +136,7 @@ func createServices(n int, timeout time.Duration, cli *CLI, waiter *Waiter) ([]h
 	}
 	services := make([]httputil.Client, 0, n)
 	baseURL := ""
-	for i := 0; i < n; i++ {
+	for range n {
 		service, err := waiter.Service(target, cli.config.cluster())
 		if err != nil {
 			return nil, "", err

--- a/client/go/internal/cli/cmd/feed_test.go
+++ b/client/go/internal/cli/cmd/feed_test.go
@@ -82,13 +82,13 @@ func TestFeed(t *testing.T) {
 	require.Nil(t, cli.Run("feed", "-"))
 	assert.Equal(t, want, stdout.String())
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		httpClient.NextResponseString(503, `{"message":"it's broken yo"}`)
 	}
 	require.Nil(t, cli.Run("feed", jsonFile1))
 	assert.Equal(t, "feed: got status 503 ({\"message\":\"it's broken yo\"}) for put id:ns:type::doc1: giving up after 10 attempts\n", stderr.String())
 	stderr.Reset()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		httpClient.NextResponseError(fmt.Errorf("something else is broken"))
 	}
 	require.Nil(t, cli.Run("feed", jsonFile1))

--- a/client/go/internal/cli/cmd/query.go
+++ b/client/go/internal/cli/cmd/query.go
@@ -84,7 +84,7 @@ func query(cli *CLI, arguments []string, timeoutSecs int, curl bool, format stri
 	}
 	url, _ := url.Parse(service.BaseURL + "/search/")
 	urlQuery := url.Query()
-	for i := 0; i < len(arguments); i++ {
+	for i := range len(arguments) {
 		key, value := splitArg(arguments[i])
 		urlQuery.Set(key, value)
 	}

--- a/client/go/internal/cli/cmd/status_test.go
+++ b/client/go/internal/cli/cmd/status_test.go
@@ -168,7 +168,7 @@ func TestStatusCloudDeployment(t *testing.T) {
 }
 
 func isLocalTarget(args []string) bool {
-	for i := 0; i < len(args)-1; i++ {
+	for i := range len(args) - 1 {
 		if args[i] == "-t" {
 			return args[i+1] == "local"
 		}
@@ -197,7 +197,7 @@ func assertStatus(expectedTarget string, args []string, t *testing.T) {
 	t.Helper()
 	client := &mock.HTTPClient{}
 	clusterName := ""
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		if isLocalTarget(args) {
 			clusterName = "foo"
 			mockServiceStatus(client, clusterName)

--- a/client/go/internal/cli/cmd/test_test.go
+++ b/client/go/internal/cli/cmd/test_test.go
@@ -26,11 +26,11 @@ func TestSuite(t *testing.T) {
 	mockServiceStatus(client, "container")
 	client.NextStatus(200)
 	client.NextStatus(200)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		client.NextResponseString(200, string(searchResponse))
 	}
 	mockServiceStatus(client, "container") // Some tests do not specify cluster, which is fine since we only have one, but this causes a cache miss
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		client.NextResponseString(200, string(searchResponse))
 	}
 	expectedBytes, _ := os.ReadFile("testdata/tests/expected-suite.out")
@@ -45,7 +45,7 @@ func TestSuite(t *testing.T) {
 	requests = append(requests, discoveryRequest)
 	requests = append(requests, createSearchRequest(baseUrl+"/search/"))
 	requests = append(requests, createSearchRequest(baseUrl+"/search/?foo=%2F"))
-	for i := 0; i < 7; i++ {
+	for range 7 {
 		requests = append(requests, createSearchRequest(baseUrl+"/search/"))
 	}
 	assertRequests(requests, client, t)

--- a/client/go/internal/cli/cmd/visit_test.go
+++ b/client/go/internal/cli/cmd/visit_test.go
@@ -41,7 +41,7 @@ func TestQuoteFunc(t *testing.T) {
 	var buf []byte = make([]byte, 3)
 	buf[0] = 'a'
 	buf[2] = 'z'
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		buf[1] = byte(i)
 		s := string(buf)
 		res := quoteArgForUrl(s)

--- a/client/go/internal/vespa/document/document_test.go
+++ b/client/go/internal/vespa/document/document_test.go
@@ -176,7 +176,7 @@ func testDocumentDecoder(t *testing.T, jsonLike string) {
 	if len(docs) != len(result) {
 		t.Errorf("len(result) = %d, want %d", len(result), len(docs))
 	}
-	for i := 0; i < len(docs); i++ {
+	for i := range len(docs) {
 		got := result[i]
 		want := docs[i]
 		if !got.Equal(want) {

--- a/client/go/internal/vespa/document/http.go
+++ b/client/go/internal/vespa/document/http.go
@@ -95,7 +95,7 @@ func NewClient(options ClientOptions, httpClients []httputil.Client) (*Client, e
 	}
 	c.gzippers.New = func() any { return gzip.NewWriter(io.Discard) }
 	c.buffers.New = func() any { return &bytes.Buffer{} }
-	for i := 0; i < runtime.NumCPU(); i++ {
+	for range runtime.NumCPU() {
 		go c.preparePending()
 	}
 	return c, nil

--- a/client/go/internal/vespa/document/http_test.go
+++ b/client/go/internal/vespa/document/http_test.go
@@ -34,7 +34,7 @@ type mockHTTPClient struct {
 func TestLeastBusyClient(t *testing.T) {
 	httpClient := mock.HTTPClient{}
 	var httpClients []httputil.Client
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		httpClients = append(httpClients, &mockHTTPClient{i, &httpClient})
 	}
 	client, _ := NewClient(ClientOptions{}, httpClients)

--- a/client/go/internal/vespa/document/throttler_test.go
+++ b/client/go/internal/vespa/document/throttler_test.go
@@ -13,7 +13,7 @@ func TestThrottler(t *testing.T) {
 	if got, want := tr.TargetInflight(), int64(16); got != want {
 		t.Errorf("got TargetInflight() = %d, but want %d", got, want)
 	}
-	for i := 0; i < 65; i++ {
+	for range 65 {
 		tr.Sent()
 		tr.Success()
 	}

--- a/client/go/internal/vespa/load_env.go
+++ b/client/go/internal/vespa/load_env.go
@@ -151,7 +151,7 @@ func nSpacedFields(s string, n int) []string {
 
 // pretty strict for now, can be more lenient if needed
 func isValidShellVariableName(s string) bool {
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		b := s[i]
 		switch {
 		case (b >= 'A' && b <= 'Z'): // ok

--- a/client/go/internal/vespa/target_test.go
+++ b/client/go/internal/vespa/target_test.go
@@ -20,7 +20,7 @@ func TestLocalTarget(t *testing.T) {
 	client := &mock.HTTPClient{}
 	lt := LocalTarget(client, TLSOptions{}, 0)
 	assertServiceURL(t, "http://127.0.0.1:19071", lt, "deploy")
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		response := `
 {
   "services": [
@@ -83,7 +83,7 @@ func TestCustomTargetWait(t *testing.T) {
 	client.NextStatus(500)
 	assertService(t, true, target, "", 0)
 	// Fails multiple times
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		client.NextStatus(500)
 		client.NextResponseError(io.EOF)
 	}
@@ -120,7 +120,7 @@ func TestCustomTargetAwaitDeployment(t *testing.T) {
 func TestCustomTargetCompatibleWith(t *testing.T) {
 	client := &mock.HTTPClient{}
 	target := CustomTarget(client, "http://192.0.2.42", TLSOptions{}, 0)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		client.NextResponse(mock.HTTPResponse{
 			URI:    "/state/v1/version",
 			Status: 200,
@@ -249,7 +249,7 @@ func TestLog(t *testing.T) {
 
 func TestCloudCompatibleWith(t *testing.T) {
 	target, client := createCloudTarget(t, io.Discard)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		client.NextResponse(mock.HTTPResponse{URI: "/cli/v1/", Status: 200, Body: []byte(`{"minVersion":"8.0.0"}`)})
 	}
 	assert.Nil(t, target.CompatibleWith(version.MustParse("8.0.0")))


### PR DESCRIPTION
Since Go 1.21, Go has the ability to bootstrap the required Go version
automatically. See https://go.dev/doc/toolchain

This means that we no longer need to limit ourselves to the exact Go version
provided by the OS package.

@aressem