### PR TITLE
fix bug in StructuredParser

### DIFF
--- a/container-search/src/main/java/com/yahoo/prelude/query/parser/StructuredParser.java
+++ b/container-search/src/main/java/com/yahoo/prelude/query/parser/StructuredParser.java
@@ -95,7 +95,7 @@ abstract class StructuredParser extends AbstractParser {
                 item = phrase(indexName == null ? null : indexPath + indexName);
             if (item == null && indexName != null && tokens.skip(LCURLYBRACKET))
                 item = sameElement(indexPath + indexName);
-            if (item == null && indexName != null && wordsAhead())
+            if (item == null && explicitIndex && wordsAhead())
                 item = phrase(indexName);
 
             submodes.reset();

--- a/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
+++ b/container-search/src/test/java/com/yahoo/prelude/test/QueryTestCase.java
@@ -64,6 +64,29 @@ public class QueryTestCase {
     }
 
     @Test
+    void testOrQueryWithDefaultIndexAllParsing() {
+        Query q = newQuery("/search?query=(fOObar foobar) kanoo&type=all&default-index=def");
+        assertEquals("AND (OR def:fOObar def:foobar) def:kanoo", q.getModel().getQueryTree().getRoot().toString());
+    }
+
+    @Test
+    void testOrQueryWithDefaultIndexWeakAndParsing() {
+        Query q = newQuery("/search?query=(fOObar foobar) kanoo&type=weakAnd&default-index=def");
+        assertEquals("WEAKAND(100) (OR def:fOObar def:foobar) def:kanoo", q.getModel().getQueryTree().getRoot().toString());
+    }
+    @Test
+    void testOrPhraseQueryWithDefaultIndexWeakAndParsing() {
+        Query q = newQuery("/search?query=(\"fOObar\" foobar) kanoo&type=weakAnd&default-index=def");
+        assertEquals("WEAKAND(100) (OR def:fOObar def:foobar) def:kanoo", q.getModel().getQueryTree().getRoot().toString());
+    }
+
+    @Test
+    void testOrPhraseQueryWithDefaultIndexAdvancedParsing() {
+        Query q = newQuery("/search?query=(\"fOObar\") AND kanoo&type=adv&default-index=def");
+        assertEquals("AND def:fOObar def:kanoo", q.getModel().getQueryTree().getRoot().toString());
+    }
+
+    @Test
     void testLongQueryParsing() {
         Query q = newQuery("/p13n?query=news"
                 + "interest:cnn!254+interest:cnnfn!171+interest:cnn+"


### PR DESCRIPTION
use explicitIndex for parsing correctly.
bug introduced in https://github.com/vespa-engine/vespa/pull/23686