### PR TITLE
Revert "require onnxruntime 1.19.0"

### DIFF
--- a/dependency-versions/pom.xml
+++ b/dependency-versions/pom.xml
@@ -129,7 +129,7 @@
         <mojo-executor.vespa.version>2.4.0</mojo-executor.vespa.version>
         <netty.vespa.version>4.1.112.Final</netty.vespa.version>
         <netty-tcnative.vespa.version>2.0.65.Final</netty-tcnative.vespa.version>
-        <onnxruntime.vespa.version>1.19.0</onnxruntime.vespa.version>
+        <onnxruntime.vespa.version>1.18.0</onnxruntime.vespa.version>
         <opennlp.vespa.version>2.4.0</opennlp.vespa.version>
         <opentest4j.vespa.version>1.3.0</opentest4j.vespa.version>
         <org.json.vespa.version>20240303</org.json.vespa.version>

--- a/dist/vespa.spec
+++ b/dist/vespa.spec
@@ -33,7 +33,7 @@
 %define _defattr_is_vespa_vespa 0
 %define _command_cmake cmake3
 %global _vespa_abseil_cpp_version 20240116.1
-%global _vespa_build_depencencies_version 1.3.4
+%global _vespa_build_depencencies_version 1.3.3
 %global _vespa_gtest_version 1.14.0
 %global _vespa_protobuf_version 5.26.1
 %global _vespa_openblas_version 0.3.27
@@ -201,7 +201,7 @@ Requires: vespa-protobuf = %{_vespa_protobuf_version}
 Requires: vespa-protobuf = %{_vespa_protobuf_version}
 Requires: llvm-libs
 %endif
-Requires: vespa-onnxruntime = 1.19.0
+Requires: vespa-onnxruntime = 1.18.0
 Requires: vespa-jllama = %{_vespa_llama_version}
 Requires: vespa-openblas >= %{_vespa_openblas_version}
 


### PR DESCRIPTION
Reverts vespa-engine/vespa#32291
@arnej27959 @hmusum @toregge
Correlates with failing build.