### PR TITLE
Migrate workflow to verify RPM installable to  GitHub Actions (#32150)

### DIFF
--- a/.github/workflows/verify-opensource-rpm-installable.yml
+++ b/.github/workflows/verify-opensource-rpm-installable.yml
@@ -1,0 +1,30 @@
+name: Verify open source RPM installable
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    paths:
+      - .github/workflows/verify-opensource-rpm-installable.yml
+    branches:
+      - master
+
+  schedule:
+   - cron: '0 0 * * *'
+
+jobs:
+  verify-opensource-rpm-installable:
+    runs-on: ubuntu-latest
+
+    container:
+      image: almalinux:8
+
+    steps:
+      - name: Install Vespa
+        run: |
+          dnf list llvm-libs --showduplicates
+          dnf install -y dnf-plugins-core
+          dnf config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-8/group_vespa-vespa-epel-8.repo
+          dnf config-manager --enable powertools
+          dnf install -y epel-release
+          dnf install -y vespa

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -302,19 +302,6 @@ jobs:
             exit 1
           fi
 
-  verify-opensource-rpm-installable:
-    image: almalinux:8
-    annotations:
-      screwdriver.cd/buildPeriodically: H 0 * * *
-    steps:
-      - install: |
-          dnf list llvm-libs --showduplicates
-          dnf install -y dnf-plugins-core
-          dnf config-manager --add-repo https://copr.fedorainfracloud.org/coprs/g/vespa/vespa/repo/epel-8/group_vespa-vespa-epel-8.repo
-          dnf config-manager --enable powertools
-          dnf install -y epel-release
-          dnf install -y vespa
-
   mirror-copr-rpms-to-archive:
     requires: [publish-release]
     image: docker.io/almalinux:8


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

## What

Adds a new workflow to verify that RPM can be installed.
The workflow is triggered either manually or on a daily schedule.

## Why

Part of the process of retiring Screwdriver as CI/CD runner.

## Additional Info

See successful test run: 
https://github.com/vespa-engine/vespa/actions/runs/10389439316/job/28767453315