### PR TITLE
Migrate workflow to delete old Cloudsmith artifacts to GitHub Actions

### DIFF
--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -30,9 +30,7 @@ done
 echo "Deleting the following RPMs:"
 cat $RPMS_TO_DELETE
 
-echo $CLOUDSMITH_API_CREDS
-
-if [[ -n $SCREWDRIVER ]] && [[ -z $SD_PULL_REQUEST ]]; then
+if [[ -n $GITHUB ]] && [[ -z $SD_PULL_REQUEST ]]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
       curl -sLf -u "$CLOUDSMITH_API_CREDS" -X DELETE \
         --header 'accept: application/json' \

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -30,9 +30,10 @@ done
 echo "Deleting the following RPMs:"
 cat $RPMS_TO_DELETE
 
-if [[ -n $GITHUB ]] && [[ -z $SD_PULL_REQUEST ]]; then
+if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
-      curl -sLf -u "$CLOUDSMITH_API_CREDS" -X DELETE \
+      curl -sLf -X DELETE \
+        --header "X-Api-Key: $CLOUDSMITH_API_TOKEN" \
         --header 'accept: application/json' \
         "https://api.cloudsmith.io/v1/packages/vespa/open-source-rpms/$RPMID/"
     done

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -7,7 +7,7 @@ MAX_NUMBER_OF_RELEASES=40
 # Cloudsmith repo
 rpm --import 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/gpg.0F3DA3C70D35DA7B.key'
 curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8' > /tmp/vespa-open-source-rpms.repo
-dnf install 'dnf-command(config-manager)'
+dnf install -y 'dnf-command(config-manager)'
 dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
 rm -f /tmp/vespa-open-source-rpms.repo
 

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+
+set -euo pipefail
+MAX_NUMBER_OF_RELEASES=40
+
+# Cloudsmith repo
+rpm --import 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/gpg.0F3DA3C70D35DA7B.key'
+curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8' > /tmp/vespa-open-source-rpms.repo
+dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
+rm -f /tmp/vespa-open-source-rpms.repo
+
+# Allow the last Vespa 7 release to remain in the repo
+VERSIONS_TO_DELETE=$(dnf list -y --quiet --showduplicates --disablerepo='*' --enablerepo=vespa-open-source-rpms vespa | awk '/[0-9].*\.[0-9].*\.[0-9].*/{print $2}' | sort -V | grep -v "7.594.36" | head -n -$MAX_NUMBER_OF_RELEASES)
+
+if [[ -z "$VERSIONS_TO_DELETE" ]]; then
+  echo "No old RPM versions to delete found. Exiting."
+  exit 0
+fi
+
+RPMS_TO_DELETE=$(mktemp)
+trap "rm -f $RPMS_TO_DELETE" EXIT
+
+for VERSION in $VERSIONS_TO_DELETE; do
+  curl -sLf --header 'accept: application/json' \
+    "https://api.cloudsmith.io/v1/packages/vespa/open-source-rpms/?query=version:${VERSION}" | jq -re '.[] | .slug' >> $RPMS_TO_DELETE
+done
+
+echo "Deleting the following RPMs:"
+cat $RPMS_TO_DELETE
+
+if [[ -n $SCREWDRIVER ]] && [[ -z $SD_PULL_REQUEST ]]; then
+    for RPMID in $(cat $RPMS_TO_DELETE); do
+      curl -sLf -u "$CLOUDSMITH_API_CREDS" -X DELETE \
+        --header 'accept: application/json' \
+        "https://api.cloudsmith.io/v1/packages/vespa/open-source-rpms/$RPMID/"
+    done
+fi
+
+

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -7,6 +7,7 @@ MAX_NUMBER_OF_RELEASES=40
 # Cloudsmith repo
 rpm --import 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/gpg.0F3DA3C70D35DA7B.key'
 curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8' > /tmp/vespa-open-source-rpms.repo
+dnf install 'dnf-command(config-manager)'
 dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
 rm -f /tmp/vespa-open-source-rpms.repo
 

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -30,6 +30,8 @@ done
 echo "Deleting the following RPMs:"
 cat $RPMS_TO_DELETE
 
+echo $CLOUDSMITH_API_CREDS
+
 if [[ -n $SCREWDRIVER ]] && [[ -z $SD_PULL_REQUEST ]]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
       curl -sLf -u "$CLOUDSMITH_API_CREDS" -X DELETE \

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -30,7 +30,7 @@ done
 echo "Deleting the following RPMs:"
 cat $RPMS_TO_DELETE
 
-if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
       curl -sLf -X DELETE \
         --header "X-Api-Key: $CLOUDSMITH_API_TOKEN" \

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
+dnf install -y 'dnf-command(config-manager)' jq
 
 set -euo pipefail
 MAX_NUMBER_OF_RELEASES=40
@@ -7,7 +8,6 @@ MAX_NUMBER_OF_RELEASES=40
 # Cloudsmith repo
 rpm --import 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/gpg.0F3DA3C70D35DA7B.key'
 curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/config.rpm.txt?distro=el&codename=8' > /tmp/vespa-open-source-rpms.repo
-dnf install -y 'dnf-command(config-manager)'
 dnf config-manager --add-repo '/tmp/vespa-open-source-rpms.repo'
 rm -f /tmp/vespa-open-source-rpms.repo
 

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -23,13 +23,14 @@ on:
 
 jobs:
   delete-old-versions-in-archive:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - name: Install DNF
