### PR TITLE
Don't construct/copy `spi::ClusterState` instances in the most expensive way possible

### DIFF
--- a/persistence/src/vespa/persistence/spi/clusterstate.h
+++ b/persistence/src/vespa/persistence/spi/clusterstate.h
@@ -21,6 +21,12 @@ class ClusterState {
 public:
     using SP = std::shared_ptr<ClusterState>;
 
+    ClusterState(std::shared_ptr<const lib::ClusterState> state,
+                 std::shared_ptr<const lib::Distribution> distribution,
+                 uint16_t node_index,
+                 bool maintenance_in_all_spaces);
+
+    // Constructor used by a bunch of unit tests. Prefer the constructor taking in shared_ptrs to avoid copying.
     ClusterState(const lib::ClusterState& state,
                  uint16_t nodeIndex,
                  const lib::Distribution& distribution,
@@ -72,18 +78,12 @@ public:
      */
     [[nodiscard]] bool nodeMaintenance() const noexcept;
 
-    /**
-     * Returns a serialized form of this object.
-     */
-    void serialize(vespalib::nbostream& o) const;
-
 private:
-    std::unique_ptr<lib::ClusterState> _state;
-    std::unique_ptr<lib::Distribution> _distribution;
-    uint16_t _nodeIndex;
-    bool _maintenanceInAllSpaces;
+    std::shared_ptr<const lib::ClusterState> _state;
+    std::shared_ptr<const lib::Distribution> _distribution;
+    uint16_t                                 _nodeIndex;
+    bool                                     _maintenanceInAllSpaces;
 
-    void deserialize(vespalib::nbostream&);
     bool nodeHasStateOneOf(const char* states) const noexcept;
 };
 

--- a/storage/src/vespa/storage/common/content_bucket_space.h
+++ b/storage/src/vespa/storage/common/content_bucket_space.h
@@ -25,7 +25,9 @@ struct ClusterStateAndDistribution {
 
     // Precondition: valid() == true
     [[nodiscard]] const lib::ClusterState& cluster_state() const noexcept { return *_cluster_state; }
+    [[nodiscard]] const std::shared_ptr<const lib::ClusterState>& cluster_state_sp() const noexcept { return _cluster_state; }
     [[nodiscard]] const lib::Distribution& distribution() const noexcept { return  *_distribution; }
+    [[nodiscard]] const std::shared_ptr<const lib::Distribution>& distribution_sp() const noexcept { return  _distribution; }
 
     [[nodiscard]] std::shared_ptr<const ClusterStateAndDistribution> with_new_state(
             std::shared_ptr<const lib::ClusterState> cluster_state) const;

--- a/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
+++ b/storage/src/vespa/storage/persistence/filestorage/filestormanager.cpp
@@ -941,8 +941,8 @@ FileStorManager::updateState()
         }
         contentBucketSpace.setNodeUpInLastNodeStateSeenByProvider(node_up_in_space);
         contentBucketSpace.setNodeMaintenanceInLastNodeStateSeenByProvider(in_maintenance);
-        spi::ClusterState spiState(state_and_distr->cluster_state(), _component.getIndex(),
-                                   state_and_distr->distribution(), in_maintenance);
+        spi::ClusterState spiState(state_and_distr->cluster_state_sp(), state_and_distr->distribution_sp(),
+                                   _component.getIndex(), in_maintenance);
         _provider->setClusterState(bucketSpace, spiState);
     }
 }


### PR DESCRIPTION
@baldersheim please review.

Now that we have `shared_ptrs` to the relevant pieces of information, use them for what they're worth. Remove the old (de-)serialization logic, as nothing else used it.
