### PR TITLE
Fix: Language server publish github action

### DIFF
--- a/integration/schema-language-server/clients/vscode/.vscodeignore
+++ b/integration/schema-language-server/clients/vscode/.vscodeignore
@@ -7,6 +7,5 @@ src/**
 **/.eslintrc.json
 **/*.map
 **/*.ts
-out/
 node_modules
 esbuild.js


### PR DESCRIPTION
Include the compiled typescript code to the extension. Then the github action will not throw an error while publishing.