### PR TITLE
Revert back to 50 Mb as default jute max buffer for ZooKeeper

### DIFF
--- a/configdefinitions/src/vespa/curator.def
+++ b/configdefinitions/src/vespa/curator.def
@@ -14,4 +14,4 @@ zookeeperSessionTimeoutSeconds int default=120
 # Jute maxbuffer. Used by zookeeper to determine max buffer when serializing/desesrializing
 # Value used in server must correspond to this one (so if decreasing it one must be sure
 # that no node has store more than this many bytes)
-juteMaxBuffer int default=104857600
+juteMaxBuffer int default=52428800


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