-        run: sudo apt-get install -y dnf dnf-plugins-core
+      - name: Pull Fedora Docker image
+        run: docker pull fedora:latest
 
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run cleanup script
-        run: sudo bash .github/scripts/delete-old-cloudsmith-artifacts.sh
+      - name: Run script in Fedora Docker container
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace fedora:latest bash .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -1,4 +1,4 @@
-name: delete-old-versions-in-archive
+name: Delete old Cloudsmith artifacts
 
 on:
   workflow_dispatch:
@@ -10,34 +10,29 @@ on:
     branches:
       - master
 
-  push:
-    paths:
-      - .github/workflows/delete-old-versions-in-archive.yml
-      - .github/scripts/delete-old-cloudsmith-artifacts.sh
-    branches:
-      - master
-      - glebashink/gh-action-delete-old-versions-in-archive
-
   schedule:
    - cron: '0 6 * * *'
 
-
-
 jobs:
-  delete-old-versions-in-archive:
+  delete-old-cloudsmith-artifacts:
     runs-on: ubuntu-latest
-    steps:
-      - name: Pull Fedora Docker image
-        run: docker pull fedora:latest
 
+    container:
+        image: fedora:latest
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          CLOUDSMITH_API_TOKEN: ${{ secrets.CLOUDSMITH_API_TOKEN }}
+        volumes:
+          - ${{ github.workspace }}:/workspace
+
+    defaults:
+      run:
+        working-directory: /workspace
+
+    steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Run script in Fedora Docker container
+      - name: Delete old artifacts
         run: |
-          docker run --rm \
-            -e GITHUB=1 \
-            -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
-            -e CLOUDSMITH_API_CREDS=${{ secrets.CLOUDSMITH_API_CREDS }} \
-            -v ${{ github.workspace }}:/workspace -w /workspace \
-            fedora:latest bash .github/scripts/delete-old-cloudsmith-artifacts.sh
+          .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -38,6 +38,6 @@ jobs:
           docker run --rm \
             -e SCREWDRIVER=1 \
             -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
-            -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
+            -e CLOUDSMITH_API_CREDS=${{ secrets.CLOUDSMITH_API_CREDS }} \
             -v ${{ github.workspace }}:/workspace -w /workspace \
             fedora:latest bash .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Run script in Fedora Docker container
         run: |
           docker run --rm \
-            -e SCREWDRIVER=1 \
+            -e GITHUB=1 \
             -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
             -e CLOUDSMITH_API_CREDS=${{ secrets.CLOUDSMITH_API_CREDS }} \
             -v ${{ github.workspace }}:/workspace -w /workspace \

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -1,0 +1,31 @@
+name: delete-old-versions-in-archive
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - .github/workflows/delete-old-versions-in-archive.yml
+      - .github/scripts/delete-old-cloudsmith-artifacts.sh
+    branches:
+      - master
+
+  push:
+    paths:
+      - .github/workflows/delete-old-versions-in-archive.yml
+      - .github/scripts/delete-old-cloudsmith-artifacts.sh
+    branches:
+      - master
+      - glebashink/gh-action-delete-old-versions-in-archive
+
+  schedule:
+   - cron: '0 6 * * *'
+
+jobs:
+  delete-old-versions-in-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: cleanup
+        run: bash .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -21,6 +21,8 @@ on:
   schedule:
    - cron: '0 6 * * *'
 
+
+
 jobs:
   delete-old-versions-in-archive:
     runs-on: ubuntu-latest
@@ -33,4 +35,9 @@ jobs:
 
       - name: Run script in Fedora Docker container
         run: |
-          docker run --rm -v ${{ github.workspace }}:/workspace -w /workspace fedora:latest bash .github/scripts/delete-old-cloudsmith-artifacts.sh
+          docker run --rm \
+            -e SCREWDRIVER=1 \
+            -e SD_PULL_REQUEST=$([[ "${{ github.event_name }}" == "pull_request" ]] && echo 1 || echo "") \
+            -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
+            -v ${{ github.workspace }}:/workspace -w /workspace \
+            fedora:latest bash .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -25,7 +25,11 @@ jobs:
   delete-old-versions-in-archive:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Install DNF
+        run: sudo apt-get install -y dnf
 
-      - name: cleanup
-        run: bash .github/scripts/delete-old-cloudsmith-artifacts.sh
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run cleanup script
+        run: sudo bash .github/scripts/delete-old-cloudsmith-artifacts.sh

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install DNF
-        run: sudo apt-get install -y dnf
+        run: sudo apt-get install -y dnf dnf-plugins-core
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/delete-old-versions-in-archive.yml
+++ b/.github/workflows/delete-old-versions-in-archive.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   delete-old-versions-in-archive:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install DNF
         run: sudo apt-get install -y dnf dnf-plugins-core


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## What

Adds a GitHub action workflow to delete old Cloudsmith artifacts.
The workflow is triggered either manually or on a daily schedule.

## Why

Part of the process of retiring Screwdriver as CI/CD runner.

## Additional Info

The corresponding Screwdriver pipeline is not removed since we don't have a dashboard for Github Actions yet.

See successful test run:
https://github.com/vespa-engine/vespa/actions/runs/10387039260/job/28759628746