### PR TITLE
Revert "Always use dynamic port for logserver-container"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/admin/LogserverContainer.java
@@ -13,7 +13,6 @@ public class LogserverContainer extends Container {
 
     public LogserverContainer(TreeConfigProducer<?> parent, DeployState deployState) {
         super(parent, "" + 0, 0, deployState);
-        useDynamicPorts();
     }
 
     @Override

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV2Builder.java
@@ -78,6 +78,7 @@ public class DomAdminV2Builder extends DomAdminBuilderBase {
         logserverClusterModel.setCluster(logServerCluster);
 
         LogserverContainer container = new LogserverContainer(logServerCluster, deployState);
+        container.useDynamicPorts();
         container.setHostResource(hostResource);
         container.initService(deployState);
         logServerCluster.addContainer(container);

--- a/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/builder/xml/dom/DomAdminV4Builder.java
@@ -111,6 +111,8 @@ public class DomAdminV4Builder extends DomAdminBuilderBase {
         logserverClusterModel.setCluster(logServerCluster);
 
         LogserverContainer container = new LogserverContainer(logServerCluster, deployState);
+        if (deployState.getProperties().applicationId().instance().isTester())
+            container.useDynamicPorts(); // TODO: read current version in ApplicationRepository, and always use this.
         container.setHostResource(hostResource);
         container.initService(deployState);
         logServerCluster.addContainer(container);


### PR DESCRIPTION
Reverts vespa-engine/vespa#31698 (testing revealed some issues related to config convergence when deploying to manual zones)