### PR TITLE
Only enable fsync for vespa-proton-bin. It is the only one that needs…

### DIFF
--- a/searchcore/src/apps/proton/proton.cpp
+++ b/searchcore/src/apps/proton/proton.cpp
@@ -327,6 +327,7 @@ App::main(int argc, char **argv)
     try {
         setupSignals();
         setup_fadvise();
+        FastOS_FileInterface::enableFSync();
         Transport transport(buildTransportConfig());
         startAndRun(transport.transport(), argc, argv);
     } catch (const vespalib::InvalidCommandLineArgumentsException &e) {

--- a/vespalib/src/vespa/fastos/file.cpp
+++ b/vespalib/src/vespa/fastos/file.cpp
@@ -27,13 +27,15 @@ DirectIOException::DirectIOException(const char * fileName, const void * buffer,
     _what = os.str();
 }
 
-DirectIOException::~DirectIOException() {}
+DirectIOException::~DirectIOException() = default;
 
 #ifdef __linux__
 int FastOS_FileInterface::_defaultFAdviseOptions = POSIX_FADV_NORMAL;
 #else
 int FastOS_FileInterface::_defaultFAdviseOptions = 0;
 #endif
+
+bool FastOS_FileInterface::_fsyncEnabled = false;
 
 static const size_t MAX_CHUNK_SIZE = 0x4000000; // 64 MB
 

--- a/vespalib/src/vespa/fastos/file.h
+++ b/vespalib/src/vespa/fastos/file.h
@@ -86,15 +86,17 @@ private:
     void WriteBufInternal(const void *buffer, size_t length);
 
 protected:
+    static bool   _fsyncEnabled;
     std::string   _filename;
     unsigned int  _openFlags;
     bool          _directIOEnabled;
     bool          _syncWritesEnabled;
 
 public:
-    static void setDefaultFAdviseOptions(int options) { _defaultFAdviseOptions = options; }
-    int getFAdviseOptions()                     const { return _fAdviseOptions; }
-    void setFAdviseOptions(int options)               { _fAdviseOptions = options; }
+    static void enableFSync() noexcept { _fsyncEnabled = true; }
+    static void setDefaultFAdviseOptions(int options) noexcept { _defaultFAdviseOptions = options; }
+    int getFAdviseOptions()                     const noexcept { return _fAdviseOptions; }
+    void setFAdviseOptions(int options)               noexcept { _fAdviseOptions = options; }
 
     /**
      * Constructor. A filename could be supplied at this point, or specified

--- a/vespalib/src/vespa/fastos/unix_file.cpp
+++ b/vespalib/src/vespa/fastos/unix_file.cpp
@@ -10,10 +10,8 @@
 #include "file.h"
 #include <sstream>
 #include <cassert>
-#include <cstring>
 #include <unistd.h>
 #include <fcntl.h>
-#include <dirent.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
 #ifdef __linux__
@@ -179,7 +177,6 @@ constexpr int ALWAYS_SUPPORTED_MMAP_FLAGS = ~0;
 bool
 FastOS_UNIX_File::Open(unsigned int openFlags, const char *filename)
 {
-    bool rc = false;
     assert(_filedes == -1);
 
     if (filename != nullptr) {
@@ -189,7 +186,7 @@ FastOS_UNIX_File::Open(unsigned int openFlags, const char *filename)
 
     _filedes = open(_filename.c_str(), accessFlags, 0664);
 
-    rc = (_filedes != -1);
+    bool rc = (_filedes != -1);
 
     if (rc) {
         _openFlags = openFlags;
@@ -292,7 +289,9 @@ FastOS_UNIX_File::Sync()
 {
     assert(IsOpened());
 
-    return (fsync(_filedes) == 0);
+    return _fsyncEnabled
+        ? (fsync(_filedes) == 0)
+        : true;
 }
 
 


### PR DESCRIPTION
… it and avoid random hickups during unit tests.

@toregge PR