### PR TITLE
Revert "Update dependency org.questdb:questdb to v8" [MERGEOK]

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -141,7 +141,7 @@
         <plexus-xml.vespa.version>4.0.4</plexus-xml.vespa.version>
         <plexus-classworlds.vespa.version>2.8.0</plexus-classworlds.vespa.version>
         <protobuf.vespa.version>3.25.3</protobuf.vespa.version>
-        <questdb.vespa.version>8.0.1</questdb.vespa.version>
+        <questdb.vespa.version>7.4.2</questdb.vespa.version>
         <spifly.vespa.version>1.3.7</spifly.vespa.version>
         <snappy.vespa.version>1.1.10.5</snappy.vespa.version>
         <surefire.vespa.version>3.3.0</surefire.vespa.version>


### PR DESCRIPTION
Reverts vespa-engine/vespa#31354

Broke the build, see https://buildkite.com/vespaai/vespa-engine-vespa/builds/2438#01903b41-e14f-4668-aaa2-97d2b5c0791e

```
[ERROR]   QuestMetricsDbTest.testClusterMetricsReadWrite:87 » NoClassDefFound Could not initialize class io.questdb.cairo.CairoEngine
[ERROR]   QuestMetricsDbTest.testGc:167 » NoClassDefFound Could not initialize class io.questdb.cairo.CairoEngine
[ERROR]   QuestMetricsDbTest.testNodeMetricsReadWrite:41 » NoClassDefFound Could not initialize class io.questdb.cairo.CairoEngine
[ERROR]   QuestMetricsDbTest.testWriteOldData:138 » UnsatisfiedLink /workspace/build/buildkite/vespaai/vespa-engine-vespa/node-repository/target/libquestdb3061820634599742507.so: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by /workspace/build/buildkite/vespaai/vespa-engine-vespa/node-repository/target/libquestdb3061820634599742507.so)
```