### PR TITLE
Include distribution config as part of cluster state bundle

### DIFF
--- a/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
+++ b/clustercontroller-apps/src/main/java/com/yahoo/vespa/clustercontroller/apps/clustercontroller/ClusterControllerClusterConfigurer.java
@@ -56,7 +56,7 @@ public class ClusterControllerClusterConfigurer extends AbstractComponent {
                                                     ZookeepersConfig zookeepersConfig) {
         Distribution distribution = new Distribution(distributionConfig);
         FleetControllerOptions.Builder builder = new FleetControllerOptions.Builder(fleetcontrollerConfig.cluster_name(), distribution.getNodes());
-        builder.setStorageDistribution(distribution);
+        builder.setDistributionConfig(distributionConfig);
         configure(builder, fleetcontrollerConfig);
         configure(builder, slobroksConfig);
         configure(builder, zookeepersConfig);

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
@@ -1,0 +1,90 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.config.ConfigInstance;
+import com.yahoo.config.subscription.ConfigInstanceSerializer;
+import com.yahoo.slime.Slime;
+import com.yahoo.vdslib.distribution.Distribution;
+import com.yahoo.vdslib.distribution.Group;
+import com.yahoo.vdslib.distribution.GroupVisitor;
+import com.yahoo.vespa.config.content.StorDistributionConfig;
+
+import java.util.Objects;
+
+/**
+ * Immutable encapsulation of a content cluster distribution configuration,
+ * including the original config object as well as its processed Distribution
+ * and Slime config representations.
+ */
+public class DistributionConfigBundle {
+
+    // Note: All the encapsulated distribution representations are for the _same_ config
+    // (enforcing this invariant is also why this is not a record type).
+    private final StorDistributionConfig config;
+    // Config instances use reflection for most iterating operations, so cache the underlying
+    // string representation to avoid this for such cases.
+    private final String canonicalStringRepr;
+    private final Slime precomputedSlimeRepr;
+    private final Distribution distribution;
+    private final int groupsTotal;
+    private final int nodesTotal;
+
+    public DistributionConfigBundle(StorDistributionConfig config) {
+        Objects.requireNonNull(config);
+        this.config = config;
+        this.canonicalStringRepr = config.toString();
+        precomputedSlimeRepr = new Slime();
+        ConfigInstance.serialize(config, new ConfigInstanceSerializer(precomputedSlimeRepr, precomputedSlimeRepr.setObject()));
+        this.distribution = new Distribution(config);
+
+        var gv = new GroupVisitor() {
+            int groupsTotal = 0;
+            int nodesTotal  = 0;
+
+            @Override
+            public boolean visitGroup(Group g) {
+                if (g.isLeafGroup()) {
+                    groupsTotal++;
+                    nodesTotal += g.getNodes().size();
+                }
+                return true;
+            }
+        };
+        this.distribution.visitGroups(gv);
+        this.groupsTotal = gv.groupsTotal;
+        this.nodesTotal  = gv.nodesTotal;
+    }
+
+    public static DistributionConfigBundle of(StorDistributionConfig config) {
+        return new DistributionConfigBundle(config);
+    }
+
+    public StorDistributionConfig config() { return config; }
+    public Slime precomputedSlimeRepr() { return precomputedSlimeRepr; }
+    public Distribution distribution() { return distribution; }
+    public int totalLeafGroupCount() { return groupsTotal; }
+    public int totalNodeCount() { return nodesTotal; }
+    public int redundancy() { return config.redundancy(); }
+    public int searchableCopies() { return config.ready_copies(); }
+
+    // Note: since all fields are deterministically derived from the original config,
+    // we use the canonical string representation for equals, hashCode and toString.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DistributionConfigBundle that = (DistributionConfigBundle) o;
+        return Objects.equals(canonicalStringRepr, that.canonicalStringRepr);
+    }
+
+    @Override
+    public int hashCode() {
+        return canonicalStringRepr.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return canonicalStringRepr;
+    }
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -850,6 +850,10 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         return timeNowMs >= firstAllowedStateBroadcast || cluster.allStatesReported();
     }
 
