### PR TITLE
fix(publish-cli): adds a missing wildcard from the bash prefix removal syntax

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ startswith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
             # Remove the "v" prefix from the tag.
-            BUILD_VERSION="${GITHUB_REF_NAME#v}"
+            BUILD_VERSION="${GITHUB_REF_NAME#*v}"
           else
             BUILD_VERSION="0.0.0-dev_${{ github.run_number }}"
           fi


### PR DESCRIPTION
## What

_In the `publish-cli.yml` workflow:_ adds a missing wildcard from the bash prefix removal syntax

## Why

The line which was supposed to remove the workflow was not actually doing what it was supposed to do.

## Contribution guidelines
<!-- This should be manually checked -->

- [x] I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
