### PR TITLE
Disabled stemming for significance model generator

### DIFF
--- a/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
+++ b/vespaclient-java/src/main/java/com/yahoo/vespasignificance/SignificanceModelGenerator.java
@@ -163,7 +163,7 @@ public class SignificanceModelGenerator {
     }
 
     private void handleTokenization(String field) {
-        var tokens = tokenizer.tokenize(field, languageTag, StemMode.ALL, false);
+        var tokens = tokenizer.tokenize(field, languageTag, StemMode.NONE, false);
 
         Set<String> uniqueWords = StreamSupport.stream(tokens.spliterator(), false)
                 .filter(t -> t.getType() == TokenType.ALPHABETIC)

--- a/vespaclient-java/src/test/java/com/yahoo/vespasignificance/SignificanceModelGeneratorTest.java
+++ b/vespaclient-java/src/test/java/com/yahoo/vespasignificance/SignificanceModelGeneratorTest.java
@@ -67,7 +67,7 @@ public class SignificanceModelGeneratorTest {
         assertEquals(3, documentFrequencyFile.frequencies().get("fra"));
         assertEquals(3, documentFrequencyFile.frequencies().get("skriveform"));
         assertEquals(3, documentFrequencyFile.frequencies().get("kategori"));
-        assertEquals(3, documentFrequencyFile.frequencies().get("eldr"));
+        assertEquals(3, documentFrequencyFile.frequencies().get("eldre"));
 
     }
 
@@ -102,7 +102,7 @@ public class SignificanceModelGeneratorTest {
         assertEquals(3, documentFrequencyFile.frequencies().get("fra"));
         assertEquals(3, documentFrequencyFile.frequencies().get("skriveform"));
         assertEquals(3, documentFrequencyFile.frequencies().get("kategori"));
-        assertEquals(3, documentFrequencyFile.frequencies().get("eldr"));
+        assertEquals(3, documentFrequencyFile.frequencies().get("eldre"));
 
     }
 
@@ -219,6 +219,6 @@ public class SignificanceModelGeneratorTest {
         assertEquals(3, documentFrequencyFile.frequencies().get("fra"));
         assertEquals(3, documentFrequencyFile.frequencies().get("skriveform"));
         assertEquals(3, documentFrequencyFile.frequencies().get("kategori"));
-        assertEquals(3, documentFrequencyFile.frequencies().get("eldr"));
+        assertEquals(3, documentFrequencyFile.frequencies().get("eldre"));
     }
 }


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Significance model is applied to queries before stemming, thus it makes sense to disable stemming when generating significance models as well.