### PR TITLE
Don't render stack traces on illegal argument

### DIFF
--- a/container-search/abi-spec.json
+++ b/container-search/abi-spec.json
@@ -7634,6 +7634,7 @@
       "protected void moreChildren()",
       "protected void renderHitGroupHead(com.yahoo.search.result.HitGroup)",
       "protected void renderErrors(java.util.Set)",
+      "protected boolean shouldRenderStacktraceOf(java.lang.Throwable)",
       "protected void renderCoverage()",
       "protected void renderHit(com.yahoo.search.result.Hit)",
       "protected boolean shouldRender(com.yahoo.search.result.Hit)",

--- a/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
+++ b/container-search/src/main/java/com/yahoo/search/rendering/JsonRenderer.java
@@ -305,7 +305,7 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
             if (message != null) {
                 generator.writeStringField(ERROR_MESSAGE, message);
             }
-            if (cause != null && cause.getStackTrace().length > 0) {
+            if (cause != null && shouldRenderStacktraceOf(cause) && cause.getStackTrace().length > 0) {
                 StringWriter s = new StringWriter();
                 PrintWriter p = new PrintWriter(s);
                 cause.printStackTrace(p);
@@ -315,6 +315,10 @@ public class JsonRenderer extends AsynchronousSectionedRenderer<Result> {
             generator.writeEndObject();
         }
         generator.writeEndArray();
+    }
+
+    protected boolean shouldRenderStacktraceOf(Throwable cause) {
+        return  ! (cause instanceof IllegalArgumentException);
     }
 
     protected void renderCoverage() throws IOException {


### PR DESCRIPTION
Since IllegalArgumentException indicates something wrong with the request, we shouldn't expect the stack trace to contain anything useful and rendering just adds noise.

@baldersheim or @arnej27959 
