### PR TITLE
Change how we validate redundancy changes

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidator.java
@@ -29,8 +29,6 @@ public class RedundancyIncreaseValidator implements ChangeValidator {
         }
     }
 
-    private int redundancyOf(ContentCluster cluster) {
-        return cluster.getRedundancy().finalRedundancy();
-    }
+    private int redundancyOf(ContentCluster cluster) { return cluster.getRedundancy().effectiveFinalRedundancy(); }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
@@ -21,9 +21,9 @@ public class RedundancyIncreaseValidatorTest {
 
     @Test
     void testRedundancyIncreaseValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices(3), Environment.prod, null, "contentClusterId.indexing");
+            tester.deploy(previous, getServices(3, 3, 1), Environment.prod, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy increase");
         }
         catch (IllegalArgumentException expected) {
@@ -36,12 +36,20 @@ public class RedundancyIncreaseValidatorTest {
     }
 
     @Test
-    void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(3), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
+    void testRedundancyIncreaseValidationWithGroups() {
+        // Changing redundancy from 1 to 2 is allowed when having 2 nodes in 2 groups versus 3 nodes in 1 group
+        // (effective redundancy for the cluster is 2 in both cases)
+        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing");
     }
 
-    private static String getServices(int redundancy) {
+    @Test
+    void testOverridingContentRemovalValidation() {
+        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(3, 3, 1), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
+    }
+
+    private static String getServices(int redundancy, int nodes, int groups) {
         return "<services version='1.0'>" +
                "  <content id='contentClusterId' version='1.0'>" +
                "    <redundancy>" + redundancy + "</redundancy>" +
@@ -51,7 +59,7 @@ public class RedundancyIncreaseValidatorTest {
                "    <documents>" +
                "      <document type='music' mode='index'/>" +
                "    </documents>" +
-               "    <nodes count='3'/>" +
+               "    <nodes count='" + nodes + "' groups='" + groups + "'/>" +
                "   </content>" +
                "</services>";
     }


### PR DESCRIPTION
Consider effective final redundancy (redundancy for whole cluster) when validating

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
