### PR TITLE
Support custom paths for cli cert checks 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ install_manifest.txt
 *.cbp
 !/.copr/Makefile
 !/.buildkite/Makefile
+.vscode/launch.json

--- a/client/go/internal/cli/cmd/deploy.go
+++ b/client/go/internal/cli/cmd/deploy.go
@@ -81,8 +81,15 @@ $ vespa deploy -t cloud -z perf.aws-us-east-1c`,
 				return err
 			}
 			var result vespa.PrepareResult
+			var certPaths []string
+			servicesXML, err := readServicesXML(pkg)
+			if err != nil {
+				certPaths = []string{}
+			} else {
+				certPaths = servicesXML.CertPaths()
+			}
 			err = cli.spinner(cli.Stderr, "Uploading application package...", func() error {
-				result, err = vespa.Deploy(opts)
+				result, err = vespa.Deploy(opts, certPaths)
 				return err
 			})
 			if err != nil {

--- a/client/go/internal/cli/cmd/prod.go
+++ b/client/go/internal/cli/cmd/prod.go
@@ -165,7 +165,12 @@ $ vespa prod deploy`,
 				AuthorEmail: options.authorEmail,
 				SourceURL:   options.sourceURL,
 			}
-			build, err := vespa.Submit(deployment, submission)
+
+			servicesXML, err := readServicesXML(pkg)
+			if err != nil {
+				return fmt.Errorf("Error reading services.xml: %w", err)
+			}
+			build, err := vespa.Submit(deployment, submission, servicesXML.CertPaths())
 			if err != nil {
 				return fmt.Errorf("could not deploy application: %w", err)
 			} else {

--- a/client/go/internal/cli/cmd/prod_test.go
+++ b/client/go/internal/cli/cmd/prod_test.go
@@ -61,6 +61,11 @@ func TestProdInit(t *testing.T) {
 	containerFragment := `<container id="qrs" version="1.0">
     <document-api></document-api>
     <search></search>
+    <clients>
+      <client id="test" permissions="read">
+        <certificate file="security/clients.pem"></certificate>
+      </client>
+    </clients>
     <nodes count="4"></nodes>
   </container>`
 	assert.Contains(t, servicesXML, containerFragment)
@@ -111,6 +116,11 @@ func createApplication(t *testing.T, pkgDir string, java bool, skipTests bool) {
   <container id="qrs" version="1.0">
     <document-api/>
     <search/>
+    <clients>
+      <client id="test" permissions="read">
+        <certificate file="security/clients.pem"/>
+      </client>
+    </clients>
     <nodes count="2">
       <resources vcpu="4" memory="8Gb" disk="100Gb"/>
     </nodes>

--- a/client/go/internal/vespa/application.go
+++ b/client/go/internal/vespa/application.go
@@ -20,7 +20,22 @@ type ApplicationPackage struct {
 	TestPath string
 }
 
-func (ap *ApplicationPackage) HasCertificate() bool { return ap.hasFile("security", "clients.pem") }
+func (ap *ApplicationPackage) HasCertificate(certPaths []string) bool {
+	if len(certPaths) == 0 {
+		if ap.hasFile("security", "clients.pem") {
+			return true
+		} else {
+			return false
+		}
+	} else {
+		for _, certPath := range certPaths {
+			if ap.hasFile(certPath) {
+				return true
+			}
+		}
+		return false
+	}
+}
 
 func (ap *ApplicationPackage) HasMatchingCertificate(certificatePEM []byte) (bool, error) {
 	clientsPEM, err := os.ReadFile(filepath.Join(ap.Path, "security", "clients.pem"))

--- a/client/go/internal/vespa/deploy_test.go
+++ b/client/go/internal/vespa/deploy_test.go
@@ -27,7 +27,7 @@ func TestDeploy(t *testing.T) {
 		Target:             target,
 		ApplicationPackage: ApplicationPackage{Path: appDir},
 	}
-	_, err := Deploy(opts)
+	_, err := Deploy(opts, []string{})
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
@@ -49,7 +49,7 @@ func TestDeployCloud(t *testing.T) {
 		Target:             target,
 		ApplicationPackage: ApplicationPackage{Path: appDir},
 	}
-	_, err := Deploy(opts)
+	_, err := Deploy(opts, []string{})
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(httpClient.Requests))
 	req := httpClient.LastRequest
@@ -62,7 +62,7 @@ func TestDeployCloud(t *testing.T) {
 	assert.False(t, hasDeployOptions)
 
 	opts.Version = version.MustParse("1.2.3")
-	_, err = Deploy(opts)
+	_, err = Deploy(opts, []string{})
 	require.Nil(t, err)
 	req = httpClient.LastRequest
 	values = parseMultiPart(t, req)
@@ -83,7 +83,7 @@ func TestSubmit(t *testing.T) {
 		ApplicationPackage: ApplicationPackage{Path: appDir},
 	}
 	httpClient.NextResponseString(200, `{"build": 42}`)
-	build, err := Submit(opts, Submission{})
+	build, err := Submit(opts, Submission{}, []string{})
 	require.Nil(t, err)
 	require.Equal(t, int64(42), build)
 	require.Nil(t, httpClient.LastRequest.ParseMultipartForm(1<<20))
@@ -102,7 +102,7 @@ func TestSubmit(t *testing.T) {
 		Description: "broken garbage",
 		AuthorEmail: "foo@example.com",
 		SourceURL:   "https://github.com/foo/repo",
-	})
+	}, []string{})
 	require.Nil(t, err)
 	require.Equal(t, int64(43), build)
 	require.Nil(t, httpClient.LastRequest.ParseMultipartForm(1<<20))

--- a/client/go/internal/vespa/xml/config.go
+++ b/client/go/internal/vespa/xml/config.go
@@ -75,14 +75,28 @@ type Services struct {
 }
 
 type Container struct {
-	Root  xml.Name `xml:"container"`
-	ID    string   `xml:"id,attr"`
-	Nodes Nodes    `xml:"nodes"`
+	Root    xml.Name `xml:"container"`
+	ID      string   `xml:"id,attr"`
+	Nodes   Nodes    `xml:"nodes"`
+	Clients Clients  `xml:"clients"`
 }
 
 type Content struct {
 	ID    string `xml:"id,attr"`
 	Nodes Nodes  `xml:"nodes"`
+}
+
+type Clients struct {
+	Client []Client `xml:"client"`
+}
+
+type Client struct {
+	Id          string      `xml:"id,attr"`
+	Certificate Certificate `xml:"certificate"`
+}
+
+type Certificate struct {
+	File string `xml:"file,attr"`
 }
 
 type Nodes struct {
@@ -97,6 +111,17 @@ type Resources struct {
 }
 
 func (s Services) String() string { return s.rawXML.String() }
+
+// Reads file paths from services.xml
+func (s Services) CertPaths() []string {
+	var certificates []string
+	for _, container := range s.Container {
+		for _, client := range container.Clients.Client {
+			certificates = append(certificates, client.Certificate.File)
+		}
+	}
+	return certificates
+}
 
 // Replace replaces any elements of name found under parentName with data.
 func (s *Services) Replace(parentName, name string, data interface{}) error {

--- a/client/go/internal/vespa/xml/config_test.go
+++ b/client/go/internal/vespa/xml/config_test.go
@@ -243,6 +243,51 @@ func TestReadServicesNoResources(t *testing.T) {
 	}
 }
 
+func TestReadClientPaths(t *testing.T) {
+	s := `
+<services xmlns:deploy="vespa" xmlns:preprocess="properties">
+  <container id="qrs">
+    <clients>
+      <client id="test" permissions="read">
+        <certificate file="security/test.pem"/>
+      </client>
+      <client id="other" permissions="read">
+        <certificate file="security/other.pem"/>
+      </client>
+    </clients>
+  </container>
+</services>
+`
+	services, err := ReadServices(strings.NewReader(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPaths := services.CertPaths()
+	if got := certPaths[0]; got != "security/test.pem" {
+		t.Errorf("got %+v, want security/test.pem", got)
+	}
+	if got := certPaths[1]; got != "security/other.pem" {
+		t.Errorf("got %+v, want security/other.pem", got)
+	}
+}
+
+func TestReadNoClientPaths(t *testing.T) {
+	s := `
+<services xmlns:deploy="vespa" xmlns:preprocess="properties">
+  <container id="qrs">
+  </container>
+</services>
+`
+	services, err := ReadServices(strings.NewReader(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPaths := services.CertPaths()
+	if got := certPaths; got != nil {
+		t.Errorf("got %+v, want nil", got)
+	}
+}
+
 func TestParseResources(t *testing.T) {
 	assertResources(t, "foo", Resources{}, true)
 	assertResources(t, "vcpu=2,memory=4Gb", Resources{}, true)


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This aims to resolve: https://github.com/vespa-engine/vespa/issues/31978

I'm hoping I took this in the right direction! I was keen to give this a go. I'm very happy to take feedback and/or see maintainers make necessary changes to this, etc.

The tldr behaviour that i've sought to add is that cert checks will now use the cert paths defined in `services.xml` if any are found, otherwise it looks for the default cert path.

Look forward to hearing your review!
