### PR TITLE
Last year javacc maven plugin moved from com.helger.maven:ph-javacc-m…

### DIFF
--- a/config-model/pom.xml
+++ b/config-model/pom.xml
@@ -485,8 +485,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/container-search/pom.xml
+++ b/container-search/pom.xml
@@ -192,8 +192,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.yahoo.vespa</groupId>

--- a/document/pom.xml
+++ b/document/pom.xml
@@ -78,8 +78,8 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.helger.maven</groupId>
-                <artifactId>ph-javacc-maven-plugin</artifactId>
+                <groupId>io.github.tulipcc</groupId>
+                <artifactId>tulipcc-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>com.yahoo.vespa</groupId>

--- a/documentapi/pom.xml
+++ b/documentapi/pom.xml
@@ -51,8 +51,8 @@
         <artifactId>protoc-jar-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
         <executions>
           <execution>
             <phase>generate-sources</phase>

--- a/indexinglanguage/pom.xml
+++ b/indexinglanguage/pom.xml
@@ -71,8 +71,8 @@
         <artifactId>maven-surefire-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/model-integration/pom.xml
+++ b/model-integration/pom.xml
@@ -176,8 +176,8 @@
         <artifactId>abi-check-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -267,9 +267,9 @@
                     <version>${project.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.helger.maven</groupId>
-                    <artifactId>ph-javacc-maven-plugin</artifactId>
-                    <version>4.1.5</version>
+                    <groupId>io.github.tulipcc</groupId>
+                    <artifactId>tulipcc-maven-plugin</artifactId>
+                    <version>5.0.0</version>
                     <executions>
                         <execution>
                             <phase>generate-sources</phase>

--- a/searchlib/pom.xml
+++ b/searchlib/pom.xml
@@ -89,8 +89,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.helger.maven</groupId>
-        <artifactId>ph-javacc-maven-plugin</artifactId>
+        <groupId>io.github.tulipcc</groupId>
+        <artifactId>tulipcc-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>com.github.os72</groupId>


### PR DESCRIPTION
…aven-plugin to io.github.tulipcc:tulipcc-maven-plugin

@bjorncs or @jonmv PR