### PR TITLE
Remove undocumented and unused env variables

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
@@ -34,9 +34,9 @@ public interface ConfigOptions {
     Optional<String> system();
     default Optional<String> cloud() { return Optional.empty(); }
     Optional<Boolean> useVespaVersionInRequest();
-    Optional<String> loadBalancerAddress();
-    Optional<String> athenzDnsSuffix();
-    Optional<String> ztsUrl();
+    default Optional<String> loadBalancerAddress() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
+    default Optional<String> athenzDnsSuffix() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
+    default Optional<String> ztsUrl() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
     String zooKeeperSnapshotMethod();
     Integer zookeeperJuteMaxBuffer(); // in bytes
 

--- a/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/container/configserver/TestOptions.java
@@ -70,19 +70,6 @@ public class TestOptions implements ConfigOptions {
     public Optional<Boolean> useVespaVersionInRequest() { return useVespaVersionInRequest; }
 
     @Override
-    public Optional<String> loadBalancerAddress() { return Optional.empty(); }
-
-    @Override
-    public Optional<String> athenzDnsSuffix() {
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<String> ztsUrl() {
-        return Optional.empty();
-    }
-
-    @Override
     public String zooKeeperSnapshotMethod() { return zooKeeperSnapshotMethod; }
 
     @Override

--- a/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
+++ b/standalone-container/src/main/java/com/yahoo/container/standalone/ConfigEnvironmentVariables.java
@@ -88,21 +88,6 @@ public class ConfigEnvironmentVariables implements ConfigOptions {
     }
 
     @Override
-    public Optional<String> loadBalancerAddress() {
-        return getInstallVariable("load_balancer_address");
-    }
-
-    @Override
-    public Optional<String> athenzDnsSuffix() {
-        return getInstallVariable("athenz_dns_suffix");
-    }
-
-    @Override
-    public Optional<String> ztsUrl() {
-        return getInstallVariable("zts_url");
-    }
-
-    @Override
     public String zooKeeperSnapshotMethod() {
         String vespaZookeeperSnapshotMethod = System.getenv("VESPA_ZOOKEEPER_SNAPSHOT_METHOD");
         return vespaZookeeperSnapshotMethod == null ? "" : vespaZookeeperSnapshotMethod;


### PR DESCRIPTION
These can be (and are, in internal repo) set by overriding `configserver` config in config server's application package instead. @tokle FYI