### PR TITLE
Remove 'statistics' from list of accepted commands

### DIFF
--- a/config/src/apps/vespa-configproxy-cmd/methods.cpp
+++ b/config/src/apps/vespa-configproxy-cmd/methods.cpp
@@ -13,7 +13,6 @@ const Method methods[] = {
     { "invalidatecache", "invalidateCache", 0 },
     { "cachefull", "listCachedConfigFull", 0 },
     { "sources", "listSourceConnections", 0 },
-    { "statistics", "printStatistics", 0 },
     { "setmode", "setMode", 1 }, // { default | memorycache }
     { "updatesources", "updateSources", 1 },
     { 0, 0, 0}


### PR DESCRIPTION
This command does not work (anymore).

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
