### PR TITLE
Revert "Change how we validate redundancy changes"

### DIFF
--- a/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidator.java
+++ b/config-model/src/main/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidator.java
@@ -29,6 +29,8 @@ public class RedundancyIncreaseValidator implements ChangeValidator {
         }
     }
 
-    private int redundancyOf(ContentCluster cluster) { return cluster.getRedundancy().effectiveFinalRedundancy(); }
+    private int redundancyOf(ContentCluster cluster) {
+        return cluster.getRedundancy().finalRedundancy();
+    }
 
 }

--- a/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
+++ b/config-model/src/test/java/com/yahoo/vespa/model/application/validation/change/RedundancyIncreaseValidatorTest.java
@@ -21,9 +21,9 @@ public class RedundancyIncreaseValidatorTest {
 
     @Test
     void testRedundancyIncreaseValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
         try {
-            tester.deploy(previous, getServices(3, 3, 1), Environment.prod, null, "contentClusterId.indexing");
+            tester.deploy(previous, getServices(3), Environment.prod, null, "contentClusterId.indexing");
             fail("Expected exception due to redundancy increase");
         }
         catch (IllegalArgumentException expected) {
@@ -36,20 +36,12 @@ public class RedundancyIncreaseValidatorTest {
     }
 
     @Test
-    void testRedundancyIncreaseValidationWithGroups() {
-        // Changing redundancy from 1 to 2 is allowed when having 2 nodes in 2 groups versus 3 nodes in 1 group
-        // (effective redundancy for the cluster is 2 in both cases)
-        VespaModel previous = tester.deploy(null, getServices(1, 2, 2), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing");
-    }
-
-    @Test
     void testOverridingContentRemovalValidation() {
-        VespaModel previous = tester.deploy(null, getServices(2, 3, 1), Environment.prod, null, "contentClusterId.indexing").getFirst();
-        tester.deploy(previous, getServices(3, 3, 1), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
+        VespaModel previous = tester.deploy(null, getServices(2), Environment.prod, null, "contentClusterId.indexing").getFirst();
+        tester.deploy(previous, getServices(3), Environment.prod, redundancyIncreaseOverride, "contentClusterId.indexing"); // Allowed due to override
     }
 
-    private static String getServices(int redundancy, int nodes, int groups) {
+    private static String getServices(int redundancy) {
         return "<services version='1.0'>" +
                "  <content id='contentClusterId' version='1.0'>" +
                "    <redundancy>" + redundancy + "</redundancy>" +
@@ -59,7 +51,7 @@ public class RedundancyIncreaseValidatorTest {
                "    <documents>" +
                "      <document type='music' mode='index'/>" +
                "    </documents>" +
-               "    <nodes count='" + nodes + "' groups='" + groups + "'/>" +
+               "    <nodes count='3'/>" +
                "   </content>" +
                "</services>";
     }


### PR DESCRIPTION
Reverts vespa-engine/vespa#32412

Suspecting that this broke https://factory.vespa.oath.cloud/testrun/94544050/test/FlatToHierarchicTransitionTest::test_transition_implicitly_indexes_and_activates_docs_per_group__INDEXED