### PR TITLE
Update default GPT model

### DIFF
--- a/vespajlib/src/main/java/ai/vespa/llm/client/openai/OpenAiClient.java
+++ b/vespajlib/src/main/java/ai/vespa/llm/client/openai/OpenAiClient.java
@@ -41,7 +41,7 @@ import java.util.stream.Stream;
 @Beta
 public class OpenAiClient implements LanguageModel {
 
-    private static final String DEFAULT_MODEL = "gpt-3.5-turbo";
+    private static final String DEFAULT_MODEL = "gpt-4o-mini";
     private static final String DATA_FIELD = "data: ";
 
     private static final int MAX_RETRIES = 3;


### PR DESCRIPTION
@kkraune Please review. 

From OpenAI: "As of July 2024, gpt-4o-mini should be used in place of gpt-3.5-turbo, as it is cheaper, more capable, multimodal, and just as fast.". It also has a context window of 128K tokens instead of 16K.