### PR TITLE
Fix significance model resolver, better tests, handling of upper case in query words

### DIFF
--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -183,6 +183,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-params</artifactId>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
@@ -132,14 +132,8 @@ public class SignificanceSearcher extends Searcher {
             return model.get();
         }
 
-        if (implicitLanguage == Language.UNKNOWN) {
-            return handleFallBackToUnknownLanguage();
-        }
         var model = significanceModelRegistry.getModel(implicitLanguage);
-        if (model.isEmpty()) {
-            throw new IllegalArgumentException("No significance model available for implicit language " + implicitLanguage);
-        }
-        return model.get();
+        return model.orElseGet(this::handleFallBackToUnknownLanguage);
     }
 
     private SignificanceModel handleFallBackToUnknownLanguage() throws IllegalArgumentException {

--- a/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
@@ -114,6 +114,15 @@ public class SignificanceSearcher extends Searcher {
     }
 
     private SignificanceModel getSignificanceModelFromQueryLanguage(Query query) throws IllegalArgumentException {
+        /*
+        Implements the following model resolving logic:
+        - When language is explicitly tagged on query
+            - Use language if available from the model registry, fail otherwise.
+            - If “un” try both “un” and “en”.
+        - When language is implicitly detected
+            - Use language if available from the model registry. Fallback to “un” then “en”, fail if none are available.
+         */
+
         Language explicitLanguage = query.getModel().getLanguage();
         Language implicitLanguage = query.getModel().getParsingLanguage();
 

--- a/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
+++ b/container-search/src/main/java/com/yahoo/search/significance/SignificanceSearcher.java
@@ -161,7 +161,7 @@ public class SignificanceSearcher extends Searcher {
 
         if (root instanceof WordItem wi) {
             var word = wi.getWord();
-            var documentFrequency = significanceModel.documentFrequency(word);
+            var documentFrequency = significanceModel.documentFrequency(word.toLowerCase());
             long N                = documentFrequency.corpusSize();
             long nq_i             = documentFrequency.frequency();
             log.log(Level.FINE, () -> "Setting document frequency for " + word + " to {frequency: " + nq_i + ", count: " + N + "}");

--- a/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
@@ -301,8 +301,9 @@ public class SignificanceSearcherTest {
                      errorMessage.getDetailedMessage());
     }
 
-    // Naming convention for tests that follow:
-    // Explicit language - language set for a query
+    // Tests that follow verify model resolving logic in different scenarios.
+    // Test naming convention is as follows:
+    // Explicit language - language set in a query
     // Implicit language - automatically detected language
     // Missing language - language without a model
     // Unknown language - Language.UNKNOWN

--- a/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
@@ -332,7 +332,7 @@ public class SignificanceSearcherTest {
         return makeDocumentFrequency(model.documentFrequency(word));
     }
 
-    private static WordItem getFistWord(Result result) {
+    private static WordItem getFirstWord(Result result) {
         var resultRoot = (AndItem) result.getQuery().getModel().getQueryTree().getRoot();
         return (WordItem) resultRoot.getItem(0);
     }
@@ -347,7 +347,7 @@ public class SignificanceSearcherTest {
         var explicitLanguage = Language.ITALIAN;
         var result = searchWord(existingWord, Optional.of(explicitLanguage), Optional.empty());
 
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
         assertEquals(Optional.empty(), resultWord.getDocumentFrequency());
 
         var errorMessage = getErrorMessage(result);
@@ -359,7 +359,7 @@ public class SignificanceSearcherTest {
         var existingWord = "hello";
         var explicitLanguage = Language.UNKNOWN;
         var result = searchWord(existingWord, Optional.of(explicitLanguage), Optional.empty());
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
         var existingDocumentFrequency = getDocumentFrequencyWithEnglish(existingWord);
         assertEquals(existingDocumentFrequency, resultWord.getDocumentFrequency());
     }
@@ -370,7 +370,7 @@ public class SignificanceSearcherTest {
         var explicitLanguage = Language.ITALIAN;
         var result = searchWord(missingWord, Optional.of(explicitLanguage), Optional.empty());
 
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
         assertEquals(Optional.empty(), resultWord.getDocumentFrequency());
 
         var errorMessage = getErrorMessage(result);
@@ -382,7 +382,7 @@ public class SignificanceSearcherTest {
         var existingWord = "hello";
         var implicitLanguage = Language.ITALIAN;
         var result = searchWord(existingWord, Optional.empty(), Optional.of(implicitLanguage));
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
         var existingDocumentFrequency = getDocumentFrequencyWithEnglish(existingWord);
         assertEquals(existingDocumentFrequency, resultWord.getDocumentFrequency());
     }
@@ -392,7 +392,7 @@ public class SignificanceSearcherTest {
         var implicitLanguage = Language.ITALIAN;
         var missingWord = "ciao";
         var result = searchWord(missingWord, Optional.empty(), Optional.of(implicitLanguage));
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
 
         var existingWord = "hello";
         var documentFrequency = getDocumentFrequencyWithEnglish(existingWord);
@@ -407,7 +407,7 @@ public class SignificanceSearcherTest {
     @ValueSource(strings = {"Hello", "HeLlo", "HELLO"})
     public void testSignificanceSearcherWithUpperCaseWord(String wordWithUpperCase) {
         var result = searchWord(wordWithUpperCase, Optional.of(Language.ENGLISH), Optional.empty());
-        var resultWord = getFistWord(result);
+        var resultWord = getFirstWord(result);
 
         var lowerCaseWord = "hello";
         var documentFrequency = getDocumentFrequencyWithEnglish(lowerCaseWord);

--- a/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
+++ b/container-search/src/test/java/com/yahoo/search/significance/test/SignificanceSearcherTest.java
@@ -23,6 +23,8 @@ import com.yahoo.search.schema.SchemaInfo;
 import com.yahoo.search.searchchain.Execution;
 import com.yahoo.search.significance.SignificanceSearcher;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -214,7 +216,7 @@ public class SignificanceSearcherTest {
         q.getModel().getQueryTree().setRoot(root);
 
         SignificanceModel model = significanceModelRegistry.getModel(Language.ENGLISH).get();
-        var helloDocumentFrequency = makeDocumentFrequency(model.documentFrequency("Hello"));
+        var helloDocumentFrequency = makeDocumentFrequency(model.documentFrequency("hello"));
         var worldDocumentFrequency = makeDocumentFrequency(model.documentFrequency("world"));
 
         Result r = createExecution(searcher).search(q);
@@ -394,5 +396,19 @@ public class SignificanceSearcherTest {
         var defaultDocumentFrequency = Optional.of(new DocumentFrequency(1, count));
 
         assertEquals(defaultDocumentFrequency, resultWord.getDocumentFrequency());
+    }
+
+    // Tests for upper case words in a query
+    @ParameterizedTest
+    @ValueSource(strings = {"Hello", "HeLlo", "HELLO"})
+    public void testSignificanceSearcherWithUpperCaseWord(String wordWithUpperCase) {
+        var result = searchWordWithLanguage(wordWithUpperCase, Optional.of(Language.ENGLISH), Optional.empty());
+        var resultRoot = (AndItem) result.getQuery().getModel().getQueryTree().getRoot();
+        var resultWord = (WordItem) resultRoot.getItem(0);
+
+        var lowerCaseWord = "hello";
+        var documentFrequency = getDocumentFrequencyWithEnglish(lowerCaseWord);
+
+        assertEquals(documentFrequency, resultWord.getDocumentFrequency());
     }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Implements the following logic for resolving models:
  - When language is explicitly tagged on query
      - Use language if available from the model registry, fail otherwise.
      - If “un” try both “un” and “en”.
  - When language is implicitly detected
      - Use language if available from the model registry. Fallback to “un” then “en”, fail if none are available.

Handling of query words containing upper case chars.