### PR TITLE
Emit cluster event with config diff on distribution config change

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/ClusterStateBundle.java
@@ -322,9 +322,7 @@ public class ClusterStateBundle {
                 ? String.format(", feed blocked: '%s'", feedBlock.description)
                 : "";
         String distributionConfigStr = (distributionConfig != null)
-                ? ", distribution config: %d nodes; %d groups; redundancy %d; searchable-copies %d".formatted(
-                    distributionConfig.totalNodeCount(), distributionConfig.totalLeafGroupCount(),
-                    distributionConfig.redundancy(), distributionConfig.searchableCopies())
+                ? ", distribution config: %s".formatted(distributionConfig.highLevelDescription())
                 : "";
         if (derivedBucketSpaceStates.isEmpty()) {
             return String.format("ClusterStateBundle('%s'%s%s%s)", baselineState,

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionConfigBundle.java
@@ -67,6 +67,11 @@ public class DistributionConfigBundle {
     public int redundancy() { return config.redundancy(); }
     public int searchableCopies() { return config.ready_copies(); }
 
+    public String highLevelDescription() {
+        return "%d nodes; %d groups; redundancy %d; searchable-copies %d".formatted(
+                totalNodeCount(), totalLeafGroupCount(), redundancy(), searchableCopies());
+    }
+
     // Note: since all fields are deterministically derived from the original config,
     // we use the canonical string representation for equals, hashCode and toString.
     @Override

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiff.java
@@ -1,0 +1,90 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/**
+ * Immutable representation of the high-level difference between two distribution configs.
+ *
+ * <code>toString()</code> gives a human-readable summary of the diff.
+ *
+ * See <code>DistributionDiffCalculatorTest</code> for examples of diff output.
+ */
+public class DistributionDiff {
+
+    public record NodeDiff(List<Integer> added, List<Integer> removed) {}
+
+    public record IntegerDiff(int before, int after) {
+
+        boolean differs() { return before != after; }
+
+        static IntegerDiff of(int before, int after) {
+            return new IntegerDiff(before, after);
+        }
+
+    }
+
+    // (Ordered) mapping from canonical group name to a node diff for that particular group.
+    private final TreeMap<String, NodeDiff> groupDiffs;
+    private final IntegerDiff groupCountDiff;
+    private final IntegerDiff redundancyDiff;
+    private final IntegerDiff searchableCopiesDiff;
+
+    public DistributionDiff(TreeMap<String, NodeDiff> groupDiffs,
+                            IntegerDiff groupCountDiff,
+                            IntegerDiff redundancyDiff,
+                            IntegerDiff searchableCopiesDiff) {
+        this.groupCountDiff = groupCountDiff;
+        this.groupDiffs = groupDiffs;
+        this.redundancyDiff = redundancyDiff;
+        this.searchableCopiesDiff = searchableCopiesDiff;
+    }
+
+    @Override
+    public String toString() {
+        var diffs = new ArrayList<String>();
+        addIfDiffers(redundancyDiff, "redundancy", diffs);
+        addIfDiffers(searchableCopiesDiff, "searchable-copies", diffs);
+        addIfDiffers(groupCountDiff, "groups", diffs);
+        for (var kv : groupDiffs.entrySet()) {
+            addGroupDiffStringIfDiffers(kv, diffs);
+        }
+        return String.join(", ", diffs);
+    }
+
+    private static void addIfDiffers(IntegerDiff diff, String name, List<String> diffs) {
+        if (diff.differs()) {
+            diffs.add("%s: %d -> %d".formatted(name, diff.before, diff.after));
+        }
+    }
+
+    private static void addGroupDiffStringIfDiffers(Map.Entry<String, NodeDiff> kv, List<String> diffs) {
+        var v = kv.getValue();
+        if (v.added.isEmpty() && v.removed.isEmpty()) {
+            return;
+        }
+        var sb = new StringBuilder();
+        sb.append(kv.getKey()).append(": ");
+        if (!v.added.isEmpty()) {
+            appendIntsAsSet(sb, "added", v.added);
+        }
+        if (!v.removed.isEmpty()) {
+            if (!v.added.isEmpty()) {
+                sb.append(' ');
+            }
+            appendIntsAsSet(sb, "removed", v.removed);
+        }
+        diffs.add(sb.toString());
+    }
+
+    private static void appendIntsAsSet(StringBuilder sb, String setName, List<Integer> ints) {
+        sb.append(setName).append(" {");
+        sb.append(ints.stream().map(i -> Integer.toString(i)).collect(Collectors.joining(", ")));
+        sb.append('}');
+    }
+
+}

--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculator.java
@@ -1,0 +1,74 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static com.yahoo.vespa.clustercontroller.core.DistributionDiff.NodeDiff;
+import static com.yahoo.vespa.clustercontroller.core.DistributionDiff.IntegerDiff;
+
+/**
+ * Utility for computing a "minimal" diff between two arbitrary distribution configs.
+ */
+public class DistributionDiffCalculator {
+
+    private record GroupNodes(Set<Integer> nodes) {
+
+        NodeDiff sortedDiff(GroupNodes other) {
+            var added   = other.nodes.stream().filter(n -> !nodes.contains(n)).sorted().toList();
+            var removed = nodes.stream().filter(n -> !other.nodes.contains(n)).sorted().toList();
+            return new NodeDiff(added, removed);
+        }
+
+    }
+
+    public static DistributionDiff computeDiff(DistributionConfigBundle oldCfg, DistributionConfigBundle newCfg) {
+        return new DistributionDiff(
+                computeGroupDiff(oldCfg, newCfg),
+                IntegerDiff.of(oldCfg.totalLeafGroupCount(), newCfg.totalLeafGroupCount()),
+                IntegerDiff.of(oldCfg.redundancy(), newCfg.redundancy()),
+                IntegerDiff.of(oldCfg.searchableCopies(), newCfg.searchableCopies()));
+    }
+
+    // Returns an ordered mapping from canonical group name to the number of added/removed nodes for
+    // that group. "Canonical" here means a name that uniquely identifies a group regardless of its
+    // placement in the topology, i.e. the name is a function of the group's path from the root.
+    // Adding a new group is represented as if all its nodes were added in one go.
+    // Conversely, removing an entire group is represented as if all its nodes were removed.
+    private static TreeMap<String, NodeDiff> computeGroupDiff(DistributionConfigBundle oldCfg, DistributionConfigBundle newCfg) {
+        var oldGroupNodes = enumerateGroupNodes(oldCfg);
+        var newGroupNodes = enumerateGroupNodes(newCfg);
+
+        var unionLeafGroupNames = new HashSet<>(oldGroupNodes.keySet());
+        unionLeafGroupNames.addAll(newGroupNodes.keySet());
+
+        var emptySentinel = new GroupNodes(Set.of());
+        var diff = new TreeMap<String, NodeDiff>();
+        for (String leafName : unionLeafGroupNames) {
+            var oldG = oldGroupNodes.getOrDefault(leafName, emptySentinel);
+            var newG = newGroupNodes.getOrDefault(leafName, emptySentinel);
+            diff.put(leafName, oldG.sortedDiff(newG));
+        }
+        return diff;
+    }
+
+    // Returns an ordered mapping from canonical group name to the set of distinct node distribution
+    // keys contained within that group. Note: we assume that no config is ever received that contains
+    // the same node in different groups; such a config is inherently invalid.
+    private static TreeMap<String, GroupNodes> enumerateGroupNodes(DistributionConfigBundle cfg) {
+        var groups = new TreeMap<String, GroupNodes>();
+        // Config is already in flattened form for groups, so use it directly.
+        for (var g : cfg.config().group()) {
+            // Use group "index" as name, as it encodes the group hierarchy as a dotted string path.
+            // "invalid" is the fixed index string value of the root group. If the root group contains
+            // any nodes at all, there will not be any nested groups by definition, as only leaf groups
+            // may contain nodes.
+            String name = "invalid".equals(g.index()) ? "root group" : "group %s".formatted(g.index());
+            groups.put(name, new GroupNodes(g.nodes().stream().map(n -> n.index()).collect(Collectors.toSet())));
+        }
+        return groups;
+    }
+
+}

--- a/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculatorTest.java
+++ b/clustercontroller-core/src/test/java/com/yahoo/vespa/clustercontroller/core/DistributionDiffCalculatorTest.java
@@ -1,0 +1,149 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+package com.yahoo.vespa.clustercontroller.core;
+
+import com.yahoo.vdslib.distribution.ConfiguredNode;
+import com.yahoo.vdslib.distribution.Distribution;
+import com.yahoo.vespa.config.content.StorDistributionConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DistributionDiffCalculatorTest {
+
+    private static DistributionConfigBundle flat(int redundancy, int searchableCopies, int nodes) {
+        return DistributionConfigBundle.of(DistributionBuilder.configForFlatCluster(redundancy, searchableCopies, nodes));
+    }
+
+    private static DistributionConfigBundle flat(int redundancy, int searchableCopies, Collection<Integer> nodes) {
+        return DistributionConfigBundle.of(DistributionBuilder.configForFlatCluster(redundancy, searchableCopies, nodes));
+    }
+
+    private static DistributionConfigBundle grouped(int... nodesInGroups) {
+        var gb = new DistributionBuilder.GroupBuilder(nodesInGroups);
+        return DistributionConfigBundle.of(DistributionBuilder.configForHierarchicCluster(gb));
+    }
+
+    private static String diff(DistributionConfigBundle oldCfg, DistributionConfigBundle newCfg) {
+        return DistributionDiffCalculator.computeDiff(oldCfg, newCfg).toString();
+    }
+
+    @Test
+    void no_diff_returns_empty_string() {
+        assertEquals("", diff(flat(1, 1, 3), flat(1, 1, 3)));
+        assertEquals("", diff(grouped(1, 2, 3), grouped(1, 2, 3)));
+    }
+
+    @Test
+    void changed_redundancy_or_searchable_copies_is_reflected() {
+        assertEquals("redundancy: 1 -> 2",                            diff(flat(1, 1, 3), flat(2, 1, 3)));
+        assertEquals("redundancy: 2 -> 1",                            diff(flat(2, 1, 3), flat(1, 1, 3)));
+        assertEquals("searchable-copies: 1 -> 2",                     diff(flat(1, 1, 3), flat(1, 2, 3)));
+        assertEquals("searchable-copies: 2 -> 1",                     diff(flat(1, 2, 3), flat(1, 1, 3)));
+        assertEquals("redundancy: 4 -> 5, searchable-copies: 1 -> 2", diff(flat(4, 1, 7), flat(5, 2, 7)));
+    }
+
+    @Test
+    void flat_group_topology_renders_changed_node_sets() {
+        assertEquals("root group: added {1}",             diff(flat(1, 1, Set.of(0)),    flat(1, 1, Set.of(0, 1))));
+        assertEquals("root group: added {2, 3}",          diff(flat(1, 1, Set.of(1)),    flat(1, 1, Set.of(1, 2, 3))));
+        assertEquals("root group: removed {3}",           diff(flat(1, 1, Set.of(2, 3)), flat(1, 1, Set.of(2))));
+        assertEquals("root group: added {1} removed {0}", diff(flat(1, 1, Set.of(0)),    flat(1, 1, Set.of(1))));
+    }
+
+    @Test
+    void grouped_topology_renders_diff_sets_across_groups() {
+        // The test group builder assigns linearly increasing node indexes, so changing the
+        // count of nodes in one group affects the indices of the nodes in subsequent groups.
+        // It also starts group name indexes at 1, not 0.
+        // group 1 {0} --> group 1 {0}, group 2 {1}
+        assertEquals("groups: 1 -> 2, group 2: added {1}",                         diff(grouped(1),       grouped(1, 1)));
+        // group 1 {0} --> group 1 {0}, group 2 {1, 2, 3}
+        assertEquals("groups: 1 -> 2, group 2: added {1, 2, 3}",                   diff(grouped(1),       grouped(1, 3)));
+        assertEquals("groups: 1 -> 3, group 2: added {1}, group 3: added {2}",     diff(grouped(1),       grouped(1, 1, 1)));
+        assertEquals("groups: 3 -> 1, group 2: removed {1}, group 3: removed {2}", diff(grouped(1, 1, 1), grouped(1)));
+        // Partial overlap
+        assertEquals("groups: 2 -> 4, group 1: removed {1}, group 2: added {1} " +
+                     "removed {2, 3}, group 3: added {2}, group 4: added {3}",     diff(grouped(2, 2),    grouped(1, 1, 1, 1)));
+
+        // Flat <--> grouped
+        assertEquals("groups: 1 -> 2, group 1: added {0}, group 2: added {1}, root group: removed {0, 1}",
+                     diff(flat(2, 0, Set.of(0, 1)), grouped(1, 1)));
+        assertEquals("groups: 2 -> 1, group 1: removed {0}, group 2: removed {1}, root group: added {0, 1}",
+                     diff(grouped(1, 1), flat(2, 0, Set.of(0, 1))));
+    }
+
+    private static StorDistributionConfig.Group.Nodes.Builder configuredNode(int nodeIndex) {
+        StorDistributionConfig.Group.Nodes.Builder builder = new StorDistributionConfig.Group.Nodes.Builder();
+        builder.index(nodeIndex);
+        return builder;
+    }
+
+    private static StorDistributionConfig.Group.Builder groupBuilder(String name, String index, String partitions, Set<Integer> nodes) {
+        var builder = new StorDistributionConfig.Group.Builder();
+        builder.name(name);
+        builder.index(index);
+        builder.partitions(partitions);
+        nodes.forEach(n -> builder.nodes(configuredNode(n)));
+        return builder;
+    }
+
+    private static StorDistributionConfig.Group.Builder groupBuilder(String name, String index, String partitions) {
+        return groupBuilder(name, index, partitions, Set.of());
+    }
+
+    private static StorDistributionConfig nestedGroupConfig2x2(Set<Integer> g1Nodes, Set<Integer> g2Nodes,
+                                                               Set<Integer> g3Nodes, Set<Integer> g4Nodes) {
+        var configBuilder = new StorDistributionConfig.Builder();
+        configBuilder.redundancy(2);
+
+        // Example group structure for g1={0, 1, 2}, g2={3, 4, 5}, g3={6, 7, 8}, g4={9, 10, 11}
+        //  root
+        //   |-- group0
+        //   |     |-- group0_0
+        //   |     |     |-- node 0
+        //   |     |     |-- node 1
+        //   |     |     `-- node 2
+        //   |     `-- group0_1
+        //   |           |-- node 3
+        //   |           |-- node 4
+        //   |           `-- node 5
+        //   |-- group1
+        //   |     |-- group1_0
+        //   |     |     |-- node 6
+        //   |     |     |-- node 7
+        //   |     |     `-- node 8
+        //   |     `-- group1_1
+        //   |           |-- node 9
+        //   |           |-- node 10
+        //   |           `-- node 11
+        configBuilder.group(groupBuilder("invalid", "invalid", "*|*"));
+        configBuilder.group(groupBuilder("group0", "0", "1|*"));
+        configBuilder.group(groupBuilder("group0_0", "0.0", "", g1Nodes));
+        configBuilder.group(groupBuilder("group0_1", "0.1", "", g2Nodes));
+        configBuilder.group(groupBuilder("group1", "1", "1|*"));
+        configBuilder.group(groupBuilder("group1_0", "1.0", "", g3Nodes));
+        configBuilder.group(groupBuilder("group1_1", "1.1", "", g4Nodes));
+
+        return new StorDistributionConfig(configBuilder);
+    }
+
+    @Test
+    void nested_grouped_topology_renders_with_canonical_group_names() {
+        var cfg1 = DistributionConfigBundle.of(nestedGroupConfig2x2(Set.of(0, 1, 2), Set.of(3, 4, 5),
+                                                                    Set.of(6, 7, 8), Set.of(9, 10, 11)));
+        // Add 1 node to 0.1 and remove 1 node from 1.1
+        var cfg2 = DistributionConfigBundle.of(nestedGroupConfig2x2(Set.of(0, 1, 2), Set.of(3, 4, 5, 12),
+                                                                    Set.of(6, 7, 8), Set.of(9, 11)));
+
+        assertEquals("group 0.1: added {12}, group 1.1: removed {10}", diff(cfg1, cfg2));
+        // Inverse
+        assertEquals("group 0.1: removed {12}, group 1.1: added {10}", diff(cfg2, cfg1));
+    }
+
+}


### PR DESCRIPTION
@geirst please review.

Adds a utility for computing the difference between two distribution configs with arbitrary parameter and topology changes, and for rendering this difference in a human-readable way. This diff is included in the cluster-level event upon distribution config changes.
