### PR TITLE
Remove cluster state version downgrade fallback

### DIFF
--- a/storage/src/tests/storageserver/statemanagertest.cpp
+++ b/storage/src/tests/storageserver/statemanagertest.cpp
@@ -33,10 +33,8 @@ struct StateManagerTest : Test, NodeStateReporter {
     void SetUp() override;
     void TearDown() override;
 
-    static std::shared_ptr<api::SetSystemStateCommand> make_set_state_cmd(std::string_view state_str, uint16_t cc_index) {
-        auto cmd = std::make_shared<api::SetSystemStateCommand>(lib::ClusterState(state_str));
-        cmd->setSourceIndex(cc_index);
-        return cmd;
+    static std::shared_ptr<api::SetSystemStateCommand> make_set_state_cmd(std::string_view state_str) {
+        return std::make_shared<api::SetSystemStateCommand>(lib::ClusterState(state_str));
     }
 
     static std::shared_ptr<const lib::ClusterStateBundle> make_state_bundle_with_config(
@@ -58,10 +56,7 @@ struct StateManagerTest : Test, NodeStateReporter {
 
     void get_single_reply(std::shared_ptr<api::StorageReply>& reply_out);
     void get_only_ok_reply(std::shared_ptr<api::StorageReply>& reply_out);
-    void force_current_cluster_state_version(uint32_t version, uint16_t cc_index);
-    void force_current_cluster_state_version(uint32_t version) {
-        force_current_cluster_state_version(version, 0);
-    }
+    void force_current_cluster_state_version(uint32_t version);
     void mark_reported_node_state_up();
     void send_down_get_node_state_request(uint16_t controller_index);
     void assert_ok_get_node_state_reply_sent_and_clear();
@@ -136,12 +131,12 @@ StateManagerTest::get_only_ok_reply(std::shared_ptr<api::StorageReply>& reply_ou
 }
 
 void
-StateManagerTest::force_current_cluster_state_version(uint32_t version, uint16_t cc_index)
+StateManagerTest::force_current_cluster_state_version(uint32_t version)
 {
     ClusterState state(*_manager->getClusterStateBundle()->getBaselineClusterState());
     state.setVersion(version);
     const auto maybe_rejected_by_ver = _manager->try_set_cluster_state_bundle(
-            std::make_shared<const lib::ClusterStateBundle>(state), cc_index);
+            std::make_shared<const lib::ClusterStateBundle>(state));
     ASSERT_EQ(maybe_rejected_by_ver, std::nullopt);
 }
 
@@ -230,7 +225,7 @@ TEST_F(StateManagerTest, receiving_cc_bundle_with_distribution_config_disables_n
 }
 
 TEST_F(StateManagerTest, internal_distribution_config_is_propagated_if_none_yet_received_from_cc) {
-    _upper->sendDown(make_set_state_cmd("version:10 distributor:1 storage:4", 0));
+    _upper->sendDown(make_set_state_cmd("version:10 distributor:1 storage:4"));
     std::shared_ptr<api::StorageReply> reply;
     ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
 
@@ -255,7 +250,7 @@ TEST_F(StateManagerTest, revert_to_internal_config_if_cc_no_longer_sends_distrib
               to_string(cmd->getClusterStateBundle().distribution_config_bundle()->config()));
 
     // CC then sends a new bundle _without_ config
-    _upper->sendDown(make_set_state_cmd("version:3 distributor:1 storage:4", 0));
+    _upper->sendDown(make_set_state_cmd("version:3 distributor:1 storage:4"));
     ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
 
     // Config implicitly reverted to the active internal config
@@ -276,10 +271,10 @@ TEST_F(StateManagerTest, revert_to_internal_config_if_cc_no_longer_sends_distrib
 TEST_F(StateManagerTest, accept_lower_state_versions_if_strict_requirement_disabled) {
     _manager->set_require_strictly_increasing_cluster_state_versions(false);
 
-    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(123, 1)); // CC 1
+    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(123));
     ASSERT_EQ(_manager->getClusterStateBundle()->getVersion(), 123);
 
-    _upper->sendDown(make_set_state_cmd("version:122 distributor:1 storage:1", 0)); // CC 0
+    _upper->sendDown(make_set_state_cmd("version:122 distributor:1 storage:1"));
     std::shared_ptr<api::StorageReply> reply;
     ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
     EXPECT_EQ(_manager->getClusterStateBundle()->getVersion(), 122);
@@ -288,40 +283,16 @@ TEST_F(StateManagerTest, accept_lower_state_versions_if_strict_requirement_disab
 TEST_F(StateManagerTest, reject_lower_state_versions_if_strict_requirement_enabled) {
     _manager->set_require_strictly_increasing_cluster_state_versions(true);
 
-    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(123, 1)); // CC 1
+    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(123));
     ASSERT_EQ(_manager->getClusterStateBundle()->getVersion(), 123);
 
-    _upper->sendDown(make_set_state_cmd("version:122 distributor:1 storage:1", 0)); // CC 0
+    _upper->sendDown(make_set_state_cmd("version:122 distributor:1 storage:1"));
     std::shared_ptr<api::StorageReply> reply;
     ASSERT_NO_FATAL_FAILURE(get_single_reply(reply));
     api::ReturnCode expected_res(api::ReturnCode::REJECTED, "Cluster state version 122 rejected; node already has "
                                                             "a higher cluster state version (123)");
     EXPECT_EQ(reply->getResult(), expected_res);
     EXPECT_EQ(_manager->getClusterStateBundle()->getVersion(), 123);
-}
-
-// Observing a lower cluster state version from the same CC index directly implies that the ZooKeeper
-// state has been lost, at which point we pragmatically (but begrudgingly) accept the state version
-// to avoid stalling the entire cluster for an indeterminate amount of time.
-TEST_F(StateManagerTest, accept_lower_state_versions_from_same_cc_index_even_if_strict_requirement_enabled) {
-    _manager->set_require_strictly_increasing_cluster_state_versions(true);
-
-    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(123, 1)); // CC 1
-    ASSERT_EQ(_manager->getClusterStateBundle()->getVersion(), 123);
-
-    ASSERT_NO_FATAL_FAILURE(force_current_cluster_state_version(124, 2)); // CC 2
-    ASSERT_EQ(_manager->getClusterStateBundle()->getVersion(), 124);
-
-    // CC 1 restarts from scratch with previous ZK state up in smoke.
-    _upper->sendDown(make_set_state_cmd("version:3 distributor:1 storage:1", 1));
-    std::shared_ptr<api::StorageReply> reply;
-    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
-    EXPECT_EQ(_manager->getClusterStateBundle()->getVersion(), 3);
-
-    // CC 2 restarts and continues from where CC 1 left off.
-    _upper->sendDown(make_set_state_cmd("version:4 distributor:1 storage:1", 2));
-    ASSERT_NO_FATAL_FAILURE(get_only_ok_reply(reply));
-    EXPECT_EQ(_manager->getClusterStateBundle()->getVersion(), 4);
 }
 
 namespace {

--- a/storage/src/vespa/storage/storageserver/statemanager.cpp
+++ b/storage/src/vespa/storage/storageserver/statemanager.cpp
@@ -474,47 +474,30 @@ StateManager::mark_controller_as_having_observed_explicit_node_state(const std::
 }
 
 std::optional<uint32_t>
-StateManager::try_set_cluster_state_bundle(std::shared_ptr<const ClusterStateBundle> c,
-                                           uint16_t origin_controller_index)
+StateManager::try_set_cluster_state_bundle(std::shared_ptr<const ClusterStateBundle> c)
 {
     {
         std::lock_guard lock(_stateLock);
         uint32_t effective_active_version = (_nextSystemState ? _nextSystemState->getVersion()
                                                               : _systemState->getVersion());
         const auto now = _component.getClock().getMonotonicTime();
-        const uint32_t last_ver_from_cc = _last_observed_version_from_cc[origin_controller_index];
-        _last_observed_version_from_cc[origin_controller_index] = c->getVersion();
 
         if (_require_strictly_increasing_cluster_state_versions && (c->getVersion() < effective_active_version)) {
-            if (c->getVersion() >= last_ver_from_cc) {
-                constexpr auto reject_warn_threshold = 30s;
-                if (now - _last_accepted_cluster_state_time <= reject_warn_threshold) {
-                    LOG(debug, "Rejecting cluster state with version %u from cluster controller %u, as "
-                               "we've already accepted version %u. Recently accepted another cluster state, "
-                               "so assuming transient CC leadership period overlap.",
-                        c->getVersion(), origin_controller_index, effective_active_version);
-                } else {
-                    // Rejections have happened for some time. Make a bit of noise.
-                    LOGBP(warning, "Rejecting cluster state with version %u from cluster controller %u, as "
-                                   "we've already accepted version %u.",
-                          c->getVersion(), origin_controller_index, effective_active_version);
-                }
-                return {effective_active_version};
+            constexpr auto reject_warn_threshold = 30s;
+            if (now - _last_accepted_cluster_state_time <= reject_warn_threshold) {
+                LOG(debug, "Rejecting cluster state with version %u from cluster controller, as "
+                           "we've already accepted version %u. Recently accepted another cluster state, "
+                           "so assuming transient CC leadership period overlap.",
+                    c->getVersion(), effective_active_version);
             } else {
-                // SetSystemState RPCs are FIFO-ordered and a particular CC should enforce strictly increasing
-                // cluster state versions through its ZooKeeper quorum (but commands may be resent for a given
-                // version). This means that commands should contain _monotonically increasing_ versions from
-                // a given CC origin index.
-                // If this is _not_ the case, it indicates ZooKeeper state on the CCs has been lost or wiped,
-                // at which point we have no other realistic choice than to accept the version, or the system
-                // will stall until an operator manually intervenes by restarting the content cluster.
-                LOG(error, "Received cluster state version %u from cluster controller %u, which is lower than "
-                           "the current state version (%u) and the last received version (%u) from the same controller. "
-                           "This indicates loss of cluster controller ZooKeeper state; accepting lower version to "
-                           "prevent content cluster operations from stalling for an indeterminate amount of time.",
-                    c->getVersion(), origin_controller_index, effective_active_version, last_ver_from_cc);
-                // Fall through to state acceptance.
+                // Rejections have happened for some time. Make a bit of noise.
+                LOGBP(warning, "Rejecting cluster state with version %u from cluster controller, as "
+                               "we've already accepted a higher version %u. If this is caused by loss "
+                               "of ZooKeeper state on the cluster controller, all content nodes and "
+                               "distributors must be restarted to force acceptance of a lower version.",
+                      c->getVersion(), effective_active_version);
             }
+            return {effective_active_version};
         }
         _last_accepted_cluster_state_time = now;
         _receiving_distribution_config_from_cc = c->has_distribution_config();
@@ -536,7 +519,7 @@ bool
 StateManager::onSetSystemState(const std::shared_ptr<api::SetSystemStateCommand>& cmd)
 {
     auto reply = std::make_shared<api::SetSystemStateReply>(*cmd);
-    const auto maybe_rejected_by_ver = try_set_cluster_state_bundle(cmd->cluster_state_bundle_ptr(), cmd->getSourceIndex());
+    const auto maybe_rejected_by_ver = try_set_cluster_state_bundle(cmd->cluster_state_bundle_ptr());
     if (maybe_rejected_by_ver) {
         reply->setResult(api::ReturnCode(api::ReturnCode::REJECTED,
                                          fmt("Cluster state version %u rejected; node already has a higher cluster state version (%u)",

--- a/storage/src/vespa/storage/storageserver/statemanager.h
+++ b/storage/src/vespa/storage/storageserver/statemanager.h
@@ -114,8 +114,7 @@ public:
     // Iff state was accepted, returns std::nullopt
     // Otherwise (i.e. state was rejected due to a higher version already having been accepted)
     // returns an optional containing the current, higher cluster state version.
-    [[nodiscard]] std::optional<uint32_t> try_set_cluster_state_bundle(std::shared_ptr<const ClusterStateBundle> c,
-                                                                       uint16_t origin_controller_index);
+    [[nodiscard]] std::optional<uint32_t> try_set_cluster_state_bundle(std::shared_ptr<const ClusterStateBundle> c);
     HostInfo& getHostInfo() { return *_hostInfo; }
 
     void immediately_send_get_node_state_replies() override;


### PR DESCRIPTION
@geirst please review

To avoid inherent race conditions with overlapping cluster controller leader intervals (caused by the old leader not yet knowing it has been deposed) where both an old state version and a newer state version is concurrently published, we want to only accept strictly increasing version numbers (for the lifetime of a process; these are currently not durably stored on content nodes). On the cluster controllers themselves, this version number is backed by a ZooKeeper quorum, ensuring that it _is_ durably stored where it matters the most.

A content node only observing strictly increasing version numbers is an invariant that holds _unless_ an explicit fallback is triggered, where we can still accept an older version.

This fallback was intended to be a "failsafe" if ZooKeeper state on the cluster controllers was lost, but its implementation depended on information that is not actually present in all CC RPCs, meaning that it could kick in even when not intended, thus rendering the race condition protection void.

The CC RPC in question is not easily extensible, so instead remove the fallback entirely. This has the bonus of content nodes actually being able to rely on the version invariant internally. Downside is that content node and distributor processes must be restarted to accept a lower state version upon ZK state loss, but in that case you probably have bigger problems.

