### PR TITLE
Revert "Enable std::span instead of vespalib::ArrayRef."

### DIFF
--- a/vespalib/src/vespa/vespalib/util/arrayref.h
+++ b/vespalib/src/vespa/vespalib/util/arrayref.h
@@ -8,7 +8,7 @@
 
 namespace vespalib {
 
-#define VESPALIB_ARRAYREF_IS_STD_SPAN 1
+#define VESPALIB_ARRAYREF_IS_STD_SPAN 0
 
 #if VESPALIB_ARRAYREF_IS_STD_SPAN
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#31973

@vekterli : please review

In case revert is needed.
