### PR TITLE
fix(CI): use the correct version for VespaCLI publishing

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -76,6 +76,9 @@ jobs:
       - prepare
       - build-test
 
+    permissions:
+      contents: write
+
     defaults:
       run:
         # This workflow only interacts with the client/go directory, so we can set the working directory here.

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -82,7 +82,7 @@ jobs:
         working-directory: client/go
 
     env:
-      VERSION: ${{ needs.prepare.outputs.version }}
+      VERSION: ${{ needs.prepare.outputs.build-version }}
 
     steps:
       - uses: actions/checkout@v4

--- a/client/go/cond_make.go
+++ b/client/go/cond_make.go
@@ -86,7 +86,16 @@ func latestReleasedTag(mirror string) (string, error) {
 	switch mirror {
 	case "github":
 		url := "https://api.github.com/repos/vespa-engine/vespa/releases/latest"
-		resp, err := http.Get(url)
+		token := "Bearer " + os.Getenv("GH_TOKEN")
+
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			log.Println("Error on setting up http request.\n[ERROR] -", err)
+		}
+		req.Header.Add("Authorization", token)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
 		if err != nil {
 			return "", err
 		}
@@ -100,6 +109,7 @@ func latestReleasedTag(mirror string) (string, error) {
 			return "", err
 		}
 		return release.TagName, nil
+
 	case "homebrew":
 		cmd, stdout, _ := newCmd("brew", "info", "--json", "--formula", "vespa-cli")
 		cmd.Stdout = stdout // skip printing output to os.Stdout


### PR DESCRIPTION
## What

- Ensure that request to the Github API are authenticated.
- Ensure the correct `VERSION` evnronment variable is set from the prepare job

## Why

- Unauthenticated http requests to GH API could return 403 (see an example [in this run](https://github.com/vespa-engine/vespa/actions/runs/10505225250/job/29102610101#step:5:14)).

## Additional Info


**Why do we need a token for a public API endpoint?**

My initial assumption was [the lack of User-Agent](https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api?apiVersion=2022-11-28#user-agent), but a quick test against [httpbin.io](https://httpbin.io/user-agent) showed that this was not the case.

As I could not reproduce it, my next assumption is that we might be hitting a Rate Limit, which can [return a 429 as well as a 403](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit). This limit is pretty low (60 req/hour) and ties to the IP address, which for GH Shared Runners is shared amongst many runners, so hitting this limit is likely quite easy.

By using the token we get access to a much higher rate limit.

---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
