### PR TITLE
Revert "Comment out doc building to fix build MERGEOK"

### DIFF
--- a/integration/schema-language-server/language-server/pom.xml
+++ b/integration/schema-language-server/language-server/pom.xml
@@ -102,7 +102,6 @@
         <groupId>com.github.os72</groupId>
         <artifactId>protoc-jar-maven-plugin</artifactId>
       </plugin>
-<!--
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -122,7 +121,6 @@
           </execution>
         </executions>
       </plugin>
--->
       <plugin>   
         <groupId>org.congocc</groupId>   
         <artifactId>org.congocc.maven.plugin</artifactId>   


### PR DESCRIPTION
Reverts vespa-engine/vespa#32407

This was not enough as more stuff depended on python. Proper fix has been merged here : https://github.com/vespaai/buildkite/pull/37

Sorry for the inconvenience.