### PR TITLE
Revert "Enable std::string as default string implementation." MERGEOK

### DIFF
--- a/vespalib/src/vespa/vespalib/data/memory.h
+++ b/vespalib/src/vespa/vespalib/data/memory.h
@@ -18,6 +18,8 @@ struct Memory
     Memory() noexcept : data(nullptr), size(0) {}
     Memory(const char *d, size_t s) noexcept : data(d), size(s) {}
     Memory(const char *str) noexcept : data(str), size(strlen(str)) {}
+    Memory(const std::string &str) noexcept
+        : data(str.data()), size(str.size()) {}
     Memory(const vespalib::string &str) noexcept
         : data(str.data()), size(str.size()) {}
     Memory(std::string_view str_ref) noexcept

--- a/vespalib/src/vespa/vespalib/objects/deserializer.h
+++ b/vespalib/src/vespa/vespalib/objects/deserializer.h
@@ -29,6 +29,7 @@ public:
     virtual Deserializer & get(int64_t & value);
 
 
+    Deserializer & get(std::string & value);
     Deserializer & operator >> (bool & value)     { return get(value); }
     Deserializer & operator >> (uint8_t & value)  { return get(value); }
     Deserializer & operator >> (int8_t  & value)  { return get(value); }

--- a/vespalib/src/vespa/vespalib/objects/nbostream.h
+++ b/vespalib/src/vespa/vespalib/objects/nbostream.h
@@ -61,6 +61,18 @@ public:
     nbostream & operator >> (char & v)     { read1(&v); return *this; }
     nbostream & operator << (bool v)       { write1(&v); return *this; }
     nbostream & operator >> (bool & v)     { read1(&v); return *this; }
+    nbostream & operator << (const std::string & v)      { uint32_t sz(v.size()); (*this) << sz; write(v.c_str(), sz); return *this; }
+    nbostream & operator >> (std::string & v) {
+        uint32_t sz;
+        (*this) >> sz;
+        if (__builtin_expect(left() >= sz, true)) {
+            v.assign(&_rbuf[_rp], sz);
+            _rp += sz;
+        } else {
+            fail(eof);
+        }
+        return *this;
+     }
     nbostream & operator << (const char * v) { uint32_t sz(strlen(v)); (*this) << sz; write(v, sz); return *this; }
     nbostream & operator << (std::string_view v) { uint32_t sz(v.size()); (*this) << sz; write(v.data(), sz); return *this; }
     nbostream & operator << (const vespalib::string & v) { uint32_t sz(v.size()); (*this) << sz; write(v.c_str(), sz); return *this; }

--- a/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/asciistream.cpp
@@ -371,6 +371,16 @@ void asciistream::eatNonWhite()
 }
 
 asciistream &
