### PR TITLE
Update cluster state publish time prior to updating convergence metrics

### DIFF
--- a/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
+++ b/clustercontroller-core/src/main/java/com/yahoo/vespa/clustercontroller/core/FleetController.java
@@ -347,11 +347,11 @@ public class FleetController implements NodeListener, SlobrokListener, SystemSta
         verifyInControllerThread();
         ClusterState baselineState = stateBundle.getBaselineClusterState();
         newStates.add(stateBundle);
+        systemStateBroadcaster.handleNewClusterStates(stateBundle);
         metricUpdater.updateClusterStateMetrics(cluster, baselineState,
                 ResourceUsageStats.calculateFrom(cluster.getNodeInfos(), options.clusterFeedBlockLimit(), stateBundle.getFeedBlock()),
                 systemStateBroadcaster.getLastStateBroadcastTimePoint());
         lastMetricUpdateCycleCount = cycleCount;
-        systemStateBroadcaster.handleNewClusterStates(stateBundle);
         // Iff master, always store new version in ZooKeeper _before_ publishing to any
         // nodes so that a cluster controller crash after publishing but before a successful
         // ZK store will not risk reusing the same version number.


### PR DESCRIPTION
@hakonhall please review

We use the time point of the last published state to infer if nodes should be counted as not converged, but this must be done for the publish time of the _new_ state, not the old state. Otherwise we risk over-counting.

