### PR TITLE
Stop using loadBalancerAddress, athenzDnsSuffix and ztsUrl from	options

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/ConfigserverCluster.java
@@ -130,11 +130,6 @@ public class ConfigserverCluster extends TreeConfigProducer
         if (options.hostedVespa().isPresent()) {
             builder.hostedVespa(options.hostedVespa().get());
         }
-        if (options.loadBalancerAddress().isPresent()) {
-            builder.loadBalancerAddress(options.loadBalancerAddress().get());
-        }
-        options.athenzDnsSuffix().ifPresent(builder::athenzDnsSuffix);
-        options.ztsUrl().ifPresent(builder::ztsUrl);
     }
 
     private String[] getConfigModelPluginDirs() {

--- a/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/container/configserver/option/ConfigOptions.java
@@ -34,9 +34,9 @@ public interface ConfigOptions {
     Optional<String> system();
     default Optional<String> cloud() { return Optional.empty(); }
     Optional<Boolean> useVespaVersionInRequest();
-    default Optional<String> loadBalancerAddress() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
-    default Optional<String> athenzDnsSuffix() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
-    default Optional<String> ztsUrl() { return Optional.empty(); } // TODO: Remove when 8.406 is oldest version in use
+    default Optional<String> loadBalancerAddress() { return Optional.empty(); } // TODO: Remove when 8.409 is oldest version in use
+    default Optional<String> athenzDnsSuffix() { return Optional.empty(); } // TODO: Remove when 8.409 is oldest version in use
+    default Optional<String> ztsUrl() { return Optional.empty(); } // TODO: Remove when 8.409 is oldest version in use
     String zooKeeperSnapshotMethod();
     Integer zookeeperJuteMaxBuffer(); // in bytes
 


### PR DESCRIPTION
These are set as config	ovverides in config server application package

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
