### PR TITLE
Remove unused member variable in searchlib field writer unit test.

### DIFF
--- a/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
+++ b/searchlib/src/tests/diskindex/fieldwriter/fieldwriter_test.cpp
@@ -230,7 +230,6 @@ public:
     std::unique_ptr<FieldReader> _fieldReader;
 private:
     std::string _namepref;
-    uint32_t _numWordIds;
     uint32_t _docIdLimit;
     WordNumMapping _wmap;
     DocIdMapping _dmap;
@@ -239,8 +238,7 @@ private:
 
 public:
     WrappedFieldReader(const std::string &namepref,
-                      uint32_t numWordIds,
-                      uint32_t docIdLimit);
+                       uint32_t docIdLimit);
 
     ~WrappedFieldReader();
     void open();
@@ -249,11 +247,9 @@ public:
 
 
 WrappedFieldReader::WrappedFieldReader(const std::string &namepref,
-                                     uint32_t numWordIds,
-                                     uint32_t docIdLimit)
+                                       uint32_t docIdLimit)
     : _fieldReader(),
       _namepref(dirprefix + namepref),
-      _numWordIds(numWordIds),
       _docIdLimit(docIdLimit),
       _wmap(),
       _dmap(),
@@ -418,7 +414,7 @@ readField(FakeWordSet &wordSet,
 {
     const char *dynamicKStr = dynamicK ? "true" : "false";
 
-    WrappedFieldReader istate(namepref, wordSet.getNumWords(), docIdLimit);
+    WrappedFieldReader istate(namepref, docIdLimit);
     LOG(info, "enter readField, namepref=%s, dynamicK=%s, decode_interleaved_features=%s",
         namepref.c_str(), dynamicKStr, bool_to_str(decode_interleaved_features));
 
@@ -571,7 +567,7 @@ fusionField(uint32_t numWordIds,
         dynamicKStr, bool_to_str(encode_interleaved_features));
 
     WrappedFieldWriter ostate(opref, dynamicK, encode_interleaved_features, numWordIds, docIdLimit);
-    WrappedFieldReader istate(ipref, numWordIds, docIdLimit);
+    WrappedFieldReader istate(ipref, docIdLimit);
 
     vespalib::Timer tv;
 


### PR DESCRIPTION
@geirst : please review
