### PR TITLE
Update node-version in js-client README.md

### DIFF
--- a/client/js/app/README.md
+++ b/client/js/app/README.md
@@ -18,7 +18,7 @@ Install and start:
 
 Alternatively, use Docker to start it without installing node:
 
-    $ docker run -v `pwd`:/w -w /w --publish 3000:3000 node:16 sh -c 'yarn install && yarn dev --host'
+    $ docker run -v `pwd`:/w -w /w --publish 3000:3000 node:18 sh -c 'yarn install && yarn dev --host'
 
 When started, open [http://127.0.0.1:3000/](http://127.0.0.1:3000/).
 


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

The existing command fails with: 

```
docker run -v `pwd`:/w -w /w --publish 3000:3000 node:16 sh -c 'yarn install && yarn dev --host'
yarn install v1.22.19
[1/4] Resolving packages...
[2/4] Fetching packages...
error eslint@9.6.0: The engine "node" is incompatible with this module. Expected version "^18.18.0 || ^20.9.0 || >=21.1.0". Got "16.20.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
Resolved by updating node docker image tag. 