### PR TITLE
fix: fetch all git references in publish-cli workflow - MERGEOK

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -89,6 +89,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## What

In the "Publish CLI" action adds [the `fetch-depth: 0` option](https://github.com/actions/checkout?tab=readme-ov-file#fetch-all-history-for-all-tags-and-branches) to the checkout github actions.

## Why

The deploy process does a check to see if there has been any changes in the codebase, but with a shallow clone it cannot do that, by setting `fetch-depth: 0` the GH Action will fetch also all references.

--- 

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
