### PR TITLE
Also pass hostname to log handler

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/http/v2/ApplicationHandler.java
@@ -4,8 +4,8 @@ package com.yahoo.vespa.config.server.http.v2;
 import ai.vespa.http.DomainName;
 import ai.vespa.http.HttpURL;
 import ai.vespa.http.HttpURL.Query;
-import com.yahoo.component.annotation.Inject;
 import com.yahoo.component.Version;
+import com.yahoo.component.annotation.Inject;
 import com.yahoo.config.application.api.ApplicationFile;
 import com.yahoo.config.model.api.Model;
 import com.yahoo.config.model.api.ServiceInfo;
@@ -217,7 +217,7 @@ public class ApplicationHandler extends HttpHandler {
     private HttpResponse logs(ApplicationId applicationId, HttpRequest request) {
         HttpURL requestURL = HttpURL.from(request.getUri());
         Optional<DomainName> hostname = Optional.ofNullable(requestURL.query().lastEntries().get("hostname")).map(DomainName::of);
-        return applicationRepository.getLogs(applicationId, hostname, requestURL.query().remove("hostname"));
+        return applicationRepository.getLogs(applicationId, hostname, requestURL.query());
     }
 
     private HttpResponse searchNodeMetrics(ApplicationId applicationId) {


### PR DESCRIPTION
Just noticed this was removed in https://github.com/vespa-engine/vespa/commit/dff253253457e1cd570de3c55364e235cf8ce2de#diff-5c31444588efca8dabc84e0614374e23bcb8f1b83ede2f768054cc5f5e896c45R220, not sure if there was any reason to this? `LogHandler` supports filtering by hostname, so this should be propagated.