### PR TITLE
feat(ci): migrate publish-cli workflow to Github Actions

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,117 @@
+name: Vespa CLI - Build and Publish
+
+on:
+  push:
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/publish-cli.yml
+      - client/go/**
+
+defaults:
+  run:
+    # Specify to ensure "pipefail and errexit" are set.
+    # Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+    shell: bash
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    outputs:
+      build-version: ${{ steps.meta.outputs.version }}
+
+    steps:
+      - name: Define Build Version
+        id: meta
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ startswith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
+            BUILD_VERSION="${{ github.ref_name }}"
+          else
+            BUILD_VERSION="0.0.0-dev_${{ github.run_number }}"
+          fi
+
+          echo "version=${BUILD_VERSION}" >> $GITHUB_OUTPUT
+
+  build-test:
+    runs-on: ubuntu-latest
+
+    needs:
+      - prepare
+
+    defaults:
+      run:
+        # This workflow only interacts with the client/go directory, so we can set the working directory here.
+        working-directory: client/go
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+
+      - name: build
+        env:
+          VERSION: ${{ needs.prepare.outputs.build-version }}
+        run: |
+          make clean dist
+
+      - name: test
+        run: |
+          make test
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vespa-cli
+          path: client/go/dist
+          retention-days: 1
+
+  publish:
+    runs-on: macos-latest
+
+    if: github.event_name == 'push' && startswith(github.ref, 'refs/tags/v')
+    needs:
+      - prepare
+      - build-test
+
+    defaults:
+      run:
+        # This workflow only interacts with the client/go directory, so we can set the working directory here.
+        working-directory: client/go
+
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: vespa-cli
+          path: client/go/dist
+
+      - name: install-dependencies
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+        run: |
+          brew install --quiet coreutils gh zip go
+
+      - name: Publish to GitHub Releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          make clean dist-github
+
+      - name: Publish to Homebrew
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+        run: |
+          make clean dist-homebrew
+
+      - name: Install via Homebrew
+        run: |
+          make install-brew

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,6 +1,5 @@
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 ---
-
 shared:
   image: docker.io/vespaengine/vespa-build-almalinux-8
   environment:
@@ -254,20 +253,6 @@ jobs:
                 .
             fi
           fi
-
-  publish-cli-release:
-    requires: [publish-release]
-    image: homebrew/brew:latest
-    secrets:
-      - HOMEBREW_GITHUB_API_TOKEN
-      - GH_TOKEN
-    steps:
-      - install-dependencies: |
-          export HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ANALYTICS=1
-          brew install --quiet gh zip go
-      - publish-github: make -C client/go clean dist-github
-      - publish-homebrew: make -C client/go clean dist-homebrew
-      - verify-brew-install: make -C client/go install-brew
 
   verify-opensource-release-7days:
     annotations:


### PR DESCRIPTION
## What

Migrates the "Build & Publish Vespa-CLI" from Screwdriver to Github Actions

## Why

Part of the process of retiring Screwdriver as CI runner.

## Additional Info

Successful run: https://github.com/vespa-engine/vespa/actions/runs/10466721837?pr=32172