+    private DistributionConfigBundle distributionConfigIfEnabledOrNull() {
+        return options.includeDistributionConfigInClusterStateBundles() ? options.distributionConfig() : null;
+    }
+
     private boolean recomputeClusterStateIfRequired() {
         boolean stateWasChanged = false;
         if (mustRecomputeCandidateClusterState()) {
@@ -860,6 +864,7 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
             final ClusterStateBundle candidateBundle = ClusterStateBundle.builder(candidate)
                     .bucketSpaces(configuredBucketSpaces)
                     .stateDeriver(createBucketSpaceStateDeriver())
+                    .distributionConfig(distributionConfigIfEnabledOrNull())
                     .deferredActivation(options.enableTwoPhaseClusterStateActivation())
                     .feedBlock(createResourceExhaustionCalculator()
                             .inferContentClusterFeedBlockOrNull(cluster))

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetControllerOptions.java
@@ -7,6 +7,7 @@ import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.state.NodeType;
 import com.yahoo.vespa.clustercontroller.core.database.DatabaseFactory;
 import com.yahoo.vespa.clustercontroller.core.database.ZooKeeperDatabaseFactory;
+import com.yahoo.vespa.config.content.StorDistributionConfig;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -108,7 +109,7 @@ public class FleetControllerOptions {
     /** Maximum time a node can be missing from slobrok before it is tagged down. */
     private final int maxSlobrokDisconnectGracePeriod;
 
-    private final Distribution storageDistribution;
+    private final DistributionConfigBundle distributionConfigBundle;
 
     // TODO: Get rid of this by always getting nodes by distribution.getNodes()
     private final Set<ConfiguredNode> nodes;
@@ -132,6 +133,8 @@ public class FleetControllerOptions {
     private final int maxNumberOfGroupsAllowedToBeDown;
 
     private final Function<FleetControllerContext, DatabaseFactory> dbFactoryFn;
+
+    private final boolean includeDistributionConfigInClusterStateBundles;
 
     // TODO less impressive length...!
     private FleetControllerOptions(String clusterName,
@@ -164,7 +167,7 @@ public class FleetControllerOptions {
                                    int minTimeBetweenNewSystemStates,
                                    boolean showLocalSystemStatesInEventLog,
                                    int maxSlobrokDisconnectGracePeriod,
-                                   Distribution storageDistribution,
+                                   DistributionConfigBundle distributionConfigBundle,
                                    Set<ConfiguredNode> nodes,
                                    Duration maxDeferredTaskVersionWaitTime,
                                    boolean clusterHasGlobalDocumentTypes,
@@ -175,7 +178,8 @@ public class FleetControllerOptions {
                                    Map<String, Double> clusterFeedBlockLimit,
                                    double clusterFeedBlockNoiseLevel,
                                    int maxNumberOfGroupsAllowedToBeDown,
-                                   Function<FleetControllerContext, DatabaseFactory> dbFactoryFn) {
+                                   Function<FleetControllerContext, DatabaseFactory> dbFactoryFn,
+                                   boolean includeDistributionConfigInClusterStateBundles) {
         this.clusterName = clusterName;
         this.fleetControllerIndex = fleetControllerIndex;
         this.fleetControllerCount = fleetControllerCount;
@@ -206,7 +210,7 @@ public class FleetControllerOptions {
         this.minTimeBetweenNewSystemStates = minTimeBetweenNewSystemStates;
         this.showLocalSystemStatesInEventLog = showLocalSystemStatesInEventLog;
         this.maxSlobrokDisconnectGracePeriod = maxSlobrokDisconnectGracePeriod;
-        this.storageDistribution = storageDistribution;
+        this.distributionConfigBundle = distributionConfigBundle;
         this.nodes = nodes;
         this.maxDeferredTaskVersionWaitTime = maxDeferredTaskVersionWaitTime;
         this.clusterHasGlobalDocumentTypes = clusterHasGlobalDocumentTypes;
@@ -218,6 +222,7 @@ public class FleetControllerOptions {
         this.clusterFeedBlockNoiseLevel = clusterFeedBlockNoiseLevel;
         this.maxNumberOfGroupsAllowedToBeDown = maxNumberOfGroupsAllowedToBeDown;
         this.dbFactoryFn = dbFactoryFn;
+        this.includeDistributionConfigInClusterStateBundles = includeDistributionConfigInClusterStateBundles;
     }
 
     public Duration getMaxDeferredTaskVersionWaitTime() {
@@ -349,7 +354,11 @@ public class FleetControllerOptions {
     }
 
     public Distribution storageDistribution() {
-        return storageDistribution;
+        return distributionConfigBundle.distribution();
+    }
+
+    public DistributionConfigBundle distributionConfig() {
+        return distributionConfigBundle;
     }
 
     public Set<ConfiguredNode> nodes() {
@@ -392,6 +401,10 @@ public class FleetControllerOptions {
 
     public Function<FleetControllerContext, DatabaseFactory> dbFactoryFn() { return dbFactoryFn; }
 
+    public boolean includeDistributionConfigInClusterStateBundles() {
+        return this.includeDistributionConfigInClusterStateBundles;
+    }
+
     public static class Builder {
 
         private String clusterName;
@@ -424,7 +437,7 @@ public class FleetControllerOptions {
         private int minTimeBetweenNewSystemStates = 0;
         private boolean showLocalSystemStatesInEventLog = true;
         private int maxSlobrokDisconnectGracePeriod = 1000;
-        private Distribution storageDistribution;
+        private DistributionConfigBundle distributionConfigBundle;
         private Set<ConfiguredNode> nodes;
         private Duration maxDeferredTaskVersionWaitTime = Duration.ofSeconds(30);
         private boolean clusterHasGlobalDocumentTypes = false;
@@ -436,6 +449,7 @@ public class FleetControllerOptions {
         private double clusterFeedBlockNoiseLevel = 0.01;
         private int maxNumberOfGroupsAllowedToBeDown = 1;
         private Function<FleetControllerContext, DatabaseFactory> dbFactoryFn = ZooKeeperDatabaseFactory::new;
+        private boolean includeDistributionConfigInClusterStateBundles = false;
 
         public Builder(String clusterName, Collection<ConfiguredNode> nodes) {
             this.clusterName = clusterName;
@@ -629,8 +643,8 @@ public class FleetControllerOptions {
             return this;
         }
 
-        public Builder setStorageDistribution(Distribution storageDistribution) {
-            this.storageDistribution = storageDistribution;
+        public Builder setDistributionConfig(StorDistributionConfig config) {
+            this.distributionConfigBundle = DistributionConfigBundle.of(config);
             return this;
         }
 
@@ -693,6 +707,11 @@ public class FleetControllerOptions {
             return this;
         }
 
+        public Builder setIncludeDistributionConfigInClusterStateBundles(boolean includeConfig) {
+            this.includeDistributionConfigInClusterStateBundles = includeConfig;
+            return this;
+        }
+
         public FleetControllerOptions build() {
             return new FleetControllerOptions(clusterName,
                                               index,
@@ -724,7 +743,7 @@ public class FleetControllerOptions {
                                               minTimeBetweenNewSystemStates,
                                               showLocalSystemStatesInEventLog,
                                               maxSlobrokDisconnectGracePeriod,
-                                              storageDistribution,
+                                              distributionConfigBundle,
                                               nodes,
                                               maxDeferredTaskVersionWaitTime,
                                               clusterHasGlobalDocumentTypes,
@@ -735,7 +754,8 @@ public class FleetControllerOptions {
                                               clusterFeedBlockLimit,
                                               clusterFeedBlockNoiseLevel,
                                               maxNumberOfGroupsAllowedToBeDown,
-                                              dbFactoryFn);
+                                              dbFactoryFn,
+                                              includeDistributionConfigInClusterStateBundles);
         }
 
         public static Builder copy(FleetControllerOptions options) {
@@ -770,7 +790,7 @@ public class FleetControllerOptions {
             builder.minTimeBetweenNewSystemStates = options.minTimeBetweenNewSystemStates;
             builder.showLocalSystemStatesInEventLog = options.showLocalSystemStatesInEventLog;
             builder.maxSlobrokDisconnectGracePeriod = options.maxSlobrokDisconnectGracePeriod;
-            builder.storageDistribution = options.storageDistribution;
+            builder.distributionConfigBundle = options.distributionConfigBundle;
             builder.nodes = Set.copyOf(options.nodes);
             builder.maxDeferredTaskVersionWaitTime = options.maxDeferredTaskVersionWaitTime;
             builder.clusterHasGlobalDocumentTypes = options.clusterHasGlobalDocumentTypes;
@@ -782,6 +802,7 @@ public class FleetControllerOptions {
             builder.clusterFeedBlockNoiseLevel = options.clusterFeedBlockNoiseLevel;
             builder.maxNumberOfGroupsAllowedToBeDown = options.maxNumberOfGroupsAllowedToBeDown;
             builder.dbFactoryFn = options.dbFactoryFn;
+            builder.includeDistributionConfigInClusterStateBundles = options.includeDistributionConfigInClusterStateBundles;
 
             return builder;
         }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/ClusterFeedBlockTest.java
@@ -61,7 +61,7 @@ public class ClusterFeedBlockTest extends FleetControllerTest {
 
     private static FleetControllerOptions.Builder createOptions(Map<String, Double> feedBlockLimits, double clusterFeedBlockNoiseLevel) {
         return defaultOptions()
-                .setStorageDistribution(DistributionBuilder.forFlatCluster(NODE_COUNT))
+                .setDistributionConfig(DistributionBuilder.configForFlatCluster(NODE_COUNT))
                 .setNodes(new HashSet<>(DistributionBuilder.buildConfiguredNodes(NODE_COUNT)))
                 .setClusterFeedBlockEnabled(true)
                 .setClusterFeedBlockLimit(feedBlockLimits)

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/FleetControllerTest.java
@@ -85,7 +85,7 @@ public abstract class FleetControllerTest implements Waiter {
     protected static FleetControllerOptions.Builder defaultOptions(Collection<ConfiguredNode> nodes) {
         var builder = new FleetControllerOptions.Builder("mycluster", nodes);
         builder.enableTwoPhaseClusterStateActivation(true); // Enable by default, tests can explicitly disable.
-        builder.setStorageDistribution(DistributionBuilder.forFlatCluster(builder.nodes().size()));
+        builder.setDistributionConfig(DistributionBuilder.configForFlatCluster(builder.nodes().size()));
         builder.setZooKeeperServerAddress("localhost:2181");
         return builder;
     }

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownLiveConfigTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/GroupAutoTakedownLiveConfigTest.java
@@ -16,7 +16,7 @@ public class GroupAutoTakedownLiveConfigTest extends FleetControllerTest {
 
     private static FleetControllerOptions.Builder createOptions(DistributionBuilder.GroupBuilder groupBuilder, double minNodeRatio) {
         return defaultOptions()
-                .setStorageDistribution(DistributionBuilder.forHierarchicCluster(groupBuilder))
+                .setDistributionConfig(DistributionBuilder.configForHierarchicCluster(groupBuilder))
                 .setNodes(new HashSet<>(DistributionBuilder.buildConfiguredNodes(groupBuilder.totalNodeCount())))
                 .setMinNodeRatioPerGroup(minNodeRatio)
                 .setMaxTransitionTime(NodeType.DISTRIBUTOR, 0)
@@ -37,7 +37,7 @@ public class GroupAutoTakedownLiveConfigTest extends FleetControllerTest {
         FleetControllerOptions.Builder builder =
                 FleetControllerOptions.Builder.copy(options)
                                               .setNodes(new HashSet<>(DistributionBuilder.buildConfiguredNodes(groupBuilder.totalNodeCount())))
-                                              .setStorageDistribution(DistributionBuilder.forHierarchicCluster(groupBuilder));
+                                              .setDistributionConfig(DistributionBuilder.configForHierarchicCluster(groupBuilder));
         updateConfigLive(builder.build());
     }
 

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/RpcServerTest.java
@@ -10,7 +10,6 @@ import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Target;
 import com.yahoo.jrt.Transport;
 import com.yahoo.vdslib.distribution.ConfiguredNode;
-import com.yahoo.vdslib.distribution.Distribution;
 import com.yahoo.vdslib.state.ClusterState;
 import com.yahoo.vdslib.state.Node;
 import com.yahoo.vdslib.state.NodeState;
@@ -439,7 +438,7 @@ public class RpcServerTest extends FleetControllerTest {
     @Test
     void testSetNodeStateOutOfRange() throws Exception {
         FleetControllerOptions.Builder options = defaultOptions();
-        options.setStorageDistribution(new Distribution(Distribution.getDefaultDistributionConfig(2, 10)));
+        options.setDistributionConfig(DistributionBuilder.configForFlatCluster(10));
         setUpFleetController(timer, options);
         setUpVdsNodes(timer);
         waitForStableSystem();

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/rpc/SlimeClusterStateBundleCodecTest.java
@@ -3,6 +3,7 @@ package com.yahoo.vespa.clustercontroller.core.rpc;
 
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundle;
 import com.yahoo.vespa.clustercontroller.core.ClusterStateBundleUtil;
+import com.yahoo.vespa.clustercontroller.core.DistributionBuilder;
 import com.yahoo.vespa.clustercontroller.core.StateMapping;
 import org.junit.jupiter.api.Test;
 
@@ -93,6 +94,16 @@ public class SlimeClusterStateBundleCodecTest {
         var stateBundle = ClusterStateBundleUtil.makeBundleBuilder("distributor:2 storage:2")
                 .feedBlock(ClusterStateBundle.FeedBlock.blockedWithDescription("more cake needed"))
                 .deriveAndBuild();
+        assertThat(roundtripEncode(stateBundle), equalTo(stateBundle));
+    }
+
+    @Test
+    void can_roundtrip_encode_bundle_with_distribution_config() {
+        var stateBundle = ClusterStateBundleUtil.makeBundleBuilder("distributor:2 storage:2")
+                .distributionConfig(DistributionBuilder.configForHierarchicCluster(
+                        DistributionBuilder.withGroups(2).eachWithNodeCount(3)))
+                .deriveAndBuild();
+
         assertThat(roundtripEncode(stateBundle), equalTo(stateBundle));
     }
 

--- a/configdefinitions/src/vespa/fleetcontroller.def
+++ b/configdefinitions/src/vespa/fleetcontroller.def
@@ -204,3 +204,10 @@ cluster_feed_block_noise_level double default=0.0
 # For apps that have several groups this controls how many groups are allowed to
 # be down simultaneously in this cluster.
 max_number_of_groups_allowed_to_be_down int default=-1
+
+## Iff true, cluster state bundles sent from the cluster controller to distributors
+## and content nodes will include the current distribution config. The CC-provided
+## distribution config takes precedence over the node-local config. When enabled,
+## a given versioned state corresponds directly to a particular bucket ownership
+## and replica placement mapping for the ideal state algorithm.
+include_distribution_config_in_cluster_state_bundle bool default=false


### PR DESCRIPTION
@geirst please review.

Opaque config Slime representation is encoded as part of the existing bundle object. Mirrors decoding in C++ impl.

New cluster state version and broadcast is triggered if the distribution config changes.

Including distribution config as part of the state bundle is controlled by a dedicated config parameter, which currently defaults to `false` (i.e. disabled).

