### PR TITLE
feat(ci): update publish-cli.yml workflow to handle prefix in tag versions

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -29,7 +29,8 @@ jobs:
         id: meta
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ startswith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
-            BUILD_VERSION="${{ github.ref_name }}"
+            # Remove the "v" prefix from the tag.
+            BUILD_VERSION="${GITHUB_REF_NAME#v}"
           else
             BUILD_VERSION="0.0.0-dev_${{ github.run_number }}"
           fi


### PR DESCRIPTION
## What

Modify the publish-cli.yml workflow to correctly extract the version from the git tag, removing the leading "v" prefix.

## Why

This ensures the correct version is used for the published artifact, this caused the failure: https://github.com/vespa-engine/vespa/actions/runs/10629284465/job/29465892057

> Error: You need to bump this formula manually since changing the version from 8.391.23 to **v**8.401.18 would be a downgrade.
