### PR TITLE
Revert back to 5 seconds as initial backoff time

### DIFF
--- a/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
+++ b/filedistribution/src/main/java/com/yahoo/vespa/filedistribution/FileDownloader.java
@@ -43,7 +43,7 @@ public class FileDownloader implements AutoCloseable {
     static {
         // Undocumented on purpose, might change or be removed at any time
         var backOff = System.getenv("VESPA_FILE_DOWNLOAD_BACKOFF_INITIAL_TIME_MS");
-        backoffInitialTime = Duration.ofMillis(backOff == null ? 1000 : Long.parseLong(backOff));
+        backoffInitialTime = Duration.ofMillis(backOff == null ? 5000 : Long.parseLong(backOff));
     }
 
     public FileDownloader(ConnectionPool connectionPool, Supervisor supervisor, Duration timeout) {

--- a/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
+++ b/flags/src/main/java/com/yahoo/vespa/flags/Flags.java
@@ -548,7 +548,7 @@ public class Flags {
             "Takes effect on next host-admin run");
 
     public static final UnboundLongFlag FILE_DOWNLOAD_BACKOFF_INITIAL_TIME = defineLongFlag(
-            "file-download-backoff-initial-time", 1000,
+            "file-download-backoff-initial-time", 5000,
             List.of("hmusum"), "2024-08-16", "2024-09-16",
             "Initial backoff time in milliseconds when failing to download a file reference",
             "Takes effect on restart of Docker container");


### PR DESCRIPTION
Revert change in https://github.com/vespa-engine/vespa/pull/32157/files and in default value for feature flag. Seeing some tests being unstable that could be related to this.