### PR TITLE
Add back support for reading xml feed files in predicate benchmark tool

### DIFF
--- a/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/HitsVerificationBenchmark.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/benchmarks/HitsVerificationBenchmark.java
@@ -46,6 +46,7 @@ public class HitsVerificationBenchmark {
     public static void main(String[] rawArgs) throws IOException {
         Optional<BenchmarkArguments> wrappedArgs = getArguments(rawArgs);
         if (wrappedArgs.isEmpty()) return;
+
         BenchmarkArguments args = wrappedArgs.get();
         Map<String, Object> output = new TreeMap<>();
         addArgsToOutput(output, args);

--- a/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaFeedParser.java
+++ b/predicate-search/src/main/java/com/yahoo/search/predicate/utils/VespaFeedParser.java
@@ -19,23 +19,52 @@ import java.util.function.Consumer;
 public class VespaFeedParser {
 
     public static int parseDocuments(String feedFile, int maxDocuments, Consumer<Predicate> consumer) throws IOException {
-        int documentCount = 0;
         try (BufferedReader reader = new BufferedReader(new FileReader(feedFile), 8 * 1024)) {
+            reader.mark(1);
             String line = reader.readLine();
-            while (!line.startsWith("]") && documentCount < maxDocuments) {
-                while (!line.contains("\"boolean\":")) {
-                    line = reader.readLine();
-                }
-                String booleanExpression = extractBooleanExpression(line);
-                try {
-                    var predicate = Predicate.fromString(booleanExpression);
-                    consumer.accept(predicate);
-                    ++documentCount;
-                } catch (IllegalArgumentException e) {
-                    throw new IllegalArgumentException("Failed to parse predicate: " + booleanExpression, e);
-                }
+            boolean xmlFeed = line.startsWith("<");
+            reader.reset();
+            return xmlFeed
+                    ? parseXmlFeedFile(reader, maxDocuments, consumer)
+                    : parseJsonFeedFile(reader, maxDocuments, consumer);
+        }
+    }
+
+    public static int parseJsonFeedFile(BufferedReader reader, int maxDocuments, Consumer<Predicate> consumer) throws IOException {
+        int documentCount = 0;
+        String line = reader.readLine();
+        while (! line.startsWith("]") && documentCount < maxDocuments) {
+            while (! line.contains("\"boolean\":")) {
                 line = reader.readLine();
             }
+            String booleanExpression = extractBooleanExpression(line);
+            try {
+                var predicate = Predicate.fromString(booleanExpression);
+                consumer.accept(predicate);
+                ++ documentCount;
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Failed to parse predicate: " + booleanExpression, e);
+            }
+            line = reader.readLine();
+        }
+        return documentCount;
+    }
+
+    public static int parseXmlFeedFile(BufferedReader reader, int maxDocuments, Consumer<Predicate> consumer) throws IOException {
+        int documentCount = 0;
+        reader.readLine();
+        String line = reader.readLine(); // Skip to start of first document
+        while (! line.startsWith("</vespafeed>") && documentCount < maxDocuments) {
+            while (!line.startsWith("<boolean>")) {
+                line = reader.readLine();
+            }
+            Predicate predicate = Predicate.fromString(extractBooleanExpressionXml(line)); consumer.accept(predicate);
+            ++ documentCount;
+            while (! line.startsWith("<document") && ! line.startsWith("</vespafeed>")) {
+                line = reader.readLine();
+            }
+            line = reader.readLine();
+            if (line == null) break;
         }
         return documentCount;
     }
@@ -45,6 +74,10 @@ public class VespaFeedParser {
         var start = line.indexOf(field);
         var end = line.indexOf("\"", start + field.length() + 1);
         return line.substring(start + field.length() +1 , end);
+    }
+
+    private static String extractBooleanExpressionXml(String line) {
+        return line.substring(9, line.length() - 10);
     }
 
 }


### PR DESCRIPTION
Need this temporarily to debug/fix switch to json feed file that failed