### PR TITLE
feat(publish-cli): add manual trigger for CLI publish workflow

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -10,6 +10,12 @@ on:
     paths:
       - .github/workflows/publish-cli.yml
       - client/go/**
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version to build and publish, it MUST be a tag in this repository without the "v" prefix.'
+        required: true
+        type: string
 
 defaults:
   run:
@@ -31,6 +37,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" && "${{ startswith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
             # Remove the "v" prefix from the tag.
             BUILD_VERSION="${GITHUB_REF_NAME#*v}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BUILD_VERSION="${{ github.event.inputs.version }}"
           else
             BUILD_VERSION="0.0.0-dev_${{ github.run_number }}"
           fi
@@ -72,7 +80,8 @@ jobs:
   publish:
     runs-on: macos-latest
 
-    if: github.event_name == 'push' && startswith(github.ref, 'refs/tags/v')
+    # Publish the CLI when a tag is pushed or a workflow is triggered manually.
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
     needs:
       - prepare
       - build-test


### PR DESCRIPTION
## What

Adds a manual workflow trigger to the CLI publish workflow to allow manually triggering the publish process with a specific version.

## Why

This provides a way to manually publish a new CLI version, this is useful for example to re-publish versions when issues in the original workflow.