### PR TITLE
Use 16x unrolling for generic floating point squared euclidean distance computations

### DIFF
--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic.cpp
@@ -169,12 +169,12 @@ GenericAccelrator::squaredEuclideanDistance(const int8_t * a, const int8_t * b, 
 
 double
 GenericAccelrator::squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept {
-    return squaredEuclideanDistanceT<float, 4>(a, b, sz);
+    return squaredEuclideanDistanceT<float, 16>(a, b, sz);
 }
 
 double
 GenericAccelrator::squaredEuclideanDistance(const double * a, const double * b, size_t sz) const noexcept {
-    return squaredEuclideanDistanceT<double, 2>(a, b, sz);
+    return squaredEuclideanDistanceT<double, 16>(a, b, sz);
 }
 
 void

--- a/vespalib/src/vespa/vespalib/hwaccelerated/generic.cpp
+++ b/vespalib/src/vespa/vespalib/hwaccelerated/generic.cpp
@@ -169,7 +169,7 @@ GenericAccelrator::squaredEuclideanDistance(const int8_t * a, const int8_t * b, 
 
 double
 GenericAccelrator::squaredEuclideanDistance(const float * a, const float * b, size_t sz) const noexcept {
-    return squaredEuclideanDistanceT<float, 2>(a, b, sz);
+    return squaredEuclideanDistanceT<float, 4>(a, b, sz);
 }
 
 double


### PR DESCRIPTION
@baldersheim please review. Noticed this when looking at the generated ARM NEON machine code.

This lets the auto-vectorized code use all 4 32-bit lanes of a 128-bit SIMD register instead of just 2, which doubles performance compared to `double` (which is in line with what could be expected).
