### PR TITLE
Resolve dimension bindings in ranking expressions

### DIFF
--- a/config-model/src/main/java/com/yahoo/schema/Application.java
+++ b/config-model/src/main/java/com/yahoo/schema/Application.java
@@ -30,6 +30,7 @@ public class Application {
     private final ApplicationPackage applicationPackage;
     private final Map<String, Schema> schemas;
     private final DocumentModel documentModel;
+    private final RankProfileRegistry rankProfileRegistry;
 
     public Application(ApplicationPackage applicationPackage,
                        List<Schema> schemas,
@@ -41,6 +42,7 @@ public class Application {
                        Set<Class<? extends Processor>> processorsToSkip,
                        DeployLogger logger) {
         this.applicationPackage = applicationPackage;
+        this.rankProfileRegistry = rankProfileRegistry;
 
         Map<String, Schema> schemaMap = new LinkedHashMap<>();
         for (Schema schema : schemas) {
@@ -86,6 +88,8 @@ public class Application {
     }
 
     public ApplicationPackage applicationPackage() { return applicationPackage; }
+
+    public RankProfileRegistry rankProfileRegistry() { return rankProfileRegistry; }
 
     /** Returns an unmodifiable list of the schemas of this application */
     public Map<String, Schema> schemas() { return schemas; }

--- a/config-model/src/main/java/com/yahoo/schema/RankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/RankProfile.java
@@ -1184,7 +1184,6 @@ public class RankProfile implements Cloneable {
                                               Map<String, RankingExpressionFunction> inlineFunctions,
                                               ExpressionTransforms expressionTransforms) {
         if (function == null) return null;
-
         RankProfileTransformContext context = new RankProfileTransformContext(this,
                                                                               queryProfiles,
                                                                               featureTypes,

--- a/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
+++ b/config-model/src/main/java/com/yahoo/schema/derived/RawRankProfile.java
@@ -288,9 +288,9 @@ public class RawRankProfile {
             for (Map.Entry<String, RankProfile.RankingExpressionFunction> e : functions.entrySet()) {
                 String propertyName = RankingExpression.propertyName(e.getKey());
                 if (! context.serializedFunctions().containsKey(propertyName)) {
-
                     String expressionString = e.getValue().function().getBody().getRoot().toString(context).toString();
                     context.addFunctionSerialization(propertyName, expressionString);
+
                     e.getValue().function().argumentTypes().entrySet().stream().sorted(Map.Entry.comparingByKey())
                             .forEach(argumentType -> context.addArgumentTypeSerialization(e.getKey(), argumentType.getKey(), argumentType.getValue()));
                 }

--- a/model-evaluation/abi-spec.json
+++ b/model-evaluation/abi-spec.json
@@ -36,6 +36,7 @@
       "public com.yahoo.searchlib.rankingexpression.evaluation.Value get(int)",
       "public double getDouble(int)",
       "public int getIndex(java.lang.String)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public int size()",
       "public java.util.Set names()",
       "public java.util.Set arguments()",

--- a/model-evaluation/src/main/java/ai/vespa/models/evaluation/LazyArrayContext.java
+++ b/model-evaluation/src/main/java/ai/vespa/models/evaluation/LazyArrayContext.java
@@ -113,6 +113,11 @@ public final class LazyArrayContext extends Context implements ContextIndex {
     }
 
     @Override
+    public String resolveBinding(String argument) {
+        return null;
+    }
+
+    @Override
     public int size() {
         return indexedBindings.names().size();
     }

--- a/searchlib/abi-spec.json
+++ b/searchlib/abi-spec.json
@@ -257,7 +257,7 @@
       "public"
     ],
     "methods" : [
-      "public void <init>(com.yahoo.searchlib.rankingexpression.ExpressionFunction, java.lang.String, java.lang.String)",
+      "public void <init>(java.lang.String, java.lang.String)",
       "public java.lang.String getName()",
       "public java.lang.String getExpressionString()"
     ],
@@ -424,6 +424,7 @@
       "public com.yahoo.searchlib.rankingexpression.evaluation.Value get(java.lang.String)",
       "public final com.yahoo.searchlib.rankingexpression.evaluation.Value get(int)",
       "public final double getDouble(int)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public com.yahoo.searchlib.rankingexpression.evaluation.ArrayContext clone()",
       "public bridge synthetic com.yahoo.searchlib.rankingexpression.evaluation.AbstractArrayContext clone()",
       "public bridge synthetic com.yahoo.tensor.TensorType getType(com.yahoo.tensor.evaluation.Name)",
@@ -537,6 +538,7 @@
       "public com.yahoo.tensor.TensorType getType(com.yahoo.searchlib.rankingexpression.Reference)",
       "public com.yahoo.searchlib.rankingexpression.evaluation.Value get(java.lang.String)",
       "public final com.yahoo.searchlib.rankingexpression.evaluation.Value get(int)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public com.yahoo.searchlib.rankingexpression.evaluation.DoubleOnlyArrayContext clone()",
       "public bridge synthetic com.yahoo.searchlib.rankingexpression.evaluation.AbstractArrayContext clone()",
       "public bridge synthetic com.yahoo.tensor.TensorType getType(com.yahoo.tensor.evaluation.Name)",
@@ -629,6 +631,7 @@
       "public com.yahoo.tensor.TensorType getType(com.yahoo.searchlib.rankingexpression.Reference)",
       "public com.yahoo.searchlib.rankingexpression.evaluation.Value get(java.lang.String)",
       "public void put(java.lang.String, com.yahoo.searchlib.rankingexpression.evaluation.Value)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public java.util.Map bindings()",
       "public com.yahoo.searchlib.rankingexpression.evaluation.MapContext thawedCopy()",
       "public java.util.Set names()",
@@ -651,6 +654,7 @@
       "public void setType(com.yahoo.searchlib.rankingexpression.Reference, com.yahoo.tensor.TensorType)",
       "public com.yahoo.tensor.TensorType getType(java.lang.String)",
       "public com.yahoo.tensor.TensorType getType(com.yahoo.searchlib.rankingexpression.Reference)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public java.util.Map bindings()",
       "public bridge synthetic com.yahoo.tensor.TensorType getType(com.yahoo.tensor.evaluation.Name)"
     ],

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/ExpressionFunction.java
@@ -216,7 +216,7 @@ public class ExpressionFunction {
      * An instance of a serialization of this function, using a particular serialization context (by {@link
      * ExpressionFunction#expand})
      */
-    public class Instance {
+    public static class Instance {
 
         private final String name;
         private final String expressionString;

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/ArrayContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/ArrayContext.java
@@ -120,6 +120,11 @@ public class ArrayContext extends AbstractArrayContext implements Cloneable {
         return value;
     }
 
+    @Override
+    public String resolveBinding(String argument) {
+        return null;
+    }
+
     /**
      * Creates a clone of this context suitable for evaluating against the same ranking expression
      * in a different thread (i.e, name name to index map, different value set.

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/DoubleOnlyArrayContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/DoubleOnlyArrayContext.java
@@ -93,6 +93,11 @@ public class DoubleOnlyArrayContext extends AbstractArrayContext {
         return new DoubleValue(getDouble(index));
     }
 
+    @Override
+    public String resolveBinding(String argument) {
+        return null;
+    }
+
     /**
      * Creates a clone of this context suitable for evaluating against the same ranking expression
      * in a different thread (i.e, name name to index map, different value set.

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/MapContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/MapContext.java
@@ -73,6 +73,11 @@ public class MapContext extends Context {
         bindings.put(key, value.freeze());
     }
 
+    @Override
+    public String resolveBinding(String argument) {
+        return null;
+    }
+
     /** Returns an immutable view of the bindings of this. */
     public Map<String, Value> bindings() {
         if (frozen) return bindings;

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/MapTypeContext.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/evaluation/MapTypeContext.java
@@ -32,6 +32,11 @@ public class MapTypeContext implements TypeContext<Reference> {
         return featureTypes.get(reference);
     }
 
+    @Override
+    public String resolveBinding(String argument) {
+        return null;
+    }
+
     /** Returns an unmodifiable map of the bindings in this */
     public Map<Reference, TensorType> bindings() { return Collections.unmodifiableMap(featureTypes); }
 

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/ReferenceNode.java
@@ -88,7 +88,6 @@ public final class ReferenceNode extends CompositeNode {
             if ( needSerialization ) {
                 ExpressionFunction.Instance instance = function.expand(context, getArguments().expressions(), path);
                 functionName = instance.getName();
-
                 context.addFunctionSerialization(RankingExpression.propertyName(functionName), instance.getExpressionString());
                 for (Map.Entry<String, TensorType> argumentType : function.argumentTypes().entrySet())
                     context.addArgumentTypeSerialization(functionName, argumentType.getKey(), argumentType.getValue());

--- a/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
+++ b/searchlib/src/main/java/com/yahoo/searchlib/rankingexpression/rule/TensorFunctionNode.java
@@ -59,8 +59,7 @@ public class TensorFunctionNode extends CompositeNode {
     }
 
     private static ScalarFunction<Reference> transform(ScalarFunction<Reference> input,
-                                                       Function<ExpressionNode, ExpressionNode> transformer)
-    {
+                                                       Function<ExpressionNode, ExpressionNode> transformer) {
         if (input instanceof ExpressionScalarFunction wrapper) {
             ExpressionNode transformed = transformer.apply(wrapper.expression);
             return new ExpressionScalarFunction(transformed);
@@ -411,6 +410,12 @@ public class TensorFunctionNode extends CompositeNode {
         public TensorType getType(Reference name) {
             return delegate.getType(name);
         }
+
+        @Override
+        public String resolveBinding(String argument) {
+            return delegate.resolveBinding(argument);
+        }
+
     }
 
     private static Context asContext(EvaluationContext<Reference> generic) {

--- a/vespajlib/abi-spec.json
+++ b/vespajlib/abi-spec.json
@@ -1570,7 +1570,8 @@
       "public void put(java.lang.String, com.yahoo.tensor.Tensor)",
       "public com.yahoo.tensor.TensorType getType(java.lang.String)",
       "public com.yahoo.tensor.TensorType getType(com.yahoo.tensor.evaluation.Name)",
-      "public com.yahoo.tensor.Tensor getTensor(java.lang.String)"
+      "public com.yahoo.tensor.Tensor getTensor(java.lang.String)",
+      "public java.lang.String resolveBinding(java.lang.String)"
     ],
     "fields" : [ ]
   },
@@ -1599,7 +1600,8 @@
     ],
     "methods" : [
       "public abstract com.yahoo.tensor.TensorType getType(com.yahoo.tensor.evaluation.Name)",
-      "public abstract com.yahoo.tensor.TensorType getType(java.lang.String)"
+      "public abstract com.yahoo.tensor.TensorType getType(java.lang.String)",
+      "public abstract java.lang.String resolveBinding(java.lang.String)"
     ],
     "fields" : [ ]
   },
@@ -1685,7 +1687,7 @@
     ],
     "methods" : [
       "public void <init>()",
-      "public final com.yahoo.tensor.TensorType type(com.yahoo.tensor.evaluation.TypeContext)",
+      "public com.yahoo.tensor.TensorType type(com.yahoo.tensor.evaluation.TypeContext)",
       "public com.yahoo.tensor.Tensor evaluate(com.yahoo.tensor.evaluation.EvaluationContext)"
     ],
     "fields" : [ ]
@@ -1809,6 +1811,7 @@
       "public java.util.List arguments()",
       "public com.yahoo.tensor.functions.TensorFunction withArguments(java.util.List)",
       "public com.yahoo.tensor.functions.PrimitiveTensorFunction toPrimitive()",
+      "public final com.yahoo.tensor.TensorType type(com.yahoo.tensor.evaluation.TypeContext)",
       "public java.lang.String toString(com.yahoo.tensor.functions.ToStringContext)",
       "public int hashCode()"
     ],
@@ -2920,6 +2923,7 @@
     "methods" : [
       "public static com.yahoo.tensor.functions.ToStringContext empty()",
       "public abstract java.lang.String getBinding(java.lang.String)",
+      "public java.lang.String resolveBinding(java.lang.String)",
       "public java.util.Optional typeContext()",
       "public abstract com.yahoo.tensor.functions.ToStringContext parent()"
     ],

--- a/vespajlib/src/main/java/com/yahoo/tensor/evaluation/MapEvaluationContext.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/evaluation/MapEvaluationContext.java
@@ -23,11 +23,12 @@ public class MapEvaluationContext<NAMETYPE extends Name> implements EvaluationCo
     }
 
     @Override
-    public TensorType getType(NAMETYPE name) {
-        return getType(name.name());
-    }
+    public TensorType getType(NAMETYPE name) { return getType(name.name()); }
 
     @Override
     public Tensor getTensor(String name) { return bindings.get(name); }
+
+    @Override
+    public String resolveBinding(String name) { return name; }
 
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/evaluation/TypeContext.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/evaluation/TypeContext.java
@@ -26,4 +26,7 @@ public interface TypeContext<NAMETYPE extends Name> {
      */
     TensorType getType(String name);
 
+    /** Returns the string a parameter is bound to, or the input name if none. */
+    String resolveBinding(String name);
+
 }

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Argmax.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Argmax.java
@@ -47,7 +47,7 @@ public class Argmax<NAMETYPE extends Name> extends CompositeTensorFunction<NAMET
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "argmax(" + argument.toString(context) + Reduce.commaSeparated(dimensions) + ")";
+        return "argmax(" + argument.toString(context) + Reduce.commaSeparatedNames(dimensions, context) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Argmin.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Argmin.java
@@ -47,7 +47,7 @@ public class Argmin<NAMETYPE extends Name> extends CompositeTensorFunction<NAMET
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "argmin(" + argument.toString(context) + Reduce.commaSeparated(dimensions) + ")";
+        return "argmin(" + argument.toString(context) + Reduce.commaSeparatedNames(dimensions, context) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/CellCast.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/CellCast.java
@@ -95,14 +95,11 @@ public class CellCast<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAM
     }
 
     static private Function<Float,Float> selectRestrict(TensorType.Value toValueType) {
-        switch (toValueType) {
-            case BFLOAT16:
-                return val -> Float.intBitsToFloat(Float.floatToRawIntBits(val) & ~0xffff);
-            case INT8:
-                return val -> (float)val.byteValue();
-            default:
-                return val -> val;
-        }
+        return switch (toValueType) {
+            case BFLOAT16 -> val -> Float.intBitsToFloat(Float.floatToRawIntBits(val) & ~0xffff);
+            case INT8 -> val -> (float) val.byteValue();
+            default -> val -> val;
+        };
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/CompositeTensorFunction.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/CompositeTensorFunction.java
@@ -17,7 +17,7 @@ public abstract class CompositeTensorFunction<NAMETYPE extends Name> extends Ten
 
     /** Finds the type this produces by first converting it to a primitive function */
     @Override
-    public final TensorType type(TypeContext<NAMETYPE> context) {
+    public TensorType type(TypeContext<NAMETYPE> context) {
         return toPrimitive().type(context);
     }
 

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Concat.java
@@ -62,7 +62,8 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "concat(" + argumentA.toString(context) + ", " + argumentB.toString(context) + ", " + dimension + ")";
+        return "concat(" + argumentA.toString(context) + ", " + argumentB.toString(context) +
+               ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override
@@ -70,7 +71,7 @@ public class Concat<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
 
     @Override
     public TensorType type(TypeContext<NAMETYPE> context) {
-        return TypeResolver.concat(argumentA.type(context), argumentB.type(context), dimension);
+        return TypeResolver.concat(argumentA.type(context), argumentB.type(context), context.resolveBinding(dimension));
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/CosineSimilarity.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/CosineSimilarity.java
@@ -2,6 +2,7 @@
 package com.yahoo.tensor.functions;
 
 import com.yahoo.tensor.evaluation.EvaluationContext;
+import com.yahoo.tensor.evaluation.MapEvaluationContext;
 import com.yahoo.tensor.evaluation.Name;
 import com.yahoo.tensor.evaluation.TypeContext;
 import com.yahoo.tensor.Tensor;
@@ -10,10 +11,12 @@ import com.yahoo.tensor.TensorType.Dimension;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Convenience for cosine similarity between vectors.
- * cosine_similarity(a, b, mydim) == sum(a*b, mydim) / sqrt(sum(a*a, mydim) * sum(b*b, mydim))
+ * cosine_similarity(a, b, mydim) == sum(a*b, mydim) / sqrt(sum(a*a, mydim) * sum(b*b, mydim)).
+ *
  * @author arnej
  */
 public class CosineSimilarity<NAMETYPE extends Name> extends TensorFunction<NAMETYPE> {
@@ -45,18 +48,18 @@ public class CosineSimilarity<NAMETYPE extends Name> extends TensorFunction<NAME
     public TensorType type(TypeContext<NAMETYPE> context) {
         TensorType t1 = arg1.toPrimitive().type(context);
         TensorType t2 = arg2.toPrimitive().type(context);
-        var d1 = t1.dimension(dimension);
-        var d2 = t2.dimension(dimension);
+        var resolvedDimension = context.resolveBinding(dimension);
+        var d1 = t1.dimension(resolvedDimension);
+        var d2 = t2.dimension(resolvedDimension);
         if (d1.isEmpty() || d2.isEmpty()
             || d1.get().type() != Dimension.Type.indexedBound
             || d2.get().type() != Dimension.Type.indexedBound
             || ! d1.get().size().equals(d2.get().size()))
         {
             throw new IllegalArgumentException("cosine_similarity expects both arguments to have the '"
-                                               + dimension + "' dimension with same size, but input types were "
+                                               + resolvedDimension + "' dimension with same size, but input types were "
                                                + t1 + " and " + t2);
         }
-        // Finds the type this produces by first converting it to a primitive function
         return toPrimitive().type(context);
     }
 
@@ -83,7 +86,7 @@ public class CosineSimilarity<NAMETYPE extends Name> extends TensorFunction<NAME
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "cosine_similarity(" + arg1.toString(context) + ", " + arg2.toString(context) + ", " + dimension + ")";
+        return "cosine_similarity(" + arg1.toString(context) + ", " + arg2.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/DenseSubspaceFunction.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/DenseSubspaceFunction.java
@@ -37,6 +37,7 @@ class DenseSubspaceFunction<NAMETYPE extends Name> {
         MyTypeContext(TensorType subspaceType) { this.subspaceType = subspaceType; }
         public TensorType getType(NAMETYPE name) { return getType(name.name()); }
         public TensorType getType(String name) { return argName.equals(name) ? subspaceType : null; }
+        public String resolveBinding(String name) { return name; }
     }
 
     TensorType outputType(TensorType subspaceType) {

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/EuclideanDistance.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/EuclideanDistance.java
@@ -45,15 +45,16 @@ public class EuclideanDistance<NAMETYPE extends Name> extends TensorFunction<NAM
     public TensorType type(TypeContext<NAMETYPE> context) {
         TensorType t1 = arg1.toPrimitive().type(context);
         TensorType t2 = arg2.toPrimitive().type(context);
-        var d1 = t1.dimension(dimension);
-        var d2 = t2.dimension(dimension);
+        String resolvedDimension = context.resolveBinding(dimension);
+        var d1 = t1.dimension(resolvedDimension);
+        var d2 = t2.dimension(resolvedDimension);
         if (d1.isEmpty() || d2.isEmpty()
             || d1.get().type() != Dimension.Type.indexedBound
             || d2.get().type() != Dimension.Type.indexedBound
             || ! d1.get().size().equals(d2.get().size()))
         {
             throw new IllegalArgumentException("euclidean_distance expects both arguments to have the '"
-                                               + dimension + "' dimension with same size, but input types were "
+                                               + resolvedDimension + "' dimension with same size, but input types were "
                                                + t1 + " and " + t2);
         }
         // Finds the type this produces by first converting it to a primitive function
@@ -79,7 +80,7 @@ public class EuclideanDistance<NAMETYPE extends Name> extends TensorFunction<NAM
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "euclidean_distance(" + arg1.toString(context) + ", " + arg2.toString(context) + ", " + dimension + ")";
+        return "euclidean_distance(" + arg1.toString(context) + ", " + arg2.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Generate.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Generate.java
@@ -183,6 +183,11 @@ public class Generate<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAM
                 return context.getType(name);
         }
 
+        @Override
+        public String resolveBinding(String name) {
+            return context.resolveBinding(name);
+        }
+
     }
 
     /** A context which adds the bindings of the generate dimension names to the given context. */

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/L1Normalize.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/L1Normalize.java
@@ -40,7 +40,7 @@ public class L1Normalize<NAMETYPE extends Name> extends CompositeTensorFunction<
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "l1_normalize(" + argument.toString(context) + ", " + dimension + ")";
+        return "l1_normalize(" + argument.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/L2Normalize.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/L2Normalize.java
@@ -42,7 +42,7 @@ public class L2Normalize<NAMETYPE extends Name> extends CompositeTensorFunction<
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "l2_normalize(" + argument.toString(context) + ", " + dimension + ")";
+        return "l2_normalize(" + argument.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Matmul.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Matmul.java
@@ -46,7 +46,7 @@ public class Matmul<NAMETYPE extends Name> extends CompositeTensorFunction<NAMET
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "matmul(" + argument1.toString(context) + ", " + argument2.toString(context) + ", " + dimension + ")";
+        return "matmul(" + argument1.toString(context) + ", " + argument2.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Reduce.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Reduce.java
@@ -87,19 +87,20 @@ public class Reduce<NAMETYPE extends Name> extends PrimitiveTensorFunction<NAMET
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "reduce(" + argument.toString(context) + ", " + aggregator + commaSeparated(dimensions) + ")";
+        return "reduce(" + argument.toString(context) + ", " + aggregator + commaSeparatedNames(dimensions, context) + ")";
     }
 
-    static String commaSeparated(List<String> list) {
+    static <NAMETYPE extends Name> String commaSeparatedNames(List<String> list, ToStringContext<NAMETYPE> context) {
         StringBuilder b = new StringBuilder();
         for (String element  : list)
-            b.append(", ").append(element);
+            b.append(", ").append(context.resolveBinding(element));
         return b.toString();
     }
 
     @Override
     public TensorType type(TypeContext<NAMETYPE> context) {
-        return outputType(argument.type(context), dimensions);
+        List<String> resolvedDimensions = dimensions.stream().map(d -> context.resolveBinding(d)).toList();
+        return outputType(argument.type(context), resolvedDimensions);
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/ReduceJoin.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/ReduceJoin.java
@@ -317,10 +317,10 @@ public class ReduceJoin<NAMETYPE extends Name> extends CompositeTensorFunction<N
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
         return "reduce_join(" + argumentA.toString(context) + ", " +
-                                argumentB.toString(context) + ", " +
-                                combinator + ", " +
-                                aggregator +
-                                Reduce.commaSeparated(dimensions) + ")";
+               argumentB.toString(context) + ", " +
+               combinator + ", " +
+               aggregator +
+               Reduce.commaSeparatedNames(dimensions, context) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/Softmax.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/Softmax.java
@@ -46,7 +46,7 @@ public class Softmax<NAMETYPE extends Name> extends CompositeTensorFunction<NAME
 
     @Override
     public String toString(ToStringContext<NAMETYPE> context) {
-        return "softmax(" + argument.toString(context) + ", " + dimension + ")";
+        return "softmax(" + argument.toString(context) + ", " + context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/ToStringContext.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/ToStringContext.java
@@ -18,6 +18,12 @@ public interface ToStringContext<NAMETYPE extends Name> {
     /** Returns the name an identifier is bound to, or null if not bound in this context */
     String getBinding(String name);
 
+    /** Returns the name an identifier is bound to, or the input name if none */
+    default String resolveBinding(String name) {
+        String binding = getBinding(name);
+        return binding == null ? name : binding;
+    }
+
     /**
      * Returns the context used to resolve types in this, if present.
      * In some functions serialization depends on type information.

--- a/vespajlib/src/main/java/com/yahoo/tensor/functions/XwPlusB.java
+++ b/vespajlib/src/main/java/com/yahoo/tensor/functions/XwPlusB.java
@@ -48,7 +48,7 @@ public class XwPlusB<NAMETYPE extends Name> extends CompositeTensorFunction<NAME
         return "xw_plus_b(" + x.toString(context) + ", " +
                w.toString(context) + ", " +
                b.toString(context) + ", " +
-               dimension + ")";
+               context.resolveBinding(dimension) + ")";
     }
 
     @Override

--- a/vespajlib/src/test/java/com/yahoo/tensor/functions/EuclideanDistanceTestCase.java
+++ b/vespajlib/src/test/java/com/yahoo/tensor/functions/EuclideanDistanceTestCase.java
@@ -50,6 +50,7 @@ public class EuclideanDistanceTestCase {
         Map<String, TensorType> map = new HashMap<>();
         public TensorType getType(Name name) { return getType(name.name()); }
         public TensorType getType(String name) { return map.get(name); }
+        public String resolveBinding(String name) { return name; }
     }
 
     @Test


### PR DESCRIPTION
People can parametrize the names of features in ranking expression functions, and then naturally expects to be able to do the same with tensor dimension names. This adds support for that in type resolution and expression generation, which is enough for supporting this in rank profiles.

We should also support it in direct evaluation of Java expressions
for completeness. I'll do that separately, this PR is already large enough.
