### PR TITLE
Mark warmup queries

### DIFF
--- a/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
+++ b/container-search/src/main/java/com/yahoo/search/handler/SearchHandler.java
@@ -159,6 +159,7 @@ public class SearchHandler extends LoggingRequestHandler {
             handle(HttpRequest.createTestRequest("/search/" +
                                                  "?timeout=2s" +
                                                  "&ranking.profile=unranked" +
+                                                 "&warmup=true" +
                                                  "&metrics.ignore=true" +
                                                  "&yql=select+*+from+sources+*+where+true+limit+0;",
                                                  com.yahoo.jdisc.http.HttpRequest.Method.GET,


### PR DESCRIPTION
If a Searcher requires something in particular from the Query warmup queries will fail, which will look in the log+console like something is wrong, so it should be possible to ignore them.