### PR TITLE
Ensure deferred tasks are aborted if blocking messages are explicitly cleared

### DIFF
--- a/storage/src/tests/distributor/visitoroperationtest.cpp
+++ b/storage/src/tests/distributor/visitoroperationtest.cpp
@@ -235,7 +235,7 @@ TEST_F(VisitorOperationTest, shutdown) {
     op->onClose(_sender); // This will fail the visitor
 
     EXPECT_EQ("CreateVisitorReply(last=BucketId(0x0000000000000000)) "
-              "ReturnCode(ABORTED, Process is shutting down)",
+              "ReturnCode(ABORTED, Operation has been aborted)",
               _sender.getLastReply());
 }
 

--- a/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
+++ b/storage/src/vespa/storage/distributor/operations/external/visitoroperation.cpp
@@ -881,7 +881,7 @@ VisitorOperation::updateReplyMetrics(const api::ReturnCode& result)
 void
 VisitorOperation::onClose(DistributorStripeMessageSender& sender)
 {
-    sendReply(api::ReturnCode(api::ReturnCode::ABORTED, "Process is shutting down"), sender);
+    sendReply(api::ReturnCode(api::ReturnCode::ABORTED, "Operation has been aborted"), sender);
 }
 
 void

--- a/storage/src/vespa/storage/distributor/pendingmessagetracker.h
+++ b/storage/src/vespa/storage/distributor/pendingmessagetracker.h
@@ -186,7 +186,7 @@ private:
     static constexpr uint32_t IndexByNodeAndBucket = 1;
     static constexpr uint32_t IndexByBucketAndType = 2;
 
-    using DeferredBucketTaskMap   = std::unordered_multimap<
+    using DeferredBucketTaskMap = std::unordered_multimap<
             document::Bucket,
             std::unique_ptr<DeferredTask>,
             document::Bucket::hash
@@ -210,7 +210,8 @@ private:
     TimePoint currentTime() const;
 
     [[nodiscard]] bool bucket_has_no_pending_write_ops(const document::Bucket& bucket) const noexcept;
-    std::vector<std::unique_ptr<DeferredTask>> get_deferred_ops_if_bucket_writes_drained(const document::Bucket&);
+    [[nodiscard]] std::vector<std::unique_ptr<DeferredTask>> get_deferred_ops_if_bucket_writes_drained(const document::Bucket&);
+    void get_and_erase_deferred_tasks_for_bucket(const document::Bucket&, std::vector<std::unique_ptr<DeferredTask>>&);
 };
 
 }


### PR DESCRIPTION
@geirst please review.

When a node becomes unavailable in the cluster state (or disappears from the distribution config), pending operations towards it are currently explicitly cleared in the pending message tracker. The code responsible for clearing messages was not functionally symmetric with the code that handles replies in how deferred tasks were handled.

Normally a deferred task expects to be run once there exist no further pending operations towards a particular bucket, or to be aborted at any point in time. This was handled as expected during reply processing and process shutdown, but not when clearing messages for individual nodes.

In particular, this meant that it was possible for deferred tasks scheduled by reindexing visitors to stall feeding to certain buckets when they raced with nodes becoming unavailable, as such tasks hold bucket-level feed locks.

With these changes, clearing operations for a node implicitly aborts deferred tasks towards all buckets touched by pending operations to the cleared node.
