### PR TITLE
fix: ensure curl errors are shown in delete-old-cloudsmith-artifacts.sh - MERGEOK

### DIFF
--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -32,7 +32,7 @@ cat $RPMS_TO_DELETE
 
 if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
-      curl -sLf -X DELETE \
+      curl -sSLf -X DELETE \
         --header "X-Api-Key: $CLOUDSMITH_API_TOKEN" \
         --header 'accept: application/json' \
         "https://api.cloudsmith.io/v1/packages/vespa/open-source-rpms/$RPMID/"

--- a/.github/scripts/delete-old-cloudsmith-artifacts.sh
+++ b/.github/scripts/delete-old-cloudsmith-artifacts.sh
@@ -30,7 +30,7 @@ done
 echo "Deleting the following RPMs:"
 cat $RPMS_TO_DELETE
 
-if [ "$GITHUB_EVENT_NAME" == "schedule" ]; then
+if [[ "$GITHUB_EVENT_NAME" == "schedule" || "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
     for RPMID in $(cat $RPMS_TO_DELETE); do
       curl -sSLf -X DELETE \
         --header "X-Api-Key: $CLOUDSMITH_API_TOKEN" \


### PR DESCRIPTION
## What

1. Adds the `-S/--show-error` argument to cURL call in the workflow.
2. Run the artifact deletion also when the Workflow is manually triggered _(via `workflow_dispatch` event)_

## Why

1. We are using the `-s/--silent` flag which hides any progress, but we still want to see the errors, because like [in this workflow run](https://github.com/vespa-engine/vespa/actions/runs/10591134812) we get a exit code, but we don't see what is the actual error.
2. Allows manually triggering the workflow.

---

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
