### PR TITLE
Make sure string passed to logging is zero-terminated

### DIFF
--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -200,7 +200,7 @@ FieldSearchSpecMap::addFieldsFromIndex(std::string_view rawIndex, StringFieldIdT
         if (fIt != fim.end()) {
             for(FieldIdT fid : fIt->second) {
                 const FieldSearchSpec & spec = specMap().find(fid)->second;
-                LOG(debug, "buildFieldsInQuery = rawIndex='%s', index='%s'", rawIndex.data(), index.c_str());
+                LOG(debug, "buildFieldsInQuery = rawIndex='%s', index='%s'", std::string(rawIndex).c_str(), index.c_str());
                 if ((rawIndex != index) && (spec.name().find(index) == 0)) {
                     vespalib::string modIndex(rawIndex);
                     modIndex.append(spec.name().substr(index.size()));
@@ -210,7 +210,7 @@ FieldSearchSpecMap::addFieldsFromIndex(std::string_view rawIndex, StringFieldIdT
                 }
             }
         } else {
-            LOG(warning, "No valid indexes registered for index %s", rawIndex.data());
+            LOG(warning, "No valid indexes registered for index %s", std::string(rawIndex).c_str());
         }
     }
 }


### PR DESCRIPTION
@toregge please review
@baldersheim FYI

`string_view::data` is not guaranteed to be zero-terminated; must go via intermediate `std::string` instead.
