### PR TITLE
Migrate workflow to mirror Copr RPMs into Cloudsmith archive to Github Actions

### DIFF
--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -65,7 +65,10 @@ echo "RPMs missing in archive:"
 ls -lh  *.rpm
 echo
 
+
 UPLOAD_FAILED=false
+echo "GitHub event: $GITHUB_EVENT_NAME"
+
 if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
   for rpm in $(ls *.rpm); do
     echo "Uploading $rpm ..."

--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -66,7 +66,7 @@ ls -lh  *.rpm
 echo
 
 UPLOAD_FAILED=false
-if [[ -n $GITHUB ]] && [[ -z $SD_PULL_REQUEST ]]; then
+if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
   for rpm in $(ls *.rpm); do
     echo "Uploading $rpm ..."
     if ! $MYDIR/upload-rpm-to-cloudsmith.sh $rpm ; then

--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -69,7 +69,7 @@ echo
 UPLOAD_FAILED=false
 echo "GitHub event: $GITHUB_EVENT_NAME"
 
-if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
   for rpm in $(ls *.rpm); do
     echo "Uploading $rpm ..."
     if ! $MYDIR/upload-rpm-to-cloudsmith.sh $rpm ; then

--- a/.github/scripts/publish-unpublished-rpms-to-archive.sh
+++ b/.github/scripts/publish-unpublished-rpms-to-archive.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set -euo pipefail
+set -x
+
+if (( $# < 1 )); then
+    echo "Usage: $0 <RPM architecture>"
+    exit 1
+fi
+
+RPMARCH=$1
+ALLOWED_ARCHS=("x86_64" "aarch64")
+
+if [[ ! ${ALLOWED_ARCHS[@]} =~ $RPMARCH ]]; then
+  echo "Architecture $RPMARCH not in allowed archs: ${ALLOWED_ARCHS[@]}"
+  exit 1
+fi
+
+readonly MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Copr repo
+dnf config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-8/group_vespa-vespa-epel-8.repo
+sed -i "s,\$basearch,$RPMARCH,g" /etc/yum.repos.d/group_vespa-vespa-epel-8.repo
+
+# Cloudsmith repo
+rpm --import 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/gpg.0F3DA3C70D35DA7B.key'
+curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8' > /tmp/vespa-open-source-rpms.repo
+dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
+rm -f /tmp/vespa-open-source-rpms.repo
+
+readonly COPR_PACKAGES=$(mktemp)
+trap "rm -f $COPR_PACKAGES" EXIT
+readonly DLDIR=$(mktemp -d)
+trap "rm -rf $DLDIR" EXIT
+
+cd $DLDIR
+
+readonly DNF="dnf -y -q --forcearch $RPMARCH"
+
+$DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa --showduplicates 'vespa*' | grep "Available Packages" -A 100000 | tail -n +2 | sed '/\.src\ */d' | sed -E "s/\.($RPMARCH|noarch)\ */-/" | awk '{print $1}' | grep -v '.src$' > $COPR_PACKAGES
+
+echo "Packages on Copr:"
+cat $COPR_PACKAGES
+echo
+
+for pv in $(cat $COPR_PACKAGES); do
+  if ! $DNF list --disablerepo='*' --enablerepo=vespa-open-source-rpms $pv &> /dev/null; then
+    # Need one extra check here for noarch packages
+    if ! dnf -y -q --forcearch noarch list --disablerepo='*' --enablerepo=vespa-open-source-rpms $pv &> /dev/null; then
+      echo "$pv not found on in archive. Downloading..."
+      $DNF download --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_vespa:vespa $pv
+      echo "$pv downloaded."
+    fi
+  fi
+done
+echo
+
+if ! ls *.rpm &> /dev/null; then
+  echo "All packages already in archive."
+  exit 0
+fi
+
+echo "RPMs missing in archive:"
+ls -lh  *.rpm
+echo
+
+UPLOAD_FAILED=false
+if [[ -n $GITHUB ]] && [[ -z $SD_PULL_REQUEST ]]; then
+  for rpm in $(ls *.rpm); do
+    echo "Uploading $rpm ..."
+    if ! $MYDIR/upload-rpm-to-cloudsmith.sh $rpm ; then
+      echo "Could not upload $rpm"
+      UPLOAD_FAILED=true
+    else
+      echo "$rpm uploaded"
+    fi
+  done
+  echo
+fi
+
+if $UPLOAD_FAILED; then
+  echo "Some RPMs failed to upload"
+  exit 1
+fi

--- a/.github/scripts/upload-rpm-to-cloudsmith.sh
+++ b/.github/scripts/upload-rpm-to-cloudsmith.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set -euo pipefail
+
+if (( $# < 1 )); then
+  echo "Usage: $0 <RPM file>"
+  exit 1
+fi
+
+if [[ -z $CLOUDSMITH_API_TOKEN ]]; then
+  echo "Environment CLOUDSMITH_API_TOKEN not set. Exiting."
+  exit 1
+fi
+
+RPM=$1
+OS_DISTRO=el
+RELEASEVER=8
+
+main() {
+
+  FID=$(curl -sLf \
+    --upload-file $RPM \
+    -H "X-Api-Key: $CLOUDSMITH_API_TOKEN" \
+    -H "Content-Sha256: $(sha256sum $RPM | cut -f1 -d' ')" \
+    https://upload.cloudsmith.io/vespa/open-source-rpms/$RPM | jq -re '.identifier')
+
+  if [[ -n $FID ]]; then
+    curl -sLf -X POST -H "Content-Type: application/json" \
+      -H "X-Api-Key: $CLOUDSMITH_API_TOKEN" \
+      -d "{\"package_file\": \"$FID\", \"distribution\": \"$OS_DISTRO/$RELEASEVER\"}" \
+      https://api-prd.cloudsmith.io/v1/packages/vespa/open-source-rpms/upload/rpm/
+  fi
+}
+
+main "$@"

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/workflows/mirror-copr-rpms-to-archive.yml
       - .github/scripts/publish-unpublished-rpms-to-archive.sh
+      - .github/scripts/upload-rpm-to-cloudsmith.sh
     branches:
       - master
 
@@ -14,6 +15,7 @@ on:
     paths:
       - .github/workflows/mirror-copr-rpms-to-archive.yml
       - .github/scripts/publish-unpublished-rpms-to-archive.sh
+      - .github/scripts/upload-rpm-to-cloudsmith.sh
     branches:
       - master
       - glebashnik/gh-action-mirror-copr-rpms-to-archive
@@ -24,22 +26,31 @@ on:
 jobs:
   mirror-copr-rpms-to-archive:
     runs-on: ubuntu-latest
+
+    container:
+        image: almalinux:8
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          CLOUDSMITH_API_TOKEN: ${{ secrets.CLOUDSMITH_API_TOKEN }}
+        volumes:
+          - ${{ github.workspace }}:/workspace
+
+    defaults:
+      run:
+        working-directory: /workspace
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Pull docker image
-        run: docker pull docker.io/almalinux:8
-
-      - name: Run scripts in docker
+      - name: install
         run: |
-          docker run --rm \
-            -e GITHUB=1 \
-            -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
-            -e CLOUDSMITH_API_CREDS=${{ secrets.CLOUDSMITH_API_CREDS }} \
-            -v ${{ github.workspace }}:/workspace -w /workspace \
-            docker.io/almalinux:8 bash -c "
-              sudo dnf install -y dnf-plugins-core jq
-              bash .github/scripts/publish-unpublished-rpms-to-archive.sh x86_64
-              bash .github/scripts/publish-unpublished-rpms-to-archive.sh aarch64
-            "
+          dnf install -y dnf-plugins-core jq
+
+      - name: mirror-x86-64
+        run: |
+          .github/scripts/publish-unpublished-rpms-to-archive.sh x86_64
+
+      - name: mirror-aarch64
+        run: |
+          .github/scripts/publish-unpublished-rpms-to-archive.sh aarch64

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -1,0 +1,45 @@
+name: mirror-copr-rpms-to-archive
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - .github/workflows/mirror-copr-rpms-to-archive.yml
+      - .github/scripts/publish-unpublished-rpms-to-archive.sh
+    branches:
+      - master
+
+  push:
+    paths:
+      - .github/workflows/mirror-copr-rpms-to-archive.yml
+      - .github/scripts/publish-unpublished-rpms-to-archive.sh
+    branches:
+      - master
+      - glebashnik/gh-action-mirror-copr-rpms-to-archive
+
+  schedule:
+   - cron: '0 6 * * *'
+
+jobs:
+  mirror-copr-rpms-to-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Pull docker image
+        run: docker pull docker.io/almalinux:8
+
+      - name: Run scripts in docker
+        run: |
+          docker run --rm \
+            -e GITHUB=1 \
+            -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
+            -e CLOUDSMITH_API_CREDS=${{ secrets.CLOUDSMITH_API_CREDS }} \
+            -v ${{ github.workspace }}:/workspace -w /workspace \
+            docker.io/almalinux:8 bash -c "
+              sudo dnf install -y dnf-plugins-core jq
+              bash .github/scripts/publish-unpublished-rpms-to-archive.sh x86_64
+              bash .github/scripts/publish-unpublished-rpms-to-archive.sh aarch64
+            "

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -11,15 +11,6 @@ on:
     branches:
       - master
 
-  push:
-    paths:
-      - .github/workflows/mirror-copr-rpms-to-archive.yml
-      - .github/scripts/publish-unpublished-rpms-to-archive.sh
-      - .github/scripts/upload-rpm-to-cloudsmith.sh
-    branches:
-      - master
-      - glebashnik/gh-action-mirror-copr-rpms-to-archive
-
   schedule:
    - cron: '0 6 * * *'
 

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -1,4 +1,4 @@
-name: mirror-copr-rpms-to-archive
+name: Mirror Copr RPMs to archive
 
 on:
   workflow_dispatch:
@@ -43,14 +43,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: install
+      - name: Install tools
         run: |
           dnf install -y dnf-plugins-core jq
 
-      - name: mirror-x86-64
+      - name: Publish to x86-64 mirror
         run: |
           .github/scripts/publish-unpublished-rpms-to-archive.sh x86_64
 
-      - name: mirror-aarch64
+      - name: Publish to aarch64 mirror
         run: |
           .github/scripts/publish-unpublished-rpms-to-archive.sh aarch64

--- a/.github/workflows/mirror-copr-rpms-to-archive.yml
+++ b/.github/workflows/mirror-copr-rpms-to-archive.yml
@@ -30,6 +30,12 @@ jobs:
       run:
         working-directory: /workspace
 
+    strategy:
+      matrix:
+        arch:
+          - x86_64
+          - aarch64
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,10 +44,6 @@ jobs:
         run: |
           dnf install -y dnf-plugins-core jq
 
-      - name: Publish to x86-64 mirror
+      - name: Publish to ${{ matrix.arch }} mirror
         run: |
-          .github/scripts/publish-unpublished-rpms-to-archive.sh x86_64
-
-      - name: Publish to aarch64 mirror
-        run: |
-          .github/scripts/publish-unpublished-rpms-to-archive.sh aarch64
+          .github/scripts/publish-unpublished-rpms-to-archive.sh ${{ matrix.arch }}

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -315,25 +315,6 @@ jobs:
           dnf install -y epel-release
           dnf install -y vespa
 
-  mirror-copr-rpms-to-archive:
-    requires: [publish-release]
-    image: docker.io/almalinux:8
-    annotations:
-      screwdriver.cd/cpu: LOW
-      screwdriver.cd/ram: LOW
-      screwdriver.cd/disk: HIGH
-      screwdriver.cd/timeout: 60
-      screwdriver.cd/buildPeriodically: H 6 * * *
-    secrets:
-      - CLOUDSMITH_API_TOKEN
-    steps:
-      - install: |
-          dnf install -y dnf-plugins-core jq
-      - mirror-x86-64: |
-          screwdriver/publish-unpublished-rpms-to-archive.sh x86_64
-      - mirror-aarch64: |
-          screwdriver/publish-unpublished-rpms-to-archive.sh aarch64
-
   delete-old-versions-in-archive:
     annotations:
       screwdriver.cd/cpu: LOW

--- a/screwdriver/publish-unpublished-rpms-to-archive.sh
+++ b/screwdriver/publish-unpublished-rpms-to-archive.sh
@@ -42,7 +42,7 @@ $DNF list --disablerepo='*' --enablerepo=copr:copr.fedorainfracloud.org:group_ve
 
 echo "Packages on Copr:"
 cat $COPR_PACKAGES
-echo 
+echo
 
 for pv in $(cat $COPR_PACKAGES); do
   if ! $DNF list --disablerepo='*' --enablerepo=vespa-open-source-rpms $pv &> /dev/null; then


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## What

Adds a new workflow to mover Copr RPMs to archive.
The workflow is triggered either manually or on a daily schedule.

## Why

Part of the process of retiring Screwdriver as CI/CD runner.

## Additional Info

The corresponding Screwdriver pipeline is not removed since we don't have a dashboard for Github Actions yet.

See successful test run: 
https://github.com/vespa-engine/vespa/actions/runs/10385493605