### PR TITLE
Emit full cluster state bundle string on state manager status page

### DIFF
--- a/storage/src/vespa/storage/storageserver/statemanager.cpp
+++ b/storage/src/vespa/storage/storageserver/statemanager.cpp
@@ -160,7 +160,7 @@ StateManager::reportHtmlStatus(std::ostream& out,
             << "<th>Received at time</th><th>State</th></tr>\n";
         for (const auto & it : std::ranges::reverse_view(_systemStateHistory)) {
             out << "<tr><td>" << vespalib::to_string(vespalib::to_utc(it.first)) << "</td><td>"
-                << xml_content_escaped(it.second->getBaselineClusterState()->toString()) << "</td></tr>\n";
+                << xml_content_escaped(it.second->toString()) << "</td></tr>\n";
         }
         out << "</table>\n";
     }


### PR DESCRIPTION
@geirst please review

Since cluster state bundles now contain distribution config, this will also show the history of distribution config changes received on a particular node.
