### PR TITLE
Glebashnik/gh action verify opensource release 7days

### DIFF
--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -18,8 +18,7 @@ jobs:
     steps:
       - name: Install xq
         run: |
-          sudo apt update -y
-          sudo apt install -y xq
+          sudo apt-get install -y xq
 
       - name: Error if current release is too old
         run: |

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -16,9 +16,9 @@ jobs:
   error-if-current-release-too-old:
     runs-on: ubuntu-latest
     steps:
-      - name: Install xq
+      - name: Install tools
         run: |
-          sudo apt-get install -y xq
+          pip install yq
 
       - name: Error if current release is too old
         run: |

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -16,6 +16,11 @@ jobs:
   error-if-current-release-too-old:
     runs-on: ubuntu-latest
     steps:
+      - name: Install xq
+        run: |
+          sudo apt update -y
+          sudo apt install -y xq
+
       - name: Error if current release is too old
         run: |
           now_epoch=`date "+%s"`

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -14,11 +14,11 @@ on:
 
 jobs:
   error-if-current-release-too-old:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - name: Install tools
+      - name: Setup xq
         run: |
-          pip install yq
+          sudo apt-get install -y xq
 
       - name: Error if current release is too old
         run: |

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -23,13 +23,11 @@ jobs:
   publish-cli-release:
     runs-on: ubuntu-latest
     steps:
-      - name: now-epoch
+      - name: error-if-current-release-too-old
         run: |
           now_epoch=`date "+%s"`
           echo "Now epoch: " $now_epoch
 
-      - name: error-if-current-release-too-old
-        run: |
           current_release_date=$(curl -sLf https://repo1.maven.org/maven2/com/yahoo/vespa/cloud-tenant-base/maven-metadata.xml | \
           grep -oP "<lastUpdated>\K\w+" | cut -c 1-8)
           echo "Current release date: " $current_release_date
@@ -45,6 +43,9 @@ jobs:
 
       - name: error-if-docker-image-too-old
         run: |
