### PR TITLE
Revert back to 50 Mb as default jute max buffer for ZooKeeper server

### DIFF
--- a/configdefinitions/src/vespa/curator.def
+++ b/configdefinitions/src/vespa/curator.def
@@ -11,7 +11,7 @@ zookeeperLocalhostAffinity bool default=false
 # session timeout, the high default is used by config servers
 zookeeperSessionTimeoutSeconds int default=120
 
-# Jute maxbuffer. Used by zookeeper to determine max buffer when serializing/desesrializing
-# Value used in server must correspond to this one (so if decreasing it one must be sure
-# that no node has store more than this many bytes)
+# Jute maxbuffer. Used by zookeeper to determine max buffer when serializing/deserializing
+# Value used in server must equal or than this one (so if decreasing it one must be sure
+# that no client needs to use more bytes than this), see corresponding field in zookeeper-server.def
 juteMaxBuffer int default=52428800

--- a/configdefinitions/src/vespa/zookeeper-server.def
+++ b/configdefinitions/src/vespa/zookeeper-server.def
@@ -24,8 +24,11 @@ autopurge.snapRetainCount int default=15
 
 # Vespa home is prepended if the file is relative
 myidFile string default="var/zookeeper/myid"
-# Change from default of 1 Mb in zookeeper to 100 Mb
-juteMaxBuffer int default=104857600
+
+# Jute maxbuffer. Used by zookeeper to determine max buffer when serializing/deserializing
+# Note: If decreasing it one must be sure that no node has stored more bytes than this
+# See also corresponding field in curator.def
+juteMaxBuffer int default=52428800
 
 myid int restart
 server[].id int


### PR DESCRIPTION
Revert back for server as well, and add some more doc

Follow-up to https://github.com/vespa-engine/vespa/pull/32053, forgot to reduce this for the server. Values are overridden through env variables in cloud, so this should not change the value there.