### PR TITLE
Cache-friendly prime table

### DIFF
--- a/vespalib/src/vespa/vespalib/stllike/hashtable.cpp
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.cpp
@@ -4,33 +4,32 @@
 
 namespace {
 
-static const unsigned long __stl_prime_list[] =
+static const size_t __chunk_size{8};
+static const unsigned long __stl_prime_list[][__chunk_size] =
 {
-            7ul,        17ul,         53ul,         97ul,        193ul,
-          389ul,       769ul,       1543ul,       3079ul,       6151ul,
-        12289ul,     24593ul,      49157ul,      98317ul,     196613ul,
-       393241ul,    786433ul,    1572869ul,    3145739ul,    6291469ul,
-     12582917ul,  25165843ul,   50331653ul,  100663319ul,  201326611ul,
-    402653189ul, 805306457ul, 1610612741ul, 3221225473ul, 4294967291ul
+  {        7ul,        17ul,        53ul,         97ul,        193ul,        389ul,        769ul,       1543ul},
+  {     3079ul,      6151ul,     12289ul,      24593ul,      49157ul,      98317ul,     196613ul,     393241ul},
+  {   786433ul,   1572869ul,   3145739ul,    6291469ul,   12582917ul,   25165843ul,   50331653ul,  100663319ul},
+  {201326611ul, 402653189ul, 805306457ul, 1610612741ul, 3221225473ul, 4294967291ul, 4294967291ul, 4294967291ul},
 };
 
+static const unsigned long __upper_bound_list[] = {1543ul, 393241ul, 100663319ul, 4294967291ul};
+static const size_t __upper_bound_list_size = sizeof(__upper_bound_list)/sizeof(__upper_bound_list[0]);
 }
 
 namespace vespalib {
 
 size_t
-hashtable_base::getModulo(size_t newSize, const unsigned long * list, size_t sz) noexcept
-{
-    const unsigned long* first = list;
-    const unsigned long* last = list + sz;
-    const unsigned long* pos = std::lower_bound(first, last, newSize);
-    return (pos == last) ? *(last - 1) : *pos;
-}
-
-size_t
 hashtable_base::getModuloStl(size_t size) noexcept
 {
-    return getModulo(size, __stl_prime_list, sizeof(__stl_prime_list)/sizeof(__stl_prime_list[0]));
+  for(size_t i = 0; i < __upper_bound_list_size; ++i) {
+    if(size <= __upper_bound_list[i]) {
+      for(size_t j = 0; j < __chunk_size; ++j) {
+        if(__stl_prime_list[i][j] >= size) return __stl_prime_list[i][j];
+      }
+    }
+  }
+  return __upper_bound_list[__upper_bound_list_size - 1];
 }
 
 }

--- a/vespalib/src/vespa/vespalib/stllike/hashtable.h
+++ b/vespalib/src/vespa/vespalib/stllike/hashtable.h
@@ -95,8 +95,6 @@ protected:
             (void) to;
         }
     };
-private:
-    static size_t getModulo(size_t newSize, const unsigned long * list, size_t sz) noexcept;
 };
 
 template<typename V>


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR optimizes the getting modulo method. Based on the benchmarks https://quick-bench.com/q/-bPdO1GtFx1DQ6Ve5dZhaah_eso, the performance increased by up to 4 times.

Method:
The original `__stl_prime_list` table is split into arrays of 8 elements. It allows the cache line to accommodate these arrays decreasing cache misses.
The `__upper_bound_list_size` array is used to find a nested array where the given `newSize` is located.

Testing:
The method is checked here: https://godbolt.org/z/bd7rM71f6