+          now_epoch=`date "+%s"`
+          echo "Now epoch: " $now_epoch
+
           image_date=$(curl -sLf https://hub.docker.com/v2/repositories/vespaengine/vespa/ | jq -re '.last_updated')
           echo "Docker image last_updated: " $image_date
           image_epoch=`date -d "$image_date" "+%s"`

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -1,0 +1,64 @@
+name: verify-opensource-release-7days
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - .github/workflows/verify-opensource-release-7days.yml
+    branches:
+      - master
+
+  push:
+    paths:
+      - .github/workflows/verify-opensource-release-7days.yml
+    branches:
+      - master
+      - glebashnik/gh-action-verify-opensource-release-7days
+
+  schedule:
+   - cron: '0 0 * * *'
+
+jobs:
+  publish-cli-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: now-epoch
+        run: |
+          now_epoch=`date "+%s"`
+          echo "Now epoch: " $now_epoch
+
+      - name: calculate-current-release-age
+        run: |
+          current_release_date=$(curl -sLf https://repo1.maven.org/maven2/com/yahoo/vespa/cloud-tenant-base/maven-metadata.xml | \
+          grep -oP "<lastUpdated>\K\w+" | cut -c 1-8)
+          echo "Current release date: " $current_release_date
+          current_release_epoch=`date -d "$current_release_date" "+%s"`
+          echo "Current release epoch: " $current_release_epoch
+          release_age_days=$((($now_epoch-$current_release_epoch)/86400))
+          echo "Release age days: " $release_age_days
+
+      - name: error-if-current-release-too-old
+        run: |
+          if [ "$release_age_days" -gt 7 ]; then
+            echo "Current open source release is older than 7 days"
+            exit 1
+          fi
+
+      - name: calculate-docker-image-age
+        run: |
+          image_date=$(curl -sLf https://hub.docker.com/v2/repositories/vespaengine/vespa/ | jq -re '.last_updated')
+          echo "Docker image last_updated: " $image_date
+          image_epoch=`date -d "$image_date" "+%s"`
+          echo "Docker image epoch: " $image_epoch
+          docker_image_age_days=$((($now_epoch-$image_epoch)/86400))
+          echo "Docker image age days: " $docker_image_age_days
+
+      - name: error-if-docker-image-too-old
+        run: |
+          if [ "$docker_image_age_days" -gt 7 ]; then
+            echo "Current Docker image is older than 7 days"
+            exit 1
+          fi
+
+

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -1,4 +1,4 @@
-name: verify-opensource-release-7days
+name: Check OSS release age
 
 on:
   workflow_dispatch:
@@ -9,13 +9,6 @@ on:
     branches:
       - master
 
-  push:
-    paths:
-      - .github/workflows/verify-opensource-release-7days.yml
-    branches:
-      - master
-      - glebashnik/gh-action-verify-opensource-release-7days
-
   schedule:
    - cron: '0 0 * * *'
 
@@ -23,13 +16,13 @@ jobs:
   error-if-current-release-too-old:
     runs-on: ubuntu-latest
     steps:
-      - name: error-if-current-release-too-old
+      - name: Error if current release is too old
         run: |
           now_epoch=`date "+%s"`
           echo "Now epoch: " $now_epoch
 
           current_release_date=$(curl -sLf https://repo1.maven.org/maven2/com/yahoo/vespa/cloud-tenant-base/maven-metadata.xml | \
-          grep -oP "<lastUpdated>\K\w+" | cut -c 1-8)
+          xq -x 'metadata/versioning/lastUpdated' | cut -c 1-8)
           echo "Current release date: " $current_release_date
           current_release_epoch=`date -d "$current_release_date" "+%s"`
           echo "Current release epoch: " $current_release_epoch
@@ -44,7 +37,7 @@ jobs:
   error-if-docker-image-too-old:
     runs-on: ubuntu-latest
     steps:
-      - name: error-if-docker-image-too-old
+      - name: Error if docker image is too old
         run: |
           now_epoch=`date "+%s"`
           echo "Now epoch: " $now_epoch

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -20,7 +20,7 @@ on:
    - cron: '0 0 * * *'
 
 jobs:
-  publish-cli-release:
+  error-if-current-release-too-old:
     runs-on: ubuntu-latest
     steps:
       - name: error-if-current-release-too-old
@@ -41,6 +41,9 @@ jobs:
             exit 1
           fi
 
+  error-if-docker-image-too-old:
+    runs-on: ubuntu-latest
+    steps:
       - name: error-if-docker-image-too-old
         run: |
           now_epoch=`date "+%s"`

--- a/.github/workflows/verify-opensource-release-7days.yml
+++ b/.github/workflows/verify-opensource-release-7days.yml
@@ -28,7 +28,7 @@ jobs:
           now_epoch=`date "+%s"`
           echo "Now epoch: " $now_epoch
 
-      - name: calculate-current-release-age
+      - name: error-if-current-release-too-old
         run: |
           current_release_date=$(curl -sLf https://repo1.maven.org/maven2/com/yahoo/vespa/cloud-tenant-base/maven-metadata.xml | \
           grep -oP "<lastUpdated>\K\w+" | cut -c 1-8)
@@ -38,14 +38,12 @@ jobs:
           release_age_days=$((($now_epoch-$current_release_epoch)/86400))
           echo "Release age days: " $release_age_days
 
-      - name: error-if-current-release-too-old
-        run: |
           if [ "$release_age_days" -gt 7 ]; then
             echo "Current open source release is older than 7 days"
             exit 1
           fi
 
-      - name: calculate-docker-image-age
+      - name: error-if-docker-image-too-old
         run: |
           image_date=$(curl -sLf https://hub.docker.com/v2/repositories/vespaengine/vespa/ | jq -re '.last_updated')
           echo "Docker image last_updated: " $image_date
@@ -54,8 +52,6 @@ jobs:
           docker_image_age_days=$((($now_epoch-$image_epoch)/86400))
           echo "Docker image age days: " $docker_image_age_days
 
-      - name: error-if-docker-image-too-old
-        run: |
           if [ "$docker_image_age_days" -gt 7 ]; then
             echo "Current Docker image is older than 7 days"
             exit 1


### PR DESCRIPTION
## What

Adds a new workflow to check the age of open source vespa release and docker image
The workflow is triggered either manually or on a daily schedule.

## Why

Part of the process of retiring Screwdriver as CI/CD runner.

## Additional Info

The corresponding Screwdriver pipeline is not removed since we don't have a dashboard for Github Actions yet.

See successful test run: 
https://github.com/vespa-engine/vespa/actions/runs/10383253715