### PR TITLE
Always set CC metric update cycle counter after update

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -374,12 +374,12 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
                 metricUpdater.updateClusterStateMetrics(cluster, baselineState,
                         ResourceUsageStats.calculateFrom(cluster.getNodeInfos(), options.clusterFeedBlockLimit(), stateBundle.getFeedBlock()),
                         systemStateBroadcaster.getLastStateBroadcastTimePoint());
-                lastMetricUpdateCycleCount = cycleCount;
             } else {
                 // If we're not the master we don't have any authoritative information about
                 // how out of sync the cluster nodes are, so reset the metric.
                 metricUpdater.updateClusterBucketsOutOfSyncRatio(0);
             }
+            lastMetricUpdateCycleCount = cycleCount;
             return true;
         } else {
             return false;


### PR DESCRIPTION
@hakonhall please review

Only setting the counter in the master CC branch means that metric updating (for cluster buckets out of sync metrics) would be done for _every_ tick on failover controllers rather than for every 300 ticks.

Would also have the side-effect of only sleeping the minimal time needed in the main event loop since the method returns a "work was done"-flag after updating.