### PR TITLE
 Remove unused member variables in word number mapping.

### DIFF
--- a/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
+++ b/searchlib/src/apps/vespa-index-inspect/vespa-index-inspect.cpp
@@ -364,7 +364,6 @@ bool
 ShowPostingListSubApp::readWordList(const SchemaUtil::IndexIterator &index)
 {
     std::vector<std::string> &words = _wordsv[index.getIndex()];
-    WordNumMapping &wm = _wmv[index.getIndex()];
 
     search::TuneFileSeqRead tuneFileRead;
     PageDict4FileSeqRead wr;
@@ -381,7 +380,6 @@ ShowPostingListSubApp::readWordList(const SchemaUtil::IndexIterator &index)
         words.push_back(word);
         wr.readWord(word, wordNum, counts);
     }
-    wm.setup(words.size() - 1);
     if (!wr.close())
         return false;
     return true;

--- a/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
+++ b/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
@@ -278,7 +278,6 @@ void
 WrappedFieldReader::open()
 {
     TuneFileSeqRead tuneFileRead;
-    _wmap.setup(_numWordIds);
     _dmap.setup(_docIdLimit);
     _fieldReader = std::make_unique<FieldReader>();
     _fieldReader->setup(_wmap, _dmap);

--- a/searchlib/src/vespa/searchlib/diskindex/wordnummapper.cpp
+++ b/searchlib/src/vespa/searchlib/diskindex/wordnummapper.cpp
@@ -7,8 +7,7 @@
 namespace search::diskindex {
 
 WordNumMapping::WordNumMapping()
-    : _old2newwords(),
-      _oldDictSize(0u)
+    : _old2newwords()
 {
 }
 
@@ -29,7 +28,6 @@ WordNumMapping::readMappingFile(const std::string &name,
             sizeof(uint64_t));
     Array &map = _old2newwords;
     map.resize(tempfileentries);
-    _oldDictSize = tempfileentries;
 
     ssize_t has_read = old2newwordfile.Read(&map[0], static_cast<size_t>(tempfilesize));
     assert(has_read == tempfilesize);
@@ -43,7 +41,6 @@ WordNumMapping::noMappingFile()
     map.resize(2);
     map[0] = noWordNum();
     map[1] = noWordNumHigh();
-    _oldDictSize = 0;
 }
 
 
@@ -52,14 +49,6 @@ WordNumMapping::clear()
 {
     Array &map = _old2newwords;
     map.clear();
-    _oldDictSize = 0;
-}
-
-
-void
-WordNumMapping::setup(uint32_t numWordIds)
-{
-    _oldDictSize = numWordIds;
 }
 
 }

--- a/searchlib/src/vespa/searchlib/diskindex/wordnummapper.h
+++ b/searchlib/src/vespa/searchlib/diskindex/wordnummapper.h
@@ -4,6 +4,7 @@
 #include <vespa/searchlib/common/tunefileinfo.h>
 #include <vespa/vespalib/util/array.h>
 #include <limits>
+#include <span>
 #include <string>
 
 namespace search::diskindex {
@@ -21,22 +22,19 @@ class WordNumMapping
     static uint64_t noWordNum() { return 0u; }
 
     Array _old2newwords;
-    uint64_t _oldDictSize;
 public:
 
     WordNumMapping();
 
-    const uint64_t *getOld2NewWordNums() const {
+    std::span<const uint64_t> getOld2NewWordNums() const {
         return (_old2newwords.empty())
-            ? nullptr
-            : &_old2newwords[0];
+            ? std::span<const uint64_t>()
+            : std::span<const uint64_t>(_old2newwords.data(), _old2newwords.size());
     }
 
-    uint64_t getOldDictSize() const { return _oldDictSize; }
     void readMappingFile(const std::string &name, const TuneFileSeqRead &tuneFileRead);
     void noMappingFile();
     void clear();
-    void setup(uint32_t numWordIds);
 };
 
 
@@ -48,22 +46,19 @@ class WordNumMapper
 
     static uint64_t noWordNum() { return 0u; }
 
-    const uint64_t *_old2newwords;
-    uint64_t _oldDictSize;
+    std::span<const uint64_t>_old2newwords;
 
 public:
     WordNumMapper()
-        : _old2newwords(nullptr),
-          _oldDictSize(0)
+        : _old2newwords()
     {}
 
     void setup(const WordNumMapping &mapping) {
         _old2newwords = mapping.getOld2NewWordNums();
-        _oldDictSize = mapping.getOldDictSize();
     }
 
     uint64_t map(uint32_t wordNum) const {
-        return (_old2newwords != nullptr)
+        return (_old2newwords.data() != nullptr)
             ? _old2newwords[wordNum]
             : wordNum;
     }


### PR DESCRIPTION
@geirst : please review
