### PR TITLE
Comment out doc building to fix build MERGEOK

### DIFF
--- a/integration/schema-language-server/language-server/pom.xml
+++ b/integration/schema-language-server/language-server/pom.xml
@@ -102,6 +102,7 @@
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
       </plugin>
+<!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -121,6 +122,7 @@
           </execution>
         </executions>
       </plugin>
+-->
       <plugin>   
         <groupId>org.congocc</groupId>   
         <artifactId>org.congocc.maven.plugin</artifactId>   


### PR DESCRIPTION
Build fails due to python dependency issues

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
