### PR TITLE
Download file reference directly from source

### DIFF
--- a/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
+++ b/config/src/main/java/com/yahoo/vespa/config/JRTConnectionPool.java
@@ -99,7 +99,7 @@ public class JRTConnectionPool implements ConnectionPool {
         return sources.get(ThreadLocalRandom.current().nextInt(0, sources.size()));
     }
 
-    protected List<JRTConnection> getSources() {
+    public List<JRTConnection> getSources() {
         List<JRTConnection> ret;
         synchronized (connections) {
             ret = new ArrayList<>(connections.values());

--- a/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/rpc/RpcServer.java
@@ -583,11 +583,17 @@ public class RpcServer implements Runnable, ConfigActivationListener, TenantList
                     var peerSpec = client.peerSpec();
                     Stream.of(fileReferenceStrings)
                             .map(FileReference::new)
-                            .forEach(fileReference -> {
-                                log.log(FINE, "Downloading file reference " + fileReference.value() + " from " + peerSpec);
-                                downloader.downloadFromSource(new FileReferenceDownload(fileReference, client.toString()), peerSpec);
-                            });
+                            .forEach(fileReference -> downloadFromSource(fileReference, client, peerSpec));
                     req.returnValues().add(new Int32Value(0));
                 });
     }
+
+    private void downloadFromSource(FileReference fileReference, Target client, Spec peerSpec) {
+        var fileReferenceDownload = new FileReferenceDownload(fileReference, client.toString());
+        var downloading = downloader.downloadFromSource(fileReferenceDownload, peerSpec);
+        log.log(FINE, () -> downloading
+                ? "Downloading file reference " + fileReference.value() + " from " + peerSpec
+                : "File reference " + fileReference.value() + " already exists");
+    }
+
 }

--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -2,6 +2,7 @@
 package com.yahoo.vespa.filedistribution;
 
 import com.yahoo.config.FileReference;
+import com.yahoo.jrt.Spec;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.vespa.config.Connection;
 import com.yahoo.vespa.config.ConnectionPool;
@@ -137,11 +138,14 @@ public class FileDownloader implements AutoCloseable {
         return downloads.get(fileReference).isPresent();
     }
 
-    /** Start a download if needed, don't wait for result */
-    public void downloadIfNeeded(FileReferenceDownload fileReferenceDownload) {
-        if (fileReferenceExists(fileReferenceDownload.fileReference(), downloadDirectory)) return;
+    /** Start a download from the specified source, don't wait for result
+     *  @return true if download was started, false if file reference already exists
+     */
+    public boolean downloadFromSource(FileReferenceDownload fileReferenceDownload, Spec source) {
+        if (fileReferenceExists(fileReferenceDownload.fileReference(), downloadDirectory)) return false;
 
-        startDownload(fileReferenceDownload);
+        fileReferenceDownloader.startDownloadFromSource(fileReferenceDownload, source);
+        return true;
     }
 
     /** Start downloading, the future returned will be complete()d by receiving method in {@link FileReceiver} */

--- a/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
+++ b/filedistribution/src/test/java/com/yahoo/vespa/filedistribution/FileDownloaderTest.java
@@ -6,6 +6,7 @@ import com.yahoo.io.IOUtils;
 import com.yahoo.jrt.Int32Value;
 import com.yahoo.jrt.Request;
 import com.yahoo.jrt.RequestWaiter;
+import com.yahoo.jrt.Spec;
 import com.yahoo.jrt.StringValue;
 import com.yahoo.jrt.Supervisor;
 import com.yahoo.jrt.Transport;
@@ -243,13 +244,13 @@ public class FileDownloaderTest {
         FileDownloader fileDownloader = createDownloader(connectionPool, timeout);
         FileReference xyzzy = new FileReference("xyzzy");
         // Should download since we do not have the file on disk
-        fileDownloader.downloadIfNeeded(new FileReferenceDownload(xyzzy, "test"));
-        assertTrue(fileDownloader.isDownloading(xyzzy));
+        Spec spec = new Spec("localhost", 1234);
+        assertTrue(fileDownloader.downloadFromSource(new FileReferenceDownload(xyzzy, "test"), spec));
         assertFalse(getFile(xyzzy).isPresent());
         // Receive files to simulate download
         receiveFile(xyzzy, "xyzzy.jar", FileReferenceData.Type.file, "content");
         // Should not download, since file has already been downloaded
-        fileDownloader.downloadIfNeeded(new FileReferenceDownload(xyzzy, "test"));
+        assertFalse(fileDownloader.downloadFromSource(new FileReferenceDownload(xyzzy, "test"), spec));
         // and file should be available
         assertTrue(getFile(xyzzy).isPresent());
     }


### PR DESCRIPTION
When getting a 'filedistribution.setFileReferencesToDownload' RPC request, use the fact that the client is the one that has the file to download from that same source instead of potentially trying some other config server that might not have it.

See https://github.com/vespa-engine/vespa/issues/32153