### PR TITLE
More `c_str()` in logging statements

### DIFF
--- a/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
+++ b/document/src/vespa/document/serialization/vespadocumentdeserializer.cpp
@@ -387,7 +387,7 @@ VespaDocumentDeserializer::readStructNoReset(StructFieldValue &value) {
                     }
                 } catch (const vespalib::Exception & e) {
                     LOG(warning, "Failed decoding field '%s' in legacy bodyfield -> Skipping it: %s",
-                                 entry.getName().data(), e.what());
+                                 entry.getName().c_str(), e.what());
                 }
             }
         }

--- a/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
+++ b/searchcore/src/vespa/searchcore/proton/attribute/attribute_writer.cpp
@@ -762,12 +762,12 @@ AttributeWriter::update(SerialNum serialNum, const DocumentUpdate &upd, Document
     }
 
     for (const auto &fupd : upd.getUpdates()) {
-        LOG(debug, "Retrieving guard for attribute vector '%s'.", fupd.getField().getName().data());
+        LOG(debug, "Retrieving guard for attribute vector '%s'.", fupd.getField().getName().c_str());
         auto found = _attrMap.find(fupd.getField().getName());
         AttributeVector * attrp = (found != _attrMap.end()) ? found->second.attribute : nullptr;
         onUpdate.onUpdateField(fupd.getField(), attrp);
         if (__builtin_expect(attrp == nullptr, false)) {
-            LOG(spam, "Failed to find attribute vector %s", fupd.getField().getName().data());
+            LOG(spam, "Failed to find attribute vector %s", fupd.getField().getName().c_str());
             continue;
         }
         // TODO: Check if we must use > due to multiple entries for same

--- a/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
+++ b/searchcore/src/vespa/searchcore/proton/server/documentretriever.cpp
@@ -96,7 +96,7 @@ DocumentRetriever
     Field::Set::Builder attrBuilder;
     for (const Field* field : fields) {
         if ((field->getDataType().getId() == positionDataTypeId) || is_array_of_position_type(field->getDataType())) {
-            LOG(debug, "Field '%s' is a position field", field->getName().data());
+            LOG(debug, "Field '%s' is a position field", field->getName().c_str());
             const vespalib::string & zcurve_name = PositionDataType::getZCurveFieldName(field->getName());
             AttributeGuard::UP attr = attr_manager.getAttribute(zcurve_name);
             if (attr && attr->valid()) {

--- a/searchlib/src/vespa/searchlib/attribute/attribute_operation.cpp
+++ b/searchlib/src/vespa/searchlib/attribute/attribute_operation.cpp
@@ -239,11 +239,12 @@ Operation::create(V vector) const {
         try {
             is >> value;
             if (!is.empty()) {
-                LOG(warning, "Invalid operand, unable to consume all of (%s). (%s) is unconsumed.", operand.data(), is.c_str());
+                LOG(warning, "Invalid operand, unable to consume all of (%s). (%s) is unconsumed.",
+                    std::string(operand).c_str(), is.c_str());
                 validOp = Type::BAD;
             }
             if (((validOp == Type::DIV) || (validOp == Type::MOD)) && (value == 0)) {
-                LOG(warning, "Division by zero is not acceptable (%s).", operand.data());
+                LOG(warning, "Division by zero is not acceptable (%s).", std::string(operand).c_str());
                 validOp = Type::BAD;
             }
         } catch (vespalib::IllegalArgumentException & e) {

--- a/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
+++ b/storage/src/vespa/storage/distributor/top_level_bucket_db_updater.cpp
@@ -130,7 +130,7 @@ TopLevelBucketDBUpdater::remove_superfluous_buckets(
             && db_pruning_may_be_elided(old_cluster_state, *new_cluster_state, up_states))
         {
             LOG(debug, "[bucket space '%s']: eliding DB pruning for state transition '%s' -> '%s'",
-                document::FixedBucketSpaces::to_string(elem.first).data(),
+                document::FixedBucketSpaces::to_string(elem.first).c_str(),
                 old_cluster_state.toString().c_str(), new_cluster_state->toString().c_str());
             continue;
         }

--- a/storage/src/vespa/storage/storageserver/mergethrottler.cpp
+++ b/storage/src/vespa/storage/storageserver/mergethrottler.cpp
@@ -1187,7 +1187,7 @@ MergeThrottler::makeAbortReply(api::StorageCommand& cmd,
                                std::string_view reason) const
 {
     LOG(debug, "Aborting message %s with reason '%s'",
-        cmd.toString().c_str(), reason.data());
+        cmd.toString().c_str(), std::string(reason).c_str());
     std::unique_ptr<api::StorageReply> reply(cmd.makeReply());
     reply->setResult(api::ReturnCode(api::ReturnCode::ABORTED, reason));
     return std::shared_ptr<api::StorageMessage>(reply.release());


### PR DESCRIPTION
@baldersheim please review

Some string wrapping of views and some conversion of `data()` to `c_str()` on objects that were _already_ full strings.
