### PR TITLE
double maximum size of ZK node

### DIFF
--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -24,7 +24,7 @@ autopurge.snapRetainCount int default=15
 
 # Vespa home is prepended if the file is relative
 myidFile string default="var/zookeeper/myid"
-# Change from default of 1 Mb in zookeeper to 50 Mb
+# Change from default of 1 Mb in zookeeper to 100 Mb
 juteMaxBuffer int default=104857600
 
 myid int restart

--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -25,7 +25,7 @@ autopurge.snapRetainCount int default=15
 # Vespa home is prepended if the file is relative
 myidFile string default="var/zookeeper/myid"
 # Change from default of 1 Mb in zookeeper to 50 Mb
-juteMaxBuffer int default=52428800
+juteMaxBuffer int default=104857600
 
 myid int restart
 server[].id int

--- a/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
+++ b/zkfacade/src/main/java/com/yahoo/vespa/curator/Curator.java
@@ -71,7 +71,7 @@ public class Curator extends AbstractComponent implements AutoCloseable {
     private static final int MAX_RETRIES = 4;
     private static final RetryPolicy DEFAULT_RETRY_POLICY = new ExponentialBackoffRetry((int) BASE_SLEEP_TIME.toMillis(), MAX_RETRIES);
     // Default value taken from ZookeeperServerConfig
-    static final long defaultJuteMaxBuffer = Long.parseLong(System.getProperty("jute.maxbuffer", "52428800"));
+    static final long defaultJuteMaxBuffer = Long.parseLong(System.getProperty("jute.maxbuffer", "104857600"));
 
     private final CuratorFramework curatorFramework;
     private final ConnectionSpec connectionSpec;


### PR DESCRIPTION
this is to allow larger rank expressions as generated by bigger xgboost models

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
