### PR TITLE
feat: add container image for query-builder client application

### DIFF
--- a/.github/workflows/query-builder-container.yml
+++ b/.github/workflows/query-builder-container.yml
@@ -1,0 +1,70 @@
+name: Build "Query Builder" Container
+
+on:
+  push:
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - master
+    paths:
+      - .github/workflows/query-builder-container.yml
+      - client/js/app/**
+
+defaults:
+  run:
+    # Specify to ensure "pipefail and errexit" are set.
+    # Ref: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+    shell: bash
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}/query-builder
+      DOCKER_USERNAME: ${{ github.actor }}
+      DOCKER_PASSWORD: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU for cross-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+          # This always adds a "dev" prefix to the image tag, to identify it as a development tool.
+          flavor: |
+            prefix=dev-,onlatest=true
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: client/js/app
+          file: client/js/app/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/client/js/app/Dockerfile
+++ b/client/js/app/Dockerfile
@@ -1,0 +1,10 @@
+FROM  node:lts-alpine
+
+COPY . /app
+
+WORKDIR /app
+
+RUN yarn install && \
+  yarn build
+
+CMD [ "yarn", "preview", "--host" ]

--- a/client/js/app/package.json
+++ b/client/js/app/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build",
-    "preview": "vite preview",
+    "preview": "vite preview --port 3000",
     "prepare": "cd ../../../ && husky client/js/app/.husky",
     "test": "CI=true vitest",
     "lint": "eslint '{**/*,*}.{js,jsx}'"


### PR DESCRIPTION
## What

This adds a simple Dockerfile and pipeline to build a container `ghcr.io/vespa-engine/vespa/query-builder` container image.

## Why

This provides a ready-made tool for the developers to use when testing/exploring Vespa, without the need to clone this repo and having node installed locally.

## Additional Info

As this is a developer-oriented tool all the container image tags are prefixed with `dev-`, to clarify that this is not to be used in a production environment.