### PR TITLE
fix: The LSP VScode client will now start without errors

### DIFF
--- a/integration/schema-language-server/clients/vscode/.vscodeignore
+++ b/integration/schema-language-server/clients/vscode/.vscodeignore
@@ -7,5 +7,6 @@ src/**
 **/.eslintrc.json
 **/*.map
 **/*.ts
+out/
 node_modules
 esbuild.js

--- a/integration/schema-language-server/clients/vscode/package.json
+++ b/integration/schema-language-server/clients/vscode/package.json
@@ -23,7 +23,7 @@
   },
   "icon": "images/icon.png",
   "activationEvents": [],
-  "main": "./out/extension.js",
+  "main": "./dist/extension.js",
   "contributes": {
     "languages": [
       {


### PR DESCRIPTION
Change the entrypoint for the extension to the bundled file.