+asciistream::operator >> (std::string & v)
+{
+    eatWhite();
+    size_t start(_rPos);
+    eatNonWhite();
+    v.assign(&_rbuf[start], _rPos-start);
+    return *this;
+}
+
+asciistream &
 asciistream::operator >> (string & v)
 {
     eatWhite();

--- a/vespalib/src/vespa/vespalib/stllike/asciistream.h
+++ b/vespalib/src/vespa/vespalib/stllike/asciistream.h
@@ -44,6 +44,7 @@ public:
     asciistream & operator << (const char * v)        { if (v != nullptr) { size_t n(strlen(v)); doFill(n); write(v, n); } return *this; }
     asciistream & operator << (const string & v)      { doFill(v.size()); write(v.data(), v.size()); return *this; }
     asciistream & operator << (std::string_view v)    { doFill(v.size()); write(v.data(), v.size()); return *this; }
+    asciistream & operator << (const std::string & v) { doFill(v.size()); write(v.data(), v.size()); return *this; }
     asciistream & operator << (short v)    { return *this << static_cast<long long>(v); }
     asciistream & operator << (unsigned short v)   { return *this << static_cast<unsigned long long>(v); }
     asciistream & operator << (int v)    { return *this << static_cast<long long>(v); }
@@ -65,6 +66,7 @@ public:
     asciistream & operator >> (char & v);
     asciistream & operator >> (signed char & v);
     asciistream & operator >> (unsigned char & v);
+    asciistream & operator >> (std::string & v);
     asciistream & operator >> (string & v);
     asciistream & operator >> (short & v);
     asciistream & operator >> (unsigned short & v);

--- a/vespalib/src/vespa/vespalib/stllike/hash_fun.h
+++ b/vespalib/src/vespa/vespalib/stllike/hash_fun.h
@@ -80,11 +80,13 @@ struct hash_strings {
     size_t operator() (const vespalib::string & arg) const noexcept { return hashValue(arg.data(), arg.size()); }
     size_t operator() (std::string_view arg) const noexcept { return hashValue(arg.data(), arg.size()); }
     size_t operator() (const char * arg) const noexcept { return hashValue(arg); }
+    size_t operator() (const std::string& arg) const noexcept { return hashValue(arg.data(), arg.size()); }
 };
 
 template<> struct hash<const char *> : hash_strings { };
 template<> struct hash<std::string_view> : public hash_strings { };
 template<> struct hash<vespalib::string> : hash_strings {};
+template<> struct hash<std::string> : hash_strings {};
 
 template<typename V> struct size {
     size_t operator() (const V & arg) const noexcept { return arg.size(); }

--- a/vespalib/src/vespa/vespalib/stllike/hash_set.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/hash_set.cpp
@@ -3,6 +3,9 @@
 #include "hash_set.hpp"
 #include <vespa/vespalib/util/array_equal.hpp>
 
+namespace vespalib {
+}
+
 VESPALIB_HASH_SET_INSTANTIATE(int16_t);
 VESPALIB_HASH_SET_INSTANTIATE(uint16_t);
 VESPALIB_HASH_SET_INSTANTIATE(int32_t);
@@ -10,4 +13,5 @@ VESPALIB_HASH_SET_INSTANTIATE(uint32_t);
 VESPALIB_HASH_SET_INSTANTIATE(uint64_t);
 VESPALIB_HASH_SET_INSTANTIATE(double);
 VESPALIB_HASH_SET_INSTANTIATE(vespalib::string);
+VESPALIB_HASH_SET_INSTANTIATE(std::string);
 VESPALIB_HASH_SET_INSTANTIATE(const void *);

--- a/vespalib/src/vespa/vespalib/stllike/string.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/string.cpp
@@ -23,16 +23,16 @@ std::istream & operator >> (std::istream & is, small_string<SS> & v)
     return is;
 }
 
-template std::ostream & operator << (std::ostream & os, const vespa_string & v);
-template std::istream & operator >> (std::istream & is, vespa_string & v);
+template std::ostream & operator << (std::ostream & os, const string & v);
+template std::istream & operator >> (std::istream & is, string & v);
 
 template class small_string<48>;
 
-template vespa_string operator + (const vespa_string & a, const vespa_string & b) noexcept;
-template vespa_string operator + (const vespa_string & a, std::string_view b) noexcept;
-template vespa_string operator + (std::string_view a, const vespa_string & b) noexcept;
-template vespa_string operator + (const vespa_string & a, const char * b) noexcept;
-template vespa_string operator + (const  char * a, const vespa_string & b) noexcept;
+template string operator + (const string & a, const string & b) noexcept;
+template string operator + (const string & a, std::string_view b) noexcept;
+template string operator + (std::string_view a, const string & b) noexcept;
+template string operator + (const string & a, const char * b) noexcept;
+template string operator + (const  char * a, const string & b) noexcept;
 
 const string &empty_string() noexcept {
     static string empty;
@@ -61,8 +61,12 @@ rtrim(std::string &s) noexcept {
 
 void
 chomp(vespalib::string & s) noexcept {
-    ltrim(s);
-    rtrim(s);
+    if constexpr (std::is_same_v<vespalib::string, std::string>) {
+        ltrim(s);
+        rtrim(s);
+    } else {
+        s.chomp();
+    }
 }
 
 vespalib::string

--- a/vespalib/src/vespa/vespalib/stllike/string.h
+++ b/vespalib/src/vespa/vespalib/stllike/string.h
@@ -10,7 +10,7 @@
 
 namespace vespalib {
 
-using string = std::string;
+using string = small_string<48>;
 
 inline bool contains(std::string_view text, std::string_view key) noexcept {
     return text.find(key) != std::string_view::npos;
@@ -47,7 +47,7 @@ static inline string stringify(uint64_t number) noexcept
     } while (number > 0);
     string retval;
     while (numdigits > 0) {
-        retval += digits[--numdigits];
+        retval.append(digits[--numdigits]);
     }
     return retval;
 }

--- a/vespalib/src/vespa/vespalib/text/utf8.cpp
+++ b/vespalib/src/vespa/vespalib/text/utf8.cpp
@@ -214,6 +214,7 @@ Utf8Writer<Target>::putChar(uint32_t codepoint)
 }
 
 template class Utf8Writer<vespalib::string>;
+template class Utf8Writer<std::string>;
 
 template <typename T>
 T Utf8::filter_invalid_sequences(const T& input) noexcept
@@ -229,5 +230,6 @@ T Utf8::filter_invalid_sequences(const T& input) noexcept
 }
 
 template vespalib::string Utf8::filter_invalid_sequences(const vespalib::string&);
+template std::string Utf8::filter_invalid_sequences(const std::string&);
 
 } // namespace

--- a/vespalib/src/vespa/vespalib/util/xmlstream.cpp
+++ b/vespalib/src/vespa/vespalib/util/xmlstream.cpp
@@ -398,7 +398,9 @@ XmlContentWrapper::XmlContentWrapper(const char* value, uint32_t size)
 }
 
 using CharP = char *;
+using ConstCharP = const char *;
 
+template XmlAttribute::XmlAttribute(const std::string &, std::string, unsigned int);
 template XmlAttribute::XmlAttribute(const std::string &, vespalib::string, unsigned int);
 template XmlAttribute::XmlAttribute(const std::string &, std::string_view, unsigned int);
 template XmlAttribute::XmlAttribute(const std::string &, CharP, unsigned int);


### PR DESCRIPTION
@toregge please review
@baldersheim FYI

Some refeeding performance tests show slightly degraded numbers after the flip. Temporarily reverting to avoid any surprises while we investigate.

Reverts vespa-engine/vespa#31894