### PR TITLE
Add logging functionality using `std::format`

### DIFF
--- a/vespalog/src/vespa/log/CMakeLists.txt
+++ b/vespalog/src/vespa/log/CMakeLists.txt
@@ -4,6 +4,7 @@ vespa_add_library(vespalog
     exceptions.cpp
     loglevelnames.cpp
     log.cpp
+    logf.cpp
     bufferedlogger.cpp
     log-target-fd.cpp
     log-target-file.cpp

--- a/vespalog/src/vespa/log/log.h
+++ b/vespalog/src/vespa/log/log.h
@@ -210,6 +210,8 @@ public:
     void doEventValue(const char *name, double value);
     void doEventState(const char *name, const char *value);
 
+    [[nodiscard]] const Timer& timer() const noexcept { return *_timer; }
+
     // Only for unit testing
     void setTimer(std::unique_ptr<Timer> timer);
 

--- a/vespalog/src/vespa/log/logf.cpp
+++ b/vespalog/src/vespa/log/logf.cpp
@@ -1,0 +1,27 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#include "logf.h"
+#include "bufferedlogger.h"
+
+#if defined(__cpp_lib_format)
+
+namespace ns_log {
+
+void
+do_fmt_log_impl(Logger& logger, Logger::LogLevel level, const char* file, int line,
+                std::string_view fmt_str, std::format_args fmt_args)
+{
+    // TODO consider `vformat_to` with a custom, bounded output iterator to a stack buffer if
+    //  we want to limit the number of allocs per log entry. But the existing legacy logging
+    //  code is pretty allocation-happy as it is, so probably doesn't matter much in practice.
+
+    // We expect that `fmt_str` has been compile-time checked, so we do not attempt to catch
+    // `std::format_error` if it happens (we consider it an invariant violation). Let it bubble
+    // up and (most likely) terminate the process instead.
+    std::string buf = std::vformat(fmt_str, fmt_args);
+    logger.doLogCore(logger.timer(), level, file, line, buf.data(), buf.size());
+    ns_log::BufferedLogger::instance().trimCache(); // Symmetric with Logger::doLog()
+}
+
+}
+
+#endif // defined(__cpp_lib_format)

--- a/vespalog/src/vespa/log/logf.h
+++ b/vespalog/src/vespa/log/logf.h
@@ -1,0 +1,40 @@
+// Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+#pragma once
+
+#include "log.h"
+#include <version>
+
+// TODO remove this once we're on a sufficiently new and shiny compiler version everywhere.
+//  The LOGF() functionality--alongside any other std::format code--cannot be used until then.
+#if defined(__cpp_lib_format)
+
+// TODO `import std` once we have modules to avoid heavy <format> include
+#include <format>
+
+// Log using std::format with compile-time checking of format string.
+// This is fully aware of std::string, std::string_view etc., so no more need for c_str().
+#define LOGF(level, ...)                                         \
+do {                                                             \
+    if (LOG_WOULD_LOG(level)) [[unlikely]] {                     \
+        ns_log::do_fmt_log(ns_log_logger, ns_log::Logger::level, \
+                           __FILE__, __LINE__, __VA_ARGS__);     \
+    }                                                            \
+} while (false)
+
+namespace ns_log {
+
+void do_fmt_log_impl(Logger& logger, Logger::LogLevel level, const char* file, int line,
+                     std::string_view fmt_str, std::format_args fmt_args);
+
+// Proxy function for std::format-based logging which invokes compile-time parsing and
+// validation of formatting string as well as type erased packing of formatting args.
+template <typename... Args>
+void do_fmt_log(Logger& logger, Logger::LogLevel level, const char* file, int line,
+                std::format_string<Args...> fmt_str, Args&&... fmt_args)
+{
+    do_fmt_log_impl(logger, level, file, line, fmt_str.get(), std::make_format_args(fmt_args...));
+}
+
+}
+
+#endif // defined(__cpp_lib_format)


### PR DESCRIPTION
@toregge please review
@baldersheim FYI

This adds a separate `logf.h` header (which transitively includes `log.h`) with a `LOGF` macro that supplements the existing `printf` syntax-based `LOG` macro.

Usage is identical to the existing macro, except that `std::format` semantics are used for the formatting string and arguments (which means no more `c_str()`) and the string is checked for validity at compile-time.

Example:
```c++
  LOGF(debug, "Have fed {} kittens", 42);
```
For now, the code is conditionally compiled iff `__cpp_lib_format` is defined, which means it cannot be used until this is the case for all compiler versions we use and/or care about.

