### PR TITLE
Change timeout in config proxy file distribution server code

### DIFF
--- a/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
+++ b/config-proxy/src/main/java/com/yahoo/vespa/config/proxy/filedistribution/FileDistributionAndUrlDownload.java
@@ -33,9 +33,7 @@ public class FileDistributionAndUrlDownload {
     private FileDownloader createDownloader(Supervisor supervisor, ConfigSourceSet source) {
         return new FileDownloader(new FileDistributionConnectionPool(source, supervisor),
                                   supervisor,
-                                  Duration.ofMinutes(5));
+                                  Duration.ofSeconds(55)); // Should be lower than the timeout in FileAcquirer
     }
-
-
 
 }


### PR DESCRIPTION
Timeout in waitFor in FileAcquirerImpl is 60 seconds, need lower timeout in config proxy to be able to respond before it times out.

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
