### PR TITLE
Support decoding distribution config as part of cluster state bundles in C++

### DIFF
--- a/storage/src/tests/storageserver/rpc/cluster_controller_rpc_api_service_test.cpp
+++ b/storage/src/tests/storageserver/rpc/cluster_controller_rpc_api_service_test.cpp
@@ -121,7 +121,7 @@ struct SetStateFixture : FixtureBase {
     }
 
     static lib::ClusterStateBundle dummy_baseline_bundle_with_deferred_activation(bool deferred) {
-        return lib::ClusterStateBundle(lib::ClusterState("version:123 distributor:3 storage:3"), {}, deferred);
+        return {lib::ClusterState("version:123 distributor:3 storage:3"), {}, deferred};
     }
 };
 
@@ -162,6 +162,16 @@ TEST_F(ClusterControllerApiRpcServiceTest, set_distribution_states_rpc_with_feed
     lib::ClusterStateBundle bundle(
             lib::ClusterState("version:123 distributor:3 storage:3"), {},
             lib::ClusterStateBundle::FeedBlock(true, "full disk"), true);
+
+    f.assert_request_received_and_propagated(bundle);
+}
+
+TEST_F(ClusterControllerApiRpcServiceTest, can_receive_cluster_state_bundle_with_embedded_distribution_config) {
+    auto distr_cfg = lib::DistributionConfigBundle::of(lib::Distribution::getDefaultDistributionConfig(3, 14));
+    SetStateFixture f;
+    lib::ClusterStateBundle bundle(
+            std::make_shared<const lib::ClusterState>("version:123 distributor:3 storage:3"),
+            {}, std::nullopt, std::move(distr_cfg), false);
 
     f.assert_request_received_and_propagated(bundle);
 }

--- a/storage/src/vespa/storage/storageserver/rpc/cluster_state_bundle_codec.h
+++ b/storage/src/vespa/storage/storageserver/rpc/cluster_state_bundle_codec.h
@@ -21,8 +21,8 @@ class ClusterStateBundleCodec {
 public:
     virtual ~ClusterStateBundleCodec() = default;
 
-    virtual EncodedClusterStateBundle encode(const lib::ClusterStateBundle&) const = 0;
-    virtual std::shared_ptr<const lib::ClusterStateBundle> decode(const EncodedClusterStateBundle&) const = 0;
+    [[nodiscard]] virtual EncodedClusterStateBundle encode(const lib::ClusterStateBundle&) const = 0;
+    [[nodiscard]] virtual std::shared_ptr<const lib::ClusterStateBundle> decode(const EncodedClusterStateBundle&) const = 0;
 };
 
 }


### PR DESCRIPTION
@geirst please review.

This mirrors 1-1 how the cluster controller will encode distribution config in state bundles (Coming Soon™️).

Actually _encoding_ config in the same format as that used for decoding config payloads is not directly supported, so we do our own roundabout conversion as part of testing.
