### PR TITLE
Change StringFieldIdTMapT back to using std::map to get old behavior

### DIFF
--- a/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
+++ b/streamingvisitors/src/vespa/searchvisitor/searchvisitor.cpp
@@ -1189,7 +1189,7 @@ SearchVisitor::fillAttributeVectors(const vespalib::string & documentId, const S
         uint32_t fieldId = finfo._field;
         if (isPosition) {
             std::string_view org = PositionDataType::cutZCurveFieldName(finfoGuard->getName());
-            fieldId = _fieldsUnion.find(org)->second;
+            fieldId = _fieldsUnion.find(vespalib::string(org))->second;
         }
         const StorageDocument::SubDocument & subDoc = document.getComplexField(fieldId);
         auto & attrV = const_cast<AttributeVector & >(*finfoGuard);

--- a/streamingvisitors/src/vespa/vsm/common/document.h
+++ b/streamingvisitors/src/vespa/vsm/common/document.h
@@ -21,7 +21,7 @@ using IndexFieldMapT = vespalib::hash_map<vespalib::string, FieldIdTList>;
 /// A type to represent all the fields contained in all the indexs in an all the document types.
 using DocumentTypeIndexFieldMapT = vespalib::hash_map<vespalib::string, IndexFieldMapT>;
 /// A type to represent a map from fieldname to fieldid.
-using StringFieldIdTMapT = vespalib::hash_map<vespalib::string, FieldIdT>;
+using StringFieldIdTMapT = std::map<vespalib::string, FieldIdT>;
 
 class StringFieldIdTMap
 {

--- a/streamingvisitors/src/vespa/vsm/common/documenttypemapping.cpp
+++ b/streamingvisitors/src/vespa/vsm/common/documenttypemapping.cpp
@@ -80,6 +80,8 @@ void DocumentTypeMapping::buildFieldMap(
             if ((elem.first[0] != '[') && (elem.first != "summaryfeatures") && (elem.first != "rankfeatures") && (elem.first != "ranklog") && (elem.first != "sddocname") && (elem.first != "documentid")) {
                 FieldPath fieldPath;
                 docType.buildFieldPath(fieldPath, fname);
+                // Note: Entries are overwritten, behavior depends on
+                // fieldList iteration order.
                 fieldMap[elem.second] = std::move(fieldPath);
                 validCount++;
                 LOG(spam, "Found %s -> %d in document", fname.c_str(), elem.second);

--- a/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
+++ b/streamingvisitors/src/vespa/vsm/vsm/fieldsearchspec.cpp
@@ -204,6 +204,7 @@ FieldSearchSpecMap::addFieldsFromIndex(std::string_view rawIndex, StringFieldIdT
                 if ((rawIndex != index) && (spec.name().find(index) == 0)) {
                     vespalib::string modIndex(rawIndex);
                     modIndex.append(spec.name().substr(index.size()));
+                    // Note: Multiple raw index names might map to the same field id
                     fieldIdMap.add(modIndex, spec.id());
                 } else {
                     fieldIdMap.add(spec.name(),spec.id());


### PR DESCRIPTION
when multiple field names maps to the same field id.

@baldersheim : please review
