### PR TITLE
Use a formulae for expected size that mimics actual implementation.

### DIFF
--- a/searchlib/src/tests/attribute/attribute_test.cpp
+++ b/searchlib/src/tests/attribute/attribute_test.cpp
@@ -55,6 +55,8 @@ namespace search {
 
 namespace {
 
+size_t sizeof_initial_string_change_vector = vespalib::roundUp2inN<ChangeTemplate<StringChangeData>>(4) * sizeof(ChangeTemplate<StringChangeData>);
+
 string empty;
 
 string make_scoped_trace_msg(string prefix, const search::attribute::Config &config)
@@ -940,7 +942,7 @@ AttributeTest::testSingle()
         {
             AttributePtr ptr = createAttribute("sv-string", Config(BasicType::STRING, CollectionType::SINGLE));
             ptr->updateStat(true);
-            EXPECT_EQ(116528u + sizeof_large_string_entry, ptr->getStatus().getAllocated());
+            EXPECT_EQ(116088u + sizeof_initial_string_change_vector, ptr->getStatus().getAllocated());
             EXPECT_EQ(52684u + sizeof_large_string_entry, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<StringAttribute, string, string>(ptr, values);
@@ -950,7 +952,7 @@ AttributeTest::testSingle()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("sv-fs-string", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(344848u + sizeof_large_string_entry, ptr->getStatus().getAllocated());
+            EXPECT_EQ(344408u + sizeof_initial_string_change_vector, ptr->getStatus().getAllocated());
             EXPECT_EQ(104300u + sizeof_large_string_entry, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testSingle<StringAttribute, string, string>(ptr, values);
@@ -1133,7 +1135,7 @@ AttributeTest::testArray()
         {
             AttributePtr ptr = createAttribute("a-string", Config(BasicType::STRING, CollectionType::ARRAY));
             ptr->updateStat(true);
-            EXPECT_EQ(406160u + sizeof_large_string_entry, ptr->getStatus().getAllocated());
+            EXPECT_EQ(405720u + sizeof_initial_string_change_vector, ptr->getStatus().getAllocated());
             EXPECT_EQ(306352u + sizeof_large_string_entry, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<StringAttribute, string>(ptr, values);
@@ -1143,7 +1145,7 @@ AttributeTest::testArray()
             cfg.setFastSearch(true);
             AttributePtr ptr = createAttribute("afs-string", cfg);
             ptr->updateStat(true);
-            EXPECT_EQ(656368u + sizeof_large_string_entry, ptr->getStatus().getAllocated());
+            EXPECT_EQ(655928u + sizeof_initial_string_change_vector, ptr->getStatus().getAllocated());
             EXPECT_EQ(357988u + sizeof_large_string_entry, ptr->getStatus().getUsed());
             addDocs(ptr, numDocs);
             testArray<StringAttribute, string>(ptr, values);


### PR DESCRIPTION
@toregge PR
This is the final test. Then actual switch will be a small PR.