### PR TITLE
Use session lifetime when calculating if a session is new

### DIFF
--- a/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
+++ b/configserver/src/main/java/com/yahoo/vespa/config/server/session/SessionRepository.java
@@ -815,8 +815,9 @@ public class SessionRepository {
         if (sessions != null) {
             for (File session : sessions) {
                 try {
+                    Duration consideredNew = Duration.ofSeconds(Math.min(configserverConfig.sessionLifetime(), 300));
                     if (Files.getLastModifiedTime(session.toPath()).toInstant()
-                             .isAfter(clock.instant().minus(Duration.ofMinutes(5))))
+                             .isAfter(clock.instant().minus(consideredNew)))
                         newSessions.add(Long.parseLong(session.getName()));
                 } catch (IOException e) {
                     log.log(Level.FINE, "Unable to find last modified time for " + session.toPath());


### PR DESCRIPTION
Makes it possible to test with smaller session lifetime

